### PR TITLE
Implement groupUniqArrayArrayMap as SimpleAggregateFunction

### DIFF
--- a/docs/en/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/en/sql-reference/data-types/simpleaggregatefunction.md
@@ -24,12 +24,13 @@ The following aggregate functions are supported:
 - [`groupBitXor`](../../sql-reference/aggregate-functions/reference/groupbitxor.md#groupbitxor)
 - [`groupArrayArray`](../../sql-reference/aggregate-functions/reference/grouparray.md#agg_function-grouparray)
 - [`groupUniqArrayArray`](../../sql-reference/aggregate-functions/reference/groupuniqarray.md)
+- [`groupUniqArrayArrayMap`](../../sql-reference/aggregate-functions/combinators#-map)
 - [`sumMap`](../../sql-reference/aggregate-functions/reference/summap.md#agg_functions-summap)
 - [`minMap`](../../sql-reference/aggregate-functions/reference/minmap.md#agg_functions-minmap)
 - [`maxMap`](../../sql-reference/aggregate-functions/reference/maxmap.md#agg_functions-maxmap)
 
 
-:::note    
+:::note
 Values of the `SimpleAggregateFunction(func, Type)` look and stored the same way as `Type`, so you do not need to apply functions with `-Merge`/`-State` suffixes.
 
 `SimpleAggregateFunction` has better performance than `AggregateFunction` with same aggregation function.

--- a/docs/ja/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/ja/sql-reference/data-types/simpleaggregatefunction.md
@@ -23,6 +23,7 @@ sidebar_label: SimpleAggregateFunction
 - [`groupBitXor`](../../sql-reference/aggregate-functions/reference/groupbitxor.md#groupbitxor)
 - [`groupArrayArray`](../../sql-reference/aggregate-functions/reference/grouparray.md#agg_function-grouparray)
 - [`groupUniqArrayArray`](../../sql-reference/aggregate-functions/reference/groupuniqarray.md)
+- [`groupUniqArrayArrayMap`](../../sql-reference/aggregate-functions/combinators#-map)
 - [`sumMap`](../../sql-reference/aggregate-functions/reference/summap.md#agg_functions-summap)
 - [`minMap`](../../sql-reference/aggregate-functions/reference/minmap.md#agg_functions-minmap)
 - [`maxMap`](../../sql-reference/aggregate-functions/reference/maxmap.md#agg_functions-maxmap)

--- a/docs/ru/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/ru/sql-reference/data-types/simpleaggregatefunction.md
@@ -21,6 +21,7 @@ slug: /ru/sql-reference/data-types/simpleaggregatefunction
 -   [`groupBitXor`](../../sql-reference/aggregate-functions/reference/groupbitxor.md#groupbitxor)
 -   [`groupArrayArray`](../../sql-reference/aggregate-functions/reference/grouparray.md#agg_function-grouparray)
 -   [`groupUniqArrayArray`](../../sql-reference/aggregate-functions/reference/groupuniqarray.md)
+-   [`groupUniqArrayArrayMap`](../../sql-reference/aggregate-functions/combinators#-map)
 -   [`sumMap`](../../sql-reference/aggregate-functions/reference/summap.md#agg_functions-summap)
 -   [`minMap`](../../sql-reference/aggregate-functions/reference/minmap.md#agg_functions-minmap)
 -   [`maxMap`](../../sql-reference/aggregate-functions/reference/maxmap.md#agg_functions-maxmap)

--- a/docs/zh/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/zh/sql-reference/data-types/simpleaggregatefunction.md
@@ -18,6 +18,7 @@ slug: /zh/sql-reference/data-types/simpleaggregatefunction
 -   [`groupBitXor`](../../sql-reference/aggregate-functions/reference/groupbitxor.md#groupbitxor)
 -   [`groupArrayArray`](../../sql-reference/aggregate-functions/reference/grouparray.md#agg_function-grouparray)
 -   [`groupUniqArrayArray`](../../sql-reference/aggregate-functions/reference/groupuniqarray.md)
+-   [`groupUniqArrayArrayMap`](../../sql-reference/aggregate-functions/combinators#-map)
 -   [`sumMap`](../../sql-reference/aggregate-functions/reference/summap.md#agg_functions-summap)
 -   [`minMap`](../../sql-reference/aggregate-functions/reference/minmap.md#agg_functions-minmap)
 -   [`maxMap`](../../sql-reference/aggregate-functions/reference/maxmap.md#agg_functions-maxmap)

--- a/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
@@ -47,6 +47,7 @@ void DataTypeCustomSimpleAggregateFunction::checkSupportedFunctions(const Aggreg
         "groupArrayArray",
         "groupArrayLastArray",
         "groupUniqArrayArray",
+        "groupUniqArrayArrayMap",
         "sumMappedArrays",
         "minMappedArrays",
         "maxMappedArrays",

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.reference
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.reference
@@ -39,7 +39,7 @@ SimpleAggregateFunction(sum, Float64)
 7	14
 8	16
 9	18
-1	1	2	2.2.2.2	3	([1,2,3],[2,1,1])	([1,2,3],[1,1,2])	([1,2,3],[2,1,2])	[1,2,2,3,4]	[4,2,1,3]
-10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5	([2,3,4],[2,1,1])	([2,3,4],[3,3,4])	([2,3,4],[4,3,4])	[]	[]
-SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
+1	1	2	2.2.2.2	3	([1,2,3],[2,1,1])	([1,2,3],[1,1,2])	([1,2,3],[2,1,2])	[1,2,2,3,4]	[4,2,1,3]	{1:[2,1,3],2:[6,5,4]}
+10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5	([2,3,4],[2,1,1])	([2,3,4],[3,3,4])	([2,3,4],[4,3,4])	[]	[]	{}
+SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))
 with_overflow	1	0

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.sql
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.sql
@@ -31,16 +31,17 @@ create table simple (
     tup_min SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64))),
     tup_max SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64))),
     arr SimpleAggregateFunction(groupArrayArray, Array(Int32)),
-    uniq_arr SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
+    uniq_arr SimpleAggregateFunction(groupUniqArrayArray, Array(Int32)),
+    map_uniq_arr SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))
 ) engine=AggregatingMergeTree order by id;
-insert into simple values(1,'1','1','1.1.1.1', 1, ([1,2], [1,1]), ([1,2], [1,1]), ([1,2], [1,1]), [1,2], [1,2]);
-insert into simple values(1,null,'2','2.2.2.2', 2, ([1,3], [1,1]), ([1,3], [2,2]), ([1,3], [2,2]), [2,3,4], [2,3,4]);
+insert into simple values(1,'1','1','1.1.1.1', 1, ([1,2], [1,1]), ([1,2], [1,1]), ([1,2], [1,1]), [1,2], [1,2], {1: [1,2], 2: [5,6]});
+insert into simple values(1,null,'2','2.2.2.2', 2, ([1,3], [1,1]), ([1,3], [2,2]), ([1,3], [2,2]), [2,3,4], [2,3,4], {1: [2,3], 2: [4,5,6]});
 -- String longer then MAX_SMALL_STRING_SIZE (actual string length is 100)
-insert into simple values(10,'10','10','10.10.10.10', 4, ([2,3], [1,1]), ([2,3], [3,3]), ([2,3], [3,3]), [], []);
-insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20', 1, ([2, 4], [1,1]), ([2, 4], [4,4]), ([2, 4], [4,4]), [], []);
+insert into simple values(10,'10','10','10.10.10.10', 4, ([2,3], [1,1]), ([2,3], [3,3]), ([2,3], [3,3]), [], [], {});
+insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20', 1, ([2, 4], [1,1]), ([2, 4], [4,4]), ([2, 4], [4,4]), [], [], {});
 
 select * from simple final order by id;
-select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(tup_min), toTypeName(tup_max), toTypeName(arr), toTypeName(uniq_arr) from simple limit 1;
+select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(tup_min), toTypeName(tup_max), toTypeName(arr), toTypeName(uniq_arr), toTypeName(map_uniq_arr) from simple limit 1;
 
 optimize table simple final;
 


### PR DESCRIPTION
Implementation for https://github.com/ClickHouse/ClickHouse/issues/74847

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for `groupUniqArrayArrayMap` as `SimpleAggregateFunction`

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [x] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache


