### PR TITLE
Fix bad test `mutations_isolation`

### DIFF
--- a/tests/queries/0_stateless/01168_mutations_isolation.reference
+++ b/tests/queries/0_stateless/01168_mutations_isolation.reference
@@ -1,40 +1,40 @@
-tx2	1	10	all_1_1_0_4
-tx2	1	30	all_3_3_0_4
-tx1	2	1	all_1_1_0
-tx1	2	2	all_2_2_0
+tx2	1	10
+tx2	1	30
+tx1	2	1
+tx1	2	2
 Serialization error
 INVALID_TRANSACTION
-tx3	3	1	all_1_1_0
+tx3	3	1
 Serialization error
 INVALID_TRANSACTION
 INVALID_TRANSACTION
-tx5	4	2	all_1_1_0_8
-tx5	4	5	all_10_10_0
-tx5	4	6	all_7_7_0_8
-tx5	5	2	all_1_1_0_8
-tx5	5	5	all_10_10_0
-tx5	5	6	all_7_7_0_8
+tx5	4	2
+tx5	4	5
+tx5	4	6
+tx5	5	2
+tx5	5	5
+tx5	5	6
 SERIALIZATION_ERROR
-tx6	6	2	all_1_1_0_11
-tx6	6	6	all_7_7_0_11
-tx7	7	20	all_1_1_0_13
-tx7	7	40	all_14_14_0
-tx7	7	60	all_7_7_0_13
-tx7	7	80	all_12_12_0_13
-tx7	8	20	all_1_14_1_13
-tx7	8	40	all_1_14_1_13
-tx7	8	60	all_1_14_1_13
-tx7	8	80	all_1_14_1_13
+tx6	6	2
+tx6	6	6
+tx7	7	20
+tx7	7	40
+tx7	7	60
+tx7	7	80
+tx7	8	20
+tx7	8	40
+tx7	8	60
+tx7	8	80
 Serialization error
 INVALID_TRANSACTION
-tx11	9	21	all_1_14_1_17
-tx11	9	41	all_1_14_1_17
-tx11	9	61	all_1_14_1_17
-tx11	9	81	all_1_14_1_17
+tx11	9	21
+tx11	9	41
+tx11	9	61
+tx11	9	81
 1	1	RUNNING
-tx14	10	22	all_1_14_1_18
-tx14	10	42	all_1_14_1_18
-tx14	10	62	all_1_14_1_18
-tx14	10	82	all_1_14_1_18
-11	2	all_2_2_0
-11	10	all_1_1_0_3
+tx14	10	22
+tx14	10	42
+tx14	10	62
+tx14	10	82
+11	2
+11	10

--- a/tests/queries/0_stateless/01168_mutations_isolation.sh
+++ b/tests/queries/0_stateless/01168_mutations_isolation.sh
@@ -19,15 +19,15 @@ tx 2                                            "begin transaction"
 tx 1 "insert into mt values (2)"
 tx 2                                            "insert into mt values (3)"
 tx 2                                            "alter table mt update n=n*10 where 1"
-tx 2                                            "select 1, n, _part from mt order by n"
-tx 1 "select 2, n, _part from mt order by n"
+tx 2                                            "select 1, n from mt order by n"
+tx 1 "select 2, n from mt order by n"
 tx 1 "alter table mt update n=n+1 where 1" | grep -Eo "Serialization error" | uniq
 tx 1 "commit" | grep -Eo "INVALID_TRANSACTION" | uniq
 tx 2                                            "rollback"
 
 
 tx 3 "begin transaction"
-tx 3 "select 3, n, _part from mt order by n"
+tx 3 "select 3, n from mt order by n"
 tx 4                                            "begin transaction"
 tx 3 "insert into mt values (2)"
 tx 4                                            "insert into mt values (3)"
@@ -40,13 +40,13 @@ tx 4                                            "commit"
 
 
 tx 5 "begin transaction"
-tx 5 "select 4, n, _part from mt order by n"
+tx 5 "select 4, n from mt order by n"
 tx 6                                            "begin transaction"
 tx 6                                            "alter table mt delete where n%2=1"
 tx 6                                            "alter table mt drop part 'all_10_10_0_11'"
-tx 5 "select 5, n, _part from mt order by n"
+tx 5 "select 5, n from mt order by n"
 tx 5 "alter table mt drop partition id 'all'" | grep -Eo "SERIALIZATION_ERROR" | uniq
-tx 6                                            "select 6, n, _part from mt order by n"
+tx 6                                            "select 6, n from mt order by n"
 tx 5 "rollback"
 tx 6                                            "insert into mt values (8)"
 tx 6                                            "alter table mt update n=n*10 where 1"
@@ -55,13 +55,13 @@ tx 6                                            "commit"
 
 
 tx 7 "begin transaction"
-tx 7 "select 7, n, _part from mt order by n"
+tx 7 "select 7, n from mt order by n"
 tx 8                                            "begin transaction"
 tx_async 8                                      "alter table mt update n = 0 where 1" >/dev/null
 $CLICKHOUSE_CLIENT -q "kill mutation where database=currentDatabase() and mutation_id='mutation_15.txt' format Null" 2>&1| grep -Fv "probably it finished"
 tx_sync 8                                            "rollback"
 tx 7 "optimize table mt final"
-tx 7 "select 8, n, _part from mt order by n"
+tx 7 "select 8, n from mt order by n"
 tx 10                                           "begin transaction"
 tx 10                                           "alter table mt update n = 0 where 1" | grep -Eo "Serialization error" | uniq
 tx 7 "alter table mt update n=n+1 where 1"
@@ -71,7 +71,7 @@ tx 7 "commit"
 
 
 tx_async 11 "begin transaction"
-tx_async 11 "select 9, n, _part from mt order by n"
+tx_async 11 "select 9, n from mt order by n"
 tx_async 12                                           "begin transaction"
 tx_async 11 "alter table mt update n=n+1 where 1" >/dev/null
 tx_async 12                                           "alter table mt update n=n+1 where 1" >/dev/null
@@ -88,7 +88,7 @@ $CLICKHOUSE_CLIENT -q "kill transaction where tid=$tid_to_kill format Null"
 tx_sync 13                                            "rollback"
 
 tx 14 "begin transaction"
-tx 14 "select 10, n, _part from mt order by n"
+tx 14 "select 10, n from mt order by n"
 
 $CLICKHOUSE_CLIENT --database_atomic_wait_for_drop_and_detach_synchronously=0 -q "drop table mt"
 
@@ -101,6 +101,6 @@ tx 16                                           "insert into mt values (2)"
 tx 15 "alter table mt update n = 10*n where 1"
 tx 15 "commit"
 tx 16                                           "commit"
-$CLICKHOUSE_CLIENT --implicit_transaction=1 -q "select 11, n, _part from mt order by n"
+$CLICKHOUSE_CLIENT --implicit_transaction=1 -q "select 11, n from mt order by n"
 
 $CLICKHOUSE_CLIENT -q "drop table mt"

--- a/tests/queries/0_stateless/transactions.lib
+++ b/tests/queries/0_stateless/transactions.lib
@@ -9,8 +9,8 @@ function tx()
     query=$2
 
     session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
-    query_id="${session}_${RANDOM}"
-    url_without_session="https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTPS}/?"
+    query_id="${session}_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+    url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
     url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0"
 
     ${CLICKHOUSE_CURL} -m 90 -sSk "$url" --data "$query" | sed "s/^/tx$tx_num\t/"
@@ -55,7 +55,7 @@ function tx_async()
 
     session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
     query_id="${session}_${RANDOM}"
-    url_without_session="https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTPS}/?"
+    url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
     url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0"
 
     # We cannot be sure that query will actually start execution and appear in system.processes before the next call to tx_wait


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This test compared part names and assumed that a quickly cancelled mutation did not go through. This assumption is unfounded.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
