### PR TITLE
Run StyleCheck and FastTest in parallel

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -81,7 +81,7 @@ jobs:
     secrets:
       robot_git_token: ${{secrets.ROBOT_CLICKHOUSE_SSH_KEY}}
   FastTest:
-    needs: [RunConfig, BuildDockers, StyleCheck]
+    needs: [RunConfig, BuildDockers]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).jobs_data.jobs_to_do, 'Fast test') }}
     uses: ./.github/workflows/reusable_test.yml
     with:


### PR DESCRIPTION
Run StyleCheck and FastTest in parallel to speed up the CI

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:

<!--
#ci_exclude_stateless
#ci_exclude_stateful
#ci_exclude_integration
#ci_exclude_performance
-->

- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [x] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
