### PR TITLE
Fix 03312_squashing_with_low_card_mem_usage for private

### DIFF
--- a/tests/queries/0_stateless/03312_squashing_with_low_card_mem_usage.sql
+++ b/tests/queries/0_stateless/03312_squashing_with_low_card_mem_usage.sql
@@ -3,7 +3,7 @@
 -- no random settings -- it was quite hard to reproduce and I'm afraid that settings randomisation will make the test weaker
 
 drop table if exists t;
-create table t(s LowCardinality(String)) Engine = MergeTree order by tuple();
+create table t(s LowCardinality(String)) Engine = MergeTree order by tuple() settings min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
 
 -- The problem was that we didn't account for dictionary size in `ColumnLowCardinality::byteSize()`.
 -- Because of that we tend to accumulate too many blocks in `SimpleSquashingChunksTransform`.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
