### PR TITLE
Enable dynamic evaluation of whether a short-circuit function's argument should be lazily executed

### DIFF
--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -346,6 +346,7 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
                         "arguments but {} columns were captured.",
                         function->getName(), toString(args), toString(captured));
 
+    Stopwatch watch;
     ColumnsWithTypeAndName columns = captured_columns;
     /// Arguments of lazy executed function can also be lazy executed.
     if (is_short_circuit_argument)
@@ -402,8 +403,14 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
 #if 1
     if constexpr (with_profile)
     {
+        size_t total_elapsed = watch.elapsed();
+        size_t side_elapsed = 0;
         for (const auto & arg_profile : profile->argument_profiles)
-            profile->executed_elapsed += arg_profile.second.executed_elapsed;
+        {
+            side_elapsed += arg_profile.second.short_circuit_side_elapsed;
+        }
+        profile->short_circuit_side_elapsed = side_elapsed;
+        profile->executed_elapsed = total_elapsed;
     }
 #endif
 

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -400,7 +400,6 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
 
     res.column = function->execute(columns, res.type, elements_size, /* dry_run = */ false, profile);
 
-#if 1
     if constexpr (with_profile)
     {
         size_t total_elapsed = watch.elapsed();
@@ -412,7 +411,6 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
         profile->short_circuit_side_elapsed = side_elapsed;
         profile->executed_elapsed = total_elapsed;
     }
-#endif
 
     if (res.column->getDataType() != res.type->getColumnType())
         throw Exception(
@@ -426,7 +424,6 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
         res.column = recursiveRemoveLowCardinality(res.column);
         res.type = recursiveRemoveLowCardinality(res.type);
     }
-
     return res;
 }
 

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -327,7 +327,7 @@ DataTypePtr ColumnFunction::getResultType() const
     return function->getResultType();
 }
 
-ColumnWithTypeAndName ColumnFunction::reduce(FunctionExecuteProfile * profile) const
+ColumnWithTypeAndName ColumnFunction::reduce(FunctionExecutionProfile * profile) const
 {
     if (profile)
         return reduceImpl<true>(profile);
@@ -336,7 +336,7 @@ ColumnWithTypeAndName ColumnFunction::reduce(FunctionExecuteProfile * profile) c
 }
 
 template <bool with_profile>
-ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profile [[maybe_unused]]) const
+ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecutionProfile * profile [[maybe_unused]]) const
 {
     auto args = function->getArgumentTypes().size();
     auto captured = captured_columns.size();
@@ -363,7 +363,7 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
                 {
                     if constexpr (with_profile)
                     {
-                        profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                        profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecutionProfile()));
                         auto & arg_profile = profile->argument_profiles.back().second;
                         columns[i] = arg->reduceImpl<with_profile>(&arg_profile);
                     }
@@ -381,7 +381,7 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
                 {
                     if constexpr (with_profile)
                     {
-                        profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                        profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecutionProfile()));
                         auto & arg_profile = profile->argument_profiles.back().second;
                         columns[i] = arg->reduceImpl<with_profile>(&arg_profile);
                     }
@@ -406,10 +406,10 @@ ColumnWithTypeAndName ColumnFunction::reduceImpl(FunctionExecuteProfile * profil
         size_t side_elapsed = 0;
         for (const auto & arg_profile : profile->argument_profiles)
         {
-            side_elapsed += arg_profile.second.short_circuit_side_elapsed;
+            side_elapsed += arg_profile.second.lazy_executed_additional_elapsed;
         }
-        profile->short_circuit_side_elapsed = side_elapsed;
-        profile->executed_elapsed = total_elapsed;
+        profile->lazy_executed_additional_elapsed = side_elapsed;
+        profile->execution_elapsed = total_elapsed;
     }
 
     if (res.column->getDataType() != res.type->getColumnType())

--- a/src/Columns/ColumnFunction.h
+++ b/src/Columns/ColumnFunction.h
@@ -12,7 +12,7 @@ namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
 }
-
+struct FunctionExecuteProfile;
 class IFunctionBase;
 using FunctionBasePtr = std::shared_ptr<const IFunctionBase>;
 
@@ -58,6 +58,7 @@ public:
 
     void appendArguments(const ColumnsWithTypeAndName & columns);
     ColumnWithTypeAndName reduce() const;
+    ColumnWithTypeAndName reduce(FunctionExecuteProfile & profile) const;
 
     Field operator[](size_t n) const override;
 
@@ -224,6 +225,9 @@ private:
     bool is_function_compiled;
 
     void appendArgument(const ColumnWithTypeAndName & column);
+
+    template<bool with_profile>
+    ColumnWithTypeAndName reduceImpl(FunctionExecuteProfile * profile) const;
 };
 
 const ColumnFunction * checkAndGetShortCircuitArgument(const ColumnPtr & column);

--- a/src/Columns/ColumnFunction.h
+++ b/src/Columns/ColumnFunction.h
@@ -12,7 +12,7 @@ namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
 }
-struct FunctionExecuteProfile;
+struct FunctionExecutionProfile;
 class IFunctionBase;
 using FunctionBasePtr = std::shared_ptr<const IFunctionBase>;
 
@@ -57,7 +57,7 @@ public:
     size_t allocatedBytes() const override;
 
     void appendArguments(const ColumnsWithTypeAndName & columns);
-    ColumnWithTypeAndName reduce(FunctionExecuteProfile * profile = nullptr) const;
+    ColumnWithTypeAndName reduce(FunctionExecutionProfile * profile = nullptr) const;
 
     Field operator[](size_t n) const override;
 
@@ -226,7 +226,7 @@ private:
     void appendArgument(const ColumnWithTypeAndName & column);
 
     template<bool with_profile>
-    ColumnWithTypeAndName reduceImpl(FunctionExecuteProfile * profile) const;
+    ColumnWithTypeAndName reduceImpl(FunctionExecutionProfile * profile) const;
 };
 
 const ColumnFunction * checkAndGetShortCircuitArgument(const ColumnPtr & column);

--- a/src/Columns/ColumnFunction.h
+++ b/src/Columns/ColumnFunction.h
@@ -57,8 +57,7 @@ public:
     size_t allocatedBytes() const override;
 
     void appendArguments(const ColumnsWithTypeAndName & columns);
-    ColumnWithTypeAndName reduce() const;
-    ColumnWithTypeAndName reduce(FunctionExecuteProfile & profile) const;
+    ColumnWithTypeAndName reduce(FunctionExecuteProfile * profile = nullptr) const;
 
     Field operator[](size_t n) const override;
 

--- a/src/Columns/MaskOperations.cpp
+++ b/src/Columns/MaskOperations.cpp
@@ -5,6 +5,8 @@
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnLowCardinality.h>
+#include <Common/Stopwatch.h>
+#include <Functions/IFunction.h>
 #include <algorithm>
 
 namespace DB
@@ -139,6 +141,7 @@ static bool extractMaskNumeric(
 
     mask_info.has_ones = ones_count > 0;
     mask_info.has_zeros = ones_count != mask.size();
+    mask_info.ones_count = ones_count;
     return true;
 }
 
@@ -251,7 +254,7 @@ void inverseMask(PaddedPODArray<UInt8> & mask, MaskInfo & mask_info)
     std::swap(mask_info.has_ones, mask_info.has_zeros);
 }
 
-void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> & mask, const MaskInfo & mask_info)
+void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> & mask, const MaskInfo & mask_info, FunctionExecuteProfile * profile)
 {
     const auto * column_function = checkAndGetShortCircuitArgument(column.column);
     if (!column_function)
@@ -273,14 +276,28 @@ void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> &
         /// First we filter the column, which creates a new column, then we apply the column, and finally we expand it
         /// Expanding is done to keep consistency in function calls (all columns the same size) and it's ok
         /// since the values won't be used by `if`
-        auto filtered = column_function->filter(mask, -1);
-        auto filter_after_execution = typeid_cast<const ColumnFunction *>(filtered.get())->reduce();
-        auto mut_column = IColumn::mutate(std::move(filter_after_execution.column));
-        mut_column->expand(mask, false);
-        column.column = std::move(mut_column);
+        if (profile)
+        {
+            Stopwatch watch;
+            auto filtered = column_function->filter(mask, -1);
+            auto filter_after_execution = typeid_cast<const ColumnFunction *>(filtered.get())->reduce(profile);
+            auto mut_column = IColumn::mutate(std::move(filter_after_execution.column));
+            mut_column->expand(mask, false);
+            auto side_elapsed = watch.elapsed();
+            profile->short_circuit_side_elapsed = side_elapsed - profile->executed_elapsed;
+            column.column = std::move(mut_column);
+        }
+        else
+        {
+            auto filtered = column_function->filter(mask, -1);
+            auto filter_after_execution = typeid_cast<const ColumnFunction *>(filtered.get())->reduce(profile);
+            auto mut_column = IColumn::mutate(std::move(filter_after_execution.column));
+            mut_column->expand(mask, false);
+            column.column = std::move(mut_column);
+        }
     }
     else
-        column = column_function->reduce();
+        column = column_function->reduce(profile);
 
     chassert(column.column->size() == original_size);
 }

--- a/src/Columns/MaskOperations.cpp
+++ b/src/Columns/MaskOperations.cpp
@@ -254,7 +254,7 @@ void inverseMask(PaddedPODArray<UInt8> & mask, MaskInfo & mask_info)
     std::swap(mask_info.has_ones, mask_info.has_zeros);
 }
 
-void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> & mask, const MaskInfo & mask_info, FunctionExecuteProfile * profile)
+void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> & mask, const MaskInfo & mask_info, FunctionExecutionProfile * profile)
 {
     const auto * column_function = checkAndGetShortCircuitArgument(column.column);
     if (!column_function)
@@ -284,8 +284,8 @@ void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> &
             auto mut_column = IColumn::mutate(std::move(filter_after_execution.column));
             mut_column->expand(mask, false);
             auto total_elapsed = watch.elapsed();
-            profile->short_circuit_side_elapsed = total_elapsed - profile->executed_elapsed + profile->short_circuit_side_elapsed;
-            profile->executed_elapsed = total_elapsed;
+            profile->lazy_executed_additional_elapsed = total_elapsed - profile->execution_elapsed + profile->lazy_executed_additional_elapsed;
+            profile->execution_elapsed = total_elapsed;
             column.column = std::move(mut_column);
         }
         else
@@ -303,7 +303,7 @@ void maskedExecute(ColumnWithTypeAndName & column, const PaddedPODArray<UInt8> &
     chassert(column.column->size() == original_size);
 }
 
-void executeColumnIfNeeded(ColumnWithTypeAndName & column, bool empty, FunctionExecuteProfile * profile)
+void executeColumnIfNeeded(ColumnWithTypeAndName & column, bool empty, FunctionExecutionProfile * profile)
 {
     const auto * column_function = checkAndGetShortCircuitArgument(column.column);
     if (!column_function)

--- a/src/Columns/MaskOperations.h
+++ b/src/Columns/MaskOperations.h
@@ -71,7 +71,7 @@ void maskedExecute(
 
 /// If given column is lazy executed argument, reduce it. If empty is true,
 /// create an empty column with the execution result type.
-void executeColumnIfNeeded(ColumnWithTypeAndName & column, bool empty = false);
+void executeColumnIfNeeded(ColumnWithTypeAndName & column, bool empty = false, FunctionExecuteProfile * profile = nullptr);
 
 /// Check if arguments contain lazy executed argument. If contain, return index of the last one,
 /// otherwise return -1.

--- a/src/Columns/MaskOperations.h
+++ b/src/Columns/MaskOperations.h
@@ -15,10 +15,13 @@ namespace DB
 template <typename T>
 void expandDataByMask(PaddedPODArray<T> & data, const PaddedPODArray<UInt8> & mask, bool inverted, T default_value = T());
 
+struct FunctionExecuteProfile;
+
 struct MaskInfo
 {
     bool has_ones;
     bool has_zeros;
+    size_t ones_count = 0;
 };
 
 /// The next functions are used to extract UInt8 mask from a column,
@@ -63,7 +66,8 @@ void inverseMask(PaddedPODArray<UInt8> & mask, MaskInfo & mask_info);
 void maskedExecute(
     ColumnWithTypeAndName & column,
     const PaddedPODArray<UInt8> & mask,
-    const MaskInfo & mask_info = {true, true});
+    const MaskInfo & mask_info = {true, true},
+    FunctionExecuteProfile * profile = nullptr);
 
 /// If given column is lazy executed argument, reduce it. If empty is true,
 /// create an empty column with the execution result type.

--- a/src/Columns/MaskOperations.h
+++ b/src/Columns/MaskOperations.h
@@ -15,7 +15,7 @@ namespace DB
 template <typename T>
 void expandDataByMask(PaddedPODArray<T> & data, const PaddedPODArray<UInt8> & mask, bool inverted, T default_value = T());
 
-struct FunctionExecuteProfile;
+struct FunctionExecutionProfile;
 
 struct MaskInfo
 {
@@ -67,11 +67,11 @@ void maskedExecute(
     ColumnWithTypeAndName & column,
     const PaddedPODArray<UInt8> & mask,
     const MaskInfo & mask_info = {true, true},
-    FunctionExecuteProfile * profile = nullptr);
+    FunctionExecutionProfile * profile = nullptr);
 
 /// If given column is lazy executed argument, reduce it. If empty is true,
 /// create an empty column with the execution result type.
-void executeColumnIfNeeded(ColumnWithTypeAndName & column, bool empty = false, FunctionExecuteProfile * profile = nullptr);
+void executeColumnIfNeeded(ColumnWithTypeAndName & column, bool empty = false, FunctionExecutionProfile * profile = nullptr);
 
 /// Check if arguments contain lazy executed argument. If contain, return index of the last one,
 /// otherwise return -1.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6105,6 +6105,9 @@ Trigger processor to spill data into external storage adpatively. grace join is 
     DECLARE(Bool, allow_experimental_ts_to_grid_aggregate_function, false, R"(
 Experimental tsToGrid aggregate function for Prometheus-like timeseries resampling. Cloud only
 )", EXPERIMENTAL) \
+    DECLARE(Bool, enable_adaptive_short_circuit_lazy_execution, false, R"(
+Enable dynamic evaluation of whether a short-circuit function's argument should be lazily executed.
+)", EXPERIMENTAL) \
     \
     /* ####################################################### */ \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -70,6 +70,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         {
             {"use_page_cache_with_distributed_cache", false, false, "New setting"},
             {"use_query_condition_cache", false, false, "New setting."},
+            {"enable_adaptive_short_circuit_lazy_execution", false, false, "Enable dynamic evaluation of whether a short-circuit function's argument should be lazily executed."},
         });
         addSettingsChanges(settings_changes_history, "25.2",
         {

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1625,6 +1625,15 @@ public:
                 && (isDecimalOrNullableDecimal(arguments[0].type) || isDecimalOrNullableDecimal(arguments[1].type)));
     }
 
+    bool isNoExcept() const override
+    {
+        const bool has_except =  IsOperation<Op>::int_div ||
+            IsOperation<Op>::modulo ||
+            IsOperation<Op>::positive_modulo ||
+            (IsOperation<Op>::div_floating);
+        return !has_except;
+    }
+
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
         return getReturnTypeImplStatic(arguments, context);

--- a/src/Functions/FunctionIfBase.h
+++ b/src/Functions/FunctionIfBase.h
@@ -42,6 +42,8 @@ public:
         return true;
     }
 
+    bool isNoExcept() const override { return true; }
+
     llvm::Value * compileImpl(llvm::IRBuilderBase & builder, const ValuesWithType & arguments, const DataTypePtr & result_type) const override
     {
         auto & b = static_cast<llvm::IRBuilder<> &>(builder);

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -670,6 +670,7 @@ public:
 
     explicit FunctionComparison(ComparisonParams params_) : params(std::move(params_)) {}
 
+    bool isNoExcept() const override { return true; }
 private:
     const ComparisonParams params;
 

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -726,10 +726,10 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             auto coalesce_elapsed = watch.elapsed();
             auto res = executeShortCircuit<true>(new_args, result_type, profile);
             profile->executed_elapsed += coalesce_elapsed;
-            // Only the ColumnFunction arguments have profiles. Need to transform the profile's position back to
-            // the original argument's position.
-            // The execution will stop early when all rows are filted, the last few short circuit arguments are not
-            // executed and there is no profile for them.
+            // Profiles are only available for short-circuit arguments, and their positions need to be mapped back to the
+            // original argument positions.
+            // The execution will stop early when all rows are filtered, the last few short-circuit arguments are skipped
+            // and no profiles are generated for them.
             for (size_t i = 0; i < profile->argument_profiles.size(); ++i)
                 profile->argument_profiles[i].first = short_circuit_args_index[i];
             return res;

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -726,7 +726,10 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             auto coalesce_elapsed = watch.elapsed();
             auto res = executeShortCircuit<true>(new_args, result_type, profile);
             profile->executed_elapsed += coalesce_elapsed;
-            chassert(profile->argument_profiles.size() == short_circuit_args_index.size());
+            if (profile->argument_profiles.size() != short_circuit_args_index.size())
+            {
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx profiles size not matched. {} ~ {}", profile->argument_profiles.size(), short_circuit_args_index.size());
+            }
             // Only the ColumnFunction arguments have profiles. Need to transform the profile's position back to
             // the original argument's position.
             for (size_t i = 0; i < short_circuit_args_index.size(); ++i)

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -8,7 +8,6 @@
 #include <Columns/ColumnFunction.h>
 #include <Columns/ColumnVector.h>
 #include <Columns/ColumnsNumber.h>
-#include <Columns/ColumnFunction.h>
 #include <Common/FieldVisitorConvertToNumber.h>
 #include <Common/Stopwatch.h>
 #include <Columns/MaskOperations.h>
@@ -740,7 +739,8 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
     ColumnPtr result_col = nullptr;
     if (result_type->isNullable())
         result_col = executeForTernaryLogicImpl<Impl>(std::move(args_in), result_type, input_rows_count);
-    result_col = basicExecuteImpl<Impl>(std::move(args_in), input_rows_count);
+    else
+        result_col = basicExecuteImpl<Impl>(std::move(args_in), input_rows_count);
     if (profile)
     {
         profile->executed_rows = input_rows_count;

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -697,6 +697,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
         ColumnRawPtrs not_short_circuit_args;
         std::vector<size_t> short_circuit_args_index;
         ColumnsWithTypeAndName new_args;
+        Stopwatch watch;
 
         for (size_t i = 0, n = args.size(); i < n; ++i)
         {
@@ -722,7 +723,12 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             new_args.swap(arguments);
 
         if (profile)
-            return executeShortCircuit<true>(new_args, result_type, profile);
+        {
+            auto coalesce_elapsed = watch.elapsed();
+            auto res = executeShortCircuit<true>(new_args, result_type, profile);
+            profile->executed_elapsed += coalesce_elapsed;
+            return res;
+        }
         return executeShortCircuit<false>(new_args, result_type, profile);
     }
 

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -677,11 +677,11 @@ template <typename Impl, typename Name>
 ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImpl(
     const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const
 {
-    return this->executeImpl(args, result_type, input_rows_count, nullptr);
+    return this->executeImplWithProfile(args, result_type, input_rows_count, nullptr);
 }
 
 template <typename Impl, typename Name>
-ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImpl(
+ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
     const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const
 {
     ColumnsWithTypeAndName arguments = args;

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -726,6 +726,9 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             auto coalesce_elapsed = watch.elapsed();
             auto res = executeShortCircuit<true>(new_args, result_type, profile);
             profile->executed_elapsed += coalesce_elapsed;
+            chassert(profile->argument_profiles.size() == short_circuit_args_index.size());
+            for (size_t i = 0; i < short_circuit_args_index.size(); ++i)
+                profile->argument_profiles[i].first = short_circuit_args_index[i];
             return res;
         }
         return executeShortCircuit<false>(new_args, result_type, profile);

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -730,6 +730,8 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             // original argument positions.
             // The execution will stop early when all rows are filtered, the last few short-circuit arguments are skipped
             // and no profiles are generated for them.
+            if (profile->argument_profiles.size() > short_circuit_args_index.size())
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid argument_profiles: {} {}", profile->argument_profiles.size(), short_circuit_args_index.size());
             for (size_t i = 0; i < profile->argument_profiles.size(); ++i)
                 profile->argument_profiles[i].first = short_circuit_args_index[i];
             return res;

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -581,6 +581,7 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(ColumnsWithTy
     if (Name::name != NameAnd::name && Name::name != NameOr::name)
         throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {} doesn't support short circuit execution", getName());
 
+    Stopwatch watch;
     if (with_profile && checkAndGetShortCircuitArgument(arguments[0].column))
     {
         profile->argument_profiles.emplace_back(std::make_pair(0, FunctionExecuteProfile()));
@@ -655,6 +656,8 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeShortCircuit(ColumnsWithTy
 
     if constexpr (with_profile)
     {
+        profile->executed_elapsed = watch.elapsed();
+        profile->executed_rows = res->size();
         size_t side_elapsed = 0;
         for (const auto & [i, arg_profile] : profile->argument_profiles)
         {

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -727,6 +727,8 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             auto res = executeShortCircuit<true>(new_args, result_type, profile);
             profile->executed_elapsed += coalesce_elapsed;
             chassert(profile->argument_profiles.size() == short_circuit_args_index.size());
+            // Only the ColumnFunction arguments have profiles. Need to transform the profile's position back to
+            // the original argument's position.
             for (size_t i = 0; i < short_circuit_args_index.size(); ++i)
                 profile->argument_profiles[i].first = short_circuit_args_index[i];
             return res;

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -726,13 +726,11 @@ ColumnPtr FunctionAnyArityLogical<Impl, Name>::executeImplWithProfile(
             auto coalesce_elapsed = watch.elapsed();
             auto res = executeShortCircuit<true>(new_args, result_type, profile);
             profile->executed_elapsed += coalesce_elapsed;
-            if (profile->argument_profiles.size() != short_circuit_args_index.size())
-            {
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx profiles size not matched. {} ~ {}", profile->argument_profiles.size(), short_circuit_args_index.size());
-            }
             // Only the ColumnFunction arguments have profiles. Need to transform the profile's position back to
             // the original argument's position.
-            for (size_t i = 0; i < short_circuit_args_index.size(); ++i)
+            // The execution will stop early when all rows are filted, the last few short circuit arguments are not
+            // executed and there is no profile for them.
+            for (size_t i = 0; i < profile->argument_profiles.size(); ++i)
                 profile->argument_profiles[i].first = short_circuit_args_index[i];
             return res;
         }

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -171,7 +171,7 @@ public:
 
     bool isNoExcept() const override { return true; }
     template <bool with_profile>
-    ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, FunctionExecuteProfile * profile) const;
+    ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, FunctionExecutionProfile * profile) const;
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 0; }
     bool canBeExecutedOnLowCardinalityDictionary() const override { return false; }
@@ -184,7 +184,7 @@ public:
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const override;
-    ColumnPtr executeImplWithProfile(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override;
+    ColumnPtr executeImplWithProfile(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecutionProfile * profile) const override;
 
     ColumnPtr getConstantResultForNonConstArguments(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const override;
 

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -168,7 +168,10 @@ public:
         settings.force_enable_lazy_execution = false;
         return name == NameAnd::name || name == NameOr::name;
     }
-    ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const;
+
+    bool isNoExcept() const override { return true; }
+    template <bool with_profile>
+    ColumnPtr executeShortCircuit(ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, FunctionExecuteProfile * profile) const;
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 0; }
     bool canBeExecutedOnLowCardinalityDictionary() const override { return false; }
@@ -181,6 +184,7 @@ public:
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const override;
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override;
 
     ColumnPtr getConstantResultForNonConstArguments(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const override;
 

--- a/src/Functions/FunctionsLogical.h
+++ b/src/Functions/FunctionsLogical.h
@@ -184,7 +184,7 @@ public:
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const override;
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override;
+    ColumnPtr executeImplWithProfile(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override;
 
     ColumnPtr getConstantResultForNonConstArguments(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const override;
 

--- a/src/Functions/FunctionsRandom.h
+++ b/src/Functions/FunctionsRandom.h
@@ -64,6 +64,7 @@ public:
 
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
+    bool isNoExcept() const override { return true; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -23,8 +23,6 @@
 #include <Common/assert_cast.h>
 #include <Common/Stopwatch.h>
 #include <Common/typeid_cast.h>
-#include <Poco/Logger.h>
-#include <Common/logger_useful.h>
 
 #include "config.h"
 

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -23,6 +23,8 @@
 #include <Common/assert_cast.h>
 #include <Common/Stopwatch.h>
 #include <Common/typeid_cast.h>
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
 
 #include "config.h"
 

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -251,7 +251,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
             ColumnsWithTypeAndName temporary_columns = createBlockWithNestedColumns(args);
             auto temporary_result_type = removeNullable(result_type);
 
-            auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, input_rows_count, dry_run);
+            auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, input_rows_count, dry_run, profile);
             return wrapInNullable(res, args, result_type, input_rows_count);
         }
 
@@ -377,7 +377,6 @@ static void convertSparseColumnsToFull(ColumnsWithTypeAndName & args)
         column.column = recursiveRemoveSparse(column.column);
 }
 
-<<<<<<< HEAD
 IExecutableFunction::IExecutableFunction()
 {
     if (CurrentThread::isInitialized())
@@ -392,15 +391,11 @@ IExecutableFunction::IExecutableFunction()
 }
 
 ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
-    const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
-=======
-ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
     size_t input_rows_count,
     bool dry_run,
     FunctionExecuteProfile * profile) const
->>>>>>> doing
 {
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
@@ -448,10 +443,6 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     return result;
 }
 
-<<<<<<< HEAD
-ColumnPtr IExecutableFunction::execute(
-    const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
-=======
 ColumnPtr IExecutableFunction::executeImplWithProfile(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
@@ -478,7 +469,6 @@ ColumnPtr IExecutableFunction::execute(
     size_t input_rows_count,
     bool dry_run,
     FunctionExecuteProfile * profile) const
->>>>>>> doing
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
 
@@ -669,7 +659,7 @@ FunctionBasePtr IFunctionOverloadResolver::build(const ColumnsWithTypeAndName & 
     return buildImpl(arguments, return_type);
 }
 
-ColumnPtr IFunction::executeImpl(
+ColumnPtr IFunction::executeImplWithProfile(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
     size_t input_rows_count,

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -21,6 +21,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/SipHash.h>
 #include <Common/assert_cast.h>
+#include <Common/Stopwatch.h>
 #include <Common/typeid_cast.h>
 
 #include "config.h"
@@ -131,7 +132,11 @@ void convertLowCardinalityColumnsToFull(ColumnsWithTypeAndName & args)
 }
 
 ColumnPtr IExecutableFunction::defaultImplementationForConstantArguments(
-    const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+    const ColumnsWithTypeAndName & args,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    FunctionExecuteProfile * profile) const
 {
     ColumnNumbers arguments_to_remain_constants = getArgumentsThatAreAlwaysConstant();
 
@@ -174,7 +179,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForConstantArguments(
             "Number of arguments for function {} doesn't match: the function requires more arguments",
             getName());
 
-    ColumnPtr result_column = executeWithoutLowCardinalityColumns(temporary_columns, result_type, 1, dry_run);
+    ColumnPtr result_column = executeWithoutLowCardinalityColumns(temporary_columns, result_type, 1, dry_run, profile);
 
     /// extremely rare case, when we have function with completely const arguments
     /// but some of them produced by non isDeterministic function
@@ -186,7 +191,11 @@ ColumnPtr IExecutableFunction::defaultImplementationForConstantArguments(
 
 
 ColumnPtr IExecutableFunction::defaultImplementationForNulls(
-    const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+    const ColumnsWithTypeAndName & args,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    FunctionExecuteProfile * profile) const
 {
     if (args.empty() || !useDefaultImplementationForNulls())
         return nullptr;
@@ -279,7 +288,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
         if (!should_short_circuit)
         {
             /// Each row should be evaluated if there are no nulls or short circuiting is disabled.
-            auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, input_rows_count, dry_run);
+            auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, input_rows_count, dry_run, profile);
             auto new_res = wrapInNullable(res, std::move(result_null_map));
             return new_res;
         }
@@ -296,7 +305,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
             for (auto & col : temporary_columns)
                 col.column = col.column->filter(filter_mask, rows_without_nulls);
 
-            auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, rows_without_nulls, dry_run);
+            auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, rows_without_nulls, dry_run, profile);
             auto mutable_res = IColumn::mutate(std::move(res));
             mutable_res->expand(filter_mask, false);
 
@@ -335,22 +344,26 @@ ColumnPtr IExecutableFunction::defaultImplementationForNothing(
 }
 
 ColumnPtr IExecutableFunction::executeWithoutLowCardinalityColumns(
-    const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+    const ColumnsWithTypeAndName & args,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    FunctionExecuteProfile * profile) const
 {
     if (auto res = defaultImplementationForNothing(args, result_type, input_rows_count))
         return res;
 
-    if (auto res = defaultImplementationForConstantArguments(args, result_type, input_rows_count, dry_run))
+    if (auto res = defaultImplementationForConstantArguments(args, result_type, input_rows_count, dry_run, profile))
         return res;
 
-    if (auto res = defaultImplementationForNulls(args, result_type, input_rows_count, dry_run))
+    if (auto res = defaultImplementationForNulls(args, result_type, input_rows_count, dry_run, profile))
         return res;
 
     ColumnPtr res;
     if (dry_run)
         res = executeDryRunImpl(args, result_type, input_rows_count);
     else
-        res = executeImpl(args, result_type, input_rows_count);
+        res = executeImplWithProfile(args, result_type, input_rows_count, profile);
 
     if (!res)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column was returned by function {}", getName());
@@ -364,6 +377,7 @@ static void convertSparseColumnsToFull(ColumnsWithTypeAndName & args)
         column.column = recursiveRemoveSparse(column.column);
 }
 
+<<<<<<< HEAD
 IExecutableFunction::IExecutableFunction()
 {
     if (CurrentThread::isInitialized())
@@ -379,6 +393,14 @@ IExecutableFunction::IExecutableFunction()
 
 ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+=======
+ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
+    const ColumnsWithTypeAndName & arguments,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    FunctionExecuteProfile * profile) const
+>>>>>>> doing
 {
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
@@ -397,7 +419,7 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
                 = columns_without_low_cardinality.empty() ? input_rows_count : columns_without_low_cardinality.front().column->size();
             checkFunctionArgumentSizes(columns_without_low_cardinality, new_input_rows_count);
 
-            auto res = executeWithoutLowCardinalityColumns(columns_without_low_cardinality, dictionary_type, new_input_rows_count, dry_run);
+            auto res = executeWithoutLowCardinalityColumns(columns_without_low_cardinality, dictionary_type, new_input_rows_count, dry_run, profile);
             bool res_is_constant = isColumnConst(*res);
 
             auto keys = res_is_constant ? res->cloneResized(1)->convertToFullColumnIfConst() : res;
@@ -417,17 +439,46 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
         else
         {
             convertLowCardinalityColumnsToFull(columns_without_low_cardinality);
-            result = executeWithoutLowCardinalityColumns(columns_without_low_cardinality, result_type, input_rows_count, dry_run);
+            result = executeWithoutLowCardinalityColumns(columns_without_low_cardinality, result_type, input_rows_count, dry_run, profile);
         }
     }
     else
-        result = executeWithoutLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
+        result = executeWithoutLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run, profile);
 
     return result;
 }
 
+<<<<<<< HEAD
 ColumnPtr IExecutableFunction::execute(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+=======
+ColumnPtr IExecutableFunction::executeImplWithProfile(
+    const ColumnsWithTypeAndName & arguments,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    FunctionExecuteProfile * profile) const
+{
+    if (profile)
+    {
+        Stopwatch watch;
+        auto res = executeImpl(arguments, result_type, input_rows_count);
+        profile->executed_rows = input_rows_count;
+        profile->executed_elapsed = watch.elapsed();
+        return res;
+    }
+    else
+    {
+        return executeImpl(arguments, result_type, input_rows_count);
+    }
+}
+
+ColumnPtr IExecutableFunction::execute(
+    const ColumnsWithTypeAndName & arguments,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    FunctionExecuteProfile * profile) const
+>>>>>>> doing
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
 
@@ -477,7 +528,7 @@ ColumnPtr IExecutableFunction::execute(
                 columns_without_sparse[i].column = columns_without_sparse[i].column->cloneResized(values_size);
             }
 
-            auto res = executeWithoutSparseColumns(columns_without_sparse, result_type, values_size, dry_run);
+            auto res = executeWithoutSparseColumns(columns_without_sparse, result_type, values_size, dry_run, profile);
 
             if (isColumnConst(*res))
                 return res->cloneResized(input_rows_count);
@@ -495,15 +546,26 @@ ColumnPtr IExecutableFunction::execute(
         }
 
         convertSparseColumnsToFull(columns_without_sparse);
-        return executeWithoutSparseColumns(columns_without_sparse, result_type, input_rows_count, dry_run);
+        return executeWithoutSparseColumns(columns_without_sparse, result_type, input_rows_count, dry_run, profile);
     }
     if (use_default_implementation_for_sparse_columns)
     {
         auto columns_without_sparse = arguments;
         convertSparseColumnsToFull(columns_without_sparse);
-        return executeWithoutSparseColumns(columns_without_sparse, result_type, input_rows_count, dry_run);
+        return executeWithoutSparseColumns(columns_without_sparse, result_type, input_rows_count, dry_run, profile);
     }
-    return executeWithoutSparseColumns(arguments, result_type, input_rows_count, dry_run);
+    return executeWithoutSparseColumns(arguments, result_type, input_rows_count, dry_run, profile);
+}
+
+ColumnPtr IFunctionBase::execute(
+    const DB::ColumnsWithTypeAndName& arguments,
+    const DB::DataTypePtr& result_type,
+    size_t input_rows_count,
+    bool dry_run,
+    FunctionExecuteProfile * profile) const
+{
+    checkFunctionArgumentSizes(arguments, input_rows_count);
+    return prepare(arguments)->execute(arguments, result_type, input_rows_count, dry_run, profile);
 }
 
 ColumnPtr IFunctionBase::execute(const DB::ColumnsWithTypeAndName& arguments, const DB::DataTypePtr& result_type,
@@ -605,6 +667,26 @@ FunctionBasePtr IFunctionOverloadResolver::build(const ColumnsWithTypeAndName & 
 
     auto return_type = getReturnType(arguments);
     return buildImpl(arguments, return_type);
+}
+
+ColumnPtr IFunction::executeImpl(
+    const ColumnsWithTypeAndName & arguments,
+    const DataTypePtr & result_type,
+    size_t input_rows_count,
+    FunctionExecuteProfile * profile) const
+{
+    if (profile)
+    {
+        Stopwatch watch;
+        auto res = executeImpl(arguments, result_type, input_rows_count);
+        profile->executed_rows = input_rows_count;
+        profile->executed_elapsed = watch.elapsed();
+        return res;
+    }
+    else
+    {
+        return executeImpl(arguments, result_type, input_rows_count);
+    }
 }
 
 void IFunctionOverloadResolver::getLambdaArgumentTypes(DataTypes & arguments [[maybe_unused]]) const

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -136,7 +136,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForConstantArguments(
     const DataTypePtr & result_type,
     size_t input_rows_count,
     bool dry_run,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     ColumnNumbers arguments_to_remain_constants = getArgumentsThatAreAlwaysConstant();
 
@@ -195,7 +195,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
     const DataTypePtr & result_type,
     size_t input_rows_count,
     bool dry_run,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     if (args.empty() || !useDefaultImplementationForNulls())
         return nullptr;
@@ -348,7 +348,7 @@ ColumnPtr IExecutableFunction::executeWithoutLowCardinalityColumns(
     const DataTypePtr & result_type,
     size_t input_rows_count,
     bool dry_run,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     if (auto res = defaultImplementationForNothing(args, result_type, input_rows_count))
         return res;
@@ -395,7 +395,7 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     const DataTypePtr & result_type,
     size_t input_rows_count,
     bool dry_run,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
@@ -447,14 +447,14 @@ ColumnPtr IExecutableFunction::executeImplWithProfile(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
     size_t input_rows_count,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     if (profile)
     {
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->executed_rows = input_rows_count;
-        profile->executed_elapsed = watch.elapsed();
+        profile->execution_elapsed = watch.elapsed();
         return res;
     }
     else
@@ -468,7 +468,7 @@ ColumnPtr IExecutableFunction::execute(
     const DataTypePtr & result_type,
     size_t input_rows_count,
     bool dry_run,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
 
@@ -552,7 +552,7 @@ ColumnPtr IFunctionBase::execute(
     const DB::DataTypePtr& result_type,
     size_t input_rows_count,
     bool dry_run,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
     return prepare(arguments)->execute(arguments, result_type, input_rows_count, dry_run, profile);
@@ -663,14 +663,14 @@ ColumnPtr IFunction::executeImplWithProfile(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
     size_t input_rows_count,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     if (profile)
     {
         Stopwatch watch;
         auto res = executeImpl(arguments, result_type, input_rows_count);
         profile->executed_rows = input_rows_count;
-        profile->executed_elapsed = watch.elapsed();
+        profile->execution_elapsed = watch.elapsed();
         return res;
     }
     else

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -40,7 +40,7 @@ struct FunctionExecuteProfile
 
     /// The total executed elapsed, including short_circuit_side_elapsed.
     size_t executed_elapsed = 0;
-  
+
     /// For a lazily executed function, we need to filter out the rows that are not executed using a bitmap,
     /// and then expand the result to the original size. `short_circuit_side_elapsed` contains the
     /// execution time of these two steps. It also includes all `short_circuit_side_elapsed` times of its
@@ -193,12 +193,13 @@ public:
     /// sample_columns should contain data types of arguments and values of constants, if relevant.
     virtual ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName & arguments) const = 0;
 
-#if USE_EMBEDDED_COMPILER
-
-    virtual bool isCompilable() const { return false; }
     // Whether `execute` throws exception on invalid input. For example, a%b throws exception when b is zero.
     // But this doesn't include invalid argument types.
     virtual bool isNoExcept() const { return false; }
+
+#if USE_EMBEDDED_COMPILER
+
+    virtual bool isCompilable() const { return false; }
 
     /** Produce LLVM IR code that operates on scalar values. See `toNativeType` in DataTypes/Native.h
       * for supported value types and how they map to LLVM types.

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -35,7 +35,6 @@ struct FunctionExecuteProfile
 {
     size_t executed_rows = 0;
     size_t executed_elapsed = 0;
-    size_t short_circuit_select_rows = 0;
     size_t short_circuit_side_elapsed = 0;
     std::vector<std::pair<size_t, FunctionExecuteProfile>> argument_profiles;
 };

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -469,11 +469,13 @@ public:
     virtual String getName() const = 0;
 
     virtual ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const = 0;
-    virtual ColumnPtr executeImpl(
+
+    virtual ColumnPtr executeImplWithProfile(
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr & result_type,
         size_t input_rows_count,
         FunctionExecuteProfile * profile) const;
+
     virtual ColumnPtr executeImplDryRun(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
     {
         return executeImpl(arguments, result_type, input_rows_count);

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -31,6 +31,15 @@ class Field;
 struct FieldInterval;
 using FieldIntervalPtr = std::shared_ptr<FieldInterval>;
 
+struct FunctionExecuteProfile
+{
+    size_t executed_rows = 0;
+    size_t executed_elapsed = 0;
+    size_t masked_execute_rows = 0;
+    size_t masked_execute_side_elapsed = 0;
+    std::vector<std::pair<size_t, FunctionExecuteProfile>> argument_profiles;
+};
+
 /// The simplest executable object.
 /// Motivation:
 ///  * Prepare something heavy once before main execution loop instead of doing it for each columns.
@@ -46,11 +55,14 @@ public:
     /// Get the main function name.
     virtual String getName() const = 0;
 
-    ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const;
+    // profile is optional. It helps to improve expression execution.
+    ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run, FunctionExecuteProfile * profile = nullptr) const;
 
 protected:
 
     virtual ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const = 0;
+
+    virtual ColumnPtr executeImplWithProfile(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const;
 
     virtual ColumnPtr executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
     {
@@ -102,19 +114,35 @@ protected:
 private:
 
     ColumnPtr defaultImplementationForConstantArguments(
-            const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const;
+            const ColumnsWithTypeAndName & args,
+            const DataTypePtr & result_type,
+            size_t input_rows_count,
+            bool dry_run,
+            FunctionExecuteProfile * profile) const;
 
     ColumnPtr defaultImplementationForNulls(
-            const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const;
+            const ColumnsWithTypeAndName & args,
+            const DataTypePtr & result_type,
+            size_t input_rows_count,
+            bool dry_run,
+            FunctionExecuteProfile * profile) const;
 
     ColumnPtr defaultImplementationForNothing(
             const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const;
 
     ColumnPtr executeWithoutLowCardinalityColumns(
-            const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const;
+            const ColumnsWithTypeAndName & args,
+            const DataTypePtr & result_type,
+            size_t input_rows_count,
+            bool dry_run,
+            FunctionExecuteProfile * profile) const;
 
     ColumnPtr executeWithoutSparseColumns(
-            const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const;
+            const ColumnsWithTypeAndName & arguments,
+            const DataTypePtr & result_type,
+            size_t input_rows_count,
+            bool dry_run,
+            FunctionExecuteProfile * profile) const;
 
     bool short_circuit_function_evaluation_for_nulls = false;
     double short_circuit_function_evaluation_for_nulls_threshold = 0.0;
@@ -136,6 +164,13 @@ public:
         const DataTypePtr & result_type,
         size_t input_rows_count,
         bool dry_run) const;
+
+    virtual ColumnPtr execute( /// NOLINT
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr & result_type,
+        size_t input_rows_count,
+        bool dry_run,
+        FunctionExecuteProfile * profile) const;
 
     /// Get the main function name.
     virtual String getName() const = 0;
@@ -432,6 +467,11 @@ public:
     virtual String getName() const = 0;
 
     virtual ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const = 0;
+    virtual ColumnPtr executeImpl(
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr & result_type,
+        size_t input_rows_count,
+        FunctionExecuteProfile * profile) const;
     virtual ColumnPtr executeImplDryRun(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
     {
         return executeImpl(arguments, result_type, input_rows_count);

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -35,8 +35,8 @@ struct FunctionExecuteProfile
 {
     size_t executed_rows = 0;
     size_t executed_elapsed = 0;
-    size_t masked_execute_rows = 0;
-    size_t masked_execute_side_elapsed = 0;
+    size_t short_circuit_select_rows = 0;
+    size_t short_circuit_side_elapsed = 0;
     std::vector<std::pair<size_t, FunctionExecuteProfile>> argument_profiles;
 };
 
@@ -184,6 +184,9 @@ public:
 #if USE_EMBEDDED_COMPILER
 
     virtual bool isCompilable() const { return false; }
+    // Whether `execute` throws exception on invalid input. For example, a%b throws exception when b is zero.
+    // But this doesn't include invalid argument types.
+    virtual bool isNoExcept() const { return false; }
 
     /** Produce LLVM IR code that operates on scalar values. See `toNativeType` in DataTypes/Native.h
       * for supported value types and how they map to LLVM types.
@@ -533,6 +536,7 @@ public:
     virtual bool isDeterministicInScopeOfQuery() const { return true; }
     virtual bool isServerConstant() const { return false; }
     virtual bool isStateful() const { return false; }
+    virtual bool isNoExcept() const { return false; }
 
     using ShortCircuitSettings = IFunctionBase::ShortCircuitSettings;
     virtual bool isShortCircuit(ShortCircuitSettings & /*settings*/, size_t /*number_of_arguments*/) const { return false; }

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -33,22 +33,21 @@ using FieldIntervalPtr = std::shared_ptr<FieldInterval>;
 
 struct FunctionExecuteProfile
 {
-    /// executed_rows keeps track of the number of rows that have been processed by the function.
-    /// For a short-circuit function, the executed rows of its lazily executed arguments may be less than
-    /// the input rows if some rows are filtered out before the lazy execution of the argument.
+    /// executed_rows records the number of rows processed by a function. In a short-circuit function,
+    /// the executed_rows for lazily executed arguments can be less than the input rows, as some rows may
+    /// be filtered out before the argument is executed.
     size_t executed_rows = 0;
 
     /// The total executed elapsed, including short_circuit_side_elapsed.
     size_t executed_elapsed = 0;
 
-    /// For a lazily executed function, we need to filter out the rows that are not executed using a bitmap,
-    /// and then expand the result to the original size. `short_circuit_side_elapsed` contains the
-    /// execution time of these two steps. It also includes all `short_circuit_side_elapsed` times of its
-    /// lazily executed arguments.
+    /// When executing a function lazily, we filter out unprocessed rows using a bitmap and expand the
+    /// result to the original size. The short_circuit_side_elapsed metric includes the time for these
+    /// operations, along with the short_circuit_side_elapsed times of its lazily executed arguments.
     size_t short_circuit_side_elapsed = 0;
 
-    /// If one argument is ColumnFunction, we need to profile its execution.
-    /// The first element of the pair is the index of the argument.
+    /// For short-circuit arguments, their execution must be profiled, with the first element of the pair
+    /// indicating the argument's index.
     std::vector<std::pair<size_t, FunctionExecuteProfile>> argument_profiles;
 };
 

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -33,9 +33,22 @@ using FieldIntervalPtr = std::shared_ptr<FieldInterval>;
 
 struct FunctionExecuteProfile
 {
+    /// executed_rows keeps track of the number of rows that have been processed by the function.
+    /// For a short-circuit function, the executed rows of its lazily executed arguments may be less than
+    /// the input rows if some rows are filtered out before the lazy execution of the argument.
     size_t executed_rows = 0;
+
+    /// The total executed elapsed, including short_circuit_side_elapsed.
     size_t executed_elapsed = 0;
+  
+    /// For a lazily executed function, we need to filter out the rows that are not executed using a bitmap,
+    /// and then expand the result to the original size. `short_circuit_side_elapsed` contains the
+    /// execution time of these two steps. It also includes all `short_circuit_side_elapsed` times of its
+    /// lazily executed arguments.
     size_t short_circuit_side_elapsed = 0;
+
+    /// If one argument is ColumnFunction, we need to profile its execution.
+    /// The first element of the pair is the index of the argument.
     std::vector<std::pair<size_t, FunctionExecuteProfile>> argument_profiles;
 };
 

--- a/src/Functions/IFunctionAdaptors.cpp
+++ b/src/Functions/IFunctionAdaptors.cpp
@@ -10,6 +10,16 @@ ColumnPtr FunctionToExecutableFunctionAdaptor::executeImpl(const ColumnsWithType
     return function->executeImpl(arguments, result_type, input_rows_count);
 }
 
+ColumnPtr FunctionToExecutableFunctionAdaptor::executeImplWithProfile(
+    const ColumnsWithTypeAndName& arguments,
+    const DataTypePtr& result_type,
+    size_t input_rows_count,
+    FunctionExecuteProfile * profile) const
+{
+    checkFunctionArgumentSizes(arguments, input_rows_count);
+    return function->executeImpl(arguments, result_type, input_rows_count, profile);
+}
+
 ColumnPtr FunctionToExecutableFunctionAdaptor::executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);

--- a/src/Functions/IFunctionAdaptors.cpp
+++ b/src/Functions/IFunctionAdaptors.cpp
@@ -17,7 +17,7 @@ ColumnPtr FunctionToExecutableFunctionAdaptor::executeImplWithProfile(
     FunctionExecuteProfile * profile) const
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
-    return function->executeImpl(arguments, result_type, input_rows_count, profile);
+    return function->executeImplWithProfile(arguments, result_type, input_rows_count, profile);
 }
 
 ColumnPtr FunctionToExecutableFunctionAdaptor::executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const

--- a/src/Functions/IFunctionAdaptors.cpp
+++ b/src/Functions/IFunctionAdaptors.cpp
@@ -14,7 +14,7 @@ ColumnPtr FunctionToExecutableFunctionAdaptor::executeImplWithProfile(
     const ColumnsWithTypeAndName& arguments,
     const DataTypePtr& result_type,
     size_t input_rows_count,
-    FunctionExecuteProfile * profile) const
+    FunctionExecutionProfile * profile) const
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
     return function->executeImplWithProfile(arguments, result_type, input_rows_count, profile);

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -17,6 +17,11 @@ public:
 protected:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const final;
+    ColumnPtr executeImplWithProfile(
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr & result_type,
+        size_t input_rows_count,
+        FunctionExecuteProfile * profile) const final;
     ColumnPtr executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const final;
 
     bool useDefaultImplementationForNulls() const final { return function->useDefaultImplementationForNulls(); }

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -92,6 +92,8 @@ public:
 
     bool hasInformationAboutPreimage() const override { return function->hasInformationAboutPreimage(); }
 
+    bool isNoExcept() const override { return function->isNoExcept(); }
+
     Monotonicity getMonotonicityForRange(const IDataType & type, const Field & left, const Field & right) const override
     {
         return function->getMonotonicityForRange(type, left, right);

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -21,7 +21,7 @@ protected:
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr & result_type,
         size_t input_rows_count,
-        FunctionExecuteProfile * profile) const final;
+        FunctionExecutionProfile * profile) const final;
     ColumnPtr executeDryRunImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const final;
 
     bool useDefaultImplementationForNulls() const final { return function->useDefaultImplementationForNulls(); }

--- a/src/Functions/compareSubstrings.cpp
+++ b/src/Functions/compareSubstrings.cpp
@@ -33,6 +33,7 @@ public:
 
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 0; }
+    bool isNoExcept() const override { return true; }
     bool isVariadic() const override { return true; }
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }

--- a/src/Functions/multiIf.cpp
+++ b/src/Functions/multiIf.cpp
@@ -164,10 +164,10 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        return this->executeImpl(args, result_type, input_rows_count, nullptr);
+        return this->executeImplWithProfile(args, result_type, input_rows_count, nullptr);
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override
+    ColumnPtr executeImplWithProfile(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override
     {
         /// Fast path when data is empty
         if (input_rows_count == 0)

--- a/src/Functions/multiIf.cpp
+++ b/src/Functions/multiIf.cpp
@@ -5,11 +5,13 @@
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnFunction.h>
 #include <Columns/MaskOperations.h>
 #include <Core/Settings.h>
 #include <Interpreters/castColumn.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
+#include <Common/Stopwatch.h>
 #include <Interpreters/Context.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -162,8 +164,22 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
+        return this->executeImpl(args, result_type, input_rows_count, nullptr);
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecuteProfile * profile) const override
+    {
+        /// Fast path when data is empty
+        if (input_rows_count == 0)
+            return result_type->createColumn();
+
+        Stopwatch watch;
         ColumnsWithTypeAndName arguments = args;
-        executeShortCircuitArguments(arguments);
+        if (profile)
+            executeShortCircuitArguments<true>(arguments, profile);
+        else
+            executeShortCircuitArguments<false>(arguments, nullptr);
+
         /** We will gather values from columns in branches to result column,
         *  depending on values of conditions.
         */
@@ -238,12 +254,22 @@ public:
                 break;
         }
 
+        auto take_profile = [](Stopwatch & watch_, size_t rows_, FunctionExecuteProfile * profile_)
+        {
+            if (profile_)
+            {
+                profile_->executed_rows = rows_;
+                profile_->executed_elapsed = watch_.elapsed();
+            }
+        };
+
         /// Special case if first instruction condition is always true and source is constant
         if (instructions.size() == 1 && instructions.front().source_is_constant && instructions.front().condition_always_true)
         {
             MutableColumnPtr res = return_type->createColumn();
             auto & instruction = instructions.front();
             res->insertFrom(assert_cast<const ColumnConst &>(*instruction.source).getDataColumn(), 0);
+            take_profile(watch, input_rows_count, profile);
             return ColumnConst::create(std::move(res), instruction.source->size());
         }
 
@@ -266,6 +292,7 @@ public:
             MutableColumnPtr res = return_type->createColumn();
             res->reserve(rows);
             executeInstructions(instructions, rows, res);
+            take_profile(watch, rows, profile);
             return std::move(res);
         }
 
@@ -285,6 +312,7 @@ public:
             auto & res_data = assert_cast<ColumnVectorOrDecimal<FIELD> &>(*res).getData(); \
             executeInstructionsColumnar<FIELD, INDEX, false>(instructions, rows, res_data, nullptr); \
         } \
+        take_profile(watch, input_rows_count, profile); \
         return std::move(res); \
     }
 
@@ -460,13 +488,20 @@ private:
         }
     }
 
-    static void executeShortCircuitArguments(ColumnsWithTypeAndName & arguments)
+    template <bool with_profile>
+    static void executeShortCircuitArguments(ColumnsWithTypeAndName & arguments, FunctionExecuteProfile * profile)
     {
         int last_short_circuit_argument_index = checkShortCircuitArguments(arguments);
         if (last_short_circuit_argument_index < 0)
             return;
 
-        executeColumnIfNeeded(arguments[0]);
+        if (with_profile && checkAndGetShortCircuitArgument(arguments[0].column))
+        {
+            profile->argument_profiles.emplace_back(std::make_pair(0, FunctionExecuteProfile()));
+            executeColumnIfNeeded(arguments[0], false, &(profile->argument_profiles.back().second));
+        }
+        else
+            executeColumnIfNeeded(arguments[0]);
 
         /// Let's denote x_i' = maskedExecute(x_i, mask).
         /// multiIf(x_0, y_0, x_1, y_1, x_2, y_2, ..., x_{n-1}, y_{n-1}, y_n)
@@ -500,7 +535,14 @@ private:
             {
                 copyMask(mask, condition_mask);
                 condition_mask_info = extractMask(condition_mask, cond_column);
-                maskedExecute(arguments[i], condition_mask, condition_mask_info);
+                if constexpr (with_profile)
+                {
+                    profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                    auto & arg_profile = profile->argument_profiles.back().second;
+                    maskedExecute(arguments[i], condition_mask, condition_mask_info, &arg_profile);
+                }
+                else
+                    maskedExecute(arguments[i], condition_mask, condition_mask_info, nullptr);
             }
 
             /// Check if the condition is always true and we don't need to execute the rest arguments.
@@ -519,14 +561,41 @@ private:
             if (!mask_info.has_ones)
                 break;
 
-            maskedExecute(arguments[i], mask, mask_info);
+            if constexpr (with_profile)
+            {
+                profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                auto & arg_profile = profile->argument_profiles.back().second;
+                maskedExecute(arguments[i], mask, mask_info, &arg_profile);
+
+            }
+            else
+                maskedExecute(arguments[i], mask, mask_info, nullptr);
             ++i;
         }
 
         /// We could skip some arguments execution, but we cannot leave them as ColumnFunction.
         /// So, create an empty column with the execution result type.
         for (; i <= last_short_circuit_argument_index; ++i)
-            executeColumnIfNeeded(arguments[i], true);
+        {
+            if (with_profile && checkAndGetShortCircuitArgument(arguments[i].column))
+            {
+                profile->argument_profiles.emplace_back(std::make_pair(i, FunctionExecuteProfile()));
+                executeColumnIfNeeded(arguments[i], true, &(profile->argument_profiles.back().second));
+            }
+            else
+                executeColumnIfNeeded(arguments[i], true);
+        }
+
+        if constexpr (with_profile)
+        {
+            size_t side_elapsed = 0;
+            for (const auto & [_, arg_profile] : profile->argument_profiles)
+            {
+                side_elapsed += arg_profile.short_circuit_side_elapsed;
+            }
+            profile->short_circuit_side_elapsed = side_elapsed;
+        }
+
     }
 
     const bool allow_execute_multiif_columnar;

--- a/src/Functions/multiIf.cpp
+++ b/src/Functions/multiIf.cpp
@@ -169,10 +169,6 @@ public:
 
     ColumnPtr executeImplWithProfile(const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, FunctionExecutionProfile * profile) const override
     {
-        /// Fast path when data is empty
-        if (input_rows_count == 0)
-            return result_type->createColumn();
-
         Stopwatch watch;
         ColumnsWithTypeAndName arguments = args;
         if (profile)

--- a/src/Functions/multiIf.cpp
+++ b/src/Functions/multiIf.cpp
@@ -24,8 +24,6 @@
 #include <DataTypes/DataTypeVariant.h>
 #include <DataTypes/getLeastSupertype.h>
 
-#include <Common/logger_useful.h>
-
 
 namespace DB
 {

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -781,7 +781,13 @@ void ExpressionActions::executeAction(
     }
 }
 
+
 void ExpressionActions::execute(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input)
+{
+    executeImpl(block, num_rows, dry_run, allow_duplicates_in_input);
+}
+
+void ExpressionActions::executeImpl(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input)
 {
     ExecutionContext execution_context
     {
@@ -1041,9 +1047,9 @@ AdaptiveExpressionActions::AdaptiveExpressionActions(ActionsDAG actions_dag_, co
     : ExpressionActions(std::move(actions_dag_), settings_, project_inputs_)
 {}
 
-void AdaptiveExpressionActions::execute(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input)
+void AdaptiveExpressionActions::executeImpl(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input)
 {
-    ExpressionActions::execute(block, num_rows, dry_run, allow_duplicates_in_input);
+    ExpressionActions::executeImpl(block, num_rows, dry_run, allow_duplicates_in_input);
     refreshLazyExecutedActions(num_rows);
 }
 

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -1132,6 +1132,7 @@ void AdaptiveExpressionActions::executeFunctionAction(
 
 void AdaptiveExpressionActions::accumulateProfile(ExpressionActions::Action & action, const FunctionExecutionProfile & profile)
 {
+    // LOG_TRACE(getLogger("AdaptiveExpressionActions"), "Accumulate profile  for action:{}", action.toString());
     ExpressionActions::Action * function_action = &action;
     // We need to eliminate aliases and access the true function node, taking into account the potential presence of nested aliases.
     while (function_action->node->type == ActionsDAG::ActionType::ALIAS)
@@ -1141,7 +1142,7 @@ void AdaptiveExpressionActions::accumulateProfile(ExpressionActions::Action & ac
 
     if (function_action->node->type != ActionsDAG::ActionType::FUNCTION)
     {
-        throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid node type.\n{}\n{}", action.toString(), actions_dag.dumpDAG());
+        throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Function node is expected, but got \n{}. The actions DAG is\n{}", action.toString(), actions_dag.dumpDAG());
     }
 
     auto accumulate_profile = [](FunctionExecutionProfile & a, const FunctionExecutionProfile & b)
@@ -1160,13 +1161,14 @@ void AdaptiveExpressionActions::accumulateProfile(ExpressionActions::Action & ac
         const auto & func_arg_pos = arg_profile.first;
         if (func_arg_pos >= function_action->arguments.size())
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid arg pos: {}. arg size: {}. action:{}\n{}", func_arg_pos, function_action->arguments.size(), function_action->toString(), actions_dag.dumpDAG());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid argument pos: {}. action argument size: {}. action:{}\naction DAG:{}", func_arg_pos, function_action->arguments.size(), function_action->toString(), actions_dag.dumpDAG());
         }
         if (function_action->arguments[func_arg_pos].actions_pos >= actions.size())
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid action pos: {}. arg size: {}", function_action->arguments[func_arg_pos].actions_pos, actions.size());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid action pos: {}. actions size: {}", function_action->arguments[func_arg_pos].actions_pos, actions.size());
         }
         auto & arg_action = actions[function_action->arguments[func_arg_pos].actions_pos];
+        // LOG_TRACE(getLogger("AdaptiveExpressionActions"), "visit arg. pos: {}, action: {}", func_arg_pos, arg_action.toString());
         accumulateProfile(arg_action, arg_profile.second);
     }
 }

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -1147,8 +1147,14 @@ void AdaptiveExpressionActions::onNewFunctionBatchProfile(ExpressionActions::Act
     for (const auto & arg_profile : profile.argument_profiles)
     {
         const auto & func_arg_pos = arg_profile.first;
-        chassert(func_arg_pos < action.arguments.size());
-        chassert(action.arguments[func_arg_pos].actions_pos < actions.size());
+        if (func_arg_pos >= action.arguments.size())
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid func_arg_pos: {} {}", func_arg_pos, action.arguments.size());
+        }
+        if (action.arguments[func_arg_pos].actions_pos >= actions.size())
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid action pos: {} {}", action.arguments[func_arg_pos].actions_pos, actions.size());
+        }
         auto & arg_action = actions[action.arguments[func_arg_pos].actions_pos];
         onNewFunctionBatchProfile(arg_action, arg_profile.second);
     }

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -1161,14 +1161,14 @@ void AdaptiveExpressionActions::accumulateProfile(ExpressionActions::Action & ac
         const auto & func_arg_pos = arg_profile.first;
         if (func_arg_pos >= function_action->arguments.size())
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid argument pos: {}. action argument size: {}. action:{}\naction DAG:{}", func_arg_pos, function_action->arguments.size(), function_action->toString(), actions_dag.dumpDAG());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Argument index({}) out of bounds. action argument size: {}. action:{}\naction DAG:{}", func_arg_pos, function_action->arguments.size(), function_action->toString(), actions_dag.dumpDAG());
         }
-        if (function_action->arguments[func_arg_pos].actions_pos >= actions.size())
+        size_t actions_pos = function_action->arguments[func_arg_pos].actions_pos;
+        if (actions_pos >= actions.size())
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid action pos: {}. actions size: {}", function_action->arguments[func_arg_pos].actions_pos, actions.size());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Actions index({}) out of bounds. actions size: {}", actions_pos, actions.size());
         }
-        auto & arg_action = actions[function_action->arguments[func_arg_pos].actions_pos];
-        // LOG_TRACE(getLogger("AdaptiveExpressionActions"), "visit arg. pos: {}, action: {}", func_arg_pos, arg_action.toString());
+        auto & arg_action = actions[actions_pos];
         accumulateProfile(arg_action, arg_profile.second);
     }
 }

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -346,7 +346,7 @@ static bool isNoExceptNode(const ActionsDAG::NodeRawConstPtrs & nodes)
 {
     for (const auto * node : nodes)
     {
-        if (node->type == ActionsDAG::ActionType::FUNCTION && !node->function_base->isNoExcept())
+        if (node->type == ActionsDAG::ActionType::FUNCTION)
         {
             if (!node->function_base->isNoExcept())
             {
@@ -1120,8 +1120,7 @@ void AdaptiveExpressionActions::executeFunctionAction(
         if (res_column.column->getDataType() != res_column.type->getColumnType())
         {
             throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Unexpected return type from {}. Expected {}. Got {}. Action:\n{},\ninput block structure:{}",
+                ErrorCodes::LOGICAL_ERROR, "Unexpected return type from {}. Expected {}. Got {}. Action:\n{},\ninput block structure:{}",
                 action.node->function->getName(),
                 res_column.type->getName(),
                 res_column.column->getName(),
@@ -1147,6 +1146,14 @@ void AdaptiveExpressionActions::accumulateProfile(ExpressionActions::Action & ac
     for (const auto & arg_profile : profile.argument_profiles)
     {
         const auto & func_arg_pos = arg_profile.first;
+        if (func_arg_pos >= action.arguments.size())
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid arg pos: {}. arg size: {}", func_arg_pos, action.arguments.size());
+        }
+        if (action.arguments[func_arg_pos].actions_pos >= actions.size())
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "xxx invalid action pos: {}. arg size: {}", action.arguments[func_arg_pos].actions_pos, actions.size());
+        }
         auto & arg_action = actions[action.arguments[func_arg_pos].actions_pos];
         accumulateProfile(arg_action, arg_profile.second);
     }

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -1147,6 +1147,8 @@ void AdaptiveExpressionActions::onNewFunctionBatchProfile(ExpressionActions::Act
     for (const auto & arg_profile : profile.argument_profiles)
     {
         const auto & func_arg_pos = arg_profile.first;
+        chassert(func_arg_pos < action.arguments.size());
+        chassert(action.arguments[func_arg_pos].actions_pos < actions.size());
         auto & arg_action = actions[action.arguments[func_arg_pos].actions_pos];
         onNewFunctionBatchProfile(arg_action, arg_profile.second);
     }

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -64,7 +64,7 @@ public:
         /// If this action's result is used by another action, called parent, then the position of the parent action in
         /// `ExpressionActions::actions`.
         std::vector<size_t> parents_actions_pos;
-    
+
         /// Keep track of the execution profile of the current round.
         FunctionExecuteProfile current_round_profile;
         /// Keep track of the whole execution profile.

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -167,9 +167,9 @@ protected:
 
     void linearizeActions(const std::unordered_set<const Node *> & lazy_executed_nodes);
 
-    void executeAction(ExpressionActions::Action & action, ExecutionContext & execute_context, bool dry_run, bool allow_duplicates_in_input);
+    void executeAction(ExpressionActions::Action & action, ExecutionContext & execution_context, bool dry_run, bool allow_duplicates_in_input);
 
-    virtual void executeFunctionAction(ExpressionActions::Action & action, ExecutionContext & execute_context, bool dry_run);
+    virtual void executeFunctionAction(ExpressionActions::Action & action, ExecutionContext & execution_context, bool dry_run);
 
     virtual void executeImpl(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input);
 
@@ -187,7 +187,7 @@ protected:
 private:
     size_t current_round_input_rows = 0;
 
-    void executeFunctionAction(ExpressionActions::Action & action, ExecutionContext & execute_context, bool dry_run) override;
+    void executeFunctionAction(ExpressionActions::Action & action, ExecutionContext & execution_context, bool dry_run) override;
     void onNewFunctionBatchProfile(ExpressionActions::Action & action, const FunctionExecuteProfile & profile);
     void refreshLazyExecutedActions(size_t current_batch_rows);
     void appendProfileToActionsParent();

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -137,7 +137,7 @@ public:
     /// preliminary query filtering (filterBlockWithExpression()), because they just
     /// pass available virtual columns, which cannot be moved in case they are
     /// used multiple times.
-    virtual void execute(Block & block, size_t & num_rows, bool dry_run = false, bool allow_duplicates_in_input = false);
+    void execute(Block & block, size_t & num_rows, bool dry_run = false, bool allow_duplicates_in_input = false);
     /// The same, but without `num_rows`. If result block is empty, adds `_dummy` column to keep block size.
     void execute(Block & block, bool dry_run = false, bool allow_duplicates_in_input = false);
 
@@ -171,6 +171,8 @@ protected:
 
     virtual void executeFunctionAction(ExpressionActions::Action & action, ExecutionContext & execute_context, bool dry_run);
 
+    virtual void executeImpl(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input);
+
 
 };
 
@@ -180,7 +182,8 @@ class AdaptiveExpressionActions : public ExpressionActions
 public:
     explicit AdaptiveExpressionActions(ActionsDAG actions_dag_, const ExpressionActionsSettings & settings_ = {}, bool project_inputs_ = false);
     ~AdaptiveExpressionActions() override = default;
-    void execute(Block & block, size_t & num_rows, bool dry_run = false, bool allow_duplicates_in_input = false) override;
+protected:
+    void executeImpl(Block & block, size_t & num_rows, bool dry_run, bool allow_duplicates_in_input) override;
 private:
     size_t current_round_input_rows = 0;
 

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -54,8 +54,8 @@ public:
         /// won't be executed and will be stored with it's arguments in ColumnFunction with isShortCircuitArgument() = true.
         bool could_lazy_executed;
         /// It's not free to lazy execute one node with short circuit. When the cost of filting out necessary rows and
-        /// expanding back to a full column is larger then fully execution of the column, we don't excute it lazily. 
-        bool worth_short_circuit_executed;
+        /// expanding back to a full column is larger then fully execution of the column, we don't excute it lazily.
+        bool worth_lazy_executed;
         bool is_short_circuit_function;
         std::vector<size_t> parents_actions_pos;
         FunctionExecuteProfile current_round_profile;

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -55,7 +55,7 @@ public:
         bool could_lazy_executed;
         /// It's not free to lazy execute one node with short circuit. When the cost of filting out necessary rows and
         /// expanding back to a full column is larger then fully execution of the column, we don't excute it lazily. 
-        bool worth_lazy_executed;
+        bool worth_short_circuit_executed;
         bool is_short_circuit_function;
         std::vector<size_t> parents_actions_pos;
         FunctionExecuteProfile current_round_profile;

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -89,6 +89,7 @@ namespace Setting
     extern const SettingsBool allow_experimental_query_deduplication;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool empty_result_for_aggregation_by_empty_set;
+    extern const SettingsBool enable_adaptive_short_circuit_lazy_execution;
     extern const SettingsBool enable_unaligned_array_join;
     extern const SettingsBool join_use_nulls;
     extern const SettingsBool query_plan_use_new_logical_join_step;
@@ -649,8 +650,16 @@ UInt64 mainQueryNodeBlockSizeByLimit(const SelectQueryInfo & select_query_info)
     return 0;
 }
 
+bool enableAdaptiveShortcircuitExection(const PlannerContextPtr & planner_context)
+{
+    auto context = planner_context->getQueryContext();
+    return context->getSettingsRef()[Setting::enable_adaptive_short_circuit_lazy_execution];
+}
+
 std::unique_ptr<ExpressionStep> createComputeAliasColumnsStep(
-    std::unordered_map<std::string, ActionsDAG> & alias_column_expressions, const Header & current_header)
+    std::unordered_map<std::string, ActionsDAG> & alias_column_expressions,
+    const Header & current_header,
+    PlannerContextPtr & planner_context)
 {
     ActionsDAG merged_alias_columns_actions_dag(current_header.getColumnsWithTypeAndName());
     ActionsDAG::NodeRawConstPtrs action_dag_outputs = merged_alias_columns_actions_dag.getInputs();
@@ -666,7 +675,9 @@ std::unique_ptr<ExpressionStep> createComputeAliasColumnsStep(
         merged_alias_columns_actions_dag.addOrReplaceInOutputs(*output_node);
     merged_alias_columns_actions_dag.removeUnusedActions(false);
 
-    auto alias_column_step = std::make_unique<ExpressionStep>(current_header, std::move(merged_alias_columns_actions_dag));
+    auto alias_column_step = std::make_unique<ExpressionStep>(current_header,
+        std::move(merged_alias_columns_actions_dag),
+        enableAdaptiveShortcircuitExection(planner_context));
     alias_column_step->setStepDescription("Compute alias columns");
     return alias_column_step;
 }
@@ -1111,7 +1122,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 auto & alias_column_expressions = table_expression_data.getAliasColumnExpressions();
                 if (!alias_column_expressions.empty() && query_plan.isInitialized() && from_stage == QueryProcessingStage::FetchColumns)
                 {
-                    auto alias_column_step = createComputeAliasColumnsStep(alias_column_expressions, query_plan.getCurrentHeader());
+                    auto alias_column_step = createComputeAliasColumnsStep(alias_column_expressions, query_plan.getCurrentHeader(), planner_context);
                     query_plan.addStep(std::move(alias_column_step));
                 }
 
@@ -1123,7 +1134,8 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                         auto filter_step = std::make_unique<FilterStep>(query_plan.getCurrentHeader(),
                             std::move(filter_info.actions),
                             filter_info.column_name,
-                            filter_info.do_remove_column);
+                            filter_info.do_remove_column,
+                            enableAdaptiveShortcircuitExection(planner_context));
                         filter_step->setStepDescription(description);
                         query_plan.addStep(std::move(filter_step));
                     }
@@ -1200,7 +1212,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
         auto & alias_column_expressions = table_expression_data.getAliasColumnExpressions();
         if (!alias_column_expressions.empty() && query_plan.isInitialized() && from_stage == QueryProcessingStage::FetchColumns)
         {
-            auto alias_column_step = createComputeAliasColumnsStep(alias_column_expressions, query_plan.getCurrentHeader());
+            auto alias_column_step = createComputeAliasColumnsStep(alias_column_expressions, query_plan.getCurrentHeader(), planner_context);
             query_plan.addStep(std::move(alias_column_step));
         }
     }
@@ -1226,7 +1238,9 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 
         rename_actions_dag.getOutputs() = std::move(updated_actions_dag_outputs);
 
-        auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag));
+        auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(),
+            std::move(rename_actions_dag),
+            enableAdaptiveShortcircuitExection(planner_context));
         rename_step->setStepDescription("Change column names to column identifiers");
         query_plan.addStep(std::move(rename_step));
     }
@@ -1249,7 +1263,9 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 expected_header.getColumnsWithTypeAndName(),
                 ActionsDAG::MatchColumnsMode::Position,
                 true /*ignore_constant_values*/);
-            auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag));
+            auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(),
+                std::move(rename_actions_dag),
+                enableAdaptiveShortcircuitExection(planner_context));
             std::string step_description = table_expression_data.isRemote() ? "Change remote column names to local column names" : "Change column names";
             rename_step->setStepDescription(std::move(step_description));
             query_plan.addStep(std::move(rename_step));
@@ -1282,7 +1298,10 @@ void joinCastPlanColumnsToNullable(QueryPlan & plan_to_add_cast, PlannerContextP
     }
 
     cast_actions_dag.appendInputsForUnusedColumns(plan_to_add_cast.getCurrentHeader());
-    auto cast_join_columns_step = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(), std::move(cast_actions_dag));
+    auto cast_join_columns_step = std::make_unique<ExpressionStep>(
+        plan_to_add_cast.getCurrentHeader(),
+        std::move(cast_actions_dag),
+        enableAdaptiveShortcircuitExection(planner_context));
     cast_join_columns_step->setStepDescription("Cast JOIN columns to Nullable");
     plan_to_add_cast.addStep(std::move(cast_join_columns_step));
 }
@@ -1560,7 +1579,8 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
         auto filter_step = std::make_unique<FilterStep>(result_plan.getCurrentHeader(),
             std::move(*join_clauses_and_actions.residual_join_expressions_actions),
             outputs[0]->result_name,
-            /* remove_column = */ false); /// Unused columns will be removed by next step
+            /* remove_column = */ false,  /// Unused columns will be removed by next step
+            enableAdaptiveShortcircuitExection(planner_context));
         filter_step->setStepDescription("Residual JOIN filter");
         result_plan.addStep(std::move(filter_step));
 
@@ -1573,7 +1593,9 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
         auto drop_unused_columns_after_join_actions_dag = createStepToDropColumns(header_after_join, outer_scope_columns, planner_context);
         if (drop_unused_columns_after_join_actions_dag)
         {
-            auto drop_unused_columns_after_join_transform_step = std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(), std::move(*drop_unused_columns_after_join_actions_dag));
+            auto drop_unused_columns_after_join_transform_step = std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(),
+                std::move(*drop_unused_columns_after_join_actions_dag),
+                enableAdaptiveShortcircuitExection(planner_context));
             drop_unused_columns_after_join_transform_step->setStepDescription("Drop unused columns after JOIN");
             result_plan.addStep(std::move(drop_unused_columns_after_join_transform_step));
         }
@@ -1709,16 +1731,18 @@ JoinTreeQueryPlan buildQueryPlanForJoinNodeLegacy(
             && (right_pre_filters.empty() || FilterStep::canUseType(right_pre_filters[0]->result_type))
             && (left_pre_filters.empty() || FilterStep::canUseType(left_pre_filters[0]->result_type));
 
-        auto add_pre_filter = [can_move_out_residuals](ActionsDAG & join_expressions_actions, QueryPlan & plan, UsefulSets & useful_sets, const auto & pre_filters)
+        auto add_pre_filter = [can_move_out_residuals, planner_context](ActionsDAG & join_expressions_actions, QueryPlan & plan, UsefulSets & useful_sets, const auto & pre_filters)
         {
             join_expressions_actions.appendInputsForUnusedColumns(plan.getCurrentHeader());
             appendSetsFromActionsDAG(join_expressions_actions, useful_sets);
 
             QueryPlanStepPtr join_expressions_actions_step;
             if (can_move_out_residuals && !pre_filters.empty())
-                join_expressions_actions_step = std::make_unique<FilterStep>(plan.getCurrentHeader(), std::move(join_expressions_actions), pre_filters[0]->result_name, false);
+                join_expressions_actions_step = std::make_unique<FilterStep>(plan.getCurrentHeader(), std::move(join_expressions_actions), pre_filters[0]->result_name, false, enableAdaptiveShortcircuitExection(planner_context));
             else
-                join_expressions_actions_step = std::make_unique<ExpressionStep>(plan.getCurrentHeader(), std::move(join_expressions_actions));
+                join_expressions_actions_step = std::make_unique<ExpressionStep>(plan.getCurrentHeader(),
+                    std::move(join_expressions_actions),
+                    enableAdaptiveShortcircuitExection(planner_context));
 
             join_expressions_actions_step->setStepDescription("JOIN actions");
             plan.addStep(std::move(join_expressions_actions_step));
@@ -1775,7 +1799,9 @@ JoinTreeQueryPlan buildQueryPlanForJoinNodeLegacy(
 
         cast_actions_dag.appendInputsForUnusedColumns(plan_to_add_cast.getCurrentHeader());
         auto cast_join_columns_step
-            = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(), std::move(cast_actions_dag));
+            = std::make_unique<ExpressionStep>(plan_to_add_cast.getCurrentHeader(),
+                std::move(cast_actions_dag),
+                enableAdaptiveShortcircuitExection(planner_context));
         cast_join_columns_step->setStepDescription("Cast JOIN USING columns");
         plan_to_add_cast.addStep(std::move(cast_join_columns_step));
     };
@@ -2108,7 +2134,9 @@ JoinTreeQueryPlan buildQueryPlanForArrayJoinNode(const QueryTreeNodePtr & array_
 
     array_join_action_dag.appendInputsForUnusedColumns(plan.getCurrentHeader());
 
-    auto array_join_actions = std::make_unique<ExpressionStep>(plan.getCurrentHeader(), std::move(array_join_action_dag));
+    auto array_join_actions = std::make_unique<ExpressionStep>(plan.getCurrentHeader(),
+            std::move(array_join_action_dag),
+            enableAdaptiveShortcircuitExection(planner_context));
     array_join_actions->setStepDescription("ARRAY JOIN actions");
     appendSetsFromActionsDAG(array_join_actions->getExpression(), join_tree_query_plan.useful_sets);
     plan.addStep(std::move(array_join_actions));
@@ -2138,7 +2166,8 @@ JoinTreeQueryPlan buildQueryPlanForArrayJoinNode(const QueryTreeNodePtr & array_
     drop_unused_columns_before_array_join_actions_dag_outputs = std::move(drop_unused_columns_before_array_join_actions_dag_updated_outputs);
 
     auto drop_unused_columns_before_array_join_transform_step = std::make_unique<ExpressionStep>(plan.getCurrentHeader(),
-        std::move(drop_unused_columns_before_array_join_actions_dag));
+        std::move(drop_unused_columns_before_array_join_actions_dag),
+        enableAdaptiveShortcircuitExection(planner_context));
     drop_unused_columns_before_array_join_transform_step->setStepDescription("DROP unused columns before ARRAY JOIN");
     plan.addStep(std::move(drop_unused_columns_before_array_join_transform_step));
 

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -43,21 +43,12 @@ ExpressionStep::ExpressionStep(const Header & input_header_, ActionsDAG actions_
 
 void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
 {
-#if 0
-    auto expression = std::make_shared<ExpressionActions>(std::move(actions_dag), settings.getActionsSettings());
-
-    pipeline.addSimpleTransform([&](const Block & header)
-    {
-        return std::make_shared<ExpressionTransform>(header, expression);
-    });
-#else
 
     pipeline.addSimpleTransform([&](const Block & header)
     {
         auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
         return std::make_shared<ExpressionTransform>(header, expression);
     });
-#endif
 
     if (!blocksHaveEqualStructure(pipeline.getHeader(), *output_header))
     {
@@ -65,21 +56,12 @@ void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const Bu
                 pipeline.getHeader().getColumnsWithTypeAndName(),
                 output_header->getColumnsWithTypeAndName(),
                 ActionsDAG::MatchColumnsMode::Name);
-#if 0
         auto convert_actions = std::make_shared<ExpressionActions>(std::move(convert_actions_dag), settings.getActionsSettings());
 
         pipeline.addSimpleTransform([&](const Block & header)
         {
             return std::make_shared<ExpressionTransform>(header, convert_actions);
         });
-#else
-        pipeline.addSimpleTransform([&](const Block & header)
-        {
-            auto convert_actions = std::make_shared<AdaptiveExpressionActions>(convert_actions_dag.clone(), settings.getActionsSettings());
-            return std::make_shared<ExpressionTransform>(header, convert_actions);
-        });
-
-#endif
     }
 }
 

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -43,12 +43,21 @@ ExpressionStep::ExpressionStep(const Header & input_header_, ActionsDAG actions_
 
 void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
 {
+#if 0
     auto expression = std::make_shared<ExpressionActions>(std::move(actions_dag), settings.getActionsSettings());
 
     pipeline.addSimpleTransform([&](const Block & header)
     {
         return std::make_shared<ExpressionTransform>(header, expression);
     });
+#else
+
+    pipeline.addSimpleTransform([&](const Block & header)
+    {
+        auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
+        return std::make_shared<ExpressionTransform>(header, expression);
+    });
+#endif
 
     if (!blocksHaveEqualStructure(pipeline.getHeader(), *output_header))
     {
@@ -56,12 +65,21 @@ void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const Bu
                 pipeline.getHeader().getColumnsWithTypeAndName(),
                 output_header->getColumnsWithTypeAndName(),
                 ActionsDAG::MatchColumnsMode::Name);
+#if 0
         auto convert_actions = std::make_shared<ExpressionActions>(std::move(convert_actions_dag), settings.getActionsSettings());
 
         pipeline.addSimpleTransform([&](const Block & header)
         {
             return std::make_shared<ExpressionTransform>(header, convert_actions);
         });
+#else
+        pipeline.addSimpleTransform([&](const Block & header)
+        {
+            auto convert_actions = std::make_shared<AdaptiveExpressionActions>(convert_actions_dag.clone(), settings.getActionsSettings());
+            return std::make_shared<ExpressionTransform>(header, convert_actions);
+        });
+
+#endif
     }
 }
 

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -32,23 +32,40 @@ static ITransformingStep::Traits getTraits(const ActionsDAG & actions)
     };
 }
 
-ExpressionStep::ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_)
+ExpressionStep::ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_, bool enable_adaptive_short_circuit_)
     : ITransformingStep(
         input_header_,
         ExpressionTransform::transformHeader(input_header_, actions_dag_),
         getTraits(actions_dag_))
     , actions_dag(std::move(actions_dag_))
+    , enable_adaptive_short_circuit(enable_adaptive_short_circuit_)
 {
 }
 
+ExpressionStep::ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_)
+    : ExpressionStep(input_header_, std::move(actions_dag_), false)
+{
+}
+
+
 void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
 {
-
-    pipeline.addSimpleTransform([&](const Block & header)
+    if (enable_adaptive_short_circuit)
     {
-        auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
-        return std::make_shared<ExpressionTransform>(header, expression);
-    });
+        pipeline.addSimpleTransform([&](const Block & header)
+        {
+            auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
+            return std::make_shared<ExpressionTransform>(header, expression);
+        });
+    }
+    else
+    {
+        auto expression = std::make_shared<ExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
+        pipeline.addSimpleTransform([&](const Block & header)
+        {
+            return std::make_shared<ExpressionTransform>(header, expression);
+        });
+    }
 
     if (!blocksHaveEqualStructure(pipeline.getHeader(), *output_header))
     {
@@ -85,16 +102,23 @@ void ExpressionStep::updateOutputHeader()
 
 void ExpressionStep::serialize(Serialization & ctx) const
 {
+    UInt8 flags = 0;
+    if (enable_adaptive_short_circuit)
+        flags |= 1;
+    writeIntBinary(flags, ctx.out);
     actions_dag.serialize(ctx.out, ctx.registry);
 }
 
 std::unique_ptr<IQueryPlanStep> ExpressionStep::deserialize(Deserialization & ctx)
 {
+    UInt8 flags = 0;
+    readIntBinary(flags, ctx.in);
+    bool enable_adaptive_short_circuit_ = bool(flags & 1);
     ActionsDAG actions_dag = ActionsDAG::deserialize(ctx.in, ctx.registry, ctx.context);
     if (ctx.input_headers.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_DATA, "ExpressionStep must have one input stream");
 
-    return std::make_unique<ExpressionStep>(ctx.input_headers.front(), std::move(actions_dag));
+    return std::make_unique<ExpressionStep>(ctx.input_headers.front(), std::move(actions_dag), enable_adaptive_short_circuit_);
 }
 
 void registerExpressionStep(QueryPlanStepRegistry & registry)

--- a/src/Processors/QueryPlan/ExpressionStep.h
+++ b/src/Processors/QueryPlan/ExpressionStep.h
@@ -13,6 +13,7 @@ class ExpressionStep : public ITransformingStep
 {
 public:
     explicit ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_);
+    explicit ExpressionStep(const Header & input_header_, ActionsDAG actions_dag_, bool enable_adaptive_short_circuit_);
     String getName() const override { return "Expression"; }
 
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
@@ -21,6 +22,7 @@ public:
 
     ActionsDAG & getExpression() { return actions_dag; }
     const ActionsDAG & getExpression() const { return actions_dag; }
+    bool enableAdaptiveShortCircuit() const { return enable_adaptive_short_circuit; }
 
     void describeActions(JSONBuilder::JSONMap & map) const override;
 
@@ -33,6 +35,7 @@ private:
     void updateOutputHeader() override;
 
     ActionsDAG actions_dag;
+    bool enable_adaptive_short_circuit = false;
 };
 
 }

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -160,18 +160,18 @@ void FilterStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQ
 
     for (auto & and_atom : and_atoms)
     {
-        auto expression = std::make_shared<ExpressionActions>(std::move(and_atom.dag), settings.getActionsSettings());
         pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
         {
+            auto expression = std::make_shared<AdaptiveExpressionActions>(and_atom.dag.clone(), settings.getActionsSettings());
             bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
             return std::make_shared<FilterTransform>(header, expression, and_atom.name, true, on_totals);
         });
     }
 
-    auto expression = std::make_shared<ExpressionActions>(std::move(actions_dag), settings.getActionsSettings());
 
     pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
     {
+        auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
         bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
         if (condition_hash)
             return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column,

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -129,7 +129,8 @@ FilterStep::FilterStep(
     const Header & input_header_,
     ActionsDAG actions_dag_,
     String filter_column_name_,
-    bool remove_filter_column_)
+    bool remove_filter_column_,
+    bool enable_adaptive_short_circuit_)
     : ITransformingStep(
         input_header_,
         FilterTransform::transformHeader(
@@ -141,12 +142,22 @@ FilterStep::FilterStep(
     , actions_dag(std::move(actions_dag_))
     , filter_column_name(std::move(filter_column_name_))
     , remove_filter_column(remove_filter_column_)
+    , enable_adaptive_short_circuit(enable_adaptive_short_circuit_)
 {
     actions_dag.removeAliasesForFilter(filter_column_name);
     /// Removing aliases may result in unneeded ALIAS node in DAG.
     /// This should not be an issue by itself,
     /// but it might trigger an issue with duplicated names in Block after plan optimizations.
     actions_dag.removeUnusedActions(false, false);
+}
+
+FilterStep::FilterStep(
+    const Header & input_header_,
+    ActionsDAG actions_dag_,
+    String filter_column_name_,
+    bool remove_filter_column_)
+    : FilterStep(input_header_, std::move(actions_dag_), std::move(filter_column_name_), remove_filter_column_, false)
+{
 }
 
 void FilterStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
@@ -160,25 +171,53 @@ void FilterStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQ
 
     for (auto & and_atom : and_atoms)
     {
-        pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
+        if (enable_adaptive_short_circuit)
         {
-            auto expression = std::make_shared<AdaptiveExpressionActions>(and_atom.dag.clone(), settings.getActionsSettings());
-            bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
-            return std::make_shared<FilterTransform>(header, expression, and_atom.name, true, on_totals);
-        });
+            pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
+            {
+                auto expression = std::make_shared<AdaptiveExpressionActions>(and_atom.dag.clone(), settings.getActionsSettings());
+                bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
+                return std::make_shared<FilterTransform>(header, expression, and_atom.name, true, on_totals);
+            });
+        }
+        else
+        {
+            auto expression = std::make_shared<ExpressionActions>(and_atom.dag.clone(), settings.getActionsSettings());
+            pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
+            {
+                bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
+                return std::make_shared<FilterTransform>(header, expression, and_atom.name, true, on_totals);
+            });
+        }
     }
 
 
-    pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
+    if (enable_adaptive_short_circuit)
     {
-        auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
-        bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
-        if (condition_hash)
-            return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column,
-                on_totals, nullptr, condition_hash);
+        pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
+        {
+            auto expression = std::make_shared<AdaptiveExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
+            bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
+            if (condition_hash)
+                return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column,
+                    on_totals, nullptr, condition_hash);
 
-        return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals);
-    });
+            return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals);
+        });
+    }
+    else
+    {
+        auto expression = std::make_shared<ExpressionActions>(actions_dag.clone(), settings.getActionsSettings());
+        pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
+        {
+            bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
+            if (condition_hash)
+                return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column,
+                    on_totals, nullptr, condition_hash);
+
+            return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals);
+        });
+    }
 
     if (!blocksHaveEqualStructure(pipeline.getHeader(), *output_header))
     {
@@ -268,6 +307,8 @@ void FilterStep::serialize(Serialization & ctx) const
     UInt8 flags = 0;
     if (remove_filter_column)
         flags |= 1;
+    if (enable_adaptive_short_circuit)
+        flags |= 2;
     writeIntBinary(flags, ctx.out);
 
     writeStringBinary(filter_column_name, ctx.out);
@@ -284,13 +325,14 @@ std::unique_ptr<IQueryPlanStep> FilterStep::deserialize(Deserialization & ctx)
     readIntBinary(flags, ctx.in);
 
     bool remove_filter_column = bool(flags & 1);
+    bool enable_adaptive_short_circuit_ = bool(flags & 2);
 
     String filter_column_name;
     readStringBinary(filter_column_name, ctx.in);
 
     ActionsDAG actions_dag = ActionsDAG::deserialize(ctx.in, ctx.registry, ctx.context);
 
-    return std::make_unique<FilterStep>(ctx.input_headers.front(), std::move(actions_dag), std::move(filter_column_name), remove_filter_column);
+    return std::make_unique<FilterStep>(ctx.input_headers.front(), std::move(actions_dag), std::move(filter_column_name), remove_filter_column, enable_adaptive_short_circuit_);
 }
 
 void registerFilterStep(QueryPlanStepRegistry & registry)

--- a/src/Processors/QueryPlan/FilterStep.h
+++ b/src/Processors/QueryPlan/FilterStep.h
@@ -16,6 +16,13 @@ public:
         String filter_column_name_,
         bool remove_filter_column_);
 
+    FilterStep(
+        const Header & input_header_,
+        ActionsDAG actions_dag_,
+        String filter_column_name_,
+        bool remove_filter_column_,
+        bool enable_adaptive_short_circuit_);
+
     String getName() const override { return "Filter"; }
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
 
@@ -26,6 +33,7 @@ public:
     ActionsDAG & getExpression() { return actions_dag; }
     const String & getFilterColumnName() const { return filter_column_name; }
     bool removesFilterColumn() const { return remove_filter_column; }
+    bool enableAdaptiveShortCircuit() const { return enable_adaptive_short_circuit; }
     void setQueryConditionKey(size_t condition_hash_);
 
     static bool canUseType(const DataTypePtr & type);
@@ -41,6 +49,7 @@ private:
     ActionsDAG actions_dag;
     String filter_column_name;
     bool remove_filter_column;
+    bool enable_adaptive_short_circuit = false;
 
     std::optional<size_t> condition_hash;
 };

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -138,7 +138,7 @@ void calculateHashTableCacheKeys(QueryPlan::Node & root);
 void applyOrder(const QueryPlanOptimizationSettings & optimization_settings, QueryPlan::Node & root);
 
 /// Returns the name of used projection or nullopt if no projection is used.
-std::optional<String> optimizeUseAggregateProjections(QueryPlan::Node & node, QueryPlan::Nodes & nodes, bool allow_implicit_projections);
+std::optional<String> optimizeUseAggregateProjections(QueryPlan::Node & node, QueryPlan::Nodes & nodes, const QueryPlanOptimizationSettings & optimization_settings);
 std::optional<String> optimizeUseNormalProjections(Stack & stack, QueryPlan::Nodes & nodes);
 
 bool addPlansForSets(QueryPlan & plan, QueryPlan::Node & node, QueryPlan::Nodes & nodes);

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -8,6 +8,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_aggregate_partitions_independently;
+    extern const SettingsBool enable_adaptive_short_circuit_lazy_execution;
     extern const SettingsBool force_optimize_projection;
     extern const SettingsBool optimize_aggregation_in_order;
     extern const SettingsBool optimize_distinct_in_order;
@@ -97,6 +98,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     actions_settings = std::move(actions_settings_);
 
     max_threads = from[Setting::max_threads];
+    enable_adaptive_short_circuit_execution = from[Setting::enable_adaptive_short_circuit_lazy_execution];
 }
 
 QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(ContextPtr from)

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -94,6 +94,8 @@ struct QueryPlanOptimizationSettings
     /// If query condition cache is enabled, the query condition cache needs to be updated in the WHERE stage.
     bool use_query_condition_cache = false;
     bool is_explain;
+
+    bool enable_adaptive_short_circuit_execution;
 };
 
 }

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -79,8 +79,9 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     auto & node_with_needed = nodes.emplace_back();
     std::swap(node_with_needed.children, child_node->children);
     child_node->children = {&node_with_needed};
+    bool enable_adaptive_short_circuit_execution = expression_step->enableAdaptiveShortCircuit();
 
-    node_with_needed.step = std::make_unique<ExpressionStep>(getChildOutputHeader(node_with_needed), std::move(needed_for_sorting));
+    node_with_needed.step = std::make_unique<ExpressionStep>(getChildOutputHeader(node_with_needed), std::move(needed_for_sorting), enable_adaptive_short_circuit_execution);
     node_with_needed.step->setStepDescription(child_step->getStepDescription());
     // Sorting (parent_node) -> so far the origin Expression (child_node) -> NeededCalculations (node_with_needed)
 
@@ -90,7 +91,7 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     sorting_step->updateInputHeader(getChildOutputHeader(*child_node));
 
     auto description = parent_step->getStepDescription();
-    parent_step = std::make_unique<DB::ExpressionStep>(child_step->getOutputHeader(), std::move(unneeded_for_sorting));
+    parent_step = std::make_unique<DB::ExpressionStep>(child_step->getOutputHeader(), std::move(unneeded_for_sorting), enable_adaptive_short_circuit_execution);
     parent_step->setStepDescription(description + " [lifted up part]");
     // UneededCalculations (parent_node) -> Sorting (child_node) -> NeededCalculations (node_with_needed)
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -309,12 +309,17 @@ bool convertLogicalJoinToPhysical(QueryPlan::Node & node, QueryPlan::Nodes & nod
     if (post_filter)
     {
         bool remove_filter = !output_header.has(post_filter.getColumnName());
-        result_node.step = std::make_unique<FilterStep>(new_join_node.step->getOutputHeader(), std::move(*join_expression_actions.post_join_actions), post_filter.getColumnName(), remove_filter);
+        result_node.step = std::make_unique<FilterStep>(new_join_node.step->getOutputHeader(),
+            std::move(*join_expression_actions.post_join_actions),
+            post_filter.getColumnName(),
+            remove_filter,
+            optimization_settings.enable_adaptive_short_circuit_execution);
         result_node.children = {&new_join_node};
     }
     else
     {
-        result_node.step = std::make_unique<ExpressionStep>(new_join_node.step->getOutputHeader(), std::move(*join_expression_actions.post_join_actions));
+        result_node.step = std::make_unique<ExpressionStep>(new_join_node.step->getOutputHeader(), std::move(*join_expression_actions.post_join_actions),
+                                optimization_settings.enable_adaptive_short_circuit_execution);
         result_node.children = {&new_join_node};
     }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -71,6 +71,7 @@ void optimizePrewhere(Stack & stack, QueryPlan::Nodes &)
     if (!filter_step)
         return;
 
+    bool enable_adaptive_short_circuit_execution = filter_step->enableAdaptiveShortCircuit();
     const auto & context = source_step_with_filter->getContext();
     const auto & settings = context->getSettingsRef();
 
@@ -191,14 +192,16 @@ void optimizePrewhere(Stack & stack, QueryPlan::Nodes &)
             source_step_with_filter->getOutputHeader(),
             std::move(split_result.second),
             filter_step->getFilterColumnName(),
-            filter_step->removesFilterColumn());
+            filter_step->removesFilterColumn(),
+            enable_adaptive_short_circuit_execution);
     }
     else
     {
         /// Have to keep this expression to change column names to column identifiers
         filter_node->step = std::make_unique<ExpressionStep>(
             source_step_with_filter->getOutputHeader(),
-            std::move(split_result.second));
+            std::move(split_result.second),
+            enable_adaptive_short_circuit_execution);
     }
 }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -193,7 +193,7 @@ void optimizeTreeSecondPass(const QueryPlanOptimizationSettings & optimization_s
                 /// Projection optimization relies on PK optimization
                 if (optimization_settings.optimize_projection)
                 {
-                    auto applied_projection = optimizeUseAggregateProjections(*frame.node, nodes, optimization_settings.optimize_use_implicit_projections);
+                    auto applied_projection = optimizeUseAggregateProjections(*frame.node, nodes, optimization_settings);
                     if (applied_projection)
                         applied_projection_names.insert(*applied_projection);
                 }

--- a/src/Processors/QueryPlan/Optimizations/splitFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/splitFilter.cpp
@@ -47,6 +47,7 @@ size_t trySplitFilter(QueryPlan::Node * node, QueryPlan::Nodes & nodes, const Op
     if (!filter_step)
         return 0;
 
+    bool enable_adaptive_short_circuit_exection = filter_step->enableAdaptiveShortCircuit();
     const auto & expr = filter_step->getExpression();
     const std::string & filter_column_name = filter_step->getFilterColumnName();
 
@@ -101,9 +102,10 @@ size_t trySplitFilter(QueryPlan::Node * node, QueryPlan::Nodes & nodes, const Op
             filter_node.children.at(0)->step->getOutputHeader(),
             std::move(split.first),
             std::move(split_filter_name),
-            remove_filter);
+            remove_filter,
+            enable_adaptive_short_circuit_exection);
 
-    node->step = std::make_unique<ExpressionStep>(filter_node.step->getOutputHeader(), std::move(split.second));
+    node->step = std::make_unique<ExpressionStep>(filter_node.step->getOutputHeader(), std::move(split.second), enable_adaptive_short_circuit_exection);
 
     filter_node.step->setStepDescription("(" + description + ")[split]");
     node->step->setStepDescription(description);

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -22,7 +22,7 @@ void ExpressionTransform::transform(Chunk & chunk)
     size_t num_rows = chunk.getNumRows();
     auto block = getInputPort().getHeader().cloneWithColumns(chunk.detachColumns());
 
-    expression->execute(block, num_rows, false, false);
+    expression->execute(block, num_rows);
 
     chunk.setColumns(block.getColumns(), num_rows);
 }

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -22,7 +22,7 @@ void ExpressionTransform::transform(Chunk & chunk)
     size_t num_rows = chunk.getNumRows();
     auto block = getInputPort().getHeader().cloneWithColumns(chunk.detachColumns());
 
-    expression->execute(block, num_rows);
+    expression->execute(block, num_rows, false, false);
 
     chunk.setColumns(block.getColumns(), num_rows);
 }

--- a/tests/performance/adaptive_disalbe_short_circuit_lazy_node.xml
+++ b/tests/performance/adaptive_disalbe_short_circuit_lazy_node.xml
@@ -1,0 +1,23 @@
+<test>
+    <query>
+        select and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) Format null settings max_threads=8
+    </query>
+    <query>
+        select and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand() , 1000) as b from numbers(10000000)) Format null settings max_threads=8, short_circuit_function_evaluation='force_enable'
+    </query>
+
+    <query>
+        select * from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) where and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) Format null settings max_thread=8, query_plan_merge_filters=false
+    </query>
+    <query>
+        select * from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) where and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) Format null settings max_thread=8, query_plan_merge_filters=false,short_circuit_function_evaluation='force_enable'
+    </query>
+
+    <query>
+        select multiIf(greater(a, 1) and less(a, 1000), a + 2, greater(a, 1000) and less(a, 2000), a * 2 , a) from(select rand() % 5000 as a from numbers(1000000)) Format null settings max_threads=8
+    </query>
+    <query>
+        select multiIf(greater(a, 1) and less(a, 1000), a + 2, greater(a, 1000) and less(a, 2000), a * 2 , a) from(select rand() % 5000 as a from numbers(1000000)) Format null settings short_circuit_function_evaluation='force_enable', max_threads=8
+    </query>
+
+</test>

--- a/tests/performance/adaptive_disalbe_short_circuit_lazy_node.xml
+++ b/tests/performance/adaptive_disalbe_short_circuit_lazy_node.xml
@@ -7,10 +7,10 @@
     </query>
 
     <query>
-        select * from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) where and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) Format null settings max_thread=8, query_plan_merge_filters=false
+        select * from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) where and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) Format null settings max_threads=8, query_plan_merge_filters=false
     </query>
     <query>
-        select * from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) where and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) Format null settings max_thread=8, query_plan_merge_filters=false,short_circuit_function_evaluation='force_enable'
+        select * from (select moduloOrZero(rand(), 1000) as a, moduloOrZero(rand(), 1000) as b from numbers(10000000)) where and(greater(a , 1) ,greater(a + b, 1) , less(a + 2 * b , 4000)) Format null settings max_threads=8, query_plan_merge_filters=false,short_circuit_function_evaluation='force_enable'
     </query>
 
     <query>

--- a/tests/performance/adaptive_short_circuit_execution.xml
+++ b/tests/performance/adaptive_short_circuit_execution.xml
@@ -20,4 +20,11 @@
         select multiIf(greater(a, 1) and less(a, 1000), a + 2, greater(a, 1000) and less(a, 2000), a * 2 , a) from(select rand() % 5000 as a from numbers(1000000)) Format null settings short_circuit_function_evaluation='force_enable', max_threads=8
     </query>
 
+    <query>
+        select and(moduloOrZero(a, 100000) = 1, less(b, '4577890123')) from (select number as a, cast(number as String ) as b from numbers(1000000)) Format null settings short_circuit_function_evaluation='force_enable', max_threads=8
+    </query>
+    <query>
+        select and(moduloOrZero(a, 2) = 1, less(b, '4577890123')) from (select number as a, cast(number as String ) as b from numbers(1000000)) Format null settings short_circuit_function_evaluation='force_enable', max_threads=8
+    </query>
+
 </test>

--- a/tests/queries/0_stateless/03371_adaptive_short_circuit_execution.reference
+++ b/tests/queries/0_stateless/03371_adaptive_short_circuit_execution.reference
@@ -1,0 +1,70 @@
+-- { echoOn }
+SET short_circuit_function_evaluation= 'force_enable';
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+5000
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+1000
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+20000
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c  from numbers(30000)));
+22000
+-- nested short-circuit functions
+select sum(flag) from (select and(a % 2 = 1, or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+7000
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+8000
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, and(c % 5 = 1, a % 3 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+7000
+-- common subexpression
+select sum(flag) from (select and(a % 2 = 2, or(b % 3 = 1, or(a % 2 = 1, c % 5 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+0
+select sum(val) from (select multiIf(a%7=1, 1, b % 5 = 1 , 2, c % 3 = 1, 3, 4) as val from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+89999
+SET short_circuit_function_evaluation= 'enable';
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+5000
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+1000
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+20000
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c  from numbers(30000)));
+22000
+-- nested short-circuit functions
+select sum(flag) from (select and(a % 2 = 1, or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+7000
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+8000
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, and(c % 5 = 1, a % 3 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+7000
+-- common subexpression
+select sum(flag) from (select and(a % 2 = 2, or(b % 3 = 1, or(a % 2 = 1, c % 5 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+0
+select sum(val) from (select multiIf(a%7=1, 1, b % 5 = 1 , 2, c % 3 = 1, 3, 4) as val from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+89999
+SET short_circuit_function_evaluation= 'disable';
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+5000
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+1000
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+20000
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c  from numbers(30000)));
+22000
+-- nested short-circuit functions
+select sum(flag) from (select and(a % 2 = 1, or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+7000
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+8000
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, and(c % 5 = 1, a % 3 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+7000
+-- common subexpression
+select sum(flag) from (select and(a % 2 = 2, or(b % 3 = 1, or(a % 2 = 1, c % 5 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+0
+select sum(val) from (select multiIf(a%7=1, 1, b % 5 = 1 , 2, c % 3 = 1, 3, 4) as val from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+89999
+SET short_circuit_function_evaluation= 'force_enable';
+select sum(flag) from (select and(a != 1, intDiv(4, b) > 0) as flag from (select (number + 1) % 2 as a, number % 2 as b from numbers(30000)));
+15000
+SET short_circuit_function_evaluation= 'enable';
+select sum(flag) from (select and(a != 1, intDiv(4, b) > 0) as flag from (select (number + 1) % 2 as a, number % 2 as b from numbers(30000)));
+15000

--- a/tests/queries/0_stateless/03371_adaptive_short_circuit_execution.sql.j2
+++ b/tests/queries/0_stateless/03371_adaptive_short_circuit_execution.sql.j2
@@ -1,0 +1,35 @@
+SET enable_adaptive_short_circuit_lazy_execution = true;
+SET max_threads=1;
+
+-- { echoOn }
+{% for short_circuit_mode in ['force_enable', 'enable', 'disable']-%}
+SET short_circuit_function_evaluation= '{{ short_circuit_mode }}';
+
+
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+select sum(flag) from (select and(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1) as flag from (select number as a, number + 1 as b from numbers(30000)));
+select sum(flag) from (select or(a % 2 = 1, b % 3 = 1, c % 5 = 1) as flag from (select number as a, number + 1 as b, number + 2 as c  from numbers(30000)));
+
+
+-- nested short-circuit functions
+select sum(flag) from (select and(a % 2 = 1, or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, c % 5 = 1)) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+select sum(flag) from (select and(or(a % 2 = 1, b % 3 = 2), or(b % 3 = 1, and(c % 5 = 1, a % 3 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+
+-- common subexpression
+select sum(flag) from (select and(a % 2 = 2, or(b % 3 = 1, or(a % 2 = 1, c % 5 = 1))) as flag from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+
+
+select sum(val) from (select multiIf(a%7=1, 1, b % 5 = 1 , 2, c % 3 = 1, 3, 4) as val from (select number as a, number + 1 as b, number + 2 as c from numbers(30000)));
+
+
+
+{% endfor -%}
+
+{% for short_circuit_mode in ['force_enable', 'enable']-%}
+SET short_circuit_function_evaluation= '{{ short_circuit_mode }}';
+select sum(flag) from (select and(a != 1, intDiv(4, b) > 0) as flag from (select (number + 1) % 2 as a, number % 2 as b from numbers(30000)));
+{% endfor -%}
+
+-- { echoOff }

--- a/tests/queries/0_stateless/03371_adaptive_short_circuit_execution.sql.j2
+++ b/tests/queries/0_stateless/03371_adaptive_short_circuit_execution.sql.j2
@@ -1,5 +1,6 @@
 SET enable_adaptive_short_circuit_lazy_execution = true;
 SET max_threads=1;
+SET max_block_size=20000;
 
 -- { echoOn }
 {% for short_circuit_mode in ['force_enable', 'enable', 'disable']-%}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Lazy execution in short-circuit evaluation is not entirely cost-free. The `maskedExecute` method incurs additional overhead for filtering and expanding columns. In certain scenarios, this overhead can exceed the cost of fully evaluating the expression.


In this PR, we have added runtime performance profiling for functions. Based on the collected runtime performance data, we can evaluate the cost of using lazy evaluation versus direct full computation for a function, and dynamically select the execution strategy with the lower cost.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing):
- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64, release, debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
