### PR TITLE
Apply statistics to estimate table sizes in joins

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6416,6 +6416,10 @@ Note that initially (24.12) there was a server setting (`send_settings_to_client
 Wait time in milliseconds when lower priority query meets higher priority query.
 )", BETA) \
     \
+    DECLARE(Bool, query_plan_join_swap_table_use_statistics, true, R"(
+    Try to use statistics (or dummy estimators) to determine row sizes for the tables involved in the join. This setting will only have effect if `query_plan_join_swap_table` setting is set to 'auto'.
+)", 0) \
+    \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \
     /* ## ADD PRODUCTION / BETA FEATURES BEFORE THIS BLOCK  ## */ \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -75,6 +75,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_hdfs_pread", true, true, "New setting."},
             {"low_priority_query_wait_time_ms", 1000, 1000, "New setting."},
             {"allow_experimental_shared_set_join", 0, 1, "A setting for ClickHouse Cloud to enable SharedSet and SharedJoin"},
+            {"query_plan_join_swap_table_use_statistics", "false", "true", "New setting. Statistics haven't been used before."},
         });
         addSettingsChanges(settings_changes_history, "25.3",
         {

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -117,6 +117,7 @@ namespace Setting
     extern const SettingsBool use_concurrency_control;
     extern const SettingsBoolAuto query_plan_join_swap_table;
     extern const SettingsUInt64 min_joined_block_size_bytes;
+    extern const SettingsBool query_plan_join_swap_table_use_statistics;
 }
 
 namespace ErrorCodes
@@ -1541,6 +1542,7 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
 
         auto setting_swap = settings[Setting::query_plan_join_swap_table];
         join_step->swap_join_tables = setting_swap.is_auto ? std::nullopt : std::make_optional(setting_swap.base);
+        join_step->swap_join_tables_use_statistics = settings[Setting::query_plan_join_swap_table_use_statistics];
 
         join_step->setStepDescription(fmt::format("JOIN {}", join_pipeline_type));
 

--- a/src/Processors/QueryPlan/JoinStep.h
+++ b/src/Processors/QueryPlan/JoinStep.h
@@ -40,6 +40,7 @@ public:
 
     /// Swap automatically if not set, otherwise always or never, depending on the value
     std::optional<bool> swap_join_tables = false;
+    bool swap_join_tables_use_statistics = false;
 
     struct PrimaryKeyNamesPair
     {

--- a/src/Processors/QueryPlan/JoinStep.h
+++ b/src/Processors/QueryPlan/JoinStep.h
@@ -40,6 +40,8 @@ public:
 
     /// Swap automatically if not set, otherwise always or never, depending on the value
     std::optional<bool> swap_join_tables = false;
+    /// Should we use statistics for row estimations in join.
+    /// Only works if swap_join_tables is nullopt
     bool swap_join_tables_use_statistics = false;
 
     struct PrimaryKeyNamesPair

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -48,6 +48,7 @@ namespace Setting
     extern const SettingsUInt64 max_rows_to_transfer;
     extern const SettingsOverflowMode transfer_overflow_mode;
     extern const SettingsUInt64 use_index_for_in_with_subqueries_max_values;
+    extern const SettingsBool query_plan_join_swap_table_use_statistics;
 }
 
 namespace ServerSetting
@@ -84,6 +85,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     join_swap_table = from[Setting::query_plan_join_swap_table].is_auto
         ? std::nullopt
         : std::make_optional(from[Setting::query_plan_join_swap_table].base);
+    join_swap_table_use_statistics = from[Setting::query_plan_join_swap_table_use_statistics];
 
     optimize_prewhere = from[Setting::query_plan_enable_optimizations] && from[Setting::query_plan_optimize_prewhere];
     read_in_order = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_read_in_order] && from[Setting::query_plan_read_in_order];

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -59,6 +59,9 @@ struct QueryPlanOptimizationSettings
     /// true/false - always/never swap
     /// nullopt - swap if it's beneficial
     std::optional<bool> join_swap_table;
+    /// Should we use statistics for row estimations in join.
+    /// Only works if join_swap_table is nullopt
+    bool join_swap_table_use_statistics;
 
     /// --- Second-pass optimizations
     bool optimize_prewhere;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -46,7 +46,6 @@
 #include <Storages/MergeTree/MergeTreeSource.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/RequestResponse.h>
-#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Poco/Logger.h>
 #include <Common/JSONBuilder.h>
 #include <Common/logger_useful.h>
@@ -190,7 +189,6 @@ namespace Setting
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool merge_tree_use_deserialization_prefixes_cache;
     extern const SettingsBool merge_tree_use_prefixes_deserialization_thread_pool;
-    extern const SettingsBool query_plan_join_swap_table_use_statistics;
 }
 
 namespace MergeTreeSetting
@@ -1929,36 +1927,6 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
     result.total_marks_pk = total_marks_pk;
     result.selected_rows = sum_rows;
     result.has_exact_ranges = result.selected_parts == 0 || find_exact_ranges;
-    result.selected_rows_after_size_hint = result.selected_rows;
-
-    if (settings[Setting::query_plan_join_swap_table_use_statistics])
-    {
-        ConditionSelectivityEstimator estimator;
-
-        for (const auto & part : result.parts_with_ranges)
-        {
-            try
-            {
-                auto stats = part.data_part->loadStatistics();
-                estimator.incrementRowCount(part.getRowsCount());
-                for (const auto & stat : stats)
-                    estimator.addStatistics(part.data_part->info.getPartNameV1(), stat);
-            }
-            catch (...)
-            {
-                tryLogCurrentException(log, fmt::format("while loading statistics on part {}", part.data_part->info.getPartNameV1()));
-            }
-        }
-
-        if (const auto * where_ast = query_info_.query->as<ASTSelectQuery &>().where().get())
-        {
-            auto block_with_constants = KeyCondition::getBlockWithConstants(query_info_.query->clone(), query_info_.syntax_analyzer_result, context_);
-            RPNBuilderTreeContext tree_context(context_, std::move(block_with_constants), {});
-            RPNBuilderTreeNode node(where_ast, tree_context);
-            const auto & unqualified_column_names = query_info_.buildNodeNameToInputNodeColumn();
-            result.selected_rows_after_size_hint = static_cast<UInt64>(std::ceil(estimator.estimateRowCount(node, unqualified_column_names)));
-        }
-    }
 
     if (query_info_.input_order_info)
         result.read_type = (query_info_.input_order_info->direction > 0)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -46,6 +46,7 @@
 #include <Storages/MergeTree/MergeTreeSource.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/RequestResponse.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Poco/Logger.h>
 #include <Common/JSONBuilder.h>
 #include <Common/logger_useful.h>
@@ -189,6 +190,7 @@ namespace Setting
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool merge_tree_use_deserialization_prefixes_cache;
     extern const SettingsBool merge_tree_use_prefixes_deserialization_thread_pool;
+    extern const SettingsBool query_plan_join_swap_table_use_statistics;
 }
 
 namespace MergeTreeSetting
@@ -1927,6 +1929,36 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
     result.total_marks_pk = total_marks_pk;
     result.selected_rows = sum_rows;
     result.has_exact_ranges = result.selected_parts == 0 || find_exact_ranges;
+    result.selected_rows_after_size_hint = result.selected_rows;
+
+    if (settings[Setting::query_plan_join_swap_table_use_statistics])
+    {
+        ConditionSelectivityEstimator estimator;
+
+        for (const auto & part : result.parts_with_ranges)
+        {
+            try
+            {
+                auto stats = part.data_part->loadStatistics();
+                estimator.incrementRowCount(part.getRowsCount());
+                for (const auto & stat : stats)
+                    estimator.addStatistics(part.data_part->info.getPartNameV1(), stat);
+            }
+            catch (...)
+            {
+                tryLogCurrentException(log, fmt::format("while loading statistics on part {}", part.data_part->info.getPartNameV1()));
+            }
+        }
+
+        if (const auto * where_ast = query_info_.query->as<ASTSelectQuery &>().where().get())
+        {
+            auto block_with_constants = KeyCondition::getBlockWithConstants(query_info_.query->clone(), query_info_.syntax_analyzer_result, context_);
+            RPNBuilderTreeContext tree_context(context_, std::move(block_with_constants), {});
+            RPNBuilderTreeNode node(where_ast, tree_context);
+            const auto & unqualified_column_names = query_info_.buildNodeNameToInputNodeColumn();
+            result.selected_rows_after_size_hint = static_cast<UInt64>(std::ceil(estimator.estimateRowCount(node, unqualified_column_names)));
+        }
+    }
 
     if (query_info_.input_order_info)
         result.read_type = (query_info_.input_order_info->direction > 0)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -105,7 +105,6 @@ public:
         UInt64 selected_marks_pk = 0;
         UInt64 total_marks_pk = 0;
         UInt64 selected_rows = 0;
-        UInt64 selected_rows_after_size_hint = 0;
         bool has_exact_ranges = false;
 
         bool readFromProjection() const { return !parts_with_ranges.empty() && parts_with_ranges.front().data_part->isProjectionPart(); }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -105,6 +105,7 @@ public:
         UInt64 selected_marks_pk = 0;
         UInt64 total_marks_pk = 0;
         UInt64 selected_rows = 0;
+        UInt64 selected_rows_after_size_hint = 0;
         bool has_exact_ranges = false;
 
         bool readFromProjection() const { return !parts_with_ranges.empty() && parts_with_ranges.front().data_part->isProjectionPart(); }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -593,15 +593,10 @@ StoragePolicyPtr MergeTreeData::getStoragePolicy() const
 ConditionSelectivityEstimator MergeTreeData::getConditionSelectivityEstimatorByPredicate(
     const StorageSnapshotPtr & storage_snapshot, const ActionsDAG * filter_dag, ContextPtr local_context) const
 {
-    if (!local_context->getSettingsRef()[Setting::allow_statistics_optimize])
-        return {};
-
     const auto & parts = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data).parts;
 
     if (parts.empty())
         return {};
-
-    ASTPtr expression_ast;
 
     ConditionSelectivityEstimator estimator;
     PartitionPruner partition_pruner(storage_snapshot->metadata, filter_dag, local_context);

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -16,7 +16,7 @@ class ConditionSelectivityEstimator
 public:
     /// TODO: Support the condition consists of CNF/DNF like (cond1 and cond2) or (cond3) ...
     /// Right now we only support simple conditions like col = val / col < val, or a conjunction of those like (cond1 and cond2 and ...)
-    Float64 estimateRowCount(const RPNBuilderTreeNode & node, const std::unordered_map<std::string, ColumnWithTypeAndName> & unqualifiedColumnsNames = {}) const;
+    Float64 estimateRowCount(const RPNBuilderTreeNode & node, const std::unordered_map<std::string, ColumnWithTypeAndName> & unqualified_column_names = {}) const;
 
     void addStatistics(String part_name, ColumnStatisticsPartPtr column_stat);
     void incrementRowCount(UInt64 rows);
@@ -32,9 +32,9 @@ private:
 
         void addStatistics(String part_name, ColumnStatisticsPartPtr stats);
 
-        Float64 estimateLess(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
-        Float64 estimateGreater(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
-        Float64 estimateEqual(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
+        Float64 estimateLess(const Field & val, Float64 rows, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const;
+        Float64 estimateGreater(const Field & val, Float64 rows, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const;
+        Float64 estimateEqual(const Field & val, Float64 rows, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const;
     };
 
     bool extractOperators(const RPNBuilderTreeNode & node, const String & qualified_column_name, std::vector<std::pair<String, Field>> & result) const;

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -37,7 +37,7 @@ private:
         Float64 estimateEqual(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
     };
 
-    void extractOperators(const RPNBuilderTreeNode & node, const String & qualified_column_name, std::vector<std::pair<String, Field>> & result) const;
+    bool extractOperators(const RPNBuilderTreeNode & node, const String & qualified_column_name, std::vector<std::pair<String, Field>> & result) const;
 
     /// Magic constants for estimating the selectivity of a condition no statistics exists.
     static constexpr auto default_cond_range_factor = 0.5;

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <optional>
 #include <Storages/Statistics/Statistics.h>
 #include <Core/Field.h>
+#include <Core/ColumnWithTypeAndName.h>
 
 namespace DB
 {
@@ -13,8 +15,8 @@ class ConditionSelectivityEstimator
 {
 public:
     /// TODO: Support the condition consists of CNF/DNF like (cond1 and cond2) or (cond3) ...
-    /// Right now we only support simple condition like col = val / col < val
-    Float64 estimateRowCount(const RPNBuilderTreeNode & node) const;
+    /// Right now we only support simple conditions like col = val / col < val, or a conjunction of those like (cond1 and cond2 and ...)
+    Float64 estimateRowCount(const RPNBuilderTreeNode & node, const std::unordered_map<std::string, ColumnWithTypeAndName> & unqualifiedColumnsNames = {}) const;
 
     void addStatistics(String part_name, ColumnStatisticsPartPtr column_stat);
     void incrementRowCount(UInt64 rows);
@@ -30,12 +32,12 @@ private:
 
         void addStatistics(String part_name, ColumnStatisticsPartPtr stats);
 
-        Float64 estimateLess(const Field & val, Float64 rows) const;
-        Float64 estimateGreater(const Field & val, Float64 rows) const;
-        Float64 estimateEqual(const Field & val, Float64 rows) const;
+        Float64 estimateLess(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
+        Float64 estimateGreater(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
+        Float64 estimateEqual(const Field & val, Float64 rows, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
     };
 
-    std::pair<String, Field> extractBinaryOp(const RPNBuilderTreeNode & node, const String & column_name) const;
+    void extractOperators(const RPNBuilderTreeNode & node, const String & qualified_column_name, std::vector<std::pair<String, Field>> & result) const;
 
     /// Magic constants for estimating the selectivity of a condition no statistics exists.
     static constexpr auto default_cond_range_factor = 0.5;

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #include <Storages/Statistics/Statistics.h>
 #include <Common/Exception.h>
 #include <Common/FieldVisitorConvertToNumber.h>
@@ -76,12 +77,12 @@ UInt64 IStatistics::estimateCardinality() const
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Cardinality estimation is not implemented for this type of statistics");
 }
 
-Float64 IStatistics::estimateEqual(const Field & /*val*/) const
+Float64 IStatistics::estimateEqual(const Field & /*val*/, std::optional<Float64> & /*calculated_val*/) const
 {
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Equality estimation is not implemented for this type of statistics");
 }
 
-Float64 IStatistics::estimateLess(const Field & /*val*/) const
+Float64 IStatistics::estimateLess(const Field & /*val*/, std::optional<Float64> & /*calculated_val*/, std::optional<Float64> /*custom_min*/, std::optional<Float64> /*custom_max*/) const
 {
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Less-than estimation is not implemented for this type of statistics");
 }
@@ -98,31 +99,31 @@ Float64 IStatistics::estimateLess(const Field & /*val*/) const
 /// Sometimes, it is possible to combine multiple statistics in a clever way. For that reason, all estimation are performed in a central
 /// place (here), and we don't simply pass the predicate to the first statistics object that supports it natively.
 
-Float64 ColumnPartStatistics::estimateLess(const Field & val) const
+Float64 ColumnPartStatistics::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const
 {
     if (stats.contains(StatisticsType::TDigest))
-        return stats.at(StatisticsType::TDigest)->estimateLess(val);
+        return stats.at(StatisticsType::TDigest)->estimateLess(val, calculated_val, custom_min, custom_max);
     if (stats.contains(StatisticsType::MinMax))
-        return stats.at(StatisticsType::MinMax)->estimateLess(val);
+        return stats.at(StatisticsType::MinMax)->estimateLess(val, calculated_val, custom_min, custom_max);
     return rows * ConditionSelectivityEstimator::default_cond_range_factor;
 }
 
-Float64 ColumnPartStatistics::estimateGreater(const Field & val) const
+Float64 ColumnPartStatistics::estimateGreater(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const
 {
-    return rows - estimateLess(val);
+    return rows - estimateLess(val, calculated_val, custom_min, custom_max);
 }
 
-Float64 ColumnPartStatistics::estimateEqual(const Field & val) const
+Float64 ColumnPartStatistics::estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const
 {
     if (stats_desc.data_type->isValueRepresentedByNumber() && stats.contains(StatisticsType::Uniq) && stats.contains(StatisticsType::TDigest))
     {
         /// 2048 is the default number of buckets in TDigest. In this case, TDigest stores exactly one value (with many rows) for every bucket.
         if (stats.at(StatisticsType::Uniq)->estimateCardinality() < 2048)
-            return stats.at(StatisticsType::TDigest)->estimateEqual(val);
+            return stats.at(StatisticsType::TDigest)->estimateEqual(val, calculated_val);
     }
 #if USE_DATASKETCHES
     if (stats.contains(StatisticsType::CountMinSketch))
-        return stats.at(StatisticsType::CountMinSketch)->estimateEqual(val);
+        return stats.at(StatisticsType::CountMinSketch)->estimateEqual(val, calculated_val);
 #endif
     if (stats.contains(StatisticsType::Uniq))
     {

--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -42,8 +42,8 @@ public:
 
     /// Per-value estimations.
     /// Throws if the statistics object is not able to do a meaningful estimation.
-    virtual Float64 estimateEqual(const Field & val) const; /// cardinality of val in the column
-    virtual Float64 estimateLess(const Field & val) const;  /// summarized cardinality of values < val in the column
+    virtual Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const; /// cardinality of val in the column
+    virtual Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const; /// summarized cardinality of values < val in the column
 
 protected:
     SingleStatisticsDescription stat;
@@ -67,9 +67,9 @@ public:
 
     void build(const ColumnPtr & column);
 
-    Float64 estimateLess(const Field & val) const;
-    Float64 estimateGreater(const Field & val) const;
-    Float64 estimateEqual(const Field & val) const;
+    Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
+    Float64 estimateGreater(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
+    Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const;
 
 private:
     friend class MergeTreeStatisticsFactory;

--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -42,8 +42,8 @@ public:
 
     /// Per-value estimations.
     /// Throws if the statistics object is not able to do a meaningful estimation.
-    virtual Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const; /// cardinality of val in the column
-    virtual Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const; /// summarized cardinality of values < val in the column
+    virtual Float64 estimateEqual(const Field & val, std::optional<Float64> & val_as_float_to_return) const; /// cardinality of val in the column
+    virtual Float64 estimateLess(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const; /// summarized cardinality of values < val in the column
 
 protected:
     SingleStatisticsDescription stat;
@@ -67,9 +67,9 @@ public:
 
     void build(const ColumnPtr & column);
 
-    Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
-    Float64 estimateGreater(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const;
-    Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const;
+    Float64 estimateLess(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const;
+    Float64 estimateGreater(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const;
+    Float64 estimateEqual(const Field & val, std::optional<Float64> & val_as_float_to_return) const;
 
 private:
     friend class MergeTreeStatisticsFactory;

--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -32,7 +32,7 @@ StatisticsCountMinSketch::StatisticsCountMinSketch(const SingleStatisticsDescrip
 {
 }
 
-Float64 StatisticsCountMinSketch::estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const
+Float64 StatisticsCountMinSketch::estimateEqual(const Field & val, std::optional<Float64> & val_as_float_to_return) const
 {
     /// Try to convert field to data_type. Converting string to proper data types such as: number, date, datetime, IPv4, Decimal etc.
     /// Return null if val larger than the range of data_type
@@ -46,7 +46,7 @@ Float64 StatisticsCountMinSketch::estimateEqual(const Field & val, std::optional
 
     if (data_type->isValueRepresentedByNumber())
     {
-        calculated_val = StatisticsUtils::tryConvertToFloat64(val_converted, data_type);
+        val_as_float_to_return = StatisticsUtils::tryConvertToFloat64(val_converted, data_type);
         return sketch.get_estimate(&val_converted, data_type->getSizeOfValueInMemory());
     }
 

--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -46,7 +46,7 @@ Float64 StatisticsCountMinSketch::estimateEqual(const Field & val, std::optional
 
     if (data_type->isValueRepresentedByNumber())
     {
-        calculated_val = StatisticsUtils::tryConvertToFloat64(val, data_type);
+        calculated_val = StatisticsUtils::tryConvertToFloat64(val_converted, data_type);
         return sketch.get_estimate(&val_converted, data_type->getSizeOfValueInMemory());
     }
 

--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -4,6 +4,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/convertFieldToType.h>
+#include "Storages/Statistics/Statistics.h"
 
 #if USE_DATASKETCHES
 
@@ -31,7 +32,7 @@ StatisticsCountMinSketch::StatisticsCountMinSketch(const SingleStatisticsDescrip
 {
 }
 
-Float64 StatisticsCountMinSketch::estimateEqual(const Field & val) const
+Float64 StatisticsCountMinSketch::estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const
 {
     /// Try to convert field to data_type. Converting string to proper data types such as: number, date, datetime, IPv4, Decimal etc.
     /// Return null if val larger than the range of data_type
@@ -44,7 +45,10 @@ Float64 StatisticsCountMinSketch::estimateEqual(const Field & val) const
         return 0;
 
     if (data_type->isValueRepresentedByNumber())
+    {
+        calculated_val = StatisticsUtils::tryConvertToFloat64(val, data_type);
         return sketch.get_estimate(&val_converted, data_type->getSizeOfValueInMemory());
+    }
 
     if (isStringOrFixedString(data_type))
         return sketch.get_estimate(val.safeGet<String>());

--- a/src/Storages/Statistics/StatisticsCountMinSketch.h
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.h
@@ -16,7 +16,7 @@ class StatisticsCountMinSketch : public IStatistics
 public:
     StatisticsCountMinSketch(const SingleStatisticsDescription & description, const DataTypePtr & data_type_);
 
-    Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const override;
+    Float64 estimateEqual(const Field & val, std::optional<Float64> & val_as_float_to_return) const override;
 
     void build(const ColumnPtr & column) override;
 

--- a/src/Storages/Statistics/StatisticsCountMinSketch.h
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.h
@@ -16,7 +16,7 @@ class StatisticsCountMinSketch : public IStatistics
 public:
     StatisticsCountMinSketch(const SingleStatisticsDescription & description, const DataTypePtr & data_type_);
 
-    Float64 estimateEqual(const Field & val) const override;
+    Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const override;
 
     void build(const ColumnPtr & column) override;
 

--- a/src/Storages/Statistics/StatisticsMinMax.cpp
+++ b/src/Storages/Statistics/StatisticsMinMax.cpp
@@ -50,15 +50,15 @@ void StatisticsMinMax::deserialize(ReadBuffer & buf)
     readFloatBinary(max, buf);
 }
 
-Float64 StatisticsMinMax::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const
+Float64 StatisticsMinMax::estimateLess(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const
 {
-    Float64 used_min = custom_min.has_value() ? *custom_min : min;
-    Float64 used_max = custom_max.has_value() ? *custom_max : max;
+    Float64 used_min = left_bound.has_value() ? *left_bound : min;
+    Float64 used_max = right_bound.has_value() ? *right_bound : max;
     if (row_count == 0)
         return 0;
 
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
-    calculated_val = val_as_float;
+    val_as_float_to_return = val_as_float;
     if (!val_as_float.has_value())
         return 0;
 

--- a/src/Storages/Statistics/StatisticsMinMax.cpp
+++ b/src/Storages/Statistics/StatisticsMinMax.cpp
@@ -3,6 +3,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <Common/logger_useful.h>
 
 #include <algorithm>
 
@@ -49,25 +50,28 @@ void StatisticsMinMax::deserialize(ReadBuffer & buf)
     readFloatBinary(max, buf);
 }
 
-Float64 StatisticsMinMax::estimateLess(const Field & val) const
+Float64 StatisticsMinMax::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const
 {
+    Float64 used_min = custom_min.has_value() ? *custom_min : min;
+    Float64 used_max = custom_max.has_value() ? *custom_max : max;
     if (row_count == 0)
         return 0;
 
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
+    calculated_val = val_as_float;
     if (!val_as_float.has_value())
         return 0;
 
-    if (val_as_float < min)
+    if (val_as_float < used_min)
         return 0;
 
-    if (val_as_float > max)
+    if (val_as_float > used_max)
         return row_count;
 
-    if (min == max)
-        return (val_as_float != max) ? 0 : row_count;
+    if (used_min == used_max)
+        return (val_as_float != used_max) ? 0 : row_count;
 
-    return ((*val_as_float - min) / (max - min)) * row_count;
+    return ((*val_as_float - used_min) / (used_max - used_min)) * row_count;
 }
 
 void minMaxStatisticsValidator(const SingleStatisticsDescription & /*description*/, const DataTypePtr & data_type)

--- a/src/Storages/Statistics/StatisticsMinMax.h
+++ b/src/Storages/Statistics/StatisticsMinMax.h
@@ -17,7 +17,7 @@ public:
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;
 
-    Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const override;
+    Float64 estimateLess(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const override;
 
 private:
     Float64 min = std::numeric_limits<Float64>::max();

--- a/src/Storages/Statistics/StatisticsMinMax.h
+++ b/src/Storages/Statistics/StatisticsMinMax.h
@@ -17,7 +17,7 @@ public:
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;
 
-    Float64 estimateLess(const Field & val) const override;
+    Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const override;
 
 private:
     Float64 min = std::numeric_limits<Float64>::max();

--- a/src/Storages/Statistics/StatisticsTDigest.cpp
+++ b/src/Storages/Statistics/StatisticsTDigest.cpp
@@ -37,15 +37,15 @@ void StatisticsTDigest::deserialize(ReadBuffer & buf)
     t_digest.deserialize(buf);
 }
 
-Float64 StatisticsTDigest::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> /*custom_max*/) const
+Float64 StatisticsTDigest::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const
 {
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
     calculated_val = val_as_float;
     if (!val_as_float.has_value())
         return 0;
-    Float64 less_than_target = t_digest.getCountLessThan(*val_as_float);
-    Float64 less_than_min = custom_min.has_value() ? t_digest.getCountLessThan(*custom_min) : 0;
-    return std::max(less_than_target - less_than_min, 0.0);
+    Float64 count_less_than_val = t_digest.getCountLessThan((custom_max.has_value() && custom_max.value() < val_as_float.value()) ? *custom_max : *val_as_float);
+    Float64 count_less_than_custom_min = custom_min.has_value() ? t_digest.getCountLessThan(*custom_min) : 0;
+    return std::max(count_less_than_val - count_less_than_custom_min, 0.0);
 }
 
 Float64 StatisticsTDigest::estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const

--- a/src/Storages/Statistics/StatisticsTDigest.cpp
+++ b/src/Storages/Statistics/StatisticsTDigest.cpp
@@ -37,21 +37,21 @@ void StatisticsTDigest::deserialize(ReadBuffer & buf)
     t_digest.deserialize(buf);
 }
 
-Float64 StatisticsTDigest::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const
+Float64 StatisticsTDigest::estimateLess(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const
 {
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
-    calculated_val = val_as_float;
+    val_as_float_to_return = val_as_float;
     if (!val_as_float.has_value())
         return 0;
-    Float64 count_less_than_val = t_digest.getCountLessThan((custom_max.has_value() && custom_max.value() < val_as_float.value()) ? *custom_max : *val_as_float);
-    Float64 count_less_than_custom_min = custom_min.has_value() ? t_digest.getCountLessThan(*custom_min) : 0;
-    return std::max(count_less_than_val - count_less_than_custom_min, 0.0);
+    Float64 count_less_than_val = t_digest.getCountLessThan((right_bound.has_value() && right_bound.value() < val_as_float.value()) ? *right_bound : *val_as_float);
+    Float64 count_less_than_left_bound = left_bound.has_value() ? t_digest.getCountLessThan(*left_bound) : 0;
+    return std::max(count_less_than_val - count_less_than_left_bound, 0.0);
 }
 
-Float64 StatisticsTDigest::estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const
+Float64 StatisticsTDigest::estimateEqual(const Field & val, std::optional<Float64> & val_as_float_to_return) const
 {
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
-    calculated_val = val_as_float;
+    val_as_float_to_return = val_as_float;
     if (!val_as_float.has_value())
         return 0;
     return t_digest.getCountEqual(*val_as_float);

--- a/src/Storages/Statistics/StatisticsTDigest.cpp
+++ b/src/Storages/Statistics/StatisticsTDigest.cpp
@@ -37,17 +37,21 @@ void StatisticsTDigest::deserialize(ReadBuffer & buf)
     t_digest.deserialize(buf);
 }
 
-Float64 StatisticsTDigest::estimateLess(const Field & val) const
+Float64 StatisticsTDigest::estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> /*custom_max*/) const
 {
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
+    calculated_val = val_as_float;
     if (!val_as_float.has_value())
         return 0;
-    return t_digest.getCountLessThan(*val_as_float);
+    Float64 less_than_target = t_digest.getCountLessThan(*val_as_float);
+    Float64 less_than_min = custom_min.has_value() ? t_digest.getCountLessThan(*custom_min) : 0;
+    return std::max(less_than_target - less_than_min, 0.0);
 }
 
-Float64 StatisticsTDigest::estimateEqual(const Field & val) const
+Float64 StatisticsTDigest::estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const
 {
     auto val_as_float = StatisticsUtils::tryConvertToFloat64(val, data_type);
+    calculated_val = val_as_float;
     if (!val_as_float.has_value())
         return 0;
     return t_digest.getCountEqual(*val_as_float);

--- a/src/Storages/Statistics/StatisticsTDigest.h
+++ b/src/Storages/Statistics/StatisticsTDigest.h
@@ -16,8 +16,8 @@ public:
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;
 
-    Float64 estimateLess(const Field & val) const override;
-    Float64 estimateEqual(const Field & val) const override;
+    Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const override;
+    Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const override;
 
 private:
     QuantileTDigest<Float64> t_digest;

--- a/src/Storages/Statistics/StatisticsTDigest.h
+++ b/src/Storages/Statistics/StatisticsTDigest.h
@@ -16,8 +16,8 @@ public:
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;
 
-    Float64 estimateLess(const Field & val, std::optional<Float64> & calculated_val, std::optional<Float64> custom_min, std::optional<Float64> custom_max) const override;
-    Float64 estimateEqual(const Field & val, std::optional<Float64> & calculated_val) const override;
+    Float64 estimateLess(const Field & val, std::optional<Float64> left_bound, std::optional<Float64> right_bound, std::optional<Float64> & val_as_float_to_return) const override;
+    Float64 estimateEqual(const Field & val, std::optional<Float64> & val_as_float_to_return) const override;
 
 private:
     QuantileTDigest<Float64> t_digest;

--- a/tests/queries/0_stateless/03279_join_choose_build_table.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.sql
@@ -18,6 +18,7 @@ CREATE TABLE products (id Int32, name String) ENGINE = MergeTree ORDER BY id;
 INSERT INTO products SELECT number, 'product ' || toString(number) FROM numbers(100_000);
 
 SET query_plan_join_swap_table = 'auto';
+SET query_plan_join_swap_table_use_statistics = 0;
 
 SELECT * FROM products, sales
 WHERE sales.product_id = products.id AND date = '2024-05-07'

--- a/tests/queries/0_stateless/03397_statistics_condition_selectivity_estimator_for_joins.reference
+++ b/tests/queries/0_stateless/03397_statistics_condition_selectivity_estimator_for_joins.reference
@@ -1,0 +1,152 @@
+TOTAL ROWS IN t_left = 100_000, t_right = 10_000
+
+=== DUMMY ESTIMATOR ===
+*** Test case - x < 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - x > 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - x > 100 and x > 200 and x > 300 and x > 400 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - x = 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - y = 0 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+
+=== MinMax STATISTICS ===
+*** Test case - x < 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - x > 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - x = 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+
+=== TDigest STATISTICS ===
+*** Test case - x < 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - x > 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - x = 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+
+=== CountMinSketch STATISTICS ===
+*** Test case - x > 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - x = 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - y = 0 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+
+=== TDigest AND Uniq STATISTICS ===
+*** Test case - x < 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - x > 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - x = 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - y = 0 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+
+TOTAL ROWS IN t_left = 1_000, t_right = 1_000_000
+
+=== MinMax AND CountMinSketch STATISTICS ON t_right TABLE  ===
+*** Test case - y < 51 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - y < 51 and y > 49 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - y = 100 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - y > 10 and y > 20 and y > 15 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - y > 10 and y < 1000 and y < 51 and y > 49 ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+
+=== TEST WITH CASTS ===
+*** Test case - y < '51' ***
+Initial join order - t_left, t_right
+Real join order - (default.t_right) (default.t_left)
+Initial join order - t_right, t_left
+Real join order - (default.t_right) (default.t_left)
+*** Test case - y < '51' and y > '49' ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - y = '100' ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)
+*** Test case - y = CAST(100, 'UInt16') ***
+Initial join order - t_left, t_right
+Real join order - (default.t_left) (default.t_right)
+Initial join order - t_right, t_left
+Real join order - (default.t_left) (default.t_right)

--- a/tests/queries/0_stateless/03397_statistics_condition_selectivity_estimator_for_joins.sh
+++ b/tests/queries/0_stateless/03397_statistics_condition_selectivity_estimator_for_joins.sh
@@ -31,8 +31,8 @@ function run_test_case
     done
 }
 
-run_query "create table t_left (id UInt64, x UInt64) order by id"
-run_query "create table t_right (id UInt64, y UInt64) order by id"
+run_query "create table t_left (id UInt64, x UInt64) order by id settings min_bytes_for_wide_part = 0"
+run_query "create table t_right (id UInt64, y UInt64) order by id settings min_bytes_for_wide_part = 0"
 run_query "insert into t_left select number, number * 10 from numbers(1e5)"
 run_query "insert into t_right select number, number % 5 from numbers(1e4)"
 

--- a/tests/queries/0_stateless/03397_statistics_condition_selectivity_estimator_for_joins.sh
+++ b/tests/queries/0_stateless/03397_statistics_condition_selectivity_estimator_for_joins.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-fasttest
+# no-random-settings - HTTP interface can override the setting "query_plan_join_swap_table"
+# no-fasttest - 'countmin' sketches need a 3rd party library
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+# shellcheck source=./mergetree_mutations.lib
+. "$CURDIR"/mergetree_mutations.lib
+
+export SETTINGS="allow_experimental_analyzer=1&query_plan_join_swap_table=auto&allow_experimental_statistics=1&query_plan_join_swap_table_use_statistics=1"
+
+function run_query
+{
+    $CLICKHOUSE_CURL -sS -d "${1}" "$CLICKHOUSE_URL&$SETTINGS"
+}
+
+function run_test_case
+{
+    CONDITION="${1}"
+    QUERY_PREFIX="select * from"
+    QUERY_SUFFIX="where t_left.id = t_right.id and ${CONDITION}"
+    echo "*** Test case - ${CONDITION} ***"
+    for join_order in "t_left, t_right" "t_right, t_left"
+    do
+        echo "Initial join order - ${join_order}"
+        echo -n "Real join order - "
+        run_query "explain ${QUERY_PREFIX} ${join_order} ${QUERY_SUFFIX}" 1 | grep "ReadFromMergeTree" | awk '{print $2}' | xargs echo -n
+        echo
+    done
+}
+
+run_query "create table t_left (id UInt64, x UInt64) order by id"
+run_query "create table t_right (id UInt64, y UInt64) order by id"
+run_query "insert into t_left select number, number * 10 from numbers(1e5)"
+run_query "insert into t_right select number, number % 5 from numbers(1e4)"
+
+echo "TOTAL ROWS IN t_left = 100_000, t_right = 10_000"
+echo
+
+echo "=== DUMMY ESTIMATOR ==="
+run_test_case "x < 100" # Expected estimation t_left = 50_000, t_right = 10_000
+run_test_case "x > 100" # Expected estimation t_left = 50_000, t_right = 10_000
+run_test_case "x > 100 and x > 200 and x > 300 and x > 400" # Expected estimation t_left = 6_250, t_right = 10_000
+run_test_case "x = 100" # Expected estimation t_left = 1_000, t_right = 10_000
+run_test_case "y = 0" # Expected estimation t_left = 100_000, t_right = 100
+echo
+
+echo "=== MinMax STATISTICS ==="
+run_query "alter table t_left add statistics x type minmax"
+run_query "alter table t_left materialize statistics x"
+wait_for_all_mutations "t_left"
+
+run_test_case "x < 100" # Expected estimation t_left ~= 10, t_right = 10_000
+run_test_case "x > 100" # Expected estimation t_left ~= 99_990, t_right = 10_000
+run_test_case "x = 100" # Expected estimation t_left = 1_000, t_right = 10_000
+echo
+
+echo "=== TDigest STATISTICS ==="
+run_query "alter table t_left modify statistics x type tdigest"
+run_query "alter table t_left materialize statistics x"
+wait_for_all_mutations "t_left"
+
+run_test_case "x < 100" # Expected estimation t_left ~= 10, t_right = 10_000
+run_test_case "x > 100" # Expected estimation t_left ~= 99_990, t_right = 10_000
+run_test_case "x = 100" # Expected estimation t_left = 1_000, t_right = 10_000
+echo
+
+echo "=== CountMinSketch STATISTICS ==="
+run_query "alter table t_left modify statistics x type countmin"
+run_query "alter table t_left materialize statistics x"
+wait_for_all_mutations "t_left"
+
+run_test_case "x > 100" # Expected estimation t_left = 50_000, t_right = 10_000
+run_test_case "x = 100" # Expected estimation t_left ~= 1, t_right = 10_000
+run_test_case "y = 0" # Expected estimation t_left = 100_000, t_right = 100
+echo
+
+echo "=== TDigest AND Uniq STATISTICS ==="
+run_query "alter table t_left modify statistics x type tdigest, uniq"
+run_query "alter table t_left materialize statistics x"
+wait_for_all_mutations "t_left"
+
+run_test_case "x < 100" # Expected estimation t_left ~= 10, t_right = 10_000
+run_test_case "x > 100" # Expected estimation t_left ~= 99_990, t_right = 10_000
+run_test_case "x = 100" # Expected estimation t_left ~= 1, t_right = 10_000
+run_test_case "y = 0" # Expected estimation t_left = 100_000, t_right = 100
+echo
+
+run_query "truncate table t_left"
+run_query "truncate table t_right"
+run_query "insert into t_left select number, number * 10 from numbers(1e3)"
+run_query "insert into t_right select number, number % 10000 from numbers(1e6)"
+
+echo "TOTAL ROWS IN t_left = 1_000, t_right = 1_000_000"
+echo
+
+echo "=== MinMax AND CountMinSketch STATISTICS ON t_right TABLE  ==="
+run_query "alter table t_right add statistics y type minmax, countmin"
+run_query "alter table t_right materialize statistics y"
+wait_for_all_mutations "t_right"
+
+run_test_case "y < 51" # Expected estimation t_left = 1_000, t_right ~= 5_000
+run_test_case "y < 51 and y > 49" # Expected estimation t_left = 1_000, t_right ~= 100
+run_test_case "y = 100" # Expected estimation t_left = 1_000, t_right ~= 100
+run_test_case "y > 10 and y > 20 and y > 15" # Expected estimation t_left = 1_000, t_right ~= 998_000
+run_test_case "y > 10 and y < 1000 and y < 51 and y > 49" # Expected estimation t_left = 1_000, t_right ~= 100
+echo
+
+echo "=== TEST WITH CASTS ==="
+run_test_case "y < '51'" # Expected estimation t_left = 1_000, t_right ~= 5_000
+run_test_case "y < '51' and y > '49'" # Expected estimation t_left = 1_000, t_right ~= 100
+run_test_case "y = '100'" # Expected estimation t_left = 1_000, t_right ~= 100
+run_test_case "y = CAST(100, 'UInt16')" # Expected estimation t_left = 1_000, t_right ~= 100


### PR DESCRIPTION
Related: #55065

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce statistics application for an estimation of table sizes that being used in joins. For now, it works only if filter contains a set of "and" expressions with one column (i.e. `col < val1 AND col > val2`)

