### PR TITLE
Fix implicit privileges (worked as wildcard before)

### DIFF
--- a/src/Access/AccessRights.cpp
+++ b/src/Access/AccessRights.cpp
@@ -1155,7 +1155,13 @@ private:
 
         calculateMinMaxFlags();
 
-        auto new_flags = function(flags, min_flags_with_children, max_flags_with_children, level, grant_option);
+        auto new_flags = function(
+            flags,
+            min_flags_with_children,
+            max_flags_with_children,
+            level,
+            grant_option,
+            isLeaf() || wildcard_grant);
 
         if (new_flags != flags)
         {

--- a/src/Access/AccessRights.h
+++ b/src/Access/AccessRights.h
@@ -166,7 +166,8 @@ public:
         const AccessFlags & min_flags_with_children,
         const AccessFlags & max_flags_with_children,
         const size_t level,
-        bool grant_option)>;
+        bool grant_option,
+        bool leaf_or_wildcard)>;
     void modifyFlags(const ModifyFlagsFunction & function);
 
     friend bool operator ==(const AccessRights & left, const AccessRights & right);

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -95,7 +95,8 @@ AccessRights ContextAccess::addImplicitAccessRights(const AccessRights & access,
                         const AccessFlags & min_flags_with_children,
                         const AccessFlags & max_flags_with_children,
                         const size_t level,
-                        bool /* grant_option */) -> AccessFlags
+                        bool /* grant_option */,
+                        bool leaf_or_wildcard) -> AccessFlags
     {
         AccessFlags res = flags;
 
@@ -153,7 +154,8 @@ AccessRights ContextAccess::addImplicitAccessRights(const AccessRights & access,
 
         if ((res & AccessFlags::allTableFlags())
             || (level <= 2 && (res & show_columns))
-            || (level == 2 && (max_flags_with_children & show_columns)))
+            /// GRANT SELECT(x) ON y => GRANT SELECT(x) ON y, GRANT SHOW_TABLES ON y
+            || (leaf_or_wildcard && level == 2 && (max_flags_with_children & show_columns)))
         {
             res |= show_tables;
         }
@@ -163,7 +165,7 @@ AccessRights ContextAccess::addImplicitAccessRights(const AccessRights & access,
 
         if ((res & AccessFlags::allDatabaseFlags())
             || (level <= 1 && (res & show_tables_or_dictionaries))
-            || (level == 1 && (max_flags_with_children & show_tables_or_dictionaries)))
+            || (leaf_or_wildcard && level == 1 && (max_flags_with_children & show_tables_or_dictionaries)))
         {
             res |= show_databases;
         }

--- a/src/Access/tests/gtest_access_rights_implicit.cpp
+++ b/src/Access/tests/gtest_access_rights_implicit.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+#include <Access/AccessRights.h>
+#include <IO/WriteBufferFromString.h>
+
+using namespace DB;
+
+namespace {
+
+/// Partial copy of ContextAccess::addImplicitAccessRights
+AccessFlags addImplicitPrivileges(AccessFlags flags,
+    const AccessFlags & /*min_flags_with_children*/,
+    const AccessFlags & max_flags_with_children,
+    const size_t level,
+    bool /*grant_option*/,
+    bool leaf_or_wildcard)
+{
+    AccessFlags res = flags;
+
+    static const AccessFlags show_columns = AccessType::SHOW_COLUMNS;
+    static const AccessFlags show_tables = AccessType::SHOW_TABLES;
+
+    if (res & AccessFlags::allColumnFlags())
+        res |= show_columns;
+    if ((res & AccessFlags::allTableFlags())
+        || (level <= 2 && (res & show_columns))
+        || (leaf_or_wildcard && level == 2 && (max_flags_with_children & show_columns)))
+    {
+        res |= show_tables;
+    }
+
+    return res;
+}
+
+std::string dumpAccessRights(AccessRights root, const std::string & prefix)
+{
+    WriteBufferFromOwnString out;
+    root.dumpTree(out);
+    return prefix + ":\n" + out.str();
+}
+
+}
+
+TEST(AccessRightsExplicitPrivileges, RevokeExplicitPrivilegeModify)
+{
+    AccessRights root;
+    root.grant(AccessType::SELECT);
+    root.grant(AccessType::SHOW_TABLES);
+    root.grant(AccessType::SHOW_COLUMNS);
+    SCOPED_TRACE(dumpAccessRights(root, "granted"));
+    root.revoke(AccessType::SHOW_TABLES, "default", "foo");
+    SCOPED_TRACE(dumpAccessRights(root, "revoke SHOW_TABLES"));
+
+    ASSERT_FALSE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_2"));
+}
+
+TEST(AccessRightsImplicitPrivileges, RevokeExplicitPrivilegeModify)
+{
+    AccessRights root;
+    root.grant(AccessType::SELECT);
+    SCOPED_TRACE(dumpAccessRights(root, "grant SELECT"));
+    root.revoke(AccessType::SELECT, "default", "foo");
+    SCOPED_TRACE(dumpAccessRights(root, "revoke SHOW_TABLES"));
+    root.modifyFlags(addImplicitPrivileges);
+    SCOPED_TRACE(dumpAccessRights(root, "modify"));
+
+    ASSERT_FALSE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_2"));
+}
+
+TEST(AccessRightsImplicitPrivileges, Table)
+{
+    AccessRights root;
+    root.grant(AccessType::SELECT, "default", "foo");
+    SCOPED_TRACE(dumpAccessRights(root, "grant"));
+    root.modifyFlags(addImplicitPrivileges);
+    SCOPED_TRACE(dumpAccessRights(root, "modify"));
+
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_FALSE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_2"));
+}
+
+TEST(AccessRightsExplicitPrivileges, Table)
+{
+    AccessRights root;
+    root.grant(AccessType::SELECT, "default", "foo");
+    root.grant(AccessType::SHOW_TABLES, "default", "foo");
+    root.grant(AccessType::SHOW_COLUMNS, "default", "foo");
+    SCOPED_TRACE(dumpAccessRights(root, "grants"));
+
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_FALSE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_2"));
+}
+
+TEST(AccessRightsImplicitPrivileges, Column)
+{
+    AccessRights root;
+    root.grant(AccessType::SELECT, "default", "foo", "x");
+    SCOPED_TRACE(dumpAccessRights(root, "grants"));
+    root.modifyFlags(addImplicitPrivileges);
+    SCOPED_TRACE(dumpAccessRights(root, "modify"));
+
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_COLUMNS, "default", "foo", "x"));
+    ASSERT_FALSE(root.isGranted(AccessType::SHOW_COLUMNS, "default", "foo", "x_2"));
+}
+
+TEST(AccessRightsImplicitPrivileges, TableWildcard)
+{
+    AccessRights root;
+    root.grantWildcard(AccessType::SELECT, "default", "foo");
+    root.modifyFlags(addImplicitPrivileges);
+    SCOPED_TRACE(dumpAccessRights(root, "grants"));
+
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_2"));
+
+    root.revokeWildcard(AccessType::SHOW_TABLES, "default", "foo_2");
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo"));
+    ASSERT_FALSE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_2"));
+    ASSERT_TRUE(root.isGranted(AccessType::SHOW_TABLES, "default", "foo_3"));
+}

--- a/src/Access/tests/gtest_access_rights_ops.cpp
+++ b/src/Access/tests/gtest_access_rights_ops.cpp
@@ -3,8 +3,6 @@
 #include <Access/AccessRights.cpp>  // NOLINT(bugprone-suspicious-include)
 #include <IO/WriteBufferFromString.h>
 
-#include <list>
-
 using namespace DB;
 
 TEST(AccessRights, Radix)

--- a/tests/queries/0_stateless/03300_implicit_privileges_system_databases.reference
+++ b/tests/queries/0_stateless/03300_implicit_privileges_system_databases.reference
@@ -1,0 +1,1 @@
+default

--- a/tests/queries/0_stateless/03300_implicit_privileges_system_databases.sh
+++ b/tests/queries/0_stateless/03300_implicit_privileges_system_databases.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user03300_$CLICKHOUSE_DATABASE"
+db=${CLICKHOUSE_DATABASE}
+db2=${CLICKHOUSE_DATABASE}_2
+
+$CLICKHOUSE_CLIENT -m -q "
+CREATE DATABASE IF NOT EXISTS $db2;
+
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+
+GRANT ALL ON $db.* TO $user;
+GRANT SELECT ON system.databases TO $user;
+"
+
+$CLICKHOUSE_CLIENT --user "$user" -m -q "
+SELECT DISTINCT name FROM system.databases WHERE database LIKE '$db%' ORDER BY 1
+"
+
+$CLICKHOUSE_CLIENT -m -q "
+DROP USER $user;
+"

--- a/tests/queries/0_stateless/03300_implicit_privileges_system_parts.reference
+++ b/tests/queries/0_stateless/03300_implicit_privileges_system_parts.reference
@@ -1,0 +1,4 @@
+system.parts via default
+test_1
+test_2
+system.parts via restricted user

--- a/tests/queries/0_stateless/03300_implicit_privileges_system_parts.sh
+++ b/tests/queries/0_stateless/03300_implicit_privileges_system_parts.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user03300_$CLICKHOUSE_DATABASE"
+db=${CLICKHOUSE_DATABASE}
+
+$CLICKHOUSE_CLIENT -m -q "
+DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS test_1;
+DROP TABLE IF EXISTS test_2;
+
+CREATE TABLE test (s String) ENGINE = Merge(currentDatabase(), 'test_');
+
+CREATE TABLE test_1 (s Int) ENGINE = MergeTree() ORDER BY s AS SELECT * FROM numbers(10);
+CREATE TABLE test_2 (s Int) ENGINE = MergeTree() ORDER BY s AS SELECT * FROM numbers(10);
+"
+
+echo "system.parts via default"
+$CLICKHOUSE_CLIENT -q "SELECT DISTINCT table FROM system.parts WHERE database = currentDatabase() AND table LIKE 'test%' ORDER BY 1"
+
+# system.parts requires SHOW_TABLES, that is granted implicitly to user due to
+# SELECT privilege
+$CLICKHOUSE_CLIENT -m -q "
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+
+GRANT SELECT ON $db.test TO $user;
+GRANT SELECT ON system.parts TO $user;
+"
+echo "system.parts via restricted user"
+$CLICKHOUSE_CLIENT --user "$user" -q "SELECT DISTINCT table FROM system.parts WHERE database = currentDatabase() AND table LIKE 'test%' ORDER BY 1"
+
+$CLICKHOUSE_CLIENT -m -q "
+DROP TABLE test;
+DROP TABLE test_1;
+DROP TABLE test_2;
+
+DROP USER $user;
+"
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix implicit privileges (worked as wildcard before)

After the introduction of wildcard grants in #65311, implicitly added privileges (e.g., CREATE_TABLE -> CREATE_VIEW, or SELECT -> SHOW_COLUMNS, like in the test) now behave as wildcard.

This means that implicitly granted privileges to "x" automatically extends the same privileges to "x*".

Cc: @pufit
Fixes: #73421