### PR TITLE
Fetch parts in parallel in ALTER TABLE FETCH PARTITION

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -236,6 +236,7 @@ namespace ServerSetting
     extern const ServerSettingsString mark_cache_policy;
     extern const ServerSettingsUInt64 mark_cache_size;
     extern const ServerSettingsDouble mark_cache_size_ratio;
+    extern const ServerSettingsUInt64 max_fetch_partition_thread_pool_size;
     extern const ServerSettingsUInt64 max_active_parts_loading_thread_pool_size;
     extern const ServerSettingsUInt64 max_backups_io_thread_pool_free_size;
     extern const ServerSettingsUInt64 max_backups_io_thread_pool_size;
@@ -1216,6 +1217,11 @@ try
         server_settings[ServerSetting::max_backups_io_thread_pool_free_size],
         server_settings[ServerSetting::backups_io_thread_pool_queue_size]);
 
+    getFetchPartitionThreadPool().initialize(
+        server_settings[ServerSetting::max_fetch_partition_thread_pool_size],
+        0, // FETCH PARTITION is relatively rare, no need to keep threads
+        server_settings[ServerSetting::max_fetch_partition_thread_pool_size]);
+
     getActivePartsLoadingThreadPool().initialize(
         server_settings[ServerSetting::max_active_parts_loading_thread_pool_size],
         0, // We don't need any threads once all the parts will be loaded
@@ -1931,6 +1937,11 @@ try
                 new_server_settings[ServerSetting::max_backups_io_thread_pool_size],
                 new_server_settings[ServerSetting::max_backups_io_thread_pool_free_size],
                 new_server_settings[ServerSetting::backups_io_thread_pool_queue_size]);
+
+            getFetchPartitionThreadPool().reloadConfiguration(
+                new_server_settings[ServerSetting::max_fetch_partition_thread_pool_size],
+                0, // FETCH PARTITION is relatively rare, no need to keep threads
+                new_server_settings[ServerSetting::max_fetch_partition_thread_pool_size]);
 
             getActivePartsLoadingThreadPool().reloadConfiguration(
                 new_server_settings[ServerSetting::max_active_parts_loading_thread_pool_size],

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -209,6 +209,9 @@
     M(DiskPlainRewritableS3FileCount, "Number of file entries in the 'plain_rewritable' in-memory map for S3ObjectStorage.") \
     M(DiskPlainRewritableS3UniqueFileNamesCount, "Number of unique file name entries in the 'plain_rewritable' in-memory map for S3ObjectStorage.") \
     \
+    M(MergeTreeFetchPartitionThreads, "Number of threads for ALTER TABLE FETCH PARTITION") \
+    M(MergeTreeFetchPartitionThreadsActive, "Number of threads for ALTER TABLE FETCH PARTITION fetching part") \
+    M(MergeTreeFetchPartitionThreadsScheduled, "Number of queued or active part fetches in ALTER TABLE FETCH PARTITION") \
     M(MergeTreePartsLoaderThreads, "Number of threads in the MergeTree parts loader thread pool.") \
     M(MergeTreePartsLoaderThreadsActive, "Number of threads in the MergeTree parts loader thread pool running a task.") \
     M(MergeTreePartsLoaderThreadsScheduled, "Number of queued or active jobs in the MergeTree parts loader thread pool.") \

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -91,6 +91,7 @@ namespace DB
     A value of `0` means unlimited.
     :::
     )", 0) \
+    DECLARE(UInt64, max_fetch_partition_thread_pool_size, 64, R"(The number of threads for ALTER TABLE FETCH PARTITION.)", 0) \
     DECLARE(UInt64, max_active_parts_loading_thread_pool_size, 64, R"(The number of threads to load active set of data parts (Active ones) at startup.)", 0) \
     DECLARE(UInt64, max_outdated_parts_loading_thread_pool_size, 32, R"(The number of threads to load inactive set of data parts (Outdated ones) at startup.)", 0) \
     DECLARE(UInt64, max_unexpected_parts_loading_thread_pool_size, 8, R"(The number of threads to load inactive set of data parts (Unexpected ones) at startup.)", 0) \

--- a/src/IO/SharedThreadPools.cpp
+++ b/src/IO/SharedThreadPools.cpp
@@ -11,6 +11,9 @@ namespace CurrentMetrics
     extern const Metric BackupsIOThreads;
     extern const Metric BackupsIOThreadsActive;
     extern const Metric BackupsIOThreadsScheduled;
+    extern const Metric MergeTreeFetchPartitionThreads;
+    extern const Metric MergeTreeFetchPartitionThreadsActive;
+    extern const Metric MergeTreeFetchPartitionThreadsScheduled;
     extern const Metric MergeTreePartsLoaderThreads;
     extern const Metric MergeTreePartsLoaderThreadsActive;
     extern const Metric MergeTreePartsLoaderThreadsScheduled;
@@ -139,6 +142,12 @@ StaticThreadPool & getIOThreadPool()
 StaticThreadPool & getBackupsIOThreadPool()
 {
     static StaticThreadPool instance("BackupsIOThreadPool", CurrentMetrics::BackupsIOThreads, CurrentMetrics::BackupsIOThreadsActive, CurrentMetrics::BackupsIOThreadsScheduled);
+    return instance;
+}
+
+StaticThreadPool & getFetchPartitionThreadPool()
+{
+    static StaticThreadPool instance("MergeTreeFetchPartitionThreadPool", CurrentMetrics::MergeTreeFetchPartitionThreads, CurrentMetrics::MergeTreeFetchPartitionThreadsActive, CurrentMetrics::MergeTreeFetchPartitionThreadsScheduled);
     return instance;
 }
 

--- a/src/IO/SharedThreadPools.h
+++ b/src/IO/SharedThreadPools.h
@@ -52,6 +52,9 @@ StaticThreadPool & getIOThreadPool();
 /// ThreadPool used for the Backup IO.
 StaticThreadPool & getBackupsIOThreadPool();
 
+/// ThreadPool used for FETCH PARTITION
+StaticThreadPool & getFetchPartitionThreadPool();
+
 /// ThreadPool used for the loading of Outdated data parts for MergeTree tables.
 StaticThreadPool & getActivePartsLoadingThreadPool();
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1,6 +1,7 @@
 #include <Core/Defines.h>
 
 #include <atomic>
+#include <mutex>
 #include <ranges>
 #include <chrono>
 
@@ -121,7 +122,6 @@
 #include <filesystem>
 #include <iterator>
 #include <numeric>
-#include <thread>
 #include <future>
 
 
@@ -7703,6 +7703,8 @@ void StorageReplicatedMergeTree::fetchPartition(
       * In this case, update the information about the available parts and try again.
       */
 
+    Stopwatch watch;
+
     unsigned try_no = 0;
     Strings missing_parts;
     do
@@ -7751,29 +7753,49 @@ void StorageReplicatedMergeTree::fetchPartition(
         LOG_INFO(log, "Parts to fetch: {}", parts_to_fetch.size());
 
         missing_parts.clear();
+
+        ThreadPoolCallbackRunnerLocal<void> fetch_partition_runner(getFetchPartitionThreadPool().get(), "FETCH PARTITION");
+        std::mutex missing_parts_mutex;
         for (const String & part : parts_to_fetch)
         {
-            bool fetched = false;
-
-            try
+            fetch_partition_runner([&]()
             {
-                fetched = fetchPart(part, metadata_snapshot, from_zookeeper_name, best_replica_path, true, 0, zookeeper, /* try_fetch_shared = */ false);
-            }
-            catch (const DB::Exception & e)
-            {
-                if (e.code() != ErrorCodes::RECEIVED_ERROR_FROM_REMOTE_IO_SERVER && e.code() != ErrorCodes::RECEIVED_ERROR_TOO_MANY_REQUESTS
-                    && e.code() != ErrorCodes::CANNOT_READ_ALL_DATA)
-                    throw;
+                bool fetched = false;
 
-                LOG_INFO(log, getExceptionMessageAndPattern(e, /* with_stacktrace */ false));
-            }
+                try
+                {
+                    fetched = fetchPart(
+                        part,
+                        metadata_snapshot,
+                        from_zookeeper_name,
+                        best_replica_path,
+                        /*to_detached=*/ true,
+                        /*quorum=*/ 0,
+                        zookeeper,
+                        /*try_fetch_shared=*/ false);
+                }
+                catch (const DB::Exception & e)
+                {
+                    if (e.code() != ErrorCodes::RECEIVED_ERROR_FROM_REMOTE_IO_SERVER && e.code() != ErrorCodes::RECEIVED_ERROR_TOO_MANY_REQUESTS
+                        && e.code() != ErrorCodes::CANNOT_READ_ALL_DATA)
+                        throw;
 
-            if (!fetched)
-                missing_parts.push_back(part);
+                    LOG_INFO(log, getExceptionMessageAndPattern(e, /* with_stacktrace */ false));
+                }
+
+                if (!fetched)
+                {
+                    std::lock_guard lock(missing_parts_mutex);
+                    missing_parts.push_back(part);
+                }
+            });
         }
+        fetch_partition_runner.waitForAllToFinishAndRethrowFirstError();
 
         ++try_no;
     } while (!missing_parts.empty());
+
+    LOG_TRACE(log, "Fetch took {} sec. ({} tries)", watch.elapsedSeconds(), try_no);
 }
 
 

--- a/tests/queries/0_stateless/03350_alter_table_fetch_partition_thread_pool.reference
+++ b/tests/queries/0_stateless/03350_alter_table_fetch_partition_thread_pool.reference
@@ -1,0 +1,3 @@
+parts in data1	100
+detached parts in data2	100
+FETCH PARTITION uses multiple threads	1

--- a/tests/queries/0_stateless/03350_alter_table_fetch_partition_thread_pool.sql
+++ b/tests/queries/0_stateless/03350_alter_table_fetch_partition_thread_pool.sql
@@ -1,0 +1,19 @@
+-- Tags: no-parallel, no-replicated-database, no-shared-merge-tree
+-- Tag: no-parallel - to avoid polluting FETCH PARTITION thread pool with other fetches
+-- Tag: no-database-replicated - replica_path is different
+
+drop table if exists data1;
+drop table if exists data2;
+
+create table data1 (key Int) engine=ReplicatedMergeTree('/tables/{database}/{table}', 'r1') order by ();
+create table data2 (key Int) engine=ReplicatedMergeTree('/tables/{database}/{table}', 'r1') order by ();
+
+system stop merges data1;
+insert into data1 select * from numbers(100) settings max_block_size=1, min_insert_block_size_rows=1;
+select 'parts in data1', count() from system.parts where database = currentDatabase() and table = 'data1';
+
+alter table data2 fetch partition () from '/tables/{database}/data1';
+select 'detached parts in data2', count() from system.detached_parts where database = currentDatabase() and table = 'data2';
+
+system flush logs;
+select 'FETCH PARTITION uses multiple threads', peak_threads_usage>10 from system.query_log where event_date >= yesterday() and type != 'QueryStart' and query_kind = 'Alter' and current_database = currentDatabase();


### PR DESCRIPTION
FETCH PARTITION can be used to migrate data from an old cluster (to avoid extra decompress-compress cycles for INSERT/SELECT), but the problem with it is that it is single-threaded, which makes it way more slower then INSERT SELECT.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fetch parts in parallel in ALTER TABLE FETCH PARTITION (thread pool size is controlled with `max_fetch_partition_thread_pool_size`)