### PR TITLE
Fix possible crash with distributed queries (likely due to async_query_sending_for_remote)

### DIFF
--- a/src/Common/AsyncTaskExecutor.h
+++ b/src/Common/AsyncTaskExecutor.h
@@ -61,6 +61,9 @@ public:
 
     bool isCancelled() const { return is_cancelled; }
 
+    void setFinished() { routine_is_finished = true; }
+    bool isFinished() const { return routine_is_finished; }
+
     virtual ~AsyncTaskExecutor() = default;
 
 

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -419,7 +419,7 @@ void PipelineExecutor::spawnThreadsImpl()
             catch (...)
             {
                 /// In case of exception from executor itself, stop other threads.
-                finish();
+                cancel();
                 tasks.getThreadContext(thread_num).setException(std::current_exception());
             }
         });

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -89,6 +89,9 @@ static void threadFunction(
 
         /// Finish lazy format in case of exception. Otherwise thread.join() may hung.
         data.lazy_format->finalize();
+
+        /// Do not set is_finished
+        return;
     }
 
     data.is_finished = true;

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -53,6 +53,11 @@ PullingAsyncPipelineExecutor::~PullingAsyncPipelineExecutor()
 {
     try
     {
+        /// NOTE: It can be error-prone to cancel the query in destructor
+        ///
+        /// For instance RemoteQueryExecutor should be cancelled before the
+        /// worker thread destroyed, otherwise active fibers could lead to
+        /// use-after-free
         cancel();
     }
     catch (...)

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -123,11 +123,12 @@ public:
     void sendQuery(ClientInfo::QueryKind query_kind = ClientInfo::QueryKind::SECONDARY_QUERY, AsyncCallback async_callback = {});
     void sendQueryUnlocked(ClientInfo::QueryKind query_kind = ClientInfo::QueryKind::SECONDARY_QUERY, AsyncCallback async_callback = {});
 
+    /// Asynchronous query sending (async_query_sending_for_remote)
+    /// Returns file descriptor which may be used for polling or -1.
     int sendQueryAsync();
 
     /// Query is resent to a replica, the query itself can be modified.
     bool resent_query { false };
-    bool recreate_read_context { false };
 
     struct ReadResult
     {
@@ -180,7 +181,8 @@ public:
 
     ReadResult read();
 
-    /// Async variant of read. Returns ready block or file descriptor which may be used for polling.
+    /// Async variant of read (async_socket_for_remote).
+    /// Returns ready block or file descriptor which may be used for polling.
     ReadResult readAsync();
 
     /// Receive all remain packets and finish query.

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -22,6 +22,7 @@ namespace DB
 class MultiplexedConnections;
 class RemoteQueryExecutor;
 
+/// NOTE: This async executor is not restartable (due to pipe notifications that may overlaps)
 class RemoteQueryExecutorReadContext : public AsyncTaskExecutor
 {
 public:

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -97,6 +97,7 @@ ColumnsDescription getStructureOfRemoteTableInShard(
 
     ParserExpression expr_parser;
 
+    executor.sendQuery();
     while (Block current = executor.readBlock())
     {
         ColumnPtr name = current.getByName("name").column;
@@ -204,6 +205,7 @@ ColumnsDescriptionByShardNum getExtendedObjectsOfRemoteTables(
 
         executor.setPoolMode(PoolMode::GET_ONE);
         executor.setMainTable(remote_table_id);
+        executor.sendQuery();
 
         ColumnsDescription res;
         while (auto block = executor.readBlock())


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash with distributed queries (likely due to async_query_sending_for_remote)

Refs: https://github.com/ClickHouse/ClickHouse/issues/65942

#### CI Settings (Only check the boxes if you know what you are doing):
- [x] <!---woolen_wolfdog--> Woolen Wolfdog

Resubmit of: https://github.com/ClickHouse/ClickHouse/pull/65984