### PR TITLE
Add address to socket errors

### DIFF
--- a/base/poco/Net/src/SocketImpl.cpp
+++ b/base/poco/Net/src/SocketImpl.cpp
@@ -943,9 +943,9 @@ void SocketImpl::error(int code, const std::string& arg)
 	case POCO_EACCES:
 		throw IOException("Permission denied", code);
 	case POCO_EFAULT:
-		throw IOException("Bad address", code);
+		throw IOException("Bad address", arg, code);
 	case POCO_EINVAL:
-		throw InvalidArgumentException(code);
+		throw InvalidArgumentException("Invalid argument", arg, code);
 	case POCO_EMFILE:
 		throw IOException("Too many open files", code);
 	case POCO_EWOULDBLOCK:
@@ -955,35 +955,35 @@ void SocketImpl::error(int code, const std::string& arg)
 	case POCO_EALREADY:
 		throw IOException("Operation already in progress", code);
 	case POCO_ENOTSOCK:
-		throw IOException("Socket operation attempted on non-socket", code);
+		throw IOException("Socket operation attempted on non-socket", arg, code);
 	case POCO_EDESTADDRREQ:
-		throw NetException("Destination address required", code);
+		throw NetException("Destination address required", arg, code);
 	case POCO_EMSGSIZE:
 		throw NetException("Message too long", code);
 	case POCO_EPROTOTYPE:
-		throw NetException("Wrong protocol type", code);
+		throw NetException("Wrong protocol type", arg, code);
 	case POCO_ENOPROTOOPT:
-		throw NetException("Protocol not available", code);
+		throw NetException("Protocol not available", arg, code);
 	case POCO_EPROTONOSUPPORT:
-		throw NetException("Protocol not supported", code);
+		throw NetException("Protocol not supported", arg, code);
 	case POCO_ESOCKTNOSUPPORT:
-		throw NetException("Socket type not supported", code);
+		throw NetException("Socket type not supported", arg, code);
 	case POCO_ENOTSUP:
 		throw NetException("Operation not supported", code);
 	case POCO_EPFNOSUPPORT:
 		throw NetException("Protocol family not supported", code);
 	case POCO_EAFNOSUPPORT:
-		throw NetException("Address family not supported", code);
+		throw NetException("Address family not supported", arg, code);
 	case POCO_EADDRINUSE:
 		throw NetException("Address already in use", arg, code);
 	case POCO_EADDRNOTAVAIL:
 		throw NetException("Cannot assign requested address", arg, code);
 	case POCO_ENETDOWN:
-		throw NetException("Network is down", code);
+		throw NetException("Network is down", arg, code);
 	case POCO_ENETUNREACH:
-		throw NetException("Network is unreachable", code);
+		throw NetException("Network is unreachable", arg, code);
 	case POCO_ENETRESET:
-		throw NetException("Network dropped connection on reset", code);
+		throw NetException("Network dropped connection on reset", arg, code);
 	case POCO_ECONNABORTED:
 		throw ConnectionAbortedException(code);
 	case POCO_ECONNRESET:
@@ -1008,7 +1008,7 @@ void SocketImpl::error(int code, const std::string& arg)
 	case EPIPE:
 		throw IOException("Broken pipe", code);
 	case EBADF:
-		throw IOException("Bad socket descriptor", code);
+		throw IOException("Bad socket descriptor", arg, code);
 	case ENOENT:
 		throw IOException("Not found", arg, code);
 #endif


### PR DESCRIPTION
Recently CI found this [1]:

    $ zstd -cdq server.log.zst  | grep -a -F -e 'ip-172-31-21-71' -e '2001:db8:1::1' | head
    2025.01.08 21:25:20.567951 [ 174075 ] {} <Debug> ReadWriteBufferFromHTTP: Failed to make request to 'http://ip-172-31-21-71:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2F00814_replicated_minimalistic_part_header_zookeeper_test_4f4fry9v%2Ftest_00814%2Fpart_header%2Fs1%2Freplicas%2F1r1&part=all_0_0_0&client_protocol_version=8&compress=false' redirect to 'http://ip-172-31-21-71:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Fclickhouse%2Ftables%2F00814_replicated_minimalistic_part_header_zookeeper_test_4f4fry9v%2Ftest_00814%2Fpart_header%2Fs1%2Freplicas%2F1r1&part=all_0_0_0&client_protocol_version=8&compress=false'. Error: 'Invalid argument'. Failed at try 1/1.
    2025.01.08 21:25:59.250675 [ 174071 ] {} <Debug> ReadWriteBufferFromHTTP: Failed to make request to 'http://ip-172-31-21-71:9009/?endpoint=DataPartsExchange%3Adefault%3A%2F02898_parallel_replicas%2Ftest_gy3mvpjl%2Ftest_tbl%2Freplicas%2Fr2&part=all_1_1_0&client_protocol_version=8&compress=false' redirect to 'http://ip-172-31-21-71:9009/?endpoint=DataPartsExchange%3Adefault%3A%2F02898_parallel_replicas%2Ftest_gy3mvpjl%2Ftest_tbl%2Freplicas%2Fr2&part=all_1_1_0&client_protocol_version=8&compress=false'. Error: 'Timeout: connect timed out: [2001:db8:1::1]:9009'. Failed at try 1/1.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/74286/5a602b5f185ee61474dc14a6bff9c0f1ef44903b/fast_test.html

My guess is that there was an IPv6 address that lead to EINVAL, let's improve logging to catch this.

Note, that simply disable ipv6 stack leads to EADDRNOTAVAIL not EINVAL:

    $ docker run --rm -it --sysctl net.ipv6.conf.all.disable_ipv6=1 ubuntu
    $ curl ipv6.google.com
    connect(5, {sa_family=AF_INET6, sin6_port=htons(80), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2a00:1450:400e:80f::200e", &sin6_addr), sin6_scope_id=0}, 28) = -1 EADDRNOTAVAIL (Cannot assign requested address)
    curl: (7) Failed to connect to ipv6.google.com port 80 after 14 ms: Couldn't connect to server

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)