### PR TITLE
Improve `CollapsingMergeTree` documentation

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
@@ -276,7 +276,7 @@ SELECT * FROM UAct FINAL
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 :::note
-This way of selecting the data is very inefficient and is not recommended for use with big tables.
+This way of selecting the data is less inefficient and is not recommended for use with large amounts of scanned data.
 :::
 
 ### Example of Another Approach {#example-of-another-approach}

--- a/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
@@ -276,7 +276,7 @@ SELECT * FROM UAct FINAL
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 :::note
-This way of selecting the data is less inefficient and is not recommended for use with large amounts of scanned data.
+This way of selecting the data is less inefficient and is not recommended for use with large amounts of scanned data (millions of rows).
 :::
 
 ### Example of Another Approach {#example-of-another-approach}

--- a/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
@@ -2,15 +2,33 @@
 slug: /en/engines/table-engines/mergetree-family/collapsingmergetree
 sidebar_position: 70
 sidebar_label: CollapsingMergeTree
+keywords: ['updates', 'collapsing']
 ---
 
 # CollapsingMergeTree
 
-The engine inherits from [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md) and adds the logic of rows collapsing to data parts merge algorithm.
+## Description
 
-`CollapsingMergeTree` asynchronously deletes (collapses) pairs of rows if all of the fields in a sorting key (`ORDER BY`) are equivalent except the particular field `Sign`, which can have `1` and `-1` values. Rows without a pair are kept. For more details see the [Collapsing](#table_engine-collapsingmergetree-collapsing) section of the document.
+The `CollapsingMergeTree` engine inherits from [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md)
+and adds logic for collapsing rows during the merge process.
+The `CollapsingMergeTree` table engine asynchronously deletes (collapses) 
+pairs of rows if all the fields in a sorting key (`ORDER BY`) are equivalent except for the special field `Sign`, 
+which can have values of either `1` or `-1`. 
+Rows without a pair of opposite valued `Sign` are kept. 
 
-The engine may significantly reduce the volume of storage and increase the efficiency of `SELECT` query as a consequence.
+For more details, see the [Collapsing](#table_engine-collapsingmergetree-collapsing) section of the document.
+
+:::note
+This engine may significantly reduce the volume of storage,
+increasing the efficiency of `SELECT` queries as a consequence.
+:::
+
+## Parameters
+
+All parameters of this table engine, with the exception of the `Sign` parameter,
+have the same meaning as in [`MergeTree`](/docs/en/engines/table-engines/mergetree-family/mergetree).
+
+- `Sign` — The name given to a column with the type of row where `1` is a “state” row and `-1` is a “cancel” row. Type: [Int8](/docs/en/sql-reference/data-types/int-uint).
 
 ## Creating a Table {#creating-a-table}
 
@@ -20,33 +38,21 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
     name1 [type1] [DEFAULT|MATERIALIZED|ALIAS expr1],
     name2 [type2] [DEFAULT|MATERIALIZED|ALIAS expr2],
     ...
-) ENGINE = CollapsingMergeTree(sign)
+) 
+ENGINE = CollapsingMergeTree(Sign)
 [PARTITION BY expr]
 [ORDER BY expr]
 [SAMPLE BY expr]
 [SETTINGS name=value, ...]
 ```
 
-For a description of query parameters, see [query description](../../../sql-reference/statements/create/table.md).
-
-## CollapsingMergeTree Parameters
-
-### sign
-
-`sign` — Name of the column with the type of row: `1` is a “state” row, `-1` is a “cancel” row.
-
-    Column data type — `Int8`.
-
-## Query clauses
-
-When creating a `CollapsingMergeTree` table, the same [query clauses](../../../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-creating-a-table) are required, as when creating a `MergeTree` table.
-
 <details markdown="1">
 
 <summary>Deprecated Method for Creating a Table</summary>
 
 :::note
-Do not use this method in new projects and, if possible, switch old projects to the method described above.
+The method below is not recommended for use in new projects. 
+We advise, if possible, to update old projects to use the new method.
 :::
 
 ``` sql
@@ -55,26 +61,33 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
     name1 [type1] [DEFAULT|MATERIALIZED|ALIAS expr1],
     name2 [type2] [DEFAULT|MATERIALIZED|ALIAS expr2],
     ...
-) ENGINE [=] CollapsingMergeTree(date-column [, sampling_expression], (primary, key), index_granularity, sign)
+) 
+ENGINE [=] CollapsingMergeTree(date-column [, sampling_expression], (primary, key), index_granularity, Sign)
 ```
 
-All of the parameters excepting `sign` have the same meaning as in `MergeTree`.
-
-- `sign` — Name of the column with the type of row: `1` — “state” row, `-1` — “cancel” row.
-
-    Column Data Type — `Int8`.
+`Sign` — The name given to a column with the type of row where `1` is a “state” row and `-1` is a “cancel” row. [Int8](/docs/en/sql-reference/data-types/int-uint).
 
 </details>
+
+- For a description of query parameters, see [query description](../../../sql-reference/statements/create/table.md).
+- When creating a `CollapsingMergeTree` table, the same [query clauses](../../../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-creating-a-table) are required, as when creating a `MergeTree` table.
 
 ## Collapsing {#table_engine-collapsingmergetree-collapsing}
 
 ### Data {#data}
 
-Consider the situation where you need to save continually changing data for some object. It sounds logical to have one row for an object and update it at any change, but update operation is expensive and slow for DBMS because it requires rewriting of the data in the storage. If you need to write data quickly, update not acceptable, but you can write the changes of an object sequentially as follows.
+Consider the situation where you need to save continually changing data for some given object.
+It may sound logical to have one row per object and update it anytime something changes,
+however, update operations are expensive and slow for the DBMS because they require rewriting the data in storage. 
+If we need to write data quickly, performing large numbers of updates is not an acceptable approach,
+but we can always write the changes of an object sequentially.
+To do so, we make use of the special column `Sign`.
 
-Use the particular column `Sign`. If `Sign = 1` it means that the row is a state of an object, let’s call it “state” row. If `Sign = -1` it means the cancellation of the state of an object with the same attributes, let’s call it “cancel” row.
+- If `Sign` = `1` it means that the row is a “state” row: _a row containing fields which represent a current valid state_. 
+- If `Sign` = `-1` it means that the row is a “cancel” row: _a row used for the cancellation of state of an object with the same attributes_.
 
-For example, we want to calculate how much pages users checked at some site and how long they were there. At some moment we write the following row with the state of user activity:
+For example, we want to calculate how many pages users checked on some website and how long they visited them for. 
+At some given moment in time, we write the following row with the state of user activity:
 
 ``` text
 ┌──────────────UserID─┬─PageViews─┬─Duration─┬─Sign─┐
@@ -82,7 +95,7 @@ For example, we want to calculate how much pages users checked at some site and 
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 
-At some moment later we register the change of user activity and write it with the following two rows.
+At a later moment in time, we register the change of user activity and write it with the following two rows:
 
 ``` text
 ┌──────────────UserID─┬─PageViews─┬─Duration─┬─Sign─┐
@@ -91,56 +104,85 @@ At some moment later we register the change of user activity and write it with t
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 
-The first row cancels the previous state of the object (user). It should copy the sorting key fields of the cancelled state excepting `Sign`.
+The first row cancels the previous state of the object (representing a user in this case). 
+It should copy all the sorting key fields for the "canceled" row except for `Sign`. 
+The second row above contains the current state.
 
-The second row contains the current state.
-
-As we need only the last state of user activity, the rows
+As we need only the last state of user activity, the original "state" row and the "cancel" 
+row that we inserted can be deleted as shown below, collapsing the invalid (old) state of an object:
 
 ``` text
 ┌──────────────UserID─┬─PageViews─┬─Duration─┬─Sign─┐
-│ 4324182021466249494 │         5 │      146 │    1 │
-│ 4324182021466249494 │         5 │      146 │   -1 │
+│ 4324182021466249494 │         5 │      146 │    1 │ -- old "state" row can be deleted
+│ 4324182021466249494 │         5 │      146 │   -1 │ -- "cancel" row can be deleted
+│ 4324182021466249494 │         6 │      185 │    1 │ -- new "state" row remains
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 
-can be deleted collapsing the invalid (old) state of an object. `CollapsingMergeTree` does this while merging of the data parts.
+`CollapsingMergeTree` carries out precisely this _collapsing_ behavior while merging of the data parts takes place.
 
-Why we need 2 rows for each change read in the [Algorithm](#table_engine-collapsingmergetree-collapsing-algorithm) paragraph.
+:::note
+The reason for why two rows are needed for each change 
+is further discussed in the [Algorithm](#table_engine-collapsingmergetree-collapsing-algorithm) paragraph.
+:::
 
-**Peculiar properties of such approach**
+**The peculiarities of such an approach**
 
-1.  The program that writes the data should remember the state of an object to be able to cancel it. “Cancel” string should contain copies of the sorting key fields of the “state” string and the opposite `Sign`. It increases the initial size of storage but allows to write the data quickly.
-2.  Long growing arrays in columns reduce the efficiency of the engine due to load for writing. The more straightforward data, the higher the efficiency.
-3.  The `SELECT` results depend strongly on the consistency of object changes history. Be accurate when preparing data for inserting. You can get unpredictable results in inconsistent data, for example, negative values for non-negative metrics such as session depth.
+1.  The program that writes the data should remember the state of an object to be able to cancel it. The “cancel” row should contain copies of sorting key fields of the “state” and the opposite `Sign`. This increases the initial size of storage but allows us to write the data quickly.
+2.  Long growing arrays in columns reduce the efficiency of the engine due to the increased load for writing. The more straightforward the data, the higher the efficiency.
+3.  The `SELECT` results depend strongly on the consistency of the object change history. Be accurate when preparing data for inserting. You can get unpredictable results with inconsistent data. For example, negative values for non-negative metrics such as session depth.
 
 ### Algorithm {#table_engine-collapsingmergetree-collapsing-algorithm}
 
-When ClickHouse merges data parts, each group of consecutive rows with the same sorting key (`ORDER BY`) is reduced to not more than two rows, one with `Sign = 1` (“state” row) and another with `Sign = -1` (“cancel” row). In other words, entries collapse.
+When ClickHouse merges data [parts](/docs/en/concepts/glossary#parts), 
+each group of consecutive rows with the same sorting key (`ORDER BY`) is reduced to no more than two rows,
+the “state” row with `Sign` = `1` and the "cancel" row with `Sign` = `-1`. 
+In other words, in ClickHouse entries collapse.
 
 For each resulting data part ClickHouse saves:
 
-1.  The first “cancel” and the last “state” rows, if the number of “state” and “cancel” rows matches and the last row is a “state” row.
-2.  The last “state” row, if there are more “state” rows than “cancel” rows.
-3.  The first “cancel” row, if there are more “cancel” rows than “state” rows.
-4.  None of the rows, in all other cases.
+|  |                                                                                                                                     |
+|--|-------------------------------------------------------------------------------------------------------------------------------------|
+|1.| The first “cancel” and the last “state” rows, if the number of “state” and “cancel” rows matches and the last row is a “state” row. |
+|2.| The last “state” row, if there are more “state” rows than “cancel” rows.                                                            |
+|3.| The first “cancel” row, if there are more “cancel” rows than “state” rows.                                                          |
+|4.| None of the rows, in all other cases.                                                                                               |
 
-Also, when there are at least 2 more “state” rows than “cancel” rows, or at least 2 more “cancel” rows then “state” rows, the merge continues, but ClickHouse treats this situation as a logical error and records it in the server log. This error can occur if the same data were inserted more than once.
-
+Additionally, when there are at least two more “state” rows than “cancel” 
+rows, or at least two more “cancel” rows than “state” rows, the merge continues.
+ClickHouse, however, treats this situation as a logical error and records it in the server log. 
+This error can occur if the same data is inserted more than once. 
 Thus, collapsing should not change the results of calculating statistics.
-Changes gradually collapsed so that in the end only the last state of almost every object left.
+Changes are gradually collapsed so that in the end only the last state of almost every object is left.
 
-The `Sign` is required because the merging algorithm does not guarantee that all of the rows with the same sorting key will be in the same resulting data part and even on the same physical server. ClickHouse process `SELECT` queries with multiple threads, and it can not predict the order of rows in the result. The aggregation is required if there is a need to get completely “collapsed” data from `CollapsingMergeTree` table.
+The `Sign` column is required because the merging algorithm does not guarantee 
+that all the rows with the same sorting key will be in the same resulting data part and even on the same physical server. 
+ClickHouse processes `SELECT` queries with multiple threads, and it cannot predict the order of rows in the result. 
 
-To finalize collapsing, write a query with `GROUP BY` clause and aggregate functions that account for the sign. For example, to calculate quantity, use `sum(Sign)` instead of `count()`. To calculate the sum of something, use `sum(Sign * x)` instead of `sum(x)`, and so on, and also add `HAVING sum(Sign) > 0`.
+Aggregation is required if there is a need to get completely “collapsed” data from the `CollapsingMergeTree` table.
+To finalize collapsing, write a query with the `GROUP BY` clause and aggregate functions that account for the sign. 
+For example, to calculate quantity, use `sum(Sign)` instead of `count()`. 
+To calculate the sum of something, use `sum(Sign * x)` together `HAVING sum(Sign) > 0` instead of `sum(x)`
+as in the [example](#example-of-use) below.
 
-The aggregates `count`, `sum` and `avg` could be calculated this way. The aggregate `uniq` could be calculated if an object has at least one state not collapsed. The aggregates `min` and `max` could not be calculated because `CollapsingMergeTree` does not save the values history of the collapsed states.
+The aggregates `count`, `sum` and `avg` could be calculated this way. 
+The aggregate `uniq` could be calculated if an object has at least one non-collapsed state. 
+The aggregates `min` and `max` could not be calculated 
+because `CollapsingMergeTree` does not save the history of the collapsed states.
 
-If you need to extract data without aggregation (for example, to check whether rows are present whose newest values match certain conditions), you can use the `FINAL` modifier for the `FROM` clause. This approach is significantly less efficient.
+:::note
+If you need to extract data without aggregation 
+(for example, to check whether rows whose newest values match certain conditions are present), 
+you can use the `FINAL` modifier for the `FROM` clause. 
 
-## Example of Use {#example-of-use}
+This approach is significantly less efficient.
+:::
 
-Example data:
+## Examples
+
+### Example of Use {#example-of-use}
+
+Given the following example data:
 
 ``` text
 ┌──────────────UserID─┬─PageViews─┬─Duration─┬─Sign─┐
@@ -150,7 +192,7 @@ Example data:
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 
-Creation of the table:
+Let's create a table `UAct` using the `CollapsingMergeTree`:
 
 ``` sql
 CREATE TABLE UAct
@@ -164,7 +206,7 @@ ENGINE = CollapsingMergeTree(Sign)
 ORDER BY UserID
 ```
 
-Insertion of the data:
+Next we will insert some data:
 
 ``` sql
 INSERT INTO UAct VALUES (4324182021466249494, 5, 146, 1)
@@ -174,9 +216,13 @@ INSERT INTO UAct VALUES (4324182021466249494, 5, 146, 1)
 INSERT INTO UAct VALUES (4324182021466249494, 5, 146, -1),(4324182021466249494, 6, 185, 1)
 ```
 
-We use two `INSERT` queries to create two different data parts. If we insert the data with one query ClickHouse creates one data part and will not perform any merge ever.
+We use two `INSERT` queries to create two different data parts. 
 
-Getting the data:
+:::note
+If we insert the data with a single query, ClickHouse creates only one data part and will not perform any merge ever.
+:::
+
+We can select the data using:
 
 ``` sql
 SELECT * FROM UAct
@@ -192,11 +238,15 @@ SELECT * FROM UAct
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 
-What do we see and where is collapsing?
+Let's take a look at the returned data above and see if collapsing occurred...
+With two `INSERT` queries, we created two data parts. 
+The `SELECT` query was performed in two threads, and we got a random order of rows. 
+However, collapsing **did not occur** because there was no merge of the data parts yet 
+and ClickHouse merges data parts in the background at an unknown moment which we cannot predict.
 
-With two `INSERT` queries, we created 2 data parts. The `SELECT` query was performed in 2 threads, and we got a random order of rows. Collapsing not occurred because there was no merge of the data parts yet. ClickHouse merges data part in an unknown moment which we can not predict.
-
-Thus, we need aggregation:
+We therefore need an aggregation 
+which we perform with the [`sum`](/docs/en/sql-reference/aggregate-functions/reference/sum) 
+aggregate function and the [`HAVING`](/docs/en/sql-reference/statements/select/having) clause:
 
 ``` sql
 SELECT
@@ -214,7 +264,7 @@ HAVING sum(Sign) > 0
 └─────────────────────┴───────────┴──────────┘
 ```
 
-If we do not need aggregation and want to force collapsing, we can use `FINAL` modifier for `FROM` clause.
+If we do not need aggregation and want to force collapsing, we can also use the `FINAL` modifier for `FROM` clause.
 
 ``` sql
 SELECT * FROM UAct FINAL
@@ -225,12 +275,17 @@ SELECT * FROM UAct FINAL
 │ 4324182021466249494 │         6 │      185 │    1 │
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
+:::note
+This way of selecting the data is very inefficient and is not recommended for use with big tables.
+:::
 
-This way of selecting the data is very inefficient. Don’t use it for big tables.
+### Example of Another Approach {#example-of-another-approach}
 
-## Example of Another Approach {#example-of-another-approach}
+The idea with this approach is that merges take into account only key fields.
+In the “cancel” row, we can therefore specify negative values
+that equalize the previous version of the row when summing without using the `Sign` column.
 
-Example data:
+For this example, we will make use of the sample data below:
 
 ``` text
 ┌──────────────UserID─┬─PageViews─┬─Duration─┬─Sign─┐
@@ -240,7 +295,9 @@ Example data:
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 
-The idea is that merges take into account only key fields. And in the “Cancel” line we can specify negative values that equalize the previous version of the row when summing without using the Sign column. For this approach, it is necessary to change the data type `PageViews`,`Duration` to store negative values of UInt8 -\> Int16.
+For this approach, it is necessary to change the data types of `PageViews` and `Duration` to store negative values. 
+We therefore change the values of these columns from `UInt8` to `Int16` when we create our table `UAct` using the
+`collapsingMergeTree`:
 
 ``` sql
 CREATE TABLE UAct
@@ -254,14 +311,16 @@ ENGINE = CollapsingMergeTree(Sign)
 ORDER BY UserID
 ```
 
-Let’s test the approach:
+Let’s test the approach by inserting data into our table. 
+Recall that use of the [`FINAL`](/docs/en/sql-reference/statements/select/from#final-modifier) keyword is not recommended production cases.
+For examples or small tables, it is, however, acceptable:
 
 ``` sql
-insert into UAct values(4324182021466249494,  5,  146,  1);
-insert into UAct values(4324182021466249494, -5, -146, -1);
-insert into UAct values(4324182021466249494,  6,  185,  1);
+INSERT INTO UAct VALUES(4324182021466249494,  5,  146,  1);
+INSERT INTO UAct VALUES(4324182021466249494, -5, -146, -1);
+INSERT INTO UAct VALUES(4324182021466249494,  6,  185,  1);
 
-select * from UAct final; // avoid using final in production (just for a test or small tables)
+SELECT * FROM UAct FINAL;
 ```
 
 ``` text
@@ -286,7 +345,7 @@ GROUP BY UserID
 ```
 
 ``` sql
-select count() FROM UAct
+SELECT COUNT() FROM UAct
 ```
 
 ``` text
@@ -296,9 +355,9 @@ select count() FROM UAct
 ```
 
 ``` sql
-optimize table UAct final;
+OPTIMIZE TABLE UAct FINAL;
 
-select * FROM UAct
+SELECT * FROM UAct
 ```
 
 ``` text


### PR DESCRIPTION
Fixes typos, grammar and formatting of page for `CollapsingMergeTree`

### Changelog category (leave one):
- Documentation (changelog entry is not required)
