### PR TITLE
Skip metadata_version.txt while restoring parts from backup

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -747,6 +747,8 @@ The server successfully detected this situation and will download merged part fr
     M(BackupEntriesCollectorMicroseconds, "Time spent making backup entries", ValueType::Microseconds) \
     M(BackupEntriesCollectorForTablesDataMicroseconds, "Time spent making backup entries for tables data", ValueType::Microseconds) \
     M(BackupEntriesCollectorRunPostTasksMicroseconds, "Time spent running post tasks after making backup entries", ValueType::Microseconds) \
+    M(RestorePartsSkippedFiles, "Number of files skipped while restoring parts", ValueType::Number) \
+    M(RestorePartsSkippedBytes, "Total size of files skipped while restoring parts", ValueType::Number) \
     \
     M(ReadTaskRequestsReceived, "The number of callbacks requested from the remote server back to the initiator server to choose the read task (for s3Cluster table function and similar). Measured on the initiator server side.", ValueType::Number) \
     M(MergeTreeReadTaskRequestsReceived, "The number of callbacks requested from the remote server back to the initiator server to choose the read task (for MergeTree tables). Measured on the initiator server side.", ValueType::Number) \

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -427,6 +427,7 @@ void DataPartStorageOnDiskBase::backup(
             backup_entries.emplace_back(filepath_in_backup, std::make_unique<BackupEntryFromSmallFile>(disk, filepath_on_disk, read_settings, copy_encrypted));
             return;
         }
+
         if (is_projection_part && allow_backup_broken_projection && !disk->existsFile(filepath_on_disk))
             return;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5991,7 +5991,8 @@ void MergeTreeData::restorePartFromBackup(std::shared_ptr<RestoredPartsHolder> r
         }
 
         /// TODO Transactions: Decide what to do with version metadata (if any). Let's just skip it for now.
-        if (filename.ends_with(IMergeTreeDataPart::TXN_VERSION_METADATA_FILE_NAME))
+        if (filename.ends_with(IMergeTreeDataPart::TXN_VERSION_METADATA_FILE_NAME) ||
+            filename.ends_with(IMergeTreeDataPart::METADATA_VERSION_FILE_NAME))
             continue;
 
         size_t file_size = backup->copyFileToDisk(part_path_in_backup_fs / filename, disk, temp_part_dir / filename, WriteMode::Rewrite);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -141,6 +141,8 @@ namespace ProfileEvents
     extern const Event PartsLockHoldMicroseconds;
     extern const Event LoadedDataParts;
     extern const Event LoadedDataPartsMicroseconds;
+    extern const Event RestorePartsSkippedFiles;
+    extern const Event RestorePartsSkippedBytes;
 }
 
 namespace CurrentMetrics
@@ -5993,7 +5995,11 @@ void MergeTreeData::restorePartFromBackup(std::shared_ptr<RestoredPartsHolder> r
         /// TODO Transactions: Decide what to do with version metadata (if any). Let's just skip it for now.
         if (filename.ends_with(IMergeTreeDataPart::TXN_VERSION_METADATA_FILE_NAME) ||
             filename.ends_with(IMergeTreeDataPart::METADATA_VERSION_FILE_NAME))
+        {
+            ProfileEvents::increment(ProfileEvents::RestorePartsSkippedFiles);
+            ProfileEvents::increment(ProfileEvents::RestorePartsSkippedBytes, backup->getFileSize(part_path_in_backup_fs / filename));
             continue;
+        }
 
         size_t file_size = backup->copyFileToDisk(part_path_in_backup_fs / filename, disk, temp_part_dir / filename, WriteMode::Rewrite);
         reservation->update(reservation->getSize() - file_size);

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -5,6 +5,7 @@ import re
 import sys
 import uuid
 from collections import namedtuple
+from typing import Dict
 
 import pytest
 
@@ -93,6 +94,27 @@ def has_mutation_in_backup(mutation_id, backup_name, database, table):
             f"data/{database}/{table}/mutations/{mutation_id}.txt",
         )
     )
+
+
+def get_events_for_query(query_id: str) -> Dict[str, int]:
+    events = TSV(
+        instance.query(
+            f"""
+            SYSTEM FLUSH LOGS;
+
+            WITH arrayJoin(ProfileEvents) as pe
+            SELECT pe.1, pe.2
+            FROM system.query_log
+            WHERE query_id = '{query_id}'
+            """
+        )
+    )
+    result = {
+        event: int(value)
+        for event, value in [line.split("\t") for line in events.lines]
+    }
+    result["query_id"] = query_id
+    return result
 
 
 BackupInfo = namedtuple(
@@ -322,8 +344,10 @@ def test_increment_backup_without_changes():
 
     # restore the second backup
     # we expect to see all files in the meta info of the restore and a sum of uncompressed and compressed sizes
+    restore_query_id = uuid.uuid4().hex
     id_restore = instance.query(
-        f"RESTORE TABLE test.table AS test.table2 FROM {incremental_backup_name}"
+        f"RESTORE TABLE test.table AS test.table2 FROM {incremental_backup_name}",
+        query_id=restore_query_id,
     ).split("\t")[0]
 
     assert instance.query("SELECT count(), sum(x) FROM test.table2") == TSV(
@@ -331,6 +355,7 @@ def test_increment_backup_without_changes():
     )
 
     restore_info = get_backup_info_from_system_backups(by_id=id_restore)
+    restore_events = get_events_for_query(restore_query_id)
 
     assert restore_info.status == "RESTORED"
     assert restore_info.error == ""
@@ -339,8 +364,14 @@ def test_increment_backup_without_changes():
     assert restore_info.num_entries == backup2_info.num_entries
     assert restore_info.uncompressed_size == backup2_info.uncompressed_size
     assert restore_info.compressed_size == backup2_info.compressed_size
-    assert restore_info.files_read == backup2_info.num_files
-    assert restore_info.bytes_read == backup2_info.total_size
+    assert (
+        restore_info.files_read + restore_events["RestorePartsSkippedFiles"]
+        == backup2_info.num_files
+    )
+    assert (
+        restore_info.bytes_read + restore_events["RestorePartsSkippedBytes"]
+        == backup2_info.total_size
+    )
 
 
 def test_incremental_backup_overflow():
@@ -1672,8 +1703,12 @@ def test_system_backups():
     instance.query("DROP TABLE test.table")
 
     # Restore
-    id = instance.query(f"RESTORE TABLE test.table FROM {backup_name}").split("\t")[0]
+    restore_query_id = uuid.uuid4().hex
+    id = instance.query(
+        f"RESTORE TABLE test.table FROM {backup_name}", query_id=restore_query_id
+    ).split("\t")[0]
     restore_info = get_backup_info_from_system_backups(by_id=id)
+    restore_events = get_events_for_query(restore_query_id)
 
     assert restore_info.name == escaped_backup_name
     assert restore_info.status == "RESTORED"
@@ -1683,8 +1718,14 @@ def test_system_backups():
     assert restore_info.num_entries == info.num_entries
     assert restore_info.uncompressed_size == info.uncompressed_size
     assert restore_info.compressed_size == info.compressed_size
-    assert restore_info.files_read == restore_info.num_files
-    assert restore_info.bytes_read == restore_info.total_size
+    assert (
+        restore_info.files_read + restore_events["RestorePartsSkippedFiles"]
+        == restore_info.num_files
+    )
+    assert (
+        restore_info.bytes_read + restore_events["RestorePartsSkippedBytes"]
+        == restore_info.total_size
+    )
 
     # Failed backup.
     backup_name = new_backup_name()

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -490,6 +490,8 @@ def test_incremental_backup_append_table_def():
     assert node.query("SELECT count(), sum(x) FROM data") == "100\t4950\n"
     assert "parts_to_throw_insert = 100" in node.query("SHOW CREATE TABLE data")
 
+    node.query("DROP TABLE data")
+
 
 @pytest.mark.parametrize(
     "in_cache_initially, allow_backup_read_cache, allow_s3_native_copy",
@@ -643,124 +645,118 @@ def test_user_specific_auth(start_cluster):
             node.query("DROP TABLE specific_auth SYNC")
             node.query(restore_query, user=user)
 
-    backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup1/')",
-        user=None,
-        should_fail=True,
+    random_str = uuid.uuid4().hex
+    backup1_path = f"http://minio1:9001/root/data/backups/limited/{random_str}/backup1/"
+    backup1_inc_path = (
+        f"http://minio1:9001/root/data/backups/limited/{random_str}/backup1_inc/"
+    )
+    backup2_path = f"http://minio1:9001/root/data/backups/limited/{random_str}/backup2/"
+    backup3_path = f"http://minio1:9001/root/data/backups/limited/{random_str}/backup3/"
+    backup3_inc_path = (
+        f"http://minio1:9001/root/data/backups/limited/{random_str}/backup3_inc/"
     )
 
-    backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup1/')",
-        user="regularuser",
-        should_fail=True,
-    )
+    backup_restore(f"S3('{backup1_path}')", user=None, should_fail=True)
+    backup_restore(f"S3('{backup1_path}')", user="regularuser", should_fail=True)
+    backup_restore(f"S3('{backup1_path}')", user="superuser1", should_fail=False)
 
-    backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup1/')",
-        user="superuser1",
-        should_fail=False,
-    )
-
-    backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup2/')",
-        user="superuser2",
-        should_fail=False,
-    )
+    backup_restore(f"S3('{backup2_path}')", user="superuser2", should_fail=False)
 
     assert "Access" in node.query_and_get_error(
-        "RESTORE TABLE specific_auth FROM S3('http://minio1:9001/root/data/backups/limited/backup1/')",
+        f"RESTORE TABLE specific_auth FROM S3('{backup1_path}')",
         user="regularuser",
     )
 
     node.query("INSERT INTO specific_auth VALUES (2)")
 
     backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup1_inc/')",
+        f"S3('{backup1_inc_path}')",
         user="regularuser",
         should_fail=True,
-        base_backup="S3('http://minio1:9001/root/data/backups/limited/backup1/')",
+        base_backup=f"S3('{backup1_path}')",
     )
 
     backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup1_inc/')",
+        f"S3('{backup1_inc_path}')",
         user="superuser1",
         should_fail=False,
-        base_backup="S3('http://minio1:9001/root/data/backups/limited/backup1/')",
+        base_backup=f"S3('{backup1_path}')",
     )
 
     assert "Access" in node.query_and_get_error(
-        "RESTORE TABLE specific_auth FROM S3('http://minio1:9001/root/data/backups/limited/backup1_inc/')",
+        f"RESTORE TABLE specific_auth FROM S3('{backup1_inc_path}')",
         user="regularuser",
     )
 
     assert "Access Denied" in node.query_and_get_error(
-        "SELECT * FROM s3('http://minio1:9001/root/data/backups/limited/backup1/*', 'RawBLOB')",
+        f"SELECT * FROM s3('{backup1_path}*', 'RawBLOB')",
         user="regularuser",
     )
 
     node.query(
-        "SELECT * FROM s3('http://minio1:9001/root/data/backups/limited/backup1/*', 'RawBLOB')",
+        f"SELECT * FROM s3('{backup1_path}*', 'RawBLOB')",
         user="superuser1",
     )
 
     backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup3/')",
+        f"S3('{backup3_path}')",
         user="regularuser",
         should_fail=True,
         on_cluster=True,
     )
 
     backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup3/')",
+        f"S3('{backup3_path}')",
         user="superuser1",
         should_fail=False,
         on_cluster=True,
     )
 
     assert "Access Denied" in node.query_and_get_error(
-        "RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('http://minio1:9001/root/data/backups/limited/backup3/')",
+        f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_path}')",
         user="regularuser",
     )
 
     node.query("INSERT INTO specific_auth VALUES (3)")
 
     backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup3_inc/')",
+        f"S3('{backup3_inc_path}')",
         user="regularuser",
         should_fail=True,
         on_cluster=True,
-        base_backup="S3('http://minio1:9001/root/data/backups/limited/backup3/')",
+        base_backup=f"S3('{backup3_path}')",
     )
 
     backup_restore(
-        "S3('http://minio1:9001/root/data/backups/limited/backup3_inc/')",
+        f"S3('{backup3_inc_path}')",
         user="superuser1",
         should_fail=False,
         on_cluster=True,
-        base_backup="S3('http://minio1:9001/root/data/backups/limited/backup3/')",
+        base_backup=f"S3('{backup3_path}')",
     )
 
     assert "Access Denied" in node.query_and_get_error(
-        "RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('http://minio1:9001/root/data/backups/limited/backup3_inc/')",
+        f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_inc_path}')",
         user="regularuser",
     )
 
     assert "Access Denied" in node.query_and_get_error(
-        "SELECT * FROM s3('http://minio1:9001/root/data/backups/limited/backup3/*', 'RawBLOB')",
+        f"SELECT * FROM s3('{backup3_path}*', 'RawBLOB')",
         user="regularuser",
     )
 
     node.query(
-        "SELECT * FROM s3('http://minio1:9001/root/data/backups/limited/backup3/*', 'RawBLOB')",
+        f"SELECT * FROM s3('{backup3_path}*', 'RawBLOB')",
         user="superuser1",
     )
 
     assert "Access Denied" in node.query_and_get_error(
-        "SELECT * FROM s3Cluster(cluster, 'http://minio1:9001/root/data/backups/limited/backup3/*', 'RawBLOB')",
+        f"SELECT * FROM s3Cluster(cluster, '{backup3_path}*', 'RawBLOB')",
         user="regularuser",
     )
 
-    node.query("DROP TABLE IF EXISTS test.specific_auth")
+    node.query("DROP TABLE specific_auth")
+    node.query("DROP USER superuser1, superuser2, regularuser")
 
 
 def test_backup_to_s3_different_credentials():

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -414,9 +414,12 @@ def test_backup_to_s3_multipart():
     )
     assert backup_events["WriteBufferFromS3Microseconds"] > 0
     assert "WriteBufferFromS3RequestsErrors" not in backup_events
+
     # restore
     assert (
-        restore_events["ReadBufferFromS3Bytes"] - backup_meta_size == restore_total_size
+        restore_events["ReadBufferFromS3Bytes"]
+        + restore_events["RestorePartsSkippedBytes"]
+        == restore_total_size + backup_meta_size
     )
     assert restore_events["ReadBufferFromS3Microseconds"] > 0
     assert "ReadBufferFromS3RequestsErrors" not in restore_events


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Skip `metadata_version.txt` in while restoring parts from a backup.

If we don't skip `metadata_version.txt` then those metadata versions extracted from a backup may conflict with the current metadata version, and as a result the table won't be able to merge parts.