### PR TITLE
Fix lifetime of callback in `threadPoolCallbackRunner`

### DIFF
--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -107,7 +107,7 @@ class ThreadPoolCallbackRunnerLocal final
 
     /// Set promise result for non-void callbacks
     template <typename Function, typename FunctionResult>
-    static void executeCallback(std::promise<FunctionResult> & promise, Function & callback)
+    static void executeCallback(std::promise<FunctionResult> & promise, Function && callback)
     {
         /// Release callback before setting value to the promise to avoid
         /// destruction of captured resources after waitForAllToFinish returns.
@@ -126,7 +126,7 @@ class ThreadPoolCallbackRunnerLocal final
 
     /// Set promise result for void callbacks
     template <typename Function>
-    static void executeCallback(std::promise<void> & promise, Function & callback)
+    static void executeCallback(std::promise<void> & promise, Function && callback)
     {
         /// Release callback before setting value to the promise to avoid
         /// destruction of captured resources after waitForAllToFinish returns.
@@ -184,16 +184,12 @@ public:
 
             SCOPE_EXIT_SAFE(
             {
-                /// Release all captured resources before detaching thread group
-                /// Releasing has to use proper memory tracker which has been set here before callback
-                my_callback = {};
-
                 if (thread_group)
                     CurrentThread::detachFromGroupIfNotDetached();
             });
 
             setThreadName(my_thread_name.data());
-            executeCallback(*promise, my_callback);
+            executeCallback(*promise, std::move(my_callback));
         };
 
         try

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -109,12 +109,17 @@ class ThreadPoolCallbackRunnerLocal final
     template <typename Function, typename FunctionResult>
     static void executeCallback(std::promise<FunctionResult> & promise, Function & callback)
     {
+        /// Release callback before setting value to the promise to avoid
+        /// destruction of captured resources after waitForAllToFinish returns.
         try
         {
-            promise.set_value(callback());
+            FunctionResult res = callback();
+            callback = {};
+            promise.set_value(std::move(res));
         }
         catch (...)
         {
+            callback = {};
             promise.set_exception(std::current_exception());
         }
     }
@@ -123,13 +128,17 @@ class ThreadPoolCallbackRunnerLocal final
     template <typename Function>
     static void executeCallback(std::promise<void> & promise, Function & callback)
     {
+        /// Release callback before setting value to the promise to avoid
+        /// destruction of captured resources after waitForAllToFinish returns.
         try
         {
             callback();
+            callback = {};
             promise.set_value();
         }
         catch (...)
         {
+            callback = {};
             promise.set_exception(std::current_exception());
         }
     }
@@ -175,19 +184,15 @@ public:
 
             SCOPE_EXIT_SAFE(
             {
-                {
-                    /// Release all captured resources before detaching thread group
-                    /// Releasing has to use proper memory tracker which has been set here before callback
-
-                    [[maybe_unused]] auto tmp = std::move(my_callback);
-                }
+                /// Release all captured resources before detaching thread group
+                /// Releasing has to use proper memory tracker which has been set here before callback
+                my_callback = {};
 
                 if (thread_group)
                     CurrentThread::detachFromGroupIfNotDetached();
             });
 
             setThreadName(my_thread_name.data());
-
             executeCallback(*promise, my_callback);
         };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #74287.

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
