### PR TITLE
s3queue: fix assert in tests

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -121,11 +121,13 @@ ObjectStorageQueueIFileMetadata::ObjectStorageQueueIFileMetadata(
     const std::string & failed_node_path_,
     FileStatusPtr file_status_,
     size_t max_loading_retries_,
+    std::atomic<size_t> & metadata_ref_count_,
     LoggerPtr log_)
     : path(path_)
     , node_name(getNodeName(path_))
     , file_status(file_status_)
     , max_loading_retries(max_loading_retries_)
+    , metadata_ref_count(metadata_ref_count_)
     , processing_node_path(processing_node_path_)
     , processed_node_path(processed_node_path_)
     , failed_node_path(failed_node_path_)
@@ -262,29 +264,32 @@ bool ObjectStorageQueueIFileMetadata::trySetProcessing()
 std::optional<ObjectStorageQueueIFileMetadata::SetProcessingResponseIndexes>
 ObjectStorageQueueIFileMetadata::prepareSetProcessingRequests(Coordination::Requests & requests)
 {
-    std::unique_lock processing_lock(file_status->processing_lock, std::defer_lock);
-    if (!processing_lock.try_lock())
+    if (metadata_ref_count.load() > 1)
     {
-        /// This is possible in case on the same server
-        /// there are more than one S3(Azure)Queue table processing the same keeper path.
-        LOG_TEST(log, "File {} is being processed on this server by another table on this server", path);
-        return std::nullopt;
-    }
+        std::unique_lock processing_lock(file_status->processing_lock, std::defer_lock);
+        if (!processing_lock.try_lock())
+        {
+            /// This is possible in case on the same server
+            /// there are more than one S3(Azure)Queue table processing the same keeper path.
+            LOG_TEST(log, "File {} is being processed on this server by another table on this server", path);
+            return std::nullopt;
+        }
 
-    auto state = file_status->state.load();
-    if (state == FileStatus::State::Processing
-        || state == FileStatus::State::Processed
-        || (state == FileStatus::State::Failed
-            && file_status->retries
-            && file_status->retries >= max_loading_retries))
-    {
-        LOG_TEST(log, "File {} has non-processable state `{}` (retries: {}/{})",
-                 path, state, file_status->retries, max_loading_retries);
+        auto state = file_status->state.load();
+        if (state == FileStatus::State::Processing
+            || state == FileStatus::State::Processed
+            || (state == FileStatus::State::Failed
+                && file_status->retries
+                && file_status->retries >= max_loading_retries))
+        {
+            LOG_TEST(log, "File {} has non-processable state `{}` (retries: {}/{})",
+                    path, state, file_status->retries, max_loading_retries);
 
-        /// This is possible in case on the same server
-        /// there are more than one S3(Azure)Queue table processing the same keeper path.
-        LOG_TEST(log, "File {} is being processed on this server by another table on this server", path);
-        return std::nullopt;
+            /// This is possible in case on the same server
+            /// there are more than one S3(Azure)Queue table processing the same keeper path.
+            LOG_TEST(log, "File {} is being processed on this server by another table on this server", path);
+            return std::nullopt;
+        }
     }
 
     return prepareProcessingRequestsImpl(requests);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -94,7 +94,7 @@ public:
         size_t create_processing_node_idx = 0;
         size_t set_processing_id_node_idx = 0;
     };
-    SetProcessingResponseIndexes prepareSetProcessingRequests(Coordination::Requests & requests);
+    std::optional<SetProcessingResponseIndexes> prepareSetProcessingRequests(Coordination::Requests & requests);
     void prepareResetProcessingRequests(Coordination::Requests & requests);
 
     /// Do some work after prepared requests to set file as Processed succeeded.

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -56,6 +56,7 @@ public:
         const std::string & failed_node_path_,
         FileStatusPtr file_status_,
         size_t max_loading_retries_,
+        std::atomic<size_t> & metadata_ref_count_,
         LoggerPtr log_);
 
     virtual ~ObjectStorageQueueIFileMetadata();
@@ -139,6 +140,7 @@ protected:
     const std::string node_name;
     const FileStatusPtr file_status;
     const size_t max_loading_retries;
+    const std::atomic<size_t> & metadata_ref_count;
 
     const std::string processing_node_path;
     const std::string processed_node_path;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -447,7 +447,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
 
         if (!table_metadata.last_processed_path.empty())
         {
-            std::atomic<size_t> noop = false;
+            std::atomic<size_t> noop = 0;
             ObjectStorageQueueOrderedFileMetadata(
                 zookeeper_path,
                 table_metadata.last_processed_path,

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -179,6 +179,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
     const std::string & path,
     ObjectStorageQueueOrderedFileMetadata::BucketInfoPtr bucket_info)
 {
+    chassert(metadata_ref_count);
     auto file_status = local_file_statuses->get(path, /* create */true);
     switch (mode)
     {
@@ -190,6 +191,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 bucket_info,
                 buckets_num,
                 table_metadata.loading_retries,
+                *metadata_ref_count,
                 log);
         case ObjectStorageQueueMode::UNORDERED:
             return std::make_shared<ObjectStorageQueueUnorderedFileMetadata>(
@@ -197,6 +199,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 path,
                 file_status,
                 table_metadata.loading_retries,
+                *metadata_ref_count,
                 log);
     }
 }
@@ -444,6 +447,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
 
         if (!table_metadata.last_processed_path.empty())
         {
+            std::atomic<size_t> noop = false;
             ObjectStorageQueueOrderedFileMetadata(
                 zookeeper_path,
                 table_metadata.last_processed_path,
@@ -451,6 +455,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
                 /* bucket_info */nullptr,
                 buckets_num,
                 table_metadata.loading_retries,
+                noop,
                 log).prepareProcessedAtStartRequests(requests, zookeeper);
         }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -141,6 +141,9 @@ public:
     ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr
     tryAcquireBucket(const Bucket & bucket, const Processor & processor);
 
+    /// Set local ref count for metadata.
+    void setMetadataRefCount(std::atomic<size_t> & ref_count_) { chassert(!metadata_ref_count); metadata_ref_count = &ref_count_; }
+
 private:
     void cleanupThreadFunc();
     void cleanupThreadFuncImpl();
@@ -186,6 +189,10 @@ private:
     std::shared_ptr<ServersHashRing> active_servers_hash_ring;
     /// Guards `active_servers` and `active_servers_hash_ring`.
     mutable SharedMutex active_servers_mutex;
+
+    /// Number of S3(Azure)Queue tables on the same
+    /// clickhouse server instance referencing the same metadata object.
+    std::atomic<size_t> * metadata_ref_count;
 };
 
 using ObjectStorageQueueMetadataPtr = std::unique_ptr<ObjectStorageQueueMetadata>;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -192,7 +192,7 @@ private:
 
     /// Number of S3(Azure)Queue tables on the same
     /// clickhouse server instance referencing the same metadata object.
-    std::atomic<size_t> * metadata_ref_count;
+    std::atomic<size_t> * metadata_ref_count = nullptr;
 };
 
 using ObjectStorageQueueMetadataPtr = std::unique_ptr<ObjectStorageQueueMetadata>;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -24,7 +24,7 @@ ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFa
     if (it == metadata_by_path.end())
     {
         it = metadata_by_path.emplace(zookeeper_path, std::move(metadata)).first;
-        it->second.metadata->setMetadataRefCount(it->second.ref_count);
+        it->second.metadata->setMetadataRefCount(*it->second.ref_count);
     }
     else
     {
@@ -35,7 +35,7 @@ ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFa
     }
 
     it->second.metadata->registerIfNot(storage_id, false);
-    it->second.ref_count += 1;
+    *it->second.ref_count += 1;
     return it->second.metadata;
 }
 
@@ -47,7 +47,7 @@ void ObjectStorageQueueMetadataFactory::remove(const std::string & zookeeper_pat
     if (it == metadata_by_path.end())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Metadata with zookeeper path {} does not exist", zookeeper_path);
 
-    it->second.ref_count -= 1;
+    *it->second.ref_count -= 1;
 
     size_t registry_size;
     try

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -24,6 +24,7 @@ ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFa
     if (it == metadata_by_path.end())
     {
         it = metadata_by_path.emplace(zookeeper_path, std::move(metadata)).first;
+        it->second.metadata->setMetadataRefCount(it->second.ref_count);
     }
     else
     {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -26,7 +26,7 @@ private:
     {
         explicit MetadataWithRefCount(std::shared_ptr<ObjectStorageQueueMetadata> metadata_) : metadata(metadata_) {}
         std::shared_ptr<ObjectStorageQueueMetadata> metadata;
-        size_t ref_count = 0;
+        std::atomic<size_t> ref_count = 0;
     };
     using MetadataByPath = std::unordered_map<std::string, MetadataWithRefCount>;
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -26,7 +26,7 @@ private:
     {
         explicit MetadataWithRefCount(std::shared_ptr<ObjectStorageQueueMetadata> metadata_) : metadata(metadata_) {}
         std::shared_ptr<ObjectStorageQueueMetadata> metadata;
-        std::atomic<size_t> ref_count = 0;
+        std::unique_ptr<std::atomic<size_t>> ref_count = std::make_unique<std::atomic<size_t>>(0);
     };
     using MetadataByPath = std::unordered_map<std::string, MetadataWithRefCount>;
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -122,6 +122,7 @@ ObjectStorageQueueOrderedFileMetadata::ObjectStorageQueueOrderedFileMetadata(
     BucketInfoPtr bucket_info_,
     size_t buckets_num_,
     size_t max_loading_retries_,
+    std::atomic<size_t> & metadata_ref_count_,
     LoggerPtr log_)
     : ObjectStorageQueueIFileMetadata(
         path_,
@@ -130,6 +131,7 @@ ObjectStorageQueueOrderedFileMetadata::ObjectStorageQueueOrderedFileMetadata(
         /* failed_node_path */zk_path_ / "failed" / getNodeName(path_),
         file_status_,
         max_loading_retries_,
+        metadata_ref_count_,
         log_)
     , buckets_num(buckets_num_)
     , zk_path(zk_path_)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
@@ -30,6 +30,7 @@ public:
         BucketInfoPtr bucket_info_,
         size_t buckets_num_,
         size_t max_loading_retries_,
+        std::atomic<size_t> & metadata_ref_count_,
         LoggerPtr log_);
 
     struct BucketHolder;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -148,6 +148,8 @@ ObjectStorageQueueSource::FileIterator::next()
                 return {};
             }
 
+            LOG_TEST(log, "Received batch of size: {}", result->size());
+
             new_batch = std::move(result.value());
             for (auto it = new_batch.begin(); it != new_batch.end();)
             {
@@ -187,13 +189,24 @@ ObjectStorageQueueSource::FileIterator::next()
                 result_indexes.resize(new_batch.size());
 
                 Coordination::Requests requests;
+                size_t num_successful_objects = 0;
                 for (size_t i = 0; i < new_batch.size(); ++i)
                 {
                     const auto & object = new_batch[i];
                     file_metadatas[i] = metadata->getFileMetadata(
                         object->relative_path,
                         /* bucket_info */{}); /// No buckets for Unordered mode.
-                    result_indexes[i] = file_metadatas[i]->prepareSetProcessingRequests(requests);
+
+                    auto set_processing_result = file_metadatas[i]->prepareSetProcessingRequests(requests);
+                    if (set_processing_result.has_value())
+                    {
+                        result_indexes[i] = set_processing_result.value();
+                        ++num_successful_objects;
+                    }
+                    else
+                    {
+                        new_batch[i] = nullptr;
+                    }
                 }
 
                 Coordination::Responses responses;
@@ -204,6 +217,9 @@ ObjectStorageQueueSource::FileIterator::next()
                     LOG_TEST(log, "Successfully set {} files as processing", new_batch.size());
                     for (size_t i = 0; i < new_batch.size(); ++i)
                     {
+                        if (!new_batch[i])
+                            continue;
+
                         const auto & response_indexes = result_indexes[i];
                         const auto & set_response = dynamic_cast<const Coordination::SetResponse &>(
                             *responses[response_indexes.set_processing_id_node_idx].get());
@@ -219,6 +235,20 @@ ObjectStorageQueueSource::FileIterator::next()
                               code, requests[failed_idx]->getPath());
 
                     file_metadatas.clear();
+                }
+
+                if (num_successful_objects != new_batch.size())
+                {
+                    Source::ObjectInfos new_batch_copy;
+                    new_batch_copy.resize(num_successful_objects);
+
+                    size_t i = 0;
+                    for (const auto & object : new_batch)
+                    {
+                        if (object)
+                            new_batch_copy[i++] = std::move(object);
+                    }
+                    new_batch = std::move(new_batch_copy);
                 }
             }
         }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -240,13 +240,12 @@ ObjectStorageQueueSource::FileIterator::next()
                 if (num_successful_objects != new_batch.size())
                 {
                     Source::ObjectInfos new_batch_copy;
-                    new_batch_copy.resize(num_successful_objects);
+                    new_batch_copy.reserve(num_successful_objects);
 
-                    size_t i = 0;
-                    for (const auto & object : new_batch)
+                    for (auto & object : new_batch)
                     {
                         if (object)
-                            new_batch_copy[i++] = std::move(object);
+                            new_batch_copy.push_back(std::move(object));
                     }
                     new_batch = std::move(new_batch_copy);
                 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
@@ -23,6 +23,7 @@ ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata
     const std::string & path_,
     FileStatusPtr file_status_,
     size_t max_loading_retries_,
+    std::atomic<size_t> & metadata_ref_count_,
     LoggerPtr log_)
     : ObjectStorageQueueIFileMetadata(
         path_,
@@ -31,6 +32,7 @@ ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata
         /* failed_node_path */zk_path / "failed" / getNodeName(path_),
         file_status_,
         max_loading_retries_,
+        metadata_ref_count_,
         log_)
 {
 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
@@ -16,6 +16,7 @@ public:
         const std::string & path_,
         FileStatusPtr file_status_,
         size_t max_loading_retries_,
+        std::atomic<size_t> & metadata_ref_count_,
         LoggerPtr log_);
 
     static std::vector<std::string> getMetadataPaths() { return {"processed", "failed", "processing"}; }

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -732,7 +732,7 @@ def test_streaming_to_many_views(started_cluster, mode):
     keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
     files_path = f"{table_name}_data"
 
-    for i in range(3):
+    for i in range(10):
         table = f"{table_name}_{i + 1}"
         create_table(
             started_cluster,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [x] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions automatically creates a merge commit with master on each push and runs the CI on it.
This trashes the build cache since artifacts won't be reused if any new C++ code got into master.
The following setting runs CI on branch's head to reuse the build cache as much as possible.
Remove it to use a merge-commit against the target branch.
#no_merge_commit
-->