### PR TITLE
Better check for changelog categories

### DIFF
--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -88,13 +88,17 @@ CATEGORY_TO_LABEL = {
 
 def normalize_category(cat: str) -> str:
     """Drop everything after open parenthesis, drop leading/trailing whitespaces, normalize case"""
-    pos = cat.find('(')
+    pos = cat.find("(")
 
     result = cat[:pos] if pos != -1 else cat
     return result.strip().casefold()
 
 
-CATEGORIES_FOLD = [normalize_category(c) for lb, categories in LABEL_CATEGORIES.items() for c in categories]
+CATEGORIES_FOLD = [
+    normalize_category(c)
+    for lb, categories in LABEL_CATEGORIES.items()
+    for c in categories
+]
 
 
 def check_pr_description(pr_body: str, repo_name: str) -> Tuple[str, str]:

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -85,6 +85,8 @@ CATEGORY_TO_LABEL = {
     c: lb for lb, categories in LABEL_CATEGORIES.items() for c in categories
 }
 
+CATEGORIES_FOLD = [c.casefold() for lb, categories in LABEL_CATEGORIES.items() for c in categories]
+
 
 def check_pr_description(pr_body: str, repo_name: str) -> Tuple[str, str]:
     """The function checks the body to being properly formatted according to
@@ -154,7 +156,7 @@ def check_pr_description(pr_body: str, repo_name: str) -> Tuple[str, str]:
     # Filter out the PR categories that are not for changelog.
     elif "(changelog entry is not required)" in category:
         pass  # to not check the rest of the conditions
-    elif category not in CATEGORY_TO_LABEL:
+    elif category.casefold() not in CATEGORIES_FOLD:
         description_error, category = f"Category '{category}' is not valid", ""
     elif not entry:
         description_error = f"Changelog entry required for category '{category}'"

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -90,12 +90,8 @@ def normalize_category(cat: str) -> str:
     """Drop everything after open parenthesis, drop leading/trailing whitespaces, normalize case"""
     pos = cat.find('(')
 
-    if pos != -1:
-        result = cat[:pos].strip()
-    else:
-        result = cat.strip()
-
-    return result.casefold()
+    result = cat[:pos] if pos != -1 else cat
+    return result.strip().casefold()
 
 
 CATEGORIES_FOLD = [normalize_category(c) for lb, categories in LABEL_CATEGORIES.items() for c in categories]

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -85,7 +85,20 @@ CATEGORY_TO_LABEL = {
     c: lb for lb, categories in LABEL_CATEGORIES.items() for c in categories
 }
 
-CATEGORIES_FOLD = [c.casefold() for lb, categories in LABEL_CATEGORIES.items() for c in categories]
+
+def normalize_category(cat: str) -> str:
+    """Drop everything after open parenthesis, drop leading/trailing whitespaces, normalize case"""
+    pos = cat.find('(')
+
+    if pos != -1:
+        result = cat[:pos].strip()
+    else:
+        result = cat.strip()
+
+    return result.casefold()
+
+
+CATEGORIES_FOLD = [normalize_category(c) for lb, categories in LABEL_CATEGORIES.items() for c in categories]
 
 
 def check_pr_description(pr_body: str, repo_name: str) -> Tuple[str, str]:
@@ -156,7 +169,7 @@ def check_pr_description(pr_body: str, repo_name: str) -> Tuple[str, str]:
     # Filter out the PR categories that are not for changelog.
     elif "(changelog entry is not required)" in category:
         pass  # to not check the rest of the conditions
-    elif category.casefold() not in CATEGORIES_FOLD:
+    elif normalize_category(category) not in CATEGORIES_FOLD:
         description_error, category = f"Category '{category}' is not valid", ""
     elif not entry:
         description_error = f"Changelog entry required for category '{category}'"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Needed for https://github.com/ClickHouse/ClickHouse/pull/72055


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
