### PR TITLE
CI: Move Release and Tidy builds to separate stage to speed up pipeline

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,12 +27,6 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 sync_pr.py --merge || :
-# Runs in MQ:
-#      - name: Python unit tests
-#        run: |
-#          cd "$GITHUB_WORKSPACE/tests/ci"
-#          echo "Testing the main ci directory"
-#          python3 -m unittest discover -s . -p 'test_*.py'
       - name: PrepareRunConfig
         id: runconfig
         run: |
@@ -50,27 +44,13 @@ jobs:
       - name: Re-create GH statuses for skipped jobs if any
         run: |
             python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --infile ${{ runner.temp }}/ci_run_data.json --update-gh-statuses
-# Runs in MQ:
-#  BuildDockers:
-#    needs: [RunConfig]
-#    if: ${{ !failure() && !cancelled() }}
-#    uses: ./.github/workflows/docker_test_images.yml
-#    with:
-#      data: ${{ needs.RunConfig.outputs.data }}
-  # StyleCheck:
-  #   needs: [RunConfig, BuildDockers]
-  #   if: ${{ !failure() && !cancelled() }}
-  #   uses: ./.github/workflows/reusable_test.yml
-  #   with:
-  #     test_name: Style check
-  #     runner_type: style-checker
-  #     data: ${{ needs.RunConfig.outputs.data }}
-  #     run_command: |
-  #         python3 style_check.py --no-push
-
-  ################################# Main stages #################################
-  # for main CI chain
-  #
+  Builds_0:
+    needs: [RunConfig]
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_0') }}
+    uses: ./.github/workflows/reusable_build_stage.yml
+    with:
+      stage: Builds_0
+      data: ${{ needs.RunConfig.outputs.data }}
   Builds_1:
     needs: [RunConfig]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_1') }}
@@ -79,13 +59,6 @@ jobs:
     with:
       stage: Builds_1
       data: ${{ needs.RunConfig.outputs.data }}
-  Tests_1:
-    needs: [RunConfig, Builds_1]
-    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_1') }}
-    uses: ./.github/workflows/reusable_test_stage.yml
-    with:
-      stage: Tests_1
-      data: ${{ needs.RunConfig.outputs.data }}
   Builds_2:
     needs: [RunConfig, Builds_1]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_2') }}
@@ -93,15 +66,21 @@ jobs:
     with:
       stage: Builds_2
       data: ${{ needs.RunConfig.outputs.data }}
-  Tests_2_ww:
-    needs: [RunConfig, Builds_2]
-    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_2_ww') }}
+  Tests_0:
+    needs: [RunConfig, Builds_0]
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_0') }}
     uses: ./.github/workflows/reusable_test_stage.yml
     with:
-      stage: Tests_2_ww
+      stage: Tests_0
+      data: ${{ needs.RunConfig.outputs.data }}
+  Tests_1:
+    needs: [RunConfig, Builds_1]
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_1') }}
+    uses: ./.github/workflows/reusable_test_stage.yml
+    with:
+      stage: Tests_1
       data: ${{ needs.RunConfig.outputs.data }}
   Tests_2:
-    # Test_3 should not wait for Test_1/Test_2 and should not be blocked by them on master branch since all jobs need to run there.
     needs: [RunConfig, Builds_1]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_2') }}
     uses: ./.github/workflows/reusable_test_stage.yml
@@ -114,7 +93,7 @@ jobs:
   Builds_Report:
     # run report check for failed builds to indicate the CI error
     if: ${{ !cancelled() && needs.RunConfig.result == 'success' && contains(fromJson(needs.RunConfig.outputs.data).jobs_data.jobs_to_do, 'Builds') }}
-    needs: [RunConfig, Builds_1, Builds_2]
+    needs: [RunConfig, Builds_1, Builds_2, Builds_0]
     uses: ./.github/workflows/reusable_test.yml
     with:
       test_name: Builds
@@ -123,7 +102,7 @@ jobs:
 
   FinishCheck:
     if: ${{ !cancelled() }}
-    needs: [RunConfig, Builds_1, Builds_2, Builds_Report, Tests_1, Tests_2_ww, Tests_2]
+    needs: [RunConfig, Builds_0, Builds_1, Builds_2, Builds_Report, Tests_1, Tests_2]
     runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Check out repository code

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -90,10 +90,16 @@ jobs:
       data: ${{ needs.RunConfig.outputs.data }}
       run_command: |
           python3 fast_test_check.py
-
   ################################# Main stages #################################
   # for main CI chain
   #
+  Builds_0:
+    needs: [RunConfig, BuildDockers, StyleCheck, FastTest]
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_0') }}
+    uses: ./.github/workflows/reusable_build_stage.yml
+    with:
+      stage: Builds_0
+      data: ${{ needs.RunConfig.outputs.data }}
   Builds_1:
     needs: [RunConfig, StyleCheck, FastTest]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_1') }}
@@ -102,19 +108,26 @@ jobs:
     with:
       stage: Builds_1
       data: ${{ needs.RunConfig.outputs.data }}
-  Tests_1:
-    needs: [RunConfig, Builds_1]
-    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_1') }}
-    uses: ./.github/workflows/reusable_test_stage.yml
-    with:
-      stage: Tests_1
-      data: ${{ needs.RunConfig.outputs.data }}
   Builds_2:
-    needs: [RunConfig, Builds_1]
+    needs: [RunConfig, Builds_1, Builds_0]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_2') }}
     uses: ./.github/workflows/reusable_build_stage.yml
     with:
       stage: Builds_2
+      data: ${{ needs.RunConfig.outputs.data }}
+  Tests_0:
+    needs: [RunConfig, Builds_0]
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_0') }}
+    uses: ./.github/workflows/reusable_test_stage.yml
+    with:
+      stage: Tests_0
+      data: ${{ needs.RunConfig.outputs.data }}
+  Tests_1:
+    needs: [RunConfig, Builds_1]
+    if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_0') }}
+    uses: ./.github/workflows/reusable_test_stage.yml
+    with:
+      stage: Tests_1
       data: ${{ needs.RunConfig.outputs.data }}
   # stage for running non-required checks without being blocked by required checks (Test_1) if corresponding settings is selected
   Tests_2_ww:
@@ -125,7 +138,7 @@ jobs:
       stage: Tests_2_ww
       data: ${{ needs.RunConfig.outputs.data }}
   Tests_2:
-    needs: [RunConfig, Builds_1, Tests_1]
+    needs: [RunConfig, Builds_1, Tests_1, Builds_0, Tests_0]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Tests_2') }}
     uses: ./.github/workflows/reusable_test_stage.yml
     with:
@@ -153,7 +166,7 @@ jobs:
     if: ${{ !cancelled() }}
     # Test_2 or Test_3 do not have the jobs required for Mergeable check,
     #  however, set them as "needs" to get all checks results before the automatic merge occurs.
-    needs: [RunConfig, BuildDockers, StyleCheck, FastTest, Builds_1, Builds_2, Builds_Report, Tests_1, Tests_2_ww, Tests_2]
+    needs: [RunConfig, BuildDockers, StyleCheck, FastTest, Builds_1, Builds_2, Builds_Report, Tests_1, Tests_2_ww, Tests_2, Builds_0, Tests_0]
     runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Check out repository code
@@ -178,7 +191,7 @@ jobs:
   #
   FinishCheck:
     if: ${{ !failure() && !cancelled() }}
-    needs: [RunConfig, BuildDockers, StyleCheck, FastTest, Builds_1, Builds_2, Builds_Report, Tests_1, Tests_2_ww, Tests_2]
+    needs: [RunConfig, BuildDockers, StyleCheck, FastTest, Builds_1, Builds_2, Builds_Report, Tests_1, Tests_2_ww, Tests_2, Builds_0]
     runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Check out repository code

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1228,7 +1228,8 @@ def main() -> int:
                 # upload binaries only for normal builds in PRs
                 upload_binary = (
                     not pr_info.is_pr
-                    or CI.get_job_ci_stage(args.job_name) not in (CI.WorkflowStages.BUILDS_2,)
+                    or CI.get_job_ci_stage(args.job_name)
+                    not in (CI.WorkflowStages.BUILDS_2,)
                     or CiSettings.create_from_run_config(indata).upload_all
                 )
 

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1228,7 +1228,7 @@ def main() -> int:
                 # upload binaries only for normal builds in PRs
                 upload_binary = (
                     not pr_info.is_pr
-                    or CI.get_job_ci_stage(args.job_name) == CI.WorkflowStages.BUILDS_1
+                    or CI.get_job_ci_stage(args.job_name) not in (CI.WorkflowStages.BUILDS_2,)
                     or CiSettings.create_from_run_config(indata).upload_all
                 )
 

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -651,12 +651,12 @@ class CI:
                     required_builds = cls.get_job_config(job_name).required_builds
                     if required_builds:
                         if any(
-                                build
-                                in (
-                                        BuildNames.PACKAGE_RELEASE,
-                                        BuildNames.PACKAGE_AARCH64,
-                                )
-                                for build in required_builds
+                            build
+                            in (
+                                BuildNames.PACKAGE_RELEASE,
+                                BuildNames.PACKAGE_AARCH64,
+                            )
+                            for build in required_builds
                         ):
                             stage_type = WorkflowStages.TESTS_0
                 else:

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -636,12 +636,29 @@ class CI:
                     break
             else:
                 stage_type = WorkflowStages.BUILDS_2
+            if job_name in (
+                BuildNames.BINARY_TIDY,
+                BuildNames.PACKAGE_RELEASE,
+                BuildNames.PACKAGE_AARCH64,
+            ):
+                stage_type = WorkflowStages.BUILDS_0
         elif cls.is_docs_job(job_name):
             stage_type = WorkflowStages.TESTS_1
         elif cls.is_test_job(job_name):
             if job_name in CI.JOB_CONFIGS:
                 if job_name in REQUIRED_CHECKS:
                     stage_type = WorkflowStages.TESTS_1
+                    required_builds = cls.get_job_config(job_name).required_builds
+                    if required_builds:
+                        if any(
+                                build
+                                in (
+                                        BuildNames.PACKAGE_RELEASE,
+                                        BuildNames.PACKAGE_AARCH64,
+                                )
+                                for build in required_builds
+                        ):
+                            stage_type = WorkflowStages.TESTS_0
                 else:
                     stage_type = WorkflowStages.TESTS_2
         assert stage_type, f"BUG [{job_name}]"

--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -50,6 +50,8 @@ class WorkflowStages(metaclass=WithIter):
     TESTS_2_WW = "Tests_2_ww"
     # all tests not required for merge
     TESTS_2 = "Tests_2"
+    BUILDS_0 = "Builds_0"
+    TESTS_0 = "Tests_0"
 
 
 class Runners(metaclass=WithIter):

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -169,10 +169,19 @@ class TestCIConfig(unittest.TestCase):
         # check stages
         for job in CI.JobNames:
             if job in CI.BuildNames:
-                self.assertTrue(
-                    CI.get_job_ci_stage(job)
-                    in (CI.WorkflowStages.BUILDS_1, CI.WorkflowStages.BUILDS_2)
-                )
+                if job in (
+                    CI.BuildNames.BINARY_TIDY,
+                    CI.BuildNames.PACKAGE_RELEASE,
+                    CI.BuildNames.PACKAGE_AARCH64,
+                ):
+                    self.assertTrue(
+                        CI.get_job_ci_stage(job) in (CI.WorkflowStages.BUILDS_0,)
+                    )
+                else:
+                    self.assertTrue(
+                        CI.get_job_ci_stage(job)
+                        in (CI.WorkflowStages.BUILDS_1, CI.WorkflowStages.BUILDS_2)
+                    )
             else:
                 if job in (
                     CI.JobNames.STYLE_CHECK,
@@ -189,7 +198,11 @@ class TestCIConfig(unittest.TestCase):
                 else:
                     self.assertTrue(
                         CI.get_job_ci_stage(job)
-                        in (CI.WorkflowStages.TESTS_1, CI.WorkflowStages.TESTS_2),
+                        in (
+                            CI.WorkflowStages.TESTS_1,
+                            CI.WorkflowStages.TESTS_0,
+                            CI.WorkflowStages.TESTS_2,
+                        ),
                         msg=f"Stage for [{job}] is not correct",
                     )
 
@@ -200,10 +213,20 @@ class TestCIConfig(unittest.TestCase):
         # check stages
         for job in CI.JobNames:
             if job in CI.BuildNames:
-                self.assertTrue(
-                    CI.get_job_ci_stage(job)
-                    in (CI.WorkflowStages.BUILDS_1, CI.WorkflowStages.BUILDS_2)
-                )
+                if job in (
+                    CI.BuildNames.BINARY_TIDY,
+                    CI.BuildNames.PACKAGE_RELEASE,
+                    CI.BuildNames.PACKAGE_AARCH64,
+                ):
+                    self.assertTrue(
+                        CI.get_job_ci_stage(job) in (CI.WorkflowStages.BUILDS_0,),
+                        f"Invalid stage [{CI.get_job_ci_stage(job)}] for [{job}]",
+                    )
+                else:
+                    self.assertTrue(
+                        CI.get_job_ci_stage(job)
+                        in (CI.WorkflowStages.BUILDS_1, CI.WorkflowStages.BUILDS_2)
+                    )
             else:
                 if job in (
                     CI.JobNames.STYLE_CHECK,
@@ -220,7 +243,11 @@ class TestCIConfig(unittest.TestCase):
                 else:
                     self.assertTrue(
                         CI.get_job_ci_stage(job, non_blocking_ci=True)
-                        in (CI.WorkflowStages.TESTS_1, CI.WorkflowStages.TESTS_2_WW),
+                        in (
+                            CI.WorkflowStages.TESTS_1,
+                            CI.WorkflowStages.TESTS_0,
+                            CI.WorkflowStages.TESTS_2_WW,
+                        ),
                         msg=f"Stage for [{job}] is not correct",
                     )
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
check tidy results asap

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [x] <!---no_merge_commit--> Disable merge-commit (Run CI on branch HEAD instead of merge commit with target branch)
- [x] <!---no_ci_cache--> Disable CI cache
