### PR TITLE
tests: fix test_system_metrics::test_broken_tables_readonly_metric flakiness

### DIFF
--- a/tests/integration/test_system_metrics/configs/overrides.xml
+++ b/tests/integration/test_system_metrics/configs/overrides.xml
@@ -1,4 +1,6 @@
 <clickhouse>
+    <async_load_databases>false</async_load_databases>
+
     <remote_servers>
         <test_cluster>
             <shard>

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -105,66 +105,74 @@ def test_readonly_metrics(start_cluster):
 
 # For LowCardinality-columns, the bytes for N rows is not N*size of 1 row.
 def test_metrics_storage_buffer_size(start_cluster):
-    node1.query(
+    try:
+        node1.query(
+            """
+            CREATE TABLE test.test_mem_table
+            (
+                `str` LowCardinality(String)
+            )
+            ENGINE = Memory;
+
+            CREATE TABLE test.buffer_table
+            (
+                `str` LowCardinality(String)
+            )
+            ENGINE = Buffer('test', 'test_mem_table', 1, 600, 600, 1000, 100000, 100000, 10000000);
         """
-        CREATE TABLE test.test_mem_table
-        (
-            `str` LowCardinality(String)
         )
-        ENGINE = Memory;
 
-        CREATE TABLE test.buffer_table
-        (
-            `str` LowCardinality(String)
+        # before flush
+        node1.query("INSERT INTO test.buffer_table VALUES('hello');")
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'StorageBufferRows'"
+            )
+            == "1\n"
         )
-        ENGINE = Buffer('test', 'test_mem_table', 1, 600, 600, 1000, 100000, 100000, 10000000);
-    """
-    )
+        # By the way, this metric does not count the LowCardinality's dictionary size.
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'StorageBufferBytes'"
+            )
+            == "1\n"
+        )
 
-    # before flush
-    node1.query("INSERT INTO test.buffer_table VALUES('hello');")
-    assert (
-        node1.query(
-            "SELECT value FROM system.metrics WHERE metric = 'StorageBufferRows'"
+        node1.query("INSERT INTO test.buffer_table VALUES('hello');")
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'StorageBufferRows'"
+            )
+            == "2\n"
         )
-        == "1\n"
-    )
-    # By the way, this metric does not count the LowCardinality's dictionary size.
-    assert (
-        node1.query(
-            "SELECT value FROM system.metrics WHERE metric = 'StorageBufferBytes'"
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'StorageBufferBytes'"
+            )
+            == "2\n"
         )
-        == "1\n"
-    )
 
-    node1.query("INSERT INTO test.buffer_table VALUES('hello');")
-    assert (
-        node1.query(
-            "SELECT value FROM system.metrics WHERE metric = 'StorageBufferRows'"
+        # flush
+        node1.query("OPTIMIZE TABLE test.buffer_table")
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'StorageBufferRows'"
+            )
+            == "0\n"
         )
-        == "2\n"
-    )
-    assert (
-        node1.query(
-            "SELECT value FROM system.metrics WHERE metric = 'StorageBufferBytes'"
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'StorageBufferBytes'"
+            )
+            == "0\n"
         )
-        == "2\n"
-    )
-
-    # flush
-    node1.query("OPTIMIZE TABLE test.buffer_table")
-    assert (
+    finally:
         node1.query(
-            "SELECT value FROM system.metrics WHERE metric = 'StorageBufferRows'"
+            """
+            DROP TABLE IF EXISTS test.test_mem_table SYNC;
+            DROP TABLE IF EXISTS test.buffer_table SYNC;
+            """
         )
-        == "0\n"
-    )
-    assert (
-        node1.query(
-            "SELECT value FROM system.metrics WHERE metric = 'StorageBufferBytes'"
-        )
-        == "0\n"
-    )
 
 
 def test_attach_without_zk_incr_readonly_metric(start_cluster):
@@ -173,52 +181,55 @@ def test_attach_without_zk_incr_readonly_metric(start_cluster):
         == "0\n"
     )
 
-    node1.query(
-        "ATTACH TABLE test.test_no_zk UUID 'a50b7933-59b2-49ce-8db6-59da3c9b4413' (i Int8, d Date) ENGINE = ReplicatedMergeTree('no_zk', 'replica') ORDER BY tuple()"
-    )
-    assert_eq_with_retry(
-        node1,
-        "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
-        "1\n",
-        retry_count=300,
-        sleep_time=1,
-    )
+    try:
+        node1.query(
+            "ATTACH TABLE test.test_no_zk UUID 'a50b7933-59b2-49ce-8db6-59da3c9b4413' (i Int8, d Date) ENGINE = ReplicatedMergeTree('no_zk', 'replica') ORDER BY tuple()"
+        )
+        assert_eq_with_retry(
+            node1,
+            "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
+            "1\n",
+            retry_count=300,
+            sleep_time=1,
+        )
 
-    node1.query("DETACH TABLE test.test_no_zk")
-    assert_eq_with_retry(
-        node1,
-        "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
-        "0\n",
-        retry_count=300,
-        sleep_time=1,
-    )
+        node1.query("DETACH TABLE test.test_no_zk")
+        assert_eq_with_retry(
+            node1,
+            "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
+            "0\n",
+            retry_count=300,
+            sleep_time=1,
+        )
 
-    node1.query("ATTACH TABLE test.test_no_zk")
-    assert_eq_with_retry(
-        node1,
-        "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
-        "1\n",
-        retry_count=300,
-        sleep_time=1,
-    )
+        node1.query("ATTACH TABLE test.test_no_zk")
+        assert_eq_with_retry(
+            node1,
+            "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
+            "1\n",
+            retry_count=300,
+            sleep_time=1,
+        )
 
-    node1.query("SYSTEM RESTORE REPLICA test.test_no_zk")
-    assert_eq_with_retry(
-        node1,
-        "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
-        "0\n",
-        retry_count=300,
-        sleep_time=1,
-    )
+        node1.query("SYSTEM RESTORE REPLICA test.test_no_zk")
+        assert_eq_with_retry(
+            node1,
+            "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
+            "0\n",
+            retry_count=300,
+            sleep_time=1,
+        )
 
-    node1.query("DROP TABLE test.test_no_zk")
-    assert_eq_with_retry(
-        node1,
-        "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
-        "0\n",
-        retry_count=300,
-        sleep_time=1,
-    )
+        node1.query("DROP TABLE test.test_no_zk SYNC")
+        assert_eq_with_retry(
+            node1,
+            "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
+            "0\n",
+            retry_count=300,
+            sleep_time=1,
+        )
+    finally:
+        node1.query("DROP TABLE IF EXISTS test.test_no_zk SYNC")
 
 
 def get_zk(timeout=30.0):
@@ -230,34 +241,41 @@ def get_zk(timeout=30.0):
 
 
 def test_broken_tables_readonly_metric(start_cluster):
-    node1.query(
-        "CREATE TABLE test.broken_table_readonly(initial_name Int8) ENGINE = ReplicatedMergeTree('/clickhouse/broken_table_readonly', 'replica') ORDER BY tuple()"
-    )
-    assert_eq_with_retry(
-        node1,
-        "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
-        "0\n",
-        retry_count=300,
-        sleep_time=1,
-    )
+    try:
+        node1.query(
+            "CREATE TABLE test.broken_table_readonly(initial_name Int8) ENGINE = ReplicatedMergeTree('/clickhouse/broken_table_readonly', 'replica') ORDER BY tuple()"
+        )
+        assert_eq_with_retry(
+            node1,
+            "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'",
+            "0\n",
+            retry_count=300,
+            sleep_time=1,
+        )
 
-    zk_path = node1.query(
-        "SELECT replica_path FROM system.replicas WHERE table = 'broken_table_readonly'"
-    ).strip()
+        zk_path = node1.query(
+            "SELECT replica_path FROM system.replicas WHERE table = 'broken_table_readonly'"
+        ).strip()
 
-    node1.stop_clickhouse()
+        node1.stop_clickhouse()
 
-    zk_client = get_zk()
+        zk_client = get_zk()
 
-    columns_path = zk_path + "/columns"
-    metadata = zk_client.get(columns_path)[0]
-    modified_metadata = metadata.replace(b"initial_name", b"new_name")
-    zk_client.set(columns_path, modified_metadata)
+        columns_path = zk_path + "/columns"
+        metadata = zk_client.get(columns_path)[0]
+        modified_metadata = metadata.replace(b"initial_name", b"new_name")
+        zk_client.set(columns_path, modified_metadata)
 
-    node1.start_clickhouse()
+        node1.start_clickhouse()
 
-    assert node1.contains_in_log("Initialization failed, table will remain readonly")
-    assert (
-        node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'")
-        == "1\n"
-    )
+        assert node1.contains_in_log(
+            "Initialization failed, table will remain readonly"
+        )
+        assert (
+            node1.query(
+                "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'"
+            )
+            == "1\n"
+        )
+    finally:
+        node1.query("DROP TABLE IF EXISTS test.broken_table_readonly SYNC")

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -27,12 +27,12 @@ def fill_nodes(nodes, shard):
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
-    main_configs=["configs/remote_servers.xml"],
+    main_configs=["configs/overrides.xml"],
     with_zookeeper=True,
     stay_alive=True,
 )
 node2 = cluster.add_instance(
-    "node2", main_configs=["configs/remote_servers.xml"], with_zookeeper=True
+    "node2", main_configs=["configs/overrides.xml"], with_zookeeper=True
 )
 
 


### PR DESCRIPTION
It was flaky due to async_load_databases

CI: https://s3.amazonaws.com/clickhouse-test-reports/74225/e82f33190edb4f14e31e2e265e92d80b598bd2b1/integration_tests__tsan__[1_6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)