### PR TITLE
Fix bad code in `CancellationChecker`

### DIFF
--- a/src/Interpreters/CancellationChecker.h
+++ b/src/Interpreters/CancellationChecker.h
@@ -49,6 +49,8 @@ private:
     void cancelTask(QueryToTrack task);
     bool removeQueryFromSet(std::shared_ptr<QueryStatus> query);
 
+    const LoggerPtr log;
+
 public:
     // Singleton instance retrieval
     static CancellationChecker& getInstance();

--- a/tests/queries/0_stateless/03008_deduplication_cases_from_docs.sql
+++ b/tests/queries/0_stateless/03008_deduplication_cases_from_docs.sql
@@ -1,4 +1,3 @@
--- #########
 select 'Different materialized view insert into one underlayed table equal data.';
 
 DROP TABLE IF EXISTS dst;
@@ -81,8 +80,6 @@ DROP TABLE mv_first;
 DROP TABLE mv_dst;
 DROP TABLE dst;
 
-
--- #########
 select 'Different insert operations generate the same data after transformation in underlied table of materialized view.';
 
 DROP TABLE IF EXISTS dst;
@@ -151,8 +148,6 @@ ORDER by all;
 DROP TABLE mv_dst;
 DROP TABLE dst;
 
-
--- #########
 select 'Indentical blocks in insertion with `insert_deduplication_token`';
 
 DROP TABLE IF EXISTS dst;
@@ -217,8 +212,6 @@ ORDER by all;
 
 DROP TABLE dst;
 
-
--- #########
 select 'Indentical blocks in insertion';
 
 DROP TABLE IF EXISTS dst;
@@ -250,8 +243,6 @@ ORDER by all;
 
 DROP TABLE dst;
 
-
--- #########
 select 'Indentical blocks after materialised view`s transformation';
 
 DROP TABLE IF EXISTS dst;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CC @yariks5s 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
