### PR TITLE
Docs: Move `TabSeparatedWithNames` and `TabSeparatedWithNamesAndTypes` to own pages

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -216,31 +216,11 @@ This format is also available under the names `TSVRaw`, `Raw`.
 
 ## TabSeparatedWithNames {#tabseparatedwithnames}
 
-Differs from the `TabSeparated` format in that the column names are written in the first row.
-
-During parsing, the first row is expected to contain the column names. You can use column names to determine their position and to check their correctness.
-
-:::note
-If setting [input_format_with_names_use_header](/docs/en/operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to 1,
-the columns from the input data will be mapped to the columns of the table by their names, columns with unknown names will be skipped if setting [input_format_skip_unknown_fields](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
-Otherwise, the first row will be skipped.
-:::
-
-This format is also available under the name `TSVWithNames`.
+See [TabSeparatedWithNames](../interfaces/formats/TabSeparated/TabSeparatedWithNames.md)
 
 ## TabSeparatedWithNamesAndTypes {#tabseparatedwithnamesandtypes}
 
-Differs from the `TabSeparated` format in that the column names are written to the first row, while the column types are in the second row.
-
-:::note
-If setting [input_format_with_names_use_header](/docs/en/operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to 1,
-the columns from the input data will be mapped to the columns in the table by their names, columns with unknown names will be skipped if setting [input_format_skip_unknown_fields](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
-Otherwise, the first row will be skipped.
-If setting [input_format_with_types_use_header](/docs/en/operations/settings/settings-formats.md/#input_format_with_types_use_header) is set to 1,
-the types from input data will be compared with the types of the corresponding columns from the table. Otherwise, the second row will be skipped.
-:::
-
-This format is also available under the name `TSVWithNamesAndTypes`.
+See [TabSeparatedWithNamesAndTypes](../interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md)
 
 ## TabSeparatedRawWithNames {#tabseparatedrawwithnames}
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNames.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNames.md
@@ -23,8 +23,6 @@ the columns from the input data will be mapped to the columns of the table by th
 Otherwise, the first row will be skipped.
 :::
 
-This format is also available under the name `TSVWithNames`, `RawWithNames`.
-
 ## Example Usage
 
 ## Format Settings

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNames.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNames.md
@@ -2,21 +2,28 @@
 title : TabSeparatedWithNames
 slug : /en/interfaces/formats/TabSeparatedWithNames
 keywords : [TabSeparatedWithNames]
+input_format: true
+output_format: true
+alias: ['TSVWithNames']
 ---
+
+| Input | Output | Alias                          |
+|-------|--------|--------------------------------|
+| 	✔    | 	✔     | `TSVWithNames`, `RawWithNames` |
 
 ## Description
 
-Differs from the `TabSeparated` format in that the column names are written in the first row.
+Differs from the [`TabSeparated`](./TabSeparated.md) format in that the column names are written in the first row.
 
 During parsing, the first row is expected to contain the column names. You can use column names to determine their position and to check their correctness.
 
 :::note
-If setting [input_format_with_names_use_header](/docs/en/operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to 1,
-the columns from the input data will be mapped to the columns of the table by their names, columns with unknown names will be skipped if setting [input_format_skip_unknown_fields](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
+If setting [`input_format_with_names_use_header`](../../../operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to `1`,
+the columns from the input data will be mapped to the columns of the table by their names, columns with unknown names will be skipped if setting [`input_format_skip_unknown_fields`](../../../operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to `1`.
 Otherwise, the first row will be skipped.
 :::
 
-This format is also available under the name `TSVWithNames`.
+This format is also available under the name `TSVWithNames`, `RawWithNames`.
 
 ## Example Usage
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md
@@ -4,12 +4,21 @@ slug : /en/interfaces/formats/TabSeparatedWithNamesAndTypes
 keywords : [TabSeparatedWithNamesAndTypes]
 ---
 
+| Input | Output | Alias                                          |
+|-------|--------|------------------------------------------------|
+| 	✔    | 	✔     | `TSVWithNamesAndTypes`, `RawWithNamesAndNames` |
+
 ## Description
 
-Differs from `TabSeparatedWithNamesAndTypes` format in that the rows are written without escaping.
-When parsing with this format, tabs or linefeeds are not allowed in each field.
+Differs from the `TabSeparated` format in that the column names are written to the first row, while the column types are in the second row.
 
-This format is also available under the names `TSVRawWithNamesAndNames`, `RawWithNamesAndNames`.
+:::note
+- If setting [`input_format_with_names_use_header`](../../../operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to `1`,
+the columns from the input data will be mapped to the columns in the table by their names, columns with unknown names will be skipped if setting [`input_format_skip_unknown_fields`](../../../operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
+Otherwise, the first row will be skipped.
+- If setting [`input_format_with_types_use_header`](../../../operations/settings/settings-formats.md/#input_format_with_types_use_header) is set to `1`,
+the types from input data will be compared with the types of the corresponding columns from the table. Otherwise, the second row will be skipped.
+:::
 
 ## Example Usage
 


### PR DESCRIPTION
As part of the effort to improve input/output format documentation.

Moves `TabSeparatedWithNames` and `TabSeparatedWithNamesAndTypes` to own pages

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
