### PR TITLE
CI scripts: remove deprecated broken `utcnow` from Python

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -188,7 +188,7 @@ class Result(MetaClasses.Serializable):
         if self.duration:
             return self
         if self.start_time:
-            self.duration = datetime.datetime.utcnow().timestamp() - self.start_time
+            self.duration = datetime.datetime.now().timestamp() - self.start_time
         else:
             print(
                 f"NOTE: start_time is not set for job [{self.name}] Result - do not update duration"

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -420,7 +420,7 @@ class Utils:
 
     @staticmethod
     def timestamp():
-        return datetime.utcnow().timestamp()
+        return datetime.now().timestamp()
 
     @staticmethod
     def timestamp_to_str(timestamp):
@@ -558,11 +558,11 @@ class Utils:
 
     class Stopwatch:
         def __init__(self):
-            self.start_time = datetime.utcnow().timestamp()
+            self.start_time = datetime.now().timestamp()
 
         @property
         def duration(self) -> float:
-            return datetime.utcnow().timestamp() - self.start_time
+            return datetime.now().timestamp() - self.start_time
 
 
 class TeePopen:

--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -459,7 +459,9 @@ class JobReport:
 
     @staticmethod
     def get_start_time_from_current():
-        return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        return datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
 
     @classmethod
     def create_dummy(cls, status: str, job_skipped: bool) -> "JobReport":
@@ -481,7 +483,7 @@ class JobReport:
             start_time = datetime.datetime.strptime(
                 self.start_time, "%Y-%m-%d %H:%M:%S"
             )
-            current_time = datetime.datetime.now()
+            current_time = datetime.datetime.now(datetime.timezone.utc)
             self.duration = (current_time - start_time).total_seconds()
 
     def __post_init__(self):

--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -459,7 +459,7 @@ class JobReport:
 
     @staticmethod
     def get_start_time_from_current():
-        return datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     @classmethod
     def create_dummy(cls, status: str, job_skipped: bool) -> "JobReport":
@@ -481,7 +481,7 @@ class JobReport:
             start_time = datetime.datetime.strptime(
                 self.start_time, "%Y-%m-%d %H:%M:%S"
             )
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now()
             self.duration = (current_time - start_time).total_seconds()
 
     def __post_init__(self):

--- a/tests/ci/stopwatch.py
+++ b/tests/ci/stopwatch.py
@@ -9,12 +9,12 @@ class Stopwatch:
 
     @property
     def duration_seconds(self) -> float:
-        return (datetime.datetime.utcnow() - self.start_time).total_seconds()
+        return (datetime.datetime.now() - self.start_time).total_seconds()
 
     @property
     def start_time_str(self) -> str:
         return self.start_time_str_value
 
     def reset(self) -> None:
-        self.start_time = datetime.datetime.utcnow()
+        self.start_time = datetime.datetime.now()
         self.start_time_str_value = self.start_time.strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/ci/stopwatch.py
+++ b/tests/ci/stopwatch.py
@@ -9,12 +9,14 @@ class Stopwatch:
 
     @property
     def duration_seconds(self) -> float:
-        return (datetime.datetime.now() - self.start_time).total_seconds()
+        return (
+            datetime.datetime.now(datetime.timezone.utc) - self.start_time
+        ).total_seconds()
 
     @property
     def start_time_str(self) -> str:
         return self.start_time_str_value
 
     def reset(self) -> None:
-        self.start_time = datetime.datetime.now()
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
         self.start_time_str_value = self.start_time.strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/fuzz/runner.py
+++ b/tests/fuzz/runner.py
@@ -18,14 +18,14 @@ class Stopwatch:
 
     @property
     def duration_seconds(self) -> float:
-        return (datetime.datetime.utcnow() - self.start_time).total_seconds()
+        return (datetime.datetime.now() - self.start_time).total_seconds()
 
     @property
     def start_time_str(self) -> str:
         return self.start_time_str_value
 
     def reset(self) -> None:
-        self.start_time = datetime.datetime.utcnow()
+        self.start_time = datetime.datetime.now()
         self.start_time_str_value = self.start_time.strftime("%Y-%m-%d %H:%M:%S")
 
 

--- a/tests/fuzz/runner.py
+++ b/tests/fuzz/runner.py
@@ -18,14 +18,16 @@ class Stopwatch:
 
     @property
     def duration_seconds(self) -> float:
-        return (datetime.datetime.now() - self.start_time).total_seconds()
+        return (
+            datetime.datetime.now(datetime.timezone.utc) - self.start_time
+        ).total_seconds()
 
     @property
     def start_time_str(self) -> str:
         return self.start_time_str_value
 
     def reset(self) -> None:
-        self.start_time = datetime.datetime.now()
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
         self.start_time_str_value = self.start_time.strftime("%Y-%m-%d %H:%M:%S")
 
 

--- a/tests/integration/test_storage_url_with_proxy/test.py
+++ b/tests/integration/test_storage_url_with_proxy/test.py
@@ -3,7 +3,7 @@ import hashlib
 import hmac
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -64,7 +64,7 @@ def test_s3_with_proxy_list(cluster):
     )
 
     content_type = "application/zstd"
-    date = datetime.now(datetime.timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
+    date = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S %z")
     resource = "/root/data/ch-proxy-test/test.csv"
     get_sig_string = f"GET\n\n{content_type}\n{date}\n{resource}"
     password = "minio123"

--- a/tests/integration/test_storage_url_with_proxy/test.py
+++ b/tests/integration/test_storage_url_with_proxy/test.py
@@ -64,7 +64,7 @@ def test_s3_with_proxy_list(cluster):
     )
 
     content_type = "application/zstd"
-    date = datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S +0000")
+    date = datetime.now().strftime("%a, %d %b %Y %H:%M:%S +0000")
     resource = "/root/data/ch-proxy-test/test.csv"
     get_sig_string = f"GET\n\n{content_type}\n{date}\n{resource}"
     password = "minio123"

--- a/tests/integration/test_storage_url_with_proxy/test.py
+++ b/tests/integration/test_storage_url_with_proxy/test.py
@@ -64,7 +64,7 @@ def test_s3_with_proxy_list(cluster):
     )
 
     content_type = "application/zstd"
-    date = datetime.now().strftime("%a, %d %b %Y %H:%M:%S +0000")
+    date = datetime.now(datetime.timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
     resource = "/root/data/ch-proxy-test/test.csv"
     get_sig_string = f"GET\n\n{content_type}\n{date}\n{resource}"
     password = "minio123"

--- a/tests/integration/test_storage_url_with_proxy/test.py
+++ b/tests/integration/test_storage_url_with_proxy/test.py
@@ -59,6 +59,7 @@ def test_s3_with_proxy_list(cluster):
         """
         INSERT INTO FUNCTION
         s3('http://minio1:9001/root/data/ch-proxy-test/test.csv', 'minio', 'minio123', 'CSV', 'key String, value String')
+        SETTINGS s3_truncate_on_insert=1
         VALUES ('color','red'),('size','10')
         """
     )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use `datetime.now` instead of `utcnow`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

```
  DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled
    for removal in a future version. Use timezone-aware objects to represent
    datetimes in UTC: datetime.datetime.now(datetime.UTC).
        "utcnow": datetime.utcnow(),
```

See the article why utcnow is broken https://habr.com/ru/articles/502088/


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
