### PR TITLE
Support internal authentication for prometheus remote_read

### DIFF
--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -138,7 +138,7 @@ protected:
 
     bool authenticateUser(HTTPServerRequest & request, HTTPServerResponse & response)
     {
-        return authenticateUserByHTTP(request, *params, response, *session, request_credentials, HTTPHandlerConnectionConfig{}, server().context(), log());
+        return authenticateUserByHTTP(request, *params, response, *session, request_credentials, config().connection_config, server().context(), log());
     }
 
     void makeContext(HTTPServerRequest & request)

--- a/src/Server/PrometheusRequestHandlerConfig.h
+++ b/src/Server/PrometheusRequestHandlerConfig.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/QualifiedTableName.h>
+#include <Server/HTTPHandler.h>
 
 
 namespace DB
@@ -34,6 +35,8 @@ struct PrometheusRequestHandlerConfig
 
     size_t keep_alive_timeout = 0;
     bool is_stacktrace_enabled = true;
+
+    HTTPHandlerConnectionConfig connection_config;
 };
 
 }

--- a/src/Server/PrometheusRequestHandlerFactory.cpp
+++ b/src/Server/PrometheusRequestHandlerFactory.cpp
@@ -1,3 +1,4 @@
+#include <Access/Credentials.h>
 #include <Server/PrometheusRequestHandlerFactory.h>
 
 #include <Core/Types_fwd.h>
@@ -84,6 +85,11 @@ namespace
         res.type = PrometheusRequestHandlerConfig::Type::RemoteRead;
         res.time_series_table_name = parseTableNameFromConfig(config, config_prefix);
         parseCommonConfig(config, res);
+        if (config.has(config_prefix + ".user"))
+        {
+            AlwaysAllowCredentials credentials(config.getString(config_prefix + ".user"));
+            res.connection_config.credentials.emplace(credentials);
+        }
         return res;
     }
 

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -16,6 +16,24 @@
                     <table>default.prometheus</table>
                 </handler>
             </my_rule_2>
+
+            <my_rule_3>
+                <url>/read_auth_ok</url>
+                <handler>
+                    <type>remote_read</type>
+                    <table>default.prometheus</table>
+                    <user>default</user>
+                </handler>
+            </my_rule_3>
+
+            <my_rule_4>
+                <url>/read_auth_fail</url>
+                <handler>
+                    <type>remote_read</type>
+                    <table>default.prometheus</table>
+                    <user>no_such_user</user>
+                </handler>
+            </my_rule_4>
         </handlers>
     </prometheus>
 </clickhouse>

--- a/tests/integration/test_prometheus_protocols/test.py
+++ b/tests/integration/test_prometheus_protocols/test.py
@@ -194,6 +194,10 @@ def test_read_auth():
         )
 
     auth_ok = get("/read_auth_ok")
+    # FIXME: prometheus read handler requires proper payload with snappy
+    # compression, but it will first try to authenticate and only after try to
+    # interpret the payload, so those two lines below is a workaround to ensure
+    # that the authentication works
     assert auth_ok.status_code == 500
     assert "DB::Exception: snappy uncomress failed" in auth_ok.text
 

--- a/tests/integration/test_prometheus_protocols/test.py
+++ b/tests/integration/test_prometheus_protocols/test.py
@@ -177,3 +177,24 @@ def test_external_tables():
         "DATA mydata TAGS mytags METRICS mymetrics"
     )
     compare_queries()
+
+
+def test_read_auth():
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+
+    def get(path):
+        headers = {
+            "Content-Type": "application/x-protobuf",
+            "Content-Encoding": "snappy",
+        }
+        return requests.request(
+            url=f"http://{node.ip_address}:{cluster.prometheus_remote_read_handler_port}{path}",
+            method="GET",
+            headers=headers,
+        )
+
+    auth_ok = get("/read_auth_ok")
+    assert auth_ok.status_code == 500
+    assert "DB::Exception: snappy uncomress failed" in auth_ok.text
+
+    assert get("/read_auth_fail").status_code == 403


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
With this patch you can set handler.user to some existing user for
remote_read handler and client will not need to provide authentication.

Though note that it make sense only for prometheus configuration, since
you cannot query remote_read handlers directly.

Cc: @vitlibar 