### PR TITLE
s3queue: allow to alter recently added settings

### DIFF
--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -170,11 +170,11 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     , engine_name(engine_args->engine->name)
     , zk_path(chooseZooKeeperPath(table_id_, context_->getSettingsRef(), *queue_settings_))
     , enable_logging_to_queue_log((*queue_settings_)[ObjectStorageQueueSetting::enable_logging_to_queue_log])
-    , list_objects_batch_size((*queue_settings_)[ObjectStorageQueueSetting::list_objects_batch_size])
-    , enable_hash_ring_filtering((*queue_settings_)[ObjectStorageQueueSetting::enable_hash_ring_filtering])
     , polling_min_timeout_ms((*queue_settings_)[ObjectStorageQueueSetting::polling_min_timeout_ms])
     , polling_max_timeout_ms((*queue_settings_)[ObjectStorageQueueSetting::polling_max_timeout_ms])
     , polling_backoff_ms((*queue_settings_)[ObjectStorageQueueSetting::polling_backoff_ms])
+    , list_objects_batch_size((*queue_settings_)[ObjectStorageQueueSetting::list_objects_batch_size])
+    , enable_hash_ring_filtering((*queue_settings_)[ObjectStorageQueueSetting::enable_hash_ring_filtering])
     , commit_settings(CommitSettings{
         .max_processed_files_before_commit = (*queue_settings_)[ObjectStorageQueueSetting::max_processed_files_before_commit],
         .max_processed_rows_before_commit = (*queue_settings_)[ObjectStorageQueueSetting::max_processed_rows_before_commit],
@@ -665,6 +665,8 @@ static const std::unordered_set<std::string_view> changeable_settings_unordered_
     "max_processed_rows_before_commit",
     "max_processed_bytes_before_commit",
     "max_processing_time_sec_before_commit",
+    "enable_hash_ring_filtering",
+    "list_objects_batch_size",
 };
 
 static const std::unordered_set<std::string_view> changeable_settings_ordered_mode
@@ -679,6 +681,7 @@ static const std::unordered_set<std::string_view> changeable_settings_ordered_mo
     "max_processed_bytes_before_commit",
     "max_processing_time_sec_before_commit",
     "buckets",
+    "list_objects_batch_size",
 };
 
 static std::string normalizeSetting(const std::string & name)
@@ -937,6 +940,11 @@ void StorageObjectStorageQueue::alter(
                 commit_settings.max_processed_bytes_before_commit = change.value.safeGet<UInt64>();
             if (change.name == "max_processing_time_sec_before_commit")
                 commit_settings.max_processing_time_sec_before_commit = change.value.safeGet<UInt64>();
+
+            if (change.name == "list_objects_batch_size")
+                list_objects_batch_size = change.value.safeGet<UInt64>();
+            if (change.name == "enable_hash_ring_filtering")
+                enable_hash_ring_filtering = change.value.safeGet<bool>();
         }
 
         DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(local_context, table_id, new_metadata);
@@ -956,17 +964,25 @@ StorageObjectStorageQueue::createFileIterator(ContextPtr local_context, const Ac
     bool file_deletion_enabled = table_metadata.getMode() == ObjectStorageQueueMode::UNORDERED
         && (table_metadata.tracked_files_ttl_sec || table_metadata.tracked_files_limit);
 
+    size_t list_objects_batch_size_copy;
+    bool enable_hash_ring_filtering_copy;
+    {
+        std::lock_guard lock(mutex);
+        list_objects_batch_size_copy = list_objects_batch_size;
+        enable_hash_ring_filtering_copy = enable_hash_ring_filtering;
+    }
+
     return std::make_shared<FileIterator>(
         files_metadata,
         object_storage,
         configuration,
         getStorageID(),
-        list_objects_batch_size,
+        list_objects_batch_size_copy,
         predicate,
         getVirtualsList(),
         local_context,
         log,
-        enable_hash_ring_filtering,
+        enable_hash_ring_filtering_copy,
         file_deletion_enabled,
         shutdown_called);
 }
@@ -1000,6 +1016,8 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
         settings[ObjectStorageQueueSetting::max_processed_rows_before_commit] = commit_settings.max_processed_rows_before_commit;
         settings[ObjectStorageQueueSetting::max_processed_bytes_before_commit] = commit_settings.max_processed_bytes_before_commit;
         settings[ObjectStorageQueueSetting::max_processing_time_sec_before_commit] = commit_settings.max_processing_time_sec_before_commit;
+        settings[ObjectStorageQueueSetting::enable_hash_ring_filtering] = enable_hash_ring_filtering;
+        settings[ObjectStorageQueueSetting::list_objects_batch_size] = list_objects_batch_size;
     }
 
     return settings;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -74,13 +74,13 @@ private:
     const std::string engine_name;
     const fs::path zk_path;
     const bool enable_logging_to_queue_log;
-    const size_t list_objects_batch_size;
-    const bool enable_hash_ring_filtering;
 
     mutable std::mutex mutex;
     UInt64 polling_min_timeout_ms TSA_GUARDED_BY(mutex);
     UInt64 polling_max_timeout_ms TSA_GUARDED_BY(mutex);
     UInt64 polling_backoff_ms TSA_GUARDED_BY(mutex);
+    UInt64 list_objects_batch_size TSA_GUARDED_BY(mutex);
+    bool enable_hash_ring_filtering TSA_GUARDED_BY(mutex);
     CommitSettings commit_settings TSA_GUARDED_BY(mutex);
 
     std::shared_ptr<ObjectStorageQueueMetadata> files_metadata;

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2319,6 +2319,10 @@ def test_alter_settings(started_cluster):
         time.sleep(1)
     assert expected_rows == get_count()
 
+    assert "true" == node1.query(
+        f"SELECT value FROM system.s3_queue_settings WHERE name = 'enable_hash_ring_filtering' and table = '{table_name}'"
+    ).strip()
+
     node1.query(
         f"""
         ALTER TABLE r.{table_name}
@@ -2333,7 +2337,9 @@ def test_alter_settings(started_cluster):
         max_processed_files_before_commit=444,
         s3queue_max_processed_rows_before_commit=555,
         max_processed_bytes_before_commit=666,
-        max_processing_time_sec_before_commit=777
+        max_processing_time_sec_before_commit=777,
+        enable_hash_ring_filtering=false,
+        list_objects_batch_size=1234
     """
     )
 
@@ -2349,6 +2355,8 @@ def test_alter_settings(started_cluster):
         "max_processed_rows_before_commit": 555,
         "max_processed_bytes_before_commit": 666,
         "max_processing_time_sec_before_commit": 777,
+        "enable_hash_ring_filtering":"false",
+        "list_objects_batch_size":1234
     }
     string_settings = {"after_processing": "delete"}
 

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -2319,9 +2319,12 @@ def test_alter_settings(started_cluster):
         time.sleep(1)
     assert expected_rows == get_count()
 
-    assert "true" == node1.query(
-        f"SELECT value FROM system.s3_queue_settings WHERE name = 'enable_hash_ring_filtering' and table = '{table_name}'"
-    ).strip()
+    assert (
+        "true"
+        == node1.query(
+            f"SELECT value FROM system.s3_queue_settings WHERE name = 'enable_hash_ring_filtering' and table = '{table_name}'"
+        ).strip()
+    )
 
     node1.query(
         f"""
@@ -2355,8 +2358,8 @@ def test_alter_settings(started_cluster):
         "max_processed_rows_before_commit": 555,
         "max_processed_bytes_before_commit": 666,
         "max_processing_time_sec_before_commit": 777,
-        "enable_hash_ring_filtering":"false",
-        "list_objects_batch_size":1234
+        "enable_hash_ring_filtering": "false",
+        "list_objects_batch_size": 1234,
     }
     string_settings = {"after_processing": "delete"}
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to alter settings `list_objects_batch_size` and `enable_hash_ring_filtering`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [x] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions automatically creates a merge commit with master on each push and runs the CI on it.
This trashes the build cache since artifacts won't be reused if any new C++ code got into master.
The following setting runs CI on branch's head to reuse the build cache as much as possible.
Remove it to use a merge-commit against the target branch.
#no_merge_commit
-->