### PR TITLE
Respect escape_quote_with_quote in SerializationFixedString (e.g. for…

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1255,6 +1255,10 @@ Quote column names with '`' characters
 If true escape ' with '', otherwise quoted with \\'
 )", 0) \
     \
+    DECLARE(Bool, output_format_values_escape_nul_with_concat_sqlite, false, R"(
+If true escape \0 with ||char(0)||, otherwise quoted with \\0
+)", 0) \
+    \
     DECLARE(Bool, output_format_bson_string_as_string, false, R"(
 Use BSON String type instead of Binary for String columns.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -122,6 +122,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"allow_general_join_planning", false, true, "Allow more general join planning algorithm when hash join algorithm is enabled."},
             {"optimize_extract_common_expressions", false, true, "Optimize WHERE, PREWHERE, ON, HAVING and QUALIFY expressions by extracting common expressions out from disjunction of conjunctions."},
             /// Release closed. Please use 25.2
+            {"output_format_values_escape_nul_with_concat_sqlite", false, false, R"(If true escape \0 with ||char(0)||, otherwise quoted with \\0)"},
         });
         addSettingsChanges(settings_changes_history, "24.12",
         {

--- a/src/DataTypes/Serializations/SerializationFixedString.cpp
+++ b/src/DataTypes/Serializations/SerializationFixedString.cpp
@@ -199,10 +199,13 @@ bool SerializationFixedString::tryDeserializeTextEscaped(IColumn & column, ReadB
 }
 
 
-void SerializationFixedString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
+void SerializationFixedString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     const char * pos = reinterpret_cast<const char *>(&assert_cast<const ColumnFixedString &>(column).getChars()[n * row_num]);
-    writeAnyQuotedString<'\''>(pos, pos + n, ostr);
+    if (settings.values.escape_quote_with_quote)
+        writeQuotedStringPostgreSQL({pos, pos + n}, ostr);
+    else
+        writeAnyQuotedString<'\''>(pos, pos + n, ostr);
 }
 
 

--- a/src/DataTypes/Serializations/SerializationFixedString.cpp
+++ b/src/DataTypes/Serializations/SerializationFixedString.cpp
@@ -202,7 +202,9 @@ bool SerializationFixedString::tryDeserializeTextEscaped(IColumn & column, ReadB
 void SerializationFixedString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     const char * pos = reinterpret_cast<const char *>(&assert_cast<const ColumnFixedString &>(column).getChars()[n * row_num]);
-    if (settings.values.escape_quote_with_quote)
+    if (settings.values.escape_nul_with_concat_sqlite)
+        writeQuotedStringSQLite({pos, pos + n}, ostr);
+    else if (settings.values.escape_quote_with_quote)
         writeQuotedStringPostgreSQL({pos, pos + n}, ostr);
     else
         writeAnyQuotedString<'\''>(pos, pos + n, ostr);

--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -338,7 +338,9 @@ bool SerializationString::tryDeserializeTextEscaped(IColumn & column, ReadBuffer
 
 void SerializationString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    if (settings.values.escape_quote_with_quote)
+    if (settings.values.escape_nul_with_concat_sqlite)
+        writeQuotedStringSQLite(assert_cast<const ColumnString &>(column).getDataAt(row_num).toView(), ostr);
+    else if (settings.values.escape_quote_with_quote)
         writeQuotedStringPostgreSQL(assert_cast<const ColumnString &>(column).getDataAt(row_num).toView(), ostr);
     else
         writeQuotedString(assert_cast<const ColumnString &>(column).getDataAt(row_num), ostr);

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -267,6 +267,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.values.deduce_templates_of_expressions = settings[Setting::input_format_values_deduce_templates_of_expressions];
     format_settings.values.interpret_expressions = settings[Setting::input_format_values_interpret_expressions];
     format_settings.values.escape_quote_with_quote = settings[Setting::output_format_values_escape_quote_with_quote];
+    format_settings.values.escape_nul_with_concat_sqlite = settings[Setting::output_format_values_escape_nul_with_concat_sqlite];
     format_settings.with_names_use_header = settings[Setting::input_format_with_names_use_header];
     format_settings.with_types_use_header = settings[Setting::input_format_with_types_use_header];
     format_settings.write_statistics = settings[Setting::output_format_write_statistics];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -414,6 +414,7 @@ struct FormatSettings
         bool accurate_types_of_literals = true;
         bool allow_data_after_semicolon = false;
         bool escape_quote_with_quote = false;
+        bool escape_nul_with_concat_sqlite = false;
     } values{};
 
     enum class ORCCompression : uint8_t

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -259,6 +259,15 @@ inline void writeJSONString(const char * begin, const char * end, WriteBuffer & 
     writeChar('"', buf);
 }
 
+enum AnyEscapedStringFlags : std::uint64_t
+{
+    escape_default = 0,
+    escape_backslash_with_backslash = 1,
+    escape_quote_with_quote = 2,
+    escape_nul_with_concat_sqlite = 4,
+    escape_stop_at_first_nul = 8,
+};
+
 
 /** Will escape quote_character and a list of special characters('\b', '\f', '\n', '\r', '\t', '\0', '\\').
  *   - when escape_quote_with_quote is true, use backslash to escape list of special characters,
@@ -266,7 +275,7 @@ inline void writeJSONString(const char * begin, const char * end, WriteBuffer & 
  *     otherwise use backslash to escape list of special characters and quote_character
  *   - when escape_backslash_with_backslash is true, backslash is escaped with another backslash
  */
-template <char quote_character, bool escape_quote_with_quote = false, bool escape_backslash_with_backslash = true, bool stop_at_first_nul = false>
+template <char quote_character, AnyEscapedStringFlags flags = AnyEscapedStringFlags::escape_backslash_with_backslash>
 void writeAnyEscapedString(const char * begin, const char * end, WriteBuffer & buf)
 {
     const char * pos = begin;
@@ -289,7 +298,7 @@ void writeAnyEscapedString(const char * begin, const char * end, WriteBuffer & b
             {
                 case quote_character:
                 {
-                    if constexpr (escape_quote_with_quote)
+                    if constexpr ((flags & AnyEscapedStringFlags::escape_quote_with_quote) == AnyEscapedStringFlags::escape_quote_with_quote)
                         writeChar(quote_character, buf);
                     else
                         writeChar('\\', buf);
@@ -317,13 +326,20 @@ void writeAnyEscapedString(const char * begin, const char * end, WriteBuffer & b
                     writeChar('t', buf);
                     break;
                 case '\0':
-                    if constexpr (stop_at_first_nul)
+                    if constexpr ((flags & AnyEscapedStringFlags::escape_stop_at_first_nul) == AnyEscapedStringFlags::escape_stop_at_first_nul)
                         return;
-                    writeChar('\\', buf);
-                    writeChar('0', buf);
+                    else if constexpr ((flags & AnyEscapedStringFlags::escape_nul_with_concat_sqlite) == AnyEscapedStringFlags::escape_nul_with_concat_sqlite)
+                    {
+                        writeString(std::string_view("'||char(0)||'"), buf);
+                    }
+                    else
+                    {
+                        writeChar('\\', buf);
+                        writeChar('0', buf);
+                    }
                     break;
                 case '\\':
-                    if constexpr (escape_backslash_with_backslash)
+                    if constexpr ((flags & AnyEscapedStringFlags::escape_backslash_with_backslash) == AnyEscapedStringFlags::escape_backslash_with_backslash)
                         writeChar('\\', buf);
                     writeChar('\\', buf);
                     break;
@@ -581,17 +597,26 @@ inline void writeQuotedString(std::string_view ref, WriteBuffer & buf)
     writeAnyQuotedString<'\''>(ref.data(), ref.data() + ref.size(), buf);
 }
 
+inline void writeQuotedStringSQLite(std::string_view ref, WriteBuffer & buf)
+{
+    // SQLite:
+    // - escape quote with quote (https://www.sqlite.org/lang_expr.html)
+    // - null inside the string not recommended (https://www.sqlite.org/nulinstr.html)
+    //   also needs to be entered as 'abc'||char(0)||'xyz'
+    constexpr auto flags = static_cast<AnyEscapedStringFlags>(AnyEscapedStringFlags::escape_quote_with_quote | AnyEscapedStringFlags::escape_nul_with_concat_sqlite);
+    writeChar('\'', buf);
+    writeAnyEscapedString<'\'', flags>(ref.data(), ref.data() + ref.size(), buf);
+    writeChar('\'', buf);
+}
+
 inline void writeQuotedStringPostgreSQL(std::string_view ref, WriteBuffer & buf)
 {
     // PostgreSQL:
     // - escape quote with quote possible (https://www.postgresql.org/docs/current/sql-syntax-lexical.html)
     // - no null char inside the string (https://www.postgresql.org/docs/current/datatype-character.html)
-    // SQLite:
-    // - escape quote with quote (https://www.sqlite.org/lang_expr.html)
-    // - null inside the string not recommended (https://www.sqlite.org/nulinstr.html)
-    //   also needs to be entered as 'abc'||char(0)||'xyz'
+    constexpr auto flags = static_cast<AnyEscapedStringFlags>(AnyEscapedStringFlags::escape_quote_with_quote | AnyEscapedStringFlags::escape_stop_at_first_nul);
     writeChar('\'', buf);
-    writeAnyEscapedString<'\'', true, false, true>(ref.data(), ref.data() + ref.size(), buf);
+    writeAnyEscapedString<'\'', flags>(ref.data(), ref.data() + ref.size(), buf);
     writeChar('\'', buf);
 }
 
@@ -620,7 +645,7 @@ inline void writeBackQuotedString(StringRef s, WriteBuffer & buf)
 inline void writeBackQuotedStringMySQL(StringRef s, WriteBuffer & buf)
 {
     writeChar('`', buf);
-    writeAnyEscapedString<'`', true>(s.data, s.data + s.size, buf);
+    writeAnyEscapedString<'`', AnyEscapedStringFlags::escape_quote_with_quote>(s.data, s.data + s.size, buf);
     writeChar('`', buf);
 }
 

--- a/src/Storages/StorageSQLite.cpp
+++ b/src/Storages/StorageSQLite.cpp
@@ -29,6 +29,7 @@ ContextPtr makeSQLiteWriteContext(ContextPtr context)
 {
     auto write_context = Context::createCopy(context);
     write_context->setSetting("output_format_values_escape_quote_with_quote", Field(true));
+    write_context->setSetting("output_format_values_escape_nul_with_concat_sqlite", Field(true));
     return write_context;
 }
 

--- a/tests/queries/0_stateless/01889_sqlite_read_write.reference
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.reference
@@ -48,6 +48,8 @@ not a null	2
 	4
 line\'6	6
 	7
+\'	8
+\\	9
 test table function
 line1	1
 line2	2

--- a/tests/queries/0_stateless/01889_sqlite_read_write.reference
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.reference
@@ -6,6 +6,7 @@ table3
 table4
 table5
 table6\'
+table7
 show creare table:
 CREATE TABLE SQLite.table1\n(\n    `col1` Nullable(String),\n    `col2` Nullable(Int64)\n)\nENGINE = SQLite
 CREATE TABLE SQLite.table2\n(\n    `col1` Nullable(Int64),\n    `col2` Nullable(String)\n)\nENGINE = SQLite
@@ -58,6 +59,19 @@ line4	4
 table6_line1	1
 table6_line2	2
 table6_line3	3
+create table engine with table7
+Data from sqlite_table7 via clickhouse:
+line\'6\0\0\0\0	6
+\0\0\0\0\0\0\0\0\0\0	7
+\'\0\0\0\0\0\0\0\0\0	8
+\\\0\0\0\0\0\0\0\0\0	9
+abc\0\0def\0\0	10
+Data from table7 from sqlite:
+line'6|6
+|7
+'|8
+\|9
+abc|10
 test schema inference
 col1	Nullable(String)					
 col2	Nullable(Int64)					

--- a/tests/queries/0_stateless/01889_sqlite_read_write.sh
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.sh
@@ -96,6 +96,8 @@ ${CLICKHOUSE_CLIENT} --query="CREATE TABLE sqlite_table3 (col1 String, col2 Int3
 ${CLICKHOUSE_CLIENT} --query='SHOW CREATE TABLE sqlite_table3;' | sed -r 's/(.*SQLite)(.*)/\1/'
 ${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES ('line\'6', 6);"
 ${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES (NULL, 7);"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES ('\'', 8);"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES ('\\\\', 9);" # Escaped backslash = \\, but we're in bash - so \\\\
 
 ${CLICKHOUSE_CLIENT} --query='SELECT * FROM sqlite_table3 ORDER BY col2'
 

--- a/tests/queries/0_stateless/01889_sqlite_read_write.sh
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.sh
@@ -42,6 +42,7 @@ sqlite3 "${DB_PATH}" 'CREATE TABLE table5 (a character(20), b varchar(10), c rea
 sqlite3 "${DB_PATH}" "CREATE TABLE \"table6'\" (col1 text, col2 smallint);"
 sqlite3 "${DB_PATH}" "INSERT INTO \"table6'\" VALUES ('table6_line1', 1), ('table6_line2', 2), ('table6_line3', 3)"
 
+sqlite3 "${DB_PATH}" 'CREATE TABLE table7 (col1 text, col2 int);'
 
 ${CLICKHOUSE_CLIENT} --query="select 'create database engine'";
 ${CLICKHOUSE_CLIENT} --query="CREATE DATABASE ${CURR_DATABASE} ENGINE = SQLite('${DB_PATH}')"
@@ -101,12 +102,26 @@ ${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table3 VALUES ('\\\\', 9);" # E
 
 ${CLICKHOUSE_CLIENT} --query='SELECT * FROM sqlite_table3 ORDER BY col2'
 
-
 ${CLICKHOUSE_CLIENT} --query="select 'test table function'";
 ${CLICKHOUSE_CLIENT} --query="INSERT INTO TABLE FUNCTION sqlite('${DB_PATH}', 'table1') SELECT 'line4', 4"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM sqlite('${DB_PATH}', 'table1') ORDER BY col2"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM sqlite('${DB_PATH}', '\\'); select 1 --') ORDER BY col2 -- { serverError SQLITE_ENGINE_ERROR }"
 ${CLICKHOUSE_CLIENT} --query="SELECT * FROM sqlite('${DB_PATH}', 'table6''') ORDER BY col2"
+
+
+${CLICKHOUSE_CLIENT} --query="select 'create table engine with table7'";
+${CLICKHOUSE_CLIENT} --query='DROP TABLE IF EXISTS sqlite_table7'
+${CLICKHOUSE_CLIENT} --query="CREATE TABLE sqlite_table7 (col1 FixedString(10), col2 Int32) ENGINE = SQLite('${DB_PATH}', 'table7')"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table7 VALUES ('line\'6', 6);"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table7 VALUES (NULL, 7);"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table7 VALUES ('\'', 8);"
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table7 VALUES ('\\\\', 9);" # Escaped backslash = \\, but we're in bash - so \\\\
+${CLICKHOUSE_CLIENT} --query="INSERT INTO sqlite_table7 VALUES ('abc\0\0def', 10);"
+${CLICKHOUSE_CLIENT} --query="select 'Data from sqlite_table7 via clickhouse:'";
+${CLICKHOUSE_CLIENT} --query='SELECT * FROM sqlite_table7 ORDER BY col2'
+${CLICKHOUSE_CLIENT} --query="select 'Data from table7 from sqlite:'";
+sqlite3 "${DB_PATH}" 'SELECT * FROM table7 ORDER BY col2;'
+
 
 
 ${CLICKHOUSE_CLIENT} --query="select 'test schema inference'";


### PR DESCRIPTION
Fixes #73519

Respect `escape_quote_with_quote` in `SerializationFixedString`.

Do not serialize `\0` within a string with SQLite / PostgreSQL

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement
<!---
- Not for changelog (changelog entry is not required)
-->


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix escaping quote with quote for `FixedString` with SQLite (use `''`). Do not serialize `\0`within a string  in SQLite and PostgreSQL.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
