### PR TITLE
Remove obsolete `expected` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -308,9 +308,6 @@
 [submodule "contrib/crc32-vpmsum"]
 	path = contrib/crc32-vpmsum
 	url = https://github.com/antonblanchard/crc32-vpmsum.git
-[submodule "contrib/expected"]
-	path = contrib/expected
-	url = https://github.com/TartanLlama/expected
 [submodule "contrib/liburing"]
 	path = contrib/liburing
 	url = https://github.com/axboe/liburing

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -214,8 +214,6 @@ endif ()
 
 add_contrib (xxHash-cmake xxHash)
 
-add_contrib (expected-cmake expected)
-
 add_contrib (libbcrypt-cmake libbcrypt)
 
 add_contrib (google-benchmark-cmake google-benchmark)

--- a/contrib/expected-cmake/CMakeLists.txt
+++ b/contrib/expected-cmake/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_library(expected INTERFACE)
-target_include_directories(expected SYSTEM BEFORE INTERFACE "${ClickHouse_SOURCE_DIR}/contrib/expected/include")
-add_library(ch_contrib::expected ALIAS expected)

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -58,7 +58,6 @@ list (APPEND PUBLIC_LIBS
 
 list (APPEND PRIVATE_LIBS
         ch_contrib::zlib
-        ch_contrib::expected
         boost::filesystem
         divide_impl
         ch_contrib::xxHash

--- a/src/Functions/parseDateTime.cpp
+++ b/src/Functions/parseDateTime.cpp
@@ -17,10 +17,9 @@
 #include <IO/WriteHelpers.h>
 #include <boost/algorithm/string/case_conv.hpp>
 
-#include "StringHelpers.h"
+#include <expected>
 
-/// TODO: Remove after we lifted the libc++ from 15 to 16 (where std::expected is supported).
-#include <tl/expected.hpp>
+#include "StringHelpers.h"
 
 namespace DB
 {
@@ -130,11 +129,10 @@ namespace
         {}
     };
 
-    /// TODO replace tl::expected by std::expected once libc++ was raised from 15 to 16
-    using VoidOrError  = tl::expected<void,  ErrorCodeAndMessage>;
-    using PosOrError   = tl::expected<Pos,   ErrorCodeAndMessage>;
-    using Int32OrError = tl::expected<Int32, ErrorCodeAndMessage>;
-    using Int64OrError = tl::expected<Int64, ErrorCodeAndMessage>;
+    using VoidOrError  = std::expected<void,  ErrorCodeAndMessage>;
+    using PosOrError   = std::expected<Pos,   ErrorCodeAndMessage>;
+    using Int32OrError = std::expected<Int32, ErrorCodeAndMessage>;
+    using Int64OrError = std::expected<Int64, ErrorCodeAndMessage>;
 
 
 /// Returns an error based on the error handling mode.
@@ -144,23 +142,23 @@ namespace
 #define RETURN_ERROR(error_code, ...)                                        \
 {                                                                            \
     if constexpr (error_handling == ErrorHandling::Exception)                \
-        return tl::unexpected(ErrorCodeAndMessage(error_code, __VA_ARGS__)); \
+        return std::unexpected(ErrorCodeAndMessage(error_code, __VA_ARGS__)); \
     else                                                                     \
-        return tl::unexpected(ErrorCodeAndMessage(error_code));              \
+        return std::unexpected(ErrorCodeAndMessage(error_code));              \
 }
 
 /// Run a function and return an error if the call failed.
 #define RETURN_ERROR_IF_FAILED(function_call)             \
 {                                                         \
     if (auto result = function_call; !result.has_value()) \
-        return tl::unexpected(result.error());            \
+        return std::unexpected(result.error());            \
 }
 
 /// Run a function and either assign the result (if successful) or return an error.
 #define ASSIGN_RESULT_OR_RETURN_ERROR(res, function_call) \
 {                                                         \
     if (auto result = function_call; !result.has_value()) \
-        return tl::unexpected(result.error());            \
+        return std::unexpected(result.error());            \
     else                                                  \
         (res) = *result;                                  \
 }
@@ -762,7 +760,7 @@ namespace
                 /// Ensure all input was consumed
                 if (cur < end)
                 {
-                    result = tl::unexpected(ErrorCodeAndMessage(
+                    result = std::unexpected(ErrorCodeAndMessage(
                         ErrorCodes::CANNOT_PARSE_DATETIME,
                         "Invalid format input {} is malformed at {}",
                         str_ref.toView(),

--- a/src/Functions/parseDateTime.cpp
+++ b/src/Functions/parseDateTime.cpp
@@ -139,11 +139,11 @@ namespace
 /// As an optimization, for error_handling = Zero/Null, we only care that
 /// an error happened but not which one specifically. This removes the need
 /// to copy the error string.
-#define RETURN_ERROR(error_code, ...)                                        \
-{                                                                            \
-    if constexpr (error_handling == ErrorHandling::Exception)                \
+#define RETURN_ERROR(error_code, ...)                                         \
+{                                                                             \
+    if constexpr (error_handling == ErrorHandling::Exception)                 \
         return std::unexpected(ErrorCodeAndMessage(error_code, __VA_ARGS__)); \
-    else                                                                     \
+    else                                                                      \
         return std::unexpected(ErrorCodeAndMessage(error_code));              \
 }
 
@@ -151,14 +151,14 @@ namespace
 #define RETURN_ERROR_IF_FAILED(function_call)             \
 {                                                         \
     if (auto result = function_call; !result.has_value()) \
-        return std::unexpected(result.error());            \
+        return std::unexpected(result.error());           \
 }
 
 /// Run a function and either assign the result (if successful) or return an error.
 #define ASSIGN_RESULT_OR_RETURN_ERROR(res, function_call) \
 {                                                         \
     if (auto result = function_call; !result.has_value()) \
-        return std::unexpected(result.error());            \
+        return std::unexpected(result.error());           \
     else                                                  \
         (res) = *result;                                  \
 }


### PR DESCRIPTION
The [expected submodule](https://github.com/TartanLlama/expected) was obsoleted by the recent LLVM upgrade.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)