### PR TITLE
Fix "Failed to make request to X redirect to X" log message

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -368,7 +368,7 @@ void ReadWriteBufferFromHTTP::doWithRetries(std::function<void()> && callable,
                           "Failed to make request to '{}'{}. "
                           "Error: '{}'. "
                           "Failed at try {}/{}.",
-                          initial_uri.toString(), current_uri == initial_uri ? String() : fmt::format(" redirect to '{}'", current_uri.toString()),
+                          initial_uri.toString(), current_uri.toString() == initial_uri.toString() ? String() : fmt::format(" redirect to '{}'", current_uri.toString()),
                           error_message,
                           attempt, read_settings.http_max_tries);
 
@@ -385,7 +385,7 @@ void ReadWriteBufferFromHTTP::doWithRetries(std::function<void()> && callable,
                          "Error: {}. "
                          "Failed at try {}/{}. "
                          "Will retry with current backoff wait is {}/{} ms.",
-                         initial_uri.toString(), current_uri == initial_uri ? String() : fmt::format(" redirect to '{}'", current_uri.toString()),
+                         initial_uri.toString(), current_uri.toString() == initial_uri.toString() ? String() : fmt::format(" redirect to '{}'", current_uri.toString()),
                          error_message,
                          attempt + 1, read_settings.http_max_tries,
                          milliseconds_to_wait, read_settings.http_retry_max_backoff_ms);


### PR DESCRIPTION
URI comparator does not normalize URI, so it can misleadingly assume that there was redirect (due to initial does not match current URI)

Example:

    2025.01.08 21:28:50.671210 [ 174090 ] {} <Debug> ReadWriteBufferFromHTTP: Failed to make request to 'http://ip-172-31-21-71:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2Ftest_5diqvuuq%2Fdata%2Freplicas%2Fdata_r1&part=all_2_2_0&client_protocol_version=8&compress=false' redirect to 'http://ip-172-31-21-71:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2Ftest_5diqvuuq%2Fdata%2Freplicas%2Fdata_r1&part=all_2_2_0&client_protocol_version=8&compress=false'. Error: 'Invalid argument'. Failed at try 1/1.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)