### PR TITLE
ci: fix ClickBench link in CI comment

### DIFF
--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -717,7 +717,7 @@ CHECK_DESCRIPTIONS = [
     ),
     CheckDescription(
         "ClickBench",
-        "Runs [ClickBench](https://github.com/ClickHouse/ClickBench/) with instant-attach table",
+        'Runs <a href="https://github.com/ClickHouse/ClickBench/">ClickBench</a> with instant-attach table',
         lambda x: x.startswith("ClickBench"),
     ),
     CheckDescription(


### PR DESCRIPTION
Looks like it should be in HTML not Markdown

Without this patch it looks like

![image](https://github.com/user-attachments/assets/5b6a47f3-7d5a-44de-9d25-8726281d38d3)


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)