### PR TITLE
tests: fix flakiness of 01700_deltasum (due to allow_not_comparable_types_in_order_by)

### DIFF
--- a/tests/queries/0_stateless/01700_deltasum.sql
+++ b/tests/queries/0_stateless/01700_deltasum.sql
@@ -7,38 +7,38 @@ select deltaSumMerge(rows) as delta_sum from
 (
     select * from
     (
-        select deltaSumState(arrayJoin([0, 1])) as rows
+        select 1 as x, deltaSumState(arrayJoin([0, 1])) as rows
         union all
-        select deltaSumState(arrayJoin([4, 5])) as rows
-    )
+        select 2, deltaSumState(arrayJoin([4, 5])) as rows
+    ) order by x
 ) order by delta_sum;
 select deltaSumMerge(rows) as delta_sum from
 (
     select * from
     (
-        select deltaSumState(arrayJoin([4, 5])) as rows
+        select 1 as x, deltaSumState(arrayJoin([4, 5])) as rows
         union all
-        select deltaSumState(arrayJoin([0, 1])) as rows
-    )
+        select 2, deltaSumState(arrayJoin([0, 1])) as rows
+    ) order by x
 ) order by delta_sum;
 select deltaSum(arrayJoin([2.25, 3, 4.5]));
 select deltaSumMerge(rows) as delta_sum from
 (
     select * from
     (
-        select deltaSumState(arrayJoin([0.1, 0.3, 0.5])) as rows
+        select 1 as x, deltaSumState(arrayJoin([0.1, 0.3, 0.5])) as rows
         union all
-        select deltaSumState(arrayJoin([4.1, 5.1, 6.6])) as rows
-    )
+        select 2, deltaSumState(arrayJoin([4.1, 5.1, 6.6])) as rows
+    ) order by x
 ) order by delta_sum;
 select deltaSumMerge(rows) as delta_sum from
 (
     select * from
     (
-        select deltaSumState(arrayJoin([3, 5])) as rows
+        select 1 as x, deltaSumState(arrayJoin([3, 5])) as rows
         union all
-        select deltaSumState(arrayJoin([1, 2])) as rows
+        select 2, deltaSumState(arrayJoin([1, 2])) as rows
         union all
-        select deltaSumState(arrayJoin([4, 6])) as rows
-    )
+        select 3, deltaSumState(arrayJoin([4, 6])) as rows
+    ) order by x
 ) order by delta_sum;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #73276 (cc @Avogar )