### PR TITLE
Fix `LowCardinality` spelling in docs

### DIFF
--- a/docs/en/engines/table-engines/integrations/azureBlobStorage.md
+++ b/docs/en/engines/table-engines/integrations/azureBlobStorage.md
@@ -53,8 +53,8 @@ SELECT * FROM test_table;
 
 ## Virtual columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/engines/table-engines/integrations/hdfs.md
+++ b/docs/en/engines/table-engines/integrations/hdfs.md
@@ -236,8 +236,8 @@ libhdfs3 support HDFS namenode HA.
 
 ## Virtual Columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/engines/table-engines/integrations/s3.md
+++ b/docs/en/engines/table-engines/integrations/s3.md
@@ -174,11 +174,11 @@ Code: 48. DB::Exception: Received from localhost:9000. DB::Exception: Reading fr
 
 ## Virtual columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
-- `_etag` — ETag of the file. Type: `LowCardinalty(String)`. If the etag is unknown, the value is `NULL`.
+- `_etag` — ETag of the file. Type: `LowCardinality(String)`. If the etag is unknown, the value is `NULL`.
 
 For more information about virtual columns see [here](../../../engines/table-engines/index.md#table_engines-virtual_columns).
 

--- a/docs/en/engines/table-engines/special/file.md
+++ b/docs/en/engines/table-engines/special/file.md
@@ -99,8 +99,8 @@ For partitioning by month, use the `toYYYYMM(date_column)` expression, where `da
 
 ## Virtual Columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/engines/table-engines/special/url.md
+++ b/docs/en/engines/table-engines/special/url.md
@@ -105,8 +105,8 @@ For partitioning by month, use the `toYYYYMM(date_column)` expression, where `da
 
 ## Virtual Columns {#virtual-columns}
 
-- `_path` — Path to the `URL`. Type: `LowCardinalty(String)`.
-- `_file` — Resource name of the `URL`. Type: `LowCardinalty(String)`.
+- `_path` — Path to the `URL`. Type: `LowCardinality(String)`.
+- `_file` — Resource name of the `URL`. Type: `LowCardinality(String)`.
 - `_size` — Size of the resource in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 - `_headers` - HTTP response headers. Type: `Map(LowCardinality(String), LowCardinality(String))`.

--- a/docs/en/sql-reference/table-functions/azureBlobStorage.md
+++ b/docs/en/sql-reference/table-functions/azureBlobStorage.md
@@ -74,8 +74,8 @@ SELECT count(*) FROM azureBlobStorage('DefaultEndpointsProtocol=https;AccountNam
 
 ## Virtual Columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the file size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/sql-reference/table-functions/file.md
+++ b/docs/en/sql-reference/table-functions/file.md
@@ -204,8 +204,8 @@ SELECT count(*) FROM file('big_dir/**/file002', 'CSV', 'name String, value UInt3
 
 ## Virtual Columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the file size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/sql-reference/table-functions/hdfs.md
+++ b/docs/en/sql-reference/table-functions/hdfs.md
@@ -98,8 +98,8 @@ FROM hdfs('hdfs://hdfs1:9000/big_dir/file{0..9}{0..9}{0..9}', 'CSV', 'name Strin
 
 ## Virtual Columns
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`.
-- `_file` — Name of the file. Type: `LowCardinalty(String)`.
+- `_path` — Path to the file. Type: `LowCardinality(String)`.
+- `_file` — Name of the file. Type: `LowCardinality(String)`.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/sql-reference/table-functions/s3.md
+++ b/docs/en/sql-reference/table-functions/s3.md
@@ -299,8 +299,8 @@ While ZIP and TAR archives can be accessed from any supported storage location, 
 
 ## Virtual Columns {#virtual-columns}
 
-- `_path` — Path to the file. Type: `LowCardinalty(String)`. In case of archive, shows path in a format: `"{path_to_archive}::{path_to_file_inside_archive}"`
-- `_file` — Name of the file. Type: `LowCardinalty(String)`. In case of archive shows name of the file inside the archive.
+- `_path` — Path to the file. Type: `LowCardinality(String)`. In case of archive, shows path in a format: `"{path_to_archive}::{path_to_file_inside_archive}"`
+- `_file` — Name of the file. Type: `LowCardinality(String)`. In case of archive shows name of the file inside the archive.
 - `_size` — Size of the file in bytes. Type: `Nullable(UInt64)`. If the file size is unknown, the value is `NULL`. In case of archive shows uncompressed file size of the file inside the archive. 
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 

--- a/docs/en/sql-reference/table-functions/url.md
+++ b/docs/en/sql-reference/table-functions/url.md
@@ -53,8 +53,8 @@ Character `|` inside patterns is used to specify failover addresses. They are it
 
 ## Virtual Columns
 
-- `_path` — Path to the `URL`. Type: `LowCardinalty(String)`.
-- `_file` — Resource name of the `URL`. Type: `LowCardinalty(String)`.
+- `_path` — Path to the `URL`. Type: `LowCardinality(String)`.
+- `_file` — Resource name of the `URL`. Type: `LowCardinality(String)`.
 - `_size` — Size of the resource in bytes. Type: `Nullable(UInt64)`. If the size is unknown, the value is `NULL`.
 - `_time` — Last modified time of the file. Type: `Nullable(DateTime)`. If the time is unknown, the value is `NULL`.
 - `_headers` - HTTP response headers. Type: `Map(LowCardinality(String), LowCardinality(String))`.

--- a/docs/ja/engines/table-engines/integrations/azureBlobStorage.md
+++ b/docs/ja/engines/table-engines/integrations/azureBlobStorage.md
@@ -51,8 +51,8 @@ SELECT * FROM test_table;
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。型: `LowCardinalty(String)`。
-- `_file` — ファイル名。型: `LowCardinalty(String)`。
+- `_path` — ファイルへのパス。型: `LowCardinality(String)`。
+- `_file` — ファイル名。型: `LowCardinality(String)`。
 - `_size` — ファイルのバイト単位でのサイズ。型: `Nullable(UInt64)`。サイズが不明な場合、値は `NULL`。
 - `_time` — ファイルの最終更新日時。型: `Nullable(DateTime)`。日時が不明な場合、値は `NULL`。
 

--- a/docs/ja/engines/table-engines/integrations/hdfs.md
+++ b/docs/ja/engines/table-engines/integrations/hdfs.md
@@ -227,8 +227,8 @@ libhdfs3はHDFS namenode HAをサポートします。
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。型：`LowCardinalty(String)`。
-- `_file` — ファイルの名称。型：`LowCardinalty(String)`。
+- `_path` — ファイルへのパス。型：`LowCardinality(String)`。
+- `_file` — ファイルの名称。型：`LowCardinality(String)`。
 - `_size` — ファイルのバイト単位のサイズ。型：`Nullable(UInt64)`。サイズが不明な場合、値は `NULL` です。
 - `_time` — ファイルの最終修正時刻。型：`Nullable(DateTime)`。時刻が不明な場合、値は `NULL` です。
 

--- a/docs/ja/engines/table-engines/integrations/s3.md
+++ b/docs/ja/engines/table-engines/integrations/s3.md
@@ -167,11 +167,11 @@ Code: 48. DB::Exception: Received from localhost:9000. DB::Exception: Reading fr
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。型: `LowCardinalty(String)`。
-- `_file` — ファイル名。型: `LowCardinalty(String)`。
+- `_path` — ファイルへのパス。型: `LowCardinality(String)`。
+- `_file` — ファイル名。型: `LowCardinality(String)`。
 - `_size` — ファイルのバイト単位のサイズ。型: `Nullable(UInt64)`。サイズが不明な場合、値は `NULL`。
 - `_time` — ファイルの最終変更時間。型: `Nullable(DateTime)`。時間が不明な場合、値は `NULL`。
-- `_etag` — ファイルのETag。型: `LowCardinalty(String)`。ETagが不明な場合、値は `NULL`。
+- `_etag` — ファイルのETag。型: `LowCardinality(String)`。ETagが不明な場合、値は `NULL`。
 
 仮想カラムについての詳細は[こちら](../../../engines/table-engines/index.md#table_engines-virtual_columns)をご覧ください。
 

--- a/docs/ja/engines/table-engines/special/file.md
+++ b/docs/ja/engines/table-engines/special/file.md
@@ -96,8 +96,8 @@ $ echo -e "1,2\n3,4" | clickhouse-local -q "CREATE TABLE table (a Int64, b Int64
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。型: `LowCardinalty(String)`。
-- `_file` — ファイルの名前。型: `LowCardinalty(String)`。
+- `_path` — ファイルへのパス。型: `LowCardinality(String)`。
+- `_file` — ファイルの名前。型: `LowCardinality(String)`。
 - `_size` — ファイルサイズ（バイト）。型: `Nullable(UInt64)`。サイズが不明な場合は値は`NULL`。
 - `_time` — ファイルの最終更新時刻。型: `Nullable(DateTime)`。時刻が不明な場合は値は`NULL`。
 

--- a/docs/ja/engines/table-engines/special/url.md
+++ b/docs/ja/engines/table-engines/special/url.md
@@ -102,8 +102,8 @@ SELECT * FROM url_engine_table
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — `URL`へのパスです。型: `LowCardinalty(String)`。
-- `_file` — `URL`のリソース名です。型: `LowCardinalty(String)`。
+- `_path` — `URL`へのパスです。型: `LowCardinality(String)`。
+- `_file` — `URL`のリソース名です。型: `LowCardinality(String)`。
 - `_size` — リソースのバイト単位のサイズです。型: `Nullable(UInt64)`。サイズが不明な場合、値は`NULL`です。
 - `_time` — ファイルの最終更新時間です。型: `Nullable(DateTime)`。時間が不明な場合、値は`NULL`です。
 - `_headers` - HTTP応答ヘッダーです。型: `Map(LowCardinality(String), LowCardinality(String))`。

--- a/docs/ja/sql-reference/table-functions/azureBlobStorage.md
+++ b/docs/ja/sql-reference/table-functions/azureBlobStorage.md
@@ -69,8 +69,8 @@ SELECT count(*) FROM azureBlobStorage('DefaultEndpointsProtocol=https;AccountNam
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。タイプ: `LowCardinalty(String)`。
-- `_file` — ファイル名。タイプ: `LowCardinalty(String)`。
+- `_path` — ファイルへのパス。タイプ: `LowCardinality(String)`。
+- `_file` — ファイル名。タイプ: `LowCardinality(String)`。
 - `_size` — ファイルのサイズ（バイト単位）。タイプ: `Nullable(UInt64)`。ファイルサイズが不明な場合、値は `NULL` になります。
 - `_time` — ファイルの最終更新時刻。タイプ: `Nullable(DateTime)`。時刻が不明な場合、値は `NULL` になります。
 

--- a/docs/ja/sql-reference/table-functions/file.md
+++ b/docs/ja/sql-reference/table-functions/file.md
@@ -198,8 +198,8 @@ SELECT count(*) FROM file('big_dir/**/file002', 'CSV', 'name String, value UInt3
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。型：`LowCardinalty(String)`。
-- `_file` — ファイル名。型：`LowCardinalty(String)`。
+- `_path` — ファイルへのパス。型：`LowCardinality(String)`。
+- `_file` — ファイル名。型：`LowCardinality(String)`。
 - `_size` — バイト単位のファイルサイズ。型：`Nullable(UInt64)`。ファイルサイズが不明な場合、値は `NULL` になります。
 - `_time` — ファイルの最終更新時刻。型：`Nullable(DateTime)`。時間が不明な場合、値は`NULL`になります。
 

--- a/docs/ja/sql-reference/table-functions/hdfs.md
+++ b/docs/ja/sql-reference/table-functions/hdfs.md
@@ -95,8 +95,8 @@ FROM hdfs('hdfs://hdfs1:9000/big_dir/file{0..9}{0..9}{0..9}', 'CSV', 'name Strin
 
 ## バーチャルカラム
 
-- `_path` — ファイルのパス。タイプ: `LowCardinalty(String)`。
-- `_file` — ファイル名。タイプ: `LowCardinalty(String)`。
+- `_path` — ファイルのパス。タイプ: `LowCardinality(String)`。
+- `_file` — ファイル名。タイプ: `LowCardinality(String)`。
 - `_size` — ファイルのサイズ（バイト単位）。タイプ: `Nullable(UInt64)`。サイズが不明な場合、値は `NULL` です。
 - `_time` — ファイルの最終更新日時。タイプ: `Nullable(DateTime)`。日時が不明な場合、値は `NULL` です。
 

--- a/docs/ja/sql-reference/table-functions/s3.md
+++ b/docs/ja/sql-reference/table-functions/s3.md
@@ -293,8 +293,8 @@ ZIPおよびTARアーカイブはサポートされる任意のストレージ�
 
 ## 仮想カラム {#virtual-columns}
 
-- `_path` — ファイルへのパス。タイプ: `LowCardinalty(String)`。アーカイブの場合、"{path_to_archive}::{path_to_file_inside_archive}"の形式でパスを表示します。
-- `_file` — ファイル名。タイプ: `LowCardinalty(String)`。アーカイブの場合、アーカイブ内ファイルの名前を表示します。
+- `_path` — ファイルへのパス。タイプ: `LowCardinality(String)`。アーカイブの場合、"{path_to_archive}::{path_to_file_inside_archive}"の形式でパスを表示します。
+- `_file` — ファイル名。タイプ: `LowCardinality(String)`。アーカイブの場合、アーカイブ内ファイルの名前を表示します。
 - `_size` — ファイルのサイズ（バイト単位）。タイプ: `Nullable(UInt64)`。ファイルサイズが不明な場合、その値は `NULL` です。アーカイブの場合、アーカイブ内ファイルの非圧縮サイズを示します。
 - `_time` — ファイルの最終変更時刻。タイプ: `Nullable(DateTime)`。時間が不明な場合、その値は `NULL` です。
 

--- a/docs/ja/sql-reference/table-functions/url.md
+++ b/docs/ja/sql-reference/table-functions/url.md
@@ -50,8 +50,8 @@ SELECT * FROM test_table;
 
 ## 仮想カラム
 
-- `_path` — `URL` へのパス。型: `LowCardinalty(String)`。
-- `_file` — `URL` のリソース名。型: `LowCardinalty(String)`。
+- `_path` — `URL` へのパス。型: `LowCardinality(String)`。
+- `_file` — `URL` のリソース名。型: `LowCardinality(String)`。
 - `_size` — リソースのサイズ（バイト単位）。型: `Nullable(UInt64)`。サイズが不明な場合、この値は `NULL` です。
 - `_time` — ファイルの最終変更時間。型: `Nullable(DateTime)`。時間が不明な場合、この値は `NULL` です。
 - `_headers` - HTTP レスポンスヘッダー。型: `Map(LowCardinality(String), LowCardinality(String))`。

--- a/tests/queries/0_stateless/01576_alter_low_cardinality_and_select.sh
+++ b/tests/queries/0_stateless/01576_alter_low_cardinality_and_select.sh
@@ -29,7 +29,7 @@ do
     create_query=$($CLICKHOUSE_CLIENT --query "$show_query")
 done
 
-# checking type is LowCardinalty
+# checking type is LowCardinality
 ${CLICKHOUSE_CLIENT} --query "SHOW CREATE TABLE alter_table"
 
 # checking no mutations happened


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
