### PR TITLE
Docs: move `TabSeparatedRawWithNamesAndTypes`, `TabSeparatedRawWithNames` to own pages

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -106,7 +106,7 @@ See [TabSeparated](../interfaces/formats/TabSeparated/TabSeparated.md)
 
 ## TabSeparatedRaw {#tabseparatedraw}
 
-See [TabSeparatedRaw](/en/interfaces/formats/TabSeparatedRaw).
+See [TabSeparatedRaw](/en/interfaces/formats/TabSeparatedRaw)
 
 ## TabSeparatedWithNames {#tabseparatedwithnames}
 
@@ -118,17 +118,11 @@ See [TabSeparatedWithNamesAndTypes](../interfaces/formats/TabSeparated/TabSepara
 
 ## TabSeparatedRawWithNames {#tabseparatedrawwithnames}
 
-Differs from `TabSeparatedWithNames` format in that the rows are written without escaping.
-When parsing with this format, tabs or linefeeds are not allowed in each field.
-
-This format is also available under the names `TSVRawWithNames`, `RawWithNames`.
+See [TabSeparatedRawWithNames](../interfaces/formats/TabSeparated/TabSeparatedRawWithNames.md)
 
 ## TabSeparatedRawWithNamesAndTypes {#tabseparatedrawwithnamesandtypes}
 
-Differs from `TabSeparatedWithNamesAndTypes` format in that the rows are written without escaping.
-When parsing with this format, tabs or linefeeds are not allowed in each field.
-
-This format is also available under the names `TSVRawWithNamesAndNames`, `RawWithNamesAndNames`.
+See [TabSeparatedRawWithNamesAndTypes](../interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md)
 
 ## Template {#format-template}
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedRaw.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedRaw.md
@@ -16,7 +16,7 @@ alias: ['TSVRaw', 'Raw']
 Differs from the [`TabSeparated`](/en/interfaces/formats/TabSeparated) format in that rows are written without escaping.
 
 :::note
-When parsing with this format, tabs or linefeeds are not allowed in each field.
+When parsing with this format, tabs or line-feeds are not allowed in each field.
 :::
 
 ## Example Usage

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNames.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNames.md
@@ -1,22 +1,24 @@
 ---
 title : TabSeparatedRawWithNames
 slug : /en/interfaces/formats/TabSeparatedRawWithNames
-keywords : [TabSeparatedRawWithNames]
+keywords : [TabSeparatedRawWithNames, TSVRawWithNames, RawWithNames]
+input_format: true
+output_format: true
+alias: ['TSVRawWithNames', 'RawWithNames']
 ---
+
+| Input | Output | Alias                             |
+|-------|--------|-----------------------------------|
+| ✔     | ✔      | `TSVRawWithNames`, `RawWithNames` |
 
 ## Description
 
-Differs from the `TabSeparated` format in that the column names are written in the first row.
-
-During parsing, the first row is expected to contain the column names. You can use column names to determine their position and to check their correctness.
+Differs from the [`TabSeparatedWithNames`](./TabSeparatedWithNames.md) format, 
+in that the rows are written without escaping.
 
 :::note
-If setting [input_format_with_names_use_header](/docs/en/operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to 1,
-the columns from the input data will be mapped to the columns of the table by their names, columns with unknown names will be skipped if setting [input_format_skip_unknown_fields](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
-Otherwise, the first row will be skipped.
+When parsing with this format, tabs or line-feeds are not allowed in each field.
 :::
-
-This format is also available under the name `TSVRawWithNames`.
 
 ## Example Usage
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md
@@ -1,10 +1,10 @@
 ---
 title : TabSeparatedRawWithNamesAndTypes
 slug : /en/interfaces/formats/TabSeparatedRawWithNamesAndTypes
-keywords : [TabSeparatedRawWithNamesAndTypes, TSVRawWithNamesAndNames, RawWithNamesAndNames]
+keywords : [TabSeparatedRawWithNamesAndTypes, TSVRawWithNamesAndTypes, RawWithNamesAndTypes]
 input_format: true
 output_format: true
-alias: ['TSVRawWithNamesAndTypes', 'RawWithNamesAndNames']
+alias: ['TSVRawWithNamesAndTypes', 'RawWithNamesAndTypes']
 ---
 
 | Input | Output | Alias                                             |

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md
@@ -4,7 +4,7 @@ slug : /en/interfaces/formats/TabSeparatedRawWithNamesAndTypes
 keywords : [TabSeparatedRawWithNamesAndTypes, TSVRawWithNamesAndNames, RawWithNamesAndNames]
 input_format: true
 output_format: true
-alias: ['TSVRawWithNamesAndNames', 'RawWithNamesAndNames']
+alias: ['TSVRawWithNamesAndTypes', 'RawWithNamesAndNames']
 ---
 
 | Input | Output | Alias                                             |

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedRawWithNamesAndTypes.md
@@ -1,15 +1,24 @@
 ---
 title : TabSeparatedRawWithNamesAndTypes
 slug : /en/interfaces/formats/TabSeparatedRawWithNamesAndTypes
-keywords : [TabSeparatedRawWithNamesAndTypes]
+keywords : [TabSeparatedRawWithNamesAndTypes, TSVRawWithNamesAndNames, RawWithNamesAndNames]
+input_format: true
+output_format: true
+alias: ['TSVRawWithNamesAndNames', 'RawWithNamesAndNames']
 ---
+
+| Input | Output | Alias                                             |
+|-------|--------|---------------------------------------------------|
+| ✔     | ✔      | `TSVRawWithNamesAndNames`, `RawWithNamesAndNames` |
 
 ## Description
 
-Differs from `TabSeparatedWithNamesAndTypes` format in that the rows are written without escaping.
-When parsing with this format, tabs or linefeeds are not allowed in each field.
+Differs from the [`TabSeparatedWithNamesAndTypes`](./TabSeparatedWithNamesAndTypes.md) format,
+in that the rows are written without escaping.
 
-This format is also available under the names `TSVRawWithNamesAndNames`, `RawWithNamesAndNames`.
+:::note
+When parsing with this format, tabs or line-feeds are not allowed in each field.
+:::
 
 ## Example Usage
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md
@@ -6,7 +6,7 @@ keywords : [TabSeparatedWithNamesAndTypes]
 
 | Input | Output | Alias                                          |
 |-------|--------|------------------------------------------------|
-| 	✔    | 	✔     | `TSVWithNamesAndTypes`, `RawWithNamesAndNames` |
+| 	✔    | 	✔     | `TSVWithNamesAndTypes`, `RawWithNamesAndTypes` |
 
 ## Description
 


### PR DESCRIPTION
As part of the effort to improve input/output format documentation.

Moves `TabSeparatedRawWithNamesAndTypes`, `TabSeparatedRawWithNames` to own pages

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:

- [ ] <!---ci_set_required--> Allow: All Required Checks
- [ ] <!---ci_include_stateless--> Allow: Stateless tests
- [ ] <!---ci_include_stateful--> Allow: Stateful tests
- [ ] <!---ci_include_integration--> Allow: Integration Tests
- [ ] <!---ci_include_performance--> Allow: Performance tests
- [ ] <!---ci_set_builds--> Allow: All Builds
- [ ] <!---batch_0_1--> Allow: batch 1, 2 for multi-batch jobs
- [ ] <!---batch_2_3--> Allow: batch 3, 4, 5, 6 for multi-batch jobs
---
- [ ] <!---ci_exclude_style--> Exclude: Style check
- [ ] <!---ci_exclude_fast--> Exclude: Fast test
- [ ] <!---ci_exclude_asan--> Exclude: All with ASAN
- [ ] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [ ] <!---ci_exclude_aarch64|release|debug--> Exclude: All with aarch64
- [ ] <!---ci_exclude_release--> Exclude: All with release
- [ ] <!---ci_exclude_debug--> Exclude: All with debug
---
- [ ] <!---ci_include_uzz--> Run only fuzzers related jobs (libFuzzer fuzzers, AST fuzzers, BuzzHouse, etc.)
- [ ] <!---ci_exclude_ast--> Exclude: AST fuzzers
---
- [ ] <!---do_not_test--> Do not test
- [ ] <!---woolen_wolfdog--> Woolen Wolfdog
- [ ] <!---upload_all--> Upload binaries for special builds
- [ ] <!---no_merge_commit--> Disable merge-commit
- [ ] <!---no_ci_cache--> Disable CI cache
