### PR TITLE
Fix keeper shutdown in case of initialization failed

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -2399,6 +2399,14 @@ Changelog::~Changelog()
     try
     {
         flush();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+
+    try
+    {
         shutdown();
     }
     catch (...)


### PR DESCRIPTION
Simple repro:

  $ clickhouse-keeper-data-dumper /tmp/no-such-dir/snapshots/ /tmp/no-such-dir/logs

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)