### PR TITLE
Docs: move `TSKV` to it's own page

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -134,38 +134,7 @@ See [TemplateIgnoreSpaces](../interfaces/formats/Template/TemplateIgnoreSpaces.m
 
 ## TSKV {#tskv}
 
-Similar to TabSeparated, but outputs a value in name=value format. Names are escaped the same way as in TabSeparated format, and the = symbol is also escaped.
-
-``` text
-SearchPhrase=   count()=8267016
-SearchPhrase=bathroom interior design    count()=2166
-SearchPhrase=clickhouse     count()=1655
-SearchPhrase=2014 spring fashion    count()=1549
-SearchPhrase=freeform photos       count()=1480
-SearchPhrase=angelina jolie    count()=1245
-SearchPhrase=omsk       count()=1112
-SearchPhrase=photos of dog breeds    count()=1091
-SearchPhrase=curtain designs        count()=1064
-SearchPhrase=baku       count()=1000
-```
-
-[NULL](/docs/en/sql-reference/syntax.md) is formatted as `\N`.
-
-``` sql
-SELECT * FROM t_null FORMAT TSKV
-```
-
-``` text
-x=1    y=\N
-```
-
-When there is a large number of small columns, this format is ineffective, and there is generally no reason to use it. Nevertheless, it is no worse than JSONEachRow in terms of efficiency.
-
-Both data output and parsing are supported in this format. For parsing, any order is supported for the values of different columns. It is acceptable for some values to be omitted – they are treated as equal to their default values. In this case, zeros and blank rows are used as default values. Complex values that could be specified in the table are not supported as defaults.
-
-Parsing allows the presence of the additional field `tskv` without the equal sign or a value. This field is ignored.
-
-During import, columns with unknown names will be skipped if setting [input_format_skip_unknown_fields](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
+See [TSKV](formats/TabSeparated/TSKV.md)
 
 ## CSV {#csv}
 

--- a/docs/en/interfaces/formats/TabSeparated/TSKV.md
+++ b/docs/en/interfaces/formats/TabSeparated/TSKV.md
@@ -2,13 +2,21 @@
 title : TSKV
 slug : /en/interfaces/formats/TSKV
 keywords : [TSKV]
+input_format: true
+output_format: true
+alias: []
 ---
+
+| Input | Output | Alias |
+|-------|--------|-------|
+| ✔     | ✔      |       |
 
 ## Description
 
-Similar to TabSeparated, but outputs a value in name=value format. Names are escaped the same way as in TabSeparated format, and the = symbol is also escaped.
+Similar to the [`TabSeparated`](./TabSeparated.md) format, but outputs a value in `name=value` format. 
+Names are escaped the same way as in the [`TabSeparated`](./TabSeparated.md) format, and the `=` symbol is also escaped.
 
-``` text
+```text
 SearchPhrase=   count()=8267016
 SearchPhrase=bathroom interior design    count()=2166
 SearchPhrase=clickhouse     count()=1655
@@ -22,21 +30,28 @@ SearchPhrase=baku       count()=1000
 ```
 
 
-``` sql
+```sql title="Query"
 SELECT * FROM t_null FORMAT TSKV
 ```
 
-``` text
+```text title="Response"
 x=1    y=\N
 ```
 
-When there is a large number of small columns, this format is ineffective, and there is generally no reason to use it. Nevertheless, it is no worse than JSONEachRow in terms of efficiency.
+:::note
+When there are a large number of small columns, this format is ineffective, and there is generally no reason to use it. 
+Nevertheless, it is no worse than the [`JSONEachRow`](../JSON/JSONEachRow.md) format in terms of efficiency.
+:::
 
-Both data output and parsing are supported in this format. For parsing, any order is supported for the values of different columns. It is acceptable for some values to be omitted – they are treated as equal to their default values. In this case, zeros and blank rows are used as default values. Complex values that could be specified in the table are not supported as defaults.
+For parsing, any order is supported for the values of the different columns. 
+It is acceptable for some values to be omitted as they are treated as equal to their default values.
+In this case, zeros and blank rows are used as default values. 
+Complex values that could be specified in the table are not supported as defaults.
 
-Parsing allows the presence of the additional field `tskv` without the equal sign or a value. This field is ignored.
+Parsing allows an additional field `tskv` to be added without the equal sign or a value. This field is ignored.
 
-During import, columns with unknown names will be skipped if setting [input_format_skip_unknown_fields](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to 1.
+During import, columns with unknown names will be skipped, 
+if setting [`input_format_skip_unknown_fields`](/docs/en/operations/settings/settings-formats.md/#input_format_skip_unknown_fields) is set to `1`.
 
 [NULL](/docs/en/sql-reference/syntax.md) is formatted as `\N`.
 

--- a/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md
+++ b/docs/en/interfaces/formats/TabSeparated/TabSeparatedWithNamesAndTypes.md
@@ -10,7 +10,7 @@ keywords : [TabSeparatedWithNamesAndTypes]
 
 ## Description
 
-Differs from the `TabSeparated` format in that the column names are written to the first row, while the column types are in the second row.
+Differs from the [`TabSeparated`](./TabSeparated.md) format in that the column names are written to the first row, while the column types are in the second row.
 
 :::note
 - If setting [`input_format_with_names_use_header`](../../../operations/settings/settings-formats.md/#input_format_with_names_use_header) is set to `1`,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Moves `TSKV` to it's own page and links it from the page with all formats on a single page.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
