### PR TITLE
Fix `00183_prewhere_conditions_order` with parallel replicas

### DIFF
--- a/tests/queries/1_stateful/00183_prewhere_conditions_order.reference
+++ b/tests/queries/1_stateful/00183_prewhere_conditions_order.reference
@@ -1,2 +1,2 @@
-                Prewhere filter column: and(like(__table1.Title, \'%Google%\'_String), notLike(__table1.URL, \'%.google.%\'_String), notEquals(__table1.SearchPhrase, \'\'_String)) (removed)
-                Prewhere filter column: and(notEquals(__table1.SearchPhrase, \'\'_String), like(__table1.Title, \'%Google%\'_String), notLike(__table1.URL, \'%.google.%\'_String)) (removed)
+Prewhere filter column: and(like(__table1.Title, \'%Google%\'_String), notLike(__table1.URL, \'%.google.%\'_String), notEquals(__table1.SearchPhrase, \'\'_String)) (removed)
+Prewhere filter column: and(notEquals(__table1.SearchPhrase, \'\'_String), like(__table1.Title, \'%Google%\'_String), notLike(__table1.URL, \'%.google.%\'_String)) (removed)

--- a/tests/queries/1_stateful/00183_prewhere_conditions_order.sql
+++ b/tests/queries/1_stateful/00183_prewhere_conditions_order.sql
@@ -1,7 +1,8 @@
 SET optimize_move_to_prewhere = 1;
 SET enable_multiple_prewhere_read_steps = 1;
+SET parallel_replicas_local_plan = 1;
 
-SELECT explain
+SELECT trimBoth(explain)
 FROM (
 EXPLAIN actions=1
 SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID)
@@ -14,7 +15,7 @@ SETTINGS allow_reorder_prewhere_conditions = 0
 )
 WHERE explain like '%Prewhere filter column%';
 
-SELECT explain
+SELECT trimBoth(explain)
 FROM (
 EXPLAIN actions=1
 SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


