### PR TITLE
ClickHouse Client: Autodetect secure connection based on port

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -37,11 +37,10 @@ The client can be used in interactive and non-interactive (batch) mode.
 
 ### Interactive
 
-To connect to your ClickHouse Cloud service, or any ClickHouse server using TLS and passwords, interactively use `--secure`, port 9440, and provide your username and password:
+To connect to your ClickHouse Cloud service or any ClickHouse server using TLS and passwords, specify port `9440` (or `--secure`) and provide your username and password:
 
 ```bash
 clickhouse-client --host <HOSTNAME> \
-                  --secure \
                   --port 9440 \
                   --user <USERNAME> \
                   --password <PASSWORD>
@@ -62,7 +61,6 @@ This example is appropriate for ClickHouse Cloud, or any ClickHouse server using
 
 ```bash
 clickhouse-client --host HOSTNAME.clickhouse.cloud \
-  --secure \
   --port 9440 \
   --user default \
   --password PASSWORD \
@@ -188,7 +186,7 @@ You can pass parameters to `clickhouse-client` (all parameters have a default va
 - `--memory-usage` – If specified, print memory usage to ‘stderr’ in non-interactive mode]. Possible values: 'none' - do not print memory usage, 'default' - print number of bytes, 'readable' - print memory usage in human-readable format.
 - `--stacktrace` – If specified, also print the stack trace if an exception occurs.
 - `--config-file` – The name of the configuration file.
-- `--secure` – If specified, will connect to server over secure connection (TLS). You might need to configure your CA certificates in the [configuration file](#configuration_files). The available configuration settings are the same as for [server-side TLS configuration](../operations/server-configuration-parameters/settings.md#openssl).
+- `--secure` – If specified, will connect to server over secure connection (TLS). Enabled automatically when connecting to port 9440 (the default secure port) or ClickHouse Cloud. You might need to configure your CA certificates in the [configuration file](#configuration_files). The available configuration settings are the same as for [server-side TLS configuration](../operations/server-configuration-parameters/settings.md#openssl).
 - `--history_file` — Path to a file containing command history.
 - `--history_max_entries` — Maximum number of entries in the history file. Default value: 1 000 000.
 - `--param_<name>` — Value for a [query with parameters](#cli-queries-with-parameters).

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -25,7 +25,8 @@ namespace ErrorCodes
 namespace
 {
 
-bool enableSecureConnection(const Poco::Util::AbstractConfiguration & config, const std::string & connection_host)
+bool enableSecureConnection(const Poco::Util::AbstractConfiguration & config, const std::string & connection_host,
+                            const std::optional<UInt16> & connection_port = std::nullopt)
 {
     if (config.getBool("secure", false))
         return true;
@@ -33,8 +34,13 @@ bool enableSecureConnection(const Poco::Util::AbstractConfiguration & config, co
     if (config.getBool("no-secure", false))
         return false;
 
-    bool is_clickhouse_cloud = connection_host.ends_with(".clickhouse.cloud") || connection_host.ends_with(".clickhouse-staging.com");
-    return is_clickhouse_cloud;
+    if (connection_host.ends_with(".clickhouse.cloud") || connection_host.ends_with(".clickhouse-staging.com"))
+        return true;
+
+    if (connection_port && connection_port.value() == DBMS_DEFAULT_SECURE_PORT)
+        return true;
+
+    return false;
 }
 
 }
@@ -45,7 +51,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     : host(connection_host)
     , port(connection_port.value_or(getPortFromConfig(config, connection_host)))
 {
-    security = enableSecureConnection(config, connection_host) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
+    security = enableSecureConnection(config, connection_host, connection_port) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
 
     default_database = config.getString("database", "");
 


### PR DESCRIPTION
ClickHouse Client already autodetects port 9440 if `--secure` is specified, but the reverse is not true. Anecdotally, I see users missing `--secure` every once in a while and not being able to connect because of it. The error message when that happens isn't very helpful either: `Poco::Exception. Code: 1000, e.code() = 22, Invalid argument (version 24.11.1.2557 (official build))`. 

This change implements autodetecting `--secure` if the port is 9440 (the default secure port). The command-line options `--secure` and `--no-secure` still take precedence.

I've also adjusted some of the docs not to specify both `--secure` and `--port 9440`. I chose to keep the port because I think users will generally expect to specify it when connecting to a database - but I don't have a strong opinion, and we could also keep `--secure`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Autodetect secure connection based on connecting to port 9440 in ClickHouse Client.