### PR TITLE
Docs: move `TabSeparatedRaw` to it's own page

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -209,10 +209,7 @@ SELECT * FROM nestedt FORMAT TSV
 
 ## TabSeparatedRaw {#tabseparatedraw}
 
-Differs from `TabSeparated` format in that the rows are written without escaping.
-When parsing with this format, tabs or linefeeds are not allowed in each field.
-
-This format is also available under the names `TSVRaw`, `Raw`.
+See [TabSeparatedRaw](/en/interfaces/formats/TabSeparatedRaw).
 
 ## TabSeparatedWithNames {#tabseparatedwithnames}
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedRaw.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedRaw.md
@@ -2,14 +2,22 @@
 title : TabSeparatedRaw
 slug : /en/interfaces/formats/TabSeparatedRaw
 keywords : [TabSeparatedRaw]
+input_format: true
+output_format: true
+alias: ['TSVRaw', 'Raw']
 ---
+
+| Input | Output | Alias           |
+|-------|--------|-----------------|
+| ✔     | ✔      | `TSVRaw`, `Raw` |
 
 ## Description
 
-Differs from `TabSeparated` format in that the rows are written without escaping.
-When parsing with this format, tabs or linefeeds are not allowed in each field.
+Differs from the [`TabSeparated`](/en/interfaces/formats/TabSeparated) format in that rows are written without escaping.
 
-This format is also available under the names `TSVRaw`, `Raw`.
+:::note
+When parsing with this format, tabs or linefeeds are not allowed in each field.
+:::
 
 ## Example Usage
 


### PR DESCRIPTION
As part of the effort to improve input/output format documentation.

Moves `TabSeparatedRaw` to it's own page.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
