### PR TITLE
Disable header detection for executable UDFs and dictionaries (could lead to Function 'X': wrong result, expected Y row(s), actual Y-1)

### DIFF
--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -357,6 +357,19 @@ namespace
             , process_pool(process_pool_)
             , check_exit_code(check_exit_code_)
         {
+            auto context_for_reading = Context::createCopy(context);
+            /// Currently parallel parsing input format cannot read exactly max_block_size rows from input,
+            /// so it will be blocked on ReadBufferFromFileDescriptor because this file descriptor represent pipe that does not have eof.
+            if (configuration.read_fixed_number_of_rows)
+                context_for_reading->setSetting("input_format_parallel_parsing", false);
+            /// Here header auto detection can only cause troubles, since if it
+            /// will find "header" the number of input and output rows will not
+            /// match.
+            context_for_reading->setSetting("input_format_csv_detect_header", false);
+            context_for_reading->setSetting("input_format_tsv_detect_header", false);
+            context_for_reading->setSetting("input_format_custom_detect_header", false);
+            context = context_for_reading;
+
             try
             {
                 for (auto && send_data_task : send_data_tasks)
@@ -382,13 +395,6 @@ namespace
 
                 if (configuration.read_fixed_number_of_rows)
                 {
-                    /** Currently parallel parsing input format cannot read exactly max_block_size rows from input,
-                    * so it will be blocked on ReadBufferFromFileDescriptor because this file descriptor represent pipe that does not have eof.
-                    */
-                    auto context_for_reading = Context::createCopy(context);
-                    context_for_reading->setSetting("input_format_parallel_parsing", false);
-                    context = context_for_reading;
-
                     if (configuration.read_number_of_rows_from_process_output)
                     {
                         /// Initialize executor in generate

--- a/tests/queries/0_stateless/02833_local_udf_options.sh
+++ b/tests/queries/0_stateless/02833_local_udf_options.sh
@@ -8,4 +8,4 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 SCRIPTS_DIR=$CUR_DIR/scripts_udf
 
-$CLICKHOUSE_LOCAL -q 'select test_function()' -- --user_scripts_path=$SCRIPTS_DIR --user_defined_executable_functions_config=$SCRIPTS_DIR/function.xml
+$CLICKHOUSE_LOCAL -q 'select test_function()' --input_format_tsv_detect_header=1 -- --user_scripts_path=$SCRIPTS_DIR --user_defined_executable_functions_config=$SCRIPTS_DIR/function.xml

--- a/tests/queries/0_stateless/03302_udf_header_detection.reference
+++ b/tests/queries/0_stateless/03302_udf_header_detection.reference
@@ -1,0 +1,2 @@
+result
+foo

--- a/tests/queries/0_stateless/03302_udf_header_detection.sh
+++ b/tests/queries/0_stateless/03302_udf_header_detection.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SCRIPTS_DIR=$CUR_DIR/scripts_udf
+
+# "result" is used as a virtual column name:
+#
+#   src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp:    String result_name = "result";
+#
+$CLICKHOUSE_LOCAL --input_format_tsv_detect_header=1 -q "select udf_proxy(*) from values('result', 'foo')" -- --user_scripts_path="$SCRIPTS_DIR" --user_defined_executable_functions_config="$SCRIPTS_DIR/proxy.xml"

--- a/tests/queries/0_stateless/scripts_udf/proxy.sh
+++ b/tests/queries/0_stateless/scripts_udf/proxy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+while read -r line; do
+    echo "$line"
+done

--- a/tests/queries/0_stateless/scripts_udf/proxy.xml
+++ b/tests/queries/0_stateless/scripts_udf/proxy.xml
@@ -1,0 +1,13 @@
+<functions>
+    <function>
+        <type>executable</type>
+        <name>udf_proxy</name>
+        <argument>
+            <name>value</name>
+            <type>String</type>
+        </argument>
+        <return_type>String</return_type>
+        <format>TabSeparated</format>
+        <command>proxy.sh</command>
+    </function>
+</functions>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable header detection for executable UDFs and dictionaries (could lead to Function 'X': wrong result, expected Y row(s), actual Y-1)

Previously using TabSeparated/CSV/Custom formats for executable UDFs (and dictionaries) could lead to the following error:

    Code: 1. DB::Exception: Function 'udf_proxy': wrong result, expected 2 row(s), actual 1: while executing 'FUNCTION udf_proxy(__table1.c1 :: 1) -> udf_proxy(__table1.c1) String : 0'. (UNSUPPORTED_METHOD)

Due to ClickHouse detects the header in the lines and eat this row.

And it is pretty tricky to investigate such issues (and yes, using `TabSeparated` format for such interaction is not a good idea)