### PR TITLE
Add TPC-H queries to performance tests

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -200,7 +200,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     {
         if (create.if_not_exists)
             return {};
-        throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Database {} already exists.", database_name);
+        throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Database {} already exists", database_name);
     }
 
     auto db_num_limit = getContext()->getGlobalContext()->getServerSettings()[ServerSetting::max_database_num_to_throw];

--- a/tests/performance/scripts/download.sh
+++ b/tests/performance/scripts/download.sh
@@ -23,6 +23,8 @@ dataset_paths["hits10"]="https://clickhouse-private-datasets.s3.amazonaws.com/hi
 dataset_paths["hits100"]="https://clickhouse-private-datasets.s3.amazonaws.com/hits_100m_single/partitions/hits_100m_single.tar"
 dataset_paths["hits1"]="https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar"
 dataset_paths["values"]="https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar"
+dataset_paths["tpch1"]="https://clickhouse-datasets.s3.amazonaws.com/h/1/tpch.tar"
+dataset_paths["tpch10"]="https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar"
 
 
 function download
@@ -74,8 +76,11 @@ function download
     ) &
 
     wait
+
+    # The datasets are in a deprecated ORDINARY database ... TODO: convert to Atomic
     echo "ATTACH DATABASE default ENGINE=Ordinary" > db0/metadata/default.sql
     echo "ATTACH DATABASE datasets ENGINE=Ordinary" > db0/metadata/datasets.sql
+
     ls db0/metadata
 }
 

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -639,7 +639,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                     WHERE
                         c_acctbal &gt; 0.00
                         AND substring(c_phone FROM 1 for 2) in
-                            (&apos;13&apos;, &apos;31&apos;, &apos;23&apos;, &apos;29&apos;, &apos;30&apos;, &apos;18&apos;, &apos;17&apos&apos;)
+                            (&apos;13&apos;, &apos;31&apos;, &apos;23&apos;, &apos;29&apos;, &apos;30&apos;, &apos;18&apos;, &apos;17&apos;&apos;)
                 )
                 AND NOT EXISTS (
                     SELECT

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -20,7 +20,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         FROM
             tpch10.lineitem
         WHERE
-            l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+            l_shipdate &lt;= DATE &apos;1998-12-01&apos; - INTERVAL &apos;90&apos; DAY
         GROUP BY
             l_returnflag,
             l_linestatus
@@ -44,7 +44,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             JOIN
                 tpch10.region r ON n.n_regionkey = r.r_regionkey
             WHERE
-                r.r_name = 'EUROPE'
+                r.r_name = &apos;EUROPE&apos;
             GROUP BY
                 ps_partkey
         )
@@ -71,8 +71,8 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             MinSupplyCost msc ON ps.ps_partkey = msc.ps_partkey AND ps.ps_supplycost = msc.min_supplycost
         WHERE
             p.p_size = 15
-            AND p.p_type LIKE '%BRASS'
-            AND r.r_name = 'EUROPE'
+            AND p.p_type LIKE &apos;%BRASS&apos;
+            AND r.r_name = &apos;EUROPE&apos;
         ORDER BY
             s.s_acctbal DESC,
             n.n_name,
@@ -92,11 +92,11 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             tpch10.orders,
             tpch10.lineitem
         WHERE
-            c_mktsegment = 'BUILDING'
+            c_mktsegment = &apos;BUILDING&apos;
             AND c_custkey = o_custkey
             AND l_orderkey = o_orderkey
-            AND o_orderdate < DATE '1995-03-15'
-            AND l_shipdate > DATE '1995-03-15'
+            AND o_orderdate &lt; DATE &apos;1995-03-15&apos;
+            AND l_shipdate &gt; DATE &apos;1995-03-15&apos;
         GROUP BY
             l_orderkey,
             o_orderdate,
@@ -114,7 +114,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             FROM
                 tpch10.lineitem
             WHERE
-                l_commitdate < l_receiptdate
+                l_commitdate &lt; l_receiptdate
             GROUP BY
                 l_orderkey
         )
@@ -126,8 +126,8 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         JOIN
             ValidLineItems vli ON o.o_orderkey = vli.l_orderkey
         WHERE
-            o.o_orderdate >= DATE '1993-07-01'
-            AND o.o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+            o.o_orderdate &gt;= DATE &apos;1993-07-01&apos;
+            AND o.o_orderdate &lt; DATE &apos;1993-07-01&apos; + INTERVAL &apos;3&apos; MONTH
         GROUP BY
             o.o_orderpriority
         ORDER BY
@@ -153,9 +153,9 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             AND c_nationkey = s_nationkey
             AND s_nationkey = n_nationkey
             AND n_regionkey = r_regionkey
-            AND r_name = 'ASIA'
-            AND o_orderdate >= DATE '1994-01-01'
-            AND o_orderdate < DATE '1994-01-01' + INTERVAL '1' year
+            AND r_name = &apos;ASIA&apos;
+            AND o_orderdate &gt;= DATE &apos;1994-01-01&apos;
+            AND o_orderdate &lt; DATE &apos;1994-01-01&apos; + INTERVAL &apos;1&apos; year
         GROUP BY
             n_name
         ORDER BY
@@ -169,10 +169,10 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         FROM
             tpch10.lineitem
         WHERE
-            l_shipdate >= DATE '1994-01-01'
-            AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
+            l_shipdate &gt;= DATE &apos;1994-01-01&apos;
+            AND l_shipdate &lt; DATE &apos;1994-01-01&apos; + INTERVAL &apos;1&apos; year
             AND l_discount BETWEEN 0.05 AND 0.07
-            AND l_quantity < 24;
+            AND l_quantity &lt; 24;
     </query>
 
     <!-- Q7 -->
@@ -202,10 +202,10 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 AND s_nationkey = n1.n_nationkey
                 AND c_nationkey = n2.n_nationkey
                 AND (
-                    (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
-                    OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+                    (n1.n_name = &apos;FRANCE&apos; AND n2.n_name = &apos;GERMANY&apos;)
+                    OR (n1.n_name = &apos;GERMANY&apos; AND n2.n_name = &apos;FRANCE&apos;)
                 )
-                AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+                AND l_shipdate BETWEEN DATE &apos;1995-01-01&apos; AND DATE &apos;1996-12-31&apos;
             ) AS shipping
         GROUP BY
             supp_nation,
@@ -222,7 +222,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         SELECT
             o_year,
             sum(CASE
-                    WHEN nation = 'BRAZIL'
+                    WHEN nation = &apos;BRAZIL&apos;
                     THEN volume
                     ELSE 0
                 END) / sum(volume) AS mkt_share
@@ -247,10 +247,10 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 AND o_custkey = c_custkey
                 AND c_nationkey = n1.n_nationkey
                 AND n1.n_regionkey = r_regionkey
-                AND r_name = 'AMERICA'
+                AND r_name = &apos;AMERICA&apos;
                 AND s_nationkey = n2.n_nationkey
-                AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
-                AND p_type = 'ECONOMY ANODIZED STEEL'
+                AND o_orderdate BETWEEN DATE &apos;1995-01-01&apos; AND DATE &apos;1996-12-31&apos;
+                AND p_type = &apos;ECONOMY ANODIZED STEEL&apos;
             ) AS all_nations
         GROUP BY
             o_year
@@ -283,7 +283,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 AND p_partkey = l_partkey
                 AND o_orderkey = l_orderkey
                 AND s_nationkey = n_nationkey
-                AND p_name LIKE '%green%'
+                AND p_name LIKE &apos;%green%&apos;
             ) AS profit
         GROUP BY
             nation,
@@ -312,9 +312,9 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         WHERE
             c_custkey = o_custkey
             AND l_orderkey = o_orderkey
-            AND o_orderdate >= DATE '1993-10-01'
-            AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' MONTH
-            AND l_returnflag = 'R'
+            AND o_orderdate &gt;= DATE &apos;1993-10-01&apos;
+            AND o_orderdate &lt; DATE &apos;1993-10-01&apos; + INTERVAL &apos;3&apos; MONTH
+            AND l_returnflag = &apos;R&apos;
             AND c_nationkey = n_nationkey
         GROUP BY
             c_custkey,
@@ -340,7 +340,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         WHERE
             ps_suppkey = s_suppkey
             AND s_nationkey = n_nationkey
-            AND n_name = 'GERMANY'
+            AND n_name = &apos;GERMANY&apos;
         GROUP BY
             ps_partkey HAVING
                 sum(ps_supplycost * ps_availqty) > (
@@ -353,7 +353,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                     WHERE
                         ps_suppkey = s_suppkey
                         AND s_nationkey = n_nationkey
-                        AND n_name = 'GERMANY'
+                        AND n_name = &apos;GERMANY&apos;
                 )
         ORDER BY
             value DESC;
@@ -364,14 +364,14 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         SELECT
             l_shipmode,
             sum(CASE
-                    WHEN o_orderpriority = '1-URGENT'
-                        OR o_orderpriority = '2-HIGH'
+                    WHEN o_orderpriority = &apos;1-URGENT&apos;
+                        OR o_orderpriority = &apos;2-HIGH&apos;
                     THEN 1
                     ELSE 0
                 END) AS high_line_count,
             sum(CASE
-                WHEN o_orderpriority <> '1-URGENT'
-                        AND o_orderpriority <> '2-HIGH'
+                WHEN o_orderpriority &lt;&gt; &apos;1-URGENT&apos;
+                        AND o_orderpriority &lt;&gt; &apos;2-HIGH&apos;
                     THEN 1
                 ELSE 0
                 END) AS low_line_count
@@ -380,11 +380,11 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             tpch10.lineitem
         WHERE
             o_orderkey = l_orderkey
-            AND l_shipmode in ('MAIL', 'SHIP')
-            AND l_commitdate < l_receiptdate
-            AND l_shipdate < l_commitdate
-            AND l_receiptdate >= DATE '1994-01-01'
-            AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' year
+            AND l_shipmode in (&apos;MAIL&apos;, &apos;SHIP&apos;)
+            AND l_commitdate &lt; l_receiptdate
+            AND l_shipdate &lt; l_commitdate
+            AND l_receiptdate &gt;= DATE &apos;1994-01-01&apos;
+            AND l_receiptdate &lt; DATE &apos;1994-01-01&apos; + INTERVAL &apos;1&apos; year
         GROUP BY
             l_shipmode
         ORDER BY
@@ -401,7 +401,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 tpch10.customer c
             LEFT OUTER JOIN
                 tpch10.orders o ON c.c_custkey = o.o_custkey
-                AND o.o_comment NOT LIKE '%special%requests%'
+                AND o.o_comment NOT LIKE &apos;%special%requests%&apos;
             GROUP BY
                 c.c_custkey
         )
@@ -421,7 +421,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
     <query>
         SELECT
             100.00 * sum(CASE
-                            WHEN p_type LIKE 'PROMO%'
+                            WHEN p_type LIKE &apos;PROMO%&apos;
                             THEN l_extendedprice * (1 - l_discount)
                             ELSE 0
                         END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
@@ -430,8 +430,8 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             tpch10.part
         WHERE
             l_partkey = p_partkey
-            AND l_shipdate >= DATE '1995-09-01'
-            AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
+            AND l_shipdate &gt;= DATE &apos;1995-09-01&apos;
+            AND l_shipdate &lt; DATE &apos;1995-09-01&apos; + INTERVAL &apos;1&apos; MONTH;
     </query>
 
     <!-- Q15 -->
@@ -443,8 +443,8 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             FROM
                 tpch10.lineitem
             WHERE
-                l_shipdate >= DATE '1996-01-01'
-                AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
+                l_shipdate &gt;= DATE &apos;1996-01-01&apos;
+                AND l_shipdate &lt; DATE &apos;1996-01-01&apos; + INTERVAL &apos;3&apos; MONTH
             GROUP BY
                 l_suppkey;
 
@@ -483,8 +483,8 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
             tpch10.part
         WHERE
             p_partkey = ps_partkey
-            AND p_brand <> 'Brand#45'
-            AND p_type NOT LIKE 'MEDIUM POLISHED%'
+            AND p_brand &lt;&gt; &apos;Brand#45&apos;
+            AND p_type NOT LIKE &apos;MEDIUM POLISHED%&apos;
             AND p_size in (49, 14, 23,  45, 19, 3, 36, 9)
             AND ps_suppkey NOT in (
                 SELECT
@@ -492,7 +492,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 FROM
                     tpch10.supplier
                 WHERE
-                    s_comment LIKE '%Customer%Complaints%'
+                    s_comment LIKE &apos;%Customer%Complaints%&apos;
             )
         GROUP BY
             p_brand,
@@ -525,9 +525,9 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         JOIN
             AvgQuantity aq ON l.l_partkey = aq.l_partkey
         WHERE
-            p.p_brand = 'Brand#23'
-            AND p.p_container = 'MED BOX'
-            AND l.l_quantity < aq.avg_quantity;
+            p.p_brand = &apos;Brand#23&apos;
+            AND p.p_container = &apos;MED BOX&apos;
+            AND l.l_quantity &lt; aq.avg_quantity;
     </query>
 
     <!-- Q18 -->
@@ -552,7 +552,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 GROUP BY
                     l_orderkey
                 HAVING
-                    sum(l_quantity) > 300
+                    sum(l_quantity) &gt; 300
             )
             AND c_custkey = o_custkey
             AND o_orderkey = l_orderkey
@@ -577,32 +577,32 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
         WHERE
             (
                 p_partkey = l_partkey
-                AND p_brand = 'Brand#12'
-                AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
-                AND l_quantity >= 1 AND l_quantity <= 1 + 10
+                AND p_brand = &apos;Brand#12&apos;
+                AND p_container in (&apos;SM CASE&apos;, &apos;SM BOX&apos;, &apos;SM PACK&apos;, &apos;SM PKG&apos;)
+                AND l_quantity &gt;= 1 AND l_quantity &lt;= 1 + 10
                 AND p_size BETWEEN 1 AND 5
-                AND l_shipmode in ('AIR', 'AIR REG')
-                AND l_shipinstruct = 'DELIVER IN PERSON'
+                AND l_shipmode in (&apos;AIR&apos;, &apos;AIR REG&apos;)
+                AND l_shipinstruct = &apos;DELIVER IN PERSON&apos;
             )
             OR
             (
                 p_partkey = l_partkey
-                AND p_brand = 'Brand#23'
-                AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
-                AND l_quantity >= 10 AND l_quantity <= 10 + 10
+                AND p_brand = &apos;Brand#23&apos;
+                AND p_container in (&apos;MED BAG&apos;, &apos;MED BOX&apos;, &apos;MED PKG&apos;, &apos;MED PACK&apos;)
+                AND l_quantity &gt;= 10 AND l_quantity &lt;= 10 + 10
                 AND p_size BETWEEN 1 AND 10
-                AND l_shipmode in ('AIR', 'AIR REG')
-                AND l_shipinstruct = 'DELIVER IN PERSON'
+                AND l_shipmode in (&apos;AIR&apos;, &apos;AIR REG&apos;)
+                AND l_shipinstruct = &apos;DELIVER IN PERSON&apos;
             )
             OR
             (
                 p_partkey = l_partkey
-                AND p_brand = 'Brand#34'
-                AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
-                AND l_quantity >= 20 AND l_quantity <= 20 + 10
+                AND p_brand = &apos;Brand#34&apos;
+                AND p_container in (&apos;LG CASE&apos;, &apos;LG BOX&apos;, &apos;LG PACK&apos;, &apos;LG PKG&apos;)
+                AND l_quantity &gt;= 20 AND l_quantity &lt;= 20 + 10
                 AND p_size BETWEEN 1 AND 15
-                AND l_shipmode in ('AIR', 'AIR REG')
-                AND l_shipinstruct = 'DELIVER IN PERSON'
+                AND l_shipmode in (&apos;AIR&apos;, &apos;AIR REG&apos;)
+                AND l_shipinstruct = &apos;DELIVER IN PERSON&apos;
             );
     </query>
 
@@ -630,16 +630,16 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                 tpch10.customer
             WHERE
                 substring(c_phone FROM 1 for 2) in
-                    ('13', '31', '23', '29', '30', '18', '17')
-                AND c_acctbal > (
+                    (&apos;13&apos;, &apos;31&apos;, &apos;23&apos;, &apos;29&apos;, &apos;30&apos;, &apos;18&apos;, &apos;17&apos;)
+                AND c_acctbal &gt; (
                     SELECT
                         avg(c_acctbal)
                     FROM
                         tpch10.customer
                     WHERE
-                        c_acctbal > 0.00
+                        c_acctbal &gt; 0.00
                         AND substring(c_phone FROM 1 for 2) in
-                            ('13', '31', '23', '29', '30', '18', '17')
+                            (&apos;13&apos;, &apos;31&apos;, &apos;23&apos;, &apos;29&apos;, &apos;30&apos;, &apos;18&apos;, &apos;17&apos&apos;)
                 )
                 AND NOT EXISTS (
                     SELECT

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -1,0 +1,659 @@
+<test>
+
+<!--
+See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
+-->
+
+    <!-- Q1 -->
+    <query>
+        SELECT
+            l_returnflag,
+            l_linestatus,
+            sum(l_quantity) AS sum_qty,
+            sum(l_extendedprice) AS sum_base_price,
+            sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+            sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+            avg(l_quantity) AS avg_qty,
+            avg(l_extendedprice) AS avg_price,
+            avg(l_discount) AS avg_disc,
+            count(*) AS count_order
+        FROM
+            tpch10.lineitem
+        WHERE
+            l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+        GROUP BY
+            l_returnflag,
+            l_linestatus
+        ORDER BY
+            l_returnflag,
+            l_linestatus;
+    </query>
+
+    <!-- Q2, manually decorrelated version -->
+    <query>
+        WITH MinSupplyCost AS (
+            SELECT
+                ps_partkey,
+                MIN(ps_supplycost) AS min_supplycost
+            FROM
+                tpch10.partsupp ps
+            JOIN
+                tpch10.supplier s ON ps.ps_suppkey = s.s_suppkey
+            JOIN
+                tpch10.nation n ON s.s_nationkey = n.n_nationkey
+            JOIN
+                tpch10.region r ON n.n_regionkey = r.r_regionkey
+            WHERE
+                r.r_name = 'EUROPE'
+            GROUP BY
+                ps_partkey
+        )
+        SELECT
+            s.s_acctbal,
+            s.s_name,
+            n.n_name,
+            p.p_partkey,
+            p.p_mfgr,
+            s.s_address,
+            s.s_phone,
+            s.s_comment
+        FROM
+            tpch10.part p
+        JOIN
+            tpch10.partsupp ps ON p.p_partkey = ps.ps_partkey
+        JOIN
+            tpch10.supplier s ON s.s_suppkey = ps.ps_suppkey
+        JOIN
+            tpch10.nation n ON s.s_nationkey = n.n_nationkey
+        JOIN
+            tpch10.region r ON n.n_regionkey = r.r_regionkey
+        JOIN
+            MinSupplyCost msc ON ps.ps_partkey = msc.ps_partkey AND ps.ps_supplycost = msc.min_supplycost
+        WHERE
+            p.p_size = 15
+            AND p.p_type LIKE '%BRASS'
+            AND r.r_name = 'EUROPE'
+        ORDER BY
+            s.s_acctbal DESC,
+            n.n_name,
+            s.s_name,
+            p.p_partkey;
+    </query>
+
+    <!-- Q3 -->
+    <query>
+        SELECT
+            l_orderkey,
+            sum(l_extendedprice * (1 - l_discount)) AS revenue,
+            o_orderdate,
+            o_shippriority
+        FROM
+            tpch10.customer,
+            tpch10.orders,
+            tpch10.lineitem
+        WHERE
+            c_mktsegment = 'BUILDING'
+            AND c_custkey = o_custkey
+            AND l_orderkey = o_orderkey
+            AND o_orderdate < DATE '1995-03-15'
+            AND l_shipdate > DATE '1995-03-15'
+        GROUP BY
+            l_orderkey,
+            o_orderdate,
+            o_shippriority
+        ORDER BY
+            revenue DESC,
+            o_orderdate;
+    </query>
+
+    <!-- Q4, manually decorrelated version -->
+    <query>
+        WITH ValidLineItems AS (
+            SELECT
+                l_orderkey
+            FROM
+                tpch10.lineitem
+            WHERE
+                l_commitdate < l_receiptdate
+            GROUP BY
+                l_orderkey
+        )
+        SELECT
+            o.o_orderpriority,
+            COUNT(*) AS order_count
+        FROM
+            tpch10.orders o
+        JOIN
+            ValidLineItems vli ON o.o_orderkey = vli.l_orderkey
+        WHERE
+            o.o_orderdate >= DATE '1993-07-01'
+            AND o.o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+        GROUP BY
+            o.o_orderpriority
+        ORDER BY
+            o.o_orderpriority;
+    </query>
+
+    <!-- Q5 -->
+    <query>
+        SELECT
+            n_name,
+            sum(l_extendedprice * (1 - l_discount)) AS revenue
+        FROM
+            tpch10.customer,
+            tpch10.orders,
+            tpch10.lineitem,
+            tpch10.supplier,
+            tpch10.nation,
+            tpch10.region
+        WHERE
+            c_custkey = o_custkey
+            AND l_orderkey = o_orderkey
+            AND l_suppkey = s_suppkey
+            AND c_nationkey = s_nationkey
+            AND s_nationkey = n_nationkey
+            AND n_regionkey = r_regionkey
+            AND r_name = 'ASIA'
+            AND o_orderdate >= DATE '1994-01-01'
+            AND o_orderdate < DATE '1994-01-01' + INTERVAL '1' year
+        GROUP BY
+            n_name
+        ORDER BY
+            revenue DESC;
+    </query>
+
+    <!-- Q6, with workaround for decimal addition bug -->
+    <query>
+        SELECT
+            sum(l_extendedprice * l_discount) AS revenue
+        FROM
+            tpch10.lineitem
+        WHERE
+            l_shipdate >= DATE '1994-01-01'
+            AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
+            AND l_discount BETWEEN 0.05 AND 0.07
+            AND l_quantity < 24;
+    </query>
+
+    <!-- Q7 -->
+    <query>
+        SELECT
+            supp_nation,
+            cust_nation,
+            l_year,
+            sum(volume) AS revenue
+        FROM (
+            SELECT
+                n1.n_name AS supp_nation,
+                n2.n_name AS cust_nation,
+                extract(year FROM l_shipdate) AS l_year,
+                l_extendedprice * (1 - l_discount) AS volume
+            FROM
+                tpch10.supplier,
+                tpch10.lineitem,
+                tpch10.orders,
+                tpch10.customer,
+                tpch10.nation n1,
+                tpch10.nation n2
+            WHERE
+                s_suppkey = l_suppkey
+                AND o_orderkey = l_orderkey
+                AND c_custkey = o_custkey
+                AND s_nationkey = n1.n_nationkey
+                AND c_nationkey = n2.n_nationkey
+                AND (
+                    (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+                    OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+                )
+                AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+            ) AS shipping
+        GROUP BY
+            supp_nation,
+            cust_nation,
+            l_year
+        ORDER BY
+            supp_nation,
+            cust_nation,
+            l_year;
+    </query>
+
+    <!-- Q8 -->
+    <query>
+        SELECT
+            o_year,
+            sum(CASE
+                    WHEN nation = 'BRAZIL'
+                    THEN volume
+                    ELSE 0
+                END) / sum(volume) AS mkt_share
+        FROM (
+            SELECT
+                extract(year FROM o_orderdate) AS o_year,
+                l_extendedprice * (1 - l_discount) AS volume,
+                n2.n_name AS nation
+            FROM
+                tpch10.part,
+                tpch10.supplier,
+                tpch10.lineitem,
+                tpch10.orders,
+                tpch10.customer,
+                tpch10.nation n1,
+                tpch10.nation n2,
+                tpch10.region
+            WHERE
+                p_partkey = l_partkey
+                AND s_suppkey = l_suppkey
+                AND l_orderkey = o_orderkey
+                AND o_custkey = c_custkey
+                AND c_nationkey = n1.n_nationkey
+                AND n1.n_regionkey = r_regionkey
+                AND r_name = 'AMERICA'
+                AND s_nationkey = n2.n_nationkey
+                AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+                AND p_type = 'ECONOMY ANODIZED STEEL'
+            ) AS all_nations
+        GROUP BY
+            o_year
+        ORDER BY
+            o_year;
+    </query>
+
+    <!-- Q9 -->
+    <query>
+        SELECT
+            nation,
+            o_year,
+            sum(amount) AS sum_profit
+        FROM (
+            SELECT
+                n_name AS nation,
+                extract(year FROM o_orderdate) AS o_year,
+                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+            FROM
+                tpch10.part,
+                tpch10.supplier,
+                tpch10.lineitem,
+                tpch10.partsupp,
+                tpch10.orders,
+                tpch10.nation
+            WHERE
+                s_suppkey = l_suppkey
+                AND ps_suppkey = l_suppkey
+                AND ps_partkey = l_partkey
+                AND p_partkey = l_partkey
+                AND o_orderkey = l_orderkey
+                AND s_nationkey = n_nationkey
+                AND p_name LIKE '%green%'
+            ) AS profit
+        GROUP BY
+            nation,
+            o_year
+        ORDER BY
+            nation,
+            o_year DESC;
+    </query>
+
+    <!-- Q10 -->
+    <query>
+        SELECT
+            c_custkey,
+            c_name,
+            sum(l_extendedprice * (1 - l_discount)) AS revenue,
+            c_acctbal,
+            n_name,
+            c_address,
+            c_phone,
+            c_comment
+        FROM
+            tpch10.customer,
+            tpch10.orders,
+            tpch10.lineitem,
+            tpch10.nation
+        WHERE
+            c_custkey = o_custkey
+            AND l_orderkey = o_orderkey
+            AND o_orderdate >= DATE '1993-10-01'
+            AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' MONTH
+            AND l_returnflag = 'R'
+            AND c_nationkey = n_nationkey
+        GROUP BY
+            c_custkey,
+            c_name,
+            c_acctbal,
+            c_phone,
+            n_name,
+            c_address,
+            c_comment
+        ORDER BY
+            revenue DESC;
+    </query>
+
+    <!-- Q11 -->
+    <query>
+        SELECT
+            ps_partkey,
+            sum(ps_supplycost * ps_availqty) AS value
+        FROM
+            tpch10.partsupp,
+            tpch10.supplier,
+            tpch10.nation
+        WHERE
+            ps_suppkey = s_suppkey
+            AND s_nationkey = n_nationkey
+            AND n_name = 'GERMANY'
+        GROUP BY
+            ps_partkey HAVING
+                sum(ps_supplycost * ps_availqty) > (
+                    SELECT
+                        sum(ps_supplycost * ps_availqty) * 0.0001
+                    FROM
+                        tpch10.partsupp,
+                        tpch10.supplier,
+                        tpch10.nation
+                    WHERE
+                        ps_suppkey = s_suppkey
+                        AND s_nationkey = n_nationkey
+                        AND n_name = 'GERMANY'
+                )
+        ORDER BY
+            value DESC;
+    </query>
+
+    <!-- Q12 -->
+    <query>
+        SELECT
+            l_shipmode,
+            sum(CASE
+                    WHEN o_orderpriority = '1-URGENT'
+                        OR o_orderpriority = '2-HIGH'
+                    THEN 1
+                    ELSE 0
+                END) AS high_line_count,
+            sum(CASE
+                WHEN o_orderpriority <> '1-URGENT'
+                        AND o_orderpriority <> '2-HIGH'
+                    THEN 1
+                ELSE 0
+                END) AS low_line_count
+        FROM
+            tpch10.orders,
+            tpch10.lineitem
+        WHERE
+            o_orderkey = l_orderkey
+            AND l_shipmode in ('MAIL', 'SHIP')
+            AND l_commitdate < l_receiptdate
+            AND l_shipdate < l_commitdate
+            AND l_receiptdate >= DATE '1994-01-01'
+            AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' year
+        GROUP BY
+            l_shipmode
+        ORDER BY
+            l_shipmode;
+    </query>
+
+    <!-- Q13, manually decorrelated version-->
+    <query>
+        WITH CustomerOrderCounts AS (
+            SELECT
+                c.c_custkey,
+                count(o.o_orderkey) AS order_count
+            FROM
+                tpch10.customer c
+            LEFT OUTER JOIN
+                tpch10.orders o ON c.c_custkey = o.o_custkey
+                AND o.o_comment NOT LIKE '%special%requests%'
+            GROUP BY
+                c.c_custkey
+        )
+        SELECT
+            order_count AS c_count,
+            count(*) AS custdist
+        FROM
+            CustomerOrderCounts
+        GROUP BY
+            order_count
+        ORDER BY
+            custdist DESC,
+            c_count DESC;
+    </query>
+
+    <!-- Q14 -->
+    <query>
+        SELECT
+            100.00 * sum(CASE
+                            WHEN p_type LIKE 'PROMO%'
+                            THEN l_extendedprice * (1 - l_discount)
+                            ELSE 0
+                        END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+        FROM
+            tpch10.lineitem,
+            tpch10.part
+        WHERE
+            l_partkey = p_partkey
+            AND l_shipdate >= DATE '1995-09-01'
+            AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
+    </query>
+
+    <!-- Q15 -->
+    <query>
+        CREATE VIEW revenue0 (supplier_no, total_revenue) AS
+            SELECT
+                l_suppkey,
+                sum(l_extendedprice * (1 - l_discount))
+            FROM
+                tpch10.lineitem
+            WHERE
+                l_shipdate >= DATE '1996-01-01'
+                AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
+            GROUP BY
+                l_suppkey;
+
+        SELECT
+            s_suppkey,
+            s_name,
+            s_address,
+            s_phone,
+            total_revenue
+        FROM
+            tpch10.supplier,
+            revenue0
+        WHERE
+            s_suppkey = supplier_no
+            AND total_revenue = (
+                SELECT
+                    max(total_revenue)
+                FROM
+                    revenue0
+            )
+        ORDER BY
+            s_suppkey;
+
+        DROP VIEW revenue0;
+    </query>
+
+    <!-- Q16 -->
+    <query>
+        SELECT
+            p_brand,
+            p_type,
+            p_size,
+            count(distinct ps_suppkey) AS supplier_cnt
+        FROM
+            tpch10.partsupp,
+            tpch10.part
+        WHERE
+            p_partkey = ps_partkey
+            AND p_brand <> 'Brand#45'
+            AND p_type NOT LIKE 'MEDIUM POLISHED%'
+            AND p_size in (49, 14, 23,  45, 19, 3, 36, 9)
+            AND ps_suppkey NOT in (
+                SELECT
+                    s_suppkey
+                FROM
+                    tpch10.supplier
+                WHERE
+                    s_comment LIKE '%Customer%Complaints%'
+            )
+        GROUP BY
+            p_brand,
+            p_type,
+            p_size
+        ORDER BY
+            supplier_cnt DESC,
+            p_brand,
+            p_type,
+            p_size;
+    </query>
+
+    <!-- Q17, manually decorrelated version -->
+    <query>
+        WITH AvgQuantity AS (
+            SELECT
+                l_partkey,
+                AVG(l_quantity) * 0.2 AS avg_quantity
+            FROM
+                tpch10.lineitem
+            GROUP BY
+                l_partkey
+        )
+        SELECT
+            SUM(l.l_extendedprice) / 7.0 AS avg_yearly
+        FROM
+            tpch10.lineitem l
+        JOIN
+            tpch10.part p ON p.p_partkey = l.l_partkey
+        JOIN
+            AvgQuantity aq ON l.l_partkey = aq.l_partkey
+        WHERE
+            p.p_brand = 'Brand#23'
+            AND p.p_container = 'MED BOX'
+            AND l.l_quantity < aq.avg_quantity;
+    </query>
+
+    <!-- Q18 -->
+    <query>
+        SELECT
+            c_name,
+            c_custkey,
+            o_orderkey,
+            o_orderdate,
+            o_totalprice,
+            sum(l_quantity)
+        FROM
+            tpch10.customer,
+            tpch10.orders,
+            tpch10.lineitem
+        WHERE
+            o_orderkey in (
+                SELECT
+                    l_orderkey
+                FROM
+                    tpch10.lineitem
+                GROUP BY
+                    l_orderkey
+                HAVING
+                    sum(l_quantity) > 300
+            )
+            AND c_custkey = o_custkey
+            AND o_orderkey = l_orderkey
+        GROUP BY
+            c_name,
+            c_custkey,
+            o_orderkey,
+            o_orderdate,
+            o_totalprice
+        ORDER BY
+            o_totalprice DESC,
+            o_orderdate;
+    </query>
+
+    <!-- Q19 -->
+    <query>
+        SELECT
+            sum(l_extendedprice * (1 - l_discount)) AS revenue
+        FROM
+            tpch10.lineitem,
+            tpch10.part
+        WHERE
+            (
+                p_partkey = l_partkey
+                AND p_brand = 'Brand#12'
+                AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+                AND l_quantity >= 1 AND l_quantity <= 1 + 10
+                AND p_size BETWEEN 1 AND 5
+                AND l_shipmode in ('AIR', 'AIR REG')
+                AND l_shipinstruct = 'DELIVER IN PERSON'
+            )
+            OR
+            (
+                p_partkey = l_partkey
+                AND p_brand = 'Brand#23'
+                AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+                AND l_quantity >= 10 AND l_quantity <= 10 + 10
+                AND p_size BETWEEN 1 AND 10
+                AND l_shipmode in ('AIR', 'AIR REG')
+                AND l_shipinstruct = 'DELIVER IN PERSON'
+            )
+            OR
+            (
+                p_partkey = l_partkey
+                AND p_brand = 'Brand#34'
+                AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+                AND l_quantity >= 20 AND l_quantity <= 20 + 10
+                AND p_size BETWEEN 1 AND 15
+                AND l_shipmode in ('AIR', 'AIR REG')
+                AND l_shipinstruct = 'DELIVER IN PERSON'
+            );
+    </query>
+
+    <!-- Q20, n/a because of correlated subqueries -->
+    <query>
+        SELECT 1;
+    </query>
+
+    <!-- Q21, n/a because of correlated subqueries -->
+    <query>
+        SELECT 1;
+    </query>
+
+    <!-- Q22 -->
+    <query>
+        SELECT
+            cntrycode,
+            count(*) AS numcust,
+            sum(c_acctbal) AS totacctbal
+        FROM (
+            SELECT
+                substring(c_phone FROM 1 for 2) AS cntrycode,
+                c_acctbal
+            FROM
+                tpch10.customer
+            WHERE
+                substring(c_phone FROM 1 for 2) in
+                    ('13', '31', '23', '29', '30', '18', '17')
+                AND c_acctbal > (
+                    SELECT
+                        avg(c_acctbal)
+                    FROM
+                        tpch10.customer
+                    WHERE
+                        c_acctbal > 0.00
+                        AND substring(c_phone FROM 1 for 2) in
+                            ('13', '31', '23', '29', '30', '18', '17')
+                )
+                AND NOT EXISTS (
+                    SELECT
+                        *
+                    FROM
+                        tpch10.orders
+                    WHERE
+                        o_custkey = c_custkey
+                )
+            ) AS custsale
+        GROUP BY
+            cntrycode
+        ORDER BY
+            cntrycode;
+    </query>
+
+</test>

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -639,7 +639,7 @@ See https://clickhouse.com/docs/en/getting-started/example-datasets/tpch
                     WHERE
                         c_acctbal &gt; 0.00
                         AND substring(c_phone FROM 1 for 2) in
-                            (&apos;13&apos;, &apos;31&apos;, &apos;23&apos;, &apos;29&apos;, &apos;30&apos;, &apos;18&apos;, &apos;17&apos;&apos;)
+                            (&apos;13&apos;, &apos;31&apos;, &apos;23&apos;, &apos;29&apos;, &apos;30&apos;, &apos;18&apos;, &apos;17&apos;)
                 )
                 AND NOT EXISTS (
                     SELECT


### PR DESCRIPTION
(same PR as [this one](https://github.com/ClickHouse/ClickHouse/pull/74543) but I wanted to test the fancy [new checkboxes](https://github.com/ClickHouse/ClickHouse/pull/74636) to control CI.)

Adds TPC-H queries to the set of performance tests. This is based on two new datasets (TPC-H, scale factors 1 and 10) which are now available in an S3 bucket.

There are multiple moving parts, so expect the first iteration of this PR to break.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [x] <!---ci_include_performance--> Only: Performance tests
---
- [x] <!---ci_exclude_style--> Skip: Style check
- [x] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_merge_commit--> Disable merge-commit (Run CI on branch HEAD instead of merge commit with target branch)
- [ ] <!---no_ci_cache--> Disable CI cache
