### PR TITLE
Fix `02597_column_update_and_replication`

### DIFF
--- a/tests/queries/0_stateless/02597_column_update_and_replication.sql
+++ b/tests/queries/0_stateless/02597_column_update_and_replication.sql
@@ -15,11 +15,7 @@ set mutations_sync=0;
 ALTER TABLE test UPDATE d = d || toString(sleepEachRow(0.3)) where 1;
 
 ALTER TABLE test ADD COLUMN x UInt32 default 0;
-ALTER TABLE test UPDATE x = x + 1 where 1;
-ALTER TABLE test DROP COLUMN x SETTINGS mutations_sync = 2; --{serverError BAD_ARGUMENTS}
-
 ALTER TABLE test UPDATE x = x + 1 where 1 SETTINGS mutations_sync = 2;
-
 ALTER TABLE test DROP COLUMN x SETTINGS mutations_sync = 2;
 
 select * from test format Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The problem explained in the [comment](https://github.com/ClickHouse/ClickHouse/issues/74798#issuecomment-2603053994).

Closes: #74798


#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
