### PR TITLE
Fix logical error in s3queue

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -346,7 +346,10 @@ void ObjectStorageQueueIFileMetadata::setFailedNonRetriable()
     }
 
     if (Coordination::isHardwareError(code))
-        throw zkutil::KeeperMultiException(code, requests, responses);
+    {
+        LOG_WARNING(log, "Cannot set file {} as Failed, because keeper session expired. Will retry", path);
+        return;
+    }
 
     if (responses[1]->error == Coordination::Error::ZNONODE)
     {
@@ -434,7 +437,10 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
         return;
 
     if (Coordination::isHardwareError(code))
-        throw zkutil::KeeperMultiException(code, requests, responses);
+    {
+        LOG_WARNING(log, "Cannot set file {} as Failed, because keeper session expired. Will retry", path);
+        return;
+    }
 
     if (responses[1]->error == Coordination::Error::ZNONODE)
     {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -333,8 +333,9 @@ void ObjectStorageQueueIFileMetadata::setFailedNonRetriable()
 {
     auto zk_client = getZooKeeper();
     Coordination::Requests requests;
-    requests.push_back(zkutil::makeCreateRequest(failed_node_path, node_metadata.toString(), zkutil::CreateMode::Persistent));
+    requests.push_back(zkutil::makeRemoveRequest(processing_node_id_path, processing_id_version.value()));
     requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));
+    requests.push_back(zkutil::makeCreateRequest(failed_node_path, node_metadata.toString(), zkutil::CreateMode::Persistent));
 
     Coordination::Responses responses;
     const auto code = zk_client->tryMulti(requests, responses);
@@ -344,20 +345,25 @@ void ObjectStorageQueueIFileMetadata::setFailedNonRetriable()
         return;
     }
 
-    if (Coordination::isHardwareError(responses[0]->error))
+    if (Coordination::isHardwareError(code))
+        throw zkutil::KeeperMultiException(code, requests, responses);
+
+    if (responses[1]->error == Coordination::Error::ZNONODE)
     {
-        LOG_WARNING(log, "Cannot set file as failed: lost connection to keeper");
+        LOG_WARNING(
+            log, "Processing node no longer exists ({}) "
+            "while setting file as non-retriable failed. "
+            "This could be as a result of expired keeper session. "
+            "Cannot set file as failed, will retry.",
+            processing_node_path);
         return;
     }
 
-    if (responses[0]->error == Coordination::Error::ZNODEEXISTS)
-    {
-        LOG_WARNING(log, "Cannot create a persistent node in /failed since it already exists");
-        chassert(false);
-        return;
-    }
-
-    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected error while setting file as failed: {}", code);
+    auto exception = zkutil::KeeperMultiException(code, requests, responses);
+    throw Exception(
+        ErrorCodes::LOGICAL_ERROR,
+        "Failed to set file {} as failed (code: {}, path: {})",
+        path, code, exception.getPathForFirstFailedOp());
 }
 
 void ObjectStorageQueueIFileMetadata::setFailedRetriable()
@@ -371,19 +377,26 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
     auto zk_client = getZooKeeper();
 
     /// Extract the number of already done retries from node_hash.retriable node if it exists.
-    Coordination::Requests requests;
-    Coordination::Stat stat;
+    Coordination::Stat retriable_failed_node_stat;
     std::string res;
-    bool has_failed_before = zk_client->tryGet(retrieable_failed_node_path, res, &stat);
-    if (has_failed_before)
+    bool has_retriable_failed_node = zk_client->tryGet(retrieable_failed_node_path, res, &retriable_failed_node_stat);
+    if (has_retriable_failed_node)
     {
         auto failed_node_metadata = NodeMetadata::fromString(res);
         node_metadata.retries = failed_node_metadata.retries + 1;
         file_status->retries = node_metadata.retries;
     }
+    else
+        chassert(!node_metadata.retries);
 
-    LOG_TRACE(log, "File `{}` failed to process, try {}/{}, retries node exists: {} (failed node path: {})",
-              path, node_metadata.retries, max_loading_retries, has_failed_before, failed_node_path);
+    LOG_TRACE(
+        log, "File `{}` failed to process, "
+        "try {}/{}, retries node exists: {} (failed node path: {})",
+        path, node_metadata.retries, max_loading_retries, has_retriable_failed_node, failed_node_path);
+
+    Coordination::Requests requests;
+    requests.push_back(zkutil::makeRemoveRequest(processing_node_id_path, processing_id_version.value()));
+    requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));
 
     if (node_metadata.retries >= max_loading_retries)
     {
@@ -391,8 +404,7 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
         /// Make a persistent node /failed/node_hash,
         /// remove /failed/node_hash.retriable node and node in /processing.
 
-        requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));
-        requests.push_back(zkutil::makeRemoveRequest(retrieable_failed_node_path, stat.version));
+        requests.push_back(zkutil::makeRemoveRequest(retrieable_failed_node_path, retriable_failed_node_stat.version));
         requests.push_back(
             zkutil::makeCreateRequest(
                 failed_node_path, node_metadata.toString(), zkutil::CreateMode::Persistent));
@@ -402,8 +414,6 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
     {
         /// File is still retriable,
         /// update retries count and remove node from /processing.
-
-        requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));
         if (node_metadata.retries == 0)
         {
             requests.push_back(
@@ -414,7 +424,7 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
         {
             requests.push_back(
                 zkutil::makeSetRequest(
-                    retrieable_failed_node_path, node_metadata.toString(), stat.version));
+                    retrieable_failed_node_path, node_metadata.toString(), retriable_failed_node_stat.version));
         }
     }
 
@@ -423,8 +433,25 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
     if (code == Coordination::Error::ZOK)
         return;
 
-    throw Exception(ErrorCodes::LOGICAL_ERROR,
-                    "Failed to set file {} as failed (code: {})", path, code);
+    if (Coordination::isHardwareError(code))
+        throw zkutil::KeeperMultiException(code, requests, responses);
+
+    if (responses[1]->error == Coordination::Error::ZNONODE)
+    {
+        LOG_WARNING(
+            log, "Processing node no longer exists ({}) while setting file as failed. "
+            "This could be as a result of expired keeper session. "
+            "Cannot set file as failed, will retry.",
+            processing_node_path);
+        return;
+    }
+
+    auto exception = zkutil::KeeperMultiException(code, requests, responses);
+    throw Exception(
+        ErrorCodes::LOGICAL_ERROR,
+        "Failed to set file {} as failed at try {}/{} (code: {}, path: {})",
+        path, node_metadata.retries, max_loading_retries,
+        code, exception.getPathForFirstFailedOp());
 }
 
 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -438,6 +438,9 @@ void ObjectStorageQueueIFileMetadata::setFailedRetriable()
 
     if (responses[1]->error == Coordination::Error::ZNONODE)
     {
+        /// TODO: Retry only keeper operation,
+        /// on condition that attempt to set new processing node will give
+        /// the next processing_id value from current one.
         LOG_WARNING(
             log, "Processing node no longer exists ({}) while setting file as failed. "
             "This could be as a result of expired keeper session. "


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix logical error in s3queue during setting file as failed.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [x] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_fuzzer--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [x] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
