### PR TITLE
Add support for extended numeric types in formatReadable functions

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -938,6 +938,10 @@ formatReadableSize(x)
 ```
 Alias: `FORMAT_BYTES`.
 
+:::note
+This function accepts any numeric type as input, but internally it casts them to Float64. Results might be suboptimal with large values
+:::
+
 **Example**
 
 Query:
@@ -969,6 +973,10 @@ Given a number, this function returns a rounded number with suffix (thousand, mi
 formatReadableQuantity(x)
 ```
 
+:::note
+This function accepts any numeric type as input, but internally it casts them to Float64. Results might be suboptimal with large values
+:::
+
 **Example**
 
 Query:
@@ -999,6 +1007,10 @@ Given a time interval (delta) in seconds, this function returns a time delta wit
 ```sql
 formatReadableTimeDelta(column[, maximum_unit, minimum_unit])
 ```
+
+:::note
+This function accepts any numeric type as input, but internally it casts them to Float64. Results might be suboptimal with large values
+:::
 
 **Arguments**
 
@@ -1065,7 +1077,7 @@ The inverse operations of this function are [formatReadableSize](#formatreadable
 **Syntax**
 
 ```sql
-formatReadableSize(x)
+parseReadableSize(x)
 ```
 
 **Arguments**

--- a/src/Functions/formatReadable.h
+++ b/src/Functions/formatReadable.h
@@ -47,8 +47,8 @@ public:
     {
         const IDataType & type = *arguments[0];
 
-        if (!isNativeNumber(type))
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Cannot format {} because it's not a native numeric type", type.getName());
+        if (!isNumber(type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Cannot format {} because it's not a numeric type", type.getName());
 
         return std::make_shared<DataTypeString>();
     }
@@ -62,51 +62,25 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
-        ColumnPtr res;
-        if (!((res = executeType<UInt8>(arguments, input_rows_count))
-            || (res = executeType<UInt16>(arguments, input_rows_count))
-            || (res = executeType<UInt32>(arguments, input_rows_count))
-            || (res = executeType<UInt64>(arguments, input_rows_count))
-            || (res = executeType<Int8>(arguments, input_rows_count))
-            || (res = executeType<Int16>(arguments, input_rows_count))
-            || (res = executeType<Int32>(arguments, input_rows_count))
-            || (res = executeType<Int64>(arguments, input_rows_count))
-            || (res = executeType<Float32>(arguments, input_rows_count))
-            || (res = executeType<Float64>(arguments, input_rows_count))))
-            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of argument of function {}",
-                            arguments[0].column->getName(), getName());
+        auto col_to = ColumnString::create();
 
-        return res;
-    }
+        ColumnString::Chars & data_to = col_to->getChars();
+        ColumnString::Offsets & offsets_to = col_to->getOffsets();
+        data_to.resize(input_rows_count * 2);
+        offsets_to.resize(input_rows_count);
 
-private:
-    template <typename T>
-    ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const
-    {
-        if (const ColumnVector<T> * col_from = checkAndGetColumn<ColumnVector<T>>(arguments[0].column.get()))
+        WriteBufferFromVector<ColumnString::Chars> buf_to(data_to);
+
+        for (size_t i = 0; i < input_rows_count; ++i)
         {
-            auto col_to = ColumnString::create();
-
-            const typename ColumnVector<T>::Container & vec_from = col_from->getData();
-            ColumnString::Chars & data_to = col_to->getChars();
-            ColumnString::Offsets & offsets_to = col_to->getOffsets();
-            data_to.resize(input_rows_count * 2);
-            offsets_to.resize(input_rows_count);
-
-            WriteBufferFromVector<ColumnString::Chars> buf_to(data_to);
-
-            for (size_t i = 0; i < input_rows_count; ++i)
-            {
-                Impl::format(static_cast<double>(vec_from[i]), buf_to);
-                writeChar(0, buf_to);
-                offsets_to[i] = buf_to.count();
-            }
-
-            buf_to.finalize();
-            return col_to;
+            /// The const of the virtual call for getFloat64 is negligible compared with the format calls
+            Impl::format(arguments[0].column->getFloat64(i), buf_to);
+            writeChar(0, buf_to);
+            offsets_to[i] = buf_to.count();
         }
 
-        return nullptr;
+        buf_to.finalize();
+        return col_to;
     }
 };
 

--- a/src/Functions/formatReadable.h
+++ b/src/Functions/formatReadable.h
@@ -16,7 +16,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int ILLEGAL_COLUMN;
 }
 
 

--- a/src/Functions/formatReadable.h
+++ b/src/Functions/formatReadable.h
@@ -72,7 +72,7 @@ public:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            /// The const of the virtual call for getFloat64 is negligible compared with the format calls
+            /// The cost of the virtual call for getFloat64 is negligible compared with the format calls
             Impl::format(arguments[0].column->getFloat64(i), buf_to);
             writeChar(0, buf_to);
             offsets_to[i] = buf_to.count();

--- a/src/Functions/formatReadableTimeDelta.cpp
+++ b/src/Functions/formatReadableTimeDelta.cpp
@@ -63,7 +63,7 @@ public:
 
         const IDataType & type = *arguments[0];
 
-        if (!isNativeNumber(type))
+        if (!isNumber(type))
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Cannot format {} as time delta", type.getName());
 
         if (arguments.size() >= 2)

--- a/tests/queries/0_stateless/03290_formatReadable_other_numeric_types.reference
+++ b/tests/queries/0_stateless/03290_formatReadable_other_numeric_types.reference
@@ -1,0 +1,10 @@
+Int128	0.00 B	0.00 B	0.00	0 seconds
+Int128	1.00 B	1.00 B	1.00	1 second
+Int128	0.00 B	0.00 B	0.00	0 seconds
+Int128	1.00 B	1.00 B	1.00	1 second
+Decimal32	0.00 B	0.00 B	0.00	0 seconds
+Decimal32	1.00 B	1.00 B	1.00	1 second
+Decimal256	0.00 B	0.00 B	0.00	0 seconds
+Decimal256	1.00 B	1.00 B	1.00	1 second
+BFloat16	0.00 B	0.00 B	0.00	0 seconds
+BFloat16	1.00 B	1.00 B	1.00	1 second

--- a/tests/queries/0_stateless/03290_formatReadable_other_numeric_types.sql
+++ b/tests/queries/0_stateless/03290_formatReadable_other_numeric_types.sql
@@ -38,34 +38,22 @@ SELECT
     formatReadableTimeDelta(number)
 FROM (SELECT number AS number FROM numbers(2));
 
-SELECT
-    'Date',
-    formatReadableDecimalSize(number),
-    formatReadableSize(number),
-    formatReadableQuantity(number),
-    formatReadableTimeDelta(number)
-FROM (SELECT number::Date AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableDecimalSize(number::Date) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableSize(number::Date) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableQuantity(number::Date) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableTimeDelta(number::Date) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
-SELECT
-    'Date32',
-    formatReadableDecimalSize(number),
-    formatReadableSize(number),
-    formatReadableQuantity(number),
-    formatReadableTimeDelta(number)
-FROM (SELECT number::Date32 AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableDecimalSize(number::Date32) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableSize(number::Date32) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableQuantity(number::Date32) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableTimeDelta(number::Date32) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
-SELECT
-    'DateTime',
-    formatReadableDecimalSize(number),
-    formatReadableSize(number),
-    formatReadableQuantity(number),
-    formatReadableTimeDelta(number)
-FROM (SELECT number::DateTime AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableDecimalSize(number::DateTime) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableSize(number::DateTime) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableQuantity(number::DateTime) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableTimeDelta(number::DateTime) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
-SELECT
-    'DateTime64(3)',
-    formatReadableDecimalSize(number),
-    formatReadableSize(number),
-    formatReadableQuantity(number),
-    formatReadableTimeDelta(number)
-FROM (SELECT number::DateTime64(3) AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableDecimalSize(number::DateTime64(3)) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableSize(number::DateTime64(3)) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableQuantity(number::DateTime64(3)) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT formatReadableTimeDelta(number::DateTime64(3)) FROM numbers(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/03290_formatReadable_other_numeric_types.sql
+++ b/tests/queries/0_stateless/03290_formatReadable_other_numeric_types.sql
@@ -1,0 +1,71 @@
+SELECT
+    'Int128',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::Int128 AS number FROM numbers(2));
+
+SELECT
+    'Int128',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::UInt256 AS number FROM numbers(2));
+
+SELECT
+    'Decimal32',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::Decimal32(2) AS number FROM numbers(2));
+
+SELECT
+    'Decimal256',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::Decimal256(2) AS number FROM numbers(2));
+
+SELECT
+    'BFloat16',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number AS number FROM numbers(2));
+
+SELECT
+    'Date',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::Date AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT
+    'Date32',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::Date32 AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT
+    'DateTime',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::DateTime AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT
+    'DateTime64(3)',
+    formatReadableDecimalSize(number),
+    formatReadableSize(number),
+    formatReadableQuantity(number),
+    formatReadableTimeDelta(number)
+FROM (SELECT number::DateTime64(3) AS number FROM numbers(2)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2786,6 +2786,7 @@ submodule
 submodules
 subnet
 subnetwork
+suboptimal
 subpattern
 subpatterns
 subqueries


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for extended numeric types (Decimal, big integers) in formatReadable functions

Closes https://github.com/ClickHouse/ClickHouse/issues/73581

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
