### PR TITLE
Show extended error messages in system.errors

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -680,7 +680,7 @@ namespace ErrorCodes
 
     ErrorCode end() { return END + 1; }
 
-    void increment(ErrorCode error_code, bool remote, const std::string & message, const FramePointers & trace)
+    size_t increment(ErrorCode error_code, bool remote, const std::string & message, const FramePointers & trace)
     {
         if (error_code < 0 || error_code >= end())
         {
@@ -689,22 +689,46 @@ namespace ErrorCodes
             error_code = end() - 1;
         }
 
-        values[error_code].increment(remote, message, trace);
+        return values[error_code].increment(remote, message, trace);
     }
 
-    void ErrorPairHolder::increment(bool remote, const std::string & message, const FramePointers & trace)
+    void extendedMessage(ErrorCode error_code, bool remote, size_t error_index, const std::string & message)
+    {
+        if (error_code < 0 || error_code >= end())
+        {
+            /// For everything outside the range, use END.
+            /// (end() is the pointer pass the end, while END is the last value that has an element in values array).
+            error_code = end() - 1;
+        }
+
+        values[error_code].extendedMessage(remote, error_index, message);
+    }
+
+    size_t ErrorPairHolder::increment(bool remote, const std::string & message, const FramePointers & trace)
     {
         const auto now = std::chrono::system_clock::now();
 
         std::lock_guard lock(mutex);
-
         auto & error = remote ? value.remote : value.local;
 
-        ++error.count;
+        size_t error_index = error.count++;
         error.message = message;
         error.trace = trace;
         error.error_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+
+        return error_index;
     }
+
+    void ErrorPairHolder::extendedMessage(bool remote, size_t error_index, const std::string & new_message)
+    {
+        std::lock_guard lock(mutex);
+        auto & error = remote ? value.remote : value.local;
+
+        /// This function is supposed to extend the current message.
+        if ((error.count == error_index + 1) && new_message.starts_with(error.message))
+            error.message = new_message;
+    }
+
     ErrorPair ErrorPairHolder::get()
     {
         std::lock_guard lock(mutex);

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -53,7 +53,8 @@ namespace ErrorCodes
     {
     public:
         ErrorPair get();
-        void increment(bool remote, const std::string & message, const FramePointers & trace);
+        size_t increment(bool remote, const std::string & message, const FramePointers & trace);
+        void extendedMessage(bool remote, size_t error_index, const std::string & new_message);
 
     private:
         ErrorPair value TSA_GUARDED_BY(mutex);
@@ -66,8 +67,17 @@ namespace ErrorCodes
     /// Get index just after last error_code identifier.
     ErrorCode end();
 
-    /// Add value for specified error_code.
-    void increment(ErrorCode error_code, bool remote, const std::string & message, const FramePointers & trace);
+    /// Increments the counter of errors for a specified error code, and remembers some information about the last error.
+    /// The function returns the index of the passed error among other errors with the same code and the same `remote` flag
+    /// since the program startup.
+    size_t increment(ErrorCode error_code, bool remote, const std::string & message, const FramePointers & trace);
+
+    /// Extends the error message after it was set by a call to increment().
+    /// The result of that call to increment() should be passed to this function as `error_index`.
+    /// Exceptions are often extended by calling Exception::addMessage() and in such cases
+    /// this function helps to update the information stored in ErrorCodes in order to
+    /// make the "system.errors" table able to show the extended error messages.
+    void extendedMessage(ErrorCode error_code, bool remote, size_t error_index, const std::string & new_message);
 }
 
 }

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -145,10 +145,7 @@ public:
         addMessage(MessageMasked(message));
     }
 
-    void addMessage(const MessageMasked & msg_masked)
-    {
-        extendedMessage(msg_masked.msg);
-    }
+    void addMessage(const MessageMasked & msg_masked);
 
     /// Used to distinguish local exceptions from the one that was received from remote node.
     void setRemoteException(bool remote_ = true) { remote = remote_; }
@@ -167,6 +164,9 @@ private:
     StackTrace trace;
 #endif
     bool remote = false;
+
+    /// Number of this error among other errors with the same code and the same `remote` flag since the program startup.
+    size_t error_index = static_cast<size_t>(-1);
 
     const char * className() const noexcept override { return "DB::Exception"; }
 

--- a/tests/queries/0_stateless/03312_system_errors_last_error.reference
+++ b/tests/queries/0_stateless/03312_system_errors_last_error.reference
@@ -1,0 +1,1 @@
+Value passed to \'throwIf\' function is non-zero: while executing \'FUNCTION throwIf(1_UInt8 :: 1) -> throwIf(1_UInt8) UInt8 : 2\'

--- a/tests/queries/0_stateless/03312_system_errors_last_error.sql
+++ b/tests/queries/0_stateless/03312_system_errors_last_error.sql
@@ -1,0 +1,12 @@
+-- Tags: no-parallel
+-- Tag no-parallel: The test checks system.errors values which are global
+
+-- For the old analyzer last_error_message is slightly different.
+SET allow_experimental_analyzer = 1;
+
+SELECT throwIf(1); -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}
+
+-- We expect an extended error message here like "Value passed to 'throwIf' function is non-zero: while executing throwIf(1)",
+-- and not just "Value passed to 'throwIf' function is non-zero".
+SELECT last_error_message FROM system.errors
+WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO' AND last_error_time > now() - 10;

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -101,6 +101,7 @@ EXTERN_TYPES_EXCLUDES=(
     ErrorCodes::getName
     ErrorCodes::increment
     ErrorCodes::end
+    ErrorCodes::extendedMessage
     ErrorCodes::values
     ErrorCodes::values[i]
     ErrorCodes::getErrorCodeByName


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Show extended error messages in `system.errors`

For example, the `last_error_message` column after `SELECT throwIf(1)`  before and after this PR:

|   | last_error_message |
|---|---|
| before | `Value passed to \'throwIf\' function is non-zero` |
| after | `Value passed to \'throwIf\' function is non-zero: while executing \'FUNCTION throwIf(1_UInt8 :: 1) -> throwIf(1_UInt8) UInt8 : 2\'` |
