### PR TITLE
Fix typo in validate_enum_literals_in_operators

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -103,7 +103,7 @@ namespace Setting
     extern const SettingsOverflowMode set_overflow_mode;
     extern const SettingsBool single_join_prefer_left_table;
     extern const SettingsBool transform_null_in;
-    extern const SettingsBool validate_enum_literals_in_opearators;
+    extern const SettingsBool validate_enum_literals_in_operators;
     extern const SettingsUInt64 use_structure_from_insertion_table_in_table_functions;
     extern const SettingsBool allow_suspicious_types_in_group_by;
     extern const SettingsBool allow_suspicious_types_in_order_by;
@@ -3500,7 +3500,7 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                 first_argument_constant_type, second_argument_constant_literal, second_argument_constant_type,
                 GetSetElementParams{
                     .transform_null_in = settings[Setting::transform_null_in],
-                    .forbid_unknown_enum_values = settings[Setting::validate_enum_literals_in_opearators],
+                    .forbid_unknown_enum_values = settings[Setting::validate_enum_literals_in_operators],
                 });
 
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5876,7 +5876,7 @@ Allows a more general join planning algorithm that can handle more complex condi
 When creating a `Merge` table without an explicit schema or when using the `merge` table function, infer schema as a union of not more than the specified number of matching tables.
 If there is a larger number of tables, the schema will be inferred from the first specified number of tables.
 )", 0) \
-    DECLARE(Bool, validate_enum_literals_in_opearators, false, R"(
+    DECLARE(Bool, validate_enum_literals_in_operators, false, R"(
 If enabled, validate enum literals in operators like `IN`, `NOT IN`, `==`, `!=` against the enum type and throw an exception if the literal is not a valid enum value.
 )", 0) \
     \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -95,7 +95,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"output_format_pretty_fallback_to_vertical_min_table_width", 0, 1000, "A new setting"},
             {"merge_table_max_tables_to_look_for_schema_inference", 1, 1000, "A new setting"},
             {"max_autoincrement_series", 1000, 1000, "A new setting"},
-            {"validate_enum_literals_in_opearators", false, false, "A new setting"},
+            {"validate_enum_literals_in_operators", false, false, "A new setting"},
             {"allow_experimental_kusto_dialect", true, false, "A new setting"},
             {"allow_experimental_prql_dialect", true, false, "A new setting"},
         });

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -49,7 +49,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_not_comparable_types_in_comparison_functions;
-    extern const SettingsBool validate_enum_literals_in_opearators;
+    extern const SettingsBool validate_enum_literals_in_operators;
 }
 
 namespace ErrorCodes
@@ -648,12 +648,12 @@ struct NameGreaterOrEquals { static constexpr auto name = "greaterOrEquals"; };
 struct ComparisonParams
 {
     bool check_decimal_overflow;
-    bool validate_enum_literals_in_opearators;
+    bool validate_enum_literals_in_operators;
     bool allow_not_comparable_types;
 
     explicit ComparisonParams(const ContextPtr & context)
         : check_decimal_overflow(decimalCheckComparisonOverflow(context))
-        , validate_enum_literals_in_opearators(context->getSettingsRef()[Setting::validate_enum_literals_in_opearators])
+        , validate_enum_literals_in_operators(context->getSettingsRef()[Setting::validate_enum_literals_in_operators])
         , allow_not_comparable_types(context->getSettingsRef()[Setting::allow_not_comparable_types_in_comparison_functions])
     {}
 };
@@ -906,7 +906,7 @@ private:
         {
             if constexpr (!IsOperation<Op>::equals && IsOperation<Op>::not_equals)
                 return false;
-            if (params.validate_enum_literals_in_opearators)
+            if (params.validate_enum_literals_in_operators)
                 return false;
             if (!enum_values || string_value.getType() != Field::Types::String)
                 return false;

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -68,7 +68,7 @@ namespace Setting
     extern const SettingsBool force_grouping_standard_compatibility;
     extern const SettingsUInt64 max_ast_elements;
     extern const SettingsBool transform_null_in;
-    extern const SettingsBool validate_enum_literals_in_opearators;
+    extern const SettingsBool validate_enum_literals_in_operators;
     extern const SettingsBool use_variant_as_common_type;
 }
 
@@ -356,7 +356,7 @@ ColumnsWithTypeAndName createBlockForSet(
 
     GetSetElementParams set_params{
         .transform_null_in = context->getSettingsRef()[Setting::transform_null_in],
-        .forbid_unknown_enum_values = context->getSettingsRef()[Setting::validate_enum_literals_in_opearators],
+        .forbid_unknown_enum_values = context->getSettingsRef()[Setting::validate_enum_literals_in_operators],
     };
 
     /// 1 in 1; (1, 2) in (1, 2); identity(tuple(tuple(tuple(1)))) in tuple(tuple(tuple(1))); etc.

--- a/src/Planner/CollectSets.cpp
+++ b/src/Planner/CollectSets.cpp
@@ -22,7 +22,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool transform_null_in;
-    extern const SettingsBool validate_enum_literals_in_opearators;
+    extern const SettingsBool validate_enum_literals_in_operators;
 }
 
 namespace ErrorCodes
@@ -78,7 +78,7 @@ public:
                 in_first_argument->getResultType(), constant_node->getValue(), constant_node->getResultType(),
                 GetSetElementParams{
                     .transform_null_in = settings[Setting::transform_null_in],
-                    .forbid_unknown_enum_values = settings[Setting::validate_enum_literals_in_opearators],
+                    .forbid_unknown_enum_values = settings[Setting::validate_enum_literals_in_operators],
                 });
 
             DataTypes set_element_types = {in_first_argument->getResultType()};

--- a/tests/queries/0_stateless/01310_enum_comparison.sql
+++ b/tests/queries/0_stateless/01310_enum_comparison.sql
@@ -5,5 +5,5 @@ SELECT count() FROM enum WHERE x = 'hello';
 SELECT count() FROM enum WHERE x = 'world';
 SELECT count() FROM enum WHERE x = 'xyz';
 
-SET validate_enum_literals_in_opearators = 1;
+SET validate_enum_literals_in_operators = 1;
 SELECT count() FROM enum WHERE x = 'xyz'; -- { serverError UNKNOWN_ELEMENT_OF_ENUM }

--- a/tests/queries/0_stateless/03278_enum_in_unknown_value.sql
+++ b/tests/queries/0_stateless/03278_enum_in_unknown_value.sql
@@ -24,7 +24,7 @@ SELECT * FROM t_enum_in_unknown_value WHERE e NOT IN ('a', 'b', 'c');
 SELECT * FROM t_enum_in_unknown_value WHERE e IN ('c');
 SELECT * FROM t_enum_in_unknown_value WHERE e NOT IN ('c');
 
-SET validate_enum_literals_in_opearators = 1;
+SET validate_enum_literals_in_operators = 1;
 
 SELECT * FROM t_enum_in_unknown_value WHERE e IN ('a', 'b', 'c'); -- { serverError UNKNOWN_ELEMENT_OF_ENUM }
 SELECT * FROM t_enum_in_unknown_value WHERE e NOT IN ('a', 'b', 'c'); -- { serverError UNKNOWN_ELEMENT_OF_ENUM }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
