### PR TITLE
tests: fix test_store_cleanup flakiness

### DIFF
--- a/tests/integration/test_store_cleanup/test.py
+++ b/tests/integration/test_store_cleanup/test.py
@@ -22,6 +22,12 @@ def started_cluster():
 
 
 def test_store_cleanup(started_cluster):
+    sync_drop = {"database_atomic_wait_for_drop_and_detach_synchronously": True}
+
+    node1.query("DROP DATABASE IF EXISTS db", settings=sync_drop)
+    node1.query("DROP DATABASE IF EXISTS db2", settings=sync_drop)
+    node1.query("DROP DATABASE IF EXISTS db3", settings=sync_drop)
+
     node1.query("CREATE DATABASE db UUID '10000000-1000-4000-8000-000000000001'")
     node1.query(
         "CREATE TABLE db.log UUID '10000000-1000-4000-8000-000000000002' ENGINE=Log AS SELECT 1"
@@ -37,10 +43,7 @@ def test_store_cleanup(started_cluster):
     node1.query(
         "CREATE TABLE db2.log UUID '20000000-1000-4000-8000-000000000002' ENGINE=Log AS SELECT 1"
     )
-    node1.query(
-        "DETACH DATABASE db2",
-        settings={"database_atomic_wait_for_drop_and_detach_synchronously": True},
-    )
+    node1.query("DETACH DATABASE db2", settings=sync_drop)
 
     node1.query("CREATE DATABASE db3 UUID '30000000-1000-4000-8000-000000000001'")
     node1.query(
@@ -87,10 +90,7 @@ def test_store_cleanup(started_cluster):
     )
 
     node1.start_clickhouse()
-    node1.query(
-        "DETACH DATABASE db2",
-        settings={"database_atomic_wait_for_drop_and_detach_synchronously": True},
-    )
+    node1.query("DETACH DATABASE db2", settings=sync_drop)
     node1.query("DETACH TABLE db3.log")
 
     node1.wait_for_log_line(

--- a/tests/integration/test_store_cleanup/test.py
+++ b/tests/integration/test_store_cleanup/test.py
@@ -37,7 +37,10 @@ def test_store_cleanup(started_cluster):
     node1.query(
         "CREATE TABLE db2.log UUID '20000000-1000-4000-8000-000000000002' ENGINE=Log AS SELECT 1"
     )
-    node1.query("DETACH DATABASE db2")
+    node1.query(
+        "DETACH DATABASE db2",
+        settings={"database_atomic_wait_for_drop_and_detach_synchronously": True},
+    )
 
     node1.query("CREATE DATABASE db3 UUID '30000000-1000-4000-8000-000000000001'")
     node1.query(
@@ -84,7 +87,10 @@ def test_store_cleanup(started_cluster):
     )
 
     node1.start_clickhouse()
-    node1.query("DETACH DATABASE db2")
+    node1.query(
+        "DETACH DATABASE db2",
+        settings={"database_atomic_wait_for_drop_and_detach_synchronously": True},
+    )
     node1.query("DETACH TABLE db3.log")
 
     node1.wait_for_log_line(


### PR DESCRIPTION
CI found [1], likely this is because of the asynchronous metrics, let's simply force synchronous DETACH.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/74338/063a6549d2d3747109d03eba1913876c5b03e903/integration_tests__aarch64__[5_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)