### PR TITLE
Fix crash when reading subcolumn from compressed Memory eng table

### DIFF
--- a/src/Interpreters/getColumnFromBlock.cpp
+++ b/src/Interpreters/getColumnFromBlock.cpp
@@ -52,7 +52,7 @@ ColumnPtr tryGetSubcolumnFromBlock(const Block & block, const DataTypePtr & requ
         return elem_column;
     }
 
-    auto elem_column = elem->type->tryGetSubcolumn(subcolumn_name, elem->column);
+    auto elem_column = elem->type->tryGetSubcolumn(subcolumn_name, elem->column->decompress());
     auto elem_type = elem->type->tryGetSubcolumnType(subcolumn_name);
 
     if (!elem_type || !elem_column)

--- a/tests/queries/0_stateless/03305_compressed_memory_eng_crash_reading_subcolumn.sql
+++ b/tests/queries/0_stateless/03305_compressed_memory_eng_crash_reading_subcolumn.sql
@@ -3,6 +3,6 @@ DROP TABLE IF EXISTS t0;
 CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = Memory() SETTINGS compress = 1;
 INSERT INTO TABLE t0 (c0) VALUES (1);
 
-SELECT t0.c0.null FROM t0 FORMAT Null;
+SELECT t0.c0.null FROM t0 FORMAT Null SETTINGS enable_analyzer = 1;
 
 DROP TABLE t0;

--- a/tests/queries/0_stateless/03305_compressed_memory_eng_crash_reading_subcolumn.sql
+++ b/tests/queries/0_stateless/03305_compressed_memory_eng_crash_reading_subcolumn.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = Memory() SETTINGS compress = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1);
+
+SELECT t0.c0.null FROM t0 FORMAT Null;
+
+DROP TABLE t0;


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash when reading a subcolumn from the compressed Memory engine table. Fixes #74009