### PR TITLE
Avoid leaving connection in broken state after INSERT finishes with exception

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -816,19 +816,15 @@ void TCPHandler::runImpl()
                 /// Assume that we can't break output here
                 sendLogs(query_state.value());
 
+                if (exception_code == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT)
+                    sendEndOfStream(query_state.value());
+                else
+                    sendException(*exception, send_exception_with_stack_trace);
+
                 /// A query packet is always followed by one or more data packets.
                 /// If some of those data packets are left, try to skip them.
                 if (!query_state->read_all_data)
                     skipData(query_state.value());
-
-                if (exception_code == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT)
-                {
-                    sendEndOfStream(query_state.value());
-                }
-                else
-                {
-                    sendException(*exception, send_exception_with_stack_trace);
-                }
 
                 LOG_TEST(log, "Logs and exception has been sent. The connection is preserved.");
             }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -548,7 +548,7 @@ void TCPHandler::runImpl()
                 checkIfQueryCanceled(query_state.value());
 
                 /// Get blocks of temporary tables
-                readData(query_state.value());
+                readTemporaryTables(query_state.value());
 
                 /// Reset the input stream, as we received an empty block while receiving external table data.
                 /// So, the stream has been marked as cancelled and we can't read from it anymore.
@@ -582,6 +582,9 @@ void TCPHandler::runImpl()
                 query_state->input_header = metadata_snapshot->getSampleBlock();
                 sendData(query_state.value(), query_state->input_header);
                 sendTimezone(query_state.value());
+
+                /// Update flag after reading external tables
+                query_state->read_all_data = false;
             });
 
             query_state->query_context->setInputBlocksReaderCallback([this, &query_state] (ContextPtr context) -> Block
@@ -596,7 +599,6 @@ void TCPHandler::runImpl()
                 if (receivePacketsExpectData(query_state.value()))
                     return query_state->block_for_input;
 
-                query_state->read_all_data = true;
                 query_state->block_in.reset();
                 query_state->maybe_compressed_in.reset();
                 return {};
@@ -758,9 +760,7 @@ void TCPHandler::runImpl()
             auto exception_code = exception->code();
 
             if (!query_state.has_value())
-            {
                 return;
-            }
 
             try
             {
@@ -783,8 +783,7 @@ void TCPHandler::runImpl()
             /// In this case, the user is already authenticated with this server,
             /// is_interserver_mode is false, and we can send the exception to the client normally.
 
-            if (is_interserver_mode
-                && !is_interserver_authenticated)
+            if (is_interserver_mode && !is_interserver_authenticated)
             {
                 /// Interserver authentication is done only after we read the query.
                 /// This fact can be abused by producing exception before or while we read the query.
@@ -801,7 +800,7 @@ void TCPHandler::runImpl()
             }
 
             if (thread_trace_context)
-                    thread_trace_context->root_span.addAttribute(*exception);
+                thread_trace_context->root_span.addAttribute(*exception);
 
             if (!out || out->isCanceled())
             {
@@ -978,9 +977,16 @@ bool TCPHandler::receivePacketsExpectData(QueryState & state)
 
             case Protocol::Client::Data:
             case Protocol::Client::Scalar:
+            {
+                bool empty_block;
                 if (state.skipping_data)
-                    return processUnexpectedData();
-                return processData(state, packet_type == Protocol::Client::Scalar);
+                    empty_block = !processUnexpectedData();
+                else
+                    empty_block = !processData(state, packet_type == Protocol::Client::Scalar);
+                if (empty_block)
+                    state.read_all_data = true;
+                return !empty_block;
+            }
 
             case Protocol::Client::Ping:
                 writeVarUInt(Protocol::Server::Pong, *out);
@@ -1002,7 +1008,7 @@ bool TCPHandler::receivePacketsExpectData(QueryState & state)
 }
 
 
-void TCPHandler::readData(QueryState & state)
+void TCPHandler::readTemporaryTables(QueryState & state)
 {
     sendLogs(state);
 
@@ -1014,8 +1020,6 @@ void TCPHandler::readData(QueryState & state)
         sendLogs(state);
         sendInsertProfileEvents(state);
     }
-
-    state.read_all_data = true;
 }
 
 
@@ -1024,18 +1028,15 @@ void TCPHandler::skipData(QueryState & state)
     state.skipping_data = true;
     SCOPE_EXIT({ state.skipping_data = false; });
 
+    size_t blocks = 0;
     while (receivePacketsExpectData(state))
-    {
-        /// no op
-    }
-
-    state.read_all_data = true;
+        ++blocks;
+    LOG_TRACE(log, "Discarded {} blocks", blocks);
 }
 
 
 void TCPHandler::startInsertQuery(QueryState & state)
 {
-
     std::lock_guard lock(callback_mutex);
 
     /// Send ColumnsDescription for insertion table
@@ -1055,6 +1056,9 @@ void TCPHandler::startInsertQuery(QueryState & state)
     /// Send block to the client - table structure.
     sendData(state, state.io.pipeline.getHeader());
     sendLogs(state);
+
+    /// Update flag after reading external tables
+    state.read_all_data = false;
 }
 
 
@@ -1083,8 +1087,6 @@ AsynchronousInsertQueue::PushResult TCPHandler::processAsyncInsertQuery(QuerySta
             };
         }
     }
-
-    state.read_all_data = true;
 
     Chunk result_chunk = Squashing::squash(squashing.flush());
     if (!result_chunk)
@@ -1122,8 +1124,6 @@ void TCPHandler::processInsertQuery(QueryState & state)
                 sendLogs(state);
                 sendInsertProfileEvents(state);
             }
-
-            state.read_all_data = true;
 
             executor.finish();
         }
@@ -2292,9 +2292,8 @@ bool TCPHandler::processUnexpectedData()
         maybe_compressed_in = in;
 
     auto skip_block_in = std::make_shared<NativeReader>(*maybe_compressed_in, client_tcp_protocol_version);
-    bool read_ok = !!skip_block_in->read();
-
-    return read_ok;
+    bool empty_block = !skip_block_in->read();
+    return !empty_block;
 }
 
 

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -276,7 +276,7 @@ private:
     bool processData(QueryState & state, bool scalar) TSA_REQUIRES(callback_mutex);
     void processClusterNameAndSalt();
 
-    void readData(QueryState & state) TSA_REQUIRES(callback_mutex);
+    void readTemporaryTables(QueryState & state) TSA_REQUIRES(callback_mutex);
     void skipData(QueryState & state) TSA_REQUIRES(callback_mutex);
 
     bool processUnexpectedData();

--- a/tests/queries/0_stateless/03320_insert_close_connection_on_error.sh
+++ b/tests/queries/0_stateless/03320_insert_close_connection_on_error.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: relies on system.errors
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+$CLICKHOUSE_CLIENT -nm -q "
+    drop table if exists in_dist;
+    drop table if exists in;
+    drop table if exists mv;
+    drop table if exists proxy;
+
+    -- we need INSERT into distributed table to trigger multiple INSERTs from one query
+    create table in_dist (dummy Int) engine=Distributed('test_shard_localhost', currentDatabase(), in);
+
+    create table in (dummy Int) engine=Null();
+    -- Distributed table that will reject any INSERTs
+    create table proxy engine=Distributed('test_shard_localhost', system, one);
+    create materialized view mv to proxy as select * from in;
+"
+
+tmp_file=$(mktemp "$CUR_DIR/clickhouse.XXXXXX.tsv")
+trap 'rm $tmp_file' EXIT
+yes 1 | head -n 10 > "$tmp_file"
+
+iterations=10
+for _ in $(seq 1 $iterations); do
+    errors_before=$($CLICKHOUSE_CLIENT -q "select value from system.errors where name = 'UNEXPECTED_PACKET_FROM_CLIENT'")
+    opts=(
+        # split file into blocks of 1 row
+        # (NOTE: cannot be set in a query, since INFILE uses client context)
+        --max_block_size=1
+
+        # disable squshing, so that the block will be processed block-by-block
+        --min_insert_block_size_rows=0
+        --min_insert_block_size_bytes=0
+
+        # disable randomization
+        --prefer_localhost_replica=1
+        --distributed_foreground_insert=0
+    )
+    $CLICKHOUSE_CLIENT "${opts[@]}" -nm -q "
+        insert into in_dist from infile '$tmp_file'; -- { serverError NOT_IMPLEMENTED }
+    "
+    errors_after=$($CLICKHOUSE_CLIENT -q "select value from system.errors where name = 'UNEXPECTED_PACKET_FROM_CLIENT'")
+    if [[ "$errors_before" != "$errors_after" ]]; then
+        # retry
+        continue
+    fi
+done
+
+if [[ "$errors_before" != "$errors_after" ]]; then
+    echo "UNEXPECTED_PACKET_FROM_CLIENT does not match ($errors_before vs $errors_after) after $iterations iterations"
+fi


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid leaving connection in broken state after INSERT finishes with exception

In case of exception during processing INSERT, it is possible to leave in the state when the will be pending Data packets, and you will get something like this in logs:

    2025.01.17 20:32:31.228897 [ 1956 ] {5e4cd57a-7f69-4a7d-bc02-5948f528bebc} <Debug> executeQuery: (from [::ffff:127.0.0.1]:56486) insert into in_dist from infile 'test.tsv' settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0 (stage: Complete)
    2025.01.17 20:32:31.248667 [ 1956 ] {5e4cd57a-7f69-4a7d-bc02-5948f528bebc} <Error> executeQuery: Code: 48. DB::Exception: Method write is not supported by storage SystemOne: while pushing to view default.mv (3e957e5d-8df3-4b84-b940-2aa5d4ad104a). (NOT_IMPLEMENTED) (version 25.1.1.1) (from [::ffff:127.0.0.1]:56486) (in query: insert into in_dist from infile 'test.tsv' settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0), Stack trace (when copying this message, always include the lines below):
    2025.01.17 20:32:31.248739 [ 1956 ] {5e4cd57a-7f69-4a7d-bc02-5948f528bebc} <Test> TCPHandler: Logs and exception has been sent. The connection is preserved.
    2025.01.17 20:32:31.248768 [ 1956 ] {} <Error> TCPHandler: Code: 48. DB::Exception: Method write is not supported by storage SystemOne: while pushing to view default.mv (3e957e5d-8df3-4b84-b940-2aa5d4ad104a). (NOT_IMPLEMENTED), Stack trace (when copying this message, always include the lines below):
    2025.01.17 20:32:31.254353 [ 1956 ] {} <Error> TCPHandler: Code: 101. DB::Exception: Unexpected packet Data received from client. (UNEXPECTED_PACKET_FROM_CLIENT), Stack trace (when copying this message, always include the lines below):

The reason for this is that the read_all_data is wrongly set after reading external tables.

But note, that this is a minor thing, since it does not affect subsequent queries, since it will receive this unexpected packet in the same connection for the same query and will close it, so the driver should only re-establish connection (as many does).
