### PR TITLE
Unflake `02354_vector_search_multiple_marks`

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_multiple_marks.sql
+++ b/tests/queries/0_stateless/02354_vector_search_multiple_marks.sql
@@ -6,7 +6,7 @@ SET allow_experimental_vector_similarity_index = 1;
 
 DROP TABLE IF EXISTS tab;
 
-CREATE TABLE tab(id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance')) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192;
+CREATE TABLE tab(id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance')) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO tab SELECT number, [toFloat32(number), 0.0] from numbers(10000);
 
 WITH [1.0, 0.0] AS reference_vec


### PR DESCRIPTION
Fixes sporadic failures

```
2024-12-26 19:16:18 Reason: result differs with reference:  
2024-12-26 19:16:18 --- /repo/tests/queries/0_stateless/02354_vector_search_multiple_marks.reference	2024-12-26 18:59:24.209678854 +1100
2024-12-26 19:16:18 +++ /repo/tests/queries/0_stateless/02354_vector_search_multiple_marks.stdout	2024-12-26 19:16:18.348605781 +1100
2024-12-26 19:16:18 @@ -1,2 +1,2 @@
2024-12-26 19:16:18  1	[1,0]	0
2024-12-26 19:16:18 -9000	[9000,0]	0
2024-12-26 19:16:18 +9025	[9025,0]	25
```

E.g. https://s3.amazonaws.com/clickhouse-test-reports/0/43577890d1fa941525f5bf290648ef188fab328d/stateless_tests__tsan__s3_storage__[2_3].html

https://play.clickhouse.com/play?user=play#U0VMRUNUIHB1bGxfcmVxdWVzdF9udW1iZXIgYXMgcHIsIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgMQogICAgLS0gQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJywgJ0JST0tFTicpCiAgICBBTkQgdG9EYXRlKGNoZWNrX3N0YXJ0X3RpbWUpID4gJzIwMjUtMDEtMDEnCiAgICBBTkQgdGVzdF9uYW1lIGxpa2UgJyUwMjM1NF92ZWN0b3Jfc2VhcmNoX211bHRpcGxlX21hcmtzJScKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBERVND

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)