### PR TITLE
Docs: add missing settings to docs

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1369,6 +1369,22 @@ A value of `0` means "never". The default value corresponds to 30 days.
 
 Default: `2592000` (30 days).
 
+## database_catalog_drop_error_cooldown_sec
+
+In case of a failed table drop, ClickHouse will wait for this time-out before retrying the operation.
+
+Type: [`UInt64`](../../sql-reference/data-types/int-uint.md)
+
+Default: `0`
+
+## database_catalog_drop_table_concurrency
+
+The size of the threadpool used for dropping tables.
+
+Type: [`UInt64`](../../sql-reference/data-types/int-uint.md)
+
+Default: `0`
+
 ## database_catalog_unused_dir_cleanup_period_sec
 
 Parameter of a task that cleans up garbage from `store/` directory.

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1375,7 +1375,7 @@ In case of a failed table drop, ClickHouse will wait for this time-out before re
 
 Type: [`UInt64`](../../sql-reference/data-types/int-uint.md)
 
-Default: `0`
+Default: `5`
 
 ## database_catalog_drop_table_concurrency
 
@@ -1383,7 +1383,7 @@ The size of the threadpool used for dropping tables.
 
 Type: [`UInt64`](../../sql-reference/data-types/int-uint.md)
 
-Default: `0`
+Default: `16`
 
 ## database_catalog_unused_dir_cleanup_period_sec
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -352,7 +352,7 @@ namespace DB
     A value of `0` means "never". The default value corresponds to 1 day.
     :::
     )", 0) \
-    DECLARE(UInt64, database_catalog_drop_error_cooldown_sec, 5, R"(In case if drop table failed, ClickHouse will wait for this timeout before retrying the operation.)", 0) \
+    DECLARE(UInt64, database_catalog_drop_error_cooldown_sec, 5, R"(In case of a failed table drop, ClickHouse will wait for this time-out before retrying the operation.)", 0) \
     DECLARE(UInt64, database_catalog_drop_table_concurrency, 16, R"(The size of the threadpool used for dropping tables.)", 0) \
     \
     \

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -1535,6 +1535,7 @@ corrmatrix
 corrstable
 cors
 cosineDistance
+cooldown
 countDigits
 countEqual
 countIf


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/3098

- Correct description of `database_catalog_drop_error_cooldown_sec`
- adds missing `database_catalog_drop_error_cooldown_sec` and `database_catalog_drop_table_concurrency` to the docs

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
