### PR TITLE
Set docs check job status to fail when htmltest fails

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -7,3 +7,6 @@ CheckMailto: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
 IgnoreInternalEmptyHash: true
+IgnoreDirs:
+- "zh"
+- "ru"

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -128,6 +128,8 @@ def main():
                 TestResult("htmltest", OK, test_sw.duration_seconds, [htmltest_log])
             )
         else:
+            description = "Docs check failed (htmltest failed)"
+            job_status = FAILURE
             logging.info("Run failed")
             test_results.append(
                 TestResult("htmltest", "FAIL", test_sw.duration_seconds, [htmltest_log])


### PR DESCRIPTION
I fixed reporting status of the docs check job, also I fixed reported issues related to `stochasticlogisticregression`.

But html contains `null` char (also in links), pages look ok, but htmltest stopped working

![image](https://github.com/user-attachments/assets/ff9556a8-14ce-441b-a8a6-0c79a896ea9e)

This issue might be fixed in docusaurus 3.7 (and react 19?), see https://github.com/facebook/docusaurus/issues/9985

Logs from master https://github.com/ClickHouse/ClickHouse/actions/runs/12768456850/job/35596857109:

```
htmltest started at 12:56:19 on /output_path/build
========================================================================
ru/engines/database-engines/sqlite.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/sqlite.html --> <nil>
ru/engines/database-engines/materialized-postgresql.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/materialized-postgresql.html --> <nil>
ru/engines/database-engines/replicated.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/replicated.html --> <nil>
ru/engines/database-engines/atomic.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/atomic.html --> <nil>
ru/engines/database-engines/lazy.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/lazy.html --> <nil>
ru/engines/database-engines/mysql.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/mysql.html --> <nil>
ru/engines/database-engines/postgresql.html
  bad reference: "parse \"/docs/category/инструкция-для-\\x00разработчиков\": net/url: invalid control character in URL" --- ru/engines/database-engines/postgresql.html --> <nil>
en/sql-reference/aggregate-functions/reference/stochasticlogisticregression.html
  hash does not exist --- en/sql-reference/aggregate-functions/reference/stochasticlogisticregression.html --> #stochasticlinearregression-usage-fitting
zh/sql-reference/aggregate-functions/reference/stochasticlogisticregression.html
  hash does not exist --- zh/sql-reference/aggregate-functions/reference/stochasticlogisticregression.html --> #stochasticlinearregression-usage-fitting
zh/engines/table-engines/integrations/hive.html
  hash does not exist --- zh/engines/table-engines/integrations/hive.html --> #在-clickhouse-中建表-2
========================================================================
✘✘✘ failed in 3.865139612s
10 errors in 2663 documents
INFO:root:Run failed
Run action done for: [Docs check]
```

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

cc: @Felixoid @gingerwizard 
