### PR TITLE
tests: fix 02350_views_max_insert_threads

### DIFF
--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -479,7 +479,7 @@ Chain buildPushingToViewsChain(
     std::atomic_uint64_t * elapsed_counter_ms,
     bool async_insert,
     const Block & live_view_header
- )
+)
 {
     checkStackSize();
     Chain result_chain;
@@ -1005,8 +1005,7 @@ void FinalizingViewsTransform::work()
 
             LOG_TRACE(
                 getLogger("PushingToViews"),
-                "Pushing ({}) from {} to {} took {} ms.",
-                views_data->max_threads <= 1 ? "sequentially" : ("parallel " + std::to_string(views_data->max_threads)),
+                "Pushing from {} to {} took {} ms.",
                 views_data->source_storage_id.getNameForLogs(),
                 view.table_id.getNameForLogs(),
                 view.runtime_stats->elapsed_ms);

--- a/tests/queries/0_stateless/02350_views_max_insert_threads.sql
+++ b/tests/queries/0_stateless/02350_views_max_insert_threads.sql
@@ -7,7 +7,7 @@ drop table if exists t_mv;
 create table t (a UInt64) Engine = Null;
 create materialized view t_mv Engine = Null AS select now() as ts, max(a) from t group by ts;
 
-insert into t select * from numbers_mt(10e6) settings max_threads = 16, max_insert_threads=16, max_block_size=100000;
+insert into t select * from numbers_mt(10e6) settings max_threads = 16, max_insert_threads=16, max_block_size=100000, parallel_view_processing=1;
 system flush logs;
 
 select peak_threads_usage>=16 from system.query_log where


### PR DESCRIPTION
To make it work in parallel with one view, you need parallel_views_processing, also fix log message (max_threads cannot be used to distinguish parallel push from sequential, since it will not show cases when max_insert_threads>1, only when you have multiple views attached)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/74078/0e31a41d06e3b85eee4706d517bb2b4652881135/stateless_tests__ubsan__[1_2].html