### PR TITLE
Disable header detection for Kafka/NATS/RabbitMQ/FileLog to improve performance

### DIFF
--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -71,6 +71,18 @@ namespace ErrorCodes
 namespace
 {
     const auto MAX_THREAD_WORK_DURATION_MS = 60000;
+
+    ContextMutablePtr configureContext(ContextPtr context)
+    {
+        auto new_context = Context::createCopy(context);
+        /// It does not make sense to use auto detection here, since the format
+        /// will be reset for each message, plus, auto detection takes CPU
+        /// time.
+        new_context->setSetting("input_format_csv_detect_header", false);
+        new_context->setSetting("input_format_tsv_detect_header", false);
+        new_context->setSetting("input_format_custom_detect_header", false);
+        return new_context;
+    }
 }
 
 static constexpr auto TMP_SUFFIX = ".tmp";
@@ -114,7 +126,7 @@ private:
             return Pipe{};
         }
 
-        auto modified_context = Context::createCopy(getContext());
+        auto modified_context = Context::createCopy(file_log.filelog_context);
 
         auto max_streams_number = std::min<UInt64>((*file_log.filelog_settings)[FileLogSetting::max_threads], file_log.file_infos.file_names.size());
 
@@ -157,6 +169,7 @@ StorageFileLog::StorageFileLog(
     LoadingStrictnessLevel mode)
     : IStorage(table_id_)
     , WithContext(context_->getGlobalContext())
+    , filelog_context(configureContext(getContext()))
     , filelog_settings(std::move(settings))
     , path(path_)
     , metadata_base_path(std::filesystem::path(metadata_base_path_) / "metadata")
@@ -759,7 +772,7 @@ bool StorageFileLog::streamToViews()
     auto insert = std::make_shared<ASTInsertQuery>();
     insert->table_id = table_id;
 
-    auto new_context = Context::createCopy(getContext());
+    auto new_context = Context::createCopy(filelog_context);
 
     InterpreterInsertQuery interpreter(
         insert,

--- a/src/Storages/FileLog/StorageFileLog.h
+++ b/src/Storages/FileLog/StorageFileLog.h
@@ -134,6 +134,7 @@ public:
 private:
     friend class ReadFromStorageFileLog;
 
+    ContextMutablePtr filelog_context;
     std::unique_ptr<FileLogSettings> filelog_settings;
 
     const String path;

--- a/src/Storages/Kafka/StorageKafkaUtils.cpp
+++ b/src/Storages/Kafka/StorageKafkaUtils.cpp
@@ -412,6 +412,14 @@ SettingsChanges createSettingsAdjustments(KafkaSettings & kafka_settings, const 
 
     auto kafka_format_settings = kafka_settings.getFormatSettings();
     result.insert(result.end(), kafka_format_settings.begin(), kafka_format_settings.end());
+
+    /// It does not make sense to use auto detection here, since the format
+    /// will be reset for each message, plus, auto detection takes CPU
+    /// time.
+    result.setSetting("input_format_csv_detect_header", false);
+    result.setSetting("input_format_tsv_detect_header", false);
+    result.setSetting("input_format_custom_detect_header", false);
+
     return result;
 }
 

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -224,6 +224,13 @@ ContextMutablePtr StorageNATS::addSettings(ContextPtr local_context) const
     /// check for non-nats-related settings
     modified_context->applySettingsChanges(nats_settings->getFormatSettings());
 
+    /// It does not make sense to use auto detection here, since the format
+    /// will be reset for each message, plus, auto detection takes CPU
+    /// time.
+    modified_context->setSetting("input_format_csv_detect_header", false);
+    modified_context->setSetting("input_format_tsv_detect_header", false);
+    modified_context->setSetting("input_format_custom_detect_header", false);
+
     return modified_context;
 }
 

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -331,6 +331,13 @@ ContextMutablePtr StorageRabbitMQ::addSettings(ContextPtr local_context) const
     /// check for non-rabbitmq-related settings
     modified_context->applySettingsChanges(rabbitmq_settings->getFormatSettings());
 
+    /// It does not make sense to use auto detection here, since the format
+    /// will be reset for each message, plus, auto detection takes CPU
+    /// time.
+    modified_context->setSetting("input_format_csv_detect_header", false);
+    modified_context->setSetting("input_format_tsv_detect_header", false);
+    modified_context->setSetting("input_format_custom_detect_header", false);
+
     return modified_context;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable header detection for Kafka/NATS/RabbitMQ/FileLog to improve performance

For streaming (when format is reseted after each row), any action that is done by the format is crucial for performance, and header detection is one of them.

Plus it does not make sense to even try it, since usually you have 1-1 mapping, i.e. 1 message -> 1 row for such formats, and I doubt that someone depends on it.
