### PR TITLE
Completely enable async_load_databases by default

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -747,7 +747,7 @@ namespace DB
     A value of `0` means all available CPUs will be used.
     :::
     )", 0) \
-    DECLARE(Bool, async_load_databases, false, R"(
+    DECLARE(Bool, async_load_databases, true, R"(
     Asynchronous loading of databases and tables.
 
     - If `true` all non-system databases with `Ordinary`, `Atomic` and `Replicated` engine will be loaded asynchronously after the ClickHouse server start up. See `system.asynchronous_loader` table, `tables_loader_background_pool_size` and `tables_loader_foreground_pool_size` server settings. Any query that tries to access a table, that is not yet loaded, will wait for exactly this table to be started up. If load job fails, query will rethrow an error (instead of shutting down the whole server in case of `async_load_databases = false`). The table that is waited for by at least one query will be loaded with higher priority. DDL queries on a database will wait for exactly that database to be started up. Also consider setting a limit `max_waiting_queries` for the total number of waiting queries.


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Completely enable async_load_databases by default (even for those installations that do not upgrade `config.xml`)

In https://github.com/ClickHouse/ClickHouse/pull/57695 it was enabled only in config.xml, which enables it only for
installations that has new config.xml, i.e. complete new installations.

But some installations may be upgraded without upgrading config.xml,
i.e. bare-metal installations.

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/57695 (cc @alexey-milovidov )

_Note: marked as `Backward Incompatible Change` since it may change the behavior for some existing installations_