### PR TITLE
change Prometheus remote write response from 200 to 204

### DIFF
--- a/docker/test/integration/runner/requirements.txt
+++ b/docker/test/integration/runner/requirements.txt
@@ -103,3 +103,4 @@ wheel==0.38.1
 zipp==1.0.0
 pyiceberg==0.7.1
 jinja2==3.1.3
+python-snappy==0.7.3

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -232,6 +232,7 @@ public:
             protocol.writeMetricsMetadata(write_request.metadata());
 
         response.setStatusAndReason(Poco::Net::HTTPResponse::HTTPStatus::HTTP_NO_CONTENT, Poco::Net::HTTPResponse::HTTP_REASON_NO_CONTENT);
+        response.setChunkedTransferEncoding(false);
         response.send();
 
 #else

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -7,6 +7,7 @@
 #include <Server/IServer.h>
 #include <Server/PrometheusMetricsWriter.h>
 #include <base/scope_guard.h>
+#include <Poco/Net/HTTPResponse.h>
 #include <Common/logger_useful.h>
 #include <Common/setThreadName.h>
 #include "config.h"
@@ -230,7 +231,7 @@ public:
         if (write_request.metadata_size())
             protocol.writeMetricsMetadata(write_request.metadata());
 
-        response.setContentType("text/plain; charset=UTF-8");
+        response.setStatusAndReason(Poco::Net::HTTPResponse::HTTPStatus::HTTP_NO_CONTENT, Poco::Net::HTTPResponse::HTTP_REASON_NO_CONTENT);
         response.send();
 
 #else

--- a/tests/integration/test_prometheus_protocols/test.py
+++ b/tests/integration/test_prometheus_protocols/test.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 
 import pytest
 import requests
+import snappy
 
 from helpers.cluster import ClickHouseCluster
 
@@ -49,6 +50,28 @@ def execute_query_impl(host, port, path, query, timestamp):
         print(f"Response: {r.text}")
         raise Exception(f"Got unexpected status code {r.status_code}")
     return r.json()
+
+
+def execute_remote_write_impl(host, port, path, body):
+    if not path.startswith("/"):
+        path += "/"
+    url = f"http://{host}:{port}/{path.strip('/')}"
+    print(f"Posting {url}")
+    r = requests.post(
+        url,
+        data=snappy.compress(data=body),
+        headers={
+            "Content-Encoding": "snappy",
+            "Content-Type": "application/x-protobuf",
+            "User-Agent": requests.utils.default_user_agent(),
+            "X-Prometheus-Remote-Write-Version": "0.1.0",
+        },
+    )
+    print(f"Status code: {r.status_code} {HTTPStatus(r.status_code).phrase}")
+    if r.status_code != requests.codes.no_content:
+        print(f"Response: {r.text}")
+        raise Exception(f"Got unexpected status code {r.status_code}")
+    return r.text
 
 
 def show_query_result(query):
@@ -202,3 +225,16 @@ def test_read_auth():
     assert "DB::Exception: snappy uncomress failed" in auth_ok.text
 
     assert get("/read_auth_fail").status_code == 403
+
+
+def test_remote_write_v1_status_code():
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+    body = bytes.fromhex(
+        "0a380a100a085f5f6e616d655f5f120474696d650a130a06726567696f6e120975732d656173742d31120f09000000000080404010afdcb5bc061a1a0802120474696d65220c48656c70204d6573736167652a026d73"
+    )
+    execute_remote_write_impl(
+        node.ip_address,
+        cluster.prometheus_remote_write_handler_port,
+        cluster.prometheus_remote_write_handler_path,
+        body,
+    )

--- a/tests/integration/test_prometheus_protocols/test.py
+++ b/tests/integration/test_prometheus_protocols/test.py
@@ -229,6 +229,22 @@ def test_read_auth():
 
 def test_remote_write_v1_status_code():
     node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+    # send a remote write v1 request created from the following object:
+    # request := prompb.WriteRequest{
+    # 	Metadata: []prompb.MetricMetadata{
+    # 		{Type: prompb.MetricMetadata_GAUGE, MetricFamilyName: "time", Unit: "ms", Help: "Help Message"},
+    # 	},
+    # 	Timeseries: []prompb.TimeSeries{
+    # 		{Labels: []prompb.Label{
+    # 			{Name: "__name__", Value: "time"},
+    # 			{Name: "region", Value: "us-east-1"},
+    # 		}, Samples: []prompb.Sample{
+    # 			{Value: 33.0, Timestamp: time.Now().Unix()},
+    # 		}},
+    # 	},
+    # }
+    # buf, _ := request.Marshal()
+    # hex.EncodeToString(buf)
     body = bytes.fromhex(
         "0a380a100a085f5f6e616d655f5f120474696d650a130a06726567696f6e120975732d656173742d31120f09000000000080404010afdcb5bc061a1a0802120474696d65220c48656c70204d6573736167652a026d73"
     )


### PR DESCRIPTION
I was using vector to send metrics to clickhouse and it fails due to the unexpected response when using status 200/OK with the error "Invalid chunk size line: missing size digit" when parsing the empty response body.

This is fixed when 204/No Content is returned instead. Additionally, going forward prometheus has clarified in the spec that this is the [expected implementation](https://prometheus.io/docs/specs/remote_write_spec_2_0/#response) and it is the value used in the canonical [go implementation](https://github.com/prometheus/prometheus/blob/a441ad771e881c0035bc90129bcae682ebf66338/storage/remote/write_handler.go#L191). This PR just changes the empty response status.

### Changelog category (leave one):
- Improvement 

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md): 
Change prometheus remote write response success status from 200/OK to 204/NoContent