### PR TITLE
Docs: move `SQLInsert` format to own page

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -394,31 +394,7 @@ the types from input data will be compared with the types of the corresponding c
 
 ## SQLInsert {#sqlinsert}
 
-Outputs data as a sequence of `INSERT INTO table (columns...) VALUES (...), (...) ...;` statements.
-
-Example:
-
-```sql
-SELECT number AS x, number + 1 AS y, 'Hello' AS z FROM numbers(10) FORMAT SQLInsert SETTINGS output_format_sql_insert_max_batch_size = 2
-```
-
-```sql
-INSERT INTO table (x, y, z) VALUES (0, 1, 'Hello'), (1, 2, 'Hello');
-INSERT INTO table (x, y, z) VALUES (2, 3, 'Hello'), (3, 4, 'Hello');
-INSERT INTO table (x, y, z) VALUES (4, 5, 'Hello'), (5, 6, 'Hello');
-INSERT INTO table (x, y, z) VALUES (6, 7, 'Hello'), (7, 8, 'Hello');
-INSERT INTO table (x, y, z) VALUES (8, 9, 'Hello'), (9, 10, 'Hello');
-```
-
-To read data output by this format you can use [MySQLDump](#mysqldump) input format.
-
-### SQLInsert format settings {#sqlinsert-format-settings}
-
-- [output_format_sql_insert_max_batch_size](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_max_batch_size) - The maximum number of rows in one INSERT statement. Default value - `65505`.
-- [output_format_sql_insert_table_name](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_table_name) - The name of the table in the output INSERT query. Default value - `'table'`.
-- [output_format_sql_insert_include_column_names](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_include_column_names) - Include column names in INSERT query. Default value - `true`.
-- [output_format_sql_insert_use_replace](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_use_replace) - Use REPLACE statement instead of INSERT. Default value - `false`.
-- [output_format_sql_insert_quote_names](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_quote_names) - Quote column names with "\`" characters. Default value - `true`.
+See [SQLInsert](formats/SQLInsert.md)
 
 ## JSON {#json}
 

--- a/docs/en/interfaces/formats/SQLInsert.md
+++ b/docs/en/interfaces/formats/SQLInsert.md
@@ -2,7 +2,14 @@
 title : SQLInsert
 slug : /en/interfaces/formats/SQLInsert
 keywords : [SQLInsert]
+input_format: false
+output_format: true
+alias: []
 ---
+
+| Input | Output | Alias |
+|-------|--------|-------|
+| ✗     | ✔      |       |
 
 ## Description
 
@@ -24,13 +31,15 @@ INSERT INTO table (x, y, z) VALUES (6, 7, 'Hello'), (7, 8, 'Hello');
 INSERT INTO table (x, y, z) VALUES (8, 9, 'Hello'), (9, 10, 'Hello');
 ```
 
-To read data output by this format you can use [MySQLDump](/docs/en/interfaces/formats/MySQLDump) input format.
+To read data output by this format you can use [MySQLDump](../formats/MySQLDump.md) input format.
 
 ## Format Settings
 
-- [output_format_sql_insert_max_batch_size](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_max_batch_size) - The maximum number of rows in one INSERT statement. Default value - `65505`.
-- [output_format_sql_insert_table_name](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_table_name) - The name of the table in the output INSERT query. Default value - `'table'`.
-- [output_format_sql_insert_include_column_names](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_include_column_names) - Include column names in INSERT query. Default value - `true`.
-- [output_format_sql_insert_use_replace](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_use_replace) - Use REPLACE statement instead of INSERT. Default value - `false`.
-- [output_format_sql_insert_quote_names](/docs/en/operations/settings/settings-formats.md/#output_format_sql_insert_quote_names) - Quote column names with "\`" characters. Default value - `true`.
+| Setting                                                                                                                                            | Description                                         | Default   |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|-----------|
+| [`output_format_sql_insert_max_batch_size`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_max_batch_size)             | The maximum number of rows in one INSERT statement. | `65505`   |
+| [`output_format_sql_insert_table_name`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_table_name)                     | The name of the table in the output INSERT query.   | `'table'` |
+| [`output_format_sql_insert_include_column_names`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_include_column_names) | Include column names in INSERT query.               | `true`    |
+| [`output_format_sql_insert_use_replace`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_use_replace)                   | Use REPLACE statement instead of INSERT.            | `false`   |
+| [`output_format_sql_insert_quote_names`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_quote_names)                   | Quote column names with "\`" characters.            | `true`    |
 

--- a/docs/en/interfaces/formats/SQLInsert.md
+++ b/docs/en/interfaces/formats/SQLInsert.md
@@ -35,11 +35,11 @@ To read data output by this format you can use [MySQLDump](../formats/MySQLDump.
 
 ## Format Settings
 
-| Setting                                                                                                                                            | Description                                         | Default   |
-|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|-----------|
-| [`output_format_sql_insert_max_batch_size`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_max_batch_size)             | The maximum number of rows in one INSERT statement. | `65505`   |
-| [`output_format_sql_insert_table_name`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_table_name)                     | The name of the table in the output INSERT query.   | `'table'` |
-| [`output_format_sql_insert_include_column_names`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_include_column_names) | Include column names in INSERT query.               | `true`    |
-| [`output_format_sql_insert_use_replace`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_use_replace)                   | Use REPLACE statement instead of INSERT.            | `false`   |
-| [`output_format_sql_insert_quote_names`](../../../operations/settings/settings-formats.md/#output_format_sql_insert_quote_names)                   | Quote column names with "\`" characters.            | `true`    |
+| Setting                                                                                                                                | Description                                         | Default   |
+|----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|-----------|
+| [`output_format_sql_insert_max_batch_size`](../../operations/settings/settings-formats.md/#output_format_sql_insert_max_batch_size)    | The maximum number of rows in one INSERT statement. | `65505`   |
+| [`output_format_sql_insert_table_name`](../../operations/settings/settings-formats.md/#output_format_sql_insert_table_name)            | The name of the table in the output INSERT query.   | `'table'` |
+| [`output_format_sql_insert_include_column_names`](../../operations/settings/settings-formats.md/#output_format_sql_insert_include_column_names) | Include column names in INSERT query.               | `true`    |
+| [`output_format_sql_insert_use_replace`](../../operations/settings/settings-formats.md/#output_format_sql_insert_use_replace)          | Use REPLACE statement instead of INSERT.            | `false`   |
+| [`output_format_sql_insert_quote_names`](../../operations/settings/settings-formats.md/#output_format_sql_insert_quote_names)          | Quote column names with "\`" characters.            | `true`    |
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Move `SQLInsert` format to it's own page and link to it from the page with all formats on one page.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_merge_commit--> Disable merge-commit (Run CI on branch HEAD instead of merge commit with target branch)
- [ ] <!---no_ci_cache--> Disable CI cache
