### PR TITLE
Unflake `test_non_default_compression`

### DIFF
--- a/tests/integration/test_non_default_compression/test.py
+++ b/tests/integration/test_non_default_compression/test.py
@@ -105,6 +105,9 @@ def test_preconfigured_default_codec(start_cluster):
             )
             == "10003\n"
         )
+        node.query(
+            "DROP TABLE compression_codec_multiple_with_key;"
+        )
 
 
 def test_preconfigured_custom_codec(start_cluster):
@@ -178,6 +181,10 @@ def test_preconfigured_custom_codec(start_cluster):
         == "11\n"
     )
 
+    node3.query(
+        "DROP TABLE compression_codec_multiple_with_key;"
+    )
+
 
 def test_uncompressed_cache_custom_codec(start_cluster):
     node4.query(
@@ -215,6 +222,10 @@ def test_uncompressed_cache_custom_codec(start_cluster):
         == "10000\n"
     )
 
+    node4.query(
+        "DROP TABLE compression_codec_multiple_with_key;"
+    )
+
 
 def test_uncompressed_cache_plus_zstd_codec(start_cluster):
     node5.query(
@@ -239,4 +250,8 @@ def test_uncompressed_cache_plus_zstd_codec(start_cluster):
             "SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1"
         )
         == "10000\n"
+    )
+
+    node5.query(
+        "DROP TABLE compression_codec_multiple_with_key;"
     )

--- a/tests/integration/test_non_default_compression/test.py
+++ b/tests/integration/test_non_default_compression/test.py
@@ -105,9 +105,7 @@ def test_preconfigured_default_codec(start_cluster):
             )
             == "10003\n"
         )
-        node.query(
-            "DROP TABLE compression_codec_multiple_with_key;"
-        )
+        node.query("DROP TABLE compression_codec_multiple_with_key;")
 
 
 def test_preconfigured_custom_codec(start_cluster):
@@ -181,9 +179,7 @@ def test_preconfigured_custom_codec(start_cluster):
         == "11\n"
     )
 
-    node3.query(
-        "DROP TABLE compression_codec_multiple_with_key;"
-    )
+    node3.query("DROP TABLE compression_codec_multiple_with_key;")
 
 
 def test_uncompressed_cache_custom_codec(start_cluster):
@@ -222,9 +218,7 @@ def test_uncompressed_cache_custom_codec(start_cluster):
         == "10000\n"
     )
 
-    node4.query(
-        "DROP TABLE compression_codec_multiple_with_key;"
-    )
+    node4.query("DROP TABLE compression_codec_multiple_with_key;")
 
 
 def test_uncompressed_cache_plus_zstd_codec(start_cluster):
@@ -252,6 +246,4 @@ def test_uncompressed_cache_plus_zstd_codec(start_cluster):
         == "10000\n"
     )
 
-    node5.query(
-        "DROP TABLE compression_codec_multiple_with_key;"
-    )
+    node5.query("DROP TABLE compression_codec_multiple_with_key;")


### PR DESCRIPTION
The flakiness check only runs changed tests, `test_non_default_compression` is changed in another PR of mine. I noticed that it was flaky even before the other PR but no one bothered. Therefore fixing it separately in this PR. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)