### PR TITLE
Fix data race for updating ZooKeeper client on DROP in ReplicatedMergeTree

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1331,7 +1331,10 @@ void StorageReplicatedMergeTree::drop()
         /// and calling StorageReplicatedMergeTree::getZooKeeper()/getAuxiliaryZooKeeper() won't suffice.
         zookeeper = getZooKeeperIfTableShutDown();
         /// Update zookeeper client, since existing may be expired, while ZooKeeper is required inside dropAllData().
-        current_zookeeper = zookeeper;
+        {
+            std::lock_guard lock(current_zookeeper_mutex);
+            current_zookeeper = zookeeper;
+        }
 
         /// If probably there is metadata in ZooKeeper, we don't allow to drop the table.
         if (!zookeeper)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data race for updating ZooKeeper client on DROP in ReplicatedMergeTree

CI found [CI]:

    WARNING: ThreadSanitizer: data race (pid=3202)
      Write of size 8 at 0x728c034f9760 by thread T953 (mutexes: write M0, write M1):
        3 DB::StorageReplicatedMergeTree::drop() build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:1334:27 (clickhouse+0x1b655b1d)
        4 DB::DatabaseOnDisk::dropTable() build_docker/./src/Databases/DatabaseOnDisk.cpp:369:20 (clickhouse+0x18866eed) (BuildId: d0f5f049336104f625efeba1d75084002380671f)
        5 DB::InterpreterDropQuery::executeToTableImpl() build_docker/./src/Interpreters/InterpreterDropQuery.cpp:308:23 (clickhouse+0x1964ba4d) (BuildId: d0f5f049336104f625efeba1d75084002380671f)

      Previous read of size 8 at 0x728c034f9760 by thread T748 (mutexes: write M2, write M3):
        1 DB::StorageReplicatedMergeTree::tryGetZooKeeper() const build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:305:12 (clickhouse+0x1b7211c0)
        2 DB::StorageReplicatedMergeTree::getStatus(DB::ReplicatedTableStatus&, bool) build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:7317:22 (clickhouse+0x1b7211c0)
        3 DB::ServerAsynchronousMetrics::updateImpl() build_docker/./src/Interpreters/ServerAsynchronousMetrics.cpp:357:50 (clickhouse+0x19c4d77b) (BuildId: d0f5f049336104f625efeba1d75084002380671f)

  CI: https://s3.amazonaws.com/clickhouse-test-reports/74113/dbd64454ae12f94a560d1b1c81d1e1889c37e372/stress_test__tsan_.html

Follow-up for: #59288