### PR TITLE
Populate version_history from RunConfig job

### DIFF
--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -934,7 +935,7 @@ def _upload_build_profile_data(
 
 def _add_build_to_version_history(
     pr_info: PRInfo,
-    job_report: JobReport,
+    start_time: str,
     version: str,
     docker_tag: str,
     ch_helper: ClickHouseHelper,
@@ -943,7 +944,7 @@ def _add_build_to_version_history(
     assert pr_info.sha and pr_info.commit_html_url and pr_info.head_ref and version
 
     data = {
-        "check_start_time": job_report.start_time,
+        "check_start_time": start_time,
         "pull_request_number": pr_info.number,
         "pull_request_url": pr_info.pr_html_url,
         "commit_sha": pr_info.sha,
@@ -1159,6 +1160,14 @@ def main() -> int:
                 },
             }
         result["docker_data"] = docker_data
+        ch_helper = ClickHouseHelper()
+        _add_build_to_version_history(
+            pr_info,
+            datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            result["version"],
+            result["build"],
+            ch_helper,
+        )
     ### CONFIGURE action: end
 
     ### PRE action: start
@@ -1294,14 +1303,6 @@ def main() -> int:
                 db="default", table="checks", events=prepared_events
             )
 
-            if "DockerServerImage" in args.job_name and indata is not None:
-                _add_build_to_version_history(
-                    pr_info,
-                    job_report,
-                    indata["version"],
-                    indata["build"],
-                    ch_helper,
-                )
         elif job_report.job_skipped:
             print(f"Skipped after rerun check {[args.job_name]} - do nothing")
         else:

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -943,11 +943,14 @@ def _add_build_to_version_history(
     # with some probability we will not silently break this logic
     assert pr_info.sha and pr_info.commit_html_url and pr_info.head_ref and version
 
+    commit = get_commit(GitHub(get_best_robot_token()), pr_info.sha)
+    parents = [p.sha for p in commit.parents]
     data = {
         "check_start_time": start_time,
         "pull_request_number": pr_info.number,
         "pull_request_url": pr_info.pr_html_url,
         "commit_sha": pr_info.sha,
+        "parent_commits_sha": parents,
         "commit_url": pr_info.commit_html_url,
         "version": version,
         "docker_tag": docker_tag,

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -124,7 +124,7 @@ class PRInfo:
         self.merged_pr = 0
         self.labels = set()
 
-        repo_prefix = f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}"
+        self.repo_prefix = f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}"
         self.task_url = GITHUB_RUN_URL
         self.repo_full_name = GITHUB_REPOSITORY
 
@@ -174,9 +174,6 @@ class PRInfo:
             else:
                 self.sha = github_event["pull_request"]["head"]["sha"]
 
-            self.commit_html_url = f"{repo_prefix}/commit/{self.sha}"
-            self.pr_html_url = f"{repo_prefix}/pull/{self.number}"
-
             # master or backport/xx.x/xxxxx - where the PR will be merged
             self.base_ref = github_event["pull_request"]["base"]["ref"]
             # ClickHouse/ClickHouse
@@ -225,7 +222,6 @@ class PRInfo:
                 .replace("{base}", base_sha)
                 .replace("{head}", self.sha)
             )
-            self.commit_html_url = f"{repo_prefix}/commit/{self.sha}"
 
         elif "commits" in github_event:
             self.event_type = EventType.PUSH
@@ -239,7 +235,6 @@ class PRInfo:
                     logging.error("Failed to convert %s to integer", merged_pr)
             self.sha = github_event["after"]
             pull_request = get_pr_for_commit(self.sha, github_event["ref"])
-            self.commit_html_url = f"{repo_prefix}/commit/{self.sha}"
 
             if pull_request is None or pull_request["state"] == "closed":
                 # it's merged PR to master
@@ -247,7 +242,6 @@ class PRInfo:
                 if pull_request:
                     self.merged_pr = pull_request["number"]
                 self.labels = set()
-                self.pr_html_url = f"{repo_prefix}/commits/{ref}"
                 self.base_ref = ref
                 self.base_name = self.repo_full_name
                 self.head_ref = ref
@@ -313,8 +307,6 @@ class PRInfo:
                 "GITHUB_SHA", "0000000000000000000000000000000000000000"
             )
             self.number = 0
-            self.commit_html_url = f"{repo_prefix}/commit/{self.sha}"
-            self.pr_html_url = f"{repo_prefix}/commits/{ref}"
             self.base_ref = ref
             self.base_name = self.repo_full_name
             self.head_ref = ref
@@ -322,6 +314,23 @@ class PRInfo:
 
         if need_changed_files:
             self.fetch_changed_files()
+
+    @property
+    def pr_html_url(self) -> str:
+        if getattr(self, "_pr_html_url", None) is not None:
+            return self._pr_html_url
+
+        if self.number != 0:
+            return f"{self.repo_prefix}/pull/{self.number}"
+        return f"{self.repo_prefix}/commits/{self.base_ref}"
+
+    @pr_html_url.setter
+    def pr_html_url(self, url: str) -> None:
+        self._pr_html_url = url
+
+    @property
+    def commit_html_url(self) -> str:
+        return f"{self.repo_prefix}/commit/{self.sha}"
 
     @property
     def is_master(self) -> bool:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make `version_helper` populated from every commit.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
