### PR TITLE
MergeTree: reduce mutex lock critical section in MergeTreeReadPool

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPool.cpp
@@ -67,91 +67,95 @@ MergeTreeReadPool::MergeTreeReadPool(
 
 MergeTreeReadTaskPtr MergeTreeReadPool::getTask(size_t task_idx, MergeTreeReadTask * previous_task)
 {
-    const std::lock_guard lock{mutex};
-
-    /// If number of threads was lowered due to backoff, then will assign work only for maximum 'backoff_state.current_threads' threads.
-    if (task_idx >= backoff_state.current_threads)
-        return nullptr;
-
-    if (remaining_thread_tasks.empty())
-        return nullptr;
-
-    const auto tasks_remaining_for_this_thread = !threads_tasks[task_idx].sum_marks_in_parts.empty();
-    if (!tasks_remaining_for_this_thread && pool_settings.do_not_steal_tasks)
-        return nullptr;
-
-    /// Steal task if nothing to do and it's not prohibited
-    auto thread_idx = task_idx;
-    if (!tasks_remaining_for_this_thread)
-    {
-        auto it = remaining_thread_tasks.lower_bound(backoff_state.current_threads);
-        // Grab the entire tasks of a thread which is killed by backoff
-        if (it != remaining_thread_tasks.end())
-        {
-            threads_tasks[task_idx] = std::move(threads_tasks[*it]);
-            remaining_thread_tasks.erase(it);
-            remaining_thread_tasks.insert(task_idx);
-        }
-        else // Try steal tasks from the next thread
-        {
-            it = remaining_thread_tasks.upper_bound(task_idx);
-            if (it == remaining_thread_tasks.end())
-                it = remaining_thread_tasks.begin();
-            thread_idx = *it;
-        }
-    }
-
-    auto & thread_tasks = threads_tasks[thread_idx];
-    auto & thread_task = thread_tasks.parts_and_ranges.back();
-
-    const auto part_idx = thread_task.part_idx;
-    auto & marks_in_part = thread_tasks.sum_marks_in_parts.back();
-    const auto min_marks_per_task = per_part_infos[part_idx]->min_marks_per_task;
-
-    size_t need_marks;
-    if (is_part_on_remote_disk[part_idx] && !pool_settings.use_const_size_tasks_for_remote_reading)
-        need_marks = marks_in_part;
-    else /// Get whole part to read if it is small enough.
-        need_marks = std::min(marks_in_part, min_marks_per_task);
-
-    /// Do not leave too little rows in part for next time.
-    if (marks_in_part > need_marks && marks_in_part - need_marks < min_marks_per_task / 2)
-        need_marks = marks_in_part;
-
+    size_t part_idx;
     MarkRanges ranges_to_get_from_part;
 
-    /// Get whole part to read if it is small enough.
-    if (marks_in_part <= need_marks)
     {
-        ranges_to_get_from_part = thread_task.ranges;
-        marks_in_part = 0;
+        const std::lock_guard lock{mutex};
 
-        thread_tasks.parts_and_ranges.pop_back();
-        thread_tasks.sum_marks_in_parts.pop_back();
+        /// If number of threads was lowered due to backoff, then will assign work only for maximum 'backoff_state.current_threads' threads.
+        if (task_idx >= backoff_state.current_threads)
+            return nullptr;
 
-        if (thread_tasks.sum_marks_in_parts.empty())
-            remaining_thread_tasks.erase(thread_idx);
-    }
-    else
-    {
-        /// Loop through part ranges.
-        while (need_marks > 0 && !thread_task.ranges.empty())
+        if (remaining_thread_tasks.empty())
+            return nullptr;
+
+        const auto tasks_remaining_for_this_thread = !threads_tasks[task_idx].sum_marks_in_parts.empty();
+        if (!tasks_remaining_for_this_thread && pool_settings.do_not_steal_tasks)
+            return nullptr;
+
+        /// Steal task if nothing to do and it's not prohibited
+        auto thread_idx = task_idx;
+        if (!tasks_remaining_for_this_thread)
         {
-            auto & range = thread_task.ranges.front();
+            auto it = remaining_thread_tasks.lower_bound(backoff_state.current_threads);
+            // Grab the entire tasks of a thread which is killed by backoff
+            if (it != remaining_thread_tasks.end())
+            {
+                threads_tasks[task_idx] = std::move(threads_tasks[*it]);
+                remaining_thread_tasks.erase(it);
+                remaining_thread_tasks.insert(task_idx);
+            }
+            else // Try steal tasks from the next thread
+            {
+                it = remaining_thread_tasks.upper_bound(task_idx);
+                if (it == remaining_thread_tasks.end())
+                    it = remaining_thread_tasks.begin();
+                thread_idx = *it;
+            }
+        }
 
-            const size_t marks_in_range = range.end - range.begin;
-            const size_t marks_to_get_from_range = std::min(marks_in_range, need_marks);
+        auto & thread_tasks = threads_tasks[thread_idx];
+        auto & thread_task = thread_tasks.parts_and_ranges.back();
 
-            ranges_to_get_from_part.emplace_back(range.begin, range.begin + marks_to_get_from_range);
-            range.begin += marks_to_get_from_range;
-            if (range.begin == range.end)
-                thread_task.ranges.pop_front();
+        part_idx = thread_task.part_idx;
+        auto & marks_in_part = thread_tasks.sum_marks_in_parts.back();
+        const auto min_marks_per_task = per_part_infos[part_idx]->min_marks_per_task;
 
-            marks_in_part -= marks_to_get_from_range;
-            need_marks -= marks_to_get_from_range;
+        size_t need_marks;
+        if (is_part_on_remote_disk[part_idx] && !pool_settings.use_const_size_tasks_for_remote_reading)
+            need_marks = marks_in_part;
+        else /// Get whole part to read if it is small enough.
+            need_marks = std::min(marks_in_part, min_marks_per_task);
+
+        /// Do not leave too little rows in part for next time.
+        if (marks_in_part > need_marks && marks_in_part - need_marks < min_marks_per_task / 2)
+            need_marks = marks_in_part;
+
+        /// Get whole part to read if it is small enough.
+        if (marks_in_part <= need_marks)
+        {
+            ranges_to_get_from_part = thread_task.ranges;
+            marks_in_part = 0;
+
+            thread_tasks.parts_and_ranges.pop_back();
+            thread_tasks.sum_marks_in_parts.pop_back();
+
+            if (thread_tasks.sum_marks_in_parts.empty())
+                remaining_thread_tasks.erase(thread_idx);
+        }
+        else
+        {
+            /// Loop through part ranges.
+            while (need_marks > 0 && !thread_task.ranges.empty())
+            {
+                auto & range = thread_task.ranges.front();
+
+                const size_t marks_in_range = range.end - range.begin;
+                const size_t marks_to_get_from_range = std::min(marks_in_range, need_marks);
+
+                ranges_to_get_from_part.emplace_back(range.begin, range.begin + marks_to_get_from_range);
+                range.begin += marks_to_get_from_range;
+                if (range.begin == range.end)
+                    thread_task.ranges.pop_front();
+
+                marks_in_part -= marks_to_get_from_range;
+                need_marks -= marks_to_get_from_range;
+            }
         }
     }
 
+    /// createTask() is costly and not needed guarded by mutex.
     return createTask(per_part_infos[part_idx], std::move(ranges_to_get_from_part), previous_task);
 }
 

--- a/src/Storages/MergeTree/MergeTreeReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPool.cpp
@@ -199,6 +199,8 @@ void MergeTreeReadPool::fillPerThreadInfo(size_t threads, size_t sum_marks)
     if (threads > 1000000ull)
         throw Exception(ErrorCodes::CANNOT_SCHEDULE_TASK, "Too many threads ({}) requested", threads);
 
+    std::lock_guard lock(mutex);
+
     threads_tasks.resize(threads);
     if (parts_ranges.empty())
         return;

--- a/src/Storages/MergeTree/MergeTreeReadPool.h
+++ b/src/Storages/MergeTree/MergeTreeReadPool.h
@@ -87,7 +87,7 @@ private:
     };
 
     const BackoffSettings backoff_settings;
-    BackoffState backoff_state;
+    BackoffState backoff_state TSA_GUARDED_BY(mutex);
 
     struct ThreadTask
     {
@@ -101,8 +101,8 @@ private:
         std::vector<size_t> sum_marks_in_parts;
     };
 
-    std::vector<ThreadTask> threads_tasks;
-    std::set<size_t> remaining_thread_tasks;
+    std::vector<ThreadTask> threads_tasks TSA_GUARDED_BY(mutex);
+    std::set<size_t> remaining_thread_tasks TSA_GUARDED_BY(mutex);
 
     LoggerPtr log = getLogger("MergeTreeReadPool");
 };


### PR DESCRIPTION
For given query, usually threads will share the same MergeTreeReadPool. When the threads try to get task (`MergeTreeReadPool::getTask`), it is guarded by a mutex, if one thread is in the critical section, the others need to wait. 

From our profiling, most of the cycles in `getTask()` is consumed by `createTask()` (about 70%), but it does NOT need mutex protection. 

If we move `createTask()` out of the critical section, we see ~5% QPS gain in ClickBench Q1 & Q2 (Tested in Xeon 8380, 160 vCPUs, 2 sockets). 
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce critical section in `MergeTreeReadPool`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
