### PR TITLE
Docs: Remove anchor which causes docusaurus v3 build to fail

### DIFF
--- a/docs/en/interfaces/formats/Parquet/ParquetMetadata.md
+++ b/docs/en/interfaces/formats/Parquet/ParquetMetadata.md
@@ -138,8 +138,4 @@ SELECT * FROM file(data.parquet, ParquetMetadata) format PrettyJSONEachRow
 }
 ```
 
-## Format Settings
-
-## ParquetMetadata {data-format-parquet-metadata}
-
 


### PR DESCRIPTION
Docusaurus v3 build fails for some reason while generating pages from formats only on `ParquetMetadata` file: 
CC @gingerwizard 

Was able to reproduce locally and isolate the problem by removing sections from the document part by part and trying to rebuild. The docs build if I remove this anchor tag. Docusaurus v3 doesn't seem to like it.

edit: I see now it's missing the # in the brackets so it is not a valid tag. Not sure why it doesn't get picked up as such. I guess maybe the pages generate before the links get checked or something.

See failing build log below: 

```text
[19:51:19.495] Running build in Portland, USA (West) – pdx1
[19:51:19.572] Cloning github.com/ClickHouse/clickhouse-docs (Branch: main, Commit: 5ab3d46)
[19:51:33.295] Cloning completed: 13.722s
[19:51:52.599] Restored build cache from previous deployment (PfdypZ8JsALKA9UKvD4hycJoJZdd)
[19:51:52.701] Running "vercel build"
[19:51:53.415] Vercel CLI 39.3.0
[19:51:56.623] Warning: Due to "engines": { "node": ">=20.18" } in your `package.json` file, the Node.js Version defined in your Project Settings ("20.x") will not apply, Node.js Version "22.x" will be used instead. Learn More: http://vercel.link/node-version
[19:51:56.623] Warning: Detected "engines": { "node": ">=20.18" } in your `package.json` that will automatically upgrade when a new major Node.js Version is released. Learn More: http://vercel.link/node-version
[19:51:56.627] Installing dependencies...
[19:51:57.032] yarn install v1.22.19
[19:51:57.118] [1/5] Validating package.json...
[19:51:57.121] [2/5] Resolving packages...
[19:51:57.478] success Already up-to-date.
[19:51:57.484] Done in 0.46s.
[19:51:57.730] yarn run v1.22.19
[19:51:57.755] $ bash ./copyClickhouseRepoDocs.sh && bash ./scripts/settings/autogenerate-settings.sh && yarn build-api-doc && yarn build && yarn build-swagger
[19:51:58.028] [copyClickhouseRepoDocs.sh] Start tasks for copying docs from ClickHouse repo
[19:51:58.028] [copyClickhouseRepoDocs.sh] Start cloning ClickHouse repo
[19:51:58.029] Cloning into 'temp'...
[19:52:08.218] Updating files:  42% (13252/31332)
Updating files:  43% (13473/31332)
Updating files:  44% (13787/31332)
Updating files:  45% (14100/31332)
Updating files:  46% (14413/31332)
Updating files:  47% (14727/31332)
Updating files:  48% (15040/31332)
Updating files:  49% (15353/31332)
Updating files:  50% (15666/31332)
Updating files:  51% (15980/31332)
Updating files:  52% (16293/31332)
Updating files:  53% (16606/31332)
Updating files:  54% (16920/31332)
Updating files:  55% (17233/31332)
Updating files:  56% (17546/31332)
Updating files:  57% (17860/31332)
Updating files:  58% (18173/31332)
Updating files:  59% (18486/31332)
Updating files:  60% (18800/31332)
Updating files:  61% (19113/31332)
Updating files:  62% (19426/31332)
Updating files:  63% (19740/31332)
Updating files:  64% (20053/31332)
Updating files:  65% (20366/31332)
Updating files:  66% (20680/31332)
Updating files:  67% (20993/31332)
Updating files:  68% (21306/31332)
Updating files:  69% (21620/31332)
Updating files:  70% (21933/31332)
Updating files:  71% (22246/31332)
Updating files:  72% (22560/31332)
Updating files:  73% (22873/31332)
Updating files:  74% (23186/31332)
Updating files:  75% (23499/31332)
Updating files:  76% (23813/31332)
Updating files:  77% (24126/31332)
Updating files:  78% (24439/31332)
Updating files:  79% (24753/31332)
Updating files:  80% (25066/31332)
Updating files:  81% (25379/31332)
Updating files:  82% (25693/31332)
Updating files:  83% (26006/31332)
Updating files:  84% (26319/31332)
Updating files:  85% (26633/31332)
Updating files:  86% (26946/31332)
Updating files:  87% (27259/31332)
Updating files:  88% (27573/31332)
Updating files:  89% (27886/31332)
Updating files:  90% (28199/31332)
Updating files:  91% (28513/31332)
Updating files:  92% (28826/31332)
Updating files:  93% (29139/31332)
Updating files:  94% (29453/31332)
Updating files:  95% (29766/31332)
Updating files:  96% (30079/31332)
Updating files:  97% (30393/31332)
Updating files:  98% (30706/31332)
Updating files:  99% (31019/31332)
Updating files: 100% (31332/31332)
Updating files: 100% (31332/31332), done.
[19:52:11.952] [copyClickhouseRepoDocs.sh] Cloning completed
[19:52:11.952] [copyClickhouseRepoDocs.sh] Start copying docs
[19:52:12.011] [copyClickhouseRepoDocs.sh] Copying completed
[19:52:12.011] [copyClickhouseRepoDocs.sh] Generate changelog
[19:52:12.053] No Changelog found for 2025.
[19:52:12.053] [copyClickhouseRepoDocs.sh] Start deleting ClickHouse repo
[19:52:12.644] [copyClickhouseRepoDocs.sh] Deleting ClickHouse repo completed
[19:52:12.644] [copyClickhouseRepoDocs.sh] Finish tasks for copying docs from ClickHouse repo
[19:52:12.648] [autogenerate-settings.sh] Autogenerating settings
[19:52:12.648] [autogenerate-settings.sh] Installing ClickHouse binary
[19:52:12.648] 
[19:52:12.652]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[19:52:12.652]                                  Dload  Upload   Total   Spent    Left  Speed
[19:52:12.801] 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  2911    0  2911    0     0  19433      0 --:--:-- --:--:-- --:--:-- 19536
[19:52:12.809] 
[19:52:12.809] Will download https://builds.clickhouse.com/master/amd64/clickhouse into clickhouse
[19:52:12.809] 
[19:52:12.813]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[19:52:12.813]                                  Dload  Upload   Total   Spent    Left  Speed
[19:52:13.686] 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 12  120M   12 14.6M    0     0  57.1M      0  0:00:02 --:--:--  0:00:02 57.0M
100  120M  100  120M    0     0   138M      0 --:--:-- --:--:-- --:--:--  138M
[19:52:13.692] 
[19:52:13.692] Successfully downloaded the ClickHouse binary, you can run it as:
[19:52:13.692]     ./clickhouse
[19:52:13.692] 
[19:52:13.692] You can also install it:
[19:52:13.692] sudo ./clickhouse install
[19:52:16.409] Decompressing the binary.....
[19:52:16.708] 
[19:52:16.708] [autogenerate-settings.sh] Deleting ClickHouse binary
[19:52:16.756] [autogenerate-settings.sh] Autogenerating settings completed
[19:52:17.080] $ node clickhouseapi.js
[19:52:17.505] Markdown files generated successfully.
[19:52:17.817] $ docusaurus build
[19:52:20.813] [INFO] [en] Creating an optimized production build...
[19:52:23.882] [info] [webpackbar] Compiling Client
[19:52:23.903] [info] [webpackbar] Compiling Server
[19:53:15.260] [success] [webpackbar] Server: Compiled successfully in 51.36s
[19:53:29.972] [success] [webpackbar] Client: Compiled successfully in 1.10m
[19:56:11.787] 
[19:56:11.790] [ERROR] Error: Unable to build website for locale en.
[19:56:11.790]     at tryToBuildLocale (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
[19:56:11.790]     at async /vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
[19:56:11.790]     ... 4 lines matching cause stack trace ...
[19:56:11.790]     at async file:///vercel/path0/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
[19:56:11.790]   [cause]: Error: Docusaurus static site generation failed for 1 paths:
[19:56:11.790]   - "/docs/en/interfaces/formats/ParquetMetadata"
[19:56:11.790]       at generateStaticFiles (/vercel/path0/node_modules/@docusaurus/core/lib/ssg/ssg.js:129:15)
[19:56:11.790]       at async executeSSG (/vercel/path0/node_modules/@docusaurus/core/lib/ssg/ssgExecutor.js:29:23)
[19:56:11.790]       ... 9 lines matching cause stack trace ...
[19:56:11.790]       at async file:///vercel/path0/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
[19:56:11.791]     [cause]: AggregateError
[19:56:11.791]         at generateStaticFiles (/vercel/path0/node_modules/@docusaurus/core/lib/ssg/ssg.js:130:20)
[19:56:11.791]         at async executeSSG (/vercel/path0/node_modules/@docusaurus/core/lib/ssg/ssgExecutor.js:29:23)
[19:56:11.791]         at async buildLocale (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:60:31)
[19:56:11.791]         at async runBuildLocaleTask (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:93:5)
[19:56:11.791]         at async /vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:74:13
[19:56:11.791]         at async tryToBuildLocale (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:70:9)
[19:56:11.791]         at async /vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
[19:56:11.791]         at async mapAsyncSequential (/vercel/path0/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
[19:56:11.791]         at async Command.build (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build/build.js:33:5)
[19:56:11.791]         at async Promise.all (index 0)
[19:56:11.791]         at async runCLI (/vercel/path0/node_modules/@docusaurus/core/lib/commands/cli.js:56:5)
[19:56:11.791]         at async file:///vercel/path0/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
[19:56:11.791]       [errors]: [
[19:56:11.791]         Error: Can't render static file for pathname "/docs/en/interfaces/formats/ParquetMetadata"
[19:56:11.791]             at generateStaticFile (/vercel/path0/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
[19:56:11.791]             at processTicksAndRejections (node:internal/process/task_queues:105:5)
[19:56:11.791]             at runNextTicks (node:internal/process/task_queues:69:3)
[19:56:11.791]             at process.processImmediate (node:internal/timers:459:9)
[19:56:11.791]             at async /vercel/path0/node_modules/p-map/index.js:57:22 {
[19:56:11.791]           [cause]: ReferenceError: data is not defined
[19:56:11.791]               at _createMdxContent (/vercel/path0/build/__server/assets/js/dbeea365.788cffa4.js:184:38)
[19:56:11.792]               at MDXContent (/vercel/path0/build/__server/assets/js/dbeea365.788cffa4.js:198:8)
[19:56:11.792]               at Uc (server.bundle.js:28078:44)
[19:56:11.792]               at Xc (server.bundle.js:28080:253)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Xc (server.bundle.js:28084:231)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Xc (server.bundle.js:28080:481)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Xc (server.bundle.js:28080:481)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at $c (server.bundle.js:28088:140)
[19:56:11.792]               at Z (server.bundle.js:28086:345)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at Xc (server.bundle.js:28081:145)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Xc (server.bundle.js:28080:481)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at $c (server.bundle.js:28088:140)
[19:56:11.792]               at Z (server.bundle.js:28086:345)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at Xc (server.bundle.js:28081:145)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at $c (server.bundle.js:28088:140)
[19:56:11.792]               at Z (server.bundle.js:28086:345)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at Xc (server.bundle.js:28081:145)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at $c (server.bundle.js:28088:140)
[19:56:11.792]               at Z (server.bundle.js:28086:345)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at Xc (server.bundle.js:28081:145)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at $c (server.bundle.js:28088:140)
[19:56:11.792]               at Z (server.bundle.js:28086:345)
[19:56:11.792]               at Yc (server.bundle.js:28089:98)
[19:56:11.792]               at Xc (server.bundle.js:28081:145)
[19:56:11.792]               at Z (server.bundle.js:28086:89)
[19:56:11.792]               at Xc (server.bundle.js:28080:481)
[19:56:11.793]               at Z (server.bundle.js:28086:89)
[19:56:11.793]               at Yc (server.bundle.js:28089:98)
[19:56:11.793]               at $c (server.bundle.js:28088:140)
[19:56:11.793]               at Z (server.bundle.js:28086:345)
[19:56:11.793]               at Yc (server.bundle.js:28089:98)
[19:56:11.793]               at $c (server.bundle.js:28088:140)
[19:56:11.793]         }
[19:56:11.793]       ]
[19:56:11.793]     }
[19:56:11.793]   }
[19:56:11.793] }
[19:56:11.793] [INFO] Docusaurus version: 3.7.0
[19:56:11.793] Node version: v22.12.0
[19:56:12.883] error Command failed with exit code 1.
[19:56:12.883] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[19:56:12.920] error Command failed with exit code 1.
[19:56:12.920] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[19:56:12.937] Error: Command "yarn new-build" exited with 1
[19:56:13.693] 
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
