### PR TITLE
Revert "make documentation for `anyHeavy` clearer"

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/anyheavy.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/anyheavy.md
@@ -5,12 +5,7 @@ sidebar_position: 104
 
 # anyHeavy
 
-Selects a frequently occurring value using the [heavy hitters](https://doi.org/10.1145/762471.762473) algorithm. If there is a value that occurs more than in half the cases in each of the query’s execution threads, this value is returned. 
-
-:::warning
-The result of this function is non-deterministic.
-Using it with aggregates can lead to unpredictable results and is generally not recommended.
-:::
+Selects a frequently occurring value using the [heavy hitters](https://doi.org/10.1145/762471.762473) algorithm. If there is a value that occurs more than in half the cases in each of the query’s execution threads, this value is returned. Normally, the result is nondeterministic.
 
 ``` sql
 anyHeavy(column)


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#74228

There used to be a bug in the merge process of anyHeavy, but it doesn't exist anymore: https://github.com/ClickHouse/ClickHouse/pull/68950/