### PR TITLE
Experiment: Enable SLP vectorizer for faster codegen

### DIFF
--- a/base/base/AlignedUnion.h
+++ b/base/base/AlignedUnion.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+/// Replacement for std::aligned_union which is deprecated in C++23
 template<std::size_t len, class... Types>
 struct AlignedUnion
 {

--- a/src/Interpreters/JIT/CHJIT.cpp
+++ b/src/Interpreters/JIT/CHJIT.cpp
@@ -7,8 +7,8 @@
 #include <boost/noncopyable.hpp>
 
 #include <llvm/Analysis/CGSCCPassManager.h>
-#include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Analysis/LoopAnalysisManager.h>
+#include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/DataLayout.h>
@@ -490,7 +490,10 @@ void CHJIT::runOptimizationPassesOnModule(llvm::Module & module) const
     llvm::CGSCCAnalysisManager cgam;
     llvm::ModuleAnalysisManager mam;
 
-    llvm::PassBuilder pb;
+    llvm::PipelineTuningOptions pto;
+    pto.SLPVectorization = true;
+
+    llvm::PassBuilder pb(nullptr, pto);
 
     pb.registerModuleAnalyses(mam);
     pb.registerCGSCCAnalyses(cgam);


### PR DESCRIPTION
After the recent upgrades to LLVM 16 and 18, folks started to complain about slower codegen: https://github.com/ClickHouse/ClickHouse/pull/66053#issuecomment-2558266063

Prior to the LLVM 16 upgrade, CHJIT force-enabled the SLP vectorizer (see https://github.com/ClickHouse/ClickHouse/pull/69654/files#diff-897102eb40b3e08e4997b80459a83b97ac7d555e4534942cd30581e4f92cefe2). This PR now does the same using the new LLVM pass manager. Let's see if it helps with performance.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)