### PR TITLE
Ignore object not found errors for Azure during `plain_rewritable` disk initialization

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -81,6 +81,7 @@ static struct InitFiu
     REGULAR(plain_object_storage_write_fail_on_directory_move) \
     REGULAR(zero_copy_unlock_zk_fail_before_op) \
     REGULAR(zero_copy_unlock_zk_fail_after_op) \
+    REGULAR(plain_rewritable_object_storage_azure_not_found_on_init) \
 
 
 namespace FailPoints

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -188,13 +188,10 @@ std::shared_ptr<InMemoryDirectoryPathMap> loadPathPrefixMap(const std::string & 
                     chassert(remote_metadata_path.string().starts_with(metadata_key_prefix));
                     auto suffix = remote_metadata_path.string().substr(metadata_key_prefix.size());
                     auto rel_path = std::filesystem::path(std::move(suffix));
-                    std::pair<Map::iterator, bool> res;
-                    {
-                        std::lock_guard lock(mutex);
-                        res = map.emplace(
-                            std::filesystem::path(local_path).parent_path(),
-                            InMemoryDirectoryPathMap::RemotePathInfo{rel_path.parent_path(), last_modified.epochTime(), {}});
-                    }
+                    std::lock_guard lock(mutex);
+                    std::pair<Map::iterator, bool> res = map.emplace(
+                        std::filesystem::path(local_path).parent_path(),
+                        InMemoryDirectoryPathMap::RemotePathInfo{rel_path.parent_path(), last_modified.epochTime(), {}});
 
                     /// This can happen if table replication is enabled, then the same local path is written
                     /// in `prefix.path` of each replica.

--- a/tests/integration/test_azure_blob_storage_plain_rewritable/test.py
+++ b/tests/integration/test_azure_blob_storage_plain_rewritable/test.py
@@ -10,6 +10,7 @@ from helpers.cluster import ClickHouseCluster
 from test_storage_azure_blob_storage.test import azure_query
 
 NODE_NAME = "node"
+OTHER_NODE = "other_node"
 
 
 def generate_cluster_def(port):
@@ -77,6 +78,11 @@ def cluster():
             with_azurite=True,
             stay_alive=True,
         )
+        cluster.add_instance(
+            OTHER_NODE,
+            with_azurite=True,
+        )
+
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -132,6 +138,35 @@ def test_restart_server(cluster):
             )
             == value
         )
+
+
+def test_failpoint_on_disk_init(cluster):
+    other_node = cluster.instances[OTHER_NODE]
+    port = cluster.env_variables["AZURITE_PORT"]
+
+    azure_query(
+        other_node,
+        "SYSTEM ENABLE FAILPOINT plain_rewritable_object_storage_azure_not_found_on_init",
+    )
+    azure_query(
+        other_node,
+        """CREATE TABLE table (id Int64, data String) ENGINE=MergeTree() ORDER BY id SETTINGS disk=disk(
+        type = object_storage,
+        metadata_type = plain_rewritable,
+        object_storage_type = azure_blob_storage,
+        container_name = 'cont',
+        endpoint = 'http://azurite1:{port}/devstoreaccount1/cont',
+        account_name = 'devstoreaccount1',
+        account_key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==')
+        """.format(
+            port=port
+        ),
+    )
+    azure_query(other_node, "DROP TABLE table SYNC")
+    azure_query(
+        other_node,
+        "SYSTEM DISABLE FAILPOINT plain_rewritable_object_storage_azure_not_found_on_init",
+    )
 
 
 def test_drop_table(cluster):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A disk using the plain_rewritable metadata can be shared among multiple server instances. It is expected for one instance to read a metadata object while another modifies it. Object not found errors are ignored during plain_rewritable initialization with Azure storage, similar to the behavior implemented for S3.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
