### PR TITLE
Add resize after aggregation with grouping sets

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -389,6 +389,8 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
             return processors;
         });
 
+        pipeline.resize(params.max_threads, /* force = */ true);
+
         aggregating = collector.detachProcessors(0);
         return;
     }

--- a/tests/performance/queries_over_aggregation.xml
+++ b/tests/performance/queries_over_aggregation.xml
@@ -8,4 +8,6 @@
   <query>select * from (select * from numbers_mt(1e7) group by number) group by number format Null settings max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0</query>
   <query>select * from (select * from remote('127.0.0.{{1,2}}', numbers_mt(1e7)) group by number) group by number format Null settings distributed_aggregation_memory_efficient = 1</query>
   <query>select * from (select * from remote('127.0.0.{{1,2}}', numbers_mt(1e7)) group by number) group by number format Null settings distributed_aggregation_memory_efficient = 0</query>
+
+  <query>select sum(cityHash64(*)) from(select number as a, number as b, count(*) from numbers_mt(1e7) group by grouping sets((a),(b)))</query>
 </test>

--- a/tests/queries/0_stateless/01883_with_grouping_sets.reference
+++ b/tests/queries/0_stateless/01883_with_grouping_sets.reference
@@ -1,19 +1,20 @@
 (Expression)
 ExpressionTransform
   (Sorting)
-  MergingSortedTransform 2 → 1
-    MergeSortingTransform × 2
-      LimitsCheckingTransform × 2
-        PartialSortingTransform × 2
+  MergingSortedTransform 8 → 1
+    MergeSortingTransform × 8
+      LimitsCheckingTransform × 8
+        PartialSortingTransform × 8
           (Expression)
-          ExpressionTransform × 2
+          ExpressionTransform × 8
             (Aggregating)
-            ExpressionTransform × 2
-              AggregatingTransform × 2
-                Copy 1 → 2
-                  (Expression)
-                  ExpressionTransform
-                    (ReadFromMemoryStorage)
+            Resize 2 → 8
+              ExpressionTransform × 2
+                AggregatingTransform × 2
+                  Copy 1 → 2
+                    (Expression)
+                    ExpressionTransform
+                      (ReadFromMemoryStorage)
 1	0	1	4500
 1	0	3	4700
 1	0	5	4900
@@ -91,21 +92,22 @@ ORDER BY
 (Expression)
 ExpressionTransform
   (Sorting)
-  MergingSortedTransform 2 → 1
-    MergeSortingTransform × 2
-      LimitsCheckingTransform × 2
-        PartialSortingTransform × 2
+  MergingSortedTransform 3 → 1
+    MergeSortingTransform × 3
+      LimitsCheckingTransform × 3
+        PartialSortingTransform × 3
           (Expression)
-          ExpressionTransform × 2
+          ExpressionTransform × 3
             (Aggregating)
-            ExpressionTransform × 2
-              Resize × 2 3 → 1
-                AggregatingTransform × 6
-                  Copy × 3 1 → 2
-                    (Expression)
-                    ExpressionTransform × 3
-                      (ReadFromSystemNumbers)
-                      NumbersRange × 3 0 → 1
+            Resize 2 → 3
+              ExpressionTransform × 2
+                Resize × 2 3 → 1
+                  AggregatingTransform × 6
+                    Copy × 3 1 → 2
+                      (Expression)
+                      ExpressionTransform × 3
+                        (ReadFromSystemNumbers)
+                        NumbersRange × 3 0 → 1
 4999500000	10000
 4999510000	10000
 4999520000	10000

--- a/tests/queries/0_stateless/01883_with_grouping_sets.sql
+++ b/tests/queries/0_stateless/01883_with_grouping_sets.sql
@@ -1,3 +1,6 @@
+-- Specific value doesn't matter, we just need it to be fixed, because it is a part of `EXPLAIN PIPELINE` output.
+SET max_threads = 8;
+
 DROP TABLE IF EXISTS grouping_sets;
 
 CREATE TABLE grouping_sets(fact_1_id Int32, fact_2_id Int32, fact_3_id Int32, fact_4_id Int32, sales_value Int32) ENGINE = Memory;

--- a/tests/queries/0_stateless/02554_fix_grouping_sets_predicate_push_down.reference
+++ b/tests/queries/0_stateless/02554_fix_grouping_sets_predicate_push_down.reference
@@ -26,55 +26,59 @@ WHERE type_1 = \'all\'
 
 ---Explain Pipeline---
 (Expression)
-ExpressionTransform × 2
+ExpressionTransform × 8
   (Filter)
-  FilterTransform × 6
+  FilterTransform × 24
     (Aggregating)
-    ExpressionTransform × 2
-      AggregatingTransform × 2
-        Copy 1 → 2
-          (Expression)
-          ExpressionTransform
+    Resize 2 → 8
+      ExpressionTransform × 2
+        AggregatingTransform × 2
+          Copy 1 → 2
             (Expression)
             ExpressionTransform
-              (ReadFromMergeTree)
-              MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+              (Expression)
+              ExpressionTransform
+                (ReadFromMergeTree)
+                MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 (Expression)
-ExpressionTransform × 2
+ExpressionTransform × 8
   (Filter)
-  FilterTransform × 2
+  FilterTransform × 8
     (Aggregating)
-    ExpressionTransform × 2
-      AggregatingTransform × 2
-        Copy 1 → 2
-          (Expression)
-          ExpressionTransform
+    Resize 2 → 8
+      ExpressionTransform × 2
+        AggregatingTransform × 2
+          Copy 1 → 2
             (Expression)
             ExpressionTransform
-              (ReadFromMergeTree)
-              MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+              (Expression)
+              ExpressionTransform
+                (ReadFromMergeTree)
+                MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 
 ---Result---
 2023-01-05	all
 
 ---Explain Pipeline---
 (Expression)
-ExpressionTransform × 2
+ExpressionTransform × 8
   (Aggregating)
-  ExpressionTransform × 2
-    AggregatingTransform × 2
-      Copy 1 → 2
-        (Expression)
-        ExpressionTransform
-          (ReadFromMergeTree)
-          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+  Resize 2 → 8
+    ExpressionTransform × 2
+      AggregatingTransform × 2
+        Copy 1 → 2
+          (Expression)
+          ExpressionTransform
+            (ReadFromMergeTree)
+            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 (Expression)
-ExpressionTransform × 2
+ExpressionTransform × 8
   (Aggregating)
-  ExpressionTransform × 2
-    AggregatingTransform × 2
-      Copy 1 → 2
-        (Expression)
-        ExpressionTransform
-          (ReadFromMergeTree)
-          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+  Resize 2 → 8
+    ExpressionTransform × 2
+      AggregatingTransform × 2
+        Copy 1 → 2
+          (Expression)
+          ExpressionTransform
+            (ReadFromMergeTree)
+            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1

--- a/tests/queries/0_stateless/02554_fix_grouping_sets_predicate_push_down.sql
+++ b/tests/queries/0_stateless/02554_fix_grouping_sets_predicate_push_down.sql
@@ -1,5 +1,8 @@
 -- Tags: no-object-storage
 
+-- Specific value doesn't matter, we just need it to be fixed, because it is a part of `EXPLAIN PIPELINE` output.
+SET max_threads = 8;
+
 DROP TABLE IF EXISTS test_grouping_sets_predicate;
 
 CREATE TABLE test_grouping_sets_predicate


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Execute pipeline with a higher degree of parallelism after aggregation with grouping sets.