### PR TITLE
ci: increase threshold for the functional tests log

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -154,7 +154,7 @@ class FTResultsProcessor:
                 status=test[1],
                 start_time=None,
                 duration=float(test[2]),
-                info="".join(test[3])[:8192],
+                info="".join(test[3])[:16384],
             )
             for test in test_results
         ]


### PR DESCRIPTION
8192 is not enough already with settings randomizations that takes ~8400, but the whole log is ~16500 chars, but it has some duplicated info, so first 16K should be enough.

**The long term fix should be to exclude not important information from the report**.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)