### PR TITLE
Revert "Revert "Add minmax indices by default""

### DIFF
--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -1133,11 +1133,13 @@ By using `ORDER BY time DESC` in the query, `ReadInOrder` is applied.
 
 ## cache_populated_by_fetch
 
-A Cloud only setting. 
+:::note
+This setting applies only to ClickHouse Cloud.
+:::
 
 When `cache_populated_by_fetch` is disabled (the default setting), new data parts are loaded into the cache only when a query is run that requires those parts.
 
-If enabled, `cache_populated_by_fetch` will instead cause all nodes to load new data parts from storage into their cache without requiring a query to trigger such an action. 
+If enabled, `cache_populated_by_fetch` will instead cause all nodes to load new data parts from storage into their cache without requiring a query to trigger such an action.
 
 Default value: 0.
 
@@ -1146,3 +1148,15 @@ Default value: 0.
 If true, adds an implicit constraint for the `sign` column of a CollapsingMergeTree or VersionedCollapsingMergeTree table to allow only valid values (`1` and `-1`).
 
 Default value: false
+
+## add_minmax_index_for_numeric_columns
+
+When enabled, min-max (skipping) indices are added for all numeric columns of the table.
+
+Default value: false.
+
+## add_minmax_index_for_string_columns
+
+When enabled, min-max (skipping) indices are added for all string columns of the table.
+
+Default value: false.

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1273,9 +1273,9 @@ Defines the behavior when [Date](../../sql-reference/data-types/date.md), [Date3
 
 Possible values:
 
-- `ignore` — Silently ignore overflows. The result is random.
-- `throw` — Throw an exception in case of conversion overflow.
-- `saturate` — Silently saturate the result. If the value is smaller than the smallest value that can be represented by the target type, the result is chosen as the smallest representable value. If the value is bigger than the largest value that can be represented by the target type, the result is chosen as the largest representable value.
+- `ignore` — Silently ignore overflows. Result are undefined.
+- `throw` — Throw an exception in case of overflow.
+- `saturate` — Saturate the result. If the value is smaller than the smallest value that can be represented by the target type, the result is chosen as the smallest representable value. If the value is bigger than the largest value that can be represented by the target type, the result is chosen as the largest representable value.
 
 Default value: `ignore`.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -625,11 +625,13 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "25.1",
         {
+            {"add_minmax_index_for_numeric_columns", false, false, "New setting"},
+            {"add_minmax_index_for_string_columns", false, false, "New setting"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "24.12",
         {
             /// Release closed. Please use 25.1
-            {"enforce_index_structure_match_on_partition_manipulation", true, false, "Add new setting to allow attach when source table's projections and secondary indices is a subset of those in the target table."},
+            {"enforce_index_structure_match_on_partition_manipulation", true, false, "New setting"},
             {"use_primary_key_cache", false, false, "New setting"},
             {"prewarm_primary_key_cache", false, false, "New setting"},
             {"min_bytes_to_prewarm_caches", 0, 0, "New setting"},

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -25,6 +25,7 @@
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTConstraintDeclaration.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTProjectionDeclaration.h>
@@ -529,9 +530,51 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
         {
             metadata.columns.add(column, after_column, first);
         }
+
+        /// Try to add "implicit" minmax index for new column
+        if (metadata.settings_changes
+            && ((isNumber(column.type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns"))
+                || (isString(column.type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns"))))
+        {
+            bool minmax_index_exists = false;
+            for (const auto & index: metadata.secondary_indices)
+            {
+                if (index.column_names.front() == column.name && index.type == "minmax")
+                {
+                    minmax_index_exists = true;
+                    break;
+                }
+            }
+
+            if (!minmax_index_exists)
+            {
+                auto index_type = makeASTFunction("minmax");
+                auto index_ast = std::make_shared<ASTIndexDeclaration>(std::make_shared<ASTIdentifier>(column.name), index_type, IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column.name);
+                index_ast->granularity = ASTIndexDeclaration::DEFAULT_INDEX_GRANULARITY;
+                metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index_ast, metadata.columns, context));
+            }
+        }
     }
     else if (type == DROP_COLUMN)
     {
+        const auto * column = metadata.columns.tryGet(column_name);
+        if (column && metadata.settings_changes
+            && ((isNumber(column->type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns"))
+                || (isString(column->type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns"))))
+        {
+            for (auto index_it = metadata.secondary_indices.begin();
+                     index_it != metadata.secondary_indices.end();)
+            {
+                if (index_it->name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name)
+                {
+                    index_it = metadata.secondary_indices.erase(index_it);
+                    break;
+                }
+                else
+                    ++index_it;
+            }
+        }
+
         /// Otherwise just clear data on disk
         if (!clear && !partition)
             metadata.columns.remove(column_name);
@@ -648,6 +691,14 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
             if (if_not_exists)
                 return;
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot add index {}: index with this name already exists", index_name);
+        }
+
+        if (index_name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX)
+            && metadata.settings_changes
+            && (metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns")
+                || metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns")))
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot add index {} because it uses a reserved index name", index_name);
         }
 
         auto insert_it = metadata.secondary_indices.end();
@@ -915,7 +966,20 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
             rename_visitor.visit(metadata.partition_key.definition_ast);
 
         for (auto & index : metadata.secondary_indices)
-            rename_visitor.visit(index.definition_ast);
+        {
+            if (index.name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name
+                && metadata.settings_changes
+                && (metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns")
+                    ||  metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns")))
+            {
+                auto index_type = makeASTFunction("minmax");
+                index.definition_ast = std::make_shared<ASTIndexDeclaration>(std::make_shared<ASTIdentifier>(rename_to), index_type,
+                                                                             IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + rename_to);
+                index.definition_ast->as<ASTIndexDeclaration>()->granularity = ASTIndexDeclaration::DEFAULT_INDEX_GRANULARITY;
+            }
+            else
+                rename_visitor.visit(index.definition_ast);
+        }
     }
     else if (type == MODIFY_SQL_SECURITY)
         metadata.setSQLSecurity(sql_security->as<ASTSQLSecurity &>());

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -17,6 +17,7 @@
 #include "config.h"
 
 constexpr auto INDEX_FILE_PREFIX = "skp_idx_";
+constexpr auto IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX = "auto_minmax_index_";
 
 namespace DB
 {

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -220,6 +220,8 @@ namespace ErrorCodes
     DECLARE(Bool, disable_fetch_partition_for_zero_copy_replication, true, "Disable FETCH PARTITION query for zero copy replication.", 0) \
     DECLARE(Bool, enable_block_number_column, false, "Enable persisting column _block_number for each row.", 0) ALIAS(allow_experimental_block_number_column) \
     DECLARE(Bool, enable_block_offset_column, false, "Enable persisting column _block_offset for each row.", 0) \
+    DECLARE(Bool, add_minmax_index_for_numeric_columns, false, "Automatically create min-max indices for columns of numeric type", 0) \
+    DECLARE(Bool, add_minmax_index_for_string_columns, false, "Automatically create min-max indices for columns of string type", 0) \
     \
     /** Experimental/work in progress feature. Unsafe for production. */ \
     DECLARE(UInt64, part_moves_between_shards_enable, 0, "Experimental/Incomplete feature to move parts between shards. Does not take into account sharding expressions.", EXPERIMENTAL) \
@@ -284,7 +286,7 @@ namespace ErrorCodes
     /// Settings that should not change after the creation of a table.
     /// NOLINTNEXTLINE
 #define APPLY_FOR_IMMUTABLE_MERGE_TREE_SETTINGS(MACRO) \
-    MACRO(index_granularity)
+    MACRO(index_granularity)                           \
 
 #define LIST_OF_MERGE_TREE_SETTINGS(M, ALIAS) \
     MERGE_TREE_SETTINGS(M, ALIAS)             \
@@ -773,7 +775,8 @@ std::string_view MergeTreeSettings::resolveName(std::string_view name)
 
 bool MergeTreeSettings::isReadonlySetting(const String & name)
 {
-    return name == "index_granularity" || name == "index_granularity_bytes" || name == "enable_mixed_granularity_parts";
+    return name == "index_granularity" || name == "index_granularity_bytes" || name == "enable_mixed_granularity_parts"
+           || name == "add_minmax_index_for_numeric_columns" || name == "add_minmax_index_for_string_columns";
 }
 
 void MergeTreeSettings::checkCanSet(std::string_view name, const Field & value)

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -19,6 +19,7 @@
 
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTSetQuery.h>
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
@@ -48,6 +49,8 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool allow_floating_point_partition_key;
     extern const MergeTreeSettingsDeduplicateMergeProjectionMode deduplicate_merge_projection_mode;
     extern const MergeTreeSettingsUInt64 index_granularity;
+    extern const MergeTreeSettingsBool add_minmax_index_for_numeric_columns;
+    extern const MergeTreeSettingsBool add_minmax_index_for_string_columns;
 }
 
 namespace ServerSetting
@@ -687,9 +690,60 @@ static StoragePtr create(const StorageFactory::Arguments & args)
                 args.storage_def->ttl_table->ptr(), metadata.columns, context, metadata.primary_key, allow_suspicious_ttl);
         }
 
+        storage_settings->loadFromQuery(*args.storage_def, context, LoadingStrictnessLevel::ATTACH <= args.mode);
+
+        /// Updates the default storage_settings with settings specified via SETTINGS arg in a query
+        if (args.storage_def->settings)
+        {
+            if (args.mode <= LoadingStrictnessLevel::CREATE)
+                args.getLocalContext()->checkMergeTreeSettingsConstraints(initial_storage_settings, storage_settings->changes());
+            metadata.settings_changes = args.storage_def->settings->ptr();
+        }
+
         if (args.query.columns_list && args.query.columns_list->indices)
-            for (auto & index : args.query.columns_list->indices->children)
+        {
+            for (const auto & index : args.query.columns_list->indices->children)
+            {
                 metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index, columns, context));
+
+                auto index_name = index->as<ASTIndexDeclaration>()->name;
+                if (((*storage_settings)[MergeTreeSetting::add_minmax_index_for_numeric_columns]
+                    || (*storage_settings)[MergeTreeSetting::add_minmax_index_for_string_columns])
+                    && index_name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX))
+                {
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot create table because index {} uses a reserved index name", index_name);
+                }
+            }
+
+            /// Try to add "implicit" min-max indexes on all columns
+            for (const auto & column : metadata.columns)
+            {
+                if ((isNumber(column.type) && (*storage_settings)[MergeTreeSetting::add_minmax_index_for_numeric_columns])
+                    || (isString(column.type) && (*storage_settings)[MergeTreeSetting::add_minmax_index_for_string_columns]))
+                {
+                    bool minmax_index_exists = false;
+
+                    for (const auto & index: metadata.secondary_indices)
+                    {
+                        if (index.column_names.front() == column.name && index.type == "minmax")
+                        {
+                            minmax_index_exists = true;
+                            break;
+                        }
+                    }
+
+                    if (minmax_index_exists)
+                        continue;
+
+                    auto index_type = makeASTFunction("minmax");
+                    auto index_ast = std::make_shared<ASTIndexDeclaration>(
+                            std::make_shared<ASTIdentifier>(column.name), index_type,
+                            IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column.name);
+                    index_ast->granularity = ASTIndexDeclaration::DEFAULT_INDEX_GRANULARITY;
+                    metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index_ast, columns, context));
+                }
+            }
+        }
 
         if (args.query.columns_list && args.query.columns_list->projections)
             for (auto & projection_ast : args.query.columns_list->projections->children)
@@ -704,16 +758,6 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         {
             auto new_ttl_entry = TTLDescription::getTTLFromAST(ast, columns, context, metadata.primary_key, allow_suspicious_ttl);
             metadata.column_ttls_by_name[name] = new_ttl_entry;
-        }
-
-        storage_settings->loadFromQuery(*args.storage_def, context, LoadingStrictnessLevel::ATTACH <= args.mode);
-
-        // updates the default storage_settings with settings specified via SETTINGS arg in a query
-        if (args.storage_def->settings)
-        {
-            if (args.mode <= LoadingStrictnessLevel::CREATE)
-                args.getLocalContext()->checkMergeTreeSettingsConstraints(initial_storage_settings, storage_settings->changes());
-            metadata.settings_changes = args.storage_def->settings->ptr();
         }
 
         auto constraints = metadata.constraints.getConstraints();

--- a/tests/queries/0_stateless/03261_minmax_indices_by_default.reference
+++ b/tests/queries/0_stateless/03261_minmax_indices_by_default.reference
@@ -1,0 +1,41 @@
+Check skipping indices after table creation
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+Add numeric column
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+auto_minmax_index_n	minmax	n	0
+After materialize
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+auto_minmax_index_n	minmax	n	34
+Drop numeric column
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+Add string column
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+auto_minmax_index_s	minmax	s	0
+Add another string column
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+auto_minmax_index_s	minmax	s	0
+auto_minmax_index_t	minmax	t	0
+Drop string column t
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+auto_minmax_index_s	minmax	s	0
+Rename column s to t
+x_idx	minmax	x	34
+auto_minmax_index_key	minmax	key	34
+auto_minmax_index_y	minmax	y	34
+auto_minmax_index_t	minmax	t	0
+tbl5 with add_minmax_index_for_numeric_columns and add_minmax_index_for_string_columns disabled
+x_idx	minmax	x	0

--- a/tests/queries/0_stateless/03261_minmax_indices_by_default.sql
+++ b/tests/queries/0_stateless/03261_minmax_indices_by_default.sql
@@ -1,0 +1,125 @@
+SET mutations_sync = 2;
+
+DROP TABLE IF EXISTS tbl1;
+DROP TABLE IF EXISTS tbl2;
+DROP TABLE IF EXISTS tbl3;
+DROP TABLE IF EXISTS tbl4;
+DROP TABLE IF EXISTS tbl5;
+
+CREATE TABLE tbl1
+(
+    key Int,
+    x Int,
+    y Int,
+    INDEX x_idx x TYPE minmax
+)
+ENGINE=MergeTree()
+ORDER BY key
+SETTINGS add_minmax_index_for_numeric_columns = true, add_minmax_index_for_string_columns = true;
+
+INSERT INTO tbl1 VALUES (1,1,1), (2,2,2), (3,3,3);
+
+SELECT 'Check skipping indices after table creation';
+-- Expect x_idx and two implicit minmax indices
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+-- Settings 'add_minmax_index_for_numeric_columns' and 'add_minmax_index_for_string_columns' cannot be changed after table creation
+ALTER TABLE tbl1 MODIFY SETTING add_minmax_index_for_numeric_columns = false; -- { serverError READONLY_SETTING }
+ALTER TABLE tbl1 MODIFY SETTING add_minmax_index_for_string_columns = false; -- { serverError READONLY_SETTING }
+ALTER TABLE tbl1 RESET SETTING add_minmax_index_for_numeric_columns; -- { serverError READONLY_SETTING }
+ALTER TABLE tbl1 RESET SETTING add_minmax_index_for_string_columns; -- { serverError READONLY_SETTING }
+
+SELECT 'Add numeric column';
+ALTER TABLE tbl1 ADD COLUMN n Int;
+-- the implicitly minmax index is only created but not materialized
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+SELECT 'After materialize';
+ALTER TABLE tbl1 MATERIALIZE INDEX auto_minmax_index_n;
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+SELECT 'Drop numeric column';
+ALTER TABLE tbl1 DROP COLUMN n;
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+SELECT 'Add string column';
+ALTER TABLE tbl1 ADD COLUMN s String;
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+SELECT 'Add another string column';
+ALTER TABLE tbl1 ADD COLUMN t String;
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+SELECT 'Drop string column t';
+ALTER TABLE tbl1 DROP COLUMN t;
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+SELECT 'Rename column s to t';
+ALTER TABLE tbl1 RENAME COLUMN s to t;
+SELECT name, type, expr, data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl1' AND database = currentDatabase();
+
+-- Check that users cannot create explicit minmax indices with the names of internal minmax indices
+
+CREATE TABLE tbl2
+(
+    key Int,
+    x Int,
+    y Int,
+    INDEX auto_minmax_index_x x TYPE minmax
+)
+ENGINE=MergeTree()
+ORDER BY key
+SETTINGS add_minmax_index_for_numeric_columns = true; -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tbl2
+(
+    key Int,
+    x Int,
+    y Int,
+    INDEX auto_minmax_index_x x TYPE minmax -- fine, add_minmax_index_for_numeric_columns isn't set
+)
+ENGINE=MergeTree()
+ORDER BY key;
+
+CREATE TABLE tbl3
+(
+    key Int,
+    x Int,
+    y Int
+)
+ENGINE=MergeTree()
+ORDER BY key;
+
+ALTER TABLE tbl3 ADD INDEX auto_minmax_index_y y TYPE minmax;
+
+CREATE TABLE tbl4
+(
+    key Int,
+    x Int,
+    y Int
+)
+ENGINE=MergeTree()
+ORDER BY key
+SETTINGS add_minmax_index_for_string_columns = true;
+
+ALTER TABLE tbl4 ADD INDEX auto_minmax_index_y y TYPE minmax; -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tbl5
+(
+    key Int,
+    x Int,
+    y Int,
+    s String,
+    INDEX x_idx x TYPE minmax
+)
+ENGINE=MergeTree()
+ORDER BY key;
+
+SELECT 'tbl5 with add_minmax_index_for_numeric_columns and add_minmax_index_for_string_columns disabled';
+SELECT name,type,expr,data_compressed_bytes FROM system.data_skipping_indices WHERE table = 'tbl5' AND database = currentDatabase();
+
+DROP TABLE tbl1;
+DROP TABLE tbl2;
+DROP TABLE tbl3;
+DROP TABLE tbl4;
+DROP TABLE tbl5;


### PR DESCRIPTION
Related to #70605 (but does not resolve it yet because of https://github.com/ClickHouse/ClickHouse/pull/72090#discussion_r1882124326)

(this is a revert of #74264 which rightfully reverted the first iteration of this PR because it had merge conflicts in the private repository)

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add the ability to create min-max (skipping) indices by default for columns managed by MergeTree using settings `add_minmax_index_for_numeric_columns` (for numeric columns) and `add_minmax_index_for_string_columns` (for string columns). For now, both settings are disabled, so there is no behavior change yet.

### Documentation entry for user-facing changes

- [ X ] Documentation is written (mandatory for new features)