### PR TITLE
ci: fix skipping of some integration tests

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -14,7 +14,7 @@ import string
 import subprocess
 import sys
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from itertools import chain
 from typing import Any, Dict, List, Optional
 
@@ -474,7 +474,7 @@ class ClickhouseIntegrationTestsRunner:
 
     @staticmethod
     def group_test_by_file(tests):
-        result = {}  # type: Dict
+        result = OrderedDict()  # type: OrderedDict
         for test in tests:
             test_file = test.split("::")[0]
             if test_file not in result:


### PR DESCRIPTION
I found (in #72959, test test_logs_with_disks, see [1]) that sometimes not all tests presented in all "Integration tests (asan, old analyzer)" job, while all tests presented in the runner_get_all_tests.log file, not all of them are executed.

The only place that I found is that group_test_by_file() returns dict, in which order of keys (and hence I guess .values()) is not deterministic (python uses some kind of seed for hash, new for each process), and this can lead to the issue that some tests won't be executed on any workers, since they are divided into 6 parts, and then, each worker execute the same code, but in one worker the test can be in "1" group, while on the other worker the same test can be on "2" group.

  [1]: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19uYW1lIExJS0UgJ0ludGVncmF0aW9uJScKICAgIGFuZCB0ZXN0X25hbWUgbGlrZSAnJXRlc3Rfa2VlcGVyX2Rpc2tzL3Rlc3QucHk6OnRlc3RfbG9nc193aXRoX2Rpc2tzJScKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMjQgREFZCiAgICBhbmQgcHVsbF9yZXF1ZXN0X251bWJlciA9IDcyOTU5Ck9SREVSIEJZIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgY2hlY2tfc3RhcnRfdGltZQ==

And that was not the only one PR with this issue:
- [number of commits that has missing tests](https://play.clickhouse.com/play?user=play#d2l0aAogICAgKAogICAgICAgIHNlbGVjdCBhcnJheVNvcnQoZ3JvdXBVbmlxQXJyYXkodGVzdF9uYW1lKSkgZnJvbSBjaGVja3MKICAgICAgICB3aGVyZQogICAgICAgICAgICBwdWxsX3JlcXVlc3RfbnVtYmVyID0gNzQxNjkgYW5kCiAgICAgICAgICAgIGNoZWNrX25hbWUgTElLRSAnSW50ZWdyYXRpb24lJyBBTkQKICAgICAgICAgICAgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IGRheSBBTkQKICAgICAgICAgICAgdGVzdF9uYW1lIExJS0UgJyU6OiUnIEFORAogICAgICAgICAgICAtLSBjaGFuZ2VkIGluIHVwc3RyZWFtCiAgICAgICAgICAgIHRlc3RfbmFtZSBOT1QgTElLRSAndGVzdF9zdG9yYWdlX3MzX3F1ZXVlL3Rlc3QucHk6OnRlc3RfbWlncmF0aW9uJScKICAgICkgYXMgZXhwZWN0ZWRfdGVzdHMsCiAgICBhcnJheVNvcnQoZ3JvdXBVbmlxQXJyYXkodGVzdF9zdGF0dXMpKSBhcyBzdGF0dXNlcywKICAgIGdyb3VwVW5pcUFycmF5KHRlc3RfbmFtZSkgYXMgdGVzdHMKc2VsZWN0IGNvbW1pdF9zaGEsIG1pbihjaGVja19zdGFydF90aW1lKSwgaGFzQWxsKHRlc3RzLCBleHBlY3RlZF90ZXN0cykKZnJvbSBjaGVja3MKd2hlcmUgY2hlY2tfbmFtZSBMSUtFICdJbnRlZ3JhdGlvbiUnIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgNyBEQVkgQU5EIHRlc3RfbmFtZSBMSUtFICclOjolJwpncm91cCBieSBjb21taXRfc2hhCmhhdmluZyBzdGF0dXNlcyA9IFsnT0snLCAnU0tJUFBFRCddIGFuZCB1bmlxRXhhY3QocmVwb3J0X3VybCkgPSAxOApvcmRlciBieSAy)
- [commits with number of missing tests (requires more memory)](https://play.clickhouse.com/play?user=play#d2l0aAogICAgKAogICAgICAgIHNlbGVjdCBhcnJheVNvcnQoZ3JvdXBVbmlxQXJyYXkodGVzdF9uYW1lKSkgZnJvbSBjaGVja3MKICAgICAgICB3aGVyZQogICAgICAgICAgICBwdWxsX3JlcXVlc3RfbnVtYmVyID0gNzQxNjkgYW5kCiAgICAgICAgICAgIGNoZWNrX25hbWUgTElLRSAnSW50ZWdyYXRpb24lJyBBTkQKICAgICAgICAgICAgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IGRheSBBTkQKICAgICAgICAgICAgdGVzdF9uYW1lIExJS0UgJyU6OiUnIEFORAogICAgICAgICAgICAtLSBjaGFuZ2VkIGluIHVwc3RyZWFtCiAgICAgICAgICAgIHRlc3RfbmFtZSBOT1QgTElLRSAndGVzdF9zdG9yYWdlX3MzX3F1ZXVlL3Rlc3QucHk6OnRlc3RfbWlncmF0aW9uJScKICAgICkgYXMgZXhwZWN0ZWRfdGVzdHMsCiAgICBhcnJheVNvcnQoZ3JvdXBVbmlxQXJyYXkodGVzdF9zdGF0dXMpKSBhcyBzdGF0dXNlcywKICAgIGdyb3VwVW5pcUFycmF5KHRlc3RfbmFtZSkgYXMgdGVzdHMsCiAgICBsZW5ndGgoYXJyYXlGaWx0ZXIoeCAtPiBub3QgaGFzKHRlc3RzLCB4KSwgZXhwZWN0ZWRfdGVzdHMpKSBhcyBtaXNzaW5nX3Rlc3RzCnNlbGVjdCBhbnkoY29tbWl0X3VybCkgdXJsLCBtaXNzaW5nX3Rlc3RzCmZyb20gY2hlY2tzCndoZXJlIGNoZWNrX25hbWUgTElLRSAnSW50ZWdyYXRpb24lJyBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDEgREFZIEFORCB0ZXN0X25hbWUgTElLRSAnJTo6JScKZ3JvdXAgYnkgY29tbWl0X3NoYQpoYXZpbmcgdW5pcUV4YWN0KHJlcG9ydF91cmwpID0gMTggYW5kIG5vdCBoYXNBbGwodGVzdHMsIGV4cGVjdGVkX3Rlc3RzKQpvcmRlciBieSAy)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
