### PR TITLE
tests: fix 00626_replace_partition_from_table flakiness

### DIFF
--- a/tests/queries/0_stateless/00626_replace_partition_from_table.sql
+++ b/tests/queries/0_stateless/00626_replace_partition_from_table.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS src;
 DROP TABLE IF EXISTS dst;
 
 CREATE TABLE src (p UInt64, k String, d UInt64) ENGINE = MergeTree PARTITION BY p ORDER BY k;
-CREATE TABLE dst (p UInt64, k String, d UInt64) ENGINE = MergeTree PARTITION BY p ORDER BY k;
+CREATE TABLE dst (p UInt64, k String, d UInt64) ENGINE = MergeTree PARTITION BY p ORDER BY k SETTINGS merge_selector_base=1000;
 
 SELECT 'Initial';
 INSERT INTO src VALUES (0, '0', 1);


### PR DESCRIPTION
In debug build this test takes 34.5 seconds [1], and this leads to merge assigned just after SYSTEM START MERGES, due to parts age exceeds 10 seconds, and this was enough to lower the base and allow a merge.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/74198/a2b4731222829a389805adc1167847a2c76d6a8a/stateless_tests__debug__s3_storage_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)