### PR TITLE
Fixed memory usage reported by dictionaries with `Array` attributes

### DIFF
--- a/src/Common/FieldVisitorByteSize.cpp
+++ b/src/Common/FieldVisitorByteSize.cpp
@@ -1,0 +1,23 @@
+#include <Common/FieldVisitorByteSize.h>
+
+namespace DB
+{
+
+bool isFixedSizeFieldType(Field::Types::Which type)
+{
+    switch (type)
+    {
+        case Field::Types::String:
+        case Field::Types::Array:
+        case Field::Types::Tuple:
+        case Field::Types::AggregateFunctionState:
+        case Field::Types::Map:
+        case Field::Types::Object:
+        case Field::Types::CustomType:
+            return false;
+        default:
+            return true;
+    }
+}
+
+}

--- a/src/Common/FieldVisitorByteSize.h
+++ b/src/Common/FieldVisitorByteSize.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <type_traits>
+#include <Common/FieldVisitors.h>
+#include <Core/Field.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+
+bool isFixedSizeFieldType(Field::Types::Which type);
+
+/// Returns the size in bytes of the field.
+/// If @allocated is true then returns the number of allocated bytes.
+/// The returned size is always not less than sizeof(Field)
+template <bool allocated = false>
+class FieldVisitorByteSize : public StaticVisitor<UInt64>
+{
+public:
+    /// If T is trivially copyable, it doesn't allocate any external memory.
+    /// However, the field size is not sizeof(T) because we always allocate the memory,
+    /// which is enough for the largest possible Field types (see Field::storage).
+    template <typename T> requires std::is_trivially_copyable_v<T>
+    UInt64 operator() (const T &)
+    {
+        return sizeof(Field);
+    }
+
+    UInt64 operator() (const String & x) const
+    {
+        return sizeof(Field) + byteSizeOfString(x);
+    }
+
+    template <typename T> requires std::is_base_of_v<FieldVector, T>
+    UInt64 operator() (const T & x) const
+    {
+        UInt64 res = sizeof(Field);
+        size_t size = x.size();
+
+        if constexpr (allocated)
+            res += (x.capacity() - size) * sizeof(Field);
+
+        if (x.empty())
+            return res;
+
+        if (isFixedSizeFieldType(x[0].getType()))
+            return res + size * sizeof(Field);
+
+        FieldVisitorByteSize<allocated> visitor;
+        for (const auto & elem : x)
+            res += applyVisitor(visitor, elem);
+
+        return res;
+    }
+
+    UInt64 operator() (const AggregateFunctionStateData & x) const
+    {
+        return sizeof(Field) + byteSizeOfString(x.name) + byteSizeOfString(x.data);
+    }
+
+    UInt64 operator() (const Object & x) const
+    {
+        UInt64 res = sizeof(Field);
+
+        if (x.empty())
+            return res;
+
+        if (isFixedSizeFieldType(x.begin()->second.getType()))
+        {
+            for (const auto & [key, _] : x)
+                res += byteSizeOfString(key);
+
+            return res + x.size() * sizeof(Object::value_type);
+        }
+
+        FieldVisitorByteSize<allocated> visitor;
+
+        for (const auto & [key, value] : x)
+        {
+            res += byteSizeOfString(key);
+            res += applyVisitor(visitor, value);
+        }
+
+        /// Sizes of element type are already counted by visitor.
+        return res + x.size() * sizeof(Object::key_type);
+    }
+
+    UInt64 operator() (const CustomType &) const
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get size if bytes of CustomType");
+    }
+
+private:
+    UInt64 byteSizeOfString(const String & str) const
+    {
+        /// If string uses small string optimization then no extra memory is allocated.
+        /// Use the capacity of empty string as a max length for SSO (see the implementation of std::string::capacity).
+        static constexpr size_t max_sso_size = std::string().capacity();
+
+        if (str.capacity() <= max_sso_size)
+            return 0;
+
+        if constexpr (allocated)
+            return str.capacity();
+        else
+            return str.size();
+    }
+};
+
+using FieldVisitorAllocatedBytes = FieldVisitorByteSize<true>;
+
+}

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <base/AlignedUnion.h>
+#include <base/StringRef.h>
 #include <Core/CompareHelper.h>
 #include <Core/Defines.h>
 #include <Core/Types.h>
@@ -259,6 +260,7 @@ template <> struct NearestFieldTypeImpl<Float32> { using Type = Float64; };
 template <> struct NearestFieldTypeImpl<Float64> { using Type = Float64; };
 template <> struct NearestFieldTypeImpl<const char *> { using Type = String; };
 template <> struct NearestFieldTypeImpl<std::string_view> { using Type = String; };
+template <> struct NearestFieldTypeImpl<StringRef> { using Type = String; };
 template <> struct NearestFieldTypeImpl<String> { using Type = String; };
 template <> struct NearestFieldTypeImpl<Array> { using Type = Array; };
 template <> struct NearestFieldTypeImpl<Tuple> { using Type = Tuple; };
@@ -383,6 +385,7 @@ public:
     Field(const String & str) { create(std::string_view{str}); } /// NOLINT
     Field(String && str) { create(std::move(str)); } /// NOLINT
     Field(const char * str) { create(std::string_view{str}); } /// NOLINT
+    Field(StringRef str) { create(str.toView()); } /// NOLINT
 
     template <typename CharT>
     Field(const CharT * data, size_t size)
@@ -441,6 +444,7 @@ public:
     Field & operator= (const String & str) { return *this = std::string_view{str}; }
     Field & operator= (String && str);
     Field & operator= (const char * str) { return *this = std::string_view{str}; }
+    Field & operator= (StringRef str) { return *this = str.toView(); }
 
     ~Field()
     {

--- a/src/Dictionaries/DictionaryBytesUtils.h
+++ b/src/Dictionaries/DictionaryBytesUtils.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Common/PODArray_fwd.h>
+#include <Common/FieldVisitorByteSize.h>
+#include <Dictionaries/HashedDictionaryCollectionTraits.h>
+
+namespace DB
+{
+
+template <typename V> bool isFixedSizeValue()
+{
+    using FieldType = Field::TypeToEnum<NearestFieldType<V>>;
+
+    /// StringRef values are stored in arenas and are accounted separately.
+    return std::is_same_v<V, StringRef> || isFixedSizeFieldType(FieldType::value);
+}
+
+template <typename C> size_t getAllocatedBytesInFields(const C & c)
+{
+    if (isFixedSizeValue<typename C::mapped_type>())
+        return 0;
+
+    size_t res = 0;
+    FieldVisitorAllocatedBytes visitor;
+
+    /// Subtract the size of Field because it is counted
+    /// as the size of a Cell in 'getBufferSizeInBytes'.
+    for (const auto & [_, value] : c)
+        res += visitor(value) - sizeof(Field);
+    return res;
+}
+
+template <typename T> size_t getAllocatedBytesInFields(const std::vector<T> & c)
+{
+    if (isFixedSizeValue<T>())
+        return 0;
+
+    size_t res = 0;
+    FieldVisitorAllocatedBytes visitor;
+
+    /// Subtract the size of Field because it is counted
+    /// as the size of a Cell in 'getBufferSizeInBytes'.
+    for (const auto & value : c)
+        res += visitor(value) - sizeof(Field);
+    return res;
+}
+
+/// PaddedPODArray cannot contain Field because is not a POD type.
+template <typename T> size_t getAllocatedBytesInFields(const PaddedPODArray<T> &) { return 0; }
+
+using HashedDictionaryImpl::getBufferSizeInBytes;
+template <typename T> size_t getBufferSizeInBytes(const std::vector<T> & c) { return c.capacity() * sizeof(T); }
+template <typename T> size_t getBufferSizeInBytes(const PaddedPODArray<T> & c) { return c.allocated_bytes(); }
+
+template <typename C> size_t getAllocatedBytesInContainer(const C & c)
+{
+    return sizeof(c) + getBufferSizeInBytes(c) + getAllocatedBytesInFields(c);
+}
+
+}

--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -18,6 +18,7 @@
 #include <Dictionaries/DictionaryPipelineExecutor.h>
 #include <Dictionaries/DictionaryFactory.h>
 #include <Dictionaries/HierarchyDictionariesUtils.h>
+#include <Dictionaries/DictionaryBytesUtils.h>
 
 namespace DB
 {
@@ -537,18 +538,7 @@ void FlatDictionary::calculateBytesAllocated()
             using ValueType = DictionaryValueType<AttributeType>;
 
             const auto & container = std::get<ContainerType<ValueType>>(attribute.container);
-            bytes_allocated += sizeof(ContainerType<ValueType>);
-
-            if constexpr (std::is_same_v<ValueType, Array>)
-            {
-                /// It is not accurate calculations
-                bytes_allocated += sizeof(Array) * container.size();
-            }
-            else
-            {
-                bytes_allocated += container.allocated_bytes();
-            }
-
+            bytes_allocated += getAllocatedBytesInContainer(container);
             bucket_count = container.capacity();
         };
 

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -14,6 +14,7 @@
 #include <Dictionaries/DictionaryPipelineExecutor.h>
 #include <Dictionaries/DictionaryFactory.h>
 #include <Dictionaries/HierarchyDictionariesUtils.h>
+#include <Dictionaries/DictionaryBytesUtils.h>
 
 namespace DB
 {
@@ -1065,18 +1066,7 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::calculateBytesAllocate
 
             for (const auto & container : std::get<AttributeContainerShardsType<ValueType>>(attribute.containers))
             {
-                bytes_allocated += sizeof(AttributeContainerType<ValueType>);
-
-                if constexpr (std::is_same_v<ValueType, Array>)
-                {
-                    /// It is not accurate calculations
-                    bytes_allocated += sizeof(Array) * container.size();
-                }
-                else
-                {
-                    bytes_allocated += container.allocated_bytes();
-                }
-
+                bytes_allocated += getAllocatedBytesInContainer(container);
                 bucket_count += container.capacity();
             }
         };

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -11,6 +11,7 @@
 #include <Dictionaries/HashedDictionaryCollectionType.h>
 #include <Dictionaries/HashedDictionaryCollectionTraits.h>
 #include <Dictionaries/HashedDictionaryParallelLoader.h>
+#include <Dictionaries/DictionaryBytesUtils.h>
 
 #include <Core/Block.h>
 #include <Core/Defines.h>
@@ -1226,8 +1227,7 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::calculateBytesAlloc
         {
             for (const auto & container : containers)
             {
-                bytes_allocated += sizeof(container);
-                bytes_allocated += getBufferSizeInBytes(container);
+                bytes_allocated += getAllocatedBytesInContainer(container);
                 bucket_count += getBufferSizeInCells(container);
             }
         });

--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -21,6 +21,7 @@
 #include <Dictionaries/DictionarySourceHelpers.h>
 #include <Dictionaries/DictionaryPipelineExecutor.h>
 #include <Dictionaries/DictionaryFactory.h>
+#include <Dictionaries/DictionaryBytesUtils.h>
 #include <Functions/FunctionHelpers.h>
 
 #include <stack>
@@ -576,7 +577,7 @@ template <typename T>
 void IPAddressDictionary::addAttributeSize(const Attribute & attribute)
 {
     const auto & vec = std::get<ContainerType<T>>(attribute.maps);
-    bytes_allocated += sizeof(ContainerType<T>) + (vec.capacity() * sizeof(T));
+    bytes_allocated += getAllocatedBytesInContainer(vec);
     bucket_count = vec.size();
 }
 

--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -17,6 +17,7 @@
 #include <Dictionaries/DictionaryHelpers.h>
 #include <Dictionaries/DictionarySource.h>
 #include <Dictionaries/DictionaryPipelineExecutor.h>
+#include <Dictionaries/DictionaryBytesUtils.h>
 
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -600,8 +601,7 @@ void RangeHashedDictionary<dictionary_key_type>::calculateBytesAllocated()
             using ValueType = DictionaryValueType<AttributeType>;
 
             const auto & container = std::get<AttributeContainerType<ValueType>>(attribute.container);
-
-            bytes_allocated += container.size() * sizeof(ValueType);
+            bytes_allocated += getAllocatedBytesInContainer(container);
 
             if (attribute.is_value_nullable)
                 bytes_allocated += (*attribute.is_value_nullable).size() * sizeof(bool);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed memory usage reported by dictionaries with `Array` attributes in `system.dictionaries` table.

Fixes #39508.

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
