### PR TITLE
Improve ClickHouse Client docs

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -113,7 +113,7 @@ $ clickhouse-client "SELECT sum(number) FROM numbers(10)"
 45
 ```
 
-You can also use the `--query` comamnd-line option:
+You can also use the `--query` command-line option:
 
 ```bash
 $ clickhouse-client --query "SELECT uniq(number) FROM numbers(10)"
@@ -169,7 +169,7 @@ cat file.csv | clickhouse-client --database=test --query="INSERT INTO test FORMA
 
 ## Notes
 
-In interactive mode, the default ouput format is `PrettyCompact`. You can change the format in the `FORMAT` clause of the query or by specifying the `--format` command-line option. To use the Vertical format, you can use `--vertical` or specify `\G` at the end of the query. In this format, each value is printed on a separate line, which is convenient for wide tables.
+In interactive mode, the default output format is `PrettyCompact`. You can change the format in the `FORMAT` clause of the query or by specifying the `--format` command-line option. To use the Vertical format, you can use `--vertical` or specify `\G` at the end of the query. In this format, each value is printed on a separate line, which is convenient for wide tables.
 
 In batch mode, the default data [format](formats.md) is `TabSeparated`. You can set the format in the `FORMAT` clause of the query.
 
@@ -214,7 +214,7 @@ In the query, place the values that you want to fill using command-line paramete
 {<name>:<data type>}
 ```
 
-- `name` — Placeholder identifier. The corresponsing command-line option is `--param_<name> = value`.
+- `name` — Placeholder identifier. The corresponding command-line option is `--param_<name> = value`.
 - `data type` — [Data type](../sql-reference/data-types/index.md) of the parameter. For example, a data structure like `(integer, ('string', integer))` can have the `Tuple(UInt8, Tuple(String, UInt8))` data type (you can also use other [integer](../sql-reference/data-types/int-uint.md) types). It is also possible to pass the table name, database name, and column names as parameters, in that case you would need to use `Identifier` as the data type.
 
 ### Examples {#cli-queries-with-parameters-examples}

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -1,63 +1,143 @@
 ---
 slug: /en/interfaces/cli
 sidebar_position: 17
-sidebar_label: Command-Line Client
-title: Command-Line Client
+sidebar_label: ClickHouse Client
+title: ClickHouse Client
 ---
-import ConnectionDetails from '@site/docs/en/_snippets/_gather_your_details_native.md';
 
-## clickhouse-client
+ClickHouse provides a native command-line client for executing SQL queries directly against a ClickHouse server. It supports both interactive mode (for live query execution) and batch mode (for scripting and automation). Query results can be displayed in the terminal or exported to a file, with support for all ClickHouse output [formats](formats.md), such as Pretty, CSV, JSON, and more.
 
-ClickHouse provides a native command-line client: `clickhouse-client`. The client supports [command-line options](#command-line-options) and [configuration files](#configuration_files).
+The client provides real-time feedback on query execution with a progress bar and the number of rows read, bytes processed and query execution time. It supports both [command-line options](#command-line-options) and [configuration files](#configuration_files).
 
-[Install](../getting-started/install.md) it from the `clickhouse-client` package and run it with the command `clickhouse-client`.
 
-``` bash
-$ clickhouse-client
-ClickHouse client version 20.13.1.5273 (official build).
-Connecting to localhost:9000 as user default.
-Connected to ClickHouse server version 20.13.1.
+## Install
+
+The easiest way to install ClickHouse is with this command:
+
+```bash
+curl https://clickhouse.com/ | sh
+```
+
+See [Install ClickHouse](../getting-started/install.md) for more installation options.
+
+Different client and server versions are compatible with one another, but some features may not be available in older clients. We recommend using the same version for client and server.
+
+
+## Run
+
+:::note
+If you are using the ClickHouse single binary, use `./clickhouse client` instead of `clickhouse-client`.
+:::
+
+To connect to a ClickHouse server, run:
+
+```bash
+$ clickhouse-client --host server
+
+ClickHouse client version 24.12.2.29 (official build).
+Connecting to server:9000 as user default.
+Connected to ClickHouse server version 24.12.2.
 
 :)
 ```
 
-Different client and server versions are compatible with one another, but some features may not be available in older clients. We recommend using the same version of the client as the server app. When you try to use a client of the older version, then the server, `clickhouse-client` displays the message:
+Specify additional connection details as necessary:
 
-```response
-ClickHouse client version is older than ClickHouse server.
-It may lack support for new features.
+**`--port <port>`** - The port ClickHouse server is accepting connections on. The default ports are 9440 (TLS) and 9000 (no TLS). Note that ClickHouse Client uses the native protocol and not HTTP(S).
+
+**`-s [ --secure ]`** - Whether to use TLS (usually autodetected).
+
+**`-u [ --user ] <username>`** - The database user to connect as. Connects as the `default` user by default.
+
+**`--password <password>`** - The password of the database user. You can also specify the password for a connection in the configuration file. If you do not specify the password, the client will ask for it.
+
+**`-c [ --config ] <path-to-file>`** - The location of the configuration file for ClickHouse Client, if it is not at one of the default locations. See [Configuration Files](#configuration_files).
+
+**`--connection <name>`** - The name of preconfigured connection details from the configuration file.
+
+For a complete list of command-line options, see [Command Line Options](#command-line-options).
+
+
+### Connecting to ClickHouse Cloud {#connecting-cloud}
+
+The details for your ClickHouse Cloud service are available in the ClickHouse Cloud console. Select the service that you want to connect to and click **Connect**:
+
+<img src={require('../_snippets/images/cloud-connect-button.png').default}
+  class="image"
+  alt="ClickHouse Cloud service connect button"
+  style={{width: '30em'}} />
+
+<br/><br/>
+
+Choose **Native**, and the details are shown with an example `clickhouse-client` command:
+
+<img src={require('../_snippets/images/connection-details-native.png').default}
+  class="image"
+  alt="ClickHouse Cloud Native TCP connection details"
+  style={{width: '40em'}} />
+
+
+### Storing connections in a configuration file {#connection-credentials}
+
+You can store connection details for one or more ClickHouse servers in a [configuration file](#configuration_files).
+
+The format looks like this:
+```xml
+<config>
+    <connections_credentials>
+        <name>default</name>
+        <hostname>hostname</hostname>
+        <port>9440</port>
+        <secure>1</secure>
+        <user>default</user>
+        <password>password</password>
+    </connections_credentials>
+</config>
 ```
 
-## Usage {#cli_usage}
+See the [section on configuration files](#configuration_files) for more information.
 
-The client can be used in interactive and non-interactive (batch) mode.
+:::note
+To concentrate on the query syntax, the rest of the examples leave off the connection details (`--host`, `--port`, etc.). Remember to add them when you use the commands.
+:::
 
-### Gather your connection details
-<ConnectionDetails />
 
-### Interactive
+## Batch mode {#batch-mode}
 
-To connect to your ClickHouse Cloud service or any ClickHouse server using TLS and passwords, specify port `9440` (or `--secure`) and provide your username and password:
+Instead of using ClickHouse Client interactively, you can run it in batch mode.
+
+You can specify a single query like this:
 
 ```bash
-clickhouse-client --host <HOSTNAME> \
-                  --port 9440 \
-                  --user <USERNAME> \
-                  --password <PASSWORD>
+$ clickhouse-client "SELECT sum(number) FROM numbers(10)"
+45
 ```
 
-To connect to a self-managed ClickHouse server you will need the details for that server.  Whether or not TLS is used, port numbers, and passwords are all configurable.  Use the above example for ClickHouse Cloud as a starting point.
+You can also use the `--query` comamnd-line option:
 
+```bash
+$ clickhouse-client --query "SELECT uniq(number) FROM numbers(10)"
+10
+```
 
-### Batch
+You can provide a query on `stdin`:
 
-To use batch mode, specify the ‘query’ parameter, or send data to ‘stdin’ (it verifies that ‘stdin’ is not a terminal), or both. Similar to the HTTP interface, when using the ‘query’ parameter and sending data to ‘stdin’, the request is a concatenation of the ‘query’ parameter, a line feed, and the data in ‘stdin’. This is convenient for large INSERT queries.
+```bash
+$ echo "SELECT avg(number) FROM numbers(10)" | clickhouse-client
+4.5
+```
 
-Examples of using the client to insert data:
+Inserting data:
 
-#### Inserting a CSV file into a remote ClickHouse service
+```bash
+$ echo "Hello\nGoodbye" | clickhouse-client --query "INSERT INTO messages FORMAT CSV"
+```
 
-This example is appropriate for ClickHouse Cloud, or any ClickHouse server using TLS and a password. In this example a sample dataset CSV file, `cell_towers.csv` is inserted into an existing table `cell_towers` in the `default` database:
+When `--query` is specified, any input is appended to the request after a line feed.
+
+**Inserting a CSV file into a remote ClickHouse service**
+
+This example is inserting a sample dataset CSV file, `cell_towers.csv` into an existing table `cell_towers` in the `default` database:
 
 ```bash
 clickhouse-client --host HOSTNAME.clickhouse.cloud \
@@ -68,11 +148,7 @@ clickhouse-client --host HOSTNAME.clickhouse.cloud \
   < cell_towers.csv
 ```
 
-:::note
-To concentrate on the query syntax, the rest of the examples leave off the connection details (`--host`, `--port`, etc.).  Add them in when you try the commands.
-:::
-
-#### Three different ways of inserting data
+**More examples of inserting data**
 
 ``` bash
 echo -ne "1, 'some text', '2016-08-14 00:00:00'\n2, 'some more text', '2016-08-14 00:00:01'" | \
@@ -90,70 +166,65 @@ _EOF
 cat file.csv | clickhouse-client --database=test --query="INSERT INTO test FORMAT CSV";
 ```
 
-### Notes
 
-In batch mode, the default data format is TabSeparated. You can set the format in the FORMAT clause of the query.
+## Notes
 
-By default, you can only process a single query in batch mode. To make multiple queries from a “script,” use the `--multiquery` parameter. This works for all queries except INSERT. Query results are output consecutively without additional separators. Similarly, to process a large number of queries, you can run ‘clickhouse-client’ for each query. Note that it may take tens of milliseconds to launch the ‘clickhouse-client’ program.
+In interactive mode, the default ouput format is `PrettyCompact`. You can change the format in the `FORMAT` clause of the query or by specifying the `--format` command-line option. To use the Vertical format, you can use `--vertical` or specify `\G` at the end of the query. In this format, each value is printed on a separate line, which is convenient for wide tables.
 
-In interactive mode, you get a command line where you can enter queries.
+In batch mode, the default data [format](formats.md) is `TabSeparated`. You can set the format in the `FORMAT` clause of the query.
 
-If ‘multiline’ is not specified (the default): To run the query, press Enter. The semicolon is not necessary at the end of the query. To enter a multiline query, enter a backslash `\` before the line feed. After you press Enter, you will be asked to enter the next line of the query.
+In interactive mode, by default whatever was entered is run when you press `Enter`. A semicolon is not necessary at the end of the query.
 
-If multiline is specified: To run a query, end it with a semicolon and press Enter. If the semicolon was omitted at the end of the entered line, you will be asked to enter the next line of the query.
+You can start the client with the `-m, --multiline` parameter. To enter a multiline query, enter a backslash `\` before the line feed. After you press `Enter`, you will be asked to enter the next line of the query. To run the query, end it with a semicolon and press `Enter`.
 
-Only a single query is run, so everything after the semicolon is ignored.
+ClickHouse Client is based on `replxx` (similar to `readline`) so it uses familiar keyboard shortcuts and keeps a history. The history is written to `~/.clickhouse-client-history` by default.
 
-You can specify `\G` instead of or after the semicolon. This indicates Vertical format. In this format, each value is printed on a separate line, which is convenient for wide tables. This unusual feature was added for compatibility with the MySQL CLI.
-
-The command line is based on ‘replxx’ (similar to ‘readline’). In other words, it uses the familiar keyboard shortcuts and keeps a history. The history is written to `~/.clickhouse-client-history`.
-
-By default, the format used is PrettyCompact. You can change the format in the FORMAT clause of the query, or by specifying `\G` at the end of the query, using the `--format` or `--vertical` argument in the command line, or using the client configuration file.
-
-To exit the client, press Ctrl+D, or enter one of the following instead of a query: “exit”, “quit”, “logout”, “exit;”, “quit;”, “logout;”, “q”, “Q”, “:q”
+To exit the client, press `Ctrl+D`, or enter one of the following instead of a query: `exit`, `quit`, `logout`, `exit;`, `quit;`, `logout;`, `q`, `Q`, `:q`.
 
 When processing a query, the client shows:
 
-1.  Progress, which is updated no more than 10 times per second (by default). For quick queries, the progress might not have time to be displayed.
+1.  Progress, which is updated no more than 10 times per second by default. For quick queries, the progress might not have time to be displayed.
 2.  The formatted query after parsing, for debugging.
 3.  The result in the specified format.
 4.  The number of lines in the result, the time passed, and the average speed of query processing. All data amounts refer to uncompressed data.
 
-You can cancel a long query by pressing Ctrl+C. However, you will still need to wait for a little for the server to abort the request. It is not possible to cancel a query at certain stages. If you do not wait and press Ctrl+C a second time, the client will exit.
+You can cancel a long query by pressing `Ctrl+C`. However, you will still need to wait for a little for the server to abort the request. It is not possible to cancel a query at certain stages. If you do not wait and press `Ctrl+C` a second time, the client will exit.
 
-The command-line client allows passing external data (external temporary tables) for querying. For more information, see the section “External data for query processing”.
+ClickHouse Client allows passing external data (external temporary tables) for querying. For more information, see the section [External data for query processing](../engines/table-engines/special/external-data.md).
 
-### Queries with Parameters {#cli-queries-with-parameters}
 
-You can create a query with parameters and pass values to them from client application. This allows to avoid formatting query with specific dynamic values on client side. For example:
+## Queries with parameters {#cli-queries-with-parameters}
+
+You can specify parameters in a query and pass values to it with command-line options. This avoids formatting a query with specific dynamic values on the client side. For example:
 
 ``` bash
-$ clickhouse-client --param_parName="[1, 2]"  -q "SELECT * FROM table WHERE a = {parName:Array(UInt16)}"
+$ clickhouse-client --param_parName="[1, 2]" --query "SELECT * FROM table WHERE a = {parName:Array(UInt16)}"
 ```
 
 It is also possible to set parameters from within an interactive session:
 ``` bash
-$ clickhouse-client -nq "
-  SET param_parName='[1, 2]';
-  SELECT {parName:Array(UInt16)}"
+$ clickhouse-client --query "SET param_parName='[1, 2]'; SELECT {parName:Array(UInt16)}"
 ```
 
-#### Query Syntax {#cli-queries-with-parameters-syntax}
+### Query Syntax {#cli-queries-with-parameters-syntax}
 
-Format a query as usual, then place the values that you want to pass from the app parameters to the query in braces in the following format:
+In the query, place the values that you want to fill using command-line parameters in braces in the following format:
 
 ``` sql
 {<name>:<data type>}
 ```
 
-- `name` — Placeholder identifier. In the console client it should be used in app parameters as `--param_<name> = value`.
-- `data type` — [Data type](../sql-reference/data-types/index.md) of the app parameter value. For example, a data structure like `(integer, ('string', integer))` can have the `Tuple(UInt8, Tuple(String, UInt8))` data type (you can also use another [integer](../sql-reference/data-types/int-uint.md) types). It's also possible to pass table, database, column names as a parameter, in that case you would need to use `Identifier` as a data type.
+- `name` — Placeholder identifier. The corresponsing command-line option is `--param_<name> = value`.
+- `data type` — [Data type](../sql-reference/data-types/index.md) of the parameter. For example, a data structure like `(integer, ('string', integer))` can have the `Tuple(UInt8, Tuple(String, UInt8))` data type (you can also use other [integer](../sql-reference/data-types/int-uint.md) types). It is also possible to pass the table name, database name, and column names as parameters, in that case you would need to use `Identifier` as the data type.
 
-#### Example {#example}
+### Examples {#cli-queries-with-parameters-examples}
 
 ``` bash
-$ clickhouse-client --param_tuple_in_tuple="(10, ('dt', 10))" -q "SELECT * FROM table WHERE val = {tuple_in_tuple:Tuple(UInt8, Tuple(String, UInt8))}"
-$ clickhouse-client --param_tbl="numbers" --param_db="system" --param_col="number" --param_alias="top_ten" --query "SELECT {col:Identifier} as {alias:Identifier} FROM {db:Identifier}.{tbl:Identifier} LIMIT 10"
+$ clickhouse-client --param_tuple_in_tuple="(10, ('dt', 10))" \
+    --query "SELECT * FROM table WHERE val = {tuple_in_tuple:Tuple(UInt8, Tuple(String, UInt8))}"
+
+$ clickhouse-client --param_tbl="numbers" --param_db="system" --param_col="number" --param_alias="top_ten" \
+    --query "SELECT {col:Identifier} as {alias:Identifier} FROM {db:Identifier}.{tbl:Identifier} LIMIT 10"
 ```
 
 
@@ -165,89 +236,84 @@ $ clickhouse-client --param_tbl="numbers" --param_db="system" --param_col="numbe
 - `.` - repeat the last query
 
 
-## Shortkeys {#shortkeys_aliases}
+## Keyboard shortcuts {#keyboard_shortcuts}
 
-- `Alt (Option) + Shift + e` - open editor with current query. It is possible to set up an environment variable - `EDITOR`, by default vim is used.
+- `Alt (Option) + Shift + e` - open editor with the current query. It is possible to specify the editor to use with the environment variable `EDITOR`. By default, `vim` is used.
 - `Alt (Option) + #` - comment line.
 - `Ctrl + r` - fuzzy history search.
 
+The full list with all available keyboard shortcuts is available at [replxx](https://github.com/AmokHuginnsson/replxx/blob/1f149bf/src/replxx_impl.cxx#L262).
+
 :::tip
-To configure the correct work of meta key (Option) on MacOS:
+To configure the correct work of the meta key (Option) on MacOS:
 
 iTerm2: Go to Preferences -> Profile -> Keys -> Left Option key and click Esc+
 :::
 
-The full list with all available shortkeys - [replxx](https://github.com/AmokHuginnsson/replxx/blob/1f149bf/src/replxx_impl.cxx#L262).
-
 
 ## Connection string {#connection_string}
 
-clickhouse-client alternatively supports connecting to clickhouse server using a connection string similar to [MongoDB](https://www.mongodb.com/docs/manual/reference/connection-string/), [PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), [MySQL](https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri). It has the following syntax:
+ClickHouse Client alternatively supports connecting to a ClickHouse server using a connection string similar to [MongoDB](https://www.mongodb.com/docs/manual/reference/connection-string/), [PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), [MySQL](https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri). It has the following syntax:
 
 ```text
 clickhouse:[//[user[:password]@][hosts_and_ports]][/database][?query_parameters]
 ```
 
-Where
+**Components**
 
-- `user` - (optional) is a user name,
-- `password` - (optional) is a user password. If `:` is specified and the password is blank, the client will prompt for the user's password.
-- `hosts_and_ports` - (optional) is a list of hosts and optional ports `host[:port] [, host:[port]], ...`,
-- `database` - (optional) is the database name,
-- `query_parameters` - (optional) is a list of key-value pairs `param1=value1[,&param2=value2], ...`. For some parameters, no value is required. Parameter names and values are case-sensitive.
+- `user` - (optional) Database username. Default: `default`.
+- `password` - (optional) Database user password. If `:` is specified and the password is blank, the client will prompt for the user's password.
+- `hosts_and_ports` - (optional) List of hosts and optional ports `host[:port] [, host:[port]], ...`. Default: `localhost:9000`.
+- `database` - (optional) Database name. Default: `default`.
+- `query_parameters` - (optional) List of key-value pairs `param1=value1[,&param2=value2], ...`. For some parameters, no value is required. Parameter names and values are case-sensitive.
 
-If no user is specified, `default` user without password will be used.
-If no host is specified, the `localhost` will be used (localhost).
-If no port is specified is not specified, `9000` will be used as port.
-If no database is specified, the `default` database will be used.
+If the username, password or database was specified in the connection string, it cannot be specified using `--user`, `--password` or `--database` (and vice versa).
 
-If the user name, password or database was specified in the connection string, it cannot be specified using `--user`, `--password` or `--database` (and vice versa).
-
-The host component can either be a host name and IP address. Put an IPv6 address in square brackets to specify it:
+The host component can either be a hostname or an IPv4 or IPv6 address. IPv6 addresses should be in square brackets:
 
 ```text
 clickhouse://[2001:db8::1234]
 ```
 
-URI allows multiple hosts to be connected to. Connection strings can contain multiple hosts. ClickHouse-client will try to connect to these hosts in order (i.e. from left to right). After the connection is established, no attempt to connect to the remaining hosts is made.
+Connection strings can contain multiple hosts. ClickHouse Client will try to connect to these hosts in order (from left to right). After the connection is established, no attempt to connect to the remaining hosts is made.
 
-The connection string must be specified as the first argument of clickhouse-client. The connection string can be combined with arbitrary other [command-line-options](#command-line-options) except `--host/-h` and `--port`.
+The connection string must be specified as the first argument of `clickHouse-client`. The connection string can be combined with arbitrary other [command-line options](#command-line-options) except `--host` and `--port`.
 
-The following keys are allowed for component `query_parameter`:
+The following keys are allowed for `query_parameters`:
 
-- `secure` or shorthanded `s` - no value. If specified, client will connect to the server over a secure connection (TLS). See `secure` in [command-line-options](#command-line-options)
+- `secure` or shorthanded `s`. If specified, the client will connect to the server over a secure connection (TLS). See `--secure` in the [command-line options](#command-line-options).
 
-### Percent encoding {#connection_string_uri_percent_encoding}
+**Percent encoding**
 
 Non-US ASCII, spaces and special characters in the `user`, `password`, `hosts`, `database` and `query parameters` must be [percent-encoded](https://en.wikipedia.org/wiki/URL_encoding).
 
 ### Examples {#connection_string_examples}
 
-Connect to localhost using port 9000 and execute the query `SELECT 1`.
+Connect to `localhost` on port 9000 and execute the query `SELECT 1`.
 
 ``` bash
 clickhouse-client clickhouse://localhost:9000 --query "SELECT 1"
 ```
 
-Connect to localhost using user `john` with password `secret`, host `127.0.0.1` and port `9000`
+Connect to `localhost` as user `john` with password `secret`, host `127.0.0.1` and port `9000`
 
 ``` bash
 clickhouse-client clickhouse://john:secret@127.0.0.1:9000
 ```
 
-Connect to localhost using default user, host with IPV6 address `[::1]` and port `9000`.
+Connect to `localhost` as the `default` user, host with IPV6 address `[::1]` and port `9000`.
 
 ``` bash
 clickhouse-client clickhouse://[::1]:9000
 ```
 
-Connect to localhost using port 9000 in multiline mode.
+Connect to `localhost` on port 9000 in multiline mode.
 
 ``` bash
 clickhouse-client clickhouse://localhost:9000 '-m'
 ```
 
-Connect to localhost using port 9000 with the user `default`.
+Connect to `localhost` using port 9000 as the user `default`.
 
 ``` bash
 clickhouse-client clickhouse://default@localhost:9000
@@ -256,7 +322,7 @@ clickhouse-client clickhouse://default@localhost:9000
 clickhouse-client clickhouse://localhost:9000 --user default
 ```
 
-Connect to localhost using port 9000 to `my_database` database.
+Connect to `localhost` on port 9000 and default to the `my_database` database.
 
 ``` bash
 clickhouse-client clickhouse://localhost:9000/my_database
@@ -265,7 +331,7 @@ clickhouse-client clickhouse://localhost:9000/my_database
 clickhouse-client clickhouse://localhost:9000 --database my_database
 ```
 
-Connect to localhost using port 9000 to `my_database` database specified in the connection string and a secure connection using shorthanded 's' URI parameter.
+Connect to `localhost` on port 9000 and default to the `my_database` database specified in the connection string and a secure connection using the shorthanded `s` parameter.
 
 ```bash
 clickhouse-client clickhouse://localhost/my_database?s
@@ -274,43 +340,74 @@ clickhouse-client clickhouse://localhost/my_database?s
 clickhouse-client clickhouse://localhost/my_database -s
 ```
 
-Connect to default host using default port, default user, and default database.
+Connect to the default host using the default port, the default user, and the default database.
 
 ``` bash
 clickhouse-client clickhouse:
 ```
 
-Connect to the default host using the default port, using user `my_user` and no password.
+Connect to the default host using the default port, as the user `my_user` and no password.
 
 ``` bash
 clickhouse-client clickhouse://my_user@
 
-# Using a blank password between : and @ means to asking user to enter the password before starting the connection.
+# Using a blank password between : and @ means to asking the user to enter the password before starting the connection.
 clickhouse-client clickhouse://my_user:@
 ```
 
-Connect to localhost using email as the user name. `@` symbol is percent encoded to `%40`.
+Connect to `localhost` using the email as the user name. `@` symbol is percent encoded to `%40`.
 
 ``` bash
 clickhouse-client clickhouse://some_user%40some_mail.com@localhost:9000
 ```
 
-Connect to one of provides hosts: `192.168.1.15`, `192.168.1.25`.
+Connect to one of two hosts: `192.168.1.15`, `192.168.1.25`.
 
 ``` bash
 clickhouse-client clickhouse://192.168.1.15,192.168.1.25
 ```
 
+
+## Query ID format {#query-id-format}
+
+In interactive mode ClickHouse Client shows the query ID for every query. By default, the ID is formatted like this:
+
+```sql
+Query id: 927f137d-00f1-4175-8914-0dd066365e96
+```
+
+A custom format may be specified in a configuration file inside a `query_id_formats` tag. The `{query_id}` placeholder in the format string is replaced with the query ID. Several format strings are allowed inside the tag.
+This feature can be used to generate URLs to facilitate profiling of queries.
+
+**Example**
+
+```xml
+<config>
+  <query_id_formats>
+    <speedscope>http://speedscope-host/#profileURL=qp%3Fid%3D{query_id}</speedscope>
+  </query_id_formats>
+</config>
+```
+
+With the configuration above, the ID of a query is shown in the following format:
+
+```response
+speedscope:http://speedscope-host/#profileURL=qp%3Fid%3Dc8ecc783-e753-4b38-97f1-42cddfb98b7d
+```
+
+
 ## Configuration Files {#configuration_files}
 
-`clickhouse-client` uses the first existing file of the following:
+ClickHouse Client uses the first existing file of the following:
 
-- Defined in the `--config-file` parameter.
-- `./clickhouse-client.xml`, `.yaml`, `.yml`
-- `~/.clickhouse-client/config.xml`, `.yaml`, `.yml`
-- `/etc/clickhouse-client/config.xml`, `.yaml`, `.yml`
+- A file that is defined with the `-c [ -C, --config, --config-file ]` parameter.
+- `./clickhouse-client.[xml|yaml|yml]`
+- `~/.clickhouse-client/config.[xml|yaml|yml]`
+- `/etc/clickhouse-client/config.[xml|yaml|yml]`
 
-Example of a config file:
+See the sample configuration file in the ClickHouse repository: [`clickhouse-client.xml`](https://github.com/ClickHouse/ClickHouse/blob/master/programs/client/clickhouse-client.xml)
+
+Example XML syntax:
 
 ```xml
 <config>
@@ -325,7 +422,7 @@ Example of a config file:
 </config>
 ```
 
-Or the same config in a YAML format:
+The same configuration in YAML format:
 
 ```yaml
 user: username
@@ -336,54 +433,6 @@ openSSL:
     caConfig: '/etc/ssl/cert.pem'
 ```
 
-### Connection credentials {#connection-credentials}
-
-If you frequently connect to the same ClickHouse server, you can save the connection details including credentials in
-the configuration file like this:
-
-```xml
-<config>
-    <connections_credentials>
-        <name>production</name>
-        <hostname>127.0.0.1</hostname>
-        <port>9000</port>
-        <secure>1</secure>
-        <user>default</user>
-        <password></password>
-        <database></database>
-
-        <!-- You can use colors and macros, see clickhouse-client.xml for more documentation. -->
-        <prompt>\e[31m[PRODUCTION]\e[0m {user}@{display_name}</prompt>
-    </connections_credentials>
-</config>
-```
-
-## Query ID Format {#query-id-format}
-
-In interactive mode `clickhouse-client` shows query ID for every query. By default, the ID is formatted like this:
-
-```sql
-Query id: 927f137d-00f1-4175-8914-0dd066365e96
-```
-
-A custom format may be specified in a configuration file inside a `query_id_formats` tag. `{query_id}` placeholder in the format string is replaced with the ID of a query. Several format strings are allowed inside the tag.
-This feature can be used to generate URLs to facilitate profiling of queries.
-
-**Example**
-
-```xml
-<config>
-  <query_id_formats>
-    <speedscope>http://speedscope-host/#profileURL=qp%3Fid%3D{query_id}</speedscope>
-  </query_id_formats>
-</config>
-```
-
-If the configuration above is applied, the ID of a query is shown in the following format:
-
-```response
-speedscope:http://speedscope-host/#profileURL=qp%3Fid%3Dc8ecc783-e753-4b38-97f1-42cddfb98b7d
-```
 
 ## Command-Line Options {#command-line-options}
 
@@ -427,7 +476,7 @@ Print version and exit.
 
 **`--connection <name>`**
 
-The name of preconfigured connection details from the configuration file. See [Connection credentials]{#connection-credentials}.
+The name of preconfigured connection details from the configuration file. See [Connection credentials](#connection-credentials).
 
 **`-d [ --database ] <database>`**
 

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -12,10 +12,15 @@ The client provides real-time feedback on query execution with a progress bar an
 
 ## Install
 
-The easiest way to install ClickHouse is with this command:
+To download ClickHouse, run:
 
 ```bash
 curl https://clickhouse.com/ | sh
+```
+
+To also install it, run:
+```bash
+sudo ./clickhouse install
 ```
 
 See [Install ClickHouse](../getting-started/install.md) for more installation options.
@@ -26,7 +31,7 @@ Different client and server versions are compatible with one another, but some f
 ## Run
 
 :::note
-If you are using the ClickHouse single binary, use `./clickhouse client` instead of `clickhouse-client`.
+If you only downloaded but did not install ClickHouse, use `./clickhouse client` instead of `clickhouse-client`.
 :::
 
 To connect to a ClickHouse server, run:

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -2732,9 +2732,9 @@ e.g. `schemafile.proto:MessageType`.
 If the file has the standard extension for the format (for example, `.proto` for `Protobuf`),
 it can be omitted and in this case, the format schema looks like `schemafile:MessageType`.
 
-If you input or output data via the [client](/docs/en/interfaces/cli.md) in the [interactive mode](/docs/en/interfaces/cli.md/#cli_usage), the file name specified in the format schema
+If you input or output data via the [client](/docs/en/interfaces/cli.md) in interactive mode, the file name specified in the format schema
 can contain an absolute path or a path relative to the current directory on the client.
-If you use the client in the [batch mode](/docs/en/interfaces/cli.md/#cli_usage), the path to the schema must be relative due to security reasons.
+If you use the client in the [batch mode](/docs/en/interfaces/cli.md/#batch-mode), the path to the schema must be relative due to security reasons.
 
 If you input or output data via the [HTTP interface](/docs/en/interfaces/http.md) the file name specified in the format schema
 should be located in the directory specified in [format_schema_path](/docs/en/operations/server-configuration-parameters/settings.md/#format_schema_path)


### PR DESCRIPTION
Reworks a large part of the ClickHouse Client docs.

Main changes:
- Page title changed from `Command-Line Client` to `ClickHouse Client` (as that's what most people know it as and how we generally refer to it)
- New intro paragraphs
- Quickstart `Run` and `Install` sections to help get it running as quickly as possible. Pulls in the simple installation `curl` installation command, so it's not necessary to go to a separate page
- Updated client output to `24.12` from `20.13`
- Discourage specifying passwords on the command line by always mentioning alternatives, such as connection credentials in a file
- In general, encourage more use of preconfigured connection credentials (such a good feature that wasn't really documented)
- Document running a query without `--query`
- Lots of small fixes

### Changelog category (leave one):
- Documentation (changelog entry is not required)