### PR TITLE
Backup faster checksums based on blob paths

### DIFF
--- a/src/Backups/BackupEntryFromAppendOnlyFile.cpp
+++ b/src/Backups/BackupEntryFromAppendOnlyFile.cpp
@@ -26,12 +26,14 @@ BackupEntryFromAppendOnlyFile::BackupEntryFromAppendOnlyFile(
     const DiskPtr & disk_,
     const String & file_path_,
     bool copy_encrypted_,
-    const std::optional<UInt64> & file_size_)
+    const std::optional<UInt64> & file_size_,
+    bool allow_checksum_from_remote_path_)
     : disk(disk_)
     , file_path(file_path_)
     , data_source_description(disk->getDataSourceDescription())
     , copy_encrypted(copy_encrypted_ && data_source_description.is_encrypted)
     , size(calculateSize(disk_, file_path_, copy_encrypted, file_size_))
+    , allow_checksum_from_remote_path(allow_checksum_from_remote_path_)
 {
 }
 

--- a/src/Backups/BackupEntryFromAppendOnlyFile.cpp
+++ b/src/Backups/BackupEntryFromAppendOnlyFile.cpp
@@ -23,7 +23,10 @@ namespace
 }
 
 BackupEntryFromAppendOnlyFile::BackupEntryFromAppendOnlyFile(
-    const DiskPtr & disk_, const String & file_path_, bool copy_encrypted_, const std::optional<UInt64> & file_size_)
+    const DiskPtr & disk_,
+    const String & file_path_,
+    bool copy_encrypted_,
+    const std::optional<UInt64> & file_size_)
     : disk(disk_)
     , file_path(file_path_)
     , data_source_description(disk->getDataSourceDescription())

--- a/src/Backups/BackupEntryFromAppendOnlyFile.cpp
+++ b/src/Backups/BackupEntryFromAppendOnlyFile.cpp
@@ -10,13 +10,15 @@ namespace DB
 namespace
 {
     /// For append-only files we must calculate its size on the construction of a backup entry.
-    UInt64 calculateSize(const DiskPtr & disk, const String & file_path, bool copy_encrypted, std::optional<UInt64> unencrypted_file_size)
+    UInt64 calculateSize(const DiskPtr & disk, const String & file_path, bool copy_encrypted, std::optional<UInt64> passed_file_size)
     {
-        if (!unencrypted_file_size)
-            return copy_encrypted ? disk->getEncryptedFileSize(file_path) : disk->getFileSize(file_path);
         if (copy_encrypted)
-            return disk->getEncryptedFileSize(*unencrypted_file_size);
-        return *unencrypted_file_size;
+            return passed_file_size ? disk->getEncryptedFileSize(*passed_file_size) : disk->getEncryptedFileSize(file_path);
+
+        if (passed_file_size)
+            return *passed_file_size;
+
+        return disk->getFileSize(file_path);
     }
 }
 

--- a/src/Backups/BackupEntryFromAppendOnlyFile.h
+++ b/src/Backups/BackupEntryFromAppendOnlyFile.h
@@ -8,7 +8,7 @@ namespace DB
 
 /// Represents a file prepared to be included in a backup, assuming that until this backup entry is destroyed
 /// the file can be appended with new data, but the bytes which are already in the file won't be changed.
-class BackupEntryFromAppendOnlyFile : public BackupEntryWithChecksumCalculation<IBackupEntry>
+class BackupEntryFromAppendOnlyFile : public BackupEntryWithChecksumCalculation
 {
 public:
     /// The constructor is allowed to not set `file_size_`, in that case it will be calculated from the data.

--- a/src/Backups/BackupEntryFromAppendOnlyFile.h
+++ b/src/Backups/BackupEntryFromAppendOnlyFile.h
@@ -16,7 +16,8 @@ public:
         const DiskPtr & disk_,
         const String & file_path_,
         bool copy_encrypted_ = false,
-        const std::optional<UInt64> & file_size_ = {});
+        const std::optional<UInt64> & file_size_ = {},
+        bool allow_checksum_from_remote_path_ = true);
 
     ~BackupEntryFromAppendOnlyFile() override;
 
@@ -30,12 +31,16 @@ public:
     DiskPtr getDisk() const override { return disk; }
     String getFilePath() const override { return file_path; }
 
+protected:
+    bool isChecksumFromRemotePathAllowed() const override { return allow_checksum_from_remote_path; }
+
 private:
     const DiskPtr disk;
     const String file_path;
     const DataSourceDescription data_source_description;
     const bool copy_encrypted;
     const UInt64 size;
+    const bool allow_checksum_from_remote_path;
 };
 
 }

--- a/src/Backups/BackupEntryFromAppendOnlyFile.h
+++ b/src/Backups/BackupEntryFromAppendOnlyFile.h
@@ -32,6 +32,7 @@ public:
     String getFilePath() const override { return file_path; }
 
 protected:
+    bool isPartialChecksumAllowed() const override { return true; }
     bool isChecksumFromRemotePathAllowed() const override { return allow_checksum_from_remote_path; }
 
 private:

--- a/src/Backups/BackupEntryFromImmutableFile.cpp
+++ b/src/Backups/BackupEntryFromImmutableFile.cpp
@@ -11,13 +11,15 @@ BackupEntryFromImmutableFile::BackupEntryFromImmutableFile(
     const String & file_path_,
     bool copy_encrypted_,
     const std::optional<UInt64> & file_size_,
-    const std::optional<UInt128> & checksum_)
+    const std::optional<UInt128> & checksum_,
+    bool allow_checksum_from_remote_path_)
     : disk(disk_)
     , file_path(file_path_)
     , data_source_description(disk->getDataSourceDescription())
     , copy_encrypted(copy_encrypted_ && data_source_description.is_encrypted)
     , passed_file_size(file_size_)
     , passed_checksum(checksum_)
+    , allow_checksum_from_remote_path(allow_checksum_from_remote_path_)
 {
 }
 

--- a/src/Backups/BackupEntryFromImmutableFile.cpp
+++ b/src/Backups/BackupEntryFromImmutableFile.cpp
@@ -1,22 +1,10 @@
 #include <Backups/BackupEntryFromImmutableFile.h>
 #include <IO/ReadBufferFromFileBase.h>
 #include <Disks/IDisk.h>
-#include <city.h>
 
 
 namespace DB
 {
-
-namespace
-{
-    /// We mix the checksum calculated for non-encrypted data with IV generated to encrypt the file
-    /// to generate kind of a checksum for encrypted data. Of course it differs from the CityHash properly calculated for encrypted data.
-    UInt128 combineChecksums(UInt128 checksum1, UInt128 checksum2)
-    {
-        chassert(std::size(checksum2.items) == 2);
-        return CityHash_v1_0_2::CityHash128WithSeed(reinterpret_cast<const char *>(&checksum1), sizeof(checksum1), {checksum2.items[0], checksum2.items[1]});
-    }
-}
 
 BackupEntryFromImmutableFile::BackupEntryFromImmutableFile(
     const DiskPtr & disk_,
@@ -60,17 +48,6 @@ UInt64 BackupEntryFromImmutableFile::calculateSize() const
         return *passed_file_size;
 
     return disk->getFileSize(file_path);
-}
-
-UInt128 BackupEntryFromImmutableFile::calculateChecksum(const ReadSettings & read_settings) const
-{
-    if (passed_checksum && !copy_encrypted)
-        return *passed_checksum;
-
-    if (passed_checksum && copy_encrypted)
-        return combineChecksums(*passed_checksum, disk->getEncryptedFileIV(file_path));
-
-    return BackupEntryWithChecksumCalculation::calculateChecksum(read_settings);
 }
 
 }

--- a/src/Backups/BackupEntryFromImmutableFile.h
+++ b/src/Backups/BackupEntryFromImmutableFile.h
@@ -47,7 +47,7 @@ private:
     const bool copy_encrypted;
     const std::optional<UInt64> passed_file_size;
     const std::optional<UInt128> passed_checksum;
-    mutable std::optional<UInt64> calculated_size;
+    mutable std::optional<UInt64> calculated_size TSA_GUARDED_BY(mutex);
 };
 
 }

--- a/src/Backups/BackupEntryFromImmutableFile.h
+++ b/src/Backups/BackupEntryFromImmutableFile.h
@@ -11,7 +11,7 @@ class IDisk;
 using DiskPtr = std::shared_ptr<IDisk>;
 
 /// Represents a file prepared to be included in a backup, assuming that until this backup entry is destroyed the file won't be changed.
-class BackupEntryFromImmutableFile : public BackupEntryWithChecksumCalculation<IBackupEntry>
+class BackupEntryFromImmutableFile : public BackupEntryWithChecksumCalculation
 {
 public:
     /// The constructor is allowed to not set `file_size_` or `checksum_`, in that case it will be calculated from the data.
@@ -25,29 +25,30 @@ public:
     ~BackupEntryFromImmutableFile() override;
 
     std::unique_ptr<SeekableReadBuffer> getReadBuffer(const ReadSettings & read_settings) const override;
-
     UInt64 getSize() const override;
-    UInt128 getChecksum(const ReadSettings & read_settings) const override;
-    std::optional<UInt128> getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const override;
 
     DataSourceDescription getDataSourceDescription() const override { return data_source_description; }
     bool isEncryptedByDisk() const override { return copy_encrypted; }
-
     bool isFromFile() const override { return true; }
     bool isFromImmutableFile() const override { return true; }
     DiskPtr getDisk() const override { return disk; }
     String getFilePath() const override { return file_path; }
+
+protected:
+    virtual UInt64 calculateSize() const;
+    UInt128 calculateChecksum(const ReadSettings & read_settings) const override;
+
+    /// For immutable files we don't use partial checksums.
+    bool isPartialChecksumAllowed() const override { return false; }
 
 private:
     const DiskPtr disk;
     const String file_path;
     const DataSourceDescription data_source_description;
     const bool copy_encrypted;
-    mutable std::optional<UInt64> file_size;
-    mutable std::optional<UInt128> checksum;
-    mutable bool file_size_adjusted = false;
-    mutable bool checksum_adjusted = false;
-    mutable std::mutex size_and_checksum_mutex;
+    const std::optional<UInt64> passed_file_size;
+    const std::optional<UInt128> passed_checksum;
+    mutable std::optional<UInt64> calculated_size;
 };
 
 }

--- a/src/Backups/BackupEntryFromImmutableFile.h
+++ b/src/Backups/BackupEntryFromImmutableFile.h
@@ -20,7 +20,8 @@ public:
         const String & file_path_,
         bool copy_encrypted_ = false,
         const std::optional<UInt64> & file_size_ = {},
-        const std::optional<UInt128> & checksum_ = {});
+        const std::optional<UInt128> & checksum_ = {},
+        bool allow_checksum_from_remote_path_ = true);
 
     ~BackupEntryFromImmutableFile() override;
 
@@ -37,6 +38,7 @@ public:
 protected:
     std::optional<UInt128> getPrecalculatedChecksum() const override { return passed_checksum; }
     bool isPartialChecksumAllowed() const override { return false; }
+    bool isChecksumFromRemotePathAllowed() const override { return allow_checksum_from_remote_path; }
 
 private:
     UInt64 calculateSize() const;
@@ -47,6 +49,7 @@ private:
     const bool copy_encrypted;
     const std::optional<UInt64> passed_file_size;
     const std::optional<UInt128> passed_checksum;
+    const bool allow_checksum_from_remote_path;
     mutable std::optional<UInt64> calculated_size TSA_GUARDED_BY(mutex);
 };
 

--- a/src/Backups/BackupEntryFromImmutableFile.h
+++ b/src/Backups/BackupEntryFromImmutableFile.h
@@ -35,13 +35,12 @@ public:
     String getFilePath() const override { return file_path; }
 
 protected:
-    virtual UInt64 calculateSize() const;
-    UInt128 calculateChecksum(const ReadSettings & read_settings) const override;
-
-    /// For immutable files we don't use partial checksums.
+    std::optional<UInt128> getPrecalculatedChecksum() const override { return passed_checksum; }
     bool isPartialChecksumAllowed() const override { return false; }
 
 private:
+    UInt64 calculateSize() const;
+
     const DiskPtr disk;
     const String file_path;
     const DataSourceDescription data_source_description;

--- a/src/Backups/BackupEntryFromMemory.h
+++ b/src/Backups/BackupEntryFromMemory.h
@@ -7,7 +7,7 @@ namespace DB
 {
 
 /// Represents small preloaded data to be included in a backup.
-class BackupEntryFromMemory : public BackupEntryWithChecksumCalculation<IBackupEntry>
+class BackupEntryFromMemory : public BackupEntryWithChecksumCalculation
 {
 public:
     /// The constructor is allowed to not set `checksum_`, in that case it will be calculated from the data.

--- a/src/Backups/BackupEntryFromMemory.h
+++ b/src/Backups/BackupEntryFromMemory.h
@@ -24,6 +24,8 @@ public:
         return res;
     }
 
+    bool isPartialChecksumAllowed() const override { return true; }
+
 private:
     const String data;
 };

--- a/src/Backups/BackupEntryFromSmallFile.h
+++ b/src/Backups/BackupEntryFromSmallFile.h
@@ -10,7 +10,7 @@ using DiskPtr = std::shared_ptr<IDisk>;
 
 /// Represents a file prepared to be included in a backup,
 /// assuming that the file is small and can be easily loaded into memory.
-class BackupEntryFromSmallFile : public BackupEntryWithChecksumCalculation<IBackupEntry>
+class BackupEntryFromSmallFile : public BackupEntryWithChecksumCalculation
 {
 public:
     explicit BackupEntryFromSmallFile(const String & file_path_, const ReadSettings & read_settings_);

--- a/src/Backups/BackupEntryFromSmallFile.h
+++ b/src/Backups/BackupEntryFromSmallFile.h
@@ -26,6 +26,8 @@ public:
     DiskPtr getDisk() const override { return disk; }
     String getFilePath() const override { return file_path; }
 
+    bool isPartialChecksumAllowed() const override { return true; }
+
 private:
     const DiskPtr disk;
     const String file_path;

--- a/src/Backups/BackupEntryWithChecksumCalculation.cpp
+++ b/src/Backups/BackupEntryWithChecksumCalculation.cpp
@@ -5,50 +5,40 @@
 namespace DB
 {
 
-template <typename Base>
-UInt128 BackupEntryWithChecksumCalculation<Base>::getChecksum(const ReadSettings & read_settings) const
+UInt128 BackupEntryWithChecksumCalculation::getChecksum(const ReadSettings & read_settings) const
 {
-    {
-        std::lock_guard lock{checksum_calculation_mutex};
-        if (calculated_checksum)
-            return *calculated_checksum;
-    }
-
-    size_t size = this->getSize();
-
-    {
-        std::lock_guard lock{checksum_calculation_mutex};
-        if (!calculated_checksum)
-        {
-            if (size == 0)
-            {
-                calculated_checksum = 0;
-            }
-            else
-            {
-                auto read_buffer = this->getReadBuffer(read_settings.adjustBufferSize(size));
-                HashingReadBuffer hashing_read_buffer(*read_buffer);
-                hashing_read_buffer.ignoreAll();
-                calculated_checksum = hashing_read_buffer.getHash();
-            }
-        }
+    if (calculated_checksum)
         return *calculated_checksum;
-    }
+
+    if (getSize() == 0)
+        calculated_checksum = 0;
+    else
+        calculated_checksum = calculateChecksum(read_settings);
+
+    return *calculated_checksum;
 }
 
-template <typename Base>
-std::optional<UInt128> BackupEntryWithChecksumCalculation<Base>::getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const
+UInt128 BackupEntryWithChecksumCalculation::calculateChecksum(const ReadSettings & read_settings) const
+{
+    auto read_buffer = getReadBuffer(read_settings.adjustBufferSize(getSize()));
+    HashingReadBuffer hashing_read_buffer(*read_buffer);
+    hashing_read_buffer.ignoreAll();
+    return hashing_read_buffer.getHash();
+}
+
+std::optional<UInt128> BackupEntryWithChecksumCalculation::getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const
 {
     if (prefix_length == 0)
         return 0;
 
-    size_t size = this->getSize();
+    size_t size = getSize();
     if (prefix_length >= size)
-        return this->getChecksum(read_settings);
+        return getChecksum(read_settings);
 
-    std::lock_guard lock{checksum_calculation_mutex};
+    if (!isPartialChecksumAllowed())
+        return {};
 
-    auto read_buffer = this->getReadBuffer(read_settings.adjustBufferSize(calculated_checksum ? prefix_length : size));
+    auto read_buffer = getReadBuffer(read_settings.adjustBufferSize(calculated_checksum ? prefix_length : size));
     HashingReadBuffer hashing_read_buffer(*read_buffer);
 
     hashing_read_buffer.ignore(prefix_length);
@@ -62,7 +52,5 @@ std::optional<UInt128> BackupEntryWithChecksumCalculation<Base>::getPartialCheck
 
     return partial_checksum;
 }
-
-template class BackupEntryWithChecksumCalculation<IBackupEntry>;
 
 }

--- a/src/Backups/BackupEntryWithChecksumCalculation.cpp
+++ b/src/Backups/BackupEntryWithChecksumCalculation.cpp
@@ -67,7 +67,7 @@ std::optional<UInt128> BackupEntryWithChecksumCalculation::getPartialChecksum(UI
     if (has_calculated_full_checksum)
         return calculateChecksum(limit, read_settings);
 
-    auto [partial_checksum, full_checksum] = calculateChecksum(limit, size, read_settings);
+    auto [partial_checksum, full_checksum] = calculateOneOrTwoChecksums(limit, size, read_settings);
     chassert(full_checksum);
 
     {
@@ -81,7 +81,7 @@ std::optional<UInt128> BackupEntryWithChecksumCalculation::getPartialChecksum(UI
 
 std::optional<UInt128> BackupEntryWithChecksumCalculation::calculateChecksum(UInt64 limit, const ReadSettings & read_settings) const
 {
-    return calculateChecksum(limit, {}, read_settings).first;
+    return calculateOneOrTwoChecksums(limit, {}, read_settings).first;
 }
 
 
@@ -127,7 +127,7 @@ bool BackupEntryWithChecksumCalculation::canCalculateChecksumFromRemotePath() co
 }
 
 
-std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksumCalculation::calculateChecksum(
+std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksumCalculation::calculateOneOrTwoChecksums(
     UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const
 {
     switch (chooseChecksumCalculationMethod())
@@ -194,34 +194,41 @@ std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksu
     UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const
 {
     UInt64 size = getSize();
+
+    /// Make sure that `limit <= size` and `*second_limit <= size`.
     limit = std::min(limit, size);
     if (second_limit)
         second_limit = std::min(*second_limit, size);
 
     UInt64 read_size = second_limit.value_or(limit);
 
-    bool is_remote_file = getDisk() && getDisk()->isRemote();
-    if (is_remote_file)
+    if (getDisk())
     {
-        ProfileEvents::increment(ProfileEvents::BackupReadRemoteFilesToCalculateChecksums);
-        ProfileEvents::increment(ProfileEvents::BackupReadRemoteBytesToCalculateChecksums, read_size);
-    }
-    else
-    {
-        ProfileEvents::increment(ProfileEvents::BackupReadLocalFilesToCalculateChecksums);
-        ProfileEvents::increment(ProfileEvents::BackupReadLocalBytesToCalculateChecksums, read_size);
+        bool is_remote_file = getDisk()->isRemote();
+        if (is_remote_file)
+        {
+            ProfileEvents::increment(ProfileEvents::BackupReadRemoteFilesToCalculateChecksums);
+            ProfileEvents::increment(ProfileEvents::BackupReadRemoteBytesToCalculateChecksums, read_size);
+        }
+        else
+        {
+            ProfileEvents::increment(ProfileEvents::BackupReadLocalFilesToCalculateChecksums);
+            ProfileEvents::increment(ProfileEvents::BackupReadLocalBytesToCalculateChecksums, read_size);
+        }
     }
 
     std::unique_ptr<ReadBuffer> read_buffer;
     std::unique_ptr<HashingReadBuffer> hashing_read_buffer;
     UInt64 offset = 0;
+    UInt128 current_hash = 0;
 
-    auto calculate_hash = [&](UInt64 limit_, std::optional<UInt128> previous_hash) -> std::optional<UInt128>
+    /// Calculates a hash of the file contents at offsets [0..limit_).
+    auto calculate_hash = [&](UInt64 limit_) -> std::optional<UInt128>
     {
         if ((limit_ != size) && !isPartialChecksumAllowed())
             return {};
         if (limit_ == offset)
-            return previous_hash;
+            return current_hash;
         chassert(limit_ > offset);
         if (!read_buffer)
         {
@@ -231,24 +238,32 @@ std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksu
         offset += hashing_read_buffer->tryIgnore(limit_ - offset);
         if (offset != limit_)
         {
+            /// The file ended before we reach offset `limit_` and we know that `limit_ <= size` (see the beginning of this function),
+            /// so now the actual size of the file is less than the value returned by getSize().
+            /// That isn't allowed for backups because all files prepared for a backup must be either immutable
+            /// or append-only.
             throw Exception(ErrorCodes::UNEXPECTED_END_OF_FILE,
                             "Size of file {} decreased ({} -> {}) unexpectedly while calculating its checksum",
                             getFilePath(), size, offset);
         }
-        if ((offset == size) && !isPartialChecksumAllowed() && !hashing_read_buffer->eof())
+        if ((limit_ == size) && !isPartialChecksumAllowed() && !hashing_read_buffer->eof())
         {
+            /// We reached offset `size` which is expected to be the end of the file but the file surprisingly didn't end there.
+            /// Perhaps it was appended after we got its size for backup but that's not allowed for immutable files
+            /// (function `isPartialChecksumAllowed()` returns false for immutable files).
             throw Exception(ErrorCodes::EXPECTED_END_OF_FILE,
                             "Size of immutable file {} increased unexpectedly while calculating its checksum",
                             getFilePath());
         }
-        return hashing_read_buffer->getHash();
+        current_hash = hashing_read_buffer->getHash();
+        return current_hash;
     };
 
-    std::optional<UInt128> checksum = calculate_hash(limit, 0);
+    std::optional<UInt128> checksum = calculate_hash(limit);
 
     std::optional<UInt128> second_checksum;
     if (second_limit)
-        second_checksum = calculate_hash(*second_limit, checksum);
+        second_checksum = calculate_hash(*second_limit);
 
     return {checksum, second_checksum};
 }
@@ -258,19 +273,27 @@ std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksu
     UInt64 limit, std::optional<UInt64> second_limit) const
 {
     UInt64 size = getSize();
+
+    /// Make sure that `limit <= size` and `*second_limit <= size`.
     limit = std::min(limit, size);
     if (second_limit)
         second_limit = std::min(*second_limit, size);
 
+    /// `stored_objects` represent parts of the file named `getFilePath()` stored on a remote disk.
+    /// They are always returned in the same order (`stored_objects[i]` represents i-th part of the file),
+    /// so we can use them in that order to calculate a hash.
     std::optional<StoredObjects> stored_objects;
-    UInt64 offset = 0;
 
-    auto calculate_hash = [&](UInt64 limit_, std::optional<UInt128> previous_hash) -> std::optional<UInt128>
+    UInt64 offset = 0;
+    UInt128 current_hash = 0;
+
+    /// Calculates a hash of the file contents at offsets [0..limit_).
+    auto calculate_hash = [&](UInt64 limit_) -> std::optional<UInt128>
     {
         if ((limit_ != size) && !isPartialChecksumAllowed())
             return {};
-        if (limit_ == offset)
-            return previous_hash;
+        if (offset == limit_)
+            return current_hash;
         if (!stored_objects)
             stored_objects = getDisk()->getStorageObjects(getFilePath());
         offset = 0;
@@ -280,6 +303,10 @@ std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksu
         {
             if (index == stored_objects->size())
             {
+                /// The file ended before we reach offset `limit_` and we know that `limit_ <= size` (see the beginning of this function),
+                /// so now the actual size of the file is less than the value returned by getSize().
+                /// That isn't allowed for backups because all files prepared for a backup must be either immutable
+                /// or append-only.
                 throw Exception(ErrorCodes::UNEXPECTED_END_OF_FILE,
                                 "Size of file {} decreased ({} -> {}) unexpectedly while calculating its checksum",
                                 getFilePath(), size, getTotalSize(*stored_objects));
@@ -295,20 +322,24 @@ std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksu
             offset = next_offset;
             ++index;
         }
-        if ((offset == size) && !isPartialChecksumAllowed() && (index != stored_objects->size()))
+        if ((limit_ == size) && !isPartialChecksumAllowed() && (index != stored_objects->size()))
         {
+            /// We reached offset `size` which is expected to be the end of the file but the file surprisingly didn't end there.
+            /// Perhaps the file was appended after we got its size for backup but that's not allowed for immutable files
+            /// (function `isPartialChecksumAllowed()` returns false for immutable files).
             throw Exception(ErrorCodes::EXPECTED_END_OF_FILE,
                             "Size of immutable file {} increased unexpectedly while calculating its checksum",
                             getFilePath());
         }
+        current_hash = hash;
         return hash;
     };
 
-    std::optional<UInt128> checksum = calculate_hash(limit, 0);
+    std::optional<UInt128> checksum = calculate_hash(limit);
 
     std::optional<UInt128> second_checksum;
     if (second_limit)
-        second_checksum = calculate_hash(*second_limit, checksum);
+        second_checksum = calculate_hash(*second_limit);
 
     return {checksum, second_checksum};
 }

--- a/src/Backups/BackupEntryWithChecksumCalculation.cpp
+++ b/src/Backups/BackupEntryWithChecksumCalculation.cpp
@@ -5,52 +5,199 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int EXPECTED_END_OF_FILE;
+    extern const int UNEXPECTED_END_OF_FILE;
+}
+
+namespace
+{
+    /// We mix the checksum calculated for non-encrypted data with IV generated to encrypt the file
+    /// to generate kind of a checksum for encrypted data. Of course it differs from the CityHash properly calculated for encrypted data.
+    UInt128 combineChecksums(UInt128 checksum1, UInt128 second_checksum)
+    {
+        chassert(std::size(second_checksum.items) == 2);
+        return CityHash_v1_0_2::CityHash128WithSeed(reinterpret_cast<const char *>(&checksum1), sizeof(checksum1), {second_checksum.items[0], second_checksum.items[1]});
+    }
+}
+
 UInt128 BackupEntryWithChecksumCalculation::getChecksum(const ReadSettings & read_settings) const
 {
-    if (calculated_checksum)
-        return *calculated_checksum;
-
-    if (getSize() == 0)
-        calculated_checksum = 0;
-    else
-        calculated_checksum = calculateChecksum(read_settings);
+    if (!calculated_checksum)
+    {
+        auto full_checksum = calculateChecksum(getSize(), read_settings);
+        chassert(full_checksum);
+        calculated_checksum = full_checksum.value();
+    }
 
     return *calculated_checksum;
 }
 
-UInt128 BackupEntryWithChecksumCalculation::calculateChecksum(const ReadSettings & read_settings) const
-{
-    auto read_buffer = getReadBuffer(read_settings.adjustBufferSize(getSize()));
-    HashingReadBuffer hashing_read_buffer(*read_buffer);
-    hashing_read_buffer.ignoreAll();
-    return hashing_read_buffer.getHash();
-}
 
-std::optional<UInt128> BackupEntryWithChecksumCalculation::getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const
+std::optional<UInt128> BackupEntryWithChecksumCalculation::getPartialChecksum(UInt64 limit, const ReadSettings & read_settings) const
 {
-    if (prefix_length == 0)
-        return 0;
-
-    size_t size = getSize();
-    if (prefix_length >= size)
+    UInt64 size = getSize();
+    if (limit >= size)
         return getChecksum(read_settings);
 
-    if (!isPartialChecksumAllowed())
-        return {};
+    if (calculated_checksum)
+        return calculateChecksum(limit, read_settings);
 
-    auto read_buffer = getReadBuffer(read_settings.adjustBufferSize(calculated_checksum ? prefix_length : size));
-    HashingReadBuffer hashing_read_buffer(*read_buffer);
+    auto [partial_checksum, full_checksum] = calculateChecksum(limit, size, read_settings);
+    chassert(full_checksum);
+    calculated_checksum = full_checksum.value();
+    return partial_checksum;
+}
 
-    hashing_read_buffer.ignore(prefix_length);
-    auto partial_checksum = hashing_read_buffer.getHash();
 
-    if (!calculated_checksum)
+std::optional<UInt128> BackupEntryWithChecksumCalculation::calculateChecksum(UInt64 limit, const ReadSettings & read_settings) const
+{
+    return calculateChecksum(limit, {}, read_settings).first;
+}
+
+
+BackupEntryWithChecksumCalculation::ChecksumCalculationMethod BackupEntryWithChecksumCalculation::chooseChecksumCalculationMethod() const
+{
+    UInt64 size = getSize();
+
+    ChecksumCalculationMethod method;
+    if (size == 0)
     {
-        hashing_read_buffer.ignoreAll();
-        calculated_checksum = hashing_read_buffer.getHash();
+        method = ChecksumCalculationMethod::EmptyZero;
+    }
+    else if (hasPrecalculatedChecksum() && !isEncryptedByDisk())
+    {
+        method = ChecksumCalculationMethod::Precalculated;
+    }
+    else if (hasPrecalculatedChecksum() && isEncryptedByDisk())
+    {
+        method = ChecksumCalculationMethod::PrecalculatedCombinedWithEncryptionIV;
+    }
+    else
+    {
+        method = ChecksumCalculationMethod::FromReading;
     }
 
-    return partial_checksum;
+    return method;
+}
+
+
+bool BackupEntryWithChecksumCalculation::hasPrecalculatedChecksum() const
+{
+    return getPrecalculatedChecksum().has_value();
+}
+
+
+std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksumCalculation::calculateChecksum(
+    UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const
+{
+    switch (chooseChecksumCalculationMethod())
+    {
+        case ChecksumCalculationMethod::EmptyZero:
+            return {0, 0};
+
+        case ChecksumCalculationMethod::Precalculated:
+            return getPrecalculatedChecksumIfFull(limit, second_limit);
+
+        case ChecksumCalculationMethod::PrecalculatedCombinedWithEncryptionIV:
+            return combinePrecalculatedChecksumWithEncryptionIV(limit, second_limit);
+
+        case ChecksumCalculationMethod::FromReading:
+            return calculateChecksumFromReading(limit, second_limit, read_settings);
+    }
+    UNREACHABLE();
+}
+
+
+std::pair<std::optional<UInt128>, std::optional<UInt128>>
+BackupEntryWithChecksumCalculation::getPrecalculatedChecksumIfFull(UInt64 limit, std::optional<UInt64> second_limit) const
+{
+    UInt64 size = getSize();
+    limit = std::min(limit, size);
+    if (second_limit)
+        second_limit = std::min(*second_limit, size);
+
+    std::optional<UInt128> checksum;
+    if (limit == size)
+        checksum = getPrecalculatedChecksum().value();
+
+    std::optional<UInt128> second_checksum;
+    if (second_limit == size)
+        second_checksum = getPrecalculatedChecksum().value();
+
+    return {checksum, second_checksum};
+}
+
+
+std::pair<std::optional<UInt128>, std::optional<UInt128>>
+BackupEntryWithChecksumCalculation::combinePrecalculatedChecksumWithEncryptionIV(UInt64 limit, std::optional<UInt64> second_limit) const
+{
+    auto [checksum, second_checksum] = getPrecalculatedChecksumIfFull(limit, second_limit);
+
+    UInt128 iv;
+    if (checksum || second_checksum)
+        iv = getDisk()->getEncryptedFileIV(getFilePath());
+
+    if (checksum)
+        checksum = combineChecksums(*checksum, iv);
+
+    if (second_checksum)
+        second_checksum = combineChecksums(*second_checksum, iv);
+
+    return {checksum, second_checksum};
+}
+
+
+std::pair<std::optional<UInt128>, std::optional<UInt128>> BackupEntryWithChecksumCalculation::calculateChecksumFromReading(
+    UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const
+{
+    UInt64 size = getSize();
+    limit = std::min(limit, size);
+    if (second_limit)
+        second_limit = std::min(*second_limit, size);
+
+    UInt64 read_size = second_limit.value_or(limit);
+
+    std::unique_ptr<ReadBuffer> read_buffer;
+    std::unique_ptr<HashingReadBuffer> hashing_read_buffer;
+    UInt64 offset = 0;
+
+    auto calculate_hash = [&](UInt64 limit_, std::optional<UInt128> previous_hash) -> std::optional<UInt128>
+    {
+        if ((limit_ != size) && !isPartialChecksumAllowed())
+            return {};
+        if (limit_ == offset)
+            return previous_hash;
+        chassert(limit_ > offset);
+        if (!read_buffer)
+        {
+            read_buffer = getReadBuffer(read_settings.adjustBufferSize(read_size));
+            hashing_read_buffer = std::make_unique<HashingReadBuffer>(*read_buffer);
+        }
+        offset += hashing_read_buffer->tryIgnore(limit_ - offset);
+        if (offset != limit_)
+        {
+            throw Exception(ErrorCodes::UNEXPECTED_END_OF_FILE,
+                            "Size of file {} decreased ({} -> {}) unexpectedly while calculating its checksum",
+                            getFilePath(), size, offset);
+        }
+        if ((offset == size) && !isPartialChecksumAllowed() && !hashing_read_buffer->eof())
+        {
+            throw Exception(ErrorCodes::EXPECTED_END_OF_FILE,
+                            "Size of immutable file {} increased unexpectedly while calculating its checksum",
+                            getFilePath());
+        }
+        return hashing_read_buffer->getHash();
+    };
+
+    std::optional<UInt128> checksum = calculate_hash(limit, 0);
+
+    std::optional<UInt128> second_checksum;
+    if (second_limit)
+        second_checksum = calculate_hash(*second_limit, checksum);
+
+    return {checksum, second_checksum};
 }
 
 }

--- a/src/Backups/BackupEntryWithChecksumCalculation.h
+++ b/src/Backups/BackupEntryWithChecksumCalculation.h
@@ -18,10 +18,10 @@ protected:
     virtual std::optional<UInt128> getPrecalculatedChecksum() const { return {}; }
 
     /// Whether it is allowed to calculate a checksum of a part of the file from its beginning up to some point.
-    virtual bool isPartialChecksumAllowed() const { return true; }
+    virtual bool isPartialChecksumAllowed() const = 0;
 
     /// Whether it is allowed to calculate a checksum from the paths to blobs on a remote disk.
-    virtual bool isChecksumFromRemotePathAllowed() const { return true; }
+    virtual bool isChecksumFromRemotePathAllowed() const { return false; }
 
     mutable std::mutex mutex;
 
@@ -29,7 +29,7 @@ private:
     std::optional<UInt128> calculateChecksum(UInt64 limit, const ReadSettings & read_settings) const;
 
     /// Calculates one or two checksums.
-    std::pair<std::optional<UInt128>, std::optional<UInt128>> calculateChecksum(
+    std::pair<std::optional<UInt128>, std::optional<UInt128>> calculateOneOrTwoChecksums(
         UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const;
 
     /// Depending on how a file is stored different methods of calculating its checksum for a backup can be used.

--- a/src/Backups/BackupEntryWithChecksumCalculation.h
+++ b/src/Backups/BackupEntryWithChecksumCalculation.h
@@ -7,16 +7,18 @@ namespace DB
 {
 
 /// Calculates the checksum and the partial checksum for a backup entry based on ReadBuffer returned by getReadBuffer().
-template <typename Base>
-class BackupEntryWithChecksumCalculation : public Base
+class BackupEntryWithChecksumCalculation : public IBackupEntry
 {
 public:
     UInt128 getChecksum(const ReadSettings & read_settings) const override;
     std::optional<UInt128> getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const override;
 
+protected:
+    virtual UInt128 calculateChecksum(const ReadSettings & read_settings) const;
+    virtual bool isPartialChecksumAllowed() const { return true; }
+
 private:
     mutable std::optional<UInt128> calculated_checksum;
-    mutable std::mutex checksum_calculation_mutex;
 };
 
 }

--- a/src/Backups/BackupEntryWithChecksumCalculation.h
+++ b/src/Backups/BackupEntryWithChecksumCalculation.h
@@ -20,6 +20,8 @@ protected:
     /// Whether it is allowed to calculate a checksum of a part of the file from its beginning up to some point.
     virtual bool isPartialChecksumAllowed() const { return true; }
 
+    mutable std::mutex mutex;
+
 private:
     std::optional<UInt128> calculateChecksum(UInt64 limit, const ReadSettings & read_settings) const;
 
@@ -63,7 +65,7 @@ private:
     std::pair<std::optional<UInt128>, std::optional<UInt128>> calculateChecksumFromReading(
         UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const;
 
-    mutable std::optional<UInt128> calculated_checksum;
+    mutable std::optional<UInt128> calculated_checksum TSA_GUARDED_BY(mutex);
 };
 
 }

--- a/src/Backups/BackupEntryWithChecksumCalculation.h
+++ b/src/Backups/BackupEntryWithChecksumCalculation.h
@@ -6,18 +6,63 @@
 namespace DB
 {
 
-/// Calculates the checksum and the partial checksum for a backup entry based on ReadBuffer returned by getReadBuffer().
+/// Calculates the checksum and a partial checksum for a backup entry.
 class BackupEntryWithChecksumCalculation : public IBackupEntry
 {
 public:
     UInt128 getChecksum(const ReadSettings & read_settings) const override;
-    std::optional<UInt128> getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const override;
+    std::optional<UInt128> getPartialChecksum(UInt64 limit, const ReadSettings & read_settings) const override;
 
 protected:
-    virtual UInt128 calculateChecksum(const ReadSettings & read_settings) const;
+    /// Returns a precalculated checksum for this file if any.
+    virtual std::optional<UInt128> getPrecalculatedChecksum() const { return {}; }
+
+    /// Whether it is allowed to calculate a checksum of a part of the file from its beginning up to some point.
     virtual bool isPartialChecksumAllowed() const { return true; }
 
 private:
+    std::optional<UInt128> calculateChecksum(UInt64 limit, const ReadSettings & read_settings) const;
+
+    /// Calculates one or two checksums.
+    std::pair<std::optional<UInt128>, std::optional<UInt128>> calculateChecksum(
+        UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const;
+
+    /// Depending on how a file is stored different methods of calculating its checksum for a backup can be used.
+    enum class ChecksumCalculationMethod
+    {
+        /// Empty file, checksum is 0.
+        EmptyZero,
+
+        /// The checksum was calculated and stored somewhere before we started making a backup,
+        /// for example all files listed in part's "checksums.txt".
+        Precalculated,
+
+        /// Similar to "Precalculated" for the case when a file is stored on an encrypted disk.
+        /// It means the precalculated checksum is going to be combined with the initialization vector for that file.
+        PrecalculatedCombinedWithEncryptionIV,
+
+        /// Reads a file and calculates a checksum from its contents.
+        /// That can be slow for big files and remote disks.
+        FromReading,
+    };
+
+    /// Chooses an appropriate checksum calculation method based on the disk settings and the file size.
+    ChecksumCalculationMethod chooseChecksumCalculationMethod() const;
+
+    bool hasPrecalculatedChecksum() const;
+
+    /// Calculates one or two checksums for method Precalculated.
+    std::pair<std::optional<UInt128>, std::optional<UInt128>> getPrecalculatedChecksumIfFull(
+        UInt64 limit, std::optional<UInt64> second_limit) const;
+
+    /// Calculates one or two checksums for method PrecalculatedCombinedWithEncryptionIV.
+    std::pair<std::optional<UInt128>, std::optional<UInt128>> combinePrecalculatedChecksumWithEncryptionIV(
+        UInt64 limit, std::optional<UInt64> second_limit) const;
+
+    /// Calculates one or two checksums for method FromReading.
+    std::pair<std::optional<UInt128>, std::optional<UInt128>> calculateChecksumFromReading(
+        UInt64 limit, std::optional<UInt64> second_limit, const ReadSettings & read_settings) const;
+
     mutable std::optional<UInt128> calculated_checksum;
 };
 

--- a/src/Backups/BackupEntryWrappedWith.h
+++ b/src/Backups/BackupEntryWrappedWith.h
@@ -18,7 +18,7 @@ public:
     std::unique_ptr<SeekableReadBuffer> getReadBuffer(const ReadSettings & read_settings) const override { return entry->getReadBuffer(read_settings); }
     UInt64 getSize() const override { return entry->getSize(); }
     UInt128 getChecksum(const ReadSettings & read_settings) const override { return entry->getChecksum(read_settings); }
-    std::optional<UInt128> getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const override { return entry->getPartialChecksum(prefix_length, read_settings); }
+    std::optional<UInt128> getPartialChecksum(UInt64 limit, const ReadSettings & read_settings) const override { return entry->getPartialChecksum(limit, read_settings); }
     DataSourceDescription getDataSourceDescription() const override { return entry->getDataSourceDescription(); }
     bool isEncryptedByDisk() const override { return entry->isEncryptedByDisk(); }
     bool isFromFile() const override { return entry->isFromFile(); }

--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -59,7 +59,7 @@ namespace
 
     /// Calculate checksum for backup entry if it's empty.
     /// Also able to calculate additional checksum of some prefix.
-    ChecksumsForNewEntry calculateNewEntryChecksumsIfNeeded(const BackupEntryPtr & entry, size_t prefix_size, const ReadSettings & read_settings)
+    ChecksumsForNewEntry calculateNewEntryChecksumsIfNeeded(const BackupEntryPtr & entry, UInt64 prefix_size, const ReadSettings & read_settings)
     {
         ChecksumsForNewEntry res;
         /// The partial checksum should be calculated before the full checksum to enable optimization in BackupEntryWithChecksumCalculation.
@@ -207,12 +207,13 @@ BackupFileInfo buildFileInfoForBackupEntry(
 
 BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, const ReadSettings & read_settings, ThreadPool & thread_pool, QueryStatusPtr process_list_element)
 {
+    LoggerPtr log = getLogger("FileInfosFromBackupEntries");
+    LOG_TRACE(log, "Building file infos for backup entries");
+
     BackupFileInfos infos;
     infos.resize(backup_entries.size());
 
     std::atomic_bool failed = false;
-
-    LoggerPtr log = getLogger("FileInfosFromBackupEntries");
 
     ThreadPoolCallbackRunnerLocal<void> runner(thread_pool, "BackupWorker");
     for (size_t i = 0; i != backup_entries.size(); ++i)

--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -12,6 +12,12 @@
 #include <base/hex.h>
 
 
+namespace ProfileEvents
+{
+    extern const Event BackupPreparingFileInfosMicroseconds;
+}
+
+
 namespace DB
 {
 
@@ -209,6 +215,7 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
 {
     LoggerPtr log = getLogger("FileInfosFromBackupEntries");
     LOG_TRACE(log, "Building file infos for backup entries");
+    auto timer = CurrentThread::getProfileEvents().timer(ProfileEvents::BackupPreparingFileInfosMicroseconds);
 
     BackupFileInfos infos;
     infos.resize(backup_entries.size());

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -31,6 +31,7 @@ namespace ProfileEvents
     extern const Event BackupsOpenedForWrite;
     extern const Event BackupReadMetadataMicroseconds;
     extern const Event BackupWriteMetadataMicroseconds;
+    extern const Event BackupLockFileReads;
 }
 
 namespace DB
@@ -576,8 +577,12 @@ void BackupImpl::createLockFile()
 
 bool BackupImpl::checkLockFile(bool throw_if_failed) const
 {
-    if (!lock_file_name.empty() && uuid && writer->fileContentsEqual(lock_file_name, toString(*uuid)))
-        return true;
+    if (!lock_file_name.empty() && uuid)
+    {
+        ProfileEvents::increment(ProfileEvents::BackupLockFileReads);
+        if (writer->fileContentsEqual(lock_file_name, toString(*uuid)))
+            return true;
+    }
 
     if (throw_if_failed)
     {

--- a/src/Backups/BackupSettings.cpp
+++ b/src/Backups/BackupSettings.cpp
@@ -39,6 +39,7 @@ namespace ErrorCodes
     M(Bool, check_projection_parts) \
     M(Bool, allow_backup_broken_projections) \
     M(Bool, write_access_entities_dependents) \
+    M(Bool, allow_checksums_from_remote_paths) \
     M(Bool, internal) \
     M(String, host_id) \
     M(OptionalUUID, backup_uuid) \

--- a/src/Backups/BackupSettings.h
+++ b/src/Backups/BackupSettings.h
@@ -83,6 +83,9 @@ struct BackupSettings
     /// this is whether the backup will contain information to grant the role to the corresponding user again.
     bool write_access_entities_dependents = true;
 
+    /// Is it allowed to use blob paths to calculate checksums of backup entries?
+    bool allow_checksums_from_remote_paths = true;
+
     /// Internal, should not be specified by user.
     /// Whether this backup is a part of a distributed backup created by BACKUP ON CLUSTER.
     bool internal = false;

--- a/src/Backups/IBackupEntriesLazyBatch.cpp
+++ b/src/Backups/IBackupEntriesLazyBatch.cpp
@@ -20,7 +20,7 @@ public:
     std::unique_ptr<SeekableReadBuffer> getReadBuffer(const ReadSettings & read_settings) const override { return getInternalBackupEntry()->getReadBuffer(read_settings); }
     UInt64 getSize() const override { return getInternalBackupEntry()->getSize(); }
     UInt128 getChecksum(const ReadSettings & read_settings) const override { return getInternalBackupEntry()->getChecksum(read_settings); }
-    std::optional<UInt128> getPartialChecksum(size_t prefix_length, const ReadSettings & read_settings) const override { return getInternalBackupEntry()->getPartialChecksum(prefix_length, read_settings); }
+    std::optional<UInt128> getPartialChecksum(UInt64 limit, const ReadSettings & read_settings) const override { return getInternalBackupEntry()->getPartialChecksum(limit, read_settings); }
     DataSourceDescription getDataSourceDescription() const override { return getInternalBackupEntry()->getDataSourceDescription(); }
     bool isEncryptedByDisk() const override { return getInternalBackupEntry()->isEncryptedByDisk(); }
     bool isFromFile() const override { return getInternalBackupEntry()->isFromFile(); }

--- a/src/Backups/IBackupEntry.h
+++ b/src/Backups/IBackupEntry.h
@@ -31,7 +31,7 @@ public:
 
     /// Returns a partial checksum, i.e. the checksum calculated for a prefix part of the data.
     /// Can return nullopt if the partial checksum is too difficult to calculate.
-    virtual std::optional<UInt128> getPartialChecksum(size_t /* prefix_length */, const ReadSettings &) const { return {}; }
+    virtual std::optional<UInt128> getPartialChecksum(UInt64 /* limit */, const ReadSettings &) const { return {}; }
 
     /// Returns a read buffer for reading the data.
     virtual std::unique_ptr<SeekableReadBuffer> getReadBuffer(const ReadSettings & read_settings) const = 0;

--- a/src/Backups/tests/gtest_backup_entries.cpp
+++ b/src/Backups/tests/gtest_backup_entries.cpp
@@ -115,7 +115,7 @@ TEST_F(BackupEntriesTest, BackupEntryFromImmutableFile)
     auto entry = std::make_shared<BackupEntryFromImmutableFile>(local_disk, "a.txt");
     EXPECT_EQ(entry->getSize(), 9);
     EXPECT_EQ(getChecksum(entry), SOME_TEXT_CHECKSUM);
-    EXPECT_EQ(getPartialChecksum(entry, 0), ZERO_CHECKSUM);
+    EXPECT_EQ(getPartialChecksum(entry, 0), NO_CHECKSUM);
     EXPECT_EQ(getPartialChecksum(entry, 1), NO_CHECKSUM);
     EXPECT_EQ(getPartialChecksum(entry, 8), NO_CHECKSUM);
     EXPECT_EQ(getPartialChecksum(entry, 9), SOME_TEXT_CHECKSUM);
@@ -136,7 +136,7 @@ TEST_F(BackupEntriesTest, BackupEntryFromImmutableFile)
     EXPECT_EQ(precalculated_entry->getSize(), PRECALCULATED_SIZE);
 
     EXPECT_EQ(getChecksum(precalculated_entry), PRECALCULATED_CHECKSUM);
-    EXPECT_EQ(getPartialChecksum(precalculated_entry, 0), ZERO_CHECKSUM);
+    EXPECT_EQ(getPartialChecksum(precalculated_entry, 0), NO_CHECKSUM);
     EXPECT_EQ(getPartialChecksum(precalculated_entry, 1), NO_CHECKSUM);
     EXPECT_EQ(getPartialChecksum(precalculated_entry, PRECALCULATED_SIZE - 1), NO_CHECKSUM);
     EXPECT_EQ(getPartialChecksum(precalculated_entry, PRECALCULATED_SIZE), PRECALCULATED_CHECKSUM);
@@ -247,7 +247,7 @@ TEST_F(BackupEntriesTest, DecryptedEntriesFromEncryptedDisk)
         {
             EXPECT_EQ(entry->getSize(), 9);
             EXPECT_EQ(getChecksum(entry), SOME_TEXT_CHECKSUM);
-            EXPECT_EQ(getPartialChecksum(entry, 0), ZERO_CHECKSUM);
+            EXPECT_EQ(getPartialChecksum(entry, 0), partial_checksum_allowed ? ZERO_CHECKSUM : NO_CHECKSUM);
             EXPECT_EQ(getPartialChecksum(entry, 1), partial_checksum_allowed ? S_CHECKSUM : NO_CHECKSUM);
             EXPECT_EQ(getPartialChecksum(entry, 8), partial_checksum_allowed ? SOME_TEX_CHECKSUM : NO_CHECKSUM);
             EXPECT_EQ(getPartialChecksum(entry, 9), SOME_TEXT_CHECKSUM);
@@ -276,7 +276,7 @@ TEST_F(BackupEntriesTest, DecryptedEntriesFromEncryptedDisk)
         auto precalculated_entry = std::make_shared<BackupEntryFromImmutableFile>(encrypted_disk, "a.txt", false, PRECALCULATED_SIZE, PRECALCULATED_CHECKSUM_UINT128);
         EXPECT_EQ(precalculated_entry->getSize(), PRECALCULATED_SIZE);
         EXPECT_EQ(getChecksum(precalculated_entry), PRECALCULATED_CHECKSUM);
-        EXPECT_EQ(getPartialChecksum(precalculated_entry, 0), ZERO_CHECKSUM);
+        EXPECT_EQ(getPartialChecksum(precalculated_entry, 0), NO_CHECKSUM);
         EXPECT_EQ(getPartialChecksum(precalculated_entry, 1), NO_CHECKSUM);
         EXPECT_EQ(getPartialChecksum(precalculated_entry, PRECALCULATED_SIZE), PRECALCULATED_CHECKSUM);
         EXPECT_EQ(getPartialChecksum(precalculated_entry, 1000), PRECALCULATED_CHECKSUM);
@@ -312,7 +312,6 @@ TEST_F(BackupEntriesTest, EncryptedEntriesFromEncryptedDisk)
         {
             EXPECT_EQ(entry->getSize(), 9 + FileEncryption::Header::kSize);
             EXPECT_EQ(getChecksum(entry), encrypted_checksum);
-            EXPECT_EQ(getPartialChecksum(entry, 0), ZERO_CHECKSUM);
             auto encrypted_checksum_9 = getPartialChecksum(entry, 9);
             EXPECT_TRUE(encrypted_checksum_9 == NO_CHECKSUM || encrypted_checksum_9 == partial_checksum);
             EXPECT_EQ(getPartialChecksum(entry, 9 + FileEncryption::Header::kSize), encrypted_checksum);
@@ -347,7 +346,7 @@ TEST_F(BackupEntriesTest, EncryptedEntriesFromEncryptedDisk)
         EXPECT_NE(encrypted_checksum, SOME_TEXT_CHECKSUM);
         EXPECT_NE(encrypted_checksum, PRECALCULATED_CHECKSUM);
 
-        EXPECT_EQ(getPartialChecksum(precalculated_entry, 0), ZERO_CHECKSUM);
+        EXPECT_EQ(getPartialChecksum(precalculated_entry, 0), NO_CHECKSUM);
         EXPECT_EQ(getPartialChecksum(precalculated_entry, 1), NO_CHECKSUM);
         EXPECT_EQ(getPartialChecksum(precalculated_entry, PRECALCULATED_SIZE), NO_CHECKSUM);
         EXPECT_EQ(getPartialChecksum(precalculated_entry, PRECALCULATED_SIZE + FileEncryption::Header::kSize), encrypted_checksum);

--- a/src/Backups/tests/gtest_backup_entries.cpp
+++ b/src/Backups/tests/gtest_backup_entries.cpp
@@ -75,7 +75,7 @@ protected:
 
     static const constexpr std::string_view NO_CHECKSUM = "no checksum";
 
-    static String getPartialChecksum(const BackupEntryPtr & backup_entry, size_t prefix_length)
+    static String getPartialChecksum(const BackupEntryPtr & backup_entry, UInt64 prefix_length)
     {
         auto partial_checksum = backup_entry->getPartialChecksum(prefix_length, {});
         if (!partial_checksum)

--- a/src/Common/ObjectStorageKeyGenerator.cpp
+++ b/src/Common/ObjectStorageKeyGenerator.cpp
@@ -19,6 +19,8 @@ public:
         return DB::ObjectStorageKey::createAsAbsolute(re_gen.generate());
     }
 
+    bool isRandom() const override { return true; }
+
 private:
     String key_template;
     DB::RandomStringGeneratorByRegexp re_gen;
@@ -51,6 +53,8 @@ public:
         return DB::ObjectStorageKey::createAsRelative(key_prefix, key);
     }
 
+    bool isRandom() const override { return true; }
+
 private:
     String key_prefix;
 };
@@ -68,6 +72,8 @@ public:
     {
         return DB::ObjectStorageKey::createAsRelative(key_prefix, path);
     }
+
+    bool isRandom() const override { return false; }
 
 private:
     String key_prefix;

--- a/src/Common/ObjectStorageKeyGenerator.h
+++ b/src/Common/ObjectStorageKeyGenerator.h
@@ -17,6 +17,9 @@ public:
     /// @param is_directory - If the path in the virtual filesystem corresponds to a directory.
     /// @param key_prefix   - Optional key prefix for the generated object storage key. If provided, this prefix will be added to the beginning of the generated key.
     virtual ObjectStorageKey generate(const String & path, bool is_directory, const std::optional<String> & key_prefix) const = 0;
+
+    /// Returns whether this generator uses a pseudorandom number generator to generate object storage keys.
+    virtual bool isRandom() const = 0;
 };
 
 using ObjectStorageKeysGeneratorPtr = std::shared_ptr<IObjectStorageKeysGenerator>;

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -752,6 +752,12 @@ The server successfully detected this situation and will download merged part fr
     M(BackupEntriesCollectorMicroseconds, "Time spent making backup entries", ValueType::Microseconds) \
     M(BackupEntriesCollectorForTablesDataMicroseconds, "Time spent making backup entries for tables data", ValueType::Microseconds) \
     M(BackupEntriesCollectorRunPostTasksMicroseconds, "Time spent running post tasks after making backup entries", ValueType::Microseconds) \
+    M(BackupPreparingFileInfosMicroseconds, "Time spent preparing file infos for backup entries", ValueType::Microseconds) \
+    M(BackupReadLocalFilesToCalculateChecksums, "Number of files read locally to calculate checksums for backup entries", ValueType::Number) \
+    M(BackupReadLocalBytesToCalculateChecksums, "Total size of files read locally to calculate checksums for backup entries", ValueType::Number) \
+    M(BackupReadRemoteFilesToCalculateChecksums, "Number of files read from remote disks to calculate checksums for backup entries", ValueType::Number) \
+    M(BackupReadRemoteBytesToCalculateChecksums, "Total size of files read from remote disks to calculate checksums for backup entries", ValueType::Number) \
+    M(BackupLockFileReads, "How many times the '.lock' file was read while making backup", ValueType::Number) \
     M(RestorePartsSkippedFiles, "Number of files skipped while restoring parts", ValueType::Number) \
     M(RestorePartsSkippedBytes, "Total size of files skipped while restoring parts", ValueType::Number) \
     \

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -199,11 +199,28 @@ public:
         return delegate->getBlobPath(wrapped_path);
     }
 
+    bool areBlobPathsRandom() const override
+    {
+        return delegate->areBlobPathsRandom();
+    }
+
     void writeFileUsingBlobWritingFunction(const String & path, WriteMode mode, WriteBlobFunction && write_blob_function) override
     {
         auto tx = createEncryptedTransaction();
         tx->writeFileUsingBlobWritingFunction(path, mode, std::move(write_blob_function));
         tx->commit();
+    }
+
+    StoredObjects getStorageObjects(const String & path) const override
+    {
+        auto wrapped_path = wrappedPath(path);
+        return delegate->getStorageObjects(wrapped_path);
+    }
+
+    std::optional<StoredObjects> getStorageObjectsIfExist(const String & path) const override
+    {
+        auto wrapped_path = wrappedPath(path);
+        return delegate->getStorageObjectsIfExist(wrapped_path);
     }
 
     std::unique_ptr<ReadBufferFromFileBase> readEncryptedFile(const String & path, const ReadSettings & settings) const override

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -91,6 +91,7 @@ public:
         const WriteSettings & settings) override;
 
     Strings getBlobPath(const String & path) const override;
+    bool areBlobPathsRandom() const override { return false; }
     void writeFileUsingBlobWritingFunction(const String & path, WriteMode mode, WriteBlobFunction && write_blob_function) override;
 
     void removeFile(const String & path) override;

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -298,6 +298,9 @@ public:
     /// StoredObject::remote_path for each stored object combined with the name of the objects' namespace.
     virtual Strings getBlobPath(const String & path) const = 0;
 
+    /// Returns whether the blob paths this disk uses are randomly generated.
+    virtual bool areBlobPathsRandom() const = 0;
+
     using WriteBlobFunction = std::function<size_t(const Strings & blob_path, WriteMode mode, const std::optional<ObjectAttributes> & object_attributes)>;
 
     /// Write a file using a custom function to write a blob representing the file.

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -92,6 +92,8 @@ public:
 
     ObjectStorageKey generateObjectKeyForPath(const std::string & path, const std::optional<std::string> & key_prefix) const override;
 
+    bool areObjectKeysRandom() const override { return true; }
+
     bool isRemote() const override { return true; }
 
     std::shared_ptr<const AzureBlobStorage::RequestSettings> getSettings() const  { return settings.get(); }

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -46,6 +46,11 @@ CachedObjectStorage::generateObjectKeyPrefixForDirectoryPath(const std::string &
     return object_storage->generateObjectKeyPrefixForDirectoryPath(path, key_prefix);
 }
 
+bool CachedObjectStorage::areObjectKeysRandom() const
+{
+    return object_storage->areObjectKeysRandom();
+}
+
 ReadSettings CachedObjectStorage::patchSettings(const ReadSettings & read_settings) const
 {
     return object_storage->patchSettings(read_settings);

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -93,6 +93,8 @@ public:
     ObjectStorageKey
     generateObjectKeyPrefixForDirectoryPath(const std::string & path, const std::optional<std::string> & key_prefix) const override;
 
+    bool areObjectKeysRandom() const override;
+
     void setKeysGenerator(ObjectStorageKeysGeneratorPtr gen) override { object_storage->setKeysGenerator(gen); }
 
     bool isPlain() const override { return object_storage->isPlain(); }

--- a/src/Disks/ObjectStorages/CommonPathPrefixKeyGenerator.h
+++ b/src/Disks/ObjectStorages/CommonPathPrefixKeyGenerator.h
@@ -30,6 +30,8 @@ public:
 
     ObjectStorageKey generate(const String & path, bool is_directory, const std::optional<String> & key_prefix) const override;
 
+    bool isRandom() const override { return true; }
+
 private:
     /// Longest key prefix and unresolved parts of the source path.
     std::tuple<std::string, std::vector<String>> getLongestObjectKeyPrefix(const String & path) const;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -778,6 +778,11 @@ Strings DiskObjectStorage::getBlobPath(const String & path) const
     return res;
 }
 
+bool DiskObjectStorage::areBlobPathsRandom() const
+{
+    return object_storage->areObjectKeysRandom();
+}
+
 void DiskObjectStorage::writeFileUsingBlobWritingFunction(const String & path, WriteMode mode, WriteBlobFunction && write_blob_function)
 {
     LOG_TEST(log, "Write file: {}", path);

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -159,6 +159,7 @@ public:
         const WriteSettings & settings) override;
 
     Strings getBlobPath(const String & path) const override;
+    bool areBlobPathsRandom() const override;
     void writeFileUsingBlobWritingFunction(const String & path, WriteMode mode, WriteBlobFunction && write_blob_function) override;
 
     void copyFile( /// NOLINT

--- a/src/Disks/ObjectStorages/FlatDirectoryStructureKeyGenerator.h
+++ b/src/Disks/ObjectStorages/FlatDirectoryStructureKeyGenerator.h
@@ -14,6 +14,8 @@ public:
 
     ObjectStorageKey generate(const String & path, bool is_directory, const std::optional<String> & key_prefix) const override;
 
+    bool isRandom() const override { return true; }
+
 private:
     const String storage_key_prefix;
 

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
@@ -102,6 +102,8 @@ public:
 
     ObjectStorageKey generateObjectKeyForPath(const std::string & path, const std::optional<std::string> & key_prefix) const override;
 
+    bool areObjectKeysRandom() const override { return true; }
+
     bool isRemote() const override { return true; }
 
     void startup() override { }

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -227,6 +227,10 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method 'generateObjectKeyPrefixForDirectoryPath' is not implemented");
     }
 
+    /// Returns whether this object storage generates a random blob name for each object.
+    /// This function returns false if this object storage just adds some constant string to a passed path to generate a blob name.
+    virtual bool areObjectKeysRandom() const = 0;
+
     /// Get unique id for passed absolute path in object storage.
     virtual std::string getUniqueId(const std::string & path) const { return path; }
 

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
@@ -73,6 +73,8 @@ public:
 
     ObjectStorageKey generateObjectKeyForPath(const std::string & path, const std::optional<std::string> & key_prefix) const override;
 
+    bool areObjectKeysRandom() const override { return true; }
+
     bool isRemote() const override { return false; }
 
     ReadSettings patchSettings(const ReadSettings & read_settings) const override;

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -530,6 +530,11 @@ ObjectStorageKey S3ObjectStorage::generateObjectKeyForPath(const std::string & p
     return key_generator->generate(path, /* is_directory */ false, key_prefix);
 }
 
+bool S3ObjectStorage::areObjectKeysRandom() const
+{
+    return key_generator->isRandom();
+}
+
 std::shared_ptr<const S3::Client> S3ObjectStorage::getS3StorageClient()
 {
     return client.get();

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -151,6 +151,8 @@ public:
 
     ObjectStorageKey generateObjectKeyForPath(const std::string & path, const std::optional<std::string> & key_prefix) const override;
 
+    bool areObjectKeysRandom() const override;
+
     bool isReadOnly() const override { return s3_settings.get()->read_only; }
 
     std::shared_ptr<const S3::Client> getS3StorageClient() override;

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.h
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.h
@@ -77,6 +77,8 @@ public:
         return ObjectStorageKey::createAsRelative(path);
     }
 
+    bool areObjectKeysRandom() const override { return false; }
+
     bool isRemote() const override { return true; }
 
     bool isReadOnly() const override { return true; }

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -448,7 +448,8 @@ void DataPartStorageOnDiskBase::backup(
             file_hash = it->second.file_hash;
         }
 
-        BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromImmutableFile>(disk, filepath_on_disk, copy_encrypted, file_size, file_hash);
+        BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromImmutableFile>(
+            disk, filepath_on_disk, copy_encrypted, file_size, file_hash);
 
         if (temp_dir_owner)
             backup_entry = wrapBackupEntryWith(std::move(backup_entry), temp_dir_owner);

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -414,6 +414,7 @@ void DataPartStorageOnDiskBase::backup(
     files_to_backup = getActualFileNamesOnDisk(files_to_backup);
 
     bool copy_encrypted = !backup_settings.decrypt_files_from_encrypted_disks;
+    bool allow_checksums_from_remote_paths = backup_settings.allow_checksums_from_remote_paths;
 
     auto backup_file = [&](const String & filepath)
     {
@@ -441,7 +442,7 @@ void DataPartStorageOnDiskBase::backup(
         }
 
         BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromImmutableFile>(
-            disk, filepath_on_disk, copy_encrypted, file_size, file_hash);
+            disk, filepath_on_disk, copy_encrypted, file_size, file_hash, allow_checksums_from_remote_paths);
 
         if (temp_dir_owner)
             backup_entry = wrapBackupEntryWith(std::move(backup_entry), temp_dir_owner);

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -9,7 +9,6 @@
 #include <Common/formatReadable.h>
 #include <Interpreters/Context.h>
 #include <Storages/MergeTree/Backup.h>
-#include <Backups/BackupEntryFromSmallFile.h>
 #include <Backups/BackupEntryFromImmutableFile.h>
 #include <Backups/BackupEntryWrappedWith.h>
 #include <Backups/BackupSettings.h>
@@ -370,7 +369,6 @@ void DataPartStorageOnDiskBase::backup(
     const NameSet & files_without_checksums,
     const String & path_in_backup,
     const BackupSettings & backup_settings,
-    const ReadSettings & read_settings,
     bool make_temporary_hard_links,
     BackupEntries & backup_entries,
     TemporaryFilesOnDisks * temp_dirs,
@@ -421,12 +419,6 @@ void DataPartStorageOnDiskBase::backup(
     {
         auto filepath_on_disk = part_path_on_disk / filepath;
         auto filepath_in_backup = part_path_in_backup / filepath;
-
-        if (files_without_checksums.contains(filepath))
-        {
-            backup_entries.emplace_back(filepath_in_backup, std::make_unique<BackupEntryFromSmallFile>(disk, filepath_on_disk, read_settings, copy_encrypted));
-            return;
-        }
 
         if (is_projection_part && allow_backup_broken_projection && !disk->existsFile(filepath_on_disk))
             return;

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
@@ -56,7 +56,6 @@ public:
         const NameSet & files_without_checksums,
         const String & path_in_backup,
         const BackupSettings & backup_settings,
-        const ReadSettings & read_settings,
         bool make_temporary_hard_links,
         BackupEntries & backup_entries,
         TemporaryFilesOnDisks * temp_dirs,

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -232,7 +232,6 @@ public:
         const NameSet & files_without_checksums,
         const String & path_in_backup,
         const BackupSettings & backup_settings,
-        const ReadSettings & read_settings,
         bool make_temporary_hard_links,
         BackupEntries & backup_entries,
         TemporaryFilesOnDisks * temp_dirs,

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5707,7 +5707,6 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
     const DataPartsVector & data_parts,
     const String & data_path_in_backup,
     const BackupSettings & backup_settings,
-    const ReadSettings & read_settings,
     const ContextPtr & local_context)
 {
     MergeTreeData::PartsBackupEntries res;
@@ -5749,7 +5748,6 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
             part->getFileNamesWithoutChecksums(),
             data_path_in_backup,
             backup_settings,
-            read_settings,
             make_temporary_hard_links,
             backup_entries_from_part,
             &temp_dirs,
@@ -5762,7 +5760,6 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
                 projection_part.getFileNamesWithoutChecksums(),
                 fs::path{data_path_in_backup} / part->name,
                 backup_settings,
-                read_settings,
                 make_temporary_hard_links,
                 backup_entries_from_part,
                 &temp_dirs,

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1533,7 +1533,7 @@ protected:
     using PartsBackupEntries = std::vector<PartBackupEntries>;
 
     /// Makes backup entries to backup the parts of this table.
-    PartsBackupEntries backupParts(const DataPartsVector & data_parts, const String & data_path_in_backup, const BackupSettings & backup_settings, const ReadSettings & read_settings, const ContextPtr & local_context);
+    PartsBackupEntries backupParts(const DataPartsVector & data_parts, const String & data_path_in_backup, const BackupSettings & backup_settings, const ContextPtr & local_context);
 
     class RestoredPartsHolder;
 

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -1003,8 +1003,8 @@ void StorageLog::backupData(BackupEntriesCollector & backup_entries_collector, c
     disk->createDirectories(temp_dir);
 
     const auto & read_settings = backup_entries_collector.getReadSettings();
-    bool copy_encrypted = !backup_entries_collector.getBackupSettings().decrypt_files_from_encrypted_disks;
-
+    const auto & backup_settings = backup_entries_collector.getBackupSettings();
+    bool copy_encrypted = !backup_settings.decrypt_files_from_encrypted_disks;
     /// *.bin
     for (const auto & data_file : data_files)
     {

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -1005,6 +1005,8 @@ void StorageLog::backupData(BackupEntriesCollector & backup_entries_collector, c
     const auto & read_settings = backup_entries_collector.getReadSettings();
     const auto & backup_settings = backup_entries_collector.getBackupSettings();
     bool copy_encrypted = !backup_settings.decrypt_files_from_encrypted_disks;
+    bool allow_checksums_from_remote_paths = backup_settings.allow_checksums_from_remote_paths;
+
     /// *.bin
     for (const auto & data_file : data_files)
     {
@@ -1013,7 +1015,7 @@ void StorageLog::backupData(BackupEntriesCollector & backup_entries_collector, c
         String hardlink_file_path = temp_dir / data_file_name;
         disk->createHardLink(data_file.path, hardlink_file_path);
         BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromAppendOnlyFile>(
-            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(data_file.path));
+            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(data_file.path), allow_checksums_from_remote_paths);
         backup_entry = wrapBackupEntryWith(std::move(backup_entry), temp_dir_owner);
         backup_entries_collector.addBackupEntry(data_path_in_backup_fs / data_file_name, std::move(backup_entry));
     }
@@ -1026,7 +1028,7 @@ void StorageLog::backupData(BackupEntriesCollector & backup_entries_collector, c
         String hardlink_file_path = temp_dir / marks_file_name;
         disk->createHardLink(marks_file_path, hardlink_file_path);
         BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromAppendOnlyFile>(
-            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(marks_file_path));
+            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(marks_file_path), allow_checksums_from_remote_paths);
         backup_entry = wrapBackupEntryWith(std::move(backup_entry), temp_dir_owner);
         backup_entries_collector.addBackupEntry(data_path_in_backup_fs / marks_file_name, std::move(backup_entry));
     }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2534,7 +2534,6 @@ std::optional<CheckResult> StorageMergeTree::checkDataNext(DataValidationTasksPt
 void StorageMergeTree::backupData(BackupEntriesCollector & backup_entries_collector, const String & data_path_in_backup, const std::optional<ASTs> & partitions)
 {
     const auto & backup_settings = backup_entries_collector.getBackupSettings();
-    const auto & read_settings = backup_entries_collector.getReadSettings();
     auto local_context = backup_entries_collector.getContext();
 
     DataPartsVector data_parts;
@@ -2547,7 +2546,7 @@ void StorageMergeTree::backupData(BackupEntriesCollector & backup_entries_collec
     for (const auto & data_part : data_parts)
         min_data_version = std::min(min_data_version, data_part->info.getDataVersion() + 1);
 
-    auto parts_backup_entries = backupParts(data_parts, data_path_in_backup, backup_settings, read_settings, local_context);
+    auto parts_backup_entries = backupParts(data_parts, data_path_in_backup, backup_settings, local_context);
     for (auto & part_backup_entries : parts_backup_entries)
         backup_entries_collector.addBackupEntries(std::move(part_backup_entries.backup_entries));
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -10893,7 +10893,6 @@ void StorageReplicatedMergeTree::backupData(
     /// because we need to coordinate them with other replicas (other replicas can have better parts).
 
     const auto & backup_settings = backup_entries_collector.getBackupSettings();
-    const auto & read_settings = backup_entries_collector.getReadSettings();
     auto local_context = backup_entries_collector.getContext();
     auto zookeeper_retries_info = backup_entries_collector.getZooKeeperRetriesInfo();
 
@@ -10903,7 +10902,7 @@ void StorageReplicatedMergeTree::backupData(
     else
         data_parts = getVisibleDataPartsVector(local_context);
 
-    auto parts_backup_entries = backupParts(data_parts, /* data_path_in_backup */ "", backup_settings, read_settings, local_context);
+    auto parts_backup_entries = backupParts(data_parts, /* data_path_in_backup */ "", backup_settings, local_context);
 
     auto coordination = backup_entries_collector.getBackupCoordination();
 

--- a/src/Storages/StorageStripeLog.cpp
+++ b/src/Storages/StorageStripeLog.cpp
@@ -575,6 +575,7 @@ void StorageStripeLog::backupData(BackupEntriesCollector & backup_entries_collec
     const auto & read_settings = backup_entries_collector.getReadSettings();
     const auto & backup_settings = backup_entries_collector.getBackupSettings();
     bool copy_encrypted = !backup_settings.decrypt_files_from_encrypted_disks;
+    bool allow_checksums_from_remote_paths = backup_settings.allow_checksums_from_remote_paths;
 
     /// data.bin
     {
@@ -583,7 +584,7 @@ void StorageStripeLog::backupData(BackupEntriesCollector & backup_entries_collec
         String hardlink_file_path = temp_dir / data_file_name;
         disk->createHardLink(data_file_path, hardlink_file_path);
         BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromAppendOnlyFile>(
-            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(data_file_path));
+            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(data_file_path), allow_checksums_from_remote_paths);
         backup_entry = wrapBackupEntryWith(std::move(backup_entry), temp_dir_owner);
         backup_entries_collector.addBackupEntry(data_path_in_backup_fs / data_file_name, std::move(backup_entry));
     }
@@ -595,7 +596,7 @@ void StorageStripeLog::backupData(BackupEntriesCollector & backup_entries_collec
         String hardlink_file_path = temp_dir / index_file_name;
         disk->createHardLink(index_file_path, hardlink_file_path);
         BackupEntryPtr backup_entry = std::make_unique<BackupEntryFromAppendOnlyFile>(
-            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(index_file_path));
+            disk, hardlink_file_path, copy_encrypted, file_checker.getFileSize(index_file_path), allow_checksums_from_remote_paths);
         backup_entry = wrapBackupEntryWith(std::move(backup_entry), temp_dir_owner);
         backup_entries_collector.addBackupEntry(data_path_in_backup_fs / index_file_name, std::move(backup_entry));
     }

--- a/src/Storages/StorageStripeLog.cpp
+++ b/src/Storages/StorageStripeLog.cpp
@@ -573,7 +573,8 @@ void StorageStripeLog::backupData(BackupEntriesCollector & backup_entries_collec
     disk->createDirectories(temp_dir);
 
     const auto & read_settings = backup_entries_collector.getReadSettings();
-    bool copy_encrypted = !backup_entries_collector.getBackupSettings().decrypt_files_from_encrypted_disks;
+    const auto & backup_settings = backup_entries_collector.getBackupSettings();
+    bool copy_encrypted = !backup_settings.decrypt_files_from_encrypted_disks;
 
     /// data.bin
     {

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -334,6 +334,9 @@ def test_backup_from_s3_to_s3_disk_native_copy(storage_policy, to_disk):
     assert backup_events["S3CopyObject"] > 0
     assert restore_events["S3CopyObject"] > 0
 
+    # BACKUP shouldn't download any files from S3 except ".lock" file.
+    assert backup_events["S3GetObject"] == backup_events["BackupLockFileReads"]
+
 
 def test_backup_to_s3():
     storage_policy = "default"

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -537,10 +537,11 @@ def test_backup_with_fs_cache(
     # print(f"restore_events = {restore_events}")
 
     # BACKUP never updates the filesystem cache but it may read it if `read_from_filesystem_cache_if_exists_otherwise_bypass_cache` allows that.
-    if allow_backup_read_cache and in_cache_initially:
+    # And if allow_s3_native_copy == True then BACKUP shouldn't read MergeTree parts from S3 and thus it shouldn't request any files from the file cache.
+    if allow_backup_read_cache and in_cache_initially and not allow_s3_native_copy:
         assert backup_events["CachedReadBufferReadFromCacheBytes"] > 0
         assert not "CachedReadBufferReadFromSourceBytes" in backup_events
-    elif allow_backup_read_cache:
+    elif allow_backup_read_cache and not allow_s3_native_copy:
         assert not "CachedReadBufferReadFromCacheBytes" in backup_events
         assert backup_events["CachedReadBufferReadFromSourceBytes"] > 0
     else:


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow using blob paths to calculate checksums while making a backup.

While ClickHouse is making a backup, it needs a checksum for every file it puts into a backup. Some files already have checksums stored in `checksums.txt` and thus those checksums can be used. Other files don't have checksums so the `BACKUP` command has to calculate them during a backup-making process. In order to do that Clickhouse can read such files up to their ends and calculate checksums, and before this PR it used to work this way. That could work rather slow for remote disks because it downloaded some files from (for example) S3 just to calculate their checksums.

This PR introduces using remote disk's blob paths to calculate checksums instead of calculating checksums from the downloaded contents of such files.