### PR TITLE
Docs: fix `distributed_ddl` menu-item pointing to the same page in two places issue

### DIFF
--- a/docs/en/sql-reference/distributed-ddl.md
+++ b/docs/en/sql-reference/distributed-ddl.md
@@ -2,9 +2,8 @@
 slug: /en/sql-reference/distributed-ddl
 sidebar_position: 3
 sidebar_label: Distributed DDL
+title: Distributed DDL Queries (ON CLUSTER Clause)
 ---
-
-# Distributed DDL Queries (ON CLUSTER Clause)
 
 By default, the `CREATE`, `DROP`, `ALTER`, and `RENAME` queries affect only the current server where they are executed. In a cluster setup, it is possible to run such queries in a distributed manner with the `ON CLUSTER` clause.
 

--- a/docs/en/sql-reference/operators/distributed-ddl.md
+++ b/docs/en/sql-reference/operators/distributed-ddl.md
@@ -1,0 +1,9 @@
+---
+title: Distributed DDL Queries (ON CLUSTER Clause)
+slug: en/sql-reference/other/distributed-ddl
+description: Page for Distributed DDL
+---
+
+import Content from '@site/docs/en/sql-reference/distributed-ddl.md';
+
+<Content/>

--- a/docs/en/sql-reference/operators/distributed-ddl.md
+++ b/docs/en/sql-reference/operators/distributed-ddl.md
@@ -2,6 +2,7 @@
 title: Distributed DDL Queries (ON CLUSTER Clause)
 slug: en/sql-reference/other/distributed-ddl
 description: Page for Distributed DDL
+sidebar_label: Distributed DDL
 ---
 
 import Content from '@site/docs/en/sql-reference/distributed-ddl.md';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

We have the page `Distributed DDL` both on SQL reference and on Server Management pages so docusaurus doesn't know which one to assign the sidebar to from the context. As a result the sidebar changes to ServerManagement one if you click on this page from SQL Reference.

- duplicates the page for SQL Reference and imports the content from the source.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_stateful--> Only: Stateful tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
