### PR TITLE
More forward declarations around S3/Azure/IObjectStorage/IDisk

### DIFF
--- a/src/Backups/BackupCoordinationStageSync.h
+++ b/src/Backups/BackupCoordinationStageSync.h
@@ -2,6 +2,7 @@
 
 #include <Backups/BackupConcurrencyCheck.h>
 #include <Backups/WithRetries.h>
+#include <Common/threadPoolCallbackRunner.h>
 
 
 namespace DB

--- a/src/Backups/BackupEntriesCollector.cpp
+++ b/src/Backups/BackupEntriesCollector.cpp
@@ -19,6 +19,7 @@
 #include <base/scope_guard.h>
 #include <base/sleep.h>
 #include <Common/escapeForFileName.h>
+#include <Common/threadPoolCallbackRunner.h>
 #include <Core/Settings.h>
 
 #include <boost/range/adaptor/map.hpp>

--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -1,5 +1,4 @@
 #include <Backups/BackupFileInfo.h>
-
 #include <Backups/IBackup.h>
 #include <Backups/IBackupEntry.h>
 #include <Common/CurrentThread.h>
@@ -7,6 +6,7 @@
 #include <Common/scope_guard_safe.h>
 #include <Common/setThreadName.h>
 #include <Common/ThreadPool.h>
+#include <Common/threadPoolCallbackRunner.h>
 #include <Interpreters/ProcessList.h>
 
 #include <base/hex.h>

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -3,6 +3,7 @@
 #include <Backups/BackupFileInfo.h>
 #include <Backups/BackupIO.h>
 #include <Backups/IBackupEntry.h>
+#include <Common/CurrentThread.h>
 #include <Common/ProfileEvents.h>
 #include <Common/StringUtils.h>
 #include <base/hex.h>

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -24,6 +24,7 @@
 #include <Common/ZooKeeper/ZooKeeperRetries.h>
 #include <Common/quoteString.h>
 #include <Common/escapeForFileName.h>
+#include <Common/threadPoolCallbackRunner.h>
 #include <base/insertAtEnd.h>
 #include <Core/Settings.h>
 

--- a/src/Common/ThreadPoolTaskTracker.h
+++ b/src/Common/ThreadPoolTaskTracker.h
@@ -1,11 +1,7 @@
 #pragma once
 
-#include "config.h"
-#include "threadPoolCallbackRunner.h"
-#include "IO/WriteBufferFromS3.h"
-
-#include "logger_useful.h"
-
+#include <Common/threadPoolCallbackRunner.h>
+#include <Common/logger_useful.h>
 #include <list>
 
 namespace DB

--- a/src/Coordination/KeeperCommon.cpp
+++ b/src/Coordination/KeeperCommon.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <filesystem>
+#include <thread>
 
 #include <Common/logger_useful.h>
 #include <Disks/IDisk.h>

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -49,6 +49,7 @@
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ZooKeeper/Types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
+#include <Common/threadPoolCallbackRunner.h>
 
 namespace DB
 {

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -24,6 +24,7 @@
 #include <Common/randomSeed.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <pcg_random.hpp>
 #include <Common/logger_useful.h>
 
 

--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -3,12 +3,21 @@
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/copyData.h>
 #include <Poco/Logger.h>
+#include <Poco/Util/AbstractConfiguration.h>
 #include <Interpreters/Context.h>
+#include <Common/ThreadPool.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/logger_useful.h>
 #include <Common/setThreadName.h>
 #include <Core/ServerUUID.h>
 #include <Disks/FakeDiskTransaction.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric IDiskCopierThreads;
+    extern const Metric IDiskCopierThreadsActive;
+    extern const Metric IDiskCopierThreadsScheduled;
+}
 
 namespace DB
 {
@@ -19,6 +28,25 @@ namespace ErrorCodes
     extern const int CANNOT_READ_ALL_DATA;
     extern const int LOGICAL_ERROR;
 }
+
+IDisk::IDisk(const String & name_, const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+    : name(name_)
+    , copying_thread_pool(std::make_unique<ThreadPool>(
+          CurrentMetrics::IDiskCopierThreads,
+          CurrentMetrics::IDiskCopierThreadsActive,
+          CurrentMetrics::IDiskCopierThreadsScheduled,
+          config.getUInt(config_prefix + ".thread_pool_size", 16)))
+{
+}
+
+IDisk::IDisk(const String & name_)
+    : name(name_)
+    , copying_thread_pool(std::make_unique<ThreadPool>(
+          CurrentMetrics::IDiskCopierThreads, CurrentMetrics::IDiskCopierThreadsActive, CurrentMetrics::IDiskCopierThreadsScheduled, 16))
+{
+}
+
+IDisk::~IDisk() = default;
 
 bool IDisk::isDirectoryEmpty(const String & path) const
 {
@@ -140,7 +168,7 @@ void IDisk::copyThroughBuffers(
     WriteSettings write_settings,
     const std::function<void()> & cancellation_hook)
 {
-    ThreadPoolCallbackRunnerLocal<void> runner(copying_thread_pool, "AsyncCopy");
+    ThreadPoolCallbackRunnerLocal<void> runner(*copying_thread_pool, "AsyncCopy");
 
     /// Disable parallel write. We already copy in parallel.
     /// Avoid high memory usage. See test_s3_zero_copy_ttl/test.py::test_move_and_s3_memory_usage
@@ -263,7 +291,7 @@ catch (Exception & e)
 
 void IDisk::applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr /*context*/, const String & config_prefix, const DisksMap & /*map*/)
 {
-    copying_thread_pool.setMaxThreads(config.getInt(config_prefix + ".thread_pool_size", 16));
+    copying_thread_pool->setMaxThreads(config.getInt(config_prefix + ".thread_pool_size", 16));
 }
 
 }

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -1,24 +1,27 @@
 #pragma once
 
+#include <Disks/ObjectStorages/StoredObject.h>
 #include <Interpreters/Context_fwd.h>
 #include <Core/Defines.h>
 #include <Core/Names.h>
 #include <base/types.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
+#include <Common/ThreadPool_fwd.h>
 #include <Disks/DiskType.h>
 #include <IO/ReadSettings.h>
 #include <IO/WriteSettings.h>
-#include <Disks/ObjectStorages/IObjectStorage.h>
 #include <Disks/WriteMode.h>
 #include <Disks/DirectoryIterator.h>
 
 #include <memory>
-#include <utility>
 #include <boost/noncopyable.hpp>
 #include <Poco/Timestamp.h>
 #include <filesystem>
+#include <optional>
 #include <sys/stat.h>
+
+#include "config.h"
 
 
 namespace fs = std::filesystem;
@@ -32,15 +35,15 @@ namespace Poco
     }
 }
 
-namespace CurrentMetrics
-{
-    extern const Metric IDiskCopierThreads;
-    extern const Metric IDiskCopierThreadsActive;
-    extern const Metric IDiskCopierThreadsScheduled;
-}
-
 namespace DB
 {
+
+#if USE_AWS_S3
+namespace S3
+{
+class Client;
+}
+#endif
 
 namespace ErrorCodes
 {
@@ -66,6 +69,8 @@ using RemoveBatchRequest = std::vector<RemoveRequest>;
 
 class DiskObjectStorage;
 using DiskObjectStoragePtr = std::shared_ptr<DiskObjectStorage>;
+
+using ObjectAttributes = std::map<std::string, std::string>;
 
 /**
  * Provide interface for reservation.
@@ -112,23 +117,9 @@ using SyncGuardPtr = std::unique_ptr<ISyncGuard>;
 class IDisk : public Space
 {
 public:
-    /// Default constructor.
-    IDisk(const String & name_, const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
-        : name(name_)
-        , copying_thread_pool(
-              CurrentMetrics::IDiskCopierThreads,
-              CurrentMetrics::IDiskCopierThreadsActive,
-              CurrentMetrics::IDiskCopierThreadsScheduled,
-              config.getUInt(config_prefix + ".thread_pool_size", 16))
-    {
-    }
-
-    explicit IDisk(const String & name_)
-        : name(name_)
-        , copying_thread_pool(
-              CurrentMetrics::IDiskCopierThreads, CurrentMetrics::IDiskCopierThreadsActive, CurrentMetrics::IDiskCopierThreadsScheduled, 16)
-    {
-    }
+    IDisk(const String & name_, const Poco::Util::AbstractConfiguration & config, const String & config_prefix);
+    explicit IDisk(const String & name_);
+    ~IDisk() override;
 
     /// This is a disk.
     bool isDisk() const override { return true; }
@@ -586,7 +577,7 @@ protected:
     virtual void checkAccessImpl(const String & path);
 
 private:
-    ThreadPool copying_thread_pool;
+    std::unique_ptr<ThreadPool> copying_thread_pool;
     // 0 means the disk is not custom, the disk is predefined in the config
     UInt128 custom_disk_settings_hash = 0;
 

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -28,11 +28,18 @@
 #include "config.h"
 
 #if USE_AZURE_BLOB_STORAGE
-#include <Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
+namespace DB::AzureBlobStorage
+{
+class ContainerClientWrapper;
+using ContainerClient = ContainerClientWrapper;
+}
 #endif
 
 #if USE_AWS_S3
-#include <IO/S3/Client.h>
+namespace DB::S3
+{
+class Client;
+}
 #endif
 
 namespace DB

--- a/src/Disks/TemporaryFileOnDisk.cpp
+++ b/src/Disks/TemporaryFileOnDisk.cpp
@@ -1,5 +1,6 @@
 #include <Core/UUID.h>
 #include <Disks/TemporaryFileOnDisk.h>
+#include <IO/WriteHelpers.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/logger_useful.h>
 

--- a/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
+++ b/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
@@ -8,10 +8,11 @@
 #include <Interpreters/Context.h>
 #include <IO/LimitSeekableReadBuffer.h>
 #include <IO/SeekableReadBuffer.h>
+#include <IO/SharedThreadPools.h>
+#include <IO/WriteBufferFromVector.h>
 #include <Disks/IO/ReadBufferFromAzureBlobStorage.h>
 #include <Disks/IO/WriteBufferFromAzureBlobStorage.h>
 #include <Common/getRandomASCIIString.h>
-#include <IO/SharedThreadPools.h>
 
 namespace ProfileEvents
 {

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <IO/S3/Client.h>
 #include <IO/HTTPHeaderEntries.h>
+#include <IO/S3/Client.h>
 #include <base/types.h>
 #include <Common/Exception.h>
-
-#include <unordered_set>
 
 #include "config.h"
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -31,6 +31,7 @@
 #include <Common/filesystemHelpers.h>
 #include <Common/noexcept_scope.h>
 #include <Common/checkStackSize.h>
+#include <Common/threadPoolCallbackRunner.h>
 #include <base/scope_guard.h>
 
 #include <base/isSharedPtrUnique.h>

--- a/src/Interpreters/InterpreterCheckQuery.cpp
+++ b/src/Interpreters/InterpreterCheckQuery.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <thread>
 
 #include <Access/Common/AccessFlags.h>
 

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -9,6 +9,7 @@
 #include <Parsers/IAST.h>
 #include <Parsers/queryNormalization.h>
 #include <Processors/Executors/PipelineExecutor.h>
+#include <base/scope_guard.h>
 #include <Common/Exception.h>
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -17,6 +17,11 @@
 #include <IO/UncompressedCache.h>
 #include <IO/MMappedFileCache.h>
 
+#include "config.h"
+#if USE_AWS_S3
+#include <IO/S3/Client.h>
+#endif
+
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/StorageMergeTree.h>
 #include <Storages/StorageReplicatedMergeTree.h>

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -1,3 +1,4 @@
+#include <IO/copyData.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -5,9 +6,7 @@
 
 
 #include <algorithm>
-#include <numeric>
 #include <thread>
-#include <chrono>
 
 #include <Core/ServerUUID.h>
 #include <Common/iota.h>

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -15,6 +15,7 @@
 #include <azure/identity/managed_identity_credential.hpp>
 #include <azure/identity/workload_identity_credential.hpp>
 #include <Core/Settings.h>
+#include <Common/RemoteHostFilter.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
 

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -33,6 +33,7 @@
 #include <Common/parseAddress.h>
 #include <Common/quoteString.h>
 #include <Common/setThreadName.h>
+#include <Common/RemoteHostFilter.h>
 
 #include <base/range.h>
 

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <IO/copyData.h>
 #include <Storages/StorageKeeperMap.h>
 
 #include <Columns/ColumnString.h>


### PR DESCRIPTION
The most important is around IObjectStorage.h/IDisk.h

Otherwise changing `S3/Client.h` leads to recompilation of 500+ units

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)