### PR TITLE
Configure clangd to always use angled brackets

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -14,3 +14,6 @@ Diagnostics:
             readability-identifier-naming,
             bugprone-reserved-identifier,
         ]
+# Require LLVM 20 (https://github.com/llvm/llvm-project/pull/67749)
+Style:
+  AngledHeaders: [".*"]


### PR DESCRIPTION
Finally clangd has an option for this, I've tested that clangd from upstream and it works like a charm.

Note, that this config is compatible with older clangd as well.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)