### PR TITLE
ClickHouse Client: More ways to specify custom prompts

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -400,7 +400,7 @@ the configuration file like this:
         <database></database>
 
         <!-- You can use colors and macros, see clickhouse-client.xml for more documentation. -->
-        <prompt>\e[31m[PRODUCTION]\e[0m {user}@{display_name} :) </prompt>
+        <prompt>\e[31m[PRODUCTION]\e[0m {user}@{display_name}</prompt>
     </connections_credentials>
 </config>
 ```

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -199,6 +199,7 @@ You can pass parameters to `clickhouse-client` (all parameters have a default va
 - `--progress` – Print progress of query execution. Possible values: 'tty|on|1|true|yes' - outputs to TTY in interactive mode; 'err' - outputs to STDERR non-interactive mode; 'off|0|false|no' - disables the progress printing. Default: TTY in interactive mode, disabled in non-interactive.
 - `--progress-table` – Print a progress table with changing metrics during query execution. Possible values: 'tty|on|1|true|yes' - outputs to TTY in interactive mode; 'err' - outputs to STDERR non-interactive mode; 'off|0|false|no' - disables the progress table. Default: TTY in interactive mode, disabled in non-interactive.
 - `--enable-progress-table-toggle` – Enable toggling of the progress table by pressing the control key (Space). Only applicable in interactive mode with the progress table printing enabled. Default: 'true'.
+- `--prompt` - Specify a custom prompt. Default value: The `display_name` of the server.
 
 Instead of `--host`, `--port`, `--user` and `--password` options, ClickHouse client also supports connection strings (see next section).
 
@@ -380,6 +381,28 @@ secure: true
 openSSL:
   client:
     caConfig: '/etc/ssl/cert.pem'
+```
+
+### Connection credentials {#connection-credentials}
+
+If you frequently connect to the same ClickHouse server, you can save the connection details including credentials in
+the configuration file like this:
+
+```xml
+<config>
+    <connections_credentials>
+        <name>production</name>
+        <hostname>127.0.0.1</hostname>
+        <port>9000</port>
+        <secure>1</secure>
+        <user>default</user>
+        <password></password>
+        <database></database>
+
+        <!-- You can use colors and macros, see clickhouse-client.xml for more documentation. -->
+        <prompt>\e[31m[PRODUCTION]\e[0m {user}@{display_name} :) </prompt>
+    </connections_credentials>
+</config>
 ```
 
 ### Query ID Format {#query-id-format}

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -600,13 +600,13 @@ void Client::connect()
         }
     }
 
-    if (!prompt)
+    if (prompt.empty())
         prompt = "{display_name}";
 
     /// Prompt may contain escape sequences including \e[ or \x1b[ sequences to set terminal color.
     {
         String prompt_escaped;
-        ReadBufferFromString in(*prompt);
+        ReadBufferFromString in(prompt);
         readEscapedString(prompt_escaped, in);
         prompt = prompt_escaped;
     }
@@ -620,9 +620,9 @@ void Client::connect()
     };
 
     for (const auto & [key, value] : prompt_substitutions)
-        boost::replace_all(*prompt, "{" + key + "}", value);
+        boost::replace_all(prompt, "{" + key + "}", value);
 
-    prompt = appendSmileyIfNeeded(*prompt);
+    prompt = appendSmileyIfNeeded(prompt);
 }
 
 // Prints changed settings to stderr. Useful for debugging fuzzing failures.

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -599,9 +599,10 @@ void Client::connect()
             }
         }
     }
-
-    if (prompt.empty())
+    else
+    {
         prompt = "{display_name}";
+    }
 
     /// Prompt may contain escape sequences including \e[ or \x1b[ sequences to set terminal color.
     {

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -600,13 +600,13 @@ void Client::connect()
         }
     }
 
-    if (prompt.empty())
+    if (!prompt)
         prompt = "{display_name}";
 
     /// Prompt may contain escape sequences including \e[ or \x1b[ sequences to set terminal color.
     {
         String prompt_escaped;
-        ReadBufferFromString in(prompt);
+        ReadBufferFromString in(*prompt);
         readEscapedString(prompt_escaped, in);
         prompt = prompt_escaped;
     }
@@ -620,9 +620,9 @@ void Client::connect()
     };
 
     for (const auto & [key, value] : prompt_substitutions)
-        boost::replace_all(prompt, "{" + key + "}", value);
+        boost::replace_all(*prompt, "{" + key + "}", value);
 
-    prompt = appendSmileyIfNeeded(prompt);
+    prompt = appendSmileyIfNeeded(*prompt);
 }
 
 // Prints changed settings to stderr. Useful for debugging fuzzing failures.

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -596,7 +596,7 @@ void Client::connect()
     }
 
     if (prompt.empty())
-        prompt = "{display_name} :) ";
+        prompt = "{display_name}";
 
     /// Prompt may contain escape sequences including \e[ or \x1b[ sequences to set terminal color.
     {

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -31,12 +31,14 @@
         replxx. This means that you don't need the following:
         - RL_PROMPT_START_IGNORE (\001)
         - RL_PROMPT_END_IGNORE   (\002)
+
+        If defined, the prompt takes precedence over the prompt defined in <prompt_by_server_display_name>.
     -->
     <!-- <prompt></prompt> -->
 
     <!-- Custom prompt according to the display_name of the server -->
     <prompt_by_server_display_name>
-        <default>{display_name}</default>
+        <default>{display_name}</default> <!-- default prompt, used if none of below patterns match -->
         <test>\e[1;32m{display_name}\e[0m</test> <!-- if the server display name contains "test" -->
         <production>\e[1;31m{display_name}\e[0m</production> <!-- if the server display name contains "production" -->
     </prompt_by_server_display_name>

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -15,7 +15,7 @@
         </client>
     </openSSL>
     <!--
-        It's a custom prompt settings for the clickhouse-client
+        Custom prompt settings for clickhouse-client. See also <connections_credentials>.
 
         Possible macros:
             {host}
@@ -32,6 +32,9 @@
         - RL_PROMPT_START_IGNORE (\001)
         - RL_PROMPT_END_IGNORE   (\002)
     -->
+    <!-- <prompt></prompt> -->
+
+    <!-- Custom prompt according to the display_name of the server -->
     <prompt_by_server_display_name>
         <default>{display_name} :) </default>
         <test>{display_name} \e[1;32m:)\e[0m </test> <!-- if it matched to the substring "test" in the server display name - -->
@@ -101,6 +104,7 @@
             <database></database>
             <!-- '~' is expanded to HOME, like in any shell -->
             <history_file></history_file>
+            <prompt></prompt>
         </connection>
     </connections_credentials>
     ]]>

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -104,7 +104,7 @@
             <database></database>
             <!-- '~' is expanded to HOME, like in any shell -->
             <history_file></history_file>
-            <prompt></prompt>
+            <!-- <prompt></prompt> -->
         </connection>
     </connections_credentials>
     ]]>

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -104,7 +104,7 @@
             <database></database>
             <!-- '~' is expanded to HOME, like in any shell -->
             <history_file></history_file>
-            <!-- <prompt></prompt> -->
+            <prompt></prompt>
         </connection>
     </connections_credentials>
     ]]>

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -14,6 +14,7 @@
             </invalidCertificateHandler>
         </client>
     </openSSL>
+
     <!--
         Custom prompt settings for clickhouse-client. See also <connections_credentials>.
 
@@ -24,7 +25,6 @@
             {display_name}
 
         You can also use colored prompt, like in [1].
-
           [1]: https://misc.flogisoft.com/bash/tip_colors_and_formatting
 
         But note, that ClickHouse does not use readline anymore, instead it uses
@@ -37,8 +37,8 @@
     <!-- Custom prompt according to the display_name of the server -->
     <prompt_by_server_display_name>
         <default>{display_name}</default>
-        <test>\e[1;32m{display_name}\e[0m</test> <!-- if it matched to the substring "test" in the server display name - -->
-        <production>\e[1;31m{display_name}\e[0m</production> <!-- if it matched to the substring "production" in the server display name -->
+        <test>\e[1;32m{display_name}\e[0m</test> <!-- if the server display name contains "test" -->
+        <production>\e[1;31m{display_name}\e[0m</production> <!-- if the server display name contains "production" -->
     </prompt_by_server_display_name>
 
     <!-- Chunked capabilities for native protocol by client.

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -36,9 +36,9 @@
 
     <!-- Custom prompt according to the display_name of the server -->
     <prompt_by_server_display_name>
-        <default>{display_name} :) </default>
-        <test>{display_name} \e[1;32m:)\e[0m </test> <!-- if it matched to the substring "test" in the server display name - -->
-        <production>{display_name} \e[1;31m:)\e[0m </production> <!-- if it matched to the substring "production" in the server display name -->
+        <default>{display_name}</default>
+        <test>\e[1;32m{display_name}\e[0m</test> <!-- if it matched to the substring "test" in the server display name - -->
+        <production>\e[1;31m{display_name}\e[0m</production> <!-- if it matched to the substring "production" in the server display name -->
     </prompt_by_server_display_name>
 
     <!-- Chunked capabilities for native protocol by client.

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -875,7 +875,8 @@ void LocalServer::processConfig()
     }
 
     server_display_name = getClientConfiguration().getString("display_name", "");
-    getClientConfiguration().setString("prompt", getClientConfiguration().getRawString("prompt_by_server_display_name.default", ":) "));
+    if (getClientConfiguration().has("prompt_by_server_display_name.default"))
+        getClientConfiguration().setString("prompt", getClientConfiguration().getRawString("prompt_by_server_display_name.default"));
 }
 
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -880,7 +880,7 @@ void LocalServer::processConfig()
         prompt = getClientConfiguration().getString("prompt");
     else if (getClientConfiguration().has("prompt_by_server_display_name.default"))
         prompt = getClientConfiguration().getRawString("prompt_by_server_display_name.default");
-    prompt = appendSmileyIfNeeded(prompt);
+    prompt = appendSmileyIfNeeded(*prompt);
 }
 
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -880,7 +880,7 @@ void LocalServer::processConfig()
         prompt = getClientConfiguration().getString("prompt");
     else if (getClientConfiguration().has("prompt_by_server_display_name.default"))
         prompt = getClientConfiguration().getRawString("prompt_by_server_display_name.default");
-    prompt = appendSmileyIfNeeded(*prompt);
+    prompt = appendSmileyIfNeeded(prompt);
 }
 
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -875,8 +875,12 @@ void LocalServer::processConfig()
     }
 
     server_display_name = getClientConfiguration().getString("display_name", "");
-    if (getClientConfiguration().has("prompt_by_server_display_name.default"))
-        getClientConfiguration().setString("prompt", getClientConfiguration().getRawString("prompt_by_server_display_name.default"));
+
+    if (getClientConfiguration().has("prompt"))
+        prompt = getClientConfiguration().getString("prompt");
+    else if (getClientConfiguration().has("prompt_by_server_display_name.default"))
+        prompt = getClientConfiguration().getRawString("prompt_by_server_display_name.default");
+    prompt = appendSmileyIfNeeded(prompt);
 }
 
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -875,7 +875,7 @@ void LocalServer::processConfig()
     }
 
     server_display_name = getClientConfiguration().getString("display_name", "");
-    prompt_by_server_display_name = getClientConfiguration().getRawString("prompt_by_server_display_name.default", ":) ");
+    getClientConfiguration().setString("prompt", getClientConfiguration().getRawString("prompt_by_server_display_name.default", ":) "));
 }
 
 

--- a/src/Client/ClientApplicationBase.cpp
+++ b/src/Client/ClientApplicationBase.cpp
@@ -150,7 +150,7 @@ void ClientApplicationBase::init(int argc, char ** argv)
 
     /// Common options for clickhouse-client and clickhouse-local.
     options_description.main_description->add_options()
-        ("help", "Print usage summary ane exit; combine with --verbose to display all options")
+        ("help", "Print usage summary and exit; combine with --verbose to display all options")
         ("verbose", "Increase output verbosity")
         ("version,V", "Print version and exit")
         ("version-clean", "Print version in machine-readable format and exit")
@@ -194,7 +194,7 @@ void ClientApplicationBase::init(int argc, char ** argv)
 
         ("highlight", po::value<bool>()->default_value(true), "Toggle syntax highlighting in interactive mode")
 
-        ("ignore-error", "Do not stop processing after an error occured")
+        ("ignore-error", "Do not stop processing after an error occurred")
         ("stacktrace", "Print stack traces of exceptions")
         ("hardware-utilization", "Print hardware utilization information in progress bar")
         ("print-profile-events", po::value(&profile_events.print)->zero_tokens(), "Printing ProfileEvents packets")

--- a/src/Client/ClientApplicationBase.cpp
+++ b/src/Client/ClientApplicationBase.cpp
@@ -205,6 +205,8 @@ void ClientApplicationBase::init(int argc, char ** argv)
         ("max_memory_usage_in_client", po::value<std::string>(), "Set memory limit in client/local server")
 
         ("client_logs_file", po::value<std::string>(), "Path to a file for writing client logs. Currently we only have fatal logs (when the client crashes)")
+
+        ("prompt", po::value<std::string>(), "Custom prompt string")
     ;
 
     addOptions(options_description);
@@ -357,6 +359,8 @@ void ClientApplicationBase::init(int argc, char ** argv)
         getClientConfiguration().setBool("interactive", true);
     if (options.count("pager"))
         getClientConfiguration().setString("pager", options["pager"].as<std::string>());
+    if (options.count("prompt"))
+        getClientConfiguration().setString("prompt", options["prompt"].as<std::string>());
 
     if (options.count("log-level"))
         Poco::Logger::root().setLevel(options["log-level"].as<std::string>());

--- a/src/Client/ClientApplicationBase.cpp
+++ b/src/Client/ClientApplicationBase.cpp
@@ -150,63 +150,64 @@ void ClientApplicationBase::init(int argc, char ** argv)
 
     /// Common options for clickhouse-client and clickhouse-local.
     options_description.main_description->add_options()
-        ("help", "print usage summary, combine with --verbose to display all options")
-        ("verbose", "print query and other debugging info")
-        ("version,V", "print version information and exit")
-        ("version-clean", "print version in machine-readable format and exit")
+        ("help", "Print usage summary ane exit; combine with --verbose to display all options")
+        ("verbose", "Increase output verbosity")
+        ("version,V", "Print version and exit")
+        ("version-clean", "Print version in machine-readable format and exit")
 
-        ("config-file,C", po::value<std::string>(), "config-file path")
+        ("config-file,C", po::value<std::string>(), "Path to config file")
 
-        ("proto_caps", po::value<std::string>(), "enable/disable chunked protocol: chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
+        ("proto_caps", po::value<std::string>(), "Enable/disable chunked protocol: chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
 
         ("query,q", po::value<std::vector<std::string>>()->multitoken(), R"(Query. Can be specified multiple times (--query "SELECT 1" --query "SELECT 2") or once with multiple comma-separated queries (--query "SELECT 1; SELECT 2;"). In the latter case, INSERT queries with non-VALUE format must be separated by empty lines.)")
-        ("queries-file", po::value<std::vector<std::string>>()->multitoken(), "file path with queries to execute; multiple files can be specified (--queries-file file1 file2...)")
+        ("queries-file", po::value<std::vector<std::string>>()->multitoken(), "File path with queries to execute; multiple files can be specified (--queries-file file1 file2...)")
         ("multiquery,n", "Obsolete, does nothing")
-        ("multiline,m", "If specified, allow multiline queries (do not send the query on Enter)")
-        ("database,d", po::value<std::string>(), "database")
+        ("multiline,m", "If specified, allow multi-line queries (Enter does not send the query)")
+        ("database,d", po::value<std::string>(), "Database")
         ("query_kind", po::value<std::string>()->default_value("initial_query"), "One of initial_query/secondary_query/no_query")
-        ("query_id", po::value<std::string>(), "query_id")
+        ("query_id", po::value<std::string>(), "Query ID")
 
-        ("history_file", po::value<std::string>(), "Path to a file containing command history.")
-        ("history_max_entries", po::value<UInt32>()->default_value(1000000), "Maximum number of entries in the history file.")
+        ("history_file", po::value<std::string>(), "Path to a file containing command history")
+        ("history_max_entries", po::value<UInt32>()->default_value(1000000), "Maximum number of entries in the history file")
 
         ("stage", po::value<std::string>()->default_value("complete"), "Request query processing up to specified stage: complete,fetch_columns,with_mergeable_state,with_mergeable_state_after_aggregation,with_mergeable_state_after_aggregation_and_limit")
+
         ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::DEFAULT, "default"), "Print progress of queries execution - to TTY: tty|on|1|true|yes; to STDERR non-interactive mode: err; OFF: off|0|false|no; DEFAULT - interactive to TTY, non-interactive is off")
-        ("progress-table", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::DEFAULT, "default"), "Print a progress table with changing metrics during query execution - to TTY: tty|on|1|true|yes; to STDERR non-interactive mode: err; OFF: off|0|false|no; DEFAULT - interactive to TTY, non-interactive is off.")
+        ("progress-table", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::DEFAULT, "default"), "Print a progress table with changing metrics during query execution - to TTY: tty|on|1|true|yes; to STDERR non-interactive mode: err; OFF: off|0|false|no; DEFAULT - interactive to TTY, non-interactive is off")
         ("enable-progress-table-toggle", po::value<bool>()->default_value(true), "Enable toggling of the progress table by pressing the control key (Space). Only applicable in interactive mode with the progress table enabled.")
 
-        ("disable_suggestion,A", "Disable loading suggestion data. Note that suggestion data is loaded asynchronously through a second connection to ClickHouse server. Also it is reasonable to disable suggestion if you want to paste a query with TAB characters. Shorthand option -A is for those who get used to mysql client.")
-        ("wait_for_suggestions_to_load", "Load suggestion data synchonously.")
-        ("time,t", "print query execution time to stderr in non-interactive mode (for benchmarks)")
-        ("memory-usage", po::value<std::string>()->implicit_value("default")->default_value("none"), "print memory usage to stderr in non-interactive mode (for benchmarks). Values: 'none', 'default', 'readable'")
+        ("disable_suggestion,A", "Disable loading suggestions. Note that suggestions are loaded asynchronously through a second connection to ClickHouse server. Recommended when pasting queries with TAB characters.") /// Shorthand -A like in MySQL client
+        ("wait_for_suggestions_to_load", "Load suggestion data synchonously")
+        ("suggestion_limit", po::value<int>()->default_value(10000), "Suggestion limit for how many databases, tables and columns to fetch")
 
-        ("echo", "in batch mode, print query before execution")
+        ("time,t", "Print query execution time to stderr in non-interactive mode (for benchmarks)")
+        ("memory-usage", po::value<std::string>()->implicit_value("default")->default_value("none"), "Print memory usage to stderr in non-interactive mode (for benchmarks). Values: 'none', 'default', 'readable'")
 
-        ("log-level", po::value<std::string>(), "log level")
-        ("server_logs_file", po::value<std::string>(), "put server logs into specified file")
+        ("echo", "In batch mode, print query before execution")
 
-        ("suggestion_limit", po::value<int>()->default_value(10000), "Suggestion limit for how many databases, tables and columns to fetch.")
+        ("log-level", po::value<std::string>(), "Log level")
+        ("server_logs_file", po::value<std::string>(), "Write server logs to specified file")
 
-        ("format,f", po::value<std::string>(), "default output format (and input format for clickhouse-local)")
-        ("output-format", po::value<std::string>(), "default output format (this option has preference over --format)")
+        ("format,f", po::value<std::string>(), "Default output format (and input format for clickhouse-local)")
+        ("output-format", po::value<std::string>(), "Default output format (this option has preference over --format)")
+        ("vertical,E", "Vertical output format, same as --format=Vertical or FORMAT Vertical or \\G at end of command")
 
-        ("vertical,E", "vertical output format, same as --format=Vertical or FORMAT Vertical or \\G at end of command")
-        ("highlight", po::value<bool>()->default_value(true), "enable or disable basic syntax highlight in interactive command line")
+        ("highlight", po::value<bool>()->default_value(true), "Toggle syntax highlighting in interactive mode")
 
-        ("ignore-error", "do not stop processing when an error occurs")
-        ("stacktrace", "print stack traces of exceptions")
-        ("hardware-utilization", "print hardware utilization information in progress bar")
+        ("ignore-error", "Do not stop processing after an error occured")
+        ("stacktrace", "Print stack traces of exceptions")
+        ("hardware-utilization", "Print hardware utilization information in progress bar")
         ("print-profile-events", po::value(&profile_events.print)->zero_tokens(), "Printing ProfileEvents packets")
         ("profile-events-delay-ms", po::value<UInt64>()->default_value(profile_events.delay_ms), "Delay between printing `ProfileEvents` packets (-1 - print only totals, 0 - print every single packet)")
-        ("processed-rows", "print the number of locally processed rows")
+        ("processed-rows", "Print the number of locally processed rows")
 
         ("interactive", "Process queries-file or --query query and start interactive mode")
         ("pager", po::value<std::string>(), "Pipe all output into this command (less or similar)")
+        ("prompt", po::value<std::string>(), "Custom prompt string")
+
         ("max_memory_usage_in_client", po::value<std::string>(), "Set memory limit in client/local server")
 
         ("client_logs_file", po::value<std::string>(), "Path to a file for writing client logs. Currently we only have fatal logs (when the client crashes)")
-
-        ("prompt", po::value<std::string>(), "Custom prompt string")
     ;
 
     addOptions(options_description);

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2610,9 +2610,12 @@ bool ClientBase::processQueryText(const String & text)
 }
 
 
-String ClientBase::prompt() const
+String ClientBase::getPrompt() const
 {
-    return prompt_by_server_display_name;
+    if (!prompt.empty())
+        return prompt;
+
+    return ":) ";
 }
 
 
@@ -2817,7 +2820,7 @@ void ClientBase::runInteractive()
             lr.enableBracketedPaste();
             SCOPE_EXIT({ lr.disableBracketedPaste(); });
 
-            input = lr.readLine(prompt(), ":-] ");
+            input = lr.readLine(getPrompt(), ":-] ");
         }
 
         if (input.empty())

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2613,7 +2613,11 @@ bool ClientBase::processQueryText(const String & text)
 String ClientBase::getPrompt() const
 {
     if (!prompt.empty())
+    {
+        if (!prompt.ends_with(":) "))
+            return prompt + " :) ";
         return prompt;
+    }
 
     return ":) ";
 }

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2627,7 +2627,7 @@ bool ClientBase::processQueryText(const String & text)
 
 String ClientBase::getPrompt() const
 {
-    return *prompt;
+    return prompt;
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -938,6 +938,21 @@ void ClientBase::initKeystrokeInterceptor()
     }
 }
 
+
+String ClientBase::appendSmileyIfNeeded(const String & prompt_)
+{
+    static constexpr String smiley = ":) ";
+
+    if (prompt_.empty())
+        return smiley;
+
+    if (prompt_.ends_with(smiley))
+        return prompt_;
+
+    return prompt_ + smiley;
+}
+
+
 void ClientBase::updateSuggest(const ASTPtr & ast)
 {
     std::vector<std::string> new_words;
@@ -2612,14 +2627,7 @@ bool ClientBase::processQueryText(const String & text)
 
 String ClientBase::getPrompt() const
 {
-    if (!prompt.empty())
-    {
-        if (!prompt.ends_with(":) "))
-            return prompt + " :) ";
-        return prompt;
-    }
-
-    return ":) ";
+    return prompt;
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -949,7 +949,7 @@ String ClientBase::appendSmileyIfNeeded(const String & prompt_)
     if (prompt_.ends_with(smiley))
         return prompt_;
 
-    return prompt_ + smiley;
+    return prompt_ + " " + smiley;
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2627,7 +2627,7 @@ bool ClientBase::processQueryText(const String & text)
 
 String ClientBase::getPrompt() const
 {
-    return prompt;
+    return *prompt;
 }
 
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -347,7 +347,7 @@ protected:
 
     UInt64 server_revision = 0;
     String server_version;
-    String prompt;
+    std::optional<String> prompt;
     String server_display_name;
 
     ProgressIndication progress_indication;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -347,7 +347,7 @@ protected:
 
     UInt64 server_revision = 0;
     String server_version;
-    std::optional<String> prompt;
+    String prompt;
     String server_display_name;
 
     ProgressIndication progress_indication;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -256,6 +256,8 @@ protected:
     void initTTYBuffer(ProgressOption progress_option, ProgressOption progress_table_option);
     void initKeystrokeInterceptor();
 
+    String appendSmileyIfNeeded(const String & prompt);
+
     /// Should be one of the first, to be destroyed the last,
     /// since other members can use them.
     SharedContextHolder shared_context;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -202,7 +202,7 @@ private:
     void initOutputFormat(const Block & block, ASTPtr parsed_query);
     void initLogsOutputStream();
 
-    String prompt() const;
+    String getPrompt() const;
 
     void resetOutput();
 
@@ -345,7 +345,7 @@ protected:
 
     UInt64 server_revision = 0;
     String server_version;
-    String prompt_by_server_display_name;
+    String prompt;
     String server_display_name;
 
     ProgressIndication progress_indication;


### PR DESCRIPTION
I often connect to a lot of different ClickHouse servers in a day. Some are my own and some belong to others. Some are production servers and many more are development instances. Some are running on my laptop while many are remote instances - often in ClickHouse Cloud.

My preferred method to connect when I can is using clickhouse-client. I will often have several connections open in different tabs, sometimes 5-10, when jumping back and forth between different tasks during the day.

It's always been difficult working with so many different connections. I'd have to remember which tab was which and would often run `SELECT hostName()` or just re-connect to be sure of where I am. Very rarely, I get it wrong and execute a command on the wrong server. Luckily, nothing very bad ever happened (knock on wood!).

clickhouse-client has the ability to specify a custom prompt in its config file but only based on the server's `display_name` (aka the hostname). In ClickHouse Cloud, this is always `clickhouse-cloud`, making it not very useful.

This PR expands the ways that the prompt can be specified in `clickhouse-client` in several ways.

There is now a CLI parameter (that even works with Unicode characters):

```
$ ./clickhouse client --prompt "{user}@{host} 🎄🎄🎄 > "
...
default@localhost 🎄🎄🎄 >
```

There is also a top-level configuration in the config file:

```xml
<config>
    <prompt>{host}:{port} $ </prompt>
</config>
```

(if defined, `<prompt>` takes precedence over `<prompt_by_server_display_name>`)

And most importantly, there is now a `<prompt>` tag in the `<connections_credentials>`:

```xml
<config>
    <connections_credentials>
        <connection>
            <name>prod</name>
            ...
            <prompt>\e[31m[PRODUCTION]\e[0m {user}@cloud-prod :) </prompt>
        </connection>
            <name>dev</name>
            ...
            <prompt>\e[34m[DEVELOPMENT]\e[0m {user}@cloud-dev :) </prompt>
        </connection>
    </connections_credentials>
</config>
```

<img width="822" alt="Screenshot 2025-01-03 at 20 12 06" src="https://github.com/user-attachments/assets/2f68440c-1faa-4691-8215-a6369083fa31" />

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
There are now three simple ways to set a custom prompt in `clickhouse-client`: 1. via command-line parameter `--prompt`, 2. in the configuration file, via settings `<prompt>[...]</prompt>`, and 3. also in the configuration file, via per-connection settings `<connections_credentials><prompt>[...]</prompt></connection_credentials>`