### PR TITLE
Fix UnicodeDecodeError in cluster.shutdown()

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3230,7 +3230,7 @@ class ClickHouseCluster:
 
         if self.up_called:
             # Here errors='replace' because docker can sometimes write non-unicode characters to its output.
-            with open(self.docker_logs_path, "w+", errors='replace') as f:
+            with open(self.docker_logs_path, "w+", errors="replace") as f:
                 try:
                     subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
                         self.base_cmd + ["logs"], stdout=f

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3229,7 +3229,8 @@ class ClickHouseCluster:
         fatal_log = None
 
         if self.up_called:
-            with open(self.docker_logs_path, "w+") as f:
+            # Here errors='replace' because docker can sometimes write non-unicode characters to its output.
+            with open(self.docker_logs_path, "w+", errors='replace') as f:
                 try:
                     subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
                         self.base_cmd + ["logs"], stdout=f


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `UnicodeDecodeError` in `cluster.shutdown()`

This PR fixes https://github.com/ClickHouse/ClickHouse/issues/74332
