### PR TITLE
parseRemoteDescription: add support for IPv6 addresses

### DIFF
--- a/src/Common/parseRemoteDescription.cpp
+++ b/src/Common/parseRemoteDescription.cpp
@@ -182,15 +182,31 @@ std::vector<std::pair<String, uint16_t>> parseRemoteDescriptionForExternalDataba
 
     for (const auto & address : addresses)
     {
-        size_t colon = address.find(':');
-        if (colon == String::npos)
+        const size_t close_bracket = address.rfind(']');
+        size_t colon;
+        std::string host;
+        if (address.length() > 2 && address[0] == '[' && close_bracket != String::npos)
         {
-            LOG_WARNING(getLogger("ParseRemoteDescription"), "Port is not found for host: {}. Using default port {}", address, default_port);
-            result.emplace_back(std::make_pair(address, default_port));
+            colon = address.find(':', close_bracket + 1);
+            host = address.substr(1, close_bracket - 1);
         }
         else
         {
-            result.emplace_back(std::make_pair(address.substr(0, colon), parseFromString<UInt16>(address.substr(colon + 1))));
+            colon = address.find(':');
+            if (colon == String::npos)
+                host = address;
+            else
+                host = address.substr(0, colon);
+
+        }
+        if (colon == String::npos)
+        {
+            LOG_WARNING(getLogger("ParseRemoteDescription"), "Port is not found for host: {}. Using default port {}", address, default_port);
+            result.emplace_back(std::make_pair(host, default_port));
+        }
+        else
+        {
+            result.emplace_back(std::make_pair(host, DB::parseFromString<UInt16>(address.substr(colon + 1))));
         }
     }
 

--- a/tests/queries/0_stateless/02479_mysql_connect_to_self.reference
+++ b/tests/queries/0_stateless/02479_mysql_connect_to_self.reference
@@ -70,3 +70,75 @@ SELECT
 FROM mysql(\'127.0.0.1:9004\', _CAST(\'default\', \'String\'), foo, \'default\', \'[HIDDEN]\', SETTINGS connection_wait_timeout = 123, connect_timeout = 40123002, read_write_timeout = 40123001, connection_pool_size = 3) AS __table1
 ---
 5
+---
+1	one	-1	een
+2	two	-2	twee
+3	three	-3	drie
+4	four	-4	vier
+5	five	-5	vijf
+---
+5
+---
+1
+1
+1
+1
+1
+---
+1
+2
+3
+4
+5
+---
+-5	five
+-4	four
+-1	one
+-3	three
+-2	two
+---
+-3	three
+-1	one
+-2	two
+-4	four
+-5	five
+---
+-1
+-3
+-4
+-5
+---
+4
+QUERY id: 0
+  PROJECTION COLUMNS
+    key String
+    a String
+    b String
+    c String
+  PROJECTION
+    LIST id: 1, nodes: 4
+      COLUMN id: 2, column_name: key, result_type: String, source_id: 3
+      COLUMN id: 4, column_name: a, result_type: String, source_id: 3
+      COLUMN id: 5, column_name: b, result_type: String, source_id: 3
+      COLUMN id: 6, column_name: c, result_type: String, source_id: 3
+  JOIN TREE
+    TABLE_FUNCTION id: 3, alias: __table1, table_function_name: mysql
+      ARGUMENTS
+        LIST id: 7, nodes: 5
+          CONSTANT id: 8, constant_value: \'[::1]:9004\', constant_value_type: String
+          CONSTANT id: 9, constant_value: \'default\', constant_value_type: String
+            EXPRESSION
+              FUNCTION id: 10, function_name: currentDatabase, function_type: ordinary, result_type: String
+          IDENTIFIER id: 11, identifier: foo
+          CONSTANT id: 12, constant_value: \'default\', constant_value_type: String
+          CONSTANT id: 13, constant_value: [HIDDEN], constant_value_type: String
+      SETTINGS connection_wait_timeout=123 connect_timeout=40123002 read_write_timeout=40123001 connection_pool_size=3
+
+SELECT
+    __table1.key AS key,
+    __table1.a AS a,
+    __table1.b AS b,
+    __table1.c AS c
+FROM mysql(\'[::1]:9004\', _CAST(\'default\', \'String\'), foo, \'default\', \'[HIDDEN]\', SETTINGS connection_wait_timeout = 123, connect_timeout = 40123002, read_write_timeout = 40123001, connection_pool_size = 3) AS __table1
+---
+5

--- a/tests/queries/0_stateless/02479_mysql_connect_to_self.sql
+++ b/tests/queries/0_stateless/02479_mysql_connect_to_self.sql
@@ -43,4 +43,38 @@ SELECT '---';
 SELECT count() FROM mysql('127.0.0.1:9004', currentDatabase(), foo, 'default', '', SETTINGS connection_pool_size = 1, connect_timeout = 100, connection_wait_timeout = 100);
 SELECT count() FROM mysql('127.0.0.1:9004', currentDatabase(), foo, 'default', '', SETTINGS connection_pool_size = 0); -- { serverError BAD_ARGUMENTS }
 
+SELECT '---';
+SELECT * FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100) ORDER BY key;
+
+SELECT '---';
+SELECT count() FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100);
+
+SELECT '---';
+SELECT 1 FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100);
+
+SELECT '---';
+SELECT key FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100) ORDER BY key;
+
+SELECT '---';
+SELECT b, a FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100) ORDER BY a;
+
+SELECT '---';
+SELECT b, a FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100) ORDER BY c;
+
+SELECT '---';
+SELECT b FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100) WHERE c != 'twee' ORDER BY b;
+
+SELECT '---';
+SELECT count() FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connect_timeout = 100, connection_wait_timeout = 100) WHERE c != 'twee';
+
+EXPLAIN QUERY TREE dump_ast = 1
+SELECT * FROM mysql(
+    '[::1]:9004', currentDatabase(), foo, 'default', '',
+    SETTINGS connection_wait_timeout = 123, connect_timeout = 40123002, read_write_timeout = 40123001, connection_pool_size = 3
+);
+
+SELECT '---';
+SELECT count() FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connection_pool_size = 1, connect_timeout = 100, connection_wait_timeout = 100);
+SELECT count() FROM mysql('[::1]:9004', currentDatabase(), foo, 'default', '', SETTINGS connection_pool_size = 0); -- { serverError BAD_ARGUMENTS }
+
 DROP TABLE foo;


### PR DESCRIPTION
This affects MySQL and PostgreSQL table functions and engines.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added support for IPv6 addresses in MySQL and PostgreSQL table functions and engines.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
