### PR TITLE
keeper: fix LOGICAL_ERROR when the connection had been terminated before establishing

### DIFF
--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -622,8 +622,8 @@ void KeeperTCPHandler::cancelWriteBuffer() noexcept
 {
     if (compressed_out)
         compressed_out->cancel();
-    chassert(out);
-    out->cancel();
+    if (out)
+        out->cancel();
 }
 
 ReadBuffer & KeeperTCPHandler::getReadBuffer()


### PR DESCRIPTION
CI found [1] as you can see what happens here is that before `out` was correctly initialized the exception had been thrown, while destructor expects valid `out`:

    2025.02.08 14:19:28.789420 [ 11 ] {} <Error> ServerErrorHandler: Poco::Exception. Code: 1000, e.code() = 107, Net Exception: Socket is not connected, Stack trace (when copying this message, always include the lines below):

    0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:106: Poco::IOException::IOException(String const&, int) @ 0x00000000394ec891
    1. ./build_docker/./base/poco/Net/src/NetException.cpp:26: Poco::Net::NetException::NetException(String const&, int) @ 0x000000003967a2ae
    2. ./build_docker/./base/poco/Net/src/SocketImpl.cpp:996: Poco::Net::SocketImpl::error(int, String const&) @ 0x000000003969b961
    3. ./build_docker/./base/poco/Net/src/SocketImpl.cpp:915: Poco::Net::SocketImpl::peerAddress() @ 0x00000000396a3744
    4. ./base/poco/Net/include/Poco/Net/Socket.h:596: DB::ReadBufferFromPocoSocketBase::ReadBufferFromPocoSocketBase(Poco::Net::Socket&, unsigned long) @ 0x000000001b49eaef
    5. ./src/IO/ReadBufferFromPocoSocket.h:48: DB::KeeperTCPHandler::runImpl() @ 0x0000000031185482
    6. ./build_docker/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x00000000396b144f
    7. ./build_docker/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x00000000396b1ffe
    8. ./build_docker/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x00000000395c35eb
    9. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x00000000395bd988
    10. asan_thread_start(void*) @ 0x000000000b8b5e77
    11. ? @ 0x00007fa596013ac3
    12. ? @ 0x00007fa5960a4a04 (version 25.2.1.1571) 2025.02.08 14:19:28.789598 [ 11 ] {} <Fatal> : Logical error: 'out'. 2025.02.08 14:19:28.801688 [ 11 ] {} <Fatal> : Stack trace (when copying this message, always include the lines below):

    0. ./build_docker/./src/Common/StackTrace.cpp:381: StackTrace::tryCapture() @ 0x000000001b203297
    1. ./build_docker/./src/Common/Exception.cpp:53: DB::abortOnFailedAssertion(String const&) @ 0x000000001b1895ee
    2. ./build_docker/./src/Server/KeeperTCPHandler.cpp:628: DB::KeeperTCPHandler::~KeeperTCPHandler() @ 0x00000000311975f7
    3. ./build_docker/./src/Server/KeeperTCPHandler.cpp:792: DB::KeeperTCPHandler::~KeeperTCPHandler() @ 0x00000000311977ae
    4. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:66: Poco::Net::TCPServerDispatcher::run() @ 0x00000000396b2032
    5. ./build_docker/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x00000000395c35eb
    6. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x00000000395bd988
    7. asan_thread_start(void*) @ 0x000000000b8b5e77
    8. ? @ 0x00007fa596013ac3
    9. ? @ 0x00007fa5960a4a04

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/75762/3b96cc4dd0d7712b42d02b276cb8575cb01c43f0/integration_tests__asan__old_analyzer__6_6_.html

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
keeper: fix LOGICAL_ERROR when the connection had been terminated before establishing

Fixes: https://github.com/ClickHouse/ClickHouse/pull/74811
Fixes: https://github.com/ClickHouse/ClickHouse/issues/73044