### PR TITLE
Parallel replicas tests: add vector search tests to blacklist

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -54,6 +54,7 @@
 02354_vector_search_multiple_marks
 02354_vector_search_expansion_search
 02354_vector_search_detach_attach
+02354_vector_search_different_array_sizes
 
     https://github.com/ClickHouse/ClickHouse/issues/74226
     Database _table_function does not exist
@@ -540,3 +541,4 @@
 00141_transform
 00443_optimize_final_vertical_merge
 01660_join_or_any
+01801_s3_cluster

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -50,8 +50,10 @@
 02861_filter_pushdown_const_bug
 
     https://github.com/ClickHouse/ClickHouse/issues/74547
+    vector search segfault
 02354_vector_search_multiple_marks
 02354_vector_search_expansion_search
+02354_vector_search_detach_attach
 
     https://github.com/ClickHouse/ClickHouse/issues/74226
     Database _table_function does not exist


### PR DESCRIPTION
Add the vector search tests to the blacklist because it causes segfaults


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [x] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Non-blocking CI mode (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
