### PR TITLE
Fix assert asof_conditions.size() == 1

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -1892,7 +1892,13 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
             if (join_clause.hasASOF())
             {
                 const auto & asof_conditions = join_clause.getASOFConditions();
-                assert(asof_conditions.size() == 1);
+                if (asof_conditions.size() > 1)
+                {
+                    throw Exception(
+                        ErrorCodes::INVALID_JOIN_ON_EXPRESSION,
+                        "JOIN {} ASOF JOIN expects exactly one inequality in ON section",
+                        join_node.formatASTForErrorMessage());
+                }
 
                 const auto & asof_condition = asof_conditions[0];
                 table_join->setAsofInequality(asof_condition.asof_inequality);

--- a/tests/queries/0_stateless/00976_asof_join_on.sql.j2
+++ b/tests/queries/0_stateless/00976_asof_join_on.sql.j2
@@ -26,6 +26,8 @@ SELECT '-';
 SELECT A.a, A.t, B.b, B.t FROM A ASOF JOIN B ON A.a == B.b AND A.t > B.t ORDER BY (A.a, A.t);
 SELECT '-';
 SELECT A.a, A.t, B.b, B.t FROM A ASOF JOIN B ON A.a == B.b AND A.t < B.t ORDER BY (A.a, A.t);
+
+SELECT A.a, A.t, B.b, B.t FROM A ASOF JOIN B ON A.a == B.b AND A.t < B.t AND A.t < B.t; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT count() FROM A ASOF JOIN B ON A.a == B.b AND A.t == B.t; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT count() FROM A ASOF JOIN B ON A.a == B.b AND A.t != B.t; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Close https://github.com/ClickHouse/ClickHouse/issues/73925

Throw same exception as in 

https://github.com/ClickHouse/ClickHouse/blob/8875f35814e4b02fc1726322c728bc2fb13deb62/src/Planner/PlannerJoins.cpp#L330-L338