### PR TITLE
Fix: hdfs can fail with sasl security context error because krb5 ticket expired

### DIFF
--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -190,11 +190,8 @@ HDFSFileInfo HDFSObjectStorage::hdfsListDirectoryWrapper(const std::string & pat
     {
         // ignore file not found exception, keep throw other exception,
         // libhdfs3 doesn't have function to get exception type, so use errno.
-        if (ls.file_info == nullptr && errno != ENOENT) // NOLINT
-        {
-            throw Exception(ErrorCodes::ACCESS_DENIED, "Cannot list directory {}: {}",
-                        path, String(hdfsGetLastError()));
-        }
+        throw Exception(ErrorCodes::ACCESS_DENIED, "Cannot list directory {}: {}",
+                    path, String(hdfsGetLastError()));
     }
 
     return ls;

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -168,7 +168,8 @@ ObjectMetadata HDFSObjectStorage::getObjectMetadata(const std::string & path) co
     return metadata;
 }
 
-HDFSFileInfo HDFSObjectStorage::hdfsListDirectoryWrapper(const std::string & path) const {
+HDFSFileInfo HDFSObjectStorage::hdfsListDirectoryWrapper(const std::string & path) const
+{
     HDFSFileInfo ls;
 
     ls.file_info = hdfsListDirectory(hdfs_fs.get(), path.data(), &ls.length);

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -168,21 +168,43 @@ ObjectMetadata HDFSObjectStorage::getObjectMetadata(const std::string & path) co
     return metadata;
 }
 
-void HDFSObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
-{
-    initializeHDFSFS();
-    LOG_TEST(log, "Trying to list files for {}", path);
-
+HDFSFileInfo HDFSObjectStorage::hdfsListDirectoryWrapper(const std::string & path) const {
     HDFSFileInfo ls;
+
     ls.file_info = hdfsListDirectory(hdfs_fs.get(), path.data(), &ls.length);
+    #if USE_KRB5
+    if (ls.file_info == nullptr && errno == EACCES) // NOLINT
+    {
+        // libhdfs3 wraps GSASL_GSSAPI_INIT_SEC_CONTEXT_ERROR into AccessControlException (EACCES),
+        // which means than sasl context is not active by the reason that krb5 ticket is expired.
+        // runKinit will handle KRB5KRB_AP_ERR_TKT_EXPIRED error and reinitialize ticket again
+        // TODO: it would be good to extract exact gsasl error code from libhdfs3,
+        // but it needs libhdfs3 exceptions refactoring
+        hdfs_builder.runKinit(); // krb5 keytab reinitialization
+        ls.file_info = hdfsListDirectory(hdfs_fs.get(), path.data(), &ls.length);
+    }
+    #endif // USE_KRB5
 
     if (ls.file_info == nullptr && errno != ENOENT) // NOLINT
     {
         // ignore file not found exception, keep throw other exception,
         // libhdfs3 doesn't have function to get exception type, so use errno.
-        throw Exception(ErrorCodes::ACCESS_DENIED, "Cannot list directory {}: {}",
+        if (ls.file_info == nullptr && errno != ENOENT) // NOLINT
+        {
+            throw Exception(ErrorCodes::ACCESS_DENIED, "Cannot list directory {}: {}",
                         path, String(hdfsGetLastError()));
+        }
     }
+
+    return ls;
+}
+
+void HDFSObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
+{
+    initializeHDFSFS();
+    LOG_TEST(log, "Trying to list files for {}", path);
+
+    HDFSFileInfo ls = hdfsListDirectoryWrapper(path);
 
     if (!ls.file_info && ls.length > 0)
     {

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
@@ -90,6 +90,7 @@ public:
         const WriteSettings & write_settings,
         std::optional<ObjectAttributes> object_to_attributes = {}) override;
 
+    HDFSFileInfo hdfsListDirectoryWrapper(const std::string & path) const;
     void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
 
     String getObjectsNamespace() const override { return ""; }

--- a/src/Storages/ObjectStorage/HDFS/HDFSCommon.cpp
+++ b/src/Storages/ObjectStorage/HDFS/HDFSCommon.cpp
@@ -101,6 +101,11 @@ void HDFSBuilderWrapper::loadFromConfig(
 #if USE_KRB5
 void HDFSBuilderWrapper::runKinit()
 {
+    if (!need_kinit)
+    {
+        return;
+    }
+
     LOG_DEBUG(getLogger("HDFSClient"), "Running KerberosInit");
     try
     {
@@ -162,10 +167,7 @@ HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::A
     }
 
     #if USE_KRB5
-    if (builder.need_kinit)
-    {
-        builder.runKinit();
-    }
+    builder.runKinit();
     #endif // USE_KRB5
 
     return builder;

--- a/src/Storages/ObjectStorage/HDFS/HDFSCommon.h
+++ b/src/Storages/ObjectStorage/HDFS/HDFSCommon.h
@@ -77,6 +77,10 @@ public:
 
     hdfsBuilder * get() { return hdfs_builder; }
 
+    #if USE_KRB5
+    void runKinit();
+    #endif // USE_KRB5
+
 private:
     void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const String & prefix, bool isUser = false);
 
@@ -90,7 +94,6 @@ private:
     std::vector<std::pair<String, String>> config_stor;
 
     #if USE_KRB5
-    void runKinit();
     String hadoop_kerberos_keytab;
     String hadoop_kerberos_principal;
     String hadoop_security_kerberos_ticket_cache_path;


### PR DESCRIPTION
### Steps to reproduce
1. configure CH with hdfs and kerberos
2. start clickhouse server
3. client: create hdfs table
4. `kinit -l 3m -kt my.keytab my_principal@D`
5. client: `SELECT 1 FROM hdfs_table` => ok
6. wait 3m _without running select on the hdfs_ (it prolongates ticket)
7. client: `SELECT 1 FROM hdfs_table`
- actual:
```
Code: 497. DB::Exception: Received from localhost:9000. DB::Exception: Cannot list directory /warehouse/exporter/stg/closed: AccessControlException: Failed to evaluate challenge: GSSAPI error in client while negotiating security context in gss_init_sec_context() in SASL library.  This is most likely due insufficient credentials or malicious interactions.. (ACCESS_DENIED)
```
- expected:
no error because CH catches the error above, reinitialize krb5 ticket and repeat hdfs request

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
HDFS refresh krb ticket if sasl error during hdfs select request

### Documentation entry for user-facing changes
none

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
