### PR TITLE
Fix native copy settings for RESTORE from base backup

### DIFF
--- a/src/Backups/BackupFactory.cpp
+++ b/src/Backups/BackupFactory.cpp
@@ -9,6 +9,23 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+
+BackupFactory::CreateParams BackupFactory::CreateParams::getCreateParamsForBaseBackup(BackupInfo base_backup_info_, String old_password) const
+{
+    CreateParams read_params;
+    read_params.open_mode = OpenMode::READ;
+    read_params.backup_info = std::move(base_backup_info_);
+    read_params.context = context;
+    read_params.is_internal_backup = is_internal_backup;
+    read_params.allow_s3_native_copy = allow_s3_native_copy;
+    read_params.allow_azure_native_copy = allow_azure_native_copy;
+    read_params.use_same_s3_credentials_for_base_backup = use_same_s3_credentials_for_base_backup;
+    read_params.use_same_password_for_base_backup = use_same_password_for_base_backup;
+    if (read_params.use_same_password_for_base_backup)
+        read_params.password = old_password;
+    return read_params;
+}
+
 BackupFactory & BackupFactory::instance()
 {
     static BackupFactory the_instance;

--- a/src/Backups/BackupFactory.h
+++ b/src/Backups/BackupFactory.h
@@ -45,6 +45,8 @@ public:
         bool azure_attempt_to_create_container = true;
         ReadSettings read_settings;
         WriteSettings write_settings;
+
+        CreateParams getCreateParamsForBaseBackup(BackupInfo base_backup_info_, String old_password) const;
     };
 
     static BackupFactory & instance();

--- a/src/Backups/BackupIO_Memory.cpp
+++ b/src/Backups/BackupIO_Memory.cpp
@@ -100,15 +100,7 @@ void registerBackupEngineMemory(BackupFactory & factory)
             auto backup_in_memory = backups_in_memory.getBackup(backup_name);
             auto reader = std::make_shared<BackupReaderMemory>(backup_in_memory, params.read_settings, params.write_settings);
 
-            return std::make_unique<BackupImpl>(
-                params.backup_info,
-                BackupImpl::ArchiveParams{},
-                params.base_backup_info,
-                reader,
-                params.context,
-                params.is_internal_backup,
-                params.use_same_s3_credentials_for_base_backup,
-                params.use_same_password_for_base_backup);
+            return std::make_unique<BackupImpl>(params, BackupImpl::ArchiveParams{}, reader);
         }
         else
         {
@@ -116,18 +108,7 @@ void registerBackupEngineMemory(BackupFactory & factory)
             auto backup_in_memory = backups_in_memory.createBackup(backup_name);
             auto writer = std::make_shared<BackupWriterMemory>(backup_in_memory, params.read_settings, params.write_settings);
 
-            return std::make_unique<BackupImpl>(
-                params.backup_info,
-                BackupImpl::ArchiveParams{},
-                params.base_backup_info,
-                writer,
-                params.context,
-                params.is_internal_backup,
-                params.backup_coordination,
-                params.backup_uuid,
-                params.deduplicate_files,
-                params.use_same_s3_credentials_for_base_backup,
-                params.use_same_password_for_base_backup);
+            return std::make_unique<BackupImpl>(params, BackupImpl::ArchiveParams{}, writer);
         }
     };
 

--- a/src/Backups/BackupIO_Null.cpp
+++ b/src/Backups/BackupIO_Null.cpp
@@ -98,18 +98,7 @@ void registerBackupEngineNull(BackupFactory & factory)
 
         auto writer = std::make_shared<BackupWriterNull>(params.read_settings, params.write_settings);
 
-        return std::make_unique<BackupImpl>(
-            params.backup_info,
-            BackupImpl::ArchiveParams{},
-            params.base_backup_info,
-            writer,
-            params.context,
-            params.is_internal_backup,
-            params.backup_coordination,
-            params.backup_uuid,
-            params.deduplicate_files,
-            params.use_same_s3_credentials_for_base_backup,
-            params.use_same_password_for_base_backup);
+        return std::make_unique<BackupImpl>(params, BackupImpl::ArchiveParams{}, writer);
     };
 
     factory.registerBackupEngine("Null", creator_fn);

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -86,26 +86,18 @@ namespace
 
 
 BackupImpl::BackupImpl(
-    const BackupInfo & backup_info_,
+    BackupFactory::CreateParams params_,
     const ArchiveParams & archive_params_,
-    const std::optional<BackupInfo> & base_backup_info_,
-    std::shared_ptr<IBackupReader> reader_,
-    const ContextPtr & context_,
-    bool is_internal_backup_,
-    bool use_same_s3_credentials_for_base_backup_,
-    bool use_same_password_for_base_backup_)
-    : backup_info(backup_info_)
+    std::shared_ptr<IBackupReader> reader_)
+    : params(std::move(params_))
+    , backup_info(params.backup_info)
     , backup_name_for_logging(backup_info.toStringForLogging())
     , use_archive(!archive_params_.archive_name.empty())
     , archive_params(archive_params_)
     , open_mode(OpenMode::READ)
     , reader(std::move(reader_))
-    , context(context_)
-    , is_internal_backup(is_internal_backup_)
     , version(INITIAL_BACKUP_VERSION)
-    , base_backup_info(base_backup_info_)
-    , use_same_s3_credentials_for_base_backup(use_same_s3_credentials_for_base_backup_)
-    , use_same_password_for_base_backup(use_same_password_for_base_backup_)
+    , base_backup_info(params.base_backup_info)
     , log(getLogger("BackupImpl"))
 {
     open();
@@ -113,32 +105,20 @@ BackupImpl::BackupImpl(
 
 
 BackupImpl::BackupImpl(
-    const BackupInfo & backup_info_,
+    BackupFactory::CreateParams params_,
     const ArchiveParams & archive_params_,
-    const std::optional<BackupInfo> & base_backup_info_,
-    std::shared_ptr<IBackupWriter> writer_,
-    const ContextPtr & context_,
-    bool is_internal_backup_,
-    const std::shared_ptr<IBackupCoordination> & coordination_,
-    const std::optional<UUID> & backup_uuid_,
-    bool deduplicate_files_,
-    bool use_same_s3_credentials_for_base_backup_,
-    bool use_same_password_for_base_backup_)
-    : backup_info(backup_info_)
+    std::shared_ptr<IBackupWriter> writer_)
+    : params(std::move(params_))
+    , backup_info(params.backup_info)
     , backup_name_for_logging(backup_info.toStringForLogging())
     , use_archive(!archive_params_.archive_name.empty())
     , archive_params(archive_params_)
     , open_mode(OpenMode::WRITE)
     , writer(std::move(writer_))
-    , context(context_)
-    , is_internal_backup(is_internal_backup_)
-    , coordination(coordination_)
-    , uuid(backup_uuid_)
+    , coordination(params.backup_coordination)
+    , uuid(params.backup_uuid)
     , version(CURRENT_BACKUP_VERSION)
-    , base_backup_info(base_backup_info_)
-    , deduplicate_files(deduplicate_files_)
-    , use_same_s3_credentials_for_base_backup(use_same_s3_credentials_for_base_backup_)
-    , use_same_password_for_base_backup(use_same_password_for_base_backup_)
+    , base_backup_info(params.base_backup_info)
     , log(getLogger("BackupImpl"))
 {
     open();
@@ -186,7 +166,7 @@ void BackupImpl::open()
 
         /// Check that we can write a backup there and create the lock file to own this destination.
         checkBackupDoesntExist();
-        if (!is_internal_backup)
+        if (!params.is_internal_backup)
             createLockFile();
         checkLockFile(true);
     }
@@ -254,23 +234,11 @@ std::shared_ptr<const IBackup> BackupImpl::getBaseBackupUnlocked() const
 {
     if (!base_backup && base_backup_info)
     {
-        if (use_same_s3_credentials_for_base_backup)
+        if (params.use_same_s3_credentials_for_base_backup)
             backup_info.copyS3CredentialsTo(*base_backup_info);
 
-        BackupFactory::CreateParams params;
-        params.backup_info = *base_backup_info;
-        params.open_mode = OpenMode::READ;
-        params.context = context;
-        params.is_internal_backup = is_internal_backup;
-        /// use_same_s3_credentials_for_base_backup should be inherited for base backups
-        params.use_same_s3_credentials_for_base_backup = use_same_s3_credentials_for_base_backup;
-        /// use_same_password_for_base_backup should be inherited for base backups
-        params.use_same_password_for_base_backup = use_same_password_for_base_backup;
-
-        if (params.use_same_password_for_base_backup)
-            params.password = archive_params.password;
-
-        base_backup = BackupFactory::instance().createBackup(params);
+        BackupFactory::CreateParams base_params = params.getCreateParamsForBaseBackup(*base_backup_info, archive_params.password);
+        base_backup = BackupFactory::instance().createBackup(base_params);
 
         if ((open_mode == OpenMode::READ) && (base_backup_uuid != base_backup->getUUID()))
         {
@@ -341,7 +309,7 @@ void BackupImpl::writeBackupMetadata()
     LOG_TRACE(log, "Backup {}: Writing metadata", backup_name_for_logging);
     auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::BackupWriteMetadataMicroseconds);
 
-    assert(!is_internal_backup);
+    assert(!params.is_internal_backup);
     checkLockFile(true);
 
     std::unique_ptr<WriteBuffer> out;
@@ -352,7 +320,7 @@ void BackupImpl::writeBackupMetadata()
 
     *out << "<config>";
     *out << "<version>" << CURRENT_BACKUP_VERSION << "</version>";
-    *out << "<deduplicate_files>" << deduplicate_files << "</deduplicate_files>";
+    *out << "<deduplicate_files>" << params.deduplicate_files << "</deduplicate_files>";
     *out << "<timestamp>" << toString(LocalDateTime{timestamp}) << "</timestamp>";
     *out << "<uuid>" << toString(*uuid) << "</uuid>";
 
@@ -409,7 +377,7 @@ void BackupImpl::writeBackupMetadata()
         }
 
         total_size += info.size;
-        bool has_entry = !deduplicate_files || (info.size && (info.size != info.base_size) && (info.data_file_name.empty() || (info.data_file_name == info.file_name)));
+        bool has_entry = !params.deduplicate_files || (info.size && (info.size != info.base_size) && (info.data_file_name.empty() || (info.data_file_name == info.file_name)));
         if (has_entry)
         {
             ++num_entries;
@@ -526,7 +494,7 @@ void BackupImpl::readBackupMetadata()
 
             ++num_files;
             total_size += info.size;
-            bool has_entry = !deduplicate_files || (info.size && (info.size != info.base_size) && (info.data_file_name.empty() || (info.data_file_name == info.file_name)));
+            bool has_entry = !params.deduplicate_files || (info.size && (info.size != info.base_size) && (info.data_file_name.empty() || (info.data_file_name == info.file_name)));
             if (has_entry)
             {
                 ++num_entries;
@@ -555,7 +523,7 @@ void BackupImpl::checkBackupDoesntExist() const
         throw Exception(ErrorCodes::BACKUP_ALREADY_EXISTS, "Backup {} already exists", backup_name_for_logging);
 
     /// Check that no other backup (excluding internal backups) is writing to the same destination.
-    if (!is_internal_backup)
+    if (!params.is_internal_backup)
     {
         assert(!lock_file_name.empty());
         if (writer->fileExists(lock_file_name))
@@ -566,7 +534,7 @@ void BackupImpl::checkBackupDoesntExist() const
 void BackupImpl::createLockFile()
 {
     /// Internal backup must not create the lock file (it should be created by the initiator).
-    assert(!is_internal_backup);
+    assert(!params.is_internal_backup);
 
     assert(uuid);
     auto out = writer->writeFile(lock_file_name);
@@ -996,7 +964,7 @@ void BackupImpl::finalizeWriting()
     if (writing_finalized)
         return;
 
-    if (!is_internal_backup)
+    if (!params.is_internal_backup)
     {
         LOG_TRACE(log, "Finalizing backup {}", backup_name_for_logging);
         writeBackupMetadata();

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Backups/BackupFactory.h>
 #include <Backups/IBackup.h>
 #include <Backups/IBackupCoordination.h>
 #include <Backups/BackupInfo.h>
@@ -34,28 +35,17 @@ public:
         size_t max_volume_size = 0;
     };
 
+    /// RESTORE
     BackupImpl(
-        const BackupInfo & backup_info_,
+        BackupFactory::CreateParams params_,
         const ArchiveParams & archive_params_,
-        const std::optional<BackupInfo> & base_backup_info_,
-        std::shared_ptr<IBackupReader> reader_,
-        const ContextPtr & context_,
-        bool is_internal_backup_,
-        bool use_same_s3_credentials_for_base_backup_,
-        bool use_same_password_for_base_backup_);
+        std::shared_ptr<IBackupReader> reader_);
 
+    /// BACKUP
     BackupImpl(
-        const BackupInfo & backup_info_,
+        BackupFactory::CreateParams params_,
         const ArchiveParams & archive_params_,
-        const std::optional<BackupInfo> & base_backup_info_,
-        std::shared_ptr<IBackupWriter> writer_,
-        const ContextPtr & context_,
-        bool is_internal_backup_,
-        const std::shared_ptr<IBackupCoordination> & coordination_,
-        const std::optional<UUID> & backup_uuid_,
-        bool deduplicate_files_,
-        bool use_same_s3_credentials_for_base_backup_,
-        bool use_same_password_for_base_backup_);
+        std::shared_ptr<IBackupWriter> writer_);
 
     ~BackupImpl() override;
 
@@ -117,6 +107,7 @@ private:
 
     std::unique_ptr<SeekableReadBuffer> readFileImpl(const SizeAndChecksum & size_and_checksum, bool read_encrypted) const;
 
+    const BackupFactory::CreateParams params;
     BackupInfo backup_info;
     const String backup_name_for_logging;
     const bool use_archive;
@@ -124,8 +115,6 @@ private:
     const OpenMode open_mode;
     std::shared_ptr<IBackupWriter> writer;
     std::shared_ptr<IBackupReader> reader;
-    const ContextPtr context;
-    const bool is_internal_backup;
     std::shared_ptr<IBackupCoordination> coordination;
 
     mutable std::mutex mutex;
@@ -155,9 +144,6 @@ private:
 
     bool writing_finalized = false;
     bool corrupted = false;
-    bool deduplicate_files = true;
-    bool use_same_s3_credentials_for_base_backup = false;
-    bool use_same_password_for_base_backup = false;
     const LoggerPtr log;
 };
 

--- a/src/Backups/registerBackupEngineAzureBlobStorage.cpp
+++ b/src/Backups/registerBackupEngineAzureBlobStorage.cpp
@@ -44,7 +44,7 @@ namespace
 
 void registerBackupEngineAzureBlobStorage(BackupFactory & factory)
 {
-    auto creator_fn = []([[maybe_unused]] const BackupFactory::CreateParams & params) -> std::unique_ptr<IBackup>
+    auto creator_fn = []([[maybe_unused]] BackupFactory::CreateParams params) -> std::unique_ptr<IBackup>
     {
 #if USE_AZURE_BLOB_STORAGE
         const String & id_arg = params.backup_info.id_arg;
@@ -124,6 +124,8 @@ void registerBackupEngineAzureBlobStorage(BackupFactory & factory)
         }
 
 
+        params.use_same_s3_credentials_for_base_backup = false;
+
         if (params.open_mode == IBackup::OpenMode::READ)
         {
             auto reader = std::make_shared<BackupReaderAzureBlobStorage>(
@@ -134,15 +136,7 @@ void registerBackupEngineAzureBlobStorage(BackupFactory & factory)
                 params.write_settings,
                 params.context);
 
-            return std::make_unique<BackupImpl>(
-                params.backup_info,
-                archive_params,
-                params.base_backup_info,
-                reader,
-                params.context,
-                params.is_internal_backup,
-                /* use_same_s3_credentials_for_base_backup*/ false,
-                params.use_same_password_for_base_backup);
+            return std::make_unique<BackupImpl>(params, archive_params, reader);
         }
 
         auto writer = std::make_shared<BackupWriterAzureBlobStorage>(
@@ -154,18 +148,7 @@ void registerBackupEngineAzureBlobStorage(BackupFactory & factory)
             params.context,
             params.azure_attempt_to_create_container);
 
-        return std::make_unique<BackupImpl>(
-            params.backup_info,
-            archive_params,
-            params.base_backup_info,
-            writer,
-            params.context,
-            params.is_internal_backup,
-            params.backup_coordination,
-            params.backup_uuid,
-            params.deduplicate_files,
-            /* use_same_s3_credentials_for_base_backup */ false,
-            params.use_same_password_for_base_backup);
+        return std::make_unique<BackupImpl>(params, archive_params, writer);
 
 #else
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "AzureBlobStorage support is disabled");

--- a/src/Backups/registerBackupEngineS3.cpp
+++ b/src/Backups/registerBackupEngineS3.cpp
@@ -115,15 +115,7 @@ void registerBackupEngineS3(BackupFactory & factory)
                                                            params.context,
                                                            params.is_internal_backup);
 
-            return std::make_unique<BackupImpl>(
-                params.backup_info,
-                archive_params,
-                params.base_backup_info,
-                reader,
-                params.context,
-                params.is_internal_backup,
-                params.use_same_s3_credentials_for_base_backup,
-                params.use_same_password_for_base_backup);
+            return std::make_unique<BackupImpl>(params, archive_params, reader);
         }
 
         auto writer = std::make_shared<BackupWriterS3>(
@@ -137,18 +129,7 @@ void registerBackupEngineS3(BackupFactory & factory)
             params.context,
             params.is_internal_backup);
 
-        return std::make_unique<BackupImpl>(
-            params.backup_info,
-            archive_params,
-            params.base_backup_info,
-            writer,
-            params.context,
-            params.is_internal_backup,
-            params.backup_coordination,
-            params.backup_uuid,
-            params.deduplicate_files,
-            params.use_same_s3_credentials_for_base_backup,
-            params.use_same_password_for_base_backup);
+        return std::make_unique<BackupImpl>(params, archive_params, writer);
 
 #else
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "S3 support is disabled");

--- a/src/Backups/registerBackupEnginesFileAndDisk.cpp
+++ b/src/Backups/registerBackupEnginesFileAndDisk.cpp
@@ -171,15 +171,7 @@ void registerBackupEnginesFileAndDisk(BackupFactory & factory)
                 reader = std::make_shared<BackupReaderFile>(path, params.read_settings, params.write_settings);
             else
                 reader = std::make_shared<BackupReaderDisk>(disk, path, params.read_settings, params.write_settings);
-            return std::make_unique<BackupImpl>(
-                params.backup_info,
-                archive_params,
-                params.base_backup_info,
-                reader,
-                params.context,
-                params.is_internal_backup,
-                params.use_same_s3_credentials_for_base_backup,
-                params.use_same_password_for_base_backup);
+            return std::make_unique<BackupImpl>(params, archive_params, reader);
         }
 
         std::shared_ptr<IBackupWriter> writer;
@@ -187,18 +179,7 @@ void registerBackupEnginesFileAndDisk(BackupFactory & factory)
             writer = std::make_shared<BackupWriterFile>(path, params.read_settings, params.write_settings);
         else
             writer = std::make_shared<BackupWriterDisk>(disk, path, params.read_settings, params.write_settings);
-        return std::make_unique<BackupImpl>(
-            params.backup_info,
-            archive_params,
-            params.base_backup_info,
-            writer,
-            params.context,
-            params.is_internal_backup,
-            params.backup_coordination,
-            params.backup_uuid,
-            params.deduplicate_files,
-            params.use_same_s3_credentials_for_base_backup,
-            params.use_same_password_for_base_backup);
+        return std::make_unique<BackupImpl>(params, archive_params, writer);
     };
 
     factory.registerBackupEngine("File", creator_fn);

--- a/tests/queries/0_stateless/02801_backup_native_copy.reference
+++ b/tests/queries/0_stateless/02801_backup_native_copy.reference
@@ -1,4 +1,8 @@
 BACKUP TABLE data TO S3(s3_conn, \'backups/default/data_native_copy\') SETTINGS allow_s3_native_copy=true	1
 BACKUP TABLE data TO S3(s3_conn, \'backups/default/data_no_native_copy\') SETTINGS allow_s3_native_copy=false	0
+BACKUP TABLE data TO S3(s3_conn, \'backups/default/data_native_copy_inc\') SETTINGS allow_s3_native_copy=true, base_backup=S3(s3_conn, \'backups/default/data_native_copy\')	0
+BACKUP TABLE data TO S3(s3_conn, \'backups/default/data_no_native_copy_inc\') SETTINGS allow_s3_native_copy=false, base_backup=S3(s3_conn, \'backups/default/data_no_native_copy\')	0
 RESTORE TABLE data AS data_native_copy FROM S3(s3_conn, \'backups/default/data_native_copy\') SETTINGS allow_s3_native_copy=true	1
 RESTORE TABLE data AS data_no_native_copy FROM S3(s3_conn, \'backups/default/data_no_native_copy\') SETTINGS allow_s3_native_copy=false	0
+RESTORE TABLE data AS data_native_copy_inc FROM S3(s3_conn, \'backups/default/data_native_copy_inc\') SETTINGS allow_s3_native_copy=true	1
+RESTORE TABLE data AS data_no_native_copy_inc FROM S3(s3_conn, \'backups/default/data_no_native_copy_inc\') SETTINGS allow_s3_native_copy=false	0

--- a/tests/queries/0_stateless/02801_backup_native_copy.sh
+++ b/tests/queries/0_stateless/02801_backup_native_copy.sh
@@ -14,29 +14,57 @@ $CLICKHOUSE_CLIENT -m -q "
     insert into data select * from numbers(10);
 "
 
+# BACKUP
 query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --format Null --query_id $query_id -q "BACKUP TABLE data TO S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy') SETTINGS allow_s3_native_copy=true"
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "BACKUP TABLE data TO S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy') SETTINGS allow_s3_native_copy=true"
+$CLICKHOUSE_CLIENT -m -q "
+    SYSTEM FLUSH LOGS;
+    SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
+"
+query_id=$(random_str 10)
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "BACKUP TABLE data TO S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy') SETTINGS allow_s3_native_copy=false"
 $CLICKHOUSE_CLIENT -m -q "
     SYSTEM FLUSH LOGS;
     SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
 "
 
+# BACKUP incremental
+# NOTE: due to base_backup S3CopyObject should be 0 here
 query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --format Null --query_id $query_id -q "BACKUP TABLE data TO S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy') SETTINGS allow_s3_native_copy=false"
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "BACKUP TABLE data TO S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy_inc') SETTINGS allow_s3_native_copy=true, base_backup=S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy')"
+$CLICKHOUSE_CLIENT -m -q "
+    SYSTEM FLUSH LOGS;
+    SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
+"
+query_id=$(random_str 10)
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "BACKUP TABLE data TO S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy_inc') SETTINGS allow_s3_native_copy=false, base_backup=S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy')"
 $CLICKHOUSE_CLIENT -m -q "
     SYSTEM FLUSH LOGS;
     SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
 "
 
+# RESTORE
 query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --format Null --query_id $query_id -q "RESTORE TABLE data AS data_native_copy FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy') SETTINGS allow_s3_native_copy=true"
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "RESTORE TABLE data AS data_native_copy FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy') SETTINGS allow_s3_native_copy=true"
 $CLICKHOUSE_CLIENT -m -q "
     SYSTEM FLUSH LOGS;
     SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
 "
-
 query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT --format Null --query_id $query_id -q "RESTORE TABLE data AS data_no_native_copy FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy') SETTINGS allow_s3_native_copy=false"
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "RESTORE TABLE data AS data_no_native_copy FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy') SETTINGS allow_s3_native_copy=false"
+$CLICKHOUSE_CLIENT -m -q "
+    SYSTEM FLUSH LOGS;
+    SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
+"
+# RESTORE from incremental backup
+query_id=$(random_str 10)
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "RESTORE TABLE data AS data_native_copy_inc FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_native_copy_inc') SETTINGS allow_s3_native_copy=true"
+$CLICKHOUSE_CLIENT -m -q "
+    SYSTEM FLUSH LOGS;
+    SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
+"
+query_id=$(random_str 10)
+$CLICKHOUSE_CLIENT --format Null --query_id "$query_id" -q "RESTORE TABLE data AS data_no_native_copy_inc FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy_inc') SETTINGS allow_s3_native_copy=false"
 $CLICKHOUSE_CLIENT -m -q "
     SYSTEM FLUSH LOGS;
     SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix native copy settings (`allow_s3_native_copy`/`allow_azure_native_copy`) for `RESTORE` from base backup

Before this patch the following settings has not been copied from the root backup query in case of base backup was used for RESTORE some files:
- allow_s3_native_copy
- allow_azure_native_copy

Now there is separate helper for this - CreateParams::cloneForReadBaseBackup()

Also now BackupImpl accept the whole CreateParams structure, over tons of bool flags.

Cc: @vitlibar 