### PR TITLE
Fix behaviour of any(Enum) and anyLast(Enum) for empty table

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionAny.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAny.cpp
@@ -1,5 +1,7 @@
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/SingleValueData.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeEnum.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <base/defines.h>
@@ -11,6 +13,7 @@ struct Settings;
 
 namespace ErrorCodes
 {
+extern const int LOGICAL_ERROR;
 extern const int NOT_IMPLEMENTED;
 }
 
@@ -130,7 +133,25 @@ public:
 
     void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
     {
-        this->data(place).insertResultInto(to);
+        if (isEnum(this->argument_types[0]) && !this->data(place).has())
+        {
+            if (checkColumn<typename DataTypeEnum8::ColumnType>(&to))
+            {
+                const auto* type_enum8 = assert_cast<const DataTypeEnum8*>(this->argument_types[0].get());
+                type_enum8->insertDefaultInto(to);
+            }
+            else if (checkColumn<typename DataTypeEnum16::ColumnType>(&to))
+            {
+                const auto* type_enum16 = assert_cast<const DataTypeEnum16*>(this->argument_types[0].get());
+                type_enum16->insertDefaultInto(to);
+            }
+            else
+            {
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected enum type: {}", this->argument_types[0]->getName());
+            }
+        }
+        else
+            this->data(place).insertResultInto(to);
     }
 
 #if USE_EMBEDDED_COMPILER
@@ -300,7 +321,25 @@ public:
 
     void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
     {
-        this->data(place).insertResultInto(to);
+        if (isEnum(this->argument_types[0]) && !this->data(place).has())
+        {
+            if (checkColumn<typename DataTypeEnum8::ColumnType>(&to))
+            {
+                const auto* type_enum8 = assert_cast<const DataTypeEnum8*>(this->argument_types[0].get());
+                type_enum8->insertDefaultInto(to);
+            }
+            else if (checkColumn<typename DataTypeEnum16::ColumnType>(&to))
+            {
+                const auto* type_enum16 = assert_cast<const DataTypeEnum16*>(this->argument_types[0].get());
+                type_enum16->insertDefaultInto(to);
+            }
+            else
+            {
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected enum type: {}", this->argument_types[0]->getName());
+            }
+        }
+        else
+            this->data(place).insertResultInto(to);
     }
 
 #if USE_EMBEDDED_COMPILER

--- a/tests/queries/0_stateless/03302_any_enum_aggregation.reference
+++ b/tests/queries/0_stateless/03302_any_enum_aggregation.reference
@@ -1,0 +1,16 @@
+Issue 68605
+LOW
+LOW		0
+LOW		0
+Empty Enum8 table:
+MEDIUM
+MEDIUM
+Enum8 table with HIGH value:
+HIGH
+HIGH
+Empty Enum16 table:
+MEDIUM
+MEDIUM
+Enum16 table with HIGH value:
+HIGH
+HIGH

--- a/tests/queries/0_stateless/03302_any_enum_aggregation.sql
+++ b/tests/queries/0_stateless/03302_any_enum_aggregation.sql
@@ -4,8 +4,10 @@ CREATE TABLE test_33602 (name String, score UInt8, user_level  Enum8('LOW' = 1, 
 SELECT any(user_level) FROM test_33602;
 SELECT any(user_level), any(name), any(score) FROM test_33602;
 SELECT anyLast(user_level), anyLast(name), anyLast(score) FROM test_33602;
+DROP TABLE test_33602;
 
 SELECT 'Empty Enum8 table:';
+DROP TABLE IF EXISTS test_33602_t0a;
 CREATE TABLE test_33602_t0a (e Enum8('LOW' = 123, 'MEDIUM' = 12, 'HIGH' = 33)) ENGINE=Memory;
 SELECT any(e) FROM test_33602_t0a;
 SELECT anyLast(e) FROM test_33602_t0a;
@@ -14,14 +16,17 @@ SELECT 'Enum8 table with HIGH value:';
 INSERT INTO test_33602_t0a VALUES('HIGH');
 SELECT any(e) FROM test_33602_t0a;
 SELECT anyLast(e) FROM test_33602_t0a;
+DROP TABLE test_33602_t0a;
 
 
 SELECT 'Empty Enum16 table:';
+DROP TABLE IF EXISTS test_33602_t0b;
 CREATE TABLE test_33602_t0b (e Enum16('LOW' = 123, 'MEDIUM' = 12, 'HIGH' = 33)) ENGINE=Memory;
 SELECT any(e) FROM test_33602_t0b;
 SELECT anyLast(e) FROM test_33602_t0b;
 
 SELECT 'Enum16 table with HIGH value:';
 INSERT INTO test_33602_t0b VALUES('HIGH');
-SELECT any(e) FROM test_33602_t0a;
-SELECT anyLast(e) FROM test_33602_t0a;
+SELECT any(e) FROM test_33602_t0b;
+SELECT anyLast(e) FROM test_33602_t0b;
+DROP TABLE test_33602_t0b;

--- a/tests/queries/0_stateless/03302_any_enum_aggregation.sql
+++ b/tests/queries/0_stateless/03302_any_enum_aggregation.sql
@@ -1,0 +1,27 @@
+SELECT 'Issue 68605';
+DROP TABLE IF EXISTS test_33602;
+CREATE TABLE test_33602 (name String, score UInt8, user_level  Enum8('LOW' = 1, 'MEDIUM' = 2, 'HIGH' = 3)) ENGINE=Memory;
+SELECT any(user_level) FROM test_33602;
+SELECT any(user_level), any(name), any(score) FROM test_33602;
+SELECT anyLast(user_level), anyLast(name), anyLast(score) FROM test_33602;
+
+SELECT 'Empty Enum8 table:';
+CREATE TABLE test_33602_t0a (e Enum8('LOW' = 123, 'MEDIUM' = 12, 'HIGH' = 33)) ENGINE=Memory;
+SELECT any(e) FROM test_33602_t0a;
+SELECT anyLast(e) FROM test_33602_t0a;
+
+SELECT 'Enum8 table with HIGH value:';
+INSERT INTO test_33602_t0a VALUES('HIGH');
+SELECT any(e) FROM test_33602_t0a;
+SELECT anyLast(e) FROM test_33602_t0a;
+
+
+SELECT 'Empty Enum16 table:';
+CREATE TABLE test_33602_t0b (e Enum16('LOW' = 123, 'MEDIUM' = 12, 'HIGH' = 33)) ENGINE=Memory;
+SELECT any(e) FROM test_33602_t0b;
+SELECT anyLast(e) FROM test_33602_t0b;
+
+SELECT 'Enum16 table with HIGH value:';
+INSERT INTO test_33602_t0b VALUES('HIGH');
+SELECT any(e) FROM test_33602_t0a;
+SELECT anyLast(e) FROM test_33602_t0a;


### PR DESCRIPTION
Fixes #68605 (`any`, `anyLast`)

```sql
CREATE TABLE test_33602_t0a (e Enum8('LOW' = 123, 'MEDIUM' = 12, 'HIGH' = 33)) ENGINE=Memory;
SELECT any(e) FROM test_33602_t0a;
```
Used to complain with `Unknown enum value: 0`. At the same time:
```sql
CREATE TABLE t1 (x INT) ENGINE=Memory;
SELECT any(x) FROM t1

Query id: 005e14dc-cd0d-4676-b45e-54401f99fcdd

   ┌─any(x)─┐
1. │      0 │
   └────────┘

```

I changed the code to return the default enum value (unlike the "nothing" suggested in #68605):
```sql
CREATE TABLE test_33602_t0a (e Enum8('LOW' = 123, 'MEDIUM' = 12, 'HIGH' = 33)) ENGINE=Memory;
SELECT any(e) FROM test_33602_t0a;

Query id: 03c6801b-770e-4d6d-ba0f-b9ebb36bf992

   ┌─any(e)─┐
1. │ MEDIUM │
   └────────┘
```

Can adjust to return "nothing" if that would be preferred.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix behaviour of `any` and `anyLast` with enum types and empty table

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
