### PR TITLE
Support inequality join with join_use_nulls

### DIFF
--- a/src/Analyzer/Utils.h
+++ b/src/Analyzer/Utils.h
@@ -7,6 +7,7 @@
 #include <Interpreters/Context_fwd.h>
 
 #include <Analyzer/IQueryTreeNode.h>
+#include <Core/Joins.h>
 
 namespace DB
 {
@@ -159,5 +160,11 @@ QueryTreeNodePtr buildSubqueryToReadColumnsFromTableExpression(const NamesAndTyp
   */
 QueryTreeNodePtr buildSubqueryToReadColumnsFromTableExpression(const QueryTreeNodePtr & table_node, const ContextPtr & context);
 
+
+QueryTreeNodePtr applyJoinUseNullsForColumn(
+    const QueryTreeNodePtr & resolved_identifier,
+    const JoinKind & join_kind,
+    std::optional<JoinTableSide> resolved_side,
+    const ContextPtr & context);
 
 }

--- a/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
+++ b/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
@@ -584,7 +584,8 @@ ColumnPtr HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::buildAdditionalFilter
         if (required_cols.empty())
         {
             Block block;
-            added_columns.additional_filter_expression->execute(block);
+            size_t num_rows = selected_rows.size();
+            added_columns.additional_filter_expression->execute(block, num_rows);
             result_column = block.getByPosition(0).column->cloneResized(selected_rows.size());
             break;
         }

--- a/src/Planner/PlannerJoins.h
+++ b/src/Planner/PlannerJoins.h
@@ -266,4 +266,12 @@ QueryTreeNodePtr getJoinExpressionFromNode(const JoinNode & join_node);
 
 void trySetStorageInTableJoin(const QueryTreeNodePtr & table_expression, std::shared_ptr<TableJoin> & table_join);
 
+/* Convert columns from the outer table to nullable if `join_use_nulls` setting is enabled.
+ * Used for constructing the proper actions DAG for JOIN ON section expressions involving both tables
+ * (with in fact executed after columns are joined and thus nullable).
+ * FIXME: Refactor query analysis, so columns in JOIN ON expression should probably have nullable type.
+ */
+QueryTreeNodePtr applyJoinUseNullsVisitor(const QueryTreeNodePtr & node, const JoinNode & join_node, const ContextPtr & context);
+
+
 }

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -627,14 +627,6 @@ JoinPtr JoinStepLogical::convertToPhysical(JoinActionRef & left_filter, JoinActi
         || join_info.kind == JoinKind::Full;
     if (need_add_nullable && join_settings.join_use_nulls)
     {
-        if (residual_filter_condition)
-        {
-            throw Exception(
-                ErrorCodes::INVALID_JOIN_ON_EXPRESSION,
-                "{} JOIN ON expression '{}' contains column from left and right table, which is not supported with `join_use_nulls`",
-                toString(join_info.kind), residual_filter_condition.column_name);
-        }
-
         auto to_nullable_function = FunctionFactory::instance().get("toNullable", query_context);
         if (join_info.kind == JoinKind::Left || join_info.kind == JoinKind::Full)
             addToNullableActions(expression_actions.right_pre_join_actions, to_nullable_function);

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_2.reference
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_2.reference
@@ -1,290 +1,292 @@
 -- { echoOn }
+
+SET join_use_nulls=1;
 -- inequality operation
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-1	10	alpha	1	5	ALPHA
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
-1	10	alpha	1	5	ALPHA
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 --
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
-1	10	alpha	1	5	ALPHA
-2	15	beta	2	10	beta
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
-0	0		4	25	delta
-1	10	alpha	1	5	ALPHA
-2	15	beta	2	10	beta
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
 --
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
-1	10	alpha	1	5	ALPHA
-2	15	beta	2	10	beta
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
-0	0		4	25	delta
-1	10	alpha	1	5	ALPHA
-2	15	beta	2	10	beta
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
 -- BETWEEN
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-1	10	alpha	0	0	
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
+1	10	alpha	\N	\N	\N
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-1	10	alpha	0	0	
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
+1	10	alpha	\N	\N	\N
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
 2	15	beta	2	10	beta
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-2	15	beta	2	10	beta
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-0	0		1	5	ALPHA
-0	0		4	25	delta
-2	15	beta	2	10	beta
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-0	0		1	5	ALPHA
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
 2	15	beta	2	10	beta
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-0	0		1	5	ALPHA
-0	0		4	25	delta
-1	10	alpha	0	0	
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	1	5	ALPHA
+\N	\N	\N	4	25	delta
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
-0	0		1	5	ALPHA
-0	0		4	25	delta
-1	10	alpha	0	0	
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	1	5	ALPHA
+\N	\N	\N	4	25	delta
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	1	5	ALPHA
+\N	\N	\N	4	25	delta
+1	10	alpha	\N	\N	\N
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	1	5	ALPHA
+\N	\N	\N	4	25	delta
+1	10	alpha	\N	\N	\N
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
 --
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
-1	10	alpha	1	5	ALPHA
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
-1	10	alpha	1	5	ALPHA
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 -- Arbitraty condition containing combination of columns and functions
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-1	10	alpha	1	5	ALPHA
-2	15	beta	2	10	beta
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta
-1	10	alpha	1	5	ALPHA
-2	15	beta	2	10	beta
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
 2	15	beta	2	10	beta
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	2	10	beta
+3	20	gamma	\N	\N	\N
 -- Window functions with stupid condition
 SET join_algorithm='hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	15	3
 2	15	beta	2	10	beta	15	3
-3	20	gamma	0	0		15	3
+3	20	gamma	\N	\N	\N	15	3
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 LEFT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	15	3
 2	15	beta	2	10	beta	15	3
-3	20	gamma	0	0		15	3
+3	20	gamma	\N	\N	\N	15	3
 SET join_algorithm='hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	12.5	3
 2	15	beta	2	10	beta	12.5	3
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 INNER JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	12.5	3
 2	15	beta	2	10	beta	12.5	3
 SET join_algorithm='hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta	8.333333333333334	7
-1	10	alpha	1	5	ALPHA	8.333333333333334	7
-2	15	beta	2	10	beta	8.333333333333334	7
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta	12.5	7
+1	10	alpha	1	5	ALPHA	12.5	7
+2	15	beta	2	10	beta	12.5	7
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta	8.333333333333334	7
-1	10	alpha	1	5	ALPHA	8.333333333333334	7
-2	15	beta	2	10	beta	8.333333333333334	7
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 RIGHT JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta	12.5	7
+1	10	alpha	1	5	ALPHA	12.5	7
+2	15	beta	2	10	beta	12.5	7
 SET join_algorithm='hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta	11.25	7
-1	10	alpha	1	5	ALPHA	11.25	7
-2	15	beta	2	10	beta	11.25	7
-3	20	gamma	0	0		11.25	7
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta	15	7
+1	10	alpha	1	5	ALPHA	15	7
+2	15	beta	2	10	beta	15	7
+3	20	gamma	\N	\N	\N	15	7
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
-0	0		4	25	delta	11.25	7
-1	10	alpha	1	5	ALPHA	11.25	7
-2	15	beta	2	10	beta	11.25	7
-3	20	gamma	0	0		11.25	7
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 FULL JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	4	25	delta	15	7
+1	10	alpha	1	5	ALPHA	15	7
+2	15	beta	2	10	beta	15	7
+3	20	gamma	\N	\N	\N	15	7
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_2.sql.j2
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_2.sql.j2
@@ -20,13 +20,18 @@ INSERT INTO t2 (key, a, attr) VALUES (1, 5, 'ALPHA'), (2, 10, 'beta'), (4, 25, '
 
 SET enable_analyzer=1;
 SET allow_experimental_join_condition=1;
-SET join_use_nulls=0;
+
+{% for join_use_nulls in [1] -%}
+
 -- { echoOn }
+
+SET join_use_nulls={{ join_use_nulls }};
+
 -- inequality operation
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -34,7 +39,7 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.att
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a > t2.key AND t1.key + t2.a > 1 ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -42,7 +47,7 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a > 
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.key < t2.a OR t1.a % 2 = 0) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -50,7 +55,7 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.key
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t2.a BETWEEN 8 AND t1.a) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -58,7 +63,7 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t2.a B
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a IN (SELECT a FROM t2 WHERE a = 10)) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -66,7 +71,7 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a I
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -74,8 +79,10 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key == t2.key AND (t1.a 
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 {{ join_type }} JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL;
+SELECT t1.*, t2.*, AVG(t1.a) OVER () AS avg_b, SUM(t2.key) OVER () AS sum_c FROM t1 {{ join_type }} JOIN t2 ON t1.key == t2.key AND (t1.a * length(t2.attr) / length(t1.attr) <> t2.a + t1.key - t2.key) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
+{% endfor -%}
+
 {% endfor -%}
 
 DROP TABLE IF EXISTS t1;

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_3.reference
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_3.reference
@@ -1,90 +1,91 @@
 -- { echoOn }
 
+SET join_use_nulls=1;
 -- Support for query lower
 SET join_algorithm='hash';
-SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 SET join_algorithm='hash';
-SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 SET join_algorithm='grace_hash';
-SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-1	10	alpha	1	5	ALPHA
-SET join_algorithm='hash';
-SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
-1	10	alpha	1	5	ALPHA
-SET join_algorithm='grace_hash';
-SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA
 SET join_algorithm='hash';
-SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
 SET join_algorithm='grace_hash';
-SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
-0	0		2	10	beta
-0	0		4	25	delta
+SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
 1	10	alpha	1	5	ALPHA
-2	15	beta	0	0	
-3	20	gamma	0	0	
+SET join_algorithm='hash';
+SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	2	10	beta
+\N	\N	\N	4	25	delta
+1	10	alpha	1	5	ALPHA
+2	15	beta	\N	\N	\N
+3	20	gamma	\N	\N	\N
 -- Subquery JOIN
 SET join_algorithm='hash';
-SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) LEFT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
+SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) LEFT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	1	100
-2	15	beta	0	0		0	0
-3	20	gamma	0	0		0	0
+2	15	beta	\N	\N	\N	\N	\N
+3	20	gamma	\N	\N	\N	\N	\N
 SET join_algorithm='grace_hash';
-SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) LEFT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
+SELECT * FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) LEFT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	1	100
-2	15	beta	0	0		0	0
-3	20	gamma	0	0		0	0
+2	15	beta	\N	\N	\N	\N	\N
+3	20	gamma	\N	\N	\N	\N	\N
 SET join_algorithm='hash';
-SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) INNER JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
+SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) INNER JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	1	100
 SET join_algorithm='grace_hash';
-SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) INNER JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
-1	10	alpha	1	5	ALPHA	1	100
-SET join_algorithm='hash';
-SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) RIGHT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
-0	0		0	0		0	10
-0	0		0	0		2	1000
-1	10	alpha	1	5	ALPHA	1	100
-SET join_algorithm='grace_hash';
-SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) RIGHT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
-0	0		0	0		0	10
-0	0		0	0		2	1000
+SELECT * FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) INNER JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
 1	10	alpha	1	5	ALPHA	1	100
 SET join_algorithm='hash';
-SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) FULL JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
-0	0		0	0		0	10
-0	0		0	0		2	1000
-0	0		2	10	beta	0	0
-0	0		4	25	delta	0	0
+SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) RIGHT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	\N	0	10
+\N	\N	\N	\N	\N	\N	2	1000
 1	10	alpha	1	5	ALPHA	1	100
-2	15	beta	0	0		0	0
-3	20	gamma	0	0		0	0
 SET join_algorithm='grace_hash';
-SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) FULL JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
-0	0		0	0		0	10
-0	0		0	0		2	1000
-0	0		2	10	beta	0	0
-0	0		4	25	delta	0	0
+SELECT * FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) RIGHT JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	\N	0	10
+\N	\N	\N	\N	\N	\N	2	1000
 1	10	alpha	1	5	ALPHA	1	100
-2	15	beta	0	0		0	0
-3	20	gamma	0	0		0	0
+SET join_algorithm='hash';
+SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) FULL JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	\N	0	10
+\N	\N	\N	\N	\N	\N	2	1000
+\N	\N	\N	2	10	beta	\N	\N
+\N	\N	\N	4	25	delta	\N	\N
+1	10	alpha	1	5	ALPHA	1	100
+2	15	beta	\N	\N	\N	\N	\N
+3	20	gamma	\N	\N	\N	\N	\N
+SET join_algorithm='grace_hash';
+SELECT * FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) FULL JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	\N	0	10
+\N	\N	\N	\N	\N	\N	2	1000
+\N	\N	\N	2	10	beta	\N	\N
+\N	\N	\N	4	25	delta	\N	\N
+1	10	alpha	1	5	ALPHA	1	100
+2	15	beta	\N	\N	\N	\N	\N
+3	20	gamma	\N	\N	\N	\N	\N
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_3.sql.j2
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_3.sql.j2
@@ -20,14 +20,18 @@ INSERT INTO t2 (key, a, attr) VALUES (1, 5, 'ALPHA'), (2, 10, 'beta'), (4, 25, '
 
 SET enable_analyzer=1;
 SET allow_experimental_join_condition=1;
-SET join_use_nulls=0;
+
+{% for join_use_nulls in [1] -%}
+
 -- { echoOn }
+
+SET join_use_nulls={{ join_use_nulls }};
 
 -- Support for query lower
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT * FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL;
+SELECT * FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -36,9 +40,11 @@ SELECT * FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.a
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT * FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) {{ join_type }} JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL;
+SELECT * FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.attr != t2.attr) {{ join_type }} JOIN (SELECT * FROM VALUES('key UInt64, a UInt64', (0, 10), (1, 100), (2, 1000))) t3 ON t1.key=t3.key AND t2.key=t3.key AND t3.a!=t1.a AND t3.a!=t2.a ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
+{% endfor -%}
+
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_4.reference
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_4.reference
@@ -1,163 +1,164 @@
 -- { echoOn }
 
+SET join_use_nulls=1;
 -- These queries work
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
 2	15	2	10
-3	20	0	0
+3	20	\N	\N
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
 2	15	2	10
-3	20	0	0
+3	20	\N	\N
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 2	15	2	10
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-2	15	2	10
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-2	15	2	10
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 2	15	2	10
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
-2	15	0	0
-3	20	0	0
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
-2	15	0	0
-3	20	0	0
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	2	10
-0	0	4	25
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	2	10
-0	0	4	25
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	2	10
-0	0	4	25
-1	10	0	0
-2	15	0	0
-3	20	0	0
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	2	10
-0	0	4	25
-1	10	0	0
-2	15	0	0
-3	20	0	0
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
 2	15	2	10
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
 2	15	2	10
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
+2	15	\N	\N
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
+2	15	\N	\N
+3	20	\N	\N
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	2	10
+\N	\N	4	25
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	2	10
+\N	\N	4	25
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	2	10
+\N	\N	4	25
+1	10	\N	\N
+2	15	\N	\N
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	2	10
+\N	\N	4	25
+1	10	\N	\N
+2	15	\N	\N
+3	20	\N	\N
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 2	15	2	10
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 2	15	2	10
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-1	10	0	0
-2	15	2	10
-3	20	0	0
-SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
 2	15	2	10
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
 2	15	2	10
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 2	15	2	10
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 2	15	2	10
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-1	10	0	0
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
 2	15	2	10
-3	20	0	0
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
-0	0	1	5
-0	0	4	25
-1	10	0	0
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
 2	15	2	10
-3	20	0	0
+SET join_algorithm='hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N
+SET join_algorithm='grace_hash';
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+\N	\N	1	5
+\N	\N	4	25
+1	10	\N	\N
+2	15	2	10
+3	20	\N	\N

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_4.sql.j2
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_4.sql.j2
@@ -18,27 +18,32 @@ INSERT INTO t2 (key, a) VALUES (1, 5), (2, 10), (4, 25);
 SET enable_analyzer=1;
 SET allow_experimental_join_condition=1;
 SET join_algorithm='hash';
+
+{% for join_use_nulls in [1] -%}
+
 -- { echoOn }
+
+SET join_use_nulls={{ join_use_nulls }};
 
 -- These queries work
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND ((t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 AND (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a = (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -46,6 +51,7 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 10))) ORDER BY ALL NULLS FIRST;
+{% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_fast.reference
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_fast.reference
@@ -1,6 +1,8 @@
 -- { echoOn }
+
+SET join_use_nulls = 1;
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -11,30 +13,30 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
-SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key1	b	2	3	2	key1	C	3	4	5
 key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2			0	0	\N
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
+key1	d	4	7	2	\N	\N	\N	\N	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
 SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
 key1	a	1	1	2	key1	A	1	2	1
@@ -57,11 +59,11 @@ key1	e	5	5	5	key1	A	1	2	1
 key1	e	5	5	5	key1	B	2	1	2
 key1	e	5	5	5	key1	C	3	4	5
 key1	e	5	5	5	key1	D	4	1	6
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -70,9 +72,9 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -84,14 +86,14 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
@@ -123,7 +125,7 @@ key1	e	5	5	5	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -133,8 +135,8 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -146,19 +148,19 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
@@ -167,7 +169,6 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	D	4	1	6
 SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
-		0	0	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -189,10 +190,11 @@ key1	e	5	5	5	key1	B	2	1	2
 key1	e	5	5	5	key1	C	3	4	5
 key1	e	5	5	5	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -202,8 +204,8 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -214,38 +216,37 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
-SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key1	b	2	3	2	key1	C	3	4	5
 key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2			0	0	\N
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
+key1	d	4	7	2	\N	\N	\N	\N	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
 SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
-		0	0	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -266,12 +267,13 @@ key1	e	5	5	5	key1	A	1	2	1
 key1	e	5	5	5	key1	B	2	1	2
 key1	e	5	5	5	key1	C	3	4	5
 key1	e	5	5	5	key1	D	4	1	6
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 FULL JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -280,10 +282,10 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -294,30 +296,30 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
-SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key1	b	2	3	2	key1	C	3	4	5
 key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2			0	0	\N
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
+key1	d	4	7	2	\N	\N	\N	\N	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
 SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
 key1	a	1	1	2	key1	A	1	2	1
@@ -340,11 +342,11 @@ key1	e	5	5	5	key1	A	1	2	1
 key1	e	5	5	5	key1	B	2	1	2
 key1	e	5	5	5	key1	C	3	4	5
 key1	e	5	5	5	key1	D	4	1	6
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -353,9 +355,9 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -367,14 +369,14 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
@@ -406,7 +408,7 @@ key1	e	5	5	5	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -416,8 +418,8 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -429,19 +431,19 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
@@ -450,7 +452,6 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	D	4	1	6
 SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 RIGHT JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
-		0	0	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -472,10 +473,11 @@ key1	e	5	5	5	key1	B	2	1	2
 key1	e	5	5	5	key1	C	3	4	5
 key1	e	5	5	5	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -485,8 +487,8 @@ key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -497,38 +499,37 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
-SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key1	b	2	3	2	key1	C	3	4	5
 key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2			0	0	\N
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
+key1	d	4	7	2	\N	\N	\N	\N	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
 SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 FULL JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
-		0	0	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -549,12 +550,13 @@ key1	e	5	5	5	key1	A	1	2	1
 key1	e	5	5	5	key1	B	2	1	2
 key1	e	5	5	5	key1	C	3	4	5
 key1	e	5	5	5	key1	D	4	1	6
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 FULL JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	C	3	4	5
 key1	b	2	3	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
@@ -563,224 +565,224 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	C	3	4	5
 key1	e	5	5	5	key1	C	3	4	5
-key2	a2	1	1	1			0	0	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
-SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2			0	0	\N
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
+key1	d	4	7	2	\N	\N	\N	\N	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 LEFT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT SEMI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 LEFT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	e	5	5	5	key1		0	0	\N
-key2	a2	1	1	1	key2		0	0	\N
-SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	e	5	5	5	key1		0	0	\N
-key2	a2	1	1	1	key2		0	0	\N
-key4	f	2	3	4	key4		0	0	\N
-SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	d	4	7	2	key1		0	0	\N
-key1	e	5	5	5	key1		0	0	\N
-key2	a2	1	1	1	key2		0	0	\N
-key4	f	2	3	4	key4		0	0	\N
+SELECT t1.*, t2.* FROM t1 LEFT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+key1	e	5	5	5	key1	\N	\N	\N	\N
+key2	a2	1	1	1	key2	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+key1	e	5	5	5	key1	\N	\N	\N	\N
+key2	a2	1	1	1	key2	\N	\N	\N	\N
+key4	f	2	3	4	key4	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+key1	d	4	7	2	key1	\N	\N	\N	\N
+key1	e	5	5	5	key1	\N	\N	\N	\N
+key2	a2	1	1	1	key2	\N	\N	\N	\N
+key4	f	2	3	4	key4	\N	\N	\N	\N
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT ANTI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
-SELECT t1.*, t2.* FROM t1 RIGHT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 RIGHT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT SEMI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT ANTI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 LEFT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
-SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2			0	0	\N
-key1	e	5	5	5			0	0	\N
-key2	a2	1	1	1			0	0	\N
-key4	f	2	3	4			0	0	\N
+key1	d	4	7	2	\N	\N	\N	\N	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
+key2	a2	1	1	1	\N	\N	\N	\N	\N
+key4	f	2	3	4	\N	\N	\N	\N	\N
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 LEFT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 LEFT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT SEMI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 LEFT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	e	5	5	5	key1		0	0	\N
-key2	a2	1	1	1	key2		0	0	\N
-SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	e	5	5	5	key1		0	0	\N
-key2	a2	1	1	1	key2		0	0	\N
-key4	f	2	3	4	key4		0	0	\N
-SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	d	4	7	2	key1		0	0	\N
-key1	e	5	5	5	key1		0	0	\N
-key2	a2	1	1	1	key2		0	0	\N
-key4	f	2	3	4	key4		0	0	\N
+SELECT t1.*, t2.* FROM t1 LEFT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+key1	e	5	5	5	key1	\N	\N	\N	\N
+key2	a2	1	1	1	key2	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+key1	e	5	5	5	key1	\N	\N	\N	\N
+key2	a2	1	1	1	key2	\N	\N	\N	\N
+key4	f	2	3	4	key4	\N	\N	\N	\N
+SELECT t1.*, t2.* from t1 LEFT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+key1	d	4	7	2	key1	\N	\N	\N	\N
+key1	e	5	5	5	key1	\N	\N	\N	\N
+key2	a2	1	1	1	key2	\N	\N	\N	\N
+key4	f	2	3	4	key4	\N	\N	\N	\N
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 LEFT ANTI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
-SELECT t1.*, t2.* FROM t1 RIGHT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 RIGHT SEMI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 RIGHT SEMI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT SEMI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
-SELECT t1.*, t2.* FROM t1 RIGHT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-		0	0	\N	key1	A	1	2	1
-		0	0	\N	key3	a3	1	1	1
-		0	0	\N	key4	F	1	1	1
+SELECT t1.*, t2.* FROM t1 RIGHT ANTI JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
+SELECT t1.*, t2.* from t1 RIGHT ANTI  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
+\N	\N	\N	\N	\N	key1	A	1	2	1
+\N	\N	\N	\N	\N	key3	a3	1	1	1
+\N	\N	\N	\N	\N	key4	F	1	1	1
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 RIGHT ANTI JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 SET join_algorithm='hash';
-SELECT t1.* FROM t1 LEFT ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 LEFT ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2
 key1	b	2	3	2
 key1	c	3	2	1
@@ -788,32 +790,32 @@ key1	d	4	7	2
 key1	e	5	5	5
 key2	a2	1	1	1
 key4	f	2	3	4
-SELECT t1.* FROM t1 LEFT SEMI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 LEFT SEMI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2
 key1	b	2	3	2
 key1	c	3	2	1
 key1	d	4	7	2
 key2	a2	1	1	1
 key4	f	2	3	4
-SELECT t1.* FROM t1 LEFT ANTI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 LEFT ANTI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	e	5	5	5
-SELECT t1.* FROM t1 RIGHT ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 RIGHT ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
-SELECT t1.* FROM t1 RIGHT SEMI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 RIGHT SEMI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
 key1	a	1	1	2
-SELECT t1.* FROM t1 RIGHT ANTI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 RIGHT ANTI JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 LEFT JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -826,29 +828,12 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
+key1	e	5	5	5	\N	\N	\N	\N	\N
 key2	a2	1	1	1	key1	A	1	2	1
 key2	a2	1	1	1	key3	a3	1	1	1
 key2	a2	1	1	1	key4	F	1	1	1
 key4	f	2	3	4	key1	B	2	1	2
-SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-key1	a	1	1	2	key1	A	1	2	1
-key1	a	1	1	2	key1	B	2	1	2
-key1	a	1	1	2	key1	C	3	4	5
-key1	a	1	1	2	key1	D	4	1	6
-key1	a	1	1	2	key3	a3	1	1	1
-key1	a	1	1	2	key4	F	1	1	1
-key1	b	2	3	2	key1	B	2	1	2
-key1	b	2	3	2	key1	C	3	4	5
-key1	b	2	3	2	key1	D	4	1	6
-key1	c	3	2	1	key1	C	3	4	5
-key1	c	3	2	1	key1	D	4	1	6
-key1	d	4	7	2	key1	D	4	1	6
-key2	a2	1	1	1	key1	A	1	2	1
-key2	a2	1	1	1	key3	a3	1	1	1
-key2	a2	1	1	1	key4	F	1	1	1
-key4	f	2	3	4	key1	B	2	1	2
-SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -865,7 +850,7 @@ key2	a2	1	1	1	key1	A	1	2	1
 key2	a2	1	1	1	key3	a3	1	1	1
 key2	a2	1	1	1	key4	F	1	1	1
 key4	f	2	3	4	key1	B	2	1	2
-SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 RIGHT JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
@@ -878,67 +863,84 @@ key1	b	2	3	2	key1	D	4	1	6
 key1	c	3	2	1	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 key1	d	4	7	2	key1	D	4	1	6
-key1	e	5	5	5			0	0	\N
+key2	a2	1	1	1	key1	A	1	2	1
+key2	a2	1	1	1	key3	a3	1	1	1
+key2	a2	1	1	1	key4	F	1	1	1
+key4	f	2	3	4	key1	B	2	1	2
+SELECT t1.*, t2.* FROM t1 FULL JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
+key1	a	1	1	2	key1	A	1	2	1
+key1	a	1	1	2	key1	B	2	1	2
+key1	a	1	1	2	key1	C	3	4	5
+key1	a	1	1	2	key1	D	4	1	6
+key1	a	1	1	2	key3	a3	1	1	1
+key1	a	1	1	2	key4	F	1	1	1
+key1	b	2	3	2	key1	B	2	1	2
+key1	b	2	3	2	key1	C	3	4	5
+key1	b	2	3	2	key1	D	4	1	6
+key1	c	3	2	1	key1	C	3	4	5
+key1	c	3	2	1	key1	D	4	1	6
+key1	d	4	7	2	key1	D	4	1	6
+key1	e	5	5	5	\N	\N	\N	\N	\N
 key2	a2	1	1	1	key1	A	1	2	1
 key2	a2	1	1	1	key3	a3	1	1	1
 key2	a2	1	1	1	key4	F	1	1	1
 key4	f	2	3	4	key1	B	2	1	2
 SET join_algorithm='hash';
-SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
 SET join_algorithm='grace_hash';
-SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
 SET join_algorithm='parallel_hash';
-SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	C	3	4	5
 key1	d	4	7	2	key1	D	4	1	6
 key4	f	2	3	4	key4	F	1	1	1
-SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	A	1	2	1
 key1	b	2	3	2	key1	B	2	1	2
 key1	c	3	2	1	key1	B	2	1	2
 key1	d	4	7	2	key1	D	4	1	6
-SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* from t1 INNER ANY  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2	key1	B	2	1	2
 key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
 SET join_algorithm='hash';
-SELECT t1.* FROM t1 INNER ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 INNER ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 key1	a	1	1	2
 key1	b	2	3	2
 key1	c	3	2	1

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_fast.sql.j2
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_fast.sql.j2
@@ -8,18 +8,22 @@ INSERT INTO t2 VALUES ('key1', 'A', 1, 2, 1), ('key1', 'B', 2, 1, 2), ('key1', '
 
 SET enable_analyzer=1;
 SET allow_experimental_join_condition=1;
-SET join_use_nulls=0;
+
 -- { echoOn }
+
+{% for join_use_nulls in [1] -%}
+SET join_use_nulls = {{ join_use_nulls }};
+
 {% for algorithm in ['hash', 'grace_hash'] -%}
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and t1.c ORDER BY (t1.key, t1.attr, t2.key, t2.attr) SETTINGS query_plan_use_new_logical_join_step = 1, enable_parallel_replicas=0;
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 {{ join_type }} JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL;
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2 OR (t2.a IN (SELECT a FROM t1 WHERE a = 3))) ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -27,9 +31,9 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND (t1.a=2
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['LEFT', 'RIGHT'] -%}
 {% for join_strictness in ['ANY', 'SEMI', 'ANTI'] -%}
-SELECT t1.*, t2.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 {{ join_type }} {{ join_strictness }} JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 {% endfor -%}
 {% endfor -%}
@@ -39,7 +43,7 @@ SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 {{ join_type }} {{ join_stri
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['LEFT', 'RIGHT'] -%}
 {% for join_strictness in ['ANY', 'SEMI', 'ANTI'] -%}
-SELECT t1.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
@@ -47,7 +51,7 @@ SELECT t1.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON t1.key = t2
 {% for algorithm in ['hash'] -%}
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['LEFT', 'INNER', 'RIGHT', 'FULL'] -%}
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
 {% endfor -%}
 {% endfor -%}
 
@@ -55,9 +59,9 @@ SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a < 
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['INNER'] -%}
 {% for join_strictness in ['ANY'] -%}
-SELECT t1.*, t2.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
-SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
+SELECT t1.*, t2.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST;
+SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST;
+SELECT t1.*, t2.* from t1 {{ join_type }} {{ join_strictness }}  JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST;
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 {{ join_type }} {{ join_strictness }} JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 {% endfor -%}
 {% endfor -%}
@@ -67,7 +71,8 @@ SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 {{ join_type }} {{ join_stri
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['INNER'] -%}
 {% for join_strictness in ['ANY'] -%}
-SELECT t1.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
+SELECT t1.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST;
+{% endfor -%}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
@@ -78,16 +83,16 @@ SELECT t1.* FROM t1 {{ join_type }} {{ join_strictness }} JOIN t2 ON t1.key = t2
 {% for algorithm in ['partial_merge', 'full_sorting_merge', 'auto', 'direct'] -%}
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['LEFT', 'RIGHT', 'FULL'] -%}
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr); -- { serverError NOT_IMPLEMENTED }
-SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY (t1.key, t1.attr, t2.key, t2.attr); -- { serverError NOT_IMPLEMENTED }
-SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr); -- { serverError NOT_IMPLEMENTED }
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY ALL NULLS FIRST; -- { serverError NOT_IMPLEMENTED }
+SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.b + t2.b == t1.c + t2.c) ORDER BY ALL NULLS FIRST; -- { serverError NOT_IMPLEMENTED }
+SELECT t1.*, t2.* from t1 {{ join_type }} JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY ALL NULLS FIRST; -- { serverError NOT_IMPLEMENTED }
 {% endfor -%}
 {% endfor -%}
 
 {% for algorithm in ['grace_hash', 'partial_merge', 'full_sorting_merge', 'parallel_hash', 'auto', 'direct'] -%}
 SET join_algorithm='{{ algorithm }}';
 {% for join_type in ['LEFT', 'RIGHT', 'FULL'] -%}
-SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY (t1.key, t1.attr, t2.key, t2.attr); -- { serverError NOT_IMPLEMENTED }
+SELECT t1.*, t2.* FROM t1 {{ join_type }} JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL NULLS FIRST; -- { serverError NOT_IMPLEMENTED }
 {% endfor -%}
 {% endfor -%}
 

--- a/tests/queries/0_stateless/03315_join_use_nulls_scopes.reference
+++ b/tests/queries/0_stateless/03315_join_use_nulls_scopes.reference
@@ -1,0 +1,18 @@
+--- LEFT [0, 1, 0] ---
+0	Int32	Int32	Int32	Int32	Int32	Int32	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Int32	Int32	Int32
+--- LEFT [1, 0, 1] ---
+0	Int32	Int32	Int32	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Int32	Int32	Int32	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)
+--- LEFT [0, 1, 1] ---
+0	Int32	Int32	Int32	Int32	Int32	Int32	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)
+--- RIGHT [0, 1, 0] ---
+0	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Int32	Int32	Int32	Int32	Int32	Int32
+--- RIGHT [1, 0, 1] ---
+0	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Int32	Int32	Int32
+--- RIGHT [0, 1, 1] ---
+0	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Int32	Int32	Int32
+--- FULL [0, 1, 0] ---
+0	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Int32	Int32	Int32
+--- FULL [1, 0, 1] ---
+0	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)
+--- FULL [0, 1, 1] ---
+0	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)	Nullable(Int32)

--- a/tests/queries/0_stateless/03315_join_use_nulls_scopes.sql.j2
+++ b/tests/queries/0_stateless/03315_join_use_nulls_scopes.sql.j2
@@ -1,0 +1,40 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+
+CREATE TABLE t1 (a INT, b INT, c INT) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (a INT, b INT, c INT) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t3 (a INT, b INT, c INT) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t4 (a INT, b INT, c INT) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t5 (a INT, b INT, c INT) ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t1 VALUES (1, 20, 100), (2, 30, 200), (3, 40, 300), (1, 25, 150), (4, 50, 400);
+INSERT INTO t2 VALUES (1, 10, 90), (2, 20, 180), (5, 30, 270), (1, 15, 95);
+INSERT INTO t3 VALUES (1, 5, 80), (1, 15, 85), (2, 25, 175), (6, 35, 265);
+INSERT INTO t4 VALUES (1, 12, 75), (2, 22, 165), (7, 32, 255), (1, 18, 78);
+INSERT INTO t5 VALUES (1, 12, 75), (2, 22, 165), (7, 32, 255), (1, 18, 78);
+
+{% for kind in ['LEFT', 'RIGHT', 'FULL'] -%}
+{% for join_use_nulls in [[0,1,0], [1,0,1], [0,1,1]] -%}
+
+SELECT '--- {{ kind }} {{ join_use_nulls }} ---';
+
+SELECT ignore(* APPLY x -> x + 1), * APPLY toTypeName FROM (
+    SELECT * FROM (
+        SELECT * FROM t1
+        {{ kind }} JOIN t2 ON t1.a = t2.a AND t1.b > t2.b AND t1.c > 1 AND t2.c > 1
+        SETTINGS join_use_nulls = {{ join_use_nulls[0] }}
+    ) t
+    {{ kind }} JOIN t3 ON t3.a = t.a AND t3.b > t.a AND t3.c > 1
+    -- enable when https://github.com/ClickHouse/ClickHouse/issues/75005 is fixed
+    -- {{ kind }} JOIN t5 ON t5.a = t.a AND t5.b > t.a AND t5.c > 1
+    SETTINGS join_use_nulls = {{ join_use_nulls[1] }}
+) tt
+{{ kind }} JOIN t4 ON t4.a = tt.a AND t4.b > tt.t3.a AND t4.c > 1
+ORDER BY rand() LIMIT 1
+SETTINGS join_use_nulls = {{ join_use_nulls[2] }}
+;
+
+{% endfor -%}
+{% endfor -%}


### PR DESCRIPTION
Resolves: #74730

### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Support inequality join with `join_use_nulls`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
