### PR TITLE
chcache: add support for configurable source and target tables

### DIFF
--- a/rust/chcache/src/main.rs
+++ b/rust/chcache/src/main.rs
@@ -1,12 +1,17 @@
 use blake3::Hasher;
 use log::{info, trace, warn};
 use std::fs;
+use std::path::Path;
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(default)]
 struct Config {
     hostname: String,
     user: String,
     password: String,
+
+    source_table: String,
+    target_table: String,
 }
 
 impl Default for Config {
@@ -15,6 +20,9 @@ impl Default for Config {
             hostname: "https://build-cache.eu-west-1.aws.clickhouse-staging.com".to_string(),
             user: "reader".to_string(),
             password: "reader".to_string(),
+
+            source_table: "default.build_cache".to_string(),
+            target_table: "default.build_cache".to_string(),
         }
     }
 }
@@ -57,6 +65,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 hostname: std::env::var("CH_HOSTNAME").unwrap(),
                 user: std::env::var("CH_USER").unwrap(),
                 password: std::env::var("CH_PASSWORD").unwrap(),
+
+                ..Default::default()
             }
         }
         (false, false) => {
@@ -256,15 +266,18 @@ fn write_to_fscache(hash: &String, data: &Vec<u8>) {
 }
 
 async fn load_from_clickhouse(
+    config: &Config,
     client: &clickhouse::Client,
     hash: &String,
     compiler_version: &String,
 ) -> Result<Option<Vec<u8>>, clickhouse::error::Error> {
+    let query = format!("SELECT ?fields FROM {} WHERE hash = ? and compiler_version = ? LIMIT 1", &config.source_table);
+
     let mut cursor = client
-        .query("SELECT ?fields FROM default.build_cache WHERE hash = ? and compiler_version = ? LIMIT 1")
+        .query(&query)
         .bind(hash)
         .bind(compiler_version)
-        .fetch::<MyRow>()
+        .fetch::<CacheLine>()
         .unwrap();
 
     while let Some(row) = cursor.next().await? {
@@ -275,7 +288,7 @@ async fn load_from_clickhouse(
 }
 
 #[derive(Debug, clickhouse::Row, serde::Serialize, serde::Deserialize)]
-struct MyRow {
+struct CacheLine {
     #[serde(with = "serde_bytes")]
     blob: Vec<u8>,
     hash: String,
@@ -283,14 +296,15 @@ struct MyRow {
 }
 
 async fn load_to_clickhouse(
+    config: &Config,
     client: &clickhouse::Client,
     hash: &String,
     compiler_version: &String,
     data: &Vec<u8>,
 ) -> Result<(), clickhouse::error::Error> {
-    let mut insert = client.insert("default.build_cache").unwrap();
+    let mut insert = client.insert(&config.target_table).unwrap();
 
-    let row = MyRow {
+    let row = CacheLine {
         blob: data.clone(),
         hash: hash.clone(),
         compiler_version: compiler_version.clone(),
@@ -311,6 +325,9 @@ async fn compiler_cache_entrypoint(config: &Config) {
 
     let assumed_base_path = assume_base_path(&rest_of_args);
     trace!("Assumed base path: {}", assumed_base_path);
+
+    let is_private = Path::new(&assumed_base_path).join("PRIVATE.md").exists();
+    trace!("Is private: {}", is_private);
 
     let stripped_args = rest_of_args
         .iter()
@@ -368,7 +385,7 @@ async fn compiler_cache_entrypoint(config: &Config) {
             trace!("Cache miss");
 
             let compiled_bytes =
-                match load_from_clickhouse(&client, &total_hash, &compiler_version).await {
+                match load_from_clickhouse(config, &client, &total_hash, &compiler_version).await {
                     Ok(Some(bytes)) => {
                         did_load_from_cache = true;
                         info!("Loaded from ClickHouse");
@@ -397,10 +414,17 @@ async fn compiler_cache_entrypoint(config: &Config) {
     };
 
     write_to_fscache(&total_hash, &compiled_bytes);
-    if !did_load_from_cache && config.user != "reader" {
+
+    let should_upload = {
+        let default_config = Config::default();
+
+        !did_load_from_cache && config.user != default_config.user
+    };
+
+    if should_upload {
         loop {
             let upload_result =
-                load_to_clickhouse(&client, &total_hash, &compiler_version, &compiled_bytes).await;
+                load_to_clickhouse(config, &client, &total_hash, &compiler_version, &compiled_bytes).await;
             if upload_result.is_ok() {
                 info!("Uploaded to ClickHouse");
                 break;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Allow specifying which tables to use for cache reading and writing via config file.

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [x] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
