### PR TITLE
Docs: Fix typos, improve formatting on page `Atomic` engine

### DIFF
--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 # Atomic 
 
-The `Atomic` engine supports non-blocking [`DROP TABLE`](#drop-detach-table) and [`RENAME TABLE`](#rename-table) queries and atomic [`EXCHANGE TABLES`](#exchange-tables) queries. The `Atomic` database engine is used by default. 
+The `Atomic` engine supports non-blocking [`DROP TABLE`](#drop-detach-table) and [`RENAME TABLE`](#rename-table) queries, and atomic [`EXCHANGE TABLES`](#exchange-tables) queries. The `Atomic` database engine is used by default. 
 
 :::note
 On ClickHouse Cloud, the `Replicated` database engine is used by default.

--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -18,7 +18,7 @@ On ClickHouse Cloud, the `Replicated` database engine is used by default.
 CREATE DATABASE test [ENGINE = Atomic];
 ```
 
-## Specifics and recommendations {#specifics-and-recommendations}
+## Specifics and Recommendations {#specifics-and-recommendations}
 
 ### Table UUID {#table-uuid}
 

--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -44,7 +44,7 @@ You can use the [show_table_uuid_in_table_create_query_if_not_nil](../../operati
 
 ### RENAME TABLE {#rename-table}
 
-[`RENAME`](../../sql-reference/statements/rename.md) queries are performed without changing the UUID or moving table data. These queries do not wait for the completion of queries using the table and are executed instantly.
+[`RENAME`](../../sql-reference/statements/rename.md) queries do not modify the UUID or move table data. These queries execute immediately and do not wait for other queries that are using the table to complete.
 
 ### DROP/DETACH TABLE {#drop-detach-table}
 

--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -66,7 +66,7 @@ EXCHANGE TABLES new_table AND old_table;
 
 ### ReplicatedMergeTree in Atomic Database {#replicatedmergetree-in-atomic-database}
 
-For [`ReplicatedMergeTree`](../table-engines/mergetree-family/replication.md#table_engines-replication) tables, it is recommended not to specify the engine parameters for the path in ZooKeeper and the replica name. In this case, configuration parameters [`default_replica_path`](../../operations/server-configuration-parameters/settings.md#default_replica_path) and [`default_replica_name`](../../operations/server-configuration-parameters/settings.md#default_replica_name) will be used. If you want to specify engine parameters explicitly, it is recommended to use `{uuid}` macros. This is useful so that unique paths are automatically generated for each table in ZooKeeper.
+For [`ReplicatedMergeTree`](../table-engines/mergetree-family/replication.md#table_engines-replication) tables, it is recommended not to specify the engine parameters for the path in ZooKeeper and the replica name. In this case, the configuration parameters [`default_replica_path`](../../operations/server-configuration-parameters/settings.md#default_replica_path) and [`default_replica_name`](../../operations/server-configuration-parameters/settings.md#default_replica_name) will be used. If you want to specify engine parameters explicitly, it is recommended to use the `{uuid}` macros. This ensures that unique paths are automatically generated for each table in ZooKeeper.
 
 ## See Also
 

--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -22,7 +22,7 @@ CREATE DATABASE test [ENGINE = Atomic];
 
 ### Table UUID {#table-uuid}
 
-All tables in database `Atomic` have persistent [UUID](../../sql-reference/data-types/uuid.md) and store data in directory:
+Each table in the `Atomic` database has a persistent [UUID](../../sql-reference/data-types/uuid.md) and stores its data in the following directory:
 
 ```
 /clickhouse_path/store/xxx/xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/

--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -30,7 +30,7 @@ All tables in database `Atomic` have persistent [UUID](../../sql-reference/data-
 
 Where `xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy` is the UUID of the table.
 
-Usually, the UUID is generated automatically, but the user can also explicitly specify the UUID in the same way when creating the table, although this is not recommended. 
+By default, the UUID is generated automatically. However, users can explicitly specify the UUID when creating a table, though this is not recommended.
 
 For example:
 

--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -6,11 +6,15 @@ sidebar_position: 10
 
 # Atomic 
 
-It supports non-blocking [DROP TABLE](#drop-detach-table) and [RENAME TABLE](#rename-table) queries and atomic [EXCHANGE TABLES](#exchange-tables) queries. `Atomic` database engine is used by default. Note that on ClickHouse Cloud, the `Replicated` database engine is used by default.
+The `Atomic` engine supports non-blocking [`DROP TABLE`](#drop-detach-table) and [`RENAME TABLE`](#rename-table) queries and atomic [`EXCHANGE TABLES`](#exchange-tables) queries. The `Atomic` database engine is used by default. 
+
+:::note
+On ClickHouse Cloud, the `Replicated` database engine is used by default.
+:::
 
 ## Creating a Database {#creating-a-database}
 
-``` sql
+```sql
 CREATE DATABASE test [ENGINE = Atomic];
 ```
 
@@ -18,8 +22,15 @@ CREATE DATABASE test [ENGINE = Atomic];
 
 ### Table UUID {#table-uuid}
 
-All tables in database `Atomic` have persistent [UUID](../../sql-reference/data-types/uuid.md) and store data in directory `/clickhouse_path/store/xxx/xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/`, where `xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy` is UUID of the table.
-Usually, the UUID is generated automatically, but the user can also explicitly specify the UUID in the same way when creating the table (this is not recommended). 
+All tables in database `Atomic` have persistent [UUID](../../sql-reference/data-types/uuid.md) and store data in directory:
+
+```
+/clickhouse_path/store/xxx/xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/
+```
+
+Where `xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy` is the UUID of the table.
+
+Usually, the UUID is generated automatically, but the user can also explicitly specify the UUID in the same way when creating the table, although this is not recommended. 
 
 For example:
 
@@ -33,29 +44,29 @@ You can use the [show_table_uuid_in_table_create_query_if_not_nil](../../operati
 
 ### RENAME TABLE {#rename-table}
 
-[RENAME](../../sql-reference/statements/rename.md) queries are performed without changing the UUID or moving table data. These queries do not wait for the completion of queries using the table and are executed instantly.
+[`RENAME`](../../sql-reference/statements/rename.md) queries are performed without changing the UUID or moving table data. These queries do not wait for the completion of queries using the table and are executed instantly.
 
 ### DROP/DETACH TABLE {#drop-detach-table}
 
-On `DROP TABLE` no data is removed, database `Atomic` just marks table as dropped by moving metadata to `/clickhouse_path/metadata_dropped/` and notifies background thread. Delay before final table data deletion is specified by the [database_atomic_delay_before_drop_table_sec](../../operations/server-configuration-parameters/settings.md#database_atomic_delay_before_drop_table_sec) setting.
-You can specify synchronous mode using `SYNC` modifier. Use the [database_atomic_wait_for_drop_and_detach_synchronously](../../operations/settings/settings.md#database_atomic_wait_for_drop_and_detach_synchronously) setting to do this. In this case `DROP` waits for running `SELECT`, `INSERT` and other queries which are using the table to finish. Table will be actually removed when it's not in use.
+When using `DROP TABLE`, no data is removed. The `Atomic` engine just marks the table as dropped by moving it's metadata to `/clickhouse_path/metadata_dropped/` and notifies the background thread. The delay before the final table data deletion is specified by the [`database_atomic_delay_before_drop_table_sec`](../../operations/server-configuration-parameters/settings.md#database_atomic_delay_before_drop_table_sec) setting.
+You can specify synchronous mode using `SYNC` modifier. Use the [`database_atomic_wait_for_drop_and_detach_synchronously`](../../operations/settings/settings.md#database_atomic_wait_for_drop_and_detach_synchronously) setting to do this. In this case `DROP` waits for running `SELECT`, `INSERT` and other queries which are using the table to finish. The table will be removed when it's not in use.
 
 ### EXCHANGE TABLES/DICTIONARIES {#exchange-tables}
 
-[EXCHANGE](../../sql-reference/statements/exchange.md) query swaps tables or dictionaries atomically. For instance, instead of this non-atomic operation:
+The [`EXCHANGE`](../../sql-reference/statements/exchange.md) query swaps tables or dictionaries atomically. For instance, instead of this non-atomic operation:
 
-```sql
+```sql title="Non-atomic"
 RENAME TABLE new_table TO tmp, old_table TO new_table, tmp TO old_table;
 ```
-you can use one atomic query:
+you can use an atomic one:
 
-``` sql
+```sql title="Atomic"
 EXCHANGE TABLES new_table AND old_table;
 ```
 
 ### ReplicatedMergeTree in Atomic Database {#replicatedmergetree-in-atomic-database}
 
-For [ReplicatedMergeTree](../table-engines/mergetree-family/replication.md#table_engines-replication) tables, it is recommended not to specify engine parameters - path in ZooKeeper and replica name. In this case, configuration parameters [default_replica_path](../../operations/server-configuration-parameters/settings.md#default_replica_path) and [default_replica_name](../../operations/server-configuration-parameters/settings.md#default_replica_name) will be used. If you want to specify engine parameters explicitly, it is recommended to use `{uuid}` macros. This is useful so that unique paths are automatically generated for each table in ZooKeeper.
+For [`ReplicatedMergeTree`](../table-engines/mergetree-family/replication.md#table_engines-replication) tables, it is recommended not to specify the engine parameters for the path in ZooKeeper and the replica name. In this case, configuration parameters [`default_replica_path`](../../operations/server-configuration-parameters/settings.md#default_replica_path) and [`default_replica_name`](../../operations/server-configuration-parameters/settings.md#default_replica_name) will be used. If you want to specify engine parameters explicitly, it is recommended to use `{uuid}` macros. This is useful so that unique paths are automatically generated for each table in ZooKeeper.
 
 ## See Also
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

- Fixes typos
- Improves formatting

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions automatically creates a merge commit with master on each push and runs the CI on it.
This trashes the build cache since artifacts won't be reused if any new C++ code got into master.
The following setting runs CI on branch's head to reuse the build cache as much as possible.
Remove it to use a merge-commit against the target branch.
#no_merge_commit
-->