### PR TITLE
Parallel replicas tests: fix flaky 02884_create_view_with_sql_security_option

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -182,6 +182,8 @@
 02989_join_using_parent_scope
 02514_if_with_lazy_low_cardinality
 
+    https://github.com/ClickHouse/ClickHouse/issues/74411
+02884_create_view_with_sql_security_option
 
     Transactions
 02421_truncate_isolation_no_merges

--- a/tests/queries/0_stateless/02884_create_view_with_sql_security_option.sh
+++ b/tests/queries/0_stateless/02884_create_view_with_sql_security_option.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -9,9 +10,6 @@ user1="user02884_1_${CLICKHOUSE_DATABASE}_$RANDOM"
 user2="user02884_2_${CLICKHOUSE_DATABASE}_$RANDOM"
 user3="user02884_3_${CLICKHOUSE_DATABASE}_$RANDOM"
 db=${CLICKHOUSE_DATABASE}
-
-#https://github.com/ClickHouse/ClickHouse/issues/74411
-CLICKHOUSE_CLIENT="${CLICKHOUSE_CLIENT} --parallel_replicas_local_plan=1"
 
 ${CLICKHOUSE_CLIENT} <<EOF
 CREATE TABLE $db.test_table (s String) ENGINE = MergeTree ORDER BY s;


### PR DESCRIPTION
Fix flaky `02884_create_view_with_sql_security_option`
Closes https://github.com/ClickHouse/ClickHouse/issues/74549

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory
and will run independently of the checks below:
- [x] <!---ci_include_stateless--> Only: Stateless tests
- [x] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_merge_commit--> Disable merge-commit (Run CI on branch HEAD instead of merge commit with target branch)
- [ ] <!---no_ci_cache--> Disable CI cache
