### PR TITLE
Do not remove parameters for the Gorilla codec

### DIFF
--- a/src/Compression/CompressionCodecGorilla.cpp
+++ b/src/Compression/CompressionCodecGorilla.cpp
@@ -359,7 +359,7 @@ UInt8 getDataBytesSize(const IDataType * column_type)
 CompressionCodecGorilla::CompressionCodecGorilla(UInt8 data_bytes_size_)
     : data_bytes_size(data_bytes_size_)
 {
-    setCodecDescription("Gorilla");
+    setCodecDescription("Gorilla", {std::make_shared<ASTLiteral>(static_cast<UInt64>(data_bytes_size))});
 }
 
 uint8_t CompressionCodecGorilla::getMethodByte() const

--- a/tests/queries/0_stateless/01272_suspicious_codecs.reference
+++ b/tests/queries/0_stateless/01272_suspicious_codecs.reference
@@ -6,9 +6,9 @@ CREATE TABLE default.codecs5\n(\n    `a` UInt8 CODEC(LZ4, ZSTD(1))\n)\nENGINE = 
 CREATE TABLE default.codecs6\n(\n    `a` UInt8 CODEC(Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs7\n(\n    `a` UInt8 CODEC(Delta(1), Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs8\n(\n    `a` UInt8 CODEC(LZ4, Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
-CREATE TABLE default.codecs9\n(\n    `a` UInt8 CODEC(Gorilla)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
-CREATE TABLE default.codecs10\n(\n    `a` FixedString(2) CODEC(Gorilla)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
-CREATE TABLE default.codecs11\n(\n    `a` Decimal(15, 5) CODEC(Gorilla)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs9\n(\n    `a` UInt8 CODEC(Gorilla(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs10\n(\n    `a` FixedString(2) CODEC(Gorilla(2))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs11\n(\n    `a` Decimal(15, 5) CODEC(Gorilla(8))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs1\n(\n    `a` UInt8 CODEC(NONE, NONE)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs2\n(\n    `a` UInt8 CODEC(NONE, LZ4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs3\n(\n    `a` UInt8 CODEC(LZ4, NONE)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
@@ -17,6 +17,6 @@ CREATE TABLE default.codecs5\n(\n    `a` UInt8 CODEC(LZ4, ZSTD(1))\n)\nENGINE = 
 CREATE TABLE default.codecs6\n(\n    `a` UInt8 CODEC(Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs7\n(\n    `a` UInt8 CODEC(Delta(1), Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 CREATE TABLE default.codecs8\n(\n    `a` UInt8 CODEC(LZ4, Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
-CREATE TABLE default.codecs9\n(\n    `a` UInt8 CODEC(Gorilla)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
-CREATE TABLE default.codecs10\n(\n    `a` FixedString(2) CODEC(Gorilla)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
-CREATE TABLE default.codecs11\n(\n    `a` Decimal(15, 5) CODEC(Gorilla)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs9\n(\n    `a` UInt8 CODEC(Gorilla(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs10\n(\n    `a` FixedString(2) CODEC(Gorilla(2))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs11\n(\n    `a` Decimal(15, 5) CODEC(Gorilla(8))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/03364_gorilla_codec_parameters.sql
+++ b/tests/queries/0_stateless/03364_gorilla_codec_parameters.sql
@@ -1,0 +1,9 @@
+SET allow_suspicious_codecs = 1;
+CREATE TABLE 03364_gorilla (c0 String CODEC(Gorilla(1))) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE 03364_delta (c0 String CODEC(Delta(1))) ENGINE = MergeTree() ORDER BY tuple();
+DETACH TABLE 03364_gorilla;
+DETACH TABLE 03364_delta;
+ATTACH TABLE 03364_gorilla;
+ATTACH TABLE 03364_delta;
+DROP TABLE 03364_gorilla;
+DROP TABLE 03364_delta;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parameters for the codec Gorilla will now always be saved in the table metadata in .sql file. This closes: https://github.com/ClickHouse/ClickHouse/issues/70072

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
