### PR TITLE
Fix huge initializer_list in SettingsChangesHistory

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-ClickHouseVersion::ClickHouseVersion(const String & version)
+ClickHouseVersion::ClickHouseVersion(std::string_view version)
 {
     Strings split;
     boost::split(split, version, [](char c){ return c == '.'; });
@@ -32,42 +32,47 @@ ClickHouseVersion::ClickHouseVersion(const String & version)
     }
 }
 
-ClickHouseVersion::ClickHouseVersion(const char * version)
-    : ClickHouseVersion(String(version))
-{
-}
-
 String ClickHouseVersion::toString() const
 {
-    String version = std::to_string(components[0]);
-    for (size_t i = 1; i < components.size(); ++i)
-        version += "." + std::to_string(components[i]);
-
-    return version;
+    return fmt::format("{}", fmt::join(components, "."));
 }
 
-// clang-format off
-/// History of settings changes that controls some backward incompatible changes
-/// across all ClickHouse versions. It maps ClickHouse version to settings changes that were done
-/// in this version. This history contains both changes to existing settings and newly added settings.
-/// Settings changes is a vector of structs
-///     {setting_name, previous_value, new_value, reason}.
-/// For newly added setting choose the most appropriate previous_value (for example, if new setting
-/// controls new feature and it's 'true' by default, use 'false' as previous_value).
-/// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
-/// Note: please check if the key already exists to prevent duplicate entries.
-static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory::SettingsChanges>> settings_changes_history_initializer =
+static void addSettingsChanges(
+    VersionToSettingsChangesMap & settings_changes_history,
+    const char * version,
+    SettingsChangesHistory::SettingsChanges && changes)
 {
-    {"25.1",
+    /// Forbid duplicate versions
+    auto [_, inserted] = settings_changes_history.emplace(ClickHouseVersion(version), std::move(changes));
+    if (!inserted)
+        throw Exception{ErrorCodes::LOGICAL_ERROR, "Detected duplicate version '{}'", ClickHouseVersion(version).toString()};
+}
+
+const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getSettingsChangesHistory()
+{
+    static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history;
+    static std::once_flag initialized_flag;
+    std::call_once(initialized_flag, [&]
+    {
+        // clang-format off
+        /// History of settings changes that controls some backward incompatible changes
+        /// across all ClickHouse versions. It maps ClickHouse version to settings changes that were done
+        /// in this version. This history contains both changes to existing settings and newly added settings.
+        /// Settings changes is a vector of structs
+        ///     {setting_name, previous_value, new_value, reason}.
+        /// For newly added setting choose the most appropriate previous_value (for example, if new setting
+        /// controls new feature and it's 'true' by default, use 'false' as previous_value).
+        /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
+        /// Note: please check if the key already exists to prevent duplicate entries.
+        addSettingsChanges(settings_changes_history, "25.1",
         {
             {"allow_experimental_ts_to_grid_aggregate_function", false, false, "Cloud only"},
             {"distributed_cache_connect_max_tries", 20, 20, "Cloud only"},
             {"distributed_cache_min_bytes_for_seek", false, false, "New private setting."},
             {"s3queue_migrate_old_metadata_to_buckets", false, false, "New setting."},
             {"distributed_cache_pool_behaviour_on_limit", "allocate_bypassing_pool", "wait", "Cloud only"},
-        }
-    },
-    {"24.12",
+        });
+        addSettingsChanges(settings_changes_history, "24.12",
         {
             /// Release closed. Please use 25.1
             {"allow_experimental_database_iceberg", false, false, "New setting."},
@@ -85,9 +90,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"parallel_replicas_index_analysis_only_on_coordinator", true, true, "Index analysis done only on replica-coordinator and skipped on other replicas. Effective only with enabled parallel_replicas_local_plan"}, // enabling it was moved to 24.10
             {"least_greatest_legacy_null_behavior", true, false, "New setting"},
             /// Release closed. Please use 25.1
-        }
-    },
-    {"24.11",
+        });
+        addSettingsChanges(settings_changes_history, "24.11",
         {
             {"validate_mutation_query", false, true, "New setting to validate mutation queries by default."},
             {"enable_job_stack_trace", false, true, "Enable by default collecting stack traces from job's scheduling."},
@@ -117,9 +121,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"enable_variant_type", false, false, "Add alias to allow_experimental_variant_type"},
             {"enable_dynamic_type", false, false, "Add alias to allow_experimental_dynamic_type"},
             {"enable_json_type", false, false, "Add alias to allow_experimental_json_type"},
-        }
-    },
-    {"24.10",
+        });
+        addSettingsChanges(settings_changes_history, "24.10",
         {
             {"query_metric_log_interval", 0, -1, "New setting."},
             {"enforce_strict_identifier_format", false, false, "New setting."},
@@ -166,9 +169,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"input_format_parquet_bloom_filter_push_down", false, true, "When reading Parquet files, skip whole row groups based on the WHERE/PREWHERE expressions and bloom filter in the Parquet metadata."},
             {"date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands", false, false, "Dynamically trim the trailing zeros of datetime64 values to adjust the output scale to (0, 3, 6), corresponding to 'seconds', 'milliseconds', and 'microseconds'."},
             {"parallel_replicas_index_analysis_only_on_coordinator", false, true, "Index analysis done only on replica-coordinator and skipped on other replicas. Effective only with enabled parallel_replicas_local_plan"},
-        }
-    },
-    {"24.9",
+        });
+        addSettingsChanges(settings_changes_history, "24.9",
         {
             {"output_format_orc_dictionary_key_size_threshold", 0.0, 0.0, "For a string column in ORC output format, if the number of distinct values is greater than this fraction of the total number of non-null rows, turn off dictionary encoding. Otherwise dictionary encoding is enabled"},
             {"input_format_json_empty_as_default", false, false, "Added new setting to allow to treat empty fields in JSON input as default values."},
@@ -186,9 +188,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"mongodb_throw_on_unsupported_query", false, true, "New setting."},
             {"min_free_disk_bytes_to_perform_insert", 0, 0, "Maintain some free disk space bytes from inserts while still allowing for temporary writing."},
             {"min_free_disk_ratio_to_perform_insert", 0.0, 0.0, "Maintain some free disk space bytes expressed as ratio to total disk space from inserts while still allowing for temporary writing."},
-        }
-    },
-    {"24.8",
+        });
+        addSettingsChanges(settings_changes_history, "24.8",
         {
             {"rows_before_aggregation", false, false, "Provide exact value for rows_before_aggregation statistic, represents the number of rows read before aggregation"},
             {"restore_replace_external_table_functions_to_null", false, false, "New setting."},
@@ -207,9 +208,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"type_json_skip_duplicated_paths", false, false, "Allow to skip duplicated paths during JSON parsing"},
             {"allow_experimental_vector_similarity_index", false, false, "Added new setting to allow experimental vector similarity indexes"},
             {"input_format_try_infer_datetimes_only_datetime64", true, false, "Allow to infer DateTime instead of DateTime64 in data formats"},
-        }
-    },
-    {"24.7",
+        });
+        addSettingsChanges(settings_changes_history, "24.7",
         {
             {"output_format_parquet_write_page_index", false, true, "Add a possibility to write page index into parquet files."},
             {"output_format_binary_encode_types_in_binary_format", false, false, "Added new setting to allow to write type names in binary format in RowBinaryWithNamesAndTypes output format"},
@@ -232,9 +232,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"backup_restore_s3_retry_attempts", 1000,1000, "Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries. It takes place only for backup/restore."},
             {"postgresql_connection_attempt_timeout", 2, 2, "Allow to control 'connect_timeout' parameter of PostgreSQL connection."},
             {"postgresql_connection_pool_retries", 2, 2, "Allow to control the number of retries in PostgreSQL connection pool."}
-        }
-    },
-    {"24.6",
+        });
+        addSettingsChanges(settings_changes_history, "24.6",
         {
             {"materialize_skip_indexes_on_insert", true, true, "Added new setting to allow to disable materialization of skip indexes on insert"},
             {"materialize_statistics_on_insert", true, true, "Added new setting to allow to disable materialization of statistics on insert"},
@@ -265,9 +264,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"output_format_csv_serialize_tuple_into_separate_columns", true, true, "A new way of how interpret tuples in CSV format was added."},
             {"input_format_csv_deserialize_separate_columns_into_tuple", true, true, "A new way of how interpret tuples in CSV format was added."},
             {"input_format_csv_try_infer_strings_from_quoted_tuples", true, true, "A new way of how interpret tuples in CSV format was added."},
-        }
-    },
-    {"24.5",
+        });
+        addSettingsChanges(settings_changes_history, "24.5",
         {
             {"allow_deprecated_error_prone_window_functions", true, false, "Allow usage of deprecated error prone window functions (neighbor, runningAccumulate, runningDifferenceStartingWithFirstValue, runningDifference)"},
             {"allow_experimental_join_condition", false, false, "Support join with inequal conditions which involve columns from both left and right table. e.g. t1.y < t2.y."},
@@ -282,9 +280,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"allow_experimental_dynamic_type", false, false, "Add new experimental Dynamic type"},
             {"azure_max_blocks_in_multipart_upload", 50000, 50000, "Maximum number of blocks in multipart upload for Azure."},
             {"allow_archive_path_syntax", false, true, "Added new setting to allow disabling archive path syntax."},
-        }
-    },
-    {"24.4",
+        });
+        addSettingsChanges(settings_changes_history, "24.4",
         {
             {"input_format_json_throw_on_bad_escape_sequence", true, true, "Allow to save JSON strings with bad escape sequences"},
             {"max_parsing_threads", 0, 0, "Add a separate setting to control number of threads in parallel parsing from files"},
@@ -299,9 +296,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"azure_allow_parallel_part_upload", "true", "true", "Use multiple threads for azure multipart upload."},
             {"max_recursive_cte_evaluation_depth", DBMS_RECURSIVE_CTE_MAX_EVALUATION_DEPTH, DBMS_RECURSIVE_CTE_MAX_EVALUATION_DEPTH, "Maximum limit on recursive CTE evaluation depth"},
             {"query_plan_convert_outer_join_to_inner_join", false, true, "Allow to convert OUTER JOIN to INNER JOIN if filter after JOIN always filters default values"},
-        }
-    },
-    {"24.3",
+        });
+        addSettingsChanges(settings_changes_history, "24.3",
         {
             {"s3_connect_timeout_ms", 1000, 1000, "Introduce new dedicated setting for s3 connection timeout"},
             {"allow_experimental_shared_merge_tree", false, true, "The setting is obsolete"},
@@ -345,9 +341,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"output_format_csv_serialize_tuple_into_separate_columns", true, true, "A new way of how interpret tuples in CSV format was added."},
             {"input_format_csv_deserialize_separate_columns_into_tuple", true, true, "A new way of how interpret tuples in CSV format was added."},
             {"input_format_csv_try_infer_strings_from_quoted_tuples", true, true, "A new way of how interpret tuples in CSV format was added."},
-        }
-    },
-    {"24.2",
+        });
+        addSettingsChanges(settings_changes_history, "24.2",
         {
             {"allow_suspicious_variant_types", true, false, "Don't allow creating Variant type with suspicious variants by default"},
             {"validate_experimental_and_suspicious_types_inside_nested_types", false, true, "Validate usage of experimental and suspicious types inside nested types"},
@@ -377,9 +372,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"default_normal_view_sql_security", "INVOKER", "INVOKER", "Allows to set default `SQL SECURITY` option while creating a normal view"},
             {"mysql_map_string_to_text_in_show_columns", false, true, "Reduce the configuration effort to connect ClickHouse with BI tools."},
             {"mysql_map_fixed_string_to_text_in_show_columns", false, true, "Reduce the configuration effort to connect ClickHouse with BI tools."},
-        }
-    },
-    {"24.1",
+        });
+        addSettingsChanges(settings_changes_history, "24.1",
         {
             {"print_pretty_type_names", false, true, "Better user experience."},
             {"input_format_json_read_bools_as_strings", false, true, "Allow to read bools as strings in JSON formats by default"},
@@ -404,22 +398,19 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"azure_max_unexpected_write_error_retries", 4, 4, "The maximum number of retries in case of unexpected errors during Azure blob storage write"},
             {"split_parts_ranges_into_intersecting_and_non_intersecting_final", false, true, "Allow to split parts ranges into intersecting and non intersecting during FINAL optimization"},
             {"split_intersecting_parts_ranges_into_layers_final", true, true, "Allow to split intersecting parts ranges into layers during FINAL optimization"}
-        }
-    },
-    {"23.12",
+        });
+        addSettingsChanges(settings_changes_history, "23.12",
         {
             {"allow_suspicious_ttl_expressions", true, false, "It is a new setting, and in previous versions the behavior was equivalent to allowing."},
             {"input_format_parquet_allow_missing_columns", false, true, "Allow missing columns in Parquet files by default"},
             {"input_format_orc_allow_missing_columns", false, true, "Allow missing columns in ORC files by default"},
             {"input_format_arrow_allow_missing_columns", false, true, "Allow missing columns in Arrow files by default"}
-        }
-    },
-    {"23.11",
+        });
+        addSettingsChanges(settings_changes_history, "23.11",
         {
             {"parsedatetime_parse_without_leading_zeros", false, true, "Improved compatibility with MySQL DATE_FORMAT/STR_TO_DATE"}
-        }
-    },
-    {"23.9",
+        });
+        addSettingsChanges(settings_changes_history, "23.9",
         {
             {"optimize_group_by_constant_keys", false, true, "Optimize group by constant keys by default"},
             {"input_format_json_try_infer_named_tuples_from_objects", false, true, "Try to infer named Tuples from JSON objects by default"},
@@ -428,33 +419,28 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"input_format_json_infer_incomplete_types_as_strings", false, true, "Allow to infer incomplete types as Strings in JSON formats by default"},
             {"input_format_json_try_infer_numbers_from_strings", true, false, "Don't infer numbers from strings in JSON formats by default to prevent possible parsing errors"},
             {"http_write_exception_in_output_format", false, true, "Output valid JSON/XML on exception in HTTP streaming."}
-        }
-    },
-    {"23.8",
+        });
+        addSettingsChanges(settings_changes_history, "23.8",
         {
             {"rewrite_count_distinct_if_with_count_distinct_implementation", false, true, "Rewrite countDistinctIf with count_distinct_implementation configuration"}
-        }
-    },
-    {"23.7",
+        });
+        addSettingsChanges(settings_changes_history, "23.7",
         {
             {"function_sleep_max_microseconds_per_block", 0, 3000000, "In previous versions, the maximum sleep time of 3 seconds was applied only for `sleep`, but not for `sleepEachRow` function. In the new version, we introduce this setting. If you set compatibility with the previous versions, we will disable the limit altogether."}
-        }
-    },
-    {"23.6",
+        });
+        addSettingsChanges(settings_changes_history, "23.6",
         {
             {"http_send_timeout", 180, 30, "3 minutes seems crazy long. Note that this is timeout for a single network write call, not for the whole upload operation."},
             {"http_receive_timeout", 180, 30, "See http_send_timeout."}
-        }
-    },
-    {"23.5",
+        });
+        addSettingsChanges(settings_changes_history, "23.5",
         {
             {"input_format_parquet_preserve_order", true, false, "Allow Parquet reader to reorder rows for better parallelism."},
             {"parallelize_output_from_storages", false, true, "Allow parallelism when executing queries that read from file/url/s3/etc. This may reorder rows."},
             {"use_with_fill_by_sorting_prefix", false, true, "Columns preceding WITH FILL columns in ORDER BY clause form sorting prefix. Rows with different values in sorting prefix are filled independently"},
             {"output_format_parquet_compliant_nested_types", false, true, "Change an internal field name in output Parquet file schema."}
-        }
-    },
-    {"23.4",
+        });
+        addSettingsChanges(settings_changes_history, "23.4",
         {
             {"allow_suspicious_indices", true, false, "If true, index can defined with identical expressions"},
             {"allow_nonconst_timezone_arguments", true, false, "Allow non-const timezone arguments in certain time-related functions like toTimeZone(), fromUnixTimestamp*(), snowflakeToDateTime*()."},
@@ -463,9 +449,8 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"hedged_connection_timeout_ms", 100, 50, "Start new connection in hedged requests after 50 ms instead of 100 to correspond with previous connect timeout"},
             {"formatdatetime_f_prints_single_zero", true, false, "Improved compatibility with MySQL DATE_FORMAT()/STR_TO_DATE()"},
             {"formatdatetime_parsedatetime_m_is_month_name", false, true, "Improved compatibility with MySQL DATE_FORMAT/STR_TO_DATE"}
-        }
-    },
-    {"23.3",
+        });
+        addSettingsChanges(settings_changes_history, "23.3",
         {
             {"output_format_parquet_version", "1.0", "2.latest", "Use latest Parquet format version for output format"},
             {"input_format_json_ignore_unknown_keys_in_named_tuple", false, true, "Improve parsing JSON objects as named tuples"},
@@ -474,18 +459,16 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"output_format_parquet_compression_method", "snappy", "lz4", "Use lz4 compression in Parquet output format by default"},
             {"output_format_orc_compression_method", "none", "lz4_frame", "Use lz4 compression in ORC output format by default"},
             {"async_query_sending_for_remote", false, true, "Create connections and send query async across shards"}
-        }
-    },
-    {"23.2",
+        });
+        addSettingsChanges(settings_changes_history, "23.2",
         {
             {"output_format_parquet_fixed_string_as_fixed_byte_array", false, true, "Use Parquet FIXED_LENGTH_BYTE_ARRAY type for FixedString by default"},
             {"output_format_arrow_fixed_string_as_fixed_byte_array", false, true, "Use Arrow FIXED_SIZE_BINARY type for FixedString by default"},
             {"query_plan_remove_redundant_distinct", false, true, "Remove redundant Distinct step in query plan"},
             {"optimize_duplicate_order_by_and_distinct", true, false, "Remove duplicate ORDER BY and DISTINCT if it's possible"},
             {"insert_keeper_max_retries", 0, 20, "Enable reconnections to Keeper on INSERT, improve reliability"}
-        }
-    },
-    {"23.1",
+        });
+        addSettingsChanges(settings_changes_history, "23.1",
         {
             {"input_format_json_read_objects_as_strings", 0, 1, "Enable reading nested json objects as strings while object type is experimental"},
             {"input_format_json_defaults_for_missing_elements_in_named_tuple", false, true, "Allow missing elements in JSON objects while reading named tuples by default"},
@@ -493,151 +476,130 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"input_format_tsv_detect_header", false, true, "Detect header in TSV format by default"},
             {"input_format_custom_detect_header", false, true, "Detect header in CustomSeparated format by default"},
             {"query_plan_remove_redundant_sorting", false, true, "Remove redundant sorting in query plan. For example, sorting steps related to ORDER BY clauses in subqueries"}
-        }
-    },
-    {"22.12",
+        });
+        addSettingsChanges(settings_changes_history, "22.12",
         {
             {"max_size_to_preallocate_for_aggregation", 10'000'000, 100'000'000, "This optimizes performance"},
             {"query_plan_aggregation_in_order", 0, 1, "Enable some refactoring around query plan"},
             {"format_binary_max_string_size", 0, 1_GiB, "Prevent allocating large amount of memory"}
-        }
-    },
-    {"22.11",
+        });
+        addSettingsChanges(settings_changes_history, "22.11",
         {
             {"use_structure_from_insertion_table_in_table_functions", 0, 2, "Improve using structure from insertion table in table functions"}
-        }
-    },
-    {"22.9",
+        });
+        addSettingsChanges(settings_changes_history, "22.9",
         {
             {"force_grouping_standard_compatibility", false, true, "Make GROUPING function output the same as in SQL standard and other DBMS"}
-        }
-    },
-    {"22.7",
+        });
+        addSettingsChanges(settings_changes_history, "22.7",
         {
             {"cross_to_inner_join_rewrite", 1, 2, "Force rewrite comma join to inner"},
             {"enable_positional_arguments", false, true, "Enable positional arguments feature by default"},
             {"format_csv_allow_single_quotes", true, false, "Most tools don't treat single quote in CSV specially, don't do it by default too"}
-        }
-    },
-    {"22.6",
+        });
+        addSettingsChanges(settings_changes_history, "22.6",
         {
             {"output_format_json_named_tuples_as_objects", false, true, "Allow to serialize named tuples as JSON objects in JSON formats by default"},
             {"input_format_skip_unknown_fields", false, true, "Optimize reading subset of columns for some input formats"}
-        }
-    },
-    {"22.5",
+        });
+        addSettingsChanges(settings_changes_history, "22.5",
         {
             {"memory_overcommit_ratio_denominator", 0, 1073741824, "Enable memory overcommit feature by default"},
             {"memory_overcommit_ratio_denominator_for_user", 0, 1073741824, "Enable memory overcommit feature by default"}
-        }
-    },
-    {"22.4",
+        });
+        addSettingsChanges(settings_changes_history, "22.4",
         {
             {"allow_settings_after_format_in_insert", true, false, "Do not allow SETTINGS after FORMAT for INSERT queries because ClickHouse interpret SETTINGS as some values, which is misleading"}
-        }
-    },
-    {"22.3",
+        });
+        addSettingsChanges(settings_changes_history, "22.3",
         {
             {"cast_ipv4_ipv6_default_on_conversion_error", true, false, "Make functions cast(value, 'IPv4') and cast(value, 'IPv6') behave same as toIPv4 and toIPv6 functions"}
-        }
-    },
-    {"21.12",
+        });
+        addSettingsChanges(settings_changes_history, "21.12",
         {
             {"stream_like_engine_allow_direct_select", true, false, "Do not allow direct select for Kafka/RabbitMQ/FileLog by default"}
-        }
-    },
-    {"21.9",
+        });
+        addSettingsChanges(settings_changes_history, "21.9",
         {
             {"output_format_decimal_trailing_zeros", true, false, "Do not output trailing zeros in text representation of Decimal types by default for better looking output"},
             {"use_hedged_requests", false, true, "Enable Hedged Requests feature by default"}
-        }
-    },
-    {"21.7",
+        });
+        addSettingsChanges(settings_changes_history, "21.7",
         {
             {"legacy_column_name_of_tuple_literal", true, false, "Add this setting only for compatibility reasons. It makes sense to set to 'true', while doing rolling update of cluster from version lower than 21.7 to higher"}
-        }
-    },
-    {"21.5",
+        });
+        addSettingsChanges(settings_changes_history, "21.5",
         {
             {"async_socket_for_remote", false, true, "Fix all problems and turn on asynchronous reads from socket for remote queries by default again"}
-        }
-    },
-    {"21.3",
+        });
+        addSettingsChanges(settings_changes_history, "21.3",
         {
             {"async_socket_for_remote", true, false, "Turn off asynchronous reads from socket for remote queries because of some problems"},
             {"optimize_normalize_count_variants", false, true, "Rewrite aggregate functions that semantically equals to count() as count() by default"},
             {"normalize_function_names", false, true, "Normalize function names to their canonical names, this was needed for projection query routing"}
-        }
-    },
-    {"21.2",
+        });
+        addSettingsChanges(settings_changes_history, "21.2",
         {
             {"enable_global_with_statement", false, true, "Propagate WITH statements to UNION queries and all subqueries by default"}
-        }
-    },
-    {"21.1",
+        });
+        addSettingsChanges(settings_changes_history, "21.1",
         {
             {"insert_quorum_parallel", false, true, "Use parallel quorum inserts by default. It is significantly more convenient to use than sequential quorum inserts"},
             {"input_format_null_as_default", false, true, "Allow to insert NULL as default for input formats by default"},
             {"optimize_on_insert", false, true, "Enable data optimization on INSERT by default for better user experience"},
             {"use_compact_format_in_distributed_parts_names", false, true, "Use compact format for async INSERT into Distributed tables by default"}
-        }
-    },
-    {"20.10",
+        });
+        addSettingsChanges(settings_changes_history, "20.10",
         {
             {"format_regexp_escaping_rule", "Escaped", "Raw", "Use Raw as default escaping rule for Regexp format to male the behaviour more like to what users expect"}
-        }
-    },
-    {"20.7",
+        });
+        addSettingsChanges(settings_changes_history, "20.7",
         {
             {"show_table_uuid_in_table_create_query_if_not_nil", true, false, "Stop showing  UID of the table in its CREATE query for Engine=Atomic"}
-        }
-    },
-    {"20.5",
+        });
+        addSettingsChanges(settings_changes_history, "20.5",
         {
             {"input_format_with_names_use_header", false, true, "Enable using header with names for formats with WithNames/WithNamesAndTypes suffixes"},
             {"allow_suspicious_codecs", true, false, "Don't allow to specify meaningless compression codecs"}
-        }
-    },
-    {"20.4",
+        });
+        addSettingsChanges(settings_changes_history, "20.4",
         {
             {"validate_polygons", false, true, "Throw exception if polygon is invalid in function pointInPolygon by default instead of returning possibly wrong results"}
-        }
-    },
-    {"19.18",
+        });
+        addSettingsChanges(settings_changes_history, "19.18",
         {
             {"enable_scalar_subquery_optimization", false, true, "Prevent scalar subqueries from (de)serializing large scalar values and possibly avoid running the same subquery more than once"}
-        }
-    },
-    {"19.14",
+        });
+        addSettingsChanges(settings_changes_history, "19.14",
         {
             {"any_join_distinct_right_table_keys", true, false, "Disable ANY RIGHT and ANY FULL JOINs by default to avoid inconsistency"}
-        }
-    },
-    {"19.12",
+        });
+        addSettingsChanges(settings_changes_history, "19.12",
         {
             {"input_format_defaults_for_omitted_fields", false, true, "Enable calculation of complex default expressions for omitted fields for some input formats, because it should be the expected behaviour"}
-        }
-    },
-    {"19.5",
+        });
+        addSettingsChanges(settings_changes_history, "19.5",
         {
             {"max_partitions_per_insert_block", 0, 100, "Add a limit for the number of partitions in one block"}
-        }
-    },
-    {"18.12.17",
+        });
+        addSettingsChanges(settings_changes_history, "18.12.17",
         {
             {"enable_optimize_predicate_expression", 0, 1, "Optimize predicates to subqueries by default"}
-        }
-    },
-};
+        });
+    });
+    return settings_changes_history;
+}
 
-static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory::SettingsChanges>> merge_tree_settings_changes_history_initializer =
+const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getMergeTreeSettingsChangesHistory()
 {
-    {"25.1",
+    static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> merge_tree_settings_changes_history;
+    static std::once_flag initialized_flag;
+    std::call_once(initialized_flag, [&]
+    {
+        addSettingsChanges(merge_tree_settings_changes_history, "25.1",
         {
-
-        }
-    },
-    {"24.12",
+        });
+        addSettingsChanges(merge_tree_settings_changes_history, "24.12",
         {
             /// Release closed. Please use 25.1
             {"enforce_index_structure_match_on_partition_manipulation", true, false, "Add new setting to allow attach when source table's projections and secondary indices is a subset of those in the target table."},
@@ -646,64 +608,21 @@ static std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory
             {"min_bytes_to_prewarm_caches", 0, 0, "New setting"},
             {"allow_experimental_reverse_key", false, false, "New setting"},
             /// Release closed. Please use 25.1
-        }
-    },
-    {"24.11",
+        });
+        addSettingsChanges(merge_tree_settings_changes_history, "24.11",
         {
-        }
-    },
-    {"24.10",
+        });
+        addSettingsChanges(merge_tree_settings_changes_history, "24.10",
         {
-        }
-    },
-    {"24.9",
+        });
+        addSettingsChanges(merge_tree_settings_changes_history, "24.9",
         {
-        }
-    },
-    {"24.8",
+        });
+        addSettingsChanges(merge_tree_settings_changes_history, "24.8",
         {
             {"deduplicate_merge_projection_mode", "ignore", "throw", "Do not allow to create inconsistent projection"}
-        }
-    },
-};
-
-static void initSettingsChangesHistory(
-    std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & settings_changes_history,
-    std::once_flag & initialized_flag,
-    std::initializer_list<std::pair<ClickHouseVersion, SettingsChangesHistory::SettingsChanges>> const & initializer
-)
-{
-    std::call_once(initialized_flag, [&]()
-    {
-        for (const auto & setting_change : initializer)
-        {
-            /// Disallow duplicate keys in the settings changes history. Example:
-            ///     {"21.2", {{"some_setting_1", false, true, "[...]"}}},
-            ///     [...]
-            ///     {"21.2", {{"some_setting_2", false, true, "[...]"}}},
-            /// As std::set has unique keys, one of the entries would be overwritten.
-            if (settings_changes_history.contains(setting_change.first))
-                throw Exception{ErrorCodes::LOGICAL_ERROR, "Detected duplicate version '{}'", setting_change.first.toString()};
-
-            settings_changes_history[setting_change.first] = setting_change.second;
-        }
+        });
     });
-}
-
-const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getSettingsChangesHistory()
-{
-    static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history;
-    static std::once_flag initialized_flag;
-    initSettingsChangesHistory(settings_changes_history, initialized_flag, settings_changes_history_initializer);
-
-    return settings_changes_history;
-}
-
-const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getMergeTreeSettingsChangesHistory()
-{
-    static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> merge_tree_settings_changes_history;
-    static std::once_flag initialized_flag;
-    initSettingsChangesHistory(merge_tree_settings_changes_history, initialized_flag, merge_tree_settings_changes_history_initializer);
 
     return merge_tree_settings_changes_history;
 }

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -39,7 +39,7 @@ String ClickHouseVersion::toString() const
 
 static void addSettingsChanges(
     VersionToSettingsChangesMap & settings_changes_history,
-    const char * version,
+    std::string_view version,
     SettingsChangesHistory::SettingsChanges && changes)
 {
     /// Forbid duplicate versions
@@ -48,9 +48,9 @@ static void addSettingsChanges(
         throw Exception{ErrorCodes::LOGICAL_ERROR, "Detected duplicate version '{}'", ClickHouseVersion(version).toString()};
 }
 
-const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getSettingsChangesHistory()
+const VersionToSettingsChangesMap & getSettingsChangesHistory()
 {
-    static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history;
+    static VersionToSettingsChangesMap settings_changes_history;
     static std::once_flag initialized_flag;
     std::call_once(initialized_flag, [&]
     {
@@ -590,9 +590,9 @@ const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & get
     return settings_changes_history;
 }
 
-const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getMergeTreeSettingsChangesHistory()
+const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
 {
-    static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> merge_tree_settings_changes_history;
+    static VersionToSettingsChangesMap merge_tree_settings_changes_history;
     static std::once_flag initialized_flag;
     std::call_once(initialized_flag, [&]
     {

--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -11,10 +11,7 @@ namespace DB
 class ClickHouseVersion
 {
 public:
-    /// NOLINTBEGIN(google-explicit-constructor)
-    ClickHouseVersion(const String & version);
-    ClickHouseVersion(const char * version);
-    /// NOLINTEND(google-explicit-constructor)
+    explicit ClickHouseVersion(std::string_view version);
 
     String toString() const;
 
@@ -38,7 +35,9 @@ namespace SettingsChangesHistory
     using SettingsChanges = std::vector<SettingChange>;
 }
 
-const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getSettingsChangesHistory();
-const std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> & getMergeTreeSettingsChangesHistory();
+using VersionToSettingsChangesMap = std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges>;
+
+const VersionToSettingsChangesMap & getSettingsChangesHistory();
+const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory();
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


cc @Michicosun 
Error: https://s3.amazonaws.com/clickhouse-builds/PRs/73422/b41b0b98206a5f36cb984b079e37f827e2c23323/binary_ppc64le/build_log.log