### PR TITLE
Fix detection of "use the Rewrite method in the JSON API" for native copy on GCS

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -83,10 +83,22 @@ bool Client::RetryStrategy::ShouldRetry(const Aws::Client::AWSError<Aws::Client:
         return false;
 
     if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
-            return false;
+        return false;
+
+    /// It does not make sense to retry when GCS suggest to use Rewrite
+    if (useGCSRewrite(error))
+        return false;
 
     return error.ShouldRetry();
 }
+
+bool Client::RetryStrategy::useGCSRewrite(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error)
+{
+    return error.GetResponseCode() == Aws::Http::HttpResponseCode::GATEWAY_TIMEOUT
+        && error.GetExceptionName() == "InternalError"
+        && error.GetMessage().contains("use the Rewrite method in the JSON API");
+}
+
 
 /// NOLINTNEXTLINE(google-runtime-int)
 long Client::RetryStrategy::CalculateDelayBeforeNextRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>&, long attemptedRetries) const

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -170,6 +170,16 @@ public:
         /// NOLINTNEXTLINE(google-runtime-int)
         long GetMaxAttempts() const override;
 
+        /// Sometimes [1] GCS may suggest to use Rewrite over CopyObject, i.e.:
+        ///
+        ///     AWSError 'InternalError': Copy spanning locations and/or storage classes could not complete within 30 seconds. Please use the Rewrite method in the JSON API (https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite) instead.
+        ///
+        /// Note, that GCS may return other errors (like EntityTooLarge), but
+        /// those are not retriable by default S3 RetryStrategy.
+        ///
+        ///   [1]: https://github.com/ClickHouse/ClickHouse/issues/59660
+        static bool useGCSRewrite(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error);
+
     private:
         uint32_t maxRetries;
         uint32_t scaleFactor;

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -759,9 +759,7 @@ namespace
                     outcome.GetError().GetExceptionName() == "InvalidRequest" ||
                     outcome.GetError().GetExceptionName() == "InvalidArgument" ||
                     outcome.GetError().GetExceptionName() == "AccessDenied" ||
-                    (outcome.GetError().GetExceptionName() == "InternalError" &&
-                        outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::GATEWAY_TIMEOUT &&
-                        outcome.GetError().GetMessage().contains("use the Rewrite method in the JSON API")))
+                    S3::Client::RetryStrategy::useGCSRewrite(outcome.GetError()))
                 {
                     if (!supports_multipart_copy || outcome.GetError().GetExceptionName() == "AccessDenied")
                     {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix detection of "use the Rewrite method in the JSON API" for native copy on GCS

The problem was that the default S3 retry strategy retries the 504 error [1], so the copyS3File() will never receive it:

    2025-01-08 13:46:17.149439      AWSClient       726     Response status: 504, Gateway Timeout
    2025-01-08 13:46:17.149646      AWSClient       726     AWSErrorMarshaller: Encountered AWSError 'InternalError': Copy spanning locations and/or storage classes could not complete within 30 seconds. Please use the Rewrite method in the JSON API (https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite) instead.
    2025-01-08 13:46:17.149831      AWSClient       726     AWSXmlClient: HTTP response code: 504
    Exception name: InternalError
    Error message: Copy spanning locations and/or storage classes could not complete within 30 seconds. Please use the Rewrite method in the JSON API (https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite) instead.
    2025-01-08 13:46:17.150249      AWSClient       726     If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.
    2025-01-08 13:46:17.150319      AWSClient       726     Request failed, now waiting 50 ms before attempting again.
    ...
    2025-01-08 13:46:45.169419      AWSClient       726     Response status: 504, Gateway Timeout
    2025-01-08 13:46:45.169718      AWSClient       726     AWSErrorMarshaller: Encountered AWSError 'InternalError': Copy spanning locations and/or storage classes could not complete within 30 seconds. Please use the Rewrite method in the JSON API (https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite) instead.

The last log came from contrib/aws code, not from the ClickHouse S3::Client, the later has "Will retry" message, that was not presented in the logs.

  [1]: https://github.com/aws/aws-sdk-cpp/blob/ed54ab193cbb847af27a5318979c0e5695e3e235/src/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h#L125

Note, what I noticed, that even after this error with couple of retries CopyObject may succeed, but this is not 100% case and it is better to fallback anyway to make progress faster.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/60164 (cc @kitaisreal @KochetovNicolai )
