### PR TITLE
Fix error in the error message about timeout

### DIFF
--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -497,7 +497,7 @@ CancellationCode QueryStatus::cancelQuery(CancelReason reason, std::exception_pt
     return CancellationCode::CancelSent;
 }
 
-void QueryStatus::throwProperExceptionIfNeeded(const UInt64 & max_execution_time, const UInt64 & elapsed_ns)
+void QueryStatus::throwProperExceptionIfNeeded(const UInt64 & max_execution_time_ms, const UInt64 & elapsed_ns)
 {
     {
         std::lock_guard<std::mutex> lock(cancel_mutex);
@@ -508,7 +508,7 @@ void QueryStatus::throwProperExceptionIfNeeded(const UInt64 & max_execution_time
                 additional_error_part = fmt::format("elapsed {} ms, ", static_cast<double>(elapsed_ns) / 1000000000ULL);
 
             if (cancel_reason == CancelReason::TIMEOUT)
-                throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: {}maximum: {} ms", additional_error_part, max_execution_time / 1000.0);
+                throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: {}maximum: {} ms", additional_error_part, max_execution_time_ms);
             throwQueryWasCancelled();
         }
     }
@@ -520,7 +520,7 @@ void QueryStatus::addPipelineExecutor(PipelineExecutor * e)
     /// addPipelineExecutor() from the cancelQuery() context, and this will
     /// lead to deadlock.
     UInt64 max_exec_time = getContext()->getSettingsRef()[Setting::max_execution_time].totalMilliseconds();
-    throwProperExceptionIfNeeded(max_exec_time);
+    throwProperExceptionIfNeeded(max_exec_time, 0);
 
     std::lock_guard lock(executors_mutex);
     assert(!executors.contains(e));

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -243,7 +243,7 @@ public:
 
     QueryStatusInfo getInfo(bool get_thread_list = false, bool get_profile_events = false, bool get_settings = false) const;
 
-    void throwProperExceptionIfNeeded(const UInt64 & max_execution_time, const UInt64 & elapsed_ns = 0);
+    void throwProperExceptionIfNeeded(const UInt64 & max_execution_time_ms, const UInt64 & elapsed_ns);
 
     /// Cancels the current query.
     /// Optional argument `exception` allows to set an exception which checkTimeLimit() will throw instead of "QUERY_WAS_CANCELLED".

--- a/src/QueryPipeline/ExecutionSpeedLimits.cpp
+++ b/src/QueryPipeline/ExecutionSpeedLimits.cpp
@@ -127,9 +127,9 @@ bool ExecutionSpeedLimits::checkTimeLimit(const UInt64 & elapsed_ns, OverflowMod
             return handleOverflowMode(
                 overflow_mode,
                 ErrorCodes::TIMEOUT_EXCEEDED,
-                "Timeout exceeded: elapsed {} seconds, maximum: {} seconds",
-                static_cast<double>(elapsed_ns) / 1000000000ULL,
-                max_execution_time.totalMicroseconds() / 1000000.0);
+                "Timeout exceeded: elapsed {} ms, maximum: {} ms",
+                static_cast<double>(watch.elapsed()) / 1000000ULL,
+                limits.max_execution_time.totalMilliseconds());
     }
 
     return true;

--- a/src/QueryPipeline/ExecutionSpeedLimits.cpp
+++ b/src/QueryPipeline/ExecutionSpeedLimits.cpp
@@ -128,8 +128,8 @@ bool ExecutionSpeedLimits::checkTimeLimit(const UInt64 & elapsed_ns, OverflowMod
                 overflow_mode,
                 ErrorCodes::TIMEOUT_EXCEEDED,
                 "Timeout exceeded: elapsed {} ms, maximum: {} ms",
-                static_cast<double>(watch.elapsed()) / 1000000ULL,
-                limits.max_execution_time.totalMilliseconds());
+                static_cast<double>(elapsed_ns) / 1000000ULL,
+                max_execution_time.totalMilliseconds());
     }
 
     return true;

--- a/tests/queries/0_stateless/02294_floating_point_second_in_settings.reference
+++ b/tests/queries/0_stateless/02294_floating_point_second_in_settings.reference
@@ -1,8 +1,8 @@
 TCP CLIENT
-maximum: 1.1
+maximum: 1100 ms
 TCP CLIENT WITH SETTINGS IN QUERY
-maximum: 1.1
+maximum: 1100 ms
 HTTP CLIENT
-maximum: 1.1
+maximum: 1100 ms
 TABLE: system.settings
 max_execution_time	30.5	1

--- a/tests/queries/0_stateless/02294_floating_point_second_in_settings.sh
+++ b/tests/queries/0_stateless/02294_floating_point_second_in_settings.sh
@@ -7,14 +7,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e -o pipefail
 
+MAX_TIMEOUT_MS=1100
+MAX_TIMEOUT_SEC=$(awk "BEGIN {printf \"%.3f\", ${MAX_TIMEOUT_MS}/1000}") # Use 1.1 because using 0.x truncates to 0 in older releases
 
-MAX_TIMEOUT=1.1 # Use 1.1 because using 0.x truncates to 0 in older releases
-
+# Function to check the output for maximum execution time in milliseconds
 function check_output() {
-  MAXTIME_USED=$(echo "$1" | grep -Eo "maximum: [0-9]+\.[0-9]+" | head -n1 || true)
-  if [ "${MAXTIME_USED}" != "maximum: ${MAX_TIMEOUT}" ];
-  then
-    echo "'$MAXTIME_USED' is not equal to 'maximum: ${MAX_TIMEOUT}'"
+  # Extract the maximum time used from the output, including 'ms'
+  MAXTIME_USED=$(echo "$1" | grep -Eo "maximum: [0-9]+(?:\.[0-9]+)? ms" | head -n1 || true)
+  EXPECTED="maximum: ${MAX_TIMEOUT_MS} ms"
+  if [ "${MAXTIME_USED}" != "${EXPECTED}" ]; then
+    echo "'${MAXTIME_USED}' is not equal to '${EXPECTED}'"
     echo "OUTPUT: $1"
   else
     echo "$MAXTIME_USED"
@@ -23,19 +25,18 @@ function check_output() {
 
 # TCP CLIENT
 echo "TCP CLIENT"
-OUTPUT=$($CLICKHOUSE_CLIENT --max_rows_to_read 0 --max_execution_time $MAX_TIMEOUT -q "SELECT count() FROM system.numbers" 2>&1 || true)
+OUTPUT=$($CLICKHOUSE_CLIENT --max_rows_to_read 0 --max_execution_time $MAX_TIMEOUT_SEC -q "SELECT count() FROM system.numbers" 2>&1 || true)
 check_output "${OUTPUT}"
 
 echo "TCP CLIENT WITH SETTINGS IN QUERY"
-OUTPUT=$($CLICKHOUSE_CLIENT --max_rows_to_read 0 -q "SELECT count() FROM system.numbers SETTINGS max_execution_time=$MAX_TIMEOUT" 2>&1 || true)
+OUTPUT=$($CLICKHOUSE_CLIENT --max_rows_to_read 0 -q "SELECT count() FROM system.numbers SETTINGS max_execution_time=${MAX_TIMEOUT_SEC}" 2>&1 || true)
 check_output "${OUTPUT}"
 
 # HTTP CLIENT
 echo "HTTP CLIENT"
-OUTPUT=$(${CLICKHOUSE_CURL_COMMAND} -q -sS "$CLICKHOUSE_URL&max_execution_time=${MAX_TIMEOUT}&max_rows_to_read=0" -d \
-    "SELECT count() FROM system.numbers" || true)
+OUTPUT=$(${CLICKHOUSE_CURL_COMMAND} -q -sS "$CLICKHOUSE_URL&max_execution_time=${MAX_TIMEOUT_SEC}&max_rows_to_read=0" -d "SELECT count() FROM system.numbers" || true)
 check_output "${OUTPUT}"
 
 # CHECK system.settings
 echo "TABLE: system.settings"
-echo "SELECT name, value, changed from system.settings where name = 'max_execution_time'" | $CLICKHOUSE_CLIENT_BINARY --max_execution_time 30.5
+echo "SELECT name, value, changed FROM system.settings WHERE name = 'max_execution_time'" | $CLICKHOUSE_CLIENT_BINARY --max_execution_time 30.5


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CC @yariks5s 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
