### PR TITLE
Fix `03319_http_exception_formatting_during_interpretation`

### DIFF
--- a/tests/queries/0_stateless/03319_http_exception_formatting_during_interpretation.sh
+++ b/tests/queries/0_stateless/03319_http_exception_formatting_during_interpretation.sh
@@ -5,4 +5,4 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-${CLICKHOUSE_CURL} -v -sS "${CLICKHOUSE_URL}" -d "SELECT * FROM nonexistent.nonexistent FORMAT JSONLines" 2>&1 | grep -P 'X-ClickHouse-Format: |X-ClickHouse-Exception-Code: |"exception": |< HTTP/1\.1 ' | sed -r -e 's/\(version [^)]+\)//'
+${CLICKHOUSE_CURL} -v -sS "${CLICKHOUSE_URL}" -d "SELECT * FROM nonexistent.nonexistent FORMAT JSONLines" 2>&1 | grep -P 'X-ClickHouse-Format: |X-ClickHouse-Exception-Code: |"exception": |< HTTP/1\.1 ' | sed -r -e 's/\(version .+\)//'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The problem was that builds in master have version with `(official build)` at end
`version 25.2.1.103 (official build)`

cc @alexey-milovidov 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
