### PR TITLE
Improve the waiting mechanism for keeper in integration tests

### DIFF
--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -360,9 +360,15 @@ def get_any_follower(cluster, nodes):
     raise Exception("No followers in Keeper cluster.")
 
 
-def get_fake_zk(cluster, node, timeout: float = 30.0) -> KazooClient:
+def get_fake_zk(cluster, nodename, timeout: float = 30.0) -> KazooClient:
+    kazoo_retry = {
+        "max_tries": 10,
+    }
     _fake = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":9181", timeout=timeout
+        hosts=cluster.get_instance_ip(nodename) + ":9181",
+        timeout=timeout,
+        connection_retry=kazoo_retry,
+        command_retry=kazoo_retry,
     )
     _fake.start()
     return _fake

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -10,6 +10,8 @@ from os import path as p
 from typing import Iterable, List, Optional, Sequence, Union
 
 from kazoo.client import KazooClient
+from kazoo.exceptions import ConnectionLoss, OperationTimeoutError
+from kazoo.handlers.threading import KazooTimeoutError
 
 from helpers.client import CommandRequest
 from helpers.cluster import ClickHouseCluster, ClickHouseInstance
@@ -256,15 +258,16 @@ class KeeperClient(object):
 
 
 def get_keeper_socket(cluster, node, port=9181):
-    hosts = cluster.get_instance_ip(node.name)
+    host = cluster.get_instance_ip(node.name)
     client = socket.socket()
     client.settimeout(10)
-    client.connect((hosts, port))
+    client.connect((host, port))
     return client
 
 
 def send_4lw_cmd(cluster, node, cmd="ruok", port=9181):
     client = None
+    logging.debug("Sending %s to %s:%d", cmd, node, port)
     try:
         client = get_keeper_socket(cluster, node, port)
         client.send(cmd.encode())
@@ -282,6 +285,12 @@ NOT_SERVING_REQUESTS_ERROR_MSG = "This instance is not currently serving request
 def wait_until_connected(cluster, node, port=9181, timeout=30.0):
     start = time.time()
 
+    logging.debug(
+        "Waiting until keeper will be ready on %s:%d (timeout=%f)",
+        node.name,
+        port,
+        timeout,
+    )
     while send_4lw_cmd(cluster, node, "mntr", port) == NOT_SERVING_REQUESTS_ERROR_MSG:
         time.sleep(0.1)
 
@@ -289,6 +298,32 @@ def wait_until_connected(cluster, node, port=9181, timeout=30.0):
             raise Exception(
                 f"{timeout}s timeout while waiting for {node.name} to start serving requests"
             )
+
+    host = cluster.get_instance_ip(node.name)
+    logging.debug(
+        "Waiting until keeper can create sessions on %s:%d (timeout=%f)",
+        host,
+        port,
+        timeout,
+    )
+    while True:
+        zk_cli = None
+        try:
+            time_passed = min(time.time() - start, 5.0)
+            if time_passed >= timeout:
+                raise Exception(
+                    f"{timeout}s timeout while waiting for {node.name} to start serving requests"
+                )
+            zk_cli = KazooClient(hosts=f"{host}:9181", timeout=timeout - time_passed)
+            zk_cli.start()
+            zk_cli.get("/keeper/api_version")
+            break
+        except (ConnectionLoss, OperationTimeoutError, KazooTimeoutError):
+            pass
+        finally:
+            if zk_cli:
+                zk_cli.stop()
+                zk_cli.close()
 
 
 def wait_until_quorum_lost(cluster, node, port=9181):

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -257,8 +257,8 @@ class KeeperClient(object):
             client.stop()
 
 
-def get_keeper_socket(cluster, node, port=9181):
-    host = cluster.get_instance_ip(node.name)
+def get_keeper_socket(cluster, nodename, port=9181):
+    host = cluster.get_instance_ip(nodename)
     client = socket.socket()
     client.settimeout(10)
     client.connect((host, port))
@@ -269,7 +269,7 @@ def send_4lw_cmd(cluster, node, cmd="ruok", port=9181):
     client = None
     logging.debug("Sending %s to %s:%d", cmd, node, port)
     try:
-        client = get_keeper_socket(cluster, node, port)
+        client = get_keeper_socket(cluster, node.name, port)
         client.send(cmd.encode())
         data = client.recv(100_000)
         data = data.decode()

--- a/tests/integration/test_keeper_auth/test.py
+++ b/tests/integration/test_keeper_auth/test.py
@@ -1,14 +1,13 @@
 import time
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 from kazoo.exceptions import (
     AuthFailedError,
     InvalidACLError,
     KazooException,
     NoAuthError,
 )
-from kazoo.security import ACL, make_acl, make_digest_acl
+from kazoo.security import make_acl
 
 from helpers import keeper_utils
 from helpers.cluster import ClickHouseCluster
@@ -38,11 +37,7 @@ def started_cluster():
 
 
 def get_fake_zk(timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip("node") + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, "node", timeout=timeout)
 
 
 def get_genuine_zk():

--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -25,8 +25,13 @@ def get_genuine_zk():
 
 def get_fake_zk():
     print("node", cluster.get_instance_ip("node"))
+    kazoo_retry = {
+        "max_tries": 10,
+    }
     _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip("node") + ":9181", timeout=30.0
+        hosts=cluster.get_instance_ip("node") + ":9181",
+        timeout=30.0,
+        connection_retry=kazoo_retry,
     )
 
     def reset_last_zxid_listener(state):

--- a/tests/integration/test_keeper_broken_logs/test.py
+++ b/tests/integration/test_keeper_broken_logs/test.py
@@ -23,8 +23,6 @@ node3 = cluster.add_instance(
     stay_alive=True,
 )
 
-from kazoo.client import KazooClient, KazooState
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -46,11 +44,7 @@ def wait_nodes():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def start_clickhouse(node):

--- a/tests/integration/test_keeper_disks/test.py
+++ b/tests/integration/test_keeper_disks/test.py
@@ -29,8 +29,6 @@ node_snapshot = cluster.add_instance(
     with_hdfs=True,
 )
 
-from kazoo.client import KazooClient, KazooState
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -43,11 +41,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def stop_zk(zk):

--- a/tests/integration/test_keeper_disks/test.py
+++ b/tests/integration/test_keeper_disks/test.py
@@ -91,7 +91,11 @@ def setup_storage(cluster, node, storage_config, cleanup_disks):
         storage_config,
     )
     node.start_clickhouse()
-    keeper_utils.wait_until_connected(cluster, node)
+    # complete readiness checks that the sessions can be established,
+    # but it creates sesssion for this, which will create one more record in log,
+    # but this test is very strict on number of entries in the log,
+    # so let's avoid this extra check and rely on retry policy
+    keeper_utils.wait_until_connected(cluster, node, wait_complete_readiness=False)
 
 
 def setup_local_storage(cluster, node):

--- a/tests/integration/test_keeper_force_recovery/test.py
+++ b/tests/integration/test_keeper_force_recovery/test.py
@@ -1,9 +1,7 @@
 import os
-import socket
 import time
 
 import pytest
-from kazoo.client import KazooClient, KazooRetry
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
@@ -49,15 +47,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181",
-        timeout=timeout,
-        connection_retry=KazooRetry(max_tries=10),
-        command_retry=KazooRetry(max_tries=10),
-    )
-
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def wait_and_assert_data(zk, path, data):

--- a/tests/integration/test_keeper_force_recovery_single_node/test.py
+++ b/tests/integration/test_keeper_force_recovery_single_node/test.py
@@ -42,14 +42,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181",
-        timeout=timeout,
-        connection_retry=KazooRetry(max_tries=10),
-        command_retry=KazooRetry(max_tries=10),
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def wait_and_assert_data(zk, path, data):

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -58,11 +58,6 @@ def get_fake_zk(nodename, timeout=30.0):
     return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
-def close_keeper_socket(cli):
-    if cli is not None:
-        cli.close()
-
-
 def reset_node_stats(node=node1):
     client = None
     try:
@@ -86,13 +81,9 @@ def reset_conn_stats(node=node1):
 
 
 def test_cmd_ruok(started_cluster):
-    client = None
-    try:
-        wait_nodes()
-        data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="ruok")
-        assert data == "imok"
-    finally:
-        close_keeper_socket(client)
+    wait_nodes()
+    data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="ruok")
+    assert data == "imok"
 
 
 def do_some_action(
@@ -199,108 +190,98 @@ def test_cmd_mntr(started_cluster):
 
 
 def test_cmd_srst(started_cluster):
-    client = None
-    try:
-        wait_nodes()
-        clear_znodes()
+    wait_nodes()
+    clear_znodes()
 
-        data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="srst")
-        assert data.strip() == "Server stats reset."
+    data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="srst")
+    assert data.strip() == "Server stats reset."
 
-        data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="mntr")
-        assert len(data) != 0
+    data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="mntr")
+    assert len(data) != 0
 
-        # print(data)
-        reader = csv.reader(data.split("\n"), delimiter="\t")
-        result = {}
+    # print(data)
+    reader = csv.reader(data.split("\n"), delimiter="\t")
+    result = {}
 
-        for row in reader:
-            if len(row) != 0:
-                result[row[0]] = row[1]
+    for row in reader:
+        if len(row) != 0:
+            result[row[0]] = row[1]
 
-        assert int(result["zk_packets_received"]) == 0
-        assert int(result["zk_packets_sent"]) == 0
-
-    finally:
-        close_keeper_socket(client)
+    assert int(result["zk_packets_received"]) == 0
+    assert int(result["zk_packets_sent"]) == 0
 
 
 def test_cmd_conf(started_cluster):
-    client = None
-    try:
-        wait_nodes()
-        clear_znodes()
+    wait_nodes()
+    clear_znodes()
 
-        data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="conf")
+    data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="conf")
 
-        reader = csv.reader(data.split("\n"), delimiter="=")
-        result = {}
+    reader = csv.reader(data.split("\n"), delimiter="=")
+    result = {}
 
-        for row in reader:
-            if len(row) != 0:
-                print(row)
-                result[row[0]] = row[1]
+    for row in reader:
+        if len(row) != 0:
+            print(row)
+            result[row[0]] = row[1]
 
-        assert result["server_id"] == "1"
-        assert result["tcp_port"] == "9181"
-        assert "tcp_port_secure" not in result
-        assert "superdigest" not in result
+    assert result["server_id"] == "1"
+    assert result["tcp_port"] == "9181"
+    assert "tcp_port_secure" not in result
+    assert "superdigest" not in result
 
-        assert result["four_letter_word_allow_list"] == "*"
-        assert result["log_storage_path"] == "/var/lib/clickhouse/coordination/log"
-        assert result["log_storage_disk"] == "LocalLogDisk"
-        assert (
-            result["snapshot_storage_path"]
-            == "/var/lib/clickhouse/coordination/snapshots"
-        )
-        assert result["snapshot_storage_disk"] == "LocalSnapshotDisk"
+    assert result["four_letter_word_allow_list"] == "*"
+    assert result["log_storage_path"] == "/var/lib/clickhouse/coordination/log"
+    assert result["log_storage_disk"] == "LocalLogDisk"
+    assert (
+        result["snapshot_storage_path"] == "/var/lib/clickhouse/coordination/snapshots"
+    )
+    assert result["snapshot_storage_disk"] == "LocalSnapshotDisk"
 
-        assert result["session_timeout_ms"] == "30000"
-        assert result["min_session_timeout_ms"] == "10000"
-        assert result["operation_timeout_ms"] == "5000"
-        assert result["dead_session_check_period_ms"] == "500"
-        assert result["heart_beat_interval_ms"] == "500"
-        assert result["election_timeout_lower_bound_ms"] == "1000"
-        assert result["election_timeout_upper_bound_ms"] == "2000"
-        assert result["leadership_expiry_ms"] == "0"
-        assert result["reserved_log_items"] == "100000"
+    assert result["session_timeout_ms"] == "30000"
+    assert result["min_session_timeout_ms"] == "10000"
+    assert result["operation_timeout_ms"] == "5000"
+    assert result["dead_session_check_period_ms"] == "500"
+    assert result["heart_beat_interval_ms"] == "500"
+    assert result["election_timeout_lower_bound_ms"] == "1000"
+    assert result["election_timeout_upper_bound_ms"] == "2000"
+    assert result["leadership_expiry_ms"] == "0"
+    assert result["reserved_log_items"] == "100000"
 
-        assert result["snapshot_distance"] == "75"
-        assert result["auto_forwarding"] == "true"
-        assert result["shutdown_timeout"] == "5000"
-        assert result["startup_timeout"] == "180000"
+    assert result["snapshot_distance"] == "75"
+    assert result["auto_forwarding"] == "true"
+    assert result["shutdown_timeout"] == "5000"
+    assert result["startup_timeout"] == "180000"
 
-        assert result["raft_logs_level"] == "trace"
-        assert result["rotate_log_storage_interval"] == "100000"
-        assert result["snapshots_to_keep"] == "3"
-        assert result["stale_log_gap"] == "10000"
-        assert result["fresh_log_gap"] == "200"
+    assert result["raft_logs_level"] == "trace"
+    assert result["rotate_log_storage_interval"] == "100000"
+    assert result["snapshots_to_keep"] == "3"
+    assert result["stale_log_gap"] == "10000"
+    assert result["fresh_log_gap"] == "200"
 
-        assert result["max_requests_batch_size"] == "100"
-        assert result["max_requests_batch_bytes_size"] == "102400"
-        assert result["max_flush_batch_size"] == "1000"
-        assert result["max_request_queue_size"] == "100000"
-        assert result["max_requests_quick_batch_size"] == "100"
-        assert result["quorum_reads"] == "false"
-        assert result["force_sync"] == "true"
+    assert result["max_requests_batch_size"] == "100"
+    assert result["max_requests_batch_bytes_size"] == "102400"
+    assert result["max_flush_batch_size"] == "1000"
+    assert result["max_request_queue_size"] == "100000"
+    assert result["max_requests_quick_batch_size"] == "100"
+    assert result["quorum_reads"] == "false"
+    assert result["force_sync"] == "true"
 
-        assert result["compress_logs"] == "false"
-        assert result["compress_snapshots_with_zstd_format"] == "true"
-        assert result["configuration_change_tries_count"] == "20"
+    assert result["compress_logs"] == "false"
+    assert result["compress_snapshots_with_zstd_format"] == "true"
+    assert result["configuration_change_tries_count"] == "20"
 
-        assert result["async_replication"] == "true"
+    assert result["async_replication"] == "true"
 
-        assert result["latest_logs_cache_size_threshold"] == "1073741824"
-        assert result["commit_logs_cache_size_threshold"] == "524288000"
+    assert result["latest_logs_cache_size_threshold"] == "1073741824"
+    assert result["commit_logs_cache_size_threshold"] == "524288000"
 
-        assert result["disk_move_retries_wait_ms"] == "1000"
-        assert result["disk_move_retries_during_init"] == "100"
+    assert result["disk_move_retries_wait_ms"] == "1000"
+    assert result["disk_move_retries_during_init"] == "100"
 
-        assert result["log_slow_total_threshold_ms"] == "5000"
-        assert result["log_slow_cpu_threshold_ms"] == "100"
-        assert result["log_slow_connection_operation_threshold_ms"] == "1000"
-    finally:
-        close_keeper_socket(client)
+    assert result["log_slow_total_threshold_ms"] == "5000"
+    assert result["log_slow_cpu_threshold_ms"] == "100"
+    assert result["log_slow_connection_operation_threshold_ms"] == "1000"
 
 
 def test_cmd_isro(started_cluster):

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -61,7 +61,7 @@ def get_fake_zk(nodename, timeout=30.0):
 def reset_node_stats(node=node1):
     client = None
     try:
-        client = keeper_utils.get_keeper_socket(cluster, node)
+        client = keeper_utils.get_keeper_socket(cluster, node.name)
         client.send(b"srst")
         client.recv(10)
     finally:
@@ -72,7 +72,7 @@ def reset_node_stats(node=node1):
 def reset_conn_stats(node=node1):
     client = None
     try:
-        client = keeper_utils.get_keeper_socket(cluster, node)
+        client = keeper_utils.get_keeper_socket(cluster, node.name)
         client.send(b"crst")
         client.recv(10_000)
     finally:

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -18,8 +18,6 @@ node3 = cluster.add_instance(
     "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
 )
 
-from kazoo.client import KazooClient
-
 
 def wait_nodes():
     keeper_utils.wait_nodes(cluster, [node1, node2, node3])
@@ -57,11 +55,7 @@ def clear_znodes():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def close_keeper_socket(cli):

--- a/tests/integration/test_keeper_four_word_command/test_allow_list.py
+++ b/tests/integration/test_keeper_four_word_command/test_allow_list.py
@@ -1,4 +1,3 @@
-import socket
 import time
 
 import pytest
@@ -65,11 +64,7 @@ def wait_nodes():
 
 
 def get_keeper_socket(nodename):
-    hosts = cluster.get_instance_ip(nodename)
-    client = socket.socket()
-    client.settimeout(10)
-    client.connect((hosts, 9181))
-    return client
+    return keeper_utils.get_keeper_socket(cluster, nodename)
 
 
 def get_fake_zk(nodename, timeout=30.0):

--- a/tests/integration/test_keeper_four_word_command/test_allow_list.py
+++ b/tests/integration/test_keeper_four_word_command/test_allow_list.py
@@ -95,12 +95,8 @@ def send_cmd(node_name, command="ruok"):
 
 
 def test_allow_list(started_cluster):
-    client = None
-    try:
-        wait_nodes()
-        assert send_cmd(node1.name) == "imok"
-        assert send_cmd(node1.name, command="mntr") == ""
-        assert send_cmd(node2.name) == "imok"
-        assert send_cmd(node3.name) == "imok"
-    finally:
-        close_keeper_socket(client)
+    wait_nodes()
+    assert send_cmd(node1.name) == "imok"
+    assert send_cmd(node1.name, command="mntr") == ""
+    assert send_cmd(node2.name) == "imok"
+    assert send_cmd(node3.name) == "imok"

--- a/tests/integration/test_keeper_four_word_command/test_allow_list.py
+++ b/tests/integration/test_keeper_four_word_command/test_allow_list.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -19,8 +20,6 @@ node3 = cluster.add_instance(
     main_configs=["configs/keeper_config_with_allow_list_all.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -74,11 +73,7 @@ def get_keeper_socket(nodename):
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def close_keeper_socket(cli):

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -52,8 +52,6 @@ nodes = [
     ),
 ]
 
-from kazoo.client import KazooClient
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -67,11 +65,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return ku.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def run_test():

--- a/tests/integration/test_keeper_mntr_pressure/test.py
+++ b/tests/integration/test_keeper_mntr_pressure/test.py
@@ -39,11 +39,6 @@ def started_cluster():
         cluster.shutdown()
 
 
-def close_keeper_socket(cli):
-    if cli is not None:
-        cli.close()
-
-
 def test_aggressive_mntr(started_cluster):
     def go_mntr(node):
         for _ in range(10000):

--- a/tests/integration/test_keeper_multinode_simple/test.py
+++ b/tests/integration/test_keeper_multinode_simple/test.py
@@ -1,8 +1,4 @@
-import os
-import random
-import string
 import time
-from multiprocessing.dummy import Pool
 
 import pytest
 
@@ -28,8 +24,6 @@ node3 = cluster.add_instance(
     stay_alive=True,
 )
 
-from kazoo.client import KazooClient, KazooState
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -51,11 +45,7 @@ def wait_nodes():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def test_read_write_multinode(started_cluster):

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -1,17 +1,13 @@
 #!/usr/bin/env python3
 
 import os
-import random
-import string
 import time
 from multiprocessing.dummy import Pool
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
@@ -24,11 +20,7 @@ node3 = cluster.add_instance("node3", main_configs=[], stay_alive=True)
 
 
 def get_fake_zk(node, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -5,11 +5,9 @@ import time
 from multiprocessing.dummy import Pool
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
@@ -43,11 +41,7 @@ def start(node):
 
 
 def get_fake_zk(node, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
 def test_node_move(started_cluster):

--- a/tests/integration/test_keeper_nodes_remove/test.py
+++ b/tests/integration/test_keeper_nodes_remove/test.py
@@ -4,8 +4,8 @@ import os
 import time
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 
+import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -34,11 +34,7 @@ def started_cluster():
 
 
 def get_fake_zk(node, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
 def test_nodes_remove(started_cluster):

--- a/tests/integration/test_keeper_persistent_log_multinode/test.py
+++ b/tests/integration/test_keeper_persistent_log_multinode/test.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-import os
-import random
-import string
-import time
-
 import pytest
 
 import helpers.keeper_utils as keeper_utils
@@ -26,8 +21,6 @@ node3 = cluster.add_instance(
     stay_alive=True,
 )
 
-from kazoo.client import KazooClient, KazooState
-
 
 def wait_nodes():
     keeper_utils.wait_nodes(cluster, [node1, node2, node3])
@@ -46,11 +39,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def stop_zk(zk):

--- a/tests/integration/test_keeper_reconfig_replace_leader_in_one_command/test.py
+++ b/tests/integration/test_keeper_reconfig_replace_leader_in_one_command/test.py
@@ -48,7 +48,7 @@ def started_cluster():
 
 
 def get_fake_zk(node):
-    return ku.get_fake_zk(cluster, node)
+    return ku.get_fake_zk(cluster, node.name)
 
 
 def get_config_str(zk):

--- a/tests/integration/test_keeper_restore_from_snapshot/test.py
+++ b/tests/integration/test_keeper_restore_from_snapshot/test.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-import os
-import random
-import string
-import time
-
 import pytest
 
 import helpers.keeper_utils as keeper_utils
@@ -26,8 +21,6 @@ node3 = cluster.add_instance(
     stay_alive=True,
 )
 
-from kazoo.client import KazooClient, KazooState
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -41,11 +34,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def stop_zk(zk):

--- a/tests/integration/test_keeper_restore_from_snapshot/test_disk_s3.py
+++ b/tests/integration/test_keeper_restore_from_snapshot/test_disk_s3.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-import os
-import random
-import string
-import time
-
 import pytest
 
 import helpers.keeper_utils as keeper_utils
@@ -41,8 +36,6 @@ node3 = cluster.add_instance(
     with_minio=True,
 )
 
-from kazoo.client import KazooClient, KazooState
-
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -56,11 +49,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def stop_zk(zk):

--- a/tests/integration/test_keeper_s3_snapshot/test.py
+++ b/tests/integration/test_keeper_s3_snapshot/test.py
@@ -2,8 +2,6 @@ from multiprocessing.dummy import Pool
 from time import sleep
 
 import pytest
-from kazoo.client import KazooClient
-from minio.deleteobjects import DeleteObject
 
 from helpers import keeper_utils
 from helpers.cluster import ClickHouseCluster
@@ -46,11 +44,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def destroy_zk_client(zk):

--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -3,7 +3,6 @@ import struct
 import time
 
 import pytest
-from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
 
 import helpers.keeper_utils as keeper_utils
@@ -60,11 +59,7 @@ def wait_nodes():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def get_keeper_socket(node_name):

--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -1,4 +1,3 @@
-import socket
 import struct
 import time
 
@@ -63,11 +62,7 @@ def get_fake_zk(nodename, timeout=30.0):
 
 
 def get_keeper_socket(node_name):
-    hosts = cluster.get_instance_ip(node_name)
-    client = socket.socket()
-    client.settimeout(10)
-    client.connect((hosts, 9181))
-    return client
+    return keeper_utils.get_keeper_socket(cluster, node_name)
 
 
 def write_buffer(bytes):

--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -70,11 +70,6 @@ def get_keeper_socket(node_name):
     return client
 
 
-def close_keeper_socket(cli):
-    if cli is not None:
-        cli.close()
-
-
 def write_buffer(bytes):
     if bytes is None:
         return int_struct.pack(-1)

--- a/tests/integration/test_keeper_snapshot_on_exit/test.py
+++ b/tests/integration/test_keeper_snapshot_on_exit/test.py
@@ -1,8 +1,8 @@
 import os
 
 import pytest
-from kazoo.client import KazooClient
 
+import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -18,11 +18,7 @@ node2 = cluster.add_instance(
 
 
 def get_fake_zk(node, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -2,7 +2,6 @@
 
 import os
 import random
-import string
 import time
 from multiprocessing.dummy import Pool
 
@@ -137,11 +136,7 @@ def started_cluster():
 
 
 def get_fake_zk(node, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
 def get_genuine_zk(node, timeout=30.0):

--- a/tests/integration/test_keeper_snapshots_multinode/test.py
+++ b/tests/integration/test_keeper_snapshots_multinode/test.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-import os
-import random
-import string
-import time
-
 import pytest
 
 import helpers.keeper_utils as keeper_utils
@@ -19,8 +14,6 @@ node2 = cluster.add_instance(
 node3 = cluster.add_instance(
     "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 def wait_nodes():
@@ -39,11 +32,7 @@ def started_cluster():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def stop_zk(zk):

--- a/tests/integration/test_keeper_three_nodes_start/test.py
+++ b/tests/integration/test_keeper_three_nodes_start/test.py
@@ -1,16 +1,7 @@
 #!/usr/bin/env python3
 
-import os
-import random
-import string
-import time
-from multiprocessing.dummy import Pool
-
-import pytest
-from kazoo.client import KazooClient, KazooState
-
+import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -22,11 +13,7 @@ node2 = cluster.add_instance(
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def test_smoke():

--- a/tests/integration/test_keeper_three_nodes_two_alive/test.py
+++ b/tests/integration/test_keeper_three_nodes_two_alive/test.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python3
-import os
-import random
-import string
 import time
 from multiprocessing.dummy import Pool
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -31,11 +26,7 @@ node3 = cluster.add_instance(
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_keeper_two_nodes_cluster/test.py
+++ b/tests/integration/test_keeper_two_nodes_cluster/test.py
@@ -1,17 +1,12 @@
 #!/usr/bin/env python3
 
-import os
-import random
-import string
 import time
-from multiprocessing.dummy import Pool
 
 import pytest
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -24,8 +19,6 @@ node2 = cluster.add_instance(
     main_configs=["configs/enable_keeper2.xml", "configs/use_keeper.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -48,11 +41,7 @@ def wait_nodes():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def test_read_write_two_nodes(started_cluster):

--- a/tests/integration/test_keeper_znode_time/test.py
+++ b/tests/integration/test_keeper_znode_time/test.py
@@ -1,14 +1,9 @@
-import os
-import random
-import string
-import time
-from multiprocessing.dummy import Pool
+#!/usr/bin/env python3
 
 import pytest
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -26,8 +21,6 @@ node3 = cluster.add_instance(
     main_configs=["configs/enable_keeper3.xml", "configs/use_keeper.xml"],
     stay_alive=True,
 )
-
-from kazoo.client import KazooClient, KazooState
 
 
 @pytest.fixture(scope="module")
@@ -50,11 +43,7 @@ def wait_nodes():
 
 
 def get_fake_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
 
 def assert_eq_stats(stat1, stat2):

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -140,11 +140,7 @@ def started_cluster():
 
 
 def get_fake_zk(timeout=60.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip("node") + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
-    return _fake_zk_instance
+    return keeper_utils.get_fake_zk(cluster, "node", timeout=timeout)
 
 
 def get_genuine_zk(timeout=60.0):


### PR DESCRIPTION
- Add `connection_retry`/`command_retry`
- Improve `wait_until_connected` to check that keeper can establish new sessions as well

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI:
- https://s3.amazonaws.com/clickhouse-test-reports/72598/a7e97aa3a2dd13ba4fd5c2e37ff7299187d85bd8/integration_tests__tsan__%5B3_6%5D.html