### PR TITLE
Exclude `00157_cache_dictionary` from msan

### DIFF
--- a/tests/queries/0_stateless/00157_cache_dictionary.sql
+++ b/tests/queries/0_stateless/00157_cache_dictionary.sql
@@ -1,4 +1,4 @@
--- Tags: stateful, no-tsan, no-parallel
+-- Tags: stateful, no-tsan, no-msan, no-parallel
 
 DROP TABLE IF EXISTS test.hits_1m;
 

--- a/tests/queries/0_stateless/00157_cache_dictionary.sql
+++ b/tests/queries/0_stateless/00157_cache_dictionary.sql
@@ -1,4 +1,4 @@
--- Tags: stateful, no-tsan, no-msan, no-parallel
+-- Tags: stateful, no-tsan, no-msan, no-asan, no-parallel
 
 DROP TABLE IF EXISTS test.hits_1m;
 


### PR DESCRIPTION
Runs into timeouts from time to time:

https://play.clickhouse.com/play?user=play#U0VMRUNUIHB1bGxfcmVxdWVzdF9udW1iZXIgYXMgcHIsIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgMQogICAgLS0gQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJywgJ0JST0tFTicpCiAgICBBTkQgdG9EYXRlKGNoZWNrX3N0YXJ0X3RpbWUpID4gJzIwMjUtMDEtMDEnCiAgICBBTkQgdGVzdF9uYW1lIGxpa2UgJyUwMDE1N19jYWNoZV9kaWN0aW9uYXJ5JScKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBERVND

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)