### PR TITLE
Support "from_zk" attribute in encrypt_decrypt tool

### DIFF
--- a/src/Common/examples/encrypt_decrypt.cpp
+++ b/src/Common/examples/encrypt_decrypt.cpp
@@ -1,13 +1,42 @@
 #include <Common/Config/ConfigProcessor.h>
+#include <Common/EventNotifier.h>
+#include <Common/ZooKeeper/ZooKeeperNodeCache.h>
 #include <Compression/ICompressionCodec.h>
 #include <Compression/CompressionCodecEncrypted.h>
+#include <Poco/Util/XMLConfiguration.h>
 #include <iostream>
 
 /** This program encrypts or decrypts text values using a symmetric encryption codec like AES_128_GCM_SIV or AES_256_GCM_SIV.
-  * Keys for codecs are loaded from <encryption_codecs> section of configuration file.
+  * Keys for codecs are loaded from <encryption_codecs> section of configuration file via value given in config/env/ZooKeeper.
   *
   * How to use:
   *     ./encrypt_decrypt /etc/clickhouse-server/config.xml -e AES_128_GCM_SIV text_to_encrypt
+  *
+  * config.xml example:
+<clickhouse>
+    <encryption_codecs>
+        <aes_128_gcm_siv>
+            <key_hex>530933fba27708642288fecc4ec02c96</key_hex>
+            <!--key_hex from_env="CLICK_KEY"/-->
+            <!--key_hex from_zk="/clickhouse/key128"/-->
+        </aes_128_gcm_siv>
+    </encryption_codecs>
+
+    <zookeeper>
+        <node>
+            <host>localhost</host>
+            <port>2181</port>
+        </node>
+        <node>
+            <host>localhost</host>
+            <port>2182</port>
+        </node>
+        <node>
+            <host>localhost</host>
+            <port>2183</port>
+        </node>
+    </zookeeper>
+</clickhouse>
   */
 
 int main(int argc, char ** argv)
@@ -31,8 +60,25 @@ int main(int argc, char ** argv)
         std::string value = argv[4];
 
         DB::ConfigProcessor processor(argv[1], false, true);
-        auto loaded_config = processor.loadConfig();
-        DB::CompressionCodecEncrypted::Configuration::instance().load(*loaded_config.configuration, "encryption_codecs");
+        bool has_zk_includes;
+        DB::XMLDocumentPtr config_xml = processor.processConfig(&has_zk_includes);
+        if (has_zk_includes)
+        {
+            DB::EventNotifier::init(); // Event notifier is needed for correct ZK work
+
+            DB::ConfigurationPtr bootstrap_configuration(new Poco::Util::XMLConfiguration(config_xml));
+
+            zkutil::validateZooKeeperConfig(*bootstrap_configuration);
+
+            auto zookeeper = zkutil::ZooKeeper::createWithoutKillingPreviousSessions(
+                *bootstrap_configuration, bootstrap_configuration->has("zookeeper") ? "zookeeper" : "keeper");
+
+            zkutil::ZooKeeperNodeCache zk_node_cache([&] { return zookeeper; });
+            config_xml = processor.processConfig(&has_zk_includes, &zk_node_cache);
+        }
+        DB::ConfigurationPtr configuration(new Poco::Util::XMLConfiguration(config_xml));
+
+        DB::CompressionCodecEncrypted::Configuration::instance().load(*configuration, "encryption_codecs");
 
         if (action == "-e")
             std::cout << DB::ConfigProcessor::encryptValue(codec_name, value) << std::endl;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes
Added "from_zk" attribute support to encrypt_decrypt tool.