### PR TITLE
Refactor BackupKeeperSettings

### DIFF
--- a/src/Backups/BackupKeeperSettings.cpp
+++ b/src/Backups/BackupKeeperSettings.cpp
@@ -40,9 +40,13 @@ BackupKeeperSettings::BackupKeeperSettings(const ContextPtr & context)
 
     if (config.has("backups.sync_period_ms"))
         sync_period_ms = std::chrono::milliseconds{config.getUInt64("backups.sync_period_ms")};
+    else
+        sync_period_ms = std::chrono::milliseconds{5000};
 
     if (config.has("backups.max_attempts_after_bad_version"))
         max_attempts_after_bad_version = config.getUInt64("backups.max_attempts_after_bad_version");
+    else
+        max_attempts_after_bad_version = 10;
 
     value_max_size = settings[Setting::backup_restore_keeper_value_max_size];
     batch_size_for_multi = settings[Setting::backup_restore_batch_size_for_keeper_multi];

--- a/src/Backups/BackupKeeperSettings.cpp
+++ b/src/Backups/BackupKeeperSettings.cpp
@@ -10,18 +10,18 @@ namespace DB
 
 namespace Setting
 {
-    extern const SettingsUInt64 backup_restore_keeper_max_retries;
-    extern const SettingsUInt64 backup_restore_keeper_retry_initial_backoff_ms;
-    extern const SettingsUInt64 backup_restore_keeper_retry_max_backoff_ms;
-    extern const SettingsUInt64 backup_restore_failure_after_host_disconnected_for_seconds;
-    extern const SettingsUInt64 backup_restore_keeper_max_retries_while_initializing;
-    extern const SettingsUInt64 backup_restore_keeper_max_retries_while_handling_error;
-    extern const SettingsUInt64 backup_restore_finish_timeout_after_error_sec;
-    extern const SettingsUInt64 backup_restore_keeper_value_max_size;
+    extern const SettingsFloat backup_restore_keeper_fault_injection_probability;
     extern const SettingsUInt64 backup_restore_batch_size_for_keeper_multi;
     extern const SettingsUInt64 backup_restore_batch_size_for_keeper_multiread;
-    extern const SettingsFloat backup_restore_keeper_fault_injection_probability;
+    extern const SettingsUInt64 backup_restore_failure_after_host_disconnected_for_seconds;
+    extern const SettingsUInt64 backup_restore_finish_timeout_after_error_sec;
     extern const SettingsUInt64 backup_restore_keeper_fault_injection_seed;
+    extern const SettingsUInt64 backup_restore_keeper_max_retries;
+    extern const SettingsUInt64 backup_restore_keeper_max_retries_while_handling_error;
+    extern const SettingsUInt64 backup_restore_keeper_max_retries_while_initializing;
+    extern const SettingsUInt64 backup_restore_keeper_retry_initial_backoff_ms;
+    extern const SettingsUInt64 backup_restore_keeper_retry_max_backoff_ms;
+    extern const SettingsUInt64 backup_restore_keeper_value_max_size;
 }
 
 BackupKeeperSettings BackupKeeperSettings::fromContext(const ContextPtr & context)

--- a/src/Backups/BackupKeeperSettings.cpp
+++ b/src/Backups/BackupKeeperSettings.cpp
@@ -24,35 +24,31 @@ namespace Setting
     extern const SettingsUInt64 backup_restore_keeper_value_max_size;
 }
 
-BackupKeeperSettings BackupKeeperSettings::fromContext(const ContextPtr & context)
+BackupKeeperSettings::BackupKeeperSettings(const ContextPtr & context)
 {
-    BackupKeeperSettings keeper_settings;
-
     const auto & settings = context->getSettingsRef();
     const auto & config = context->getConfigRef();
 
-    keeper_settings.max_retries = settings[Setting::backup_restore_keeper_max_retries];
-    keeper_settings.retry_initial_backoff_ms = std::chrono::milliseconds{settings[Setting::backup_restore_keeper_retry_initial_backoff_ms]};
-    keeper_settings.retry_max_backoff_ms = std::chrono::milliseconds{settings[Setting::backup_restore_keeper_retry_max_backoff_ms]};
+    max_retries = settings[Setting::backup_restore_keeper_max_retries];
+    retry_initial_backoff_ms = std::chrono::milliseconds{settings[Setting::backup_restore_keeper_retry_initial_backoff_ms]};
+    retry_max_backoff_ms = std::chrono::milliseconds{settings[Setting::backup_restore_keeper_retry_max_backoff_ms]};
 
-    keeper_settings.failure_after_host_disconnected_for_seconds = std::chrono::seconds{settings[Setting::backup_restore_failure_after_host_disconnected_for_seconds]};
-    keeper_settings.max_retries_while_initializing = settings[Setting::backup_restore_keeper_max_retries_while_initializing];
-    keeper_settings.max_retries_while_handling_error = settings[Setting::backup_restore_keeper_max_retries_while_handling_error];
-    keeper_settings.finish_timeout_after_error = std::chrono::seconds(settings[Setting::backup_restore_finish_timeout_after_error_sec]);
+    failure_after_host_disconnected_for_seconds = std::chrono::seconds{settings[Setting::backup_restore_failure_after_host_disconnected_for_seconds]};
+    max_retries_while_initializing = settings[Setting::backup_restore_keeper_max_retries_while_initializing];
+    max_retries_while_handling_error = settings[Setting::backup_restore_keeper_max_retries_while_handling_error];
+    finish_timeout_after_error = std::chrono::seconds(settings[Setting::backup_restore_finish_timeout_after_error_sec]);
 
     if (config.has("backups.sync_period_ms"))
-        keeper_settings.sync_period_ms = std::chrono::milliseconds{config.getUInt64("backups.sync_period_ms")};
+        sync_period_ms = std::chrono::milliseconds{config.getUInt64("backups.sync_period_ms")};
 
     if (config.has("backups.max_attempts_after_bad_version"))
-        keeper_settings.max_attempts_after_bad_version = config.getUInt64("backups.max_attempts_after_bad_version");
+        max_attempts_after_bad_version = config.getUInt64("backups.max_attempts_after_bad_version");
 
-    keeper_settings.value_max_size = settings[Setting::backup_restore_keeper_value_max_size];
-    keeper_settings.batch_size_for_multi = settings[Setting::backup_restore_batch_size_for_keeper_multi];
-    keeper_settings.batch_size_for_multiread = settings[Setting::backup_restore_batch_size_for_keeper_multiread];
-    keeper_settings.fault_injection_probability = settings[Setting::backup_restore_keeper_fault_injection_probability];
-    keeper_settings.fault_injection_seed = settings[Setting::backup_restore_keeper_fault_injection_seed];
-
-    return keeper_settings;
+    value_max_size = settings[Setting::backup_restore_keeper_value_max_size];
+    batch_size_for_multi = settings[Setting::backup_restore_batch_size_for_keeper_multi];
+    batch_size_for_multiread = settings[Setting::backup_restore_batch_size_for_keeper_multiread];
+    fault_injection_probability = settings[Setting::backup_restore_keeper_fault_injection_probability];
+    fault_injection_seed = settings[Setting::backup_restore_keeper_fault_injection_seed];
 }
 
 }

--- a/src/Backups/BackupKeeperSettings.h
+++ b/src/Backups/BackupKeeperSettings.h
@@ -9,56 +9,56 @@ namespace DB
 /// Settings for [Zoo]Keeper-related works during BACKUP or RESTORE.
 struct BackupKeeperSettings
 {
+    explicit BackupKeeperSettings(const ContextPtr & context);
+
     /// Maximum number of retries in the middle of a BACKUP ON CLUSTER or RESTORE ON CLUSTER operation.
     /// Should be big enough so the whole operation won't be cancelled in the middle of it because of a temporary ZooKeeper failure.
-    UInt64 max_retries{1000};
+    UInt64 max_retries;
 
     /// Initial backoff timeout for ZooKeeper operations during backup or restore.
-    std::chrono::milliseconds retry_initial_backoff_ms{100};
+    std::chrono::milliseconds retry_initial_backoff_ms;
 
     /// Max backoff timeout for ZooKeeper operations during backup or restore.
-    std::chrono::milliseconds retry_max_backoff_ms{5000};
+    std::chrono::milliseconds retry_max_backoff_ms;
 
     /// If a host during BACKUP ON CLUSTER or RESTORE ON CLUSTER doesn't recreate its 'alive' node in ZooKeeper
     /// for this amount of time then the whole backup or restore is considered as failed.
     /// Should be bigger than any reasonable time for a host to reconnect to ZooKeeper after a failure.
     /// Set to zero to disable (if it's zero and some host crashed then BACKUP ON CLUSTER or RESTORE ON CLUSTER will be waiting
     /// for the crashed host forever until the operation is explicitly cancelled with KILL QUERY).
-    std::chrono::seconds failure_after_host_disconnected_for_seconds{3600};
+    std::chrono::seconds failure_after_host_disconnected_for_seconds;
 
     /// Maximum number of retries during the initialization of a BACKUP ON CLUSTER or RESTORE ON CLUSTER operation.
     /// Shouldn't be too big because if the operation is going to fail then it's better if it fails faster.
-    UInt64 max_retries_while_initializing{20};
+    UInt64 max_retries_while_initializing;
 
     /// Maximum number of retries while handling an error of a BACKUP ON CLUSTER or RESTORE ON CLUSTER operation.
     /// Shouldn't be too big because those retries are just for cleanup after the operation has failed already.
-    UInt64 max_retries_while_handling_error{20};
+    UInt64 max_retries_while_handling_error;
 
     /// How long the initiator should wait for other host to handle the 'error' node and finish their work.
-    std::chrono::seconds finish_timeout_after_error{180};
+    std::chrono::seconds finish_timeout_after_error;
 
     /// How often the "stage" folder in ZooKeeper must be scanned in a background thread to track changes done by other hosts.
-    std::chrono::milliseconds sync_period_ms{5000};
+    std::chrono::milliseconds sync_period_ms;
 
     /// Number of attempts after getting error ZBADVERSION from ZooKeeper.
-    size_t max_attempts_after_bad_version{10};
+    size_t max_attempts_after_bad_version;
 
     /// Maximum size of data of a ZooKeeper's node during backup.
-    UInt64 value_max_size{1048576};
+    UInt64 value_max_size;
 
     /// Maximum size of a batch for a multi request.
-    UInt64 batch_size_for_multi{1000};
+    UInt64 batch_size_for_multi;
 
     /// Maximum size of a batch for a multiread request.
-    UInt64 batch_size_for_multiread{10000};
+    UInt64 batch_size_for_multiread;
 
     /// Approximate probability of failure for a keeper request during backup or restore. Valid value is in interval [0.0f, 1.0f].
-    Float64 fault_injection_probability{0};
+    Float64 fault_injection_probability;
 
     /// Seed for `fault_injection_probability`: 0 - random seed, otherwise the setting value.
-    UInt64 fault_injection_seed{0};
-
-    static BackupKeeperSettings fromContext(const ContextPtr & context);
+    UInt64 fault_injection_seed;
 };
 
 }

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -975,7 +975,7 @@ BackupsWorker::makeBackupCoordination(bool on_cluster, const BackupSettings & ba
 
     String root_zk_path = context->getConfigRef().getString("backups.zookeeper_path", "/clickhouse/backups");
     auto get_zookeeper = [global_context = context->getGlobalContext()] { return global_context->getZooKeeper(); };
-    auto keeper_settings = BackupKeeperSettings::fromContext(context);
+    auto keeper_settings = BackupKeeperSettings(context);
 
     auto all_hosts = BackupSettings::Util::filterHostIDs(
         backup_settings.cluster_host_ids, backup_settings.shard_num, backup_settings.replica_num);
@@ -1013,7 +1013,7 @@ BackupsWorker::makeRestoreCoordination(bool on_cluster, const RestoreSettings & 
 
     String root_zk_path = context->getConfigRef().getString("backups.zookeeper_path", "/clickhouse/backups");
     auto get_zookeeper = [global_context = context->getGlobalContext()] { return global_context->getZooKeeper(); };
-    auto keeper_settings = BackupKeeperSettings::fromContext(context);
+    auto keeper_settings = BackupKeeperSettings(context);
 
     auto all_hosts = BackupSettings::Util::filterHostIDs(
         restore_settings.cluster_host_ids, restore_settings.shard_num, restore_settings.replica_num);

--- a/src/Interpreters/ExpressionActionsSettings.h
+++ b/src/Interpreters/ExpressionActionsSettings.h
@@ -18,8 +18,8 @@ enum class CompileExpressions: uint8_t
 
 struct ExpressionActionsSettings
 {
-    ExpressionActionsSettings(); /// TODO Remove this contructor. ExpressionActionsSettings should only be initializable from Settings or
-                                 /// ContextPtr (i.e. the other two contructors).
+    ExpressionActionsSettings(); /// TODO Remove this constructor. ExpressionActionsSettings should only be initializable from Settings or
+                                 /// ContextPtr (i.e. the other two constructors).
     explicit ExpressionActionsSettings(const Settings & from, CompileExpressions compile_expressions_ = CompileExpressions::no);
     explicit ExpressionActionsSettings(ContextPtr from, CompileExpressions compile_expressions_ = CompileExpressions::no);
 

--- a/src/Interpreters/ExpressionActionsSettings.h
+++ b/src/Interpreters/ExpressionActionsSettings.h
@@ -18,7 +18,8 @@ enum class CompileExpressions: uint8_t
 
 struct ExpressionActionsSettings
 {
-    ExpressionActionsSettings();
+    ExpressionActionsSettings(); /// TODO Remove this contructor. ExpressionActionsSettings should only be initializable from Settings or
+                                 /// ContextPtr (i.e. the other two contructors).
     explicit ExpressionActionsSettings(const Settings & from, CompileExpressions compile_expressions_ = CompileExpressions::no);
     explicit ExpressionActionsSettings(ContextPtr from, CompileExpressions compile_expressions_ = CompileExpressions::no);
 

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -947,7 +947,7 @@ void StorageKeeperMap::backupData(BackupEntriesCollector & backup_entries_collec
         (
             getLogger(fmt::format("StorageKeeperMapBackup ({})", getStorageID().getNameForLogs())),
             [&] { return getClient(); },
-            BackupKeeperSettings::fromContext(backup_entries_collector.getContext()),
+            BackupKeeperSettings(backup_entries_collector.getContext()),
             backup_entries_collector.getContext()->getProcessListElement()
         );
 
@@ -977,7 +977,7 @@ void StorageKeeperMap::restoreDataFromBackup(RestorerFromBackup & restorer, cons
     (
         getLogger(fmt::format("StorageKeeperMapRestore ({})", getStorageID().getNameForLogs())),
         [&] { return getClient(); },
-        BackupKeeperSettings::fromContext(restorer.getContext()),
+        BackupKeeperSettings(restorer.getContext()),
         restorer.getContext()->getProcessListElement()
     );
 


### PR DESCRIPTION
Refactor `BackupKeeperSettings` in a similar way as #73693 did for query engine settings. Pushed this PR separately because there were some weird issues with FastTest when I pushed both refactorings together.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)