### PR TITLE
Add missed include <stdlib.h> && <vector>

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -107,6 +107,7 @@
 #    if defined(DEBUG_OR_SANITIZER_BUILD)
         // clang-format off
         #include <base/types.h>
+        #include <stdlib.h>
         namespace DB
         {
             [[noreturn]] void abortOnFailedAssertion(const String & description);

--- a/src/Backups/BackupStatus.h
+++ b/src/Backups/BackupStatus.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <base/types.h>
-
+#include <vector>
 
 namespace DB
 {

--- a/src/IO/HTTPHeaderEntries.h
+++ b/src/IO/HTTPHeaderEntries.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <vector>
 
 namespace DB
 {


### PR DESCRIPTION
<!---
[Here](https://github.com/4JustMe4/ClickHouse/commit/055af4b755fc60f6876c43471f466acf99727f14#diff-6ba2a33f2d009b6e85faff831f43f344942fd312ddb796da61df884b936b7155R117) abort was called without include
-->

### Changelog category (leave one):
Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes
After defining _LIBCPP_REMOVE_TRANSITIVE_INCLUDES in libc++, some of the transitive includes will disappear.
Therefore, we have to include them explicitly