### PR TITLE
ci: fix "can't subtract offset-naive and offset-aware datetimes"

### DIFF
--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -485,7 +485,7 @@ class JobReport:
             start_time = datetime.datetime.strptime(
                 self.start_time, "%Y-%m-%d %H:%M:%S"
             )
-            current_time = datetime.datetime.now(datetime.timezone.utc)
+            current_time = datetime.datetime.now()
             self.duration = (current_time - start_time).total_seconds()
 
     def __post_init__(self):


### PR DESCRIPTION
Sometimes CI reports [1]:

    ERROR: Job was killed - generate evidence
    Traceback (most recent call last):
      File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/ci.py", line 1415, in <module>
        sys.exit(main())
      File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/ci.py", line 1319, in main
        job_report.update_duration()
      File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/report.py", line 489, in update_duration
        self.duration = (current_time - start_time).total_seconds()
    TypeError: can't subtract offset-naive and offset-aware datetimes

  [1]: https://github.com/ClickHouse/ClickHouse/actions/runs/12989260764/job/36223462582?pr=74765

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @maxknv 