### PR TITLE
Authenticate users with username only (without password) for http_handlers

### DIFF
--- a/src/Server/HTTP/authenticateUserByHTTP.cpp
+++ b/src/Server/HTTP/authenticateUserByHTTP.cpp
@@ -206,7 +206,7 @@ bool authenticateUserByHTTP(
     }
     else if (has_config_credentials)
     {
-        current_credentials = std::make_unique<BasicCredentials>(*config_credentials);
+        current_credentials = std::make_unique<AlwaysAllowCredentials>(*config_credentials);
     }
     else // I.e., now using user name and password strings ("Basic").
     {

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -75,6 +75,7 @@ namespace ErrorCodes
     extern const int NO_ELEMENTS_IN_CONFIG;
 
     extern const int INVALID_SESSION_TIMEOUT;
+    extern const int INVALID_CONFIG_PARAMETER;
     extern const int HTTP_LENGTH_REQUIRED;
 }
 
@@ -143,12 +144,10 @@ static std::chrono::steady_clock::duration parseSessionTimeout(
 
 HTTPHandlerConnectionConfig::HTTPHandlerConnectionConfig(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
 {
-    if (config.has(config_prefix + ".handler.user") || config.has(config_prefix + ".handler.password"))
-    {
-        credentials.emplace(
-            config.getString(config_prefix + ".handler.user", "default"),
-            config.getString(config_prefix + ".handler.password", ""));
-    }
+    if (config.has(config_prefix + ".handler.password"))
+        throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "{}.handler.password will be ignored. Please remove it from config.", config_prefix);
+    if (config.has(config_prefix + ".handler.user"))
+        credentials.emplace(config.getString(config_prefix + ".handler.user", "default"));
 }
 
 void HTTPHandler::pushDelayedResults(Output & used_output)

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -35,7 +35,7 @@ using CompiledRegexPtr = std::shared_ptr<const re2::RE2>;
 
 struct HTTPHandlerConnectionConfig
 {
-    std::optional<BasicCredentials> credentials;
+    std::optional<AlwaysAllowCredentials> credentials;
 
     /// TODO:
     /// String quota;

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -97,15 +97,28 @@ def test_dynamic_query_handler():
             == res_custom_ct.headers["X-Test-Http-Response-Headers-Even-Multiple"]
         )
 
-        assert cluster.instance.http_request(
-            "test_dynamic_handler_auth_with_password?query=select+currentUser()"
-        ).content, "with_password"
-        assert cluster.instance.http_request(
-            "test_dynamic_handler_auth_with_password_fail?query=select+currentUser()"
-        ).status_code, 403
-        assert cluster.instance.http_request(
-            "test_dynamic_handler_auth_without_password?query=select+currentUser()"
-        ).content, "without_password"
+        assert (
+            cluster.instance.http_request(
+                "test_dynamic_handler_auth_with_password?query=select+currentUser()"
+            )
+            .content.strip()
+            .decode()
+            == "with_password"
+        )
+        assert (
+            cluster.instance.http_request(
+                "test_dynamic_handler_auth_with_password_fail?query=select+currentUser()"
+            ).status_code
+            == 403
+        )
+        assert (
+            cluster.instance.http_request(
+                "test_dynamic_handler_auth_without_password?query=select+currentUser()"
+            )
+            .content.strip()
+            .decode()
+            == "without_password"
+        )
 
 
 def test_predefined_query_handler():
@@ -188,15 +201,26 @@ def test_predefined_query_handler():
         )
         assert b"max_threads\t1\n" == res1.content
 
-        assert cluster.instance.http_request(
-            "test_predefined_handler_auth_with_password"
-        ).content, "with_password"
-        assert cluster.instance.http_request(
-            "test_predefined_handler_auth_with_password_fail"
-        ).status_code, 403
-        assert cluster.instance.http_request(
-            "test_predefined_handler_auth_without_password"
-        ).content, "without_password"
+        assert (
+            cluster.instance.http_request("test_predefined_handler_auth_with_password")
+            .content.strip()
+            .decode()
+            == "with_password"
+        )
+        assert (
+            cluster.instance.http_request(
+                "test_predefined_handler_auth_with_password_fail"
+            ).status_code
+            == 403
+        )
+        assert (
+            cluster.instance.http_request(
+                "test_predefined_handler_auth_without_password"
+            )
+            .content.strip()
+            .decode()
+            == "without_password"
+        )
 
 
 def test_fixed_static_handler():

--- a/tests/integration/test_http_handlers_config/test_dynamic_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_dynamic_handler/config.xml
@@ -31,7 +31,6 @@
             <handler>
                 <type>dynamic_query_handler</type>
                 <user>with_password</user>
-                <password>password</password>
             </handler>
         </rule>
         <rule>
@@ -39,8 +38,7 @@
             <url>/test_dynamic_handler_auth_with_password_fail</url>
             <handler>
                 <type>dynamic_query_handler</type>
-                <user>with_password</user>
-                <!-- No password - authentication should fail -->
+                <user>incorrect_user</user>
             </handler>
         </rule>
         <rule>

--- a/tests/integration/test_http_handlers_config/test_predefined_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_predefined_handler/config.xml
@@ -40,7 +40,6 @@
             <handler>
                 <type>predefined_query_handler</type>
                 <user>with_password</user>
-                <password>password</password>
                 <query>SELECT currentUser()</query>
             </handler>
         </rule>
@@ -49,8 +48,7 @@
             <url>/test_predefined_handler_auth_with_password_fail</url>
             <handler>
                 <type>predefined_query_handler</type>
-                <user>with_password</user>
-                <!-- No password - authentication should fail -->
+                <user>incorrect_user</user>
                 <query>SELECT currentUser()</query>
             </handler>
         </rule>


### PR DESCRIPTION
This is internal authentication, so it should not require password.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Authenticate users with username only for http_handlers (previously it requires user to put the password as well)

Follow-up for: #70725 (cc @vitlibar )