### PR TITLE
Fix queries to Replicated database in startup_scripts

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1,6 +1,7 @@
 #include "Server.h"
 
 #include <memory>
+#include <Interpreters/ClientInfo.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -792,7 +793,7 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
                 auto condition_write_buffer = WriteBufferFromOwnString();
 
                 LOG_DEBUG(log, "Checking startup query condition `{}`", condition);
-
+                startup_context->setQueryKind(ClientInfo::QueryKind::INITIAL_QUERY);
                 executeQuery(condition_read_buffer, condition_write_buffer, true, startup_context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
 
                 auto result = condition_write_buffer.str();
@@ -813,6 +814,7 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
             auto write_buffer = WriteBufferFromOwnString();
 
             LOG_DEBUG(log, "Executing query `{}`", query);
+            startup_context->setQueryKind(ClientInfo::QueryKind::INITIAL_QUERY);
             executeQuery(read_buffer, write_buffer, true, startup_context, callback, QueryFlags{ .internal = true }, std::nullopt, {});
         }
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1083,7 +1083,7 @@ BlockIO DatabaseReplicated::tryEnqueueReplicatedDDL(const ASTPtr & query, Contex
     entry.setSettingsIfRequired(query_context);
     entry.tracing_context = OpenTelemetry::CurrentContext();
     entry.is_backup_restore = flags.distributed_backup_restore;
-    String node_path = ddl_worker->tryEnqueueAndExecuteEntry(entry, query_context);
+    String node_path = ddl_worker->tryEnqueueAndExecuteEntry(entry, query_context, flags.internal);
 
     Strings hosts_to_wait;
     Strings unfiltered_hosts = getZooKeeper()->getChildren(zookeeper_path + "/replicas");

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -307,7 +307,7 @@ String DatabaseReplicatedDDLWorker::enqueueQueryImpl(const ZooKeeperPtr & zookee
     return node_path;
 }
 
-String DatabaseReplicatedDDLWorker::tryEnqueueAndExecuteEntry(DDLLogEntry & entry, ContextPtr query_context)
+String DatabaseReplicatedDDLWorker::tryEnqueueAndExecuteEntry(DDLLogEntry & entry, ContextPtr query_context, bool internal_query)
 {
     /// NOTE Possibly it would be better to execute initial query on the most up-to-date node,
     /// but it requires more complex logic around /try node.
@@ -368,7 +368,7 @@ String DatabaseReplicatedDDLWorker::tryEnqueueAndExecuteEntry(DDLLogEntry & entr
     if (entry.parent_table_uuid.has_value() && !checkParentTableExists(entry.parent_table_uuid.value()))
         throw Exception(ErrorCodes::TABLE_IS_DROPPED, "Parent table doesn't exist");
 
-    processTask(*task, zookeeper);
+    processTask(*task, zookeeper, internal_query);
 
     if (!task->was_executed)
     {

--- a/src/Databases/DatabaseReplicatedWorker.h
+++ b/src/Databases/DatabaseReplicatedWorker.h
@@ -26,7 +26,7 @@ public:
 
     String enqueueQuery(DDLLogEntry & entry, const ZooKeeperRetriesInfo &) override;
 
-    String tryEnqueueAndExecuteEntry(DDLLogEntry & entry, ContextPtr query_context);
+    String tryEnqueueAndExecuteEntry(DDLLogEntry & entry, ContextPtr query_context, bool internal_query);
 
     void shutdown() override;
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -319,7 +319,7 @@ void DDLWorker::scheduleTasks(bool reinitialized)
                 }
                 else
                 {
-                    processTask(*task, zookeeper);
+                    processTask(*task, zookeeper, /*internal_query=*/ false);
                 }
                 ++task_it;
             }
@@ -443,12 +443,12 @@ void DDLWorker::scheduleTasks(bool reinitialized)
             worker_pool->scheduleOrThrowOnError([this, &saved_task, zookeeper]()
             {
                 setThreadName("DDLWorkerExec");
-                processTask(saved_task, zookeeper);
+                processTask(saved_task, zookeeper, /*internal_query=*/ false);
             });
         }
         else
         {
-            processTask(saved_task, zookeeper);
+            processTask(saved_task, zookeeper, /*internal_query=*/ false);
         }
     }
 }
@@ -477,7 +477,7 @@ DDLTaskBase & DDLWorker::saveTask(DDLTaskPtr && task)
     return *current_tasks.back();
 }
 
-bool DDLWorker::tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeeper)
+bool DDLWorker::tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeeper, bool internal)
 {
     /// Add special comment at the start of query to easily identify DDL-produced queries in query_log
     String query_prefix = "/* ddl_entry=" + task.entry_name + " */ ";
@@ -505,7 +505,7 @@ bool DDLWorker::tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeep
             query_scope.emplace(query_context);
 
         NullWriteBuffer nullwb;
-        executeQuery(istr, nullwb, !task.is_initial_query, query_context, {}, QueryFlags{ .internal = false, .distributed_backup_restore = task.entry.is_backup_restore });
+        executeQuery(istr, nullwb, !task.is_initial_query, query_context, {}, QueryFlags{ .internal = internal, .distributed_backup_restore = task.entry.is_backup_restore });
 
         if (auto txn = query_context->getZooKeeperMetadataTransaction())
         {
@@ -571,7 +571,7 @@ void DDLWorker::updateMaxDDLEntryID(const String & entry_name)
     }
 }
 
-void DDLWorker::processTask(DDLTaskBase & task, const ZooKeeperPtr & zookeeper)
+void DDLWorker::processTask(DDLTaskBase & task, const ZooKeeperPtr & zookeeper, bool internal_query)
 {
     LOG_DEBUG(log, "Processing task {} (query: {}, backup restore: {})", task.entry_name, task.query_for_logging, task.entry.is_backup_restore);
     chassert(!task.completely_processed);
@@ -669,7 +669,7 @@ void DDLWorker::processTask(DDLTaskBase & task, const ZooKeeperPtr & zookeeper)
             else
             {
                 storage.reset();
-                tryExecuteQuery(task, zookeeper);
+                tryExecuteQuery(task, zookeeper, internal_query);
             }
         }
         catch (const Coordination::Exception &)
@@ -864,7 +864,7 @@ bool DDLWorker::tryExecuteQueryOnLeaderReplica(
 
             /// If the leader will unexpectedly changed this method will return false
             /// and on the next iteration new leader will take lock
-            if (tryExecuteQuery(task, zookeeper))
+            if (tryExecuteQuery(task, zookeeper, /*internal=*/ false))
             {
                 executed_by_us = true;
                 break;

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -136,7 +136,7 @@ protected:
     /// If dry_run = false, the task will be processed right after this call.
     virtual DDLTaskPtr initAndCheckTask(const String & entry_name, String & out_reason, const ZooKeeperPtr & zookeeper, bool dry_run);
 
-    void processTask(DDLTaskBase & task, const ZooKeeperPtr & zookeeper);
+    void processTask(DDLTaskBase & task, const ZooKeeperPtr & zookeeper, bool internal_query);
     void updateMaxDDLEntryID(const String & entry_name);
 
     /// Check that query should be executed on leader replica only
@@ -154,7 +154,7 @@ protected:
         const ZooKeeperPtr & zookeeper,
         std::unique_ptr<zkutil::ZooKeeperLock> & execute_on_leader_lock);
 
-    bool tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeeper);
+    bool tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeeper, bool internal);
 
     /// Checks and cleanups queue's nodes
     void cleanupQueue(Int64 current_time_seconds, const ZooKeeperPtr & zookeeper);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1441,6 +1441,7 @@ static BlockIO executeQueryImpl(
                 if (auto * create_interpreter = typeid_cast<InterpreterCreateQuery *>(&*interpreter))
                 {
                     create_interpreter->setIsRestoreFromBackup(flags.distributed_backup_restore);
+                    create_interpreter->setInternal(internal);
                 }
 
                 {

--- a/tests/integration/test_startup_scripts/configs/config.d/startup_scripts.xml
+++ b/tests/integration/test_startup_scripts/configs/config.d/startup_scripts.xml
@@ -1,4 +1,15 @@
 <clickhouse>
+    <remote_servers>
+        <test>
+            <shard>
+                <replica>
+                    <host>node</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test>
+    </remote_servers>
+
     <startup_scripts>
         <scripts>
             <query>CREATE ROLE OR REPLACE testrole</query>
@@ -34,6 +45,13 @@
                 LAYOUT(HASHED);
             </query>
             <user>default</user>
+        </scripts>
+
+        <scripts>
+            <query>CREATE DATABASE replicated ON CLUSTER test Engine=Replicated('/clickhouse/databases/replicated', '{shard}', '{replica}')</query>
+        </scripts>
+        <scripts>
+            <query>CREATE TABLE replicated.test_replica (key Int) Engine=ReplicatedMergeTree() ORDER BY ()</query>
         </scripts>
     </startup_scripts>
 </clickhouse>

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -10,7 +10,8 @@ def test_startup_scripts():
             "configs/config.d/query_log.xml",
             "configs/config.d/startup_scripts.xml",
         ],
-        with_zookeeper=False,
+        macros={"replica": "node", "shard": "node"},
+        with_zookeeper=True,
     )
 
     try:
@@ -25,5 +26,7 @@ def test_startup_scripts():
             == "0\t0\n"
         )
 
+        tables = node.query("SHOW TABLES FROM replicated")
+        assert "test_replica" in tables
     finally:
         cluster.shutdown()


### PR DESCRIPTION
Otherwise the following fails:

```xml
    <startup_scripts>
        <scripts>
            <query>CREATE DATABASE IF NOT EXISTS datasets ON CLUSTER test_shard_localhost Engine=Replicated('/clickhouse/databases/datasets', '{shard}', '{replica}')</query>
        </scripts>
        <scripts>
            <query>CREATE TABLE IF NOT EXISTS datasets.x (key Int) Engine=ReplicatedMergeTree() ORDER BY ()</query>
        </scripts>
    </startup_scripts>
```

    2025.01.22 18:31:00.396210 [ 25057 ] {} <Error> Application: Failed to parse startup scripts file: Code: 80. DB::Exception: It's not initial query. ON CLUSTER is not allowed for Replicated database. (INCORRECT_QUERY), Stack trace (when copying this message, always include the lines below):

And then it will fail with:

    2025.01.22 18:34:12.206346 [ 29329 ] {} <Error> executeQuery: Code: 49. DB::Exception: No thread group attached to the thread 29329. (LOGICAL_ERROR) (version 25.1.1.1) (from 0.0.0.0:0) (in query: /* ddl_entry=query-0000000002 */ CREATE TABLE IF NOT EXISTS datasets.x UUID '6a7c259b-9b85-46dc-8a37-3aeb516dea6e' (`key` Int32) ENGINE = ReplicatedMergeTree ORDER BY tuple()), Stack trace (when copying this message, always include the lines below):

Because `internal` query is not passed correctly for `INSERT` and in `DDLWorker` for `Replicated` database.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix queries to Replicated database in startup_scripts