### PR TITLE
Setting object_storage_max_nodes

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5882,6 +5882,15 @@ As each series represents a node in Keeper, it is recommended to have no more th
 When enabled, ClickHouse will detect Hive-style partitioning in path (`/name=value/`) in file-like table engines [File](../../engines/table-engines/special/file.md#hive-style-partitioning)/[S3](../../engines/table-engines/integrations/s3.md#hive-style-partitioning)/[URL](../../engines/table-engines/special/url.md#hive-style-partitioning)/[HDFS](../../engines/table-engines/integrations/hdfs.md#hive-style-partitioning)/[AzureBlobStorage](../../engines/table-engines/integrations/azureBlobStorage.md#hive-style-partitioning) and will allow to use partition columns as virtual columns in the query. These virtual columns will have the same names as in the partitioned path, but starting with `_`.
 )", 0) \
     \
+    DECLARE(UInt64, object_storage_max_nodes, 0, R"(
+Limit for hosts used for request in object storage cluster table functions - azureBlobStorageCluster, s3Cluster, hdfsCluster, etc.
+
+Possible values:
+
+- Positive integer.
+- 0 — All hosts in cluster.
+)", 0) \
+    \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \
     /* ## ADD PRODUCTION / BETA FEATURES BEFORE THIS BLOCK  ## */ \
@@ -6027,14 +6036,6 @@ Enable PRQL - an alternative to SQL.
 Experimental tsToGrid aggregate function for Prometheus-like timeseries resampling. Cloud only
 )", EXPERIMENTAL) \
     \
-    DECLARE(UInt64, object_storage_max_nodes, 0, R"(
-Limit for hosts used for request in object storage cluster table functions - azureBlobStorageCluster, s3Cluster, hdfsCluster, etc.
-
-Possible values:
-
-- Positive integer.
-- 0 — All hosts in cluster.
-)", EXPERIMENTAL) \
     /* ####################################################### */ \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \
     /* ####################################################### */ \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6027,7 +6027,7 @@ Enable PRQL - an alternative to SQL.
 Experimental tsToGrid aggregate function for Prometheus-like timeseries resampling. Cloud only
 )", EXPERIMENTAL) \
     \
-    DECLARE(UInt64, object_storage_cluster_function_max_hosts, 0, R"(
+    DECLARE(UInt64, object_storage_max_nodes, 0, R"(
 Limit for hosts used for request in object storage cluster table functions - azureBlobStorageCluster, s3Cluster, hdfsCluster, etc.
 
 Possible values:

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6027,6 +6027,14 @@ Enable PRQL - an alternative to SQL.
 Experimental tsToGrid aggregate function for Prometheus-like timeseries resampling. Cloud only
 )", EXPERIMENTAL) \
     \
+    DECLARE(UInt64, object_storage_cluster_function_max_hosts, 0, R"(
+Limit for hosts used for request in object storage cluster table functions - azureBlobStorageCluster, s3Cluster, hdfsCluster, etc.
+
+Possible values:
+
+- Positive integer.
+- 0 — All hosts in cluster.
+)", EXPERIMENTAL) \
     /* ####################################################### */ \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \
     /* ####################################################### */ \

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -265,7 +265,7 @@ public:
     std::unique_ptr<Cluster> getClusterWithMultipleShards(const std::vector<size_t> & indices) const;
 
     /// Get a new Cluster that contains all servers (all shards with all replicas) from existing cluster as independent shards.
-    std::unique_ptr<Cluster> getClusterWithReplicasAsShards(const Settings & settings, size_t max_replicas_from_shard = 0) const;
+    std::unique_ptr<Cluster> getClusterWithReplicasAsShards(const Settings & settings, size_t max_replicas_from_shard = 0, size_t max_hosts = 0) const;
 
     /// Returns false if cluster configuration doesn't allow to use it for cross-replication.
     /// NOTE: true does not mean, that it's actually a cross-replication cluster.
@@ -291,7 +291,7 @@ private:
 
     /// For getClusterWithReplicasAsShards implementation
     struct ReplicasAsShardsTag {};
-    Cluster(ReplicasAsShardsTag, const Cluster & from, const Settings & settings, size_t max_replicas_from_shard);
+    Cluster(ReplicasAsShardsTag, const Cluster & from, const Settings & settings, size_t max_replicas_from_shard, size_t max_hosts);
 
     void addShard(
         const Settings & settings,

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -33,7 +33,6 @@
 #include <Parsers/ASTInsertQuery.h>
 #include <Server/TCPServer.h>
 #include <Storages/MergeTree/MergeTreeDataPartUUID.h>
-#include <Storages/ObjectStorage/StorageObjectStorageCluster.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/SocketAddress.h>

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -35,6 +35,7 @@ namespace Setting
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool skip_unavailable_shards;
+    extern const SettingsUInt64 object_storage_cluster_function_max_hosts;
 }
 
 IStorageCluster::IStorageCluster(
@@ -125,7 +126,7 @@ void IStorageCluster::read(
     storage_snapshot->check(column_names);
 
     updateBeforeRead(context);
-    auto cluster = getCluster(context);
+    auto cluster = getCluster(context, context->getSettingsRef()[Setting::object_storage_cluster_function_max_hosts]);
 
     /// Calculate the header. This is significant, because some columns could be thrown away in some cases like query with count(*)
 
@@ -242,9 +243,9 @@ ContextPtr ReadFromCluster::updateSettings(const Settings & settings)
     return new_context;
 }
 
-ClusterPtr IStorageCluster::getCluster(ContextPtr context) const
+ClusterPtr IStorageCluster::getCluster(ContextPtr context, size_t max_hosts) const
 {
-    return context->getCluster(cluster_name)->getClusterWithReplicasAsShards(context->getSettingsRef());
+    return context->getCluster(cluster_name)->getClusterWithReplicasAsShards(context->getSettingsRef(), /* max_replicas_from_shard */ 0, max_hosts);
 }
 
 }

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -35,7 +35,7 @@ namespace Setting
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool skip_unavailable_shards;
-    extern const SettingsUInt64 object_storage_cluster_function_max_hosts;
+    extern const SettingsUInt64 object_storage_max_nodes;
 }
 
 IStorageCluster::IStorageCluster(
@@ -126,7 +126,7 @@ void IStorageCluster::read(
     storage_snapshot->check(column_names);
 
     updateBeforeRead(context);
-    auto cluster = getCluster(context, context->getSettingsRef()[Setting::object_storage_cluster_function_max_hosts]);
+    auto cluster = getCluster(context, context->getSettingsRef()[Setting::object_storage_max_nodes]);
 
     /// Calculate the header. This is significant, because some columns could be thrown away in some cases like query with count(*)
 

--- a/src/Storages/IStorageCluster.h
+++ b/src/Storages/IStorageCluster.h
@@ -31,7 +31,8 @@ public:
         size_t /*max_block_size*/,
         size_t /*num_streams*/) override;
 
-    ClusterPtr getCluster(ContextPtr context) const;
+    ClusterPtr getCluster(ContextPtr context, size_t max_hosts = 0) const;
+
     /// Query is needed for pruning by virtual columns (_file, _path)
     virtual RemoteQueryExecutor::Extension getTaskIteratorExtension(const ActionsDAG::Node * predicate, const ContextPtr & context) const = 0;
 

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -523,7 +523,7 @@ def test_cluster_hosts_limit(started_cluster):
         query_id = query_id_def
     )
 
-    #  object_storage_cluster_function_max_hosts is greater than number of hosts in cluster
+    #  object_storage_max_nodes is greater than number of hosts in cluster
     query_id_4_hosts = str(uuid.uuid4())
     resp_4_hosts = node.query(
         """
@@ -531,13 +531,13 @@ def test_cluster_hosts_limit(started_cluster):
             'cluster_simple',
             'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
             'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
-            SETTINGS object_storage_cluster_function_max_hosts=4
+            SETTINGS object_storage_max_nodes=4
         """,
         query_id = query_id_4_hosts
     )
     assert resp_def == resp_4_hosts
 
-    #  object_storage_cluster_function_max_hosts is equal number of hosts in cluster
+    #  object_storage_max_nodes is equal number of hosts in cluster
     query_id_3_hosts = str(uuid.uuid4())
     resp_3_hosts = node.query(
         """
@@ -545,13 +545,13 @@ def test_cluster_hosts_limit(started_cluster):
             'cluster_simple',
             'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
             'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
-            SETTINGS object_storage_cluster_function_max_hosts=3
+            SETTINGS object_storage_max_nodes=3
         """,
         query_id = query_id_3_hosts
     )
     assert resp_def == resp_3_hosts
 
-    #  object_storage_cluster_function_max_hosts is less than number of hosts in cluster
+    #  object_storage_max_nodes is less than number of hosts in cluster
     query_id_2_hosts = str(uuid.uuid4())
     resp_2_hosts = node.query(
         """
@@ -559,7 +559,7 @@ def test_cluster_hosts_limit(started_cluster):
             'cluster_simple',
             'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
             'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
-            SETTINGS object_storage_cluster_function_max_hosts=2
+            SETTINGS object_storage_max_nodes=2
         """,
         query_id = query_id_2_hosts
     )

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -2,7 +2,7 @@ import csv
 import logging
 import os
 import shutil
-import time
+import uuid
 from email.errors import HeaderParseError
 
 import pytest
@@ -72,7 +72,7 @@ def started_cluster():
             "s0_0_0",
             main_configs=["configs/cluster.xml", "configs/named_collections.xml"],
             user_configs=["configs/users.xml"],
-            macros={"replica": "node1", "shard": "shard1"},
+            macros={"replica": "replica1", "shard": "shard1"},
             with_minio=True,
             with_zookeeper=True,
         )
@@ -508,3 +508,97 @@ def test_cluster_default_expression(started_cluster):
     )
 
     assert result == expected_result
+
+def test_cluster_hosts_limit(started_cluster):
+    node = started_cluster.instances["s0_0_0"]
+
+    query_id_def = str(uuid.uuid4())
+    resp_def = node.query(
+        """
+        SELECT * from s3Cluster(
+            'cluster_simple',
+            'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
+            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
+        """,
+        query_id = query_id_def
+    )
+
+    #  object_storage_cluster_function_max_hosts is greater than number of hosts in cluster
+    query_id_4_hosts = str(uuid.uuid4())
+    resp_4_hosts = node.query(
+        """
+        SELECT * from s3Cluster(
+            'cluster_simple',
+            'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
+            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
+            SETTINGS object_storage_cluster_function_max_hosts=4
+        """,
+        query_id = query_id_4_hosts
+    )
+    assert resp_def == resp_4_hosts
+
+    #  object_storage_cluster_function_max_hosts is equal number of hosts in cluster
+    query_id_3_hosts = str(uuid.uuid4())
+    resp_3_hosts = node.query(
+        """
+        SELECT * from s3Cluster(
+            'cluster_simple',
+            'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
+            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
+            SETTINGS object_storage_cluster_function_max_hosts=3
+        """,
+        query_id = query_id_3_hosts
+    )
+    assert resp_def == resp_3_hosts
+
+    #  object_storage_cluster_function_max_hosts is less than number of hosts in cluster
+    query_id_2_hosts = str(uuid.uuid4())
+    resp_2_hosts = node.query(
+        """
+        SELECT * from s3Cluster(
+            'cluster_simple',
+            'http://minio1:9001/root/data/{clickhouse,database}/*', 'minio', 'minio123', 'CSV',
+            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
+            SETTINGS object_storage_cluster_function_max_hosts=2
+        """,
+        query_id = query_id_2_hosts
+    )
+    assert resp_def == resp_2_hosts
+
+    node.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster_simple'")
+
+    hosts_def = node.query(
+        f"""
+        SELECT uniq(hostname)
+            FROM clusterAllReplicas('cluster_simple', system.query_log)
+            WHERE type='QueryFinish' AND initial_query_id='{query_id_def}' AND query_id!='{query_id_def}'
+        """
+    )
+    assert int(hosts_def) == 3
+
+    hosts_4 = node.query(
+        f"""
+        SELECT uniq(hostname)
+            FROM clusterAllReplicas('cluster_simple', system.query_log)
+            WHERE type='QueryFinish' AND initial_query_id='{query_id_4_hosts}' AND query_id!='{query_id_4_hosts}'
+        """
+    )
+    assert int(hosts_4) == 3
+
+    hosts_3 = node.query(
+        f"""
+        SELECT uniq(hostname)
+            FROM clusterAllReplicas('cluster_simple', system.query_log)
+            WHERE type='QueryFinish' AND initial_query_id='{query_id_3_hosts}' AND query_id!='{query_id_3_hosts}'
+        """
+    )
+    assert int(hosts_3) == 3
+
+    hosts_2 = node.query(
+        f"""
+        SELECT uniq(hostname)
+            FROM clusterAllReplicas('cluster_simple', system.query_log)
+            WHERE type='QueryFinish' AND initial_query_id='{query_id_2_hosts}' AND query_id!='{query_id_2_hosts}'
+        """
+    )
+    assert int(hosts_2) == 2


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Setting `object_storage_max_nodes` to limit used hosts in object storage cluster family functions (s3Cluster, hdfsCluster, etc).

### Documentation entry for user-facing changes
Setting `object_storage_max_nodes` to limit used hosts in object storage cluster family functions (s3Cluster, hdfsCluster, etc).
Default value 0 - unlimited.
Sometimes with large clusters makes sense to limit number of hosts involved in distributed request to object storage.
This setting allow to do it.
Now it chooses random hosts from cluster, in common case it should make more or less equable host loading.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
