### PR TITLE
Fix fuzzing failure in `AggregateFunctionCombinatorResample` 

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionResample.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionResample.cpp
@@ -47,6 +47,8 @@ public:
     {
         WhichDataType which{arguments.back()};
 
+        chassert(params.size() > 3);
+
         if (which.isNativeUInt() || which.isDate() || which.isDateTime() || which.isDateTime64())
         {
             UInt64 begin = params[params.size() - 3].safeGet<UInt64>();

--- a/src/AggregateFunctions/Combinators/AggregateFunctionResample.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionResample.cpp
@@ -47,7 +47,9 @@ public:
     {
         WhichDataType which{arguments.back()};
 
-        chassert(params.size() > 3);
+        if (params.size() < 3)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Incorrect number of parameters for aggregate function with {} suffix", getName());
 
         if (which.isNativeUInt() || which.isDate() || which.isDateTime() || which.isDateTime64())
         {

--- a/tests/queries/0_stateless/03318_ubsan_resample_arguments_count.sql
+++ b/tests/queries/0_stateless/03318_ubsan_resample_arguments_count.sql
@@ -1,0 +1,1 @@
+SELECT quantileResampleMerge(0.5, 257, 65536, 1)(tuple(*).1) IGNORE NULLS FROM (SELECT quantileResampleState(0.1, 1, 2, 42)(murmurHash3_128(88, NULL), number, number) FROM numbers(100)); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://github.com/ClickHouse/ClickHouse/issues/74964

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
