### PR TITLE
Docs: Add description of MergeTree setting `assign_part_uuids`

### DIFF
--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -1195,6 +1195,6 @@ Default: true
 
 ## assign_part_uuids
 
-Generate UUIDs for parts. Before enabling check that all replicas support new format.
+When enabled, unique part identifier ([UUID](../../sql-reference/data-types/uuid.md)) will be assigned for every new part. Before enabling, check that all replicas support new format uuid version 4.
 
-Default: 0
+Default: 0.

--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -1192,3 +1192,9 @@ Default value: false.
 When enabled, merges build and store skip indices for new parts.
 
 Default: true
+
+## assign_part_uuids
+
+Generate UUIDs for parts. Before enabling check that all replicas support new format.
+
+Default: 0

--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -1195,6 +1195,6 @@ Default: true
 
 ## assign_part_uuids
 
-When enabled, unique part identifier ([UUID](../../sql-reference/data-types/uuid.md)) will be assigned for every new part. Before enabling, check that all replicas support new format uuid version 4.
+When enabled, unique part identifier will be assigned for every new part. Before enabling, check that all replicas support UUID version 4.
 
 Default: 0.

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -232,7 +232,7 @@ namespace ErrorCodes
     DECLARE(String, disk, "", "Name of storage disk. Can be specified instead of storage policy.", 0) \
     DECLARE(Bool, allow_nullable_key, false, "Allow Nullable types as primary keys.", 0) \
     DECLARE(Bool, remove_empty_parts, true, "Remove empty parts after they were pruned by TTL, mutation, or collapsing merge algorithm.", 0) \
-    DECLARE(Bool, assign_part_uuids, false, "Generate UUIDs for parts. Before enabling check that all replicas support new format.", 0) \
+    DECLARE(Bool, assign_part_uuids, false, "When enabled, a unique part identifier will be assigned for every new part. Before enabling, check that all replicas support UUID version 4.", 0) \
     DECLARE(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited. This setting is the default that can be overridden by the query-level setting with the same name.", 0) \
     DECLARE(UInt64, max_concurrent_queries, 0, "Max number of concurrently executed queries related to the MergeTree table (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
     DECLARE(UInt64, min_marks_to_honor_max_concurrent_queries, 0, "Minimal number of marks to honor the MergeTree-level's max_concurrent_queries (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -2910,8 +2910,8 @@ timeZoneOffset
 timezones
 tinylog
 tmp
-toBool
 toBFloat
+toBool
 toColumnTypeName
 toDate
 toDateOrDefault
@@ -3124,6 +3124,7 @@ userspace
 userver
 utils
 uuid
+uuids
 uuidv
 vCPU
 varPop


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)