### PR TITLE
CI: Move tidy back to Builds_2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       stage: Builds_1
       data: ${{ needs.RunConfig.outputs.data }}
   Builds_2:
-    needs: [RunConfig, Builds_1, Builds_0]
+    needs: [RunConfig, StyleCheck, FastTest]
     if: ${{ !failure() && !cancelled() && contains(fromJson(needs.RunConfig.outputs.data).stages_data.stages_to_do, 'Builds_2') }}
     uses: ./.github/workflows/reusable_build_stage.yml
     with:

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -637,7 +637,6 @@ class CI:
             else:
                 stage_type = WorkflowStages.BUILDS_2
             if job_name in (
-                BuildNames.BINARY_TIDY,
                 BuildNames.PACKAGE_RELEASE,
                 BuildNames.PACKAGE_AARCH64,
             ):

--- a/tests/ci/test_ci_config.py
+++ b/tests/ci/test_ci_config.py
@@ -170,7 +170,6 @@ class TestCIConfig(unittest.TestCase):
         for job in CI.JobNames:
             if job in CI.BuildNames:
                 if job in (
-                    CI.BuildNames.BINARY_TIDY,
                     CI.BuildNames.PACKAGE_RELEASE,
                     CI.BuildNames.PACKAGE_AARCH64,
                 ):
@@ -214,7 +213,6 @@ class TestCIConfig(unittest.TestCase):
         for job in CI.JobNames:
             if job in CI.BuildNames:
                 if job in (
-                    CI.BuildNames.BINARY_TIDY,
                     CI.BuildNames.PACKAGE_RELEASE,
                     CI.BuildNames.PACKAGE_AARCH64,
                 ):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Move tidy build back to Builds_2: Having Tidy build in Builds_0 or Builds_1 blocks Tests stages on build failure
- Make all builds stages starting in parallel to not wait too long for tidy results

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
