### PR TITLE
Increase spectre width for trace-visualizer

### DIFF
--- a/utils/trace-visualizer/index.html
+++ b/utils/trace-visualizer/index.html
@@ -173,7 +173,7 @@
                 t1: convertTime(+span.start_time_us),
                 t2: convertTime(+span.finish_time_us),
                 band,
-                color: d3.interpolateRainbow((strHash(span.color) % 256) / 256),
+                color: d3.interpolateRainbow((strHash(span.color) % 1024) / 1024),
                 text: span.operation_name
             });
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

Might be not enough for a complex query with many processors - colors will collide.