### PR TITLE
Repro for insert detach race in rmt

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2678,6 +2678,8 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
         }
     }
 
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
     /// Forcibly remove parts from ZooKeeper
     removePartsFromZooKeeperWithRetries(parts_to_remove);
     paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry.new_part_name, *this);

--- a/tests/queries/0_stateless/03297_insert_detach_race.sh
+++ b/tests/queries/0_stateless/03297_insert_detach_race.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: race, zookeeper
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+# shellcheck source=./replication.lib
+. "$CURDIR"/replication.lib
+
+
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS insert_detach_race;
+
+    CREATE TABLE insert_detach_race (a UInt8, b Int16)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/insert_detach_race', 'r1')
+    ORDER BY a
+    SETTINGS sleep_before_commit_local_part_in_replicated_table_ms=5000;
+" || exit 1
+
+function thread_detach()
+{
+    $CLICKHOUSE_CLIENT -q "ALTER TABLE insert_detach_race DETACH PARTITION ID 'all'"
+}
+
+$CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "INSERT INTO insert_detach_race SELECT 1, 2"
+$CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "INSERT INTO insert_detach_race SELECT 3, 4" &
+
+sleep 2
+$CLICKHOUSE_CLIENT -q "ALTER TABLE insert_detach_race DETACH PARTITION ID 'all'"
+
+wait


### PR DESCRIPTION
https://pastila.nl/?02590246/05fd66921278197f1f2ee2c42db9dcbe#0Zfb40dlhyye0WwOzKLNUA==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
