### PR TITLE
Validate numeric values when inserting into `Enum` column

### DIFF
--- a/tests/queries/0_stateless/02841_valid_json_and_xml_on_http_exception.reference
+++ b/tests/queries/0_stateless/02841_valid_json_and_xml_on_http_exception.reference
@@ -298,8 +298,8 @@ JSON
 			"type": "String"
 		},
 		{
-			"name": "y",
-			"type": "Enum8('a' = 1)"
+			"name": "throwIf(equals(y, 'b'))",
+			"type": "UInt8"
 		}
 	],
 
@@ -308,29 +308,29 @@ JSON
 		{
 			"x": 1,
 			"s": "str1",
-			"y": "a"
+			"throwIf(equals(y, 'b'))": 0
 		},
 		{
 			"x": 2,
 			"s": "str2",
-			"y": "a"
+			"throwIf(equals(y, 'b'))": 0
 		},
 		{
 			"x": 3,
 			"s": "str3",
-			"y": "a"
+			"throwIf(equals(y, 'b'))": 0
 		}
 	],
 
 	"rows": 3,
 
-	"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "
+	"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "
 }
 JSONEachRow
-{"x":1,"s":"str1","y":"a"}
-{"x":2,"s":"str2","y":"a"}
-{"x":3,"s":"str3","y":"a"}
-{"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONEachRowRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "}
+{"x":1,"s":"str1","throwIf(equals(y, 'b'))":0}
+{"x":2,"s":"str2","throwIf(equals(y, 'b'))":0}
+{"x":3,"s":"str3","throwIf(equals(y, 'b'))":0}
+{"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "}
 JSONCompact
 {
 	"meta":
@@ -344,33 +344,33 @@ JSONCompact
 			"type": "String"
 		},
 		{
-			"name": "y",
-			"type": "Enum8('a' = 1)"
+			"name": "throwIf(equals(y, 'b'))",
+			"type": "UInt8"
 		}
 	],
 
 	"data":
 	[
-		[1, "str1", "a"],
-		[2, "str2", "a"],
-		[3, "str3", "a"]
+		[1, "str1", 0],
+		[2, "str2", 0],
+		[3, "str3", 0]
 	],
 
 	"rows": 3,
 
-	"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONCompactRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "
+	"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "
 }
 JSONCompactEachRow
-[1, "str1", "a"]
-[2, "str2", "a"]
-[3, "str3", "a"]
-["Code: 691. : Unexpected value 99 in enum: While executing JSONCompactEachRowRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "]
+[1, "str1", 0]
+[2, "str2", 0]
+[3, "str3", 0]
+["Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "]
 JSONObjectEachRow
 {
-	"row_1": {"x":1,"s":"str1","y":"a"},
-	"row_2": {"x":2,"s":"str2","y":"a"},
-	"row_3": {"x":3,"s":"str3","y":"a"},
-	"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONObjectEachRowRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "
+	"row_1": {"x":1,"s":"str1","throwIf(equals(y, 'b'))":0},
+	"row_2": {"x":2,"s":"str2","throwIf(equals(y, 'b'))":0},
+	"row_3": {"x":3,"s":"str3","throwIf(equals(y, 'b'))":0},
+	"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "
 }
 XML
 <?xml version='1.0' encoding='UTF-8' ?>
@@ -386,8 +386,8 @@ XML
 				<type>String</type>
 			</column>
 			<column>
-				<name>y</name>
-				<type>Enum8('a' = 1)</type>
+				<name>throwIf(equals(y, 'b'))</name>
+				<type>UInt8</type>
 			</column>
 		</columns>
 	</meta>
@@ -395,21 +395,21 @@ XML
 		<row>
 			<x>1</x>
 			<s>str1</s>
-			<y>a</y>
+			<field>0</field>
 		</row>
 		<row>
 			<x>2</x>
 			<s>str2</s>
-			<y>a</y>
+			<field>0</field>
 		</row>
 		<row>
 			<x>3</x>
 			<s>str3</s>
-			<y>a</y>
+			<field>0</field>
 		</row>
 	</data>
 	<rows>3</rows>
-	<exception>Code: 691. : Unexpected value 99 in enum: While executing XMLRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) </exception>
+	<exception>Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) </exception>
 </result>
 With parallel formatting
 JSON
@@ -685,8 +685,8 @@ JSON
 			"type": "String"
 		},
 		{
-			"name": "y",
-			"type": "Enum8('a' = 1)"
+			"name": "throwIf(equals(y, 'b'))",
+			"type": "UInt8"
 		}
 	],
 
@@ -697,10 +697,10 @@ JSON
 
 	"rows": 0,
 
-	"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "
+	"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "
 }
 JSONEachRow
-{"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONEachRowRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "}
+{"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "}
 JSONCompact
 {
 	"meta":
@@ -714,8 +714,8 @@ JSONCompact
 			"type": "String"
 		},
 		{
-			"name": "y",
-			"type": "Enum8('a' = 1)"
+			"name": "throwIf(equals(y, 'b'))",
+			"type": "UInt8"
 		}
 	],
 
@@ -726,13 +726,13 @@ JSONCompact
 
 	"rows": 0,
 
-	"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONCompactRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "
+	"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "
 }
 JSONCompactEachRow
-["Code: 691. : Unexpected value 99 in enum: While executing JSONCompactEachRowRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "]
+["Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "]
 JSONObjectEachRow
 {
-	"exception": "Code: 691. : Unexpected value 99 in enum: While executing JSONObjectEachRowRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) "
+	"exception": "Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) "
 }
 XML
 <?xml version='1.0' encoding='UTF-8' ?>
@@ -748,15 +748,15 @@ XML
 				<type>String</type>
 			</column>
 			<column>
-				<name>y</name>
-				<type>Enum8('a' = 1)</type>
+				<name>throwIf(equals(y, 'b'))</name>
+				<type>UInt8</type>
 			</column>
 		</columns>
 	</meta>
 	<data>
 	</data>
 	<rows>0</rows>
-	<exception>Code: 691. : Unexpected value 99 in enum: While executing XMLRowOutputFormat. (UNKNOWN_ELEMENT_OF_ENUM) </exception>
+	<exception>Code: 395. : Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(equals(y, 'b') :: 4) -> throwIf(equals(y, 'b')) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) </exception>
 </result>
 With parallel formatting
 JSON


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

A part of #https://github.com/ClickHouse/ClickHouse/issues/69683
The `NULL` value is treated differently and is not covered by this fix.

Tests are TODO, I'd like to check the state of the existing tests first.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Validate numeric values when inserting into the Enum column. An enum should only store values listed in the type definition. While this is true for the Enum names, numeric values are inserted without validation, leading to repetitive 'Unexpected value in enum' errors when executing background tasks. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
