### PR TITLE
Fix usage of indexes with enabled `optimize_function_to_subcolumns`

### DIFF
--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -386,6 +386,9 @@ private:
     void enterImpl(const TableNode & table_node)
     {
         auto table_name = table_node.getStorage()->getStorageID().getFullTableName();
+
+        /// If table occurs in query several times (e.g., in subquery), process only once
+        /// because we collect only static properties of the table, which are the same for each occurrence.
         if (!processed_tables.emplace(table_name).second)
             return;
 

--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -386,7 +386,7 @@ private:
     void enterImpl(const TableNode & table_node)
     {
         auto table_name = table_node.getStorage()->getStorageID().getFullTableName();
-        if (processed_tables.emplace(table_name).second)
+        if (!processed_tables.emplace(table_name).second)
             return;
 
         auto add_key_columns = [&](const auto & key_columns)

--- a/tests/queries/0_stateless/03321_functions_to_subcolumns_skip_index.reference
+++ b/tests/queries/0_stateless/03321_functions_to_subcolumns_skip_index.reference
@@ -1,0 +1,6 @@
+Granules: 3/3
+Granules: 1/3
+1
+Granules: 3/3
+Granules: 1/3
+1	{'1':'1'}

--- a/tests/queries/0_stateless/03321_functions_to_subcolumns_skip_index.sql
+++ b/tests/queries/0_stateless/03321_functions_to_subcolumns_skip_index.sql
@@ -1,0 +1,46 @@
+DROP TABLE IF EXISTS bloom_filter_test;
+
+CREATE TABLE bloom_filter_test
+(
+    id UInt64,
+    m Map(String, String),
+    INDEX idx_mk mapKeys(m) TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1;
+
+INSERT INTO bloom_filter_test VALUES (1, {'1': '1'}), (2, {'2': '2'}), (3, {'3': '3'});
+
+SET enable_analyzer = 1;
+SET optimize_functions_to_subcolumns = 1;
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN indexes = 1
+    SELECT id          -- 'm' not in projection columns
+    FROM bloom_filter_test
+    WHERE mapContains(m, '1')
+    ORDER BY id
+) WHERE explain LIKE '%Granules:%';
+
+SELECT id          -- 'm' not in projection columns
+FROM bloom_filter_test
+WHERE mapContains(m, '1')
+ORDER BY id;
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN indexes = 1
+    SELECT *           -- 'm' in projection columns
+    FROM bloom_filter_test
+    WHERE mapContains(m, '1')
+    ORDER BY id
+) WHERE explain LIKE '%Granules:%';
+
+SELECT *           -- 'm' in projection columns
+FROM bloom_filter_test
+WHERE mapContains(m, '1')
+ORDER BY id;
+
+DROP TABLE bloom_filter_test;

--- a/tests/queries/0_stateless/03321_functions_to_subcolumns_skip_index.sql
+++ b/tests/queries/0_stateless/03321_functions_to_subcolumns_skip_index.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel-replicas
+
 DROP TABLE IF EXISTS bloom_filter_test;
 
 CREATE TABLE bloom_filter_test


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed usage of indexes (primary and secondary) for `Array`, `Map` and `Nullable(..)` columns with enabled setting `optimize_function_to_subcolumns`. Previously, indexes for these columns could have been ignored.

Fixes #74353.

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
