### PR TITLE
Fix `INSERT SELECT` between tables with tuples and sparse columns

### DIFF
--- a/src/DataTypes/DataTypeTuple.cpp
+++ b/src/DataTypes/DataTypeTuple.cpp
@@ -367,7 +367,7 @@ MutableSerializationInfoPtr DataTypeTuple::createSerializationInfo(const Seriali
     for (const auto & elem : elems)
         infos.push_back(elem->createSerializationInfo(settings));
 
-    return std::make_shared<SerializationInfoTuple>(std::move(infos), names, settings);
+    return std::make_shared<SerializationInfoTuple>(std::move(infos), names);
 }
 
 SerializationInfoPtr DataTypeTuple::getSerializationInfo(const IColumn & column) const
@@ -387,7 +387,7 @@ SerializationInfoPtr DataTypeTuple::getSerializationInfo(const IColumn & column)
         infos.push_back(const_pointer_cast<SerializationInfo>(element_info));
     }
 
-    return std::make_shared<SerializationInfoTuple>(std::move(infos), names, SerializationInfo::Settings{});
+    return std::make_shared<SerializationInfoTuple>(std::move(infos), names);
 }
 
 void DataTypeTuple::forEachChild(const ChildCallback & callback) const

--- a/src/DataTypes/Serializations/SerializationInfoTuple.h
+++ b/src/DataTypes/Serializations/SerializationInfoTuple.h
@@ -8,7 +8,7 @@ namespace DB
 class SerializationInfoTuple : public SerializationInfo
 {
 public:
-    SerializationInfoTuple(MutableSerializationInfos elems_, Names names_, const Settings & settings_);
+    SerializationInfoTuple(MutableSerializationInfos elems_, Names names_);
 
     bool hasCustomSerialization() const override;
     bool structureEquals(const SerializationInfo & rhs) const override;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -681,7 +681,7 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeTempPartImpl(
     for (const auto & [column_name, _] : columns)
     {
         auto & column = block.getByName(column_name);
-        if (column.column->isSparse() && infos.getKind(column_name) != ISerialization::Kind::SPARSE)
+        if (infos.getKind(column_name) != ISerialization::Kind::SPARSE)
             column.column = recursiveRemoveSparse(column.column);
     }
 

--- a/tests/queries/0_stateless/03312_sparse_column_tuple.reference
+++ b/tests/queries/0_stateless/03312_sparse_column_tuple.reference
@@ -1,0 +1,6 @@
+1000
+dst_sparse	budget	Default	['currencyCode']	['Sparse']
+mytable_sparse	budget	Default	['currencyCode']	['Default']
+1000
+dst_sparse	budget	Default	['currencyCode']	['Sparse']
+mytable_sparse	budget	Default	['currencyCode']	['Sparse']

--- a/tests/queries/0_stateless/03312_sparse_column_tuple.sql
+++ b/tests/queries/0_stateless/03312_sparse_column_tuple.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS dst_sparse;
 DROP TABLE IF EXISTS mytable_sparse;
 
-CREATE or replace TABLE dst_sparse (
+CREATE TABLE dst_sparse (
     `id` Int64,
     `budget` Tuple(currencyCode String)
 )
@@ -27,7 +27,7 @@ ORDER BY table;
 DROP TABLE IF EXISTS dst_sparse;
 DROP TABLE IF EXISTS mytable_sparse;
 
-CREATE or replace TABLE dst_sparse (
+CREATE TABLE dst_sparse (
     `id` Int64,
     `budget` Tuple(currencyCode String)
 )

--- a/tests/queries/0_stateless/03312_sparse_column_tuple.sql
+++ b/tests/queries/0_stateless/03312_sparse_column_tuple.sql
@@ -1,0 +1,54 @@
+DROP TABLE IF EXISTS dst_sparse;
+DROP TABLE IF EXISTS mytable_sparse;
+
+CREATE or replace TABLE dst_sparse (
+    `id` Int64,
+    `budget` Tuple(currencyCode String)
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9
+AS SELECT number, arrayJoin([tuple('')]) FROM numbers(999);
+
+INSERT INTO dst_sparse VALUES (999, tuple('x'));
+
+OPTIMIZE TABLE dst_sparse FINAL;
+
+CREATE TABLE mytable_sparse ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 1.0
+AS SELECT id, budget FROM dst_sparse;
+
+SELECT count() from mytable_sparse;
+
+SELECT DISTINCT table, column, serialization_kind, subcolumns.names, subcolumns.serializations
+FROM system.parts_columns
+WHERE database = currentDatabase() AND table IN ('dst_sparse', 'mytable_sparse') AND active AND column = 'budget'
+ORDER BY table;
+
+DROP TABLE IF EXISTS dst_sparse;
+DROP TABLE IF EXISTS mytable_sparse;
+
+CREATE or replace TABLE dst_sparse (
+    `id` Int64,
+    `budget` Tuple(currencyCode String)
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9
+AS SELECT number, arrayJoin([tuple('')]) FROM numbers(999);
+
+INSERT INTO dst_sparse VALUES (999, tuple('x'));
+
+OPTIMIZE TABLE dst_sparse FINAL;
+
+CREATE TABLE mytable_sparse ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9
+AS SELECT id, budget FROM dst_sparse;
+
+SELECT count() from mytable_sparse;
+
+SELECT DISTINCT table, column, serialization_kind, subcolumns.names, subcolumns.serializations
+FROM system.parts_columns
+WHERE database = currentDatabase() AND table IN ('dst_sparse', 'mytable_sparse') AND active AND column = 'budget'
+ORDER BY table;
+
+DROP TABLE IF EXISTS dst_sparse;
+DROP TABLE IF EXISTS mytable_sparse;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `INSERT SELECT` queries between tables with `Tuple` columns and enabled sparse serialization.

Fixes #74419.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions automatically creates a merge commit with master on each push and runs the CI on it.
This trashes the build cache since artifacts won't be reused if any new C++ code got into master.
The following setting runs CI on branch's head to reuse the build cache as much as possible.
Remove it to use a merge-commit against the target branch.
#no_merge_commit
-->