### PR TITLE
bump node version to 20 for docs

### DIFF
--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 go install github.com/wjdp/htmltest@v${HTMLTEST_VERSION} \
     && mv "${GOPATH}/bin/htmltest" /usr/bin/htmltest
 
 # nodejs 17 prefers ipv6 and is broken in our environment
-FROM node:16-alpine
+FROM node:20-alpine
 
 RUN apk add --no-cache git openssh bash
 


### PR DESCRIPTION
Node 16 is EOL and 20 is LTS. We need this to update do docusaurus to v3 + add visual testing.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
