### PR TITLE
Fix altering s3queue settings with "s3queue_" prefix to without and vice versa

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -869,9 +869,14 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
             auto it = std::find_if(settings_from_storage.begin(), settings_from_storage.end(), finder);
 
             if (it != settings_from_storage.end())
+            {
                 settings_from_storage.erase(it);
-
-            /// Intentionally ignore if there is no such setting name
+            }
+            else
+            {
+                /// Intentionally ignore if there is no such setting name
+                LOG_TEST(getLogger("AlterCommands"), "No such setting name {}, will ignore", setting_name);
+            }
         }
     }
     else if (type == RENAME_COLUMN)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -129,6 +129,8 @@ void ObjectStorageQueueSettings::loadFromQuery(ASTStorage & storage_def)
             std::vector<std::string> ignore_settings;
             auto settings_changes = storage_def.settings->changes;
 
+            std::set<std::string> names;
+
             /// We support settings starting with s3_ for compatibility.
             for (auto & change : settings_changes)
             {
@@ -140,8 +142,14 @@ void ObjectStorageQueueSettings::loadFromQuery(ASTStorage & storage_def)
 
                 if (change.name == "current_shard_num")
                     ignore_settings.push_back(change.name);
-                if (change.name == "total_shards_num")
+                else if (change.name == "total_shards_num")
                     ignore_settings.push_back(change.name);
+                else
+                {
+                    bool inserted = names.insert(change.name).second;
+                    if (!inserted)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is duplicated", change.name);
+                }
             }
 
             for (const auto & setting : ignore_settings)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -14,6 +14,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_SETTING;
+    extern const int BAD_ARGUMENTS;
 }
 
 #define OBJECT_STORAGE_QUEUE_RELATED_SETTINGS(DECLARE, ALIAS) \

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -658,7 +658,7 @@ static AlterCommands normalizeAlterCommands(const AlterCommands & alter_commands
             setting.name = normalizeSetting(setting.name);
 
         std::set<std::string> settings_resets;
-        for (auto & setting : command.settings_resets)
+        for (const auto & setting : command.settings_resets)
             settings_resets.insert(normalizeSetting(setting));
 
         command.settings_resets = settings_resets;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -617,8 +617,24 @@ static const std::unordered_set<std::string_view> changeable_settings_ordered_mo
     "buckets",
 };
 
+static std::string normalizeSetting(const std::string & name)
+{
+    /// We support this prefix for compatibility.
+    if (name.starts_with("s3queue_"))
+        return name.substr(std::strlen("s3queue_"));
+    return name;
+}
+
+void checkNormalizedSetting(const std::string & name)
+{
+    if (name.starts_with("s3queue_"))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Setting is not normalized: {}", name);
+}
+
 static bool isSettingChangeable(const std::string & name, ObjectStorageQueueMode mode)
 {
+    checkNormalizedSetting(name);
+
     if (mode == ObjectStorageQueueMode::UNORDERED)
         return changeable_settings_unordered_mode.contains(name);
     else
@@ -627,7 +643,27 @@ static bool isSettingChangeable(const std::string & name, ObjectStorageQueueMode
 
 static bool requiresDetachedMV(const std::string & name)
 {
-    return name == "buckets" || name == "s3queue_buckets";
+    checkNormalizedSetting(name);
+    return name == "buckets";
+}
+
+static AlterCommands normalizeAlterCommands(const AlterCommands & alter_commands)
+{
+    /// Remove s3queue_ prefix from setting to avoid duplicated settings,
+    /// because of altering setting with the prefix to a setting without the prefix.
+    AlterCommands normalized_alter_commands(alter_commands);
+    for (auto & command : normalized_alter_commands)
+    {
+        for (auto & setting : command.settings_changes)
+            setting.name = normalizeSetting(setting.name);
+
+        std::set<std::string> settings_resets;
+        for (auto & setting : command.settings_resets)
+            settings_resets.insert(normalizeSetting(setting));
+
+        command.settings_resets = settings_resets;
+    }
+    return normalized_alter_commands;
 }
 
 void StorageObjectStorageQueue::checkAlterIsPossible(const AlterCommands & commands, ContextPtr local_context) const
@@ -635,56 +671,70 @@ void StorageObjectStorageQueue::checkAlterIsPossible(const AlterCommands & comma
     for (const auto & command : commands)
     {
         if (command.type != AlterCommand::MODIFY_SETTING && command.type != AlterCommand::RESET_SETTING)
-            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Only MODIFY/RESET SETTING alter is allowed for {}", getName());
+        {
+            throw Exception(
+                ErrorCodes::SUPPORT_IS_DISABLED,
+                "Only MODIFY/RESET SETTING alter is allowed for {}", getName());
+        }
     }
 
-    StorageInMemoryMetadata new_metadata = getInMemoryMetadata();
-    commands.apply(new_metadata, local_context);
+    StorageInMemoryMetadata old_metadata(getInMemoryMetadata());
+    SettingsChanges * old_settings = nullptr;
+    if (old_metadata.settings_changes)
+    {
+        old_settings = &old_metadata.settings_changes->as<ASTSetQuery &>().changes;
+        for (auto & setting : *old_settings)
+            setting.name = normalizeSetting(setting.name);
+    }
+
+    StorageInMemoryMetadata new_metadata(old_metadata);
+
+    auto alter_commands = normalizeAlterCommands(commands);
+    alter_commands.apply(new_metadata, local_context);
 
     if (!new_metadata.hasSettingsChanges())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No settings changes");
 
-    const auto & new_changes = new_metadata.settings_changes->as<const ASTSetQuery &>().changes;
-
-    StorageInMemoryMetadata old_metadata = getInMemoryMetadata();
-    const SettingsChanges * old_changes = nullptr;
-    if (old_metadata.hasSettingsChanges())
-        old_changes = &old_metadata.settings_changes->as<const ASTSetQuery &>().changes;
-
     const auto mode = getTableMetadata().getMode();
-    for (const auto & changed_setting : new_changes)
+    const auto & new_settings = new_metadata.settings_changes->as<ASTSetQuery &>().changes;
+
+    for (const auto & setting : new_settings)
     {
         bool setting_changed = true;
-        if (old_changes)
+        if (old_settings)
         {
             auto it = std::find_if(
-                old_changes->begin(), old_changes->end(),
-                [&](const SettingChange & change) { return change.name == changed_setting.name; });
+                old_settings->begin(), old_settings->end(),
+                [&](const SettingChange & change) { return change.name == setting.name; });
 
-            setting_changed = it != old_changes->end() && it->value != changed_setting.value;
+            setting_changed = it != old_settings->end() && it->value != setting.value;
         }
 
         if (setting_changed)
         {
-            SettingChange result_setting(changed_setting);
-            if (result_setting.name.starts_with("s3queue_"))
-                result_setting.name = result_setting.name.substr(std::strlen("s3queue_"));
-
-            if (!isSettingChangeable(result_setting.name, mode))
+            /// `new_settings` contains a full set of settings, changed and non-changed together.
+            /// So we check whether setting is allowed to be changed only if it is actually changed.
+            if (!isSettingChangeable(setting.name, mode))
             {
                 throw Exception(
                     ErrorCodes::SUPPORT_IS_DISABLED,
                     "Changing setting {} is not allowed for {} mode of {}",
-                    changed_setting.name, magic_enum::enum_name(mode), getName());
+                    setting.name, magic_enum::enum_name(mode), getName());
             }
-            if (requiresDetachedMV(changed_setting.name))
+
+            /// Some settings affect the work of background processing thread,
+            /// so might require its cancellation.
+            if (requiresDetachedMV(setting.name))
             {
                 const size_t dependencies_count = getDependencies();
                 if (dependencies_count)
+                {
                     throw Exception(
                         ErrorCodes::SUPPORT_IS_DISABLED,
-                        "Changing setting {} is not allowed only with detached dependencies (dependencies count: {})",
-                        changed_setting.name, dependencies_count);
+                        "Changing setting {} is allowed "
+                        "only with detached dependencies (dependencies count: {})",
+                        setting.name, dependencies_count);
+                }
             }
         }
     }
@@ -698,39 +748,70 @@ void StorageObjectStorageQueue::alter(
     if (commands.isSettingsAlter())
     {
         auto table_id = getStorageID();
+        auto alter_commands = normalizeAlterCommands(commands);
 
-        StorageInMemoryMetadata new_metadata = getInMemoryMetadata();
-        commands.apply(new_metadata, local_context);
-        auto new_settings = new_metadata.settings_changes->as<ASTSetQuery &>().changes;
+        StorageInMemoryMetadata old_metadata(getInMemoryMetadata());
+        SettingsChanges * old_settings = nullptr;
+        if (old_metadata.settings_changes)
+        {
+            old_settings = &old_metadata.settings_changes->as<ASTSetQuery &>().changes;
+            for (auto & setting : *old_settings)
+                setting.name = normalizeSetting(setting.name);
+        }
 
-        StorageInMemoryMetadata old_metadata = getInMemoryMetadata();
-        const SettingsChanges * old_settings = nullptr;
-        if (old_metadata.hasSettingsChanges())
-            old_settings = &old_metadata.settings_changes->as<const ASTSetQuery &>().changes;
+        /// settings_changes will be cloned.
+        StorageInMemoryMetadata new_metadata(old_metadata);
+        alter_commands.apply(new_metadata, local_context);
+        auto & new_settings = new_metadata.settings_changes->as<ASTSetQuery &>().changes;
 
         if (old_settings)
         {
-            ObjectStorageQueueSettings default_settings;
-            for (const auto & setting : *old_settings)
+            auto get_names = [](const SettingsChanges & settings)
             {
-                auto it = std::find_if(
-                    new_settings.begin(), new_settings.end(),
-                    [&](const SettingChange & change) { return change.name == setting.name; });
-
-                if (it == new_settings.end())
+                std::set<std::string> names;
+                for (const auto & [name, _] : settings)
                 {
-                    /// Setting was reset.
-                    new_settings.push_back(SettingChange(setting.name, default_settings.get(setting.name)));
+                    auto inserted = names.insert(name).second;
+                    if (!inserted)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is duplicated", name);
                 }
+                return names;
+            };
+
+            auto old_settings_set = get_names(*old_settings);
+            auto new_settings_set = get_names(new_settings);
+
+            std::set<std::string> reset_settings;
+            std::set_difference(
+                old_settings_set.begin(), old_settings_set.end(),
+                new_settings_set.begin(), new_settings_set.end(),
+                std::inserter(reset_settings, reset_settings.begin()));
+
+            if (!reset_settings.empty())
+            {
+                LOG_TRACE(
+                    log, "Will reset settings: {} (old settings: {}, new_settings: {})",
+                    fmt::join(reset_settings, ", "),
+                    fmt::join(old_settings_set, ", "), fmt::join(new_settings_set, ", "));
+
+                ObjectStorageQueueSettings default_settings;
+                for (const auto & name : reset_settings)
+                    new_settings.push_back(SettingChange(name, default_settings.get(name)));
             }
         }
 
         SettingsChanges changed_settings;
-        std::set<std::string> changed_settings_set;
+        std::set<std::string> new_settings_set;
 
         const auto mode = getTableMetadata().getMode();
-        for (const auto & setting : new_settings)
+        for (auto & setting : new_settings)
         {
+            LOG_TEST(log, "New setting {}: {}", setting.name, setting.value);
+
+            auto inserted = new_settings_set.emplace(setting.name).second;
+            if (!inserted)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is duplicated", setting.name);
+
             bool setting_changed = true;
             if (old_settings)
             {
@@ -743,11 +824,7 @@ void StorageObjectStorageQueue::alter(
             if (!setting_changed)
                 continue;
 
-            SettingChange result_setting(setting);
-            if (result_setting.name.starts_with("s3queue_"))
-                result_setting.name = result_setting.name.substr(std::strlen("s3queue_"));
-
-            if (!isSettingChangeable(result_setting.name, mode))
+            if (!isSettingChangeable(setting.name, mode))
             {
                 throw Exception(
                     ErrorCodes::SUPPORT_IS_DISABLED,
@@ -759,17 +836,16 @@ void StorageObjectStorageQueue::alter(
             {
                 const size_t dependencies_count = getDependencies();
                 if (dependencies_count)
+                {
                     throw Exception(
                         ErrorCodes::SUPPORT_IS_DISABLED,
-                        "Changing setting {} is not allowed only with detached dependencies (dependencies count: {})",
+                        "Changing setting {} is not allowed only with detached dependencies "
+                        "(dependencies count: {})",
                         setting.name, dependencies_count);
+                }
             }
 
-            changed_settings.push_back(result_setting);
-
-            auto inserted = changed_settings_set.emplace(result_setting.name).second;
-            if (!inserted)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is duplicated", setting.name);
+            changed_settings.push_back(setting);
         }
 
         LOG_TEST(log, "New settings: {}", serializeAST(*new_metadata.settings_changes));
@@ -799,11 +875,8 @@ void StorageObjectStorageQueue::alter(
                 commit_settings.max_processing_time_sec_before_commit = change.value.safeGet<UInt64>();
         }
 
-        StorageInMemoryMetadata metadata = getInMemoryMetadata();
-        metadata.setSettingsChanges(new_metadata.settings_changes);
-        setInMemoryMetadata(metadata);
-
         DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(local_context, table_id, new_metadata);
+        setInMemoryMetadata(new_metadata);
     }
 }
 

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -1029,11 +1029,9 @@ def test_max_set_age(started_cluster):
             "tracked_file_ttl_sec": max_age,
             "cleanup_interval_min_ms": max_age / 3,
             "cleanup_interval_max_ms": max_age / 3,
-            "loading_retries": 0,
             "polling_max_timeout_ms": 5000,
             "polling_backoff_ms": 1000,
             "processing_threads_num": 1,
-            "loading_retries": 0,
         },
     )
     create_mv(node, table_name, dst_table_name)
@@ -2241,8 +2239,9 @@ def test_alter_settings(started_cluster):
         files_path,
         additional_settings={
             "keeper_path": keeper_path,
-            "processing_threads_num": 10,
-            "loading_retries": 20,
+            "s3queue_processing_threads_num": 10,
+            "s3queue_loading_retries": 20,
+            "s3queue_tracked_files_limit": 1000,
         },
         database_name="r",
     )
@@ -2284,15 +2283,15 @@ def test_alter_settings(started_cluster):
         f"""
         ALTER TABLE r.{table_name}
         MODIFY SETTING processing_threads_num=5,
-        loading_retries=10,
+        loading_retries=44,
         after_processing='delete',
         tracked_files_limit=50,
         tracked_file_ttl_sec=10000,
         polling_min_timeout_ms=222,
-        polling_max_timeout_ms=333,
+        s3queue_polling_max_timeout_ms=333,
         polling_backoff_ms=111,
         max_processed_files_before_commit=444,
-        max_processed_rows_before_commit=555,
+        s3queue_max_processed_rows_before_commit=555,
         max_processed_bytes_before_commit=666,
         max_processing_time_sec_before_commit=777
     """
@@ -2300,7 +2299,7 @@ def test_alter_settings(started_cluster):
 
     int_settings = {
         "processing_threads_num": 5,
-        "loading_retries": 10,
+        "loading_retries": 44,
         "tracked_files_ttl_sec": 10000,
         "tracked_files_limit": 50,
         "polling_min_timeout_ms": 222,
@@ -2361,7 +2360,7 @@ def test_alter_settings(started_cluster):
 
     node1.query(
         f"""
-        ALTER TABLE r.{table_name} RESET SETTING after_processing, tracked_file_ttl_sec
+        ALTER TABLE r.{table_name} RESET SETTING after_processing, tracked_file_ttl_sec, loading_retries, s3queue_tracked_files_limit
     """
     )
 
@@ -2369,7 +2368,7 @@ def test_alter_settings(started_cluster):
         "processing_threads_num": 5,
         "loading_retries": 10,
         "tracked_files_ttl_sec": 0,
-        "tracked_files_limit": 50,
+        "tracked_files_limit": 1000,
     }
     string_settings = {"after_processing": "keep"}
 
@@ -2674,7 +2673,8 @@ def test_upgrade_3(started_cluster):
     node.query(f"DROP TABLE {table_name} SYNC")
 
 
-def test_migration(started_cluster):
+@pytest.mark.parametrize("setting_prefix", ["", "s3queue_"])
+def test_migration(started_cluster, setting_prefix):
     node1 = started_cluster.instances["instance3_24.5"]
     node2 = started_cluster.instances["instance4_24.5"]
 
@@ -2771,7 +2771,7 @@ def test_migration(started_cluster):
     assert (
         "Changing setting buckets is not allowed only with detached dependencies"
         in node1.query_and_get_error(
-            f"ALTER TABLE r.{table_name} MODIFY SETTING buckets={buckets_num}"
+            f"ALTER TABLE r.{table_name} MODIFY SETTING {setting_prefix}buckets={buckets_num}"
         )
     )
 
@@ -2781,12 +2781,12 @@ def test_migration(started_cluster):
     assert (
         "To allow migration set s3queue_migrate_old_metadata_to_buckets = 1"
         in node1.query_and_get_error(
-            f"ALTER TABLE r.{table_name} MODIFY SETTING buckets={buckets_num}"
+            f"ALTER TABLE r.{table_name} MODIFY SETTING {setting_prefix}buckets={buckets_num}"
         )
     )
 
     node1.query(
-        f"ALTER TABLE r.{table_name} MODIFY SETTING buckets={buckets_num} SETTINGS s3queue_migrate_old_metadata_to_buckets = 1"
+        f"ALTER TABLE r.{table_name} MODIFY SETTING {setting_prefix}buckets={buckets_num} SETTINGS s3queue_migrate_old_metadata_to_buckets = 1"
     )
 
     for node in [node1, node2]:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix altering Storage `S3Queue` settings with "s3queue_" prefix to without and vice versa

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
