### PR TITLE
Add `endpoint_subpath` parameter to Azure endpoint configuration

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -21,6 +21,8 @@ namespace ProfileEvents
     extern const Event DiskAzureCreateContainer;
 }
 
+namespace fs = std::filesystem;
+
 namespace DB
 {
 namespace Setting
@@ -241,6 +243,12 @@ Endpoint processEndpoint(const Poco::Util::AbstractConfiguration & config, const
             {
                 container_name = endpoint.substr(cont_pos_begin + 1);
             }
+        }
+
+        if (config.has(config_prefix + ".endpoint_subpath"))
+        {
+            String endpoint_subpath = config.getString(config_prefix + ".endpoint_subpath");
+            prefix = fs::path(prefix) / endpoint_subpath;
         }
     }
     else if (config.has(config_prefix + ".connection_string"))

--- a/tests/integration/test_azure_blob_storage_plain_rewritable/test.py
+++ b/tests/integration/test_azure_blob_storage_plain_rewritable/test.py
@@ -13,7 +13,7 @@ NODE_NAME = "node"
 OTHER_NODE = "other_node"
 
 
-def generate_cluster_def(port):
+def generate_cluster_def(port, node_name):
     path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         "./_gen/disk_storage_conf.xml",
@@ -28,8 +28,8 @@ def generate_cluster_def(port):
                 <type>object_storage</type>
                 <object_storage_type>azure_blob_storage</object_storage_type>
                 <metadata_type>plain_rewritable</metadata_type>
-                <storage_account_url>http://azurite1:{port}/devstoreaccount1</storage_account_url>
-                <container_name>cont</container_name>
+                <endpoint>http://azurite1:{port}/devstoreaccount1/cont</endpoint>
+                <endpoint_subpath>{node_name}</endpoint_subpath>
                 <skip_access_check>true</skip_access_check>
                 <account_name>devstoreaccount1</account_name>
                 <account_key>Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==</account_key>
@@ -69,7 +69,7 @@ def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
         port = cluster.azurite_port
-        path = generate_cluster_def(port)
+        path = generate_cluster_def(port, NODE_NAME)
         cluster.add_instance(
             NODE_NAME,
             main_configs=[
@@ -154,12 +154,13 @@ def test_failpoint_on_disk_init(cluster):
         type = object_storage,
         metadata_type = plain_rewritable,
         object_storage_type = azure_blob_storage,
-        container_name = 'cont',
         endpoint = 'http://azurite1:{port}/devstoreaccount1/cont',
+        endpoint_subpath = '{node}',
         account_name = 'devstoreaccount1',
         account_key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==')
         """.format(
-            port=port
+            port=port,
+            node=NODE_NAME,
         ),
     )
     azure_query(other_node, "DROP TABLE table SYNC")

--- a/tests/queries/0_stateless/03008_azure_plain_rewritable_with_slash.sh
+++ b/tests/queries/0_stateless/03008_azure_plain_rewritable_with_slash.sh
@@ -12,6 +12,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 container="cont-$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr _ -)"
 
+hostname="${HOSTNAME}"
+
 ${CLICKHOUSE_CLIENT} --query "drop table if exists test_azure_mt"
 
 ${CLICKHOUSE_CLIENT} -nm --query "
@@ -24,6 +26,7 @@ settings disk = disk(
     path='/var/lib/clickhouse/disks/${container}/tables',
     container_name = '${container}',
     endpoint = 'http://localhost:10000/devstoreaccount1/${container}/plain-tables/',
+    endpoint_subpath = '${hostname}',
     account_name = 'devstoreaccount1',
     account_key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==');
 "


### PR DESCRIPTION
Make Azure endpoint configuration consistent with the S3 configuration, for which `endpoint_subpath` was introduced in https://github.com/ClickHouse/ClickHouse/pull/63806. This is required for the cloud.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
