### PR TITLE
Docs: Update docs for HTTP sessions to clarify settings are in seconds

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -283,7 +283,9 @@ $ echo 'SELECT number FROM system.numbers LIMIT 10' | curl 'http://localhost:812
 
 For information about other parameters, see the section “SET”.
 
-Similarly, you can use ClickHouse sessions in the HTTP protocol. To do this, you need to add the `session_id` GET parameter to the request. You can use any string as the session ID. By default, the session is terminated after 60 seconds of inactivity. To change this timeout, modify the `default_session_timeout` setting in the server configuration, or add the `session_timeout` GET parameter to the request. To check the session status, use the `session_check=1` parameter. Only one query at a time can be executed within a single session.
+## Using ClickHouse sessions in the HTTP protocol 
+
+You can also use ClickHouse sessions in the HTTP protocol. To do this, you need to add the `session_id` GET parameter to the request. You can use any string as the session ID. By default, the session is terminated after 60 seconds of inactivity. To change this timeout (in seconds), modify the `default_session_timeout` setting in the server configuration, or add the `session_timeout` GET parameter to the request. To check the session status, use the `session_check=1` parameter. Only one query at a time can be executed within a single session.
 
 You can receive information about the progress of a query in `X-ClickHouse-Progress` response headers. To do this, enable [send_progress_in_http_headers](../operations/settings/settings.md#send_progress_in_http_headers). Example of the header sequence:
 


### PR DESCRIPTION
In response to https://github.com/ClickHouse/clickhouse-docs/issues/3099

- Make the information about sessions it's own section so it is easier to find.
- clarify that settings for timeout are in seconds.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
