### PR TITLE
Fix deserialization of Dynamic/Object structure

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -442,6 +442,14 @@ bool ISerialization::isLowCardinalityDictionarySubcolumn(const DB::ISerializatio
     return path[path.size() - 1].type == SubstreamType::DictionaryKeys;
 }
 
+bool ISerialization::isDynamicOrObjectStructureSubcolumn(const DB::ISerialization::SubstreamPath & path)
+{
+    if (path.empty())
+        return false;
+
+    return path[path.size() - 1].type == SubstreamType::DynamicStructure || path[path.size() - 1].type == SubstreamType::ObjectStructure;
+}
+
 ISerialization::SubstreamData ISerialization::createFromPath(const SubstreamPath & path, size_t prefix_len)
 {
     assert(prefix_len <= path.size());

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -467,6 +467,7 @@ public:
     static bool isDynamicSubcolumn(const SubstreamPath & path, size_t prefix_len);
 
     static bool isLowCardinalityDictionarySubcolumn(const SubstreamPath & path);
+    static bool isDynamicOrObjectStructureSubcolumn(const SubstreamPath & path);
 
 protected:
     template <typename State, typename StatePtr>

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -37,6 +37,8 @@ struct MergeTreeReaderSettings
     CompactPartsReadMethod compact_parts_read_method = CompactPartsReadMethod::SingleBuffer;
     /// True if we read stream for dictionary of LowCardinality type.
     bool is_low_cardinality_dictionary = false;
+    /// True if we read stream for structure of Dynamic/Object type.
+    bool is_dynamic_or_object_structure = false;
     /// True if data may be compressed by different codecs in one stream.
     bool allow_different_codecs = false;
     /// Deleted mask is applied to all reads except internal select from mutate some part columns.

--- a/src/Storages/MergeTree/MergeTreeReaderStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.cpp
@@ -258,6 +258,13 @@ size_t MergeTreeReaderStreamSingleColumn::getRightOffset(size_t right_mark)
         right_mark = *it;
     }
 
+    /// Special case for streams with dynamic/object structure.
+    /// It consists of 2 parts of data - during the serialization the first part is written before the data and second - after the data.
+    /// But during deserialization we read both parts before the data, so we can't use the marks and need to always return the
+    /// whole file size.
+    if (settings.is_dynamic_or_object_structure)
+        return file_size;
+
     /// This is a good scenario. The compressed block is finished within the right mark,
     /// and previous mark was different.
     if (marks_getter->getMark(right_mark, 0).offset_in_decompressed_block == 0

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -263,6 +263,7 @@ MergeTreeReaderWide::FileStreams::iterator MergeTreeReaderWide::addStream(const 
 
     auto stream_settings = settings;
     stream_settings.is_low_cardinality_dictionary = ISerialization::isLowCardinalityDictionarySubcolumn(substream_path);
+    stream_settings.is_dynamic_or_object_structure = ISerialization::isDynamicOrObjectStructureSubcolumn(substream_path);
 
     auto create_stream = [&]<typename Stream>()
     {

--- a/tests/queries/0_stateless/03291_json_big_structure_deserialization.sql
+++ b/tests/queries/0_stateless/03291_json_big_structure_deserialization.sql
@@ -1,6 +1,6 @@
 set enable_json_type=1;
 
-create table test (json JSON) engine=MergeTree order by tuple() settings max_compress_block_size = 128, marks_compress_block_size=128, min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+create table test (json JSON) engine=MergeTree order by tuple() settings max_compress_block_size = 128, marks_compress_block_size=128, min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192, replace_long_file_name_to_hash=1;
 insert into test select toJSONString(map(repeat('a' || number, 1000), 42)) from numbers(10000);
 
 set max_threads=1;

--- a/tests/queries/0_stateless/03291_json_big_structure_deserialization.sql
+++ b/tests/queries/0_stateless/03291_json_big_structure_deserialization.sql
@@ -1,0 +1,13 @@
+set enable_json_type=1;
+
+create table test (json JSON) engine=MergeTree order by tuple() settings max_compress_block_size = 128, marks_compress_block_size=128, min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+insert into test select toJSONString(map(repeat('a' || number, 1000), 42)) from numbers(10000);
+
+set max_threads=1;
+set enable_filesystem_cache=0;
+set max_parallel_replicas=1;
+set remote_filesystem_read_method='read';
+set remote_filesystem_read_prefetch=0;
+
+select json.a from test format Null;
+drop table test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix deserialization of Dynamic/Object structure. It could lead to CANNOT_READ_ALL_DATA exceptions.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
