### PR TITLE
Disable `compile_aggregate_expressions` by default

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -906,7 +906,7 @@ Compile some scalar functions and operators to native code. Due to a bug in the 
     DECLARE(UInt64, min_count_to_compile_expression, 3, R"(
 Minimum count of executing same expression before it is get compiled.
 )", 0) \
-    DECLARE(Bool, compile_aggregate_expressions, true, R"(
+    DECLARE(Bool, compile_aggregate_expressions, false, R"(
 Enables or disables JIT-compilation of aggregate functions to native code. Enabling this setting can improve the performance.
 
 Possible values:

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -101,6 +101,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"allow_experimental_kusto_dialect", true, false, "A new setting"},
             {"allow_experimental_prql_dialect", true, false, "A new setting"},
             {"h3togeo_lon_lat_result_order", true, false, "A new setting"},
+            {"compile_aggregate_expressions", true, false, "Disabled JIT-compilation of aggregate functions as it still has bugs under AArch64."},
         });
         addSettingsChanges(settings_changes_history, "24.12",
         {


### PR DESCRIPTION
Resolves #74743

Disabled `compile_aggregate_expressions` by default as it has bugs when building with JIT on AArch64.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable `compile_aggregate_expressions` by default as it has bugs when building with JIT.