### PR TITLE
Do not make requests to Azure on server restart

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -23,9 +23,9 @@
 #include <Storages/StorageFactory.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Common/parseGlobs.h>
-#include "Databases/LoadingStrictnessLevel.h"
-#include "Storages/ColumnsDescription.h"
-#include "Storages/ObjectStorage/StorageObjectStorageSettings.h"
+#include <Databases/LoadingStrictnessLevel.h>
+#include <Storages/ColumnsDescription.h>
+#include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 
 #include <Poco/Logger.h>
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -8,8 +8,8 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 #include <Storages/prepareReadingFromFormat.h>
 #include <Common/threadPoolCallbackRunner.h>
-#include "Interpreters/ActionsDAG.h"
-#include "Storages/ColumnsDescription.h"
+#include <Interpreters/ActionsDAG.h>
+#include <Storages/ColumnsDescription.h>
 
 #include <memory>
 namespace DB

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -8,8 +8,8 @@
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/StorageFactory.h>
 #include <Poco/Logger.h>
-#include "Common/logger_useful.h"
-#include "Storages/ObjectStorage/StorageObjectStorageSettings.h"
+#include <Databases/LoadingStrictnessLevel.h>
+#include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 
 namespace DB
 {
@@ -63,7 +63,9 @@ createStorageObjectStorage(const StorageFactory::Arguments & args, StorageObject
 
     return std::make_shared<StorageObjectStorage>(
         configuration,
-        configuration->createObjectStorage(context, /* is_readonly */ false),
+        // We only want to perform write actions (e.g. create a container in Azure) when the table is being created,
+        // and we want to avoid it when we load the table after a server restart.
+        configuration->createObjectStorage(context, /* is_readonly */ args.mode != LoadingStrictnessLevel::CREATE),
         args.getContext(),
         args.table_id,
         args.columns,

--- a/tests/integration/test_restart_with_unavailable_azure/__init__.py
+++ b/tests/integration/test_restart_with_unavailable_azure/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_restart_with_unavailable_azure/azure_endpoint/endpoint.py
+++ b/tests/integration/test_restart_with_unavailable_azure/azure_endpoint/endpoint.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from bottle import request, response, route, run
+
+
+@route("/<_bucket>/<_path:path>", ["GET", "POST", "PUT", "DELETE"])
+def server(_bucket, _path):
+    response.status = 403
+    return "Forbidden"
+
+
+@route("/")
+def ping():
+    return "OK"
+
+
+run(host="0.0.0.0", port=8080)

--- a/tests/integration/test_restart_with_unavailable_azure/configs/disable_async_loader.xml
+++ b/tests/integration/test_restart_with_unavailable_azure/configs/disable_async_loader.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <async_load_databases>false</async_load_databases>
+</clickhouse>

--- a/tests/integration/test_restart_with_unavailable_azure/test.py
+++ b/tests/integration/test_restart_with_unavailable_azure/test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import gzip
+import io
+import json
+import logging
+import os
+import random
+import threading
+import time
+
+import pytest
+from azure.storage.blob import BlobServiceClient
+
+import helpers.client
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+from helpers.mock_servers import start_mock_servers
+from helpers.network import PartitionManager
+from helpers.test_tools import exec_query_with_retry
+
+
+RESOLVER_CONTAINER_NAME = "resolver"
+RESOLVER_PORT = 8080
+
+
+def generate_endpoint(port):
+    read_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "./azure_endpoint/endpoint.py",
+    )
+    with open(read_path, "r") as f:
+        content = f.read()
+    write_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "./_gen/endpoint.py",
+    )
+    os.makedirs(os.path.dirname(write_path), exist_ok=True)
+    with open(write_path, "w") as f:
+        f.write(content.format(port=port))
+
+
+def run_endpoint(cluster):
+    logging.info("Starting custom Azure endpoint")
+    script_dir = os.path.join(os.path.dirname(__file__), "_gen")
+    start_mock_servers(
+        cluster, script_dir, [("endpoint.py", RESOLVER_CONTAINER_NAME, RESOLVER_PORT)]
+    )
+    logging.info("Azure endpoint started")
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        port = cluster.azurite_port
+        generate_endpoint(port)
+        cluster.add_instance(
+            "node",
+            with_minio=True,
+            with_azurite=True,
+            stay_alive=True,
+            main_configs=["configs/disable_async_loader.xml"],
+        )
+        cluster.start()
+
+        run_endpoint(cluster)
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_cluster_alive_after_restart(cluster):
+    node = cluster.instances["node"]
+    azurite_port = cluster.azurite_port
+    node.query(
+        f"""
+        CREATE TABLE test_table (a UInt64, b String)
+        ENGINE = AzureBlobStorage('DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite1:{azurite_port}/devstoreaccount1;', 'cont', 'test_table.csv', 'CSV')
+        ORDER BY tuple()
+        """
+    )
+
+    node.stop_clickhouse()
+    node.exec_in_container(["bash", "-c", f"sed -i 's|azurite1:{azurite_port}|{RESOLVER_CONTAINER_NAME}:{RESOLVER_PORT}|g' /var/lib/clickhouse/metadata/default/test_table.sql"])
+    node.start_clickhouse()
+    node.query("DROP TABLE test_table")
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a behavior when the server couldn't startup when there's a table using `AzureBlobStorage`. Tables are loaded without any requests to Azure.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
