### PR TITLE
Add ability to specify password in keeper protocol

### DIFF
--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -146,7 +146,7 @@ void KeeperClient::defineOptions(Poco::Util::OptionSet & options)
             .binding("port"));
 
     options.addOption(
-        Poco::Util::Option("password", "", "password to connect to server")
+        Poco::Util::Option("password", "", "password to connect to keeper server")
             .argument("<password>")
             .binding("password"));
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -146,6 +146,11 @@ void KeeperClient::defineOptions(Poco::Util::OptionSet & options)
             .binding("port"));
 
     options.addOption(
+        Poco::Util::Option("password", "", "password to connect to server")
+            .argument("<password>")
+            .binding("password"));
+
+    options.addOption(
         Poco::Util::Option("query", "q", "will execute given query, then exit.")
             .argument("<query>")
             .binding("query"));
@@ -422,6 +427,7 @@ int KeeperClient::main(const std::vector<String> & /* args */)
     zk_args.session_timeout_ms = config().getInt("session-timeout", 10) * 1000;
     zk_args.operation_timeout_ms = config().getInt("operation-timeout", 10) * 1000;
     zk_args.use_xid_64 = config().hasOption("use-xid-64");
+    zk_args.password = config().getString("password", "");
     zookeeper = zkutil::ZooKeeper::createWithoutKillingPreviousSessions(zk_args);
 
     if (config().has("no-confirmation") || config().has("query"))

--- a/src/Common/ZooKeeper/ZooKeeperArgs.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.cpp
@@ -258,6 +258,12 @@ void ZooKeeperArgs::initFromKeeperSection(const Poco::Util::AbstractConfiguratio
         {
             availability_zone_autodetect = config.getBool(config_name + "." + key);
         }
+        else if (key == "password")
+        {
+            password = config.getString(config_name + "." + key);
+            if (password.size() > Coordination::PASSWORD_LENGTH)
+                throw KeeperException(Coordination::Error::ZBADARGUMENTS, "Password cannot be longer than {} characters, specified {}", Coordination::PASSWORD_LENGTH, password.size());
+        }
         else
             throw KeeperException(Coordination::Error::ZBADARGUMENTS, "Unknown key {} in config file", key);
     }

--- a/src/Common/ZooKeeper/ZooKeeperArgs.h
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.h
@@ -53,6 +53,7 @@ struct ZooKeeperArgs
     bool use_xid_64 = false;
     bool prefer_local_availability_zone = false;
     bool availability_zone_autodetect = false;
+    String password;
 
     SessionLifetimeConfiguration fallback_session_lifetime = {};
     DB::GetPriorityForLoadBalancing get_priority_load_balancing;

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -598,8 +598,8 @@ void ZooKeeper::sendHandshake()
     int64_t last_zxid_seen = 0;
     int32_t timeout = args.session_timeout_ms;
     int64_t previous_session_id = 0;    /// We don't support session restore. So previous session_id is always zero.
-    constexpr int32_t passwd_len = 16;
-    std::array<char, passwd_len> passwd {};
+    std::string password = args.password;
+    password.resize(Coordination::PASSWORD_LENGTH, '\0');
     bool read_only = true;
 
     write(handshake_length);
@@ -619,7 +619,7 @@ void ZooKeeper::sendHandshake()
     write(last_zxid_seen);
     write(timeout);
     write(previous_session_id);
-    write(passwd);
+    write(password);
     write(read_only);
     flushWriteBuffer();
 }

--- a/src/Coordination/KeeperDispatcher.h
+++ b/src/Coordination/KeeperDispatcher.h
@@ -252,6 +252,8 @@ public:
     }
 
     static void cleanResources();
+
+    std::optional<AuthenticationData> getAuthenticationData() const { return server->getAuthenticationData(); }
 };
 
 }

--- a/src/Coordination/KeeperServer.h
+++ b/src/Coordination/KeeperServer.h
@@ -154,6 +154,8 @@ public:
     void yieldLeadership();
 
     void recalculateStorageStats();
+
+    std::optional<AuthenticationData> getAuthenticationData() const { return state_manager->getAuthenticationData(); }
 };
 
 }

--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -33,6 +33,7 @@ namespace ErrorCodes
 {
     extern const int RAFT_ERROR;
     extern const int CORRUPTED_DATA;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace

--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -80,6 +80,44 @@ std::unordered_map<UInt64, std::string> getClientPorts(const Poco::Util::Abstrac
     return ports;
 }
 
+
+std::optional<AuthenticationData> getClientPasswordAuthentication(const Poco::Util::AbstractConfiguration & config)
+{
+    static const std::unordered_map<std::string, AuthenticationType> AUTH_TYPE_MAP
+    {
+        {"client_password", AuthenticationType::PLAINTEXT_PASSWORD},
+        {"keeper_server.client_password", AuthenticationType::PLAINTEXT_PASSWORD},
+        {"client_password_sha256_hex", AuthenticationType::SHA256_PASSWORD},
+        {"keeper_server.client_password_sha256_hex", AuthenticationType::SHA256_PASSWORD},
+        {"client_password_double_sha1_hex", AuthenticationType::DOUBLE_SHA1_PASSWORD},
+        {"keeper_server.client_password_double_sha1_hex", AuthenticationType::DOUBLE_SHA1_PASSWORD},
+    };
+
+    std::optional<AuthenticationData> data;
+    for (const auto & [config_password_name, auth_type] : AUTH_TYPE_MAP)
+    {
+        if (config.has(config_password_name))
+        {
+            if (data.has_value())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Only one authentication type is allowed in config");
+
+            data.emplace(AuthenticationData(auth_type));
+            if (config_password_name.ends_with("client_password"))
+            {
+                auto password = config.getString(config_password_name);
+                if (password.length() > Coordination::PASSWORD_LENGTH)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Password cannot be longer than {} characters, specified {}", Coordination::PASSWORD_LENGTH, password.size());
+
+                data->setPassword(password, true);
+            }
+            else
+                data->setPasswordHashHex(config.getString(config_password_name), true);
+        }
+    }
+
+    return data;
+}
+
 }
 
 /// this function quite long because contains a lot of sanity checks in config:
@@ -228,6 +266,8 @@ KeeperStateManager::parseServersConfiguration(const Poco::Util::AbstractConfigur
         }
     }
 
+    result.auth_data = getClientPasswordAuthentication(config);
+
     return result;
 }
 
@@ -302,6 +342,12 @@ ClusterConfigPtr KeeperStateManager::getLatestConfigFromLogStore() const
     if (entry_with_change)
         return ClusterConfig::deserialize(entry_with_change->get_buf());
     return nullptr;
+}
+
+std::optional<AuthenticationData> KeeperStateManager::getAuthenticationData() const
+{
+    std::lock_guard lock(configuration_wrapper_mutex);
+    return configuration_wrapper.auth_data;
 }
 
 void KeeperStateManager::flushAndShutDownLogStore()

--- a/src/Coordination/KeeperStateManager.h
+++ b/src/Coordination/KeeperStateManager.h
@@ -8,6 +8,7 @@
 #include <Poco/Util/AbstractConfiguration.h>
 #include "Coordination/KeeperStateMachine.h"
 #include "Coordination/RaftServerConfig.h"
+#include <Access/AuthenticationData.h>
 
 namespace DB
 {
@@ -93,6 +94,8 @@ public:
     // TODO (myrrc) This should be removed once "reconfig" is stabilized
     ClusterUpdateActions getRaftConfigurationDiff(const Poco::Util::AbstractConfiguration & config, const CoordinationSettings & coordination_settings) const;
 
+    std::optional<AuthenticationData> getAuthenticationData() const;
+
 private:
     const String & getOldServerStatePath();
 
@@ -106,6 +109,8 @@ private:
         int port;
         /// Our config
         KeeperServerConfigPtr config;
+        /// Password to access keeper
+        std::optional<AuthenticationData> auth_data;
         /// Servers id's to start as followers
         std::unordered_set<int> servers_start_as_followers;
         /// Cluster config

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -388,7 +388,6 @@ void KeeperTCPHandler::runImpl()
     /// Hand shake package length must be lower than 2^24 and larger than 0.
     /// So collision never happens.
     int32_t four_letter_cmd = header;
-    LOG_DEBUG(log, "LENGTH {} EXPECTED LENGTH {}", four_letter_cmd, Coordination::SERVER_HANDSHAKE_LENGTH_WITH_READONLY);
     if (!isHandShake(four_letter_cmd))
     {
         connected.store(true, std::memory_order_relaxed);

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -65,6 +65,7 @@ namespace ErrorCodes
     extern const int UNEXPECTED_PACKET_FROM_CLIENT;
     extern const int TIMEOUT_EXCEEDED;
     extern const int BAD_ARGUMENTS;
+    extern const int AUTHENTICATION_FAILED;
 }
 
 struct PollResult
@@ -327,9 +328,21 @@ Poco::Timespan KeeperTCPHandler::receiveHandshake(int32_t handshake_length, bool
     Coordination::read(last_zxid_seen, *in);
     Coordination::read(timeout_ms, *in);
 
-    /// TODO Stop ignoring this value
     Coordination::read(previous_session_id, *in);
     Coordination::read(passwd, *in);
+
+
+    auto auth_data = keeper_dispatcher->getAuthenticationData();
+    if (auth_data)
+    {
+        String password{std::begin(passwd), std::end(passwd)};
+        /// It was padded to Coordination::PASSWORD_LENGTH with '\0'
+        boost::trim_right_if(password, [](char c) { return c == '\0'; });
+        AuthenticationData client_auth_data(auth_data->getType());
+        client_auth_data.setPassword(password, true);
+        if (client_auth_data != *auth_data)
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Wrong password specified, authentication failed");
+    }
 
     int8_t readonly;
     if (handshake_length == Coordination::CLIENT_HANDSHAKE_LENGTH_WITH_READONLY)
@@ -375,6 +388,7 @@ void KeeperTCPHandler::runImpl()
     /// Hand shake package length must be lower than 2^24 and larger than 0.
     /// So collision never happens.
     int32_t four_letter_cmd = header;
+    LOG_DEBUG(log, "LENGTH {} EXPECTED LENGTH {}", four_letter_cmd, Coordination::SERVER_HANDSHAKE_LENGTH_WITH_READONLY);
     if (!isHandShake(four_letter_cmd))
     {
         connected.store(true, std::memory_order_relaxed);

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -295,7 +295,6 @@ def wait_until_connected(
     )
     while send_4lw_cmd(cluster, node, "mntr", port) == NOT_SERVING_REQUESTS_ERROR_MSG:
         time.sleep(0.1)
-        print("Sending 4LW")
 
         if time.time() - start > timeout:
             raise Exception(

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -283,7 +283,7 @@ NOT_SERVING_REQUESTS_ERROR_MSG = "This instance is not currently serving request
 
 
 def wait_until_connected(
-        cluster, node, port=9181, timeout=30.0, wait_complete_readiness=True, password=b""
+    cluster, node, port=9181, timeout=30.0, wait_complete_readiness=True, password=b""
 ):
     start = time.time()
 
@@ -318,7 +318,9 @@ def wait_until_connected(
                         f"{timeout}s timeout while waiting for {node.name} to start serving requests"
                     )
                 zk_cli = KazooClient(
-                    hosts=f"{host}:9181", timeout=timeout - time_passed, client_id=(0, password)
+                    hosts=f"{host}:9181",
+                    timeout=timeout - time_passed,
+                    client_id=(0, password),
                 )
                 zk_cli.start()
                 zk_cli.get("/keeper/api_version")
@@ -365,7 +367,9 @@ def get_any_follower(cluster, nodes):
     raise Exception("No followers in Keeper cluster.")
 
 
-def get_fake_zk(cluster, nodename, timeout: float = 30.0, password = b"", retries=10) -> KazooClient:
+def get_fake_zk(
+    cluster, nodename, timeout: float = 30.0, password=b"", retries=10
+) -> KazooClient:
     kazoo_retry = {
         "max_tries": retries,
     }

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -318,7 +318,6 @@ def wait_until_connected(
                     raise Exception(
                         f"{timeout}s timeout while waiting for {node.name} to start serving requests"
                     )
-                print("HELLO")
                 zk_cli = KazooClient(
                     hosts=f"{host}:9181", timeout=timeout - time_passed, client_id=(0, password)
                 )

--- a/tests/integration/test_keeper_password/__init__.py
+++ b/tests/integration/test_keeper_password/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_keeper_password/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_password/configs/keeper_config.xml
@@ -1,0 +1,28 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <client_password>foobar</client_password>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <snapshot_distance>75</snapshot_distance>
+            <!-- For instant start in single node configuration -->
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_password/configs/keeper_config_hashed.xml
+++ b/tests/integration/test_keeper_password/configs/keeper_config_hashed.xml
@@ -1,0 +1,28 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <client_password_sha256_hex>c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2</client_password_sha256_hex>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <snapshot_distance>75</snapshot_distance>
+            <!-- For instant start in single node configuration -->
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_password/configs/use_keeper_from_second.xml
+++ b/tests/integration/test_keeper_password/configs/use_keeper_from_second.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <zookeeper>
+        <password>foobar</password>
+        <node index="1">
+            <host>node2</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_password/test.py
+++ b/tests/integration/test_keeper_password/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import time
 import pytest
+
 from helpers import keeper_utils
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_keeper_password/test.py
+++ b/tests/integration/test_keeper_password/test.py
@@ -27,12 +27,13 @@ node3 = cluster.add_instance(
     stay_alive=True,
 )
 
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
         password = "foobar"
-        p = (password + ''.join([chr(0)] * (16 - len(password)))).encode('ascii')
+        p = (password + "".join([chr(0)] * (16 - len(password)))).encode("ascii")
         keeper_utils.wait_until_connected(cluster, node1, password=p)
         keeper_utils.wait_until_connected(cluster, node2, password=p)
 
@@ -41,17 +42,22 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def get_zk(nodename, timeout=30.0):
     password = "foobar"
-    p = (password + ''.join([chr(0)] * (16 - len(password)))).encode('ascii')
+    p = (password + "".join([chr(0)] * (16 - len(password)))).encode("ascii")
 
     return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout, password=p)
 
+
 def get_wrong_password_zk(nodename, timeout=30.0):
     password = "foobarqwe"
-    p = (password + ''.join([chr(0)] * (16 - len(password)))).encode('ascii')
+    p = (password + "".join([chr(0)] * (16 - len(password)))).encode("ascii")
 
-    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout, password=p, retries=1)
+    return keeper_utils.get_fake_zk(
+        cluster, nodename, timeout=timeout, password=p, retries=1
+    )
+
 
 def get_zk_no_password(nodename, timeout=30.0):
     return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout, retries=1)
@@ -79,7 +85,6 @@ def test_password_works(started_cluster):
     with pytest.raises(Exception):
         auth_connection = get_zk_no_password(node2.name, timeout=1)
         auth_connection.get_children("/")
-
 
     print(node3.query("select * from system.zookeeper where path = '/'", timeout=3))
 

--- a/tests/integration/test_keeper_password/test.py
+++ b/tests/integration/test_keeper_password/test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import time
+import pytest
+from helpers import keeper_utils
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/keeper_config.xml"],
+    with_zookeeper=True,
+    use_keeper=False,
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/keeper_config_hashed.xml"],
+    with_zookeeper=True,
+    use_keeper=False,
+)
+
+node3 = cluster.add_instance(
+    "node3",
+    main_configs=["configs/use_keeper_from_second.xml"],
+    with_zookeeper=False,
+    use_keeper=False,
+    stay_alive=True,
+)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        password = "foobar"
+        p = (password + ''.join([chr(0)] * (16 - len(password)))).encode('ascii')
+        keeper_utils.wait_until_connected(cluster, node1, password=p)
+        keeper_utils.wait_until_connected(cluster, node2, password=p)
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def get_zk(nodename, timeout=30.0):
+    password = "foobar"
+    p = (password + ''.join([chr(0)] * (16 - len(password)))).encode('ascii')
+
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout, password=p)
+
+def get_wrong_password_zk(nodename, timeout=30.0):
+    password = "foobarqwe"
+    p = (password + ''.join([chr(0)] * (16 - len(password)))).encode('ascii')
+
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout, password=p, retries=1)
+
+def get_zk_no_password(nodename, timeout=30.0):
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout, retries=1)
+
+
+def test_password_works(started_cluster):
+    auth_connection = get_zk(node1.name)
+    auth_connection.get_children("/")
+
+    auth_connection = get_zk(node2.name)
+    auth_connection.get_children("/")
+
+    with pytest.raises(Exception):
+        auth_connection = get_wrong_password_zk(node1.name, timeout=1)
+        auth_connection.get_children("/")
+
+    with pytest.raises(Exception):
+        auth_connection = get_wrong_password_zk(node2.name, timeout=1)
+        auth_connection.get_children("/")
+
+    with pytest.raises(Exception):
+        auth_connection = get_zk_no_password(node1.name, timeout=1)
+        auth_connection.get_children("/")
+
+    with pytest.raises(Exception):
+        auth_connection = get_zk_no_password(node2.name, timeout=1)
+        auth_connection.get_children("/")
+
+
+    print(node3.query("select * from system.zookeeper where path = '/'", timeout=3))
+
+    node3.replace_in_config(
+        "/etc/clickhouse-server/config.d/use_keeper_from_second.xml",
+        "foobar",
+        "qqqqqq",
+    )
+
+    with pytest.raises(Exception):
+        node3.restart_clickhouse(stop_start_wait_sec=10)
+        print(node3.query("select * from system.zookeeper where path = '/'", timeout=3))

--- a/tests/integration/test_keeper_password/test.py
+++ b/tests/integration/test_keeper_password/test.py
@@ -70,6 +70,16 @@ def test_password_works(started_cluster):
     auth_connection = get_zk(node2.name)
     auth_connection.get_children("/")
 
+    data = node3.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "clickhouse keeper-client -h node2 -p 9181 --password foobar -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+    )
+    assert data.strip() == "api_version feature_flags"
+
     with pytest.raises(Exception):
         auth_connection = get_wrong_password_zk(node1.name, timeout=1)
         auth_connection.get_children("/")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to use password for client communication with clickhouse-keeper. This feature is not very useful if you specify proper SSL configuration for server and client, but still can be useful for some cases. Password cannot be longer than 16 characters. It's not connected with Keeper Auth model.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_merge_commit--> Disable merge-commit (Run CI on branch HEAD instead of merge commit with target branch)
- [ ] <!---no_ci_cache--> Disable CI cache
