### PR TITLE
Follow up to #74715 (fixes flaky `test_storage_s3_queue/test.py::test_shards`)

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -192,9 +192,8 @@ ObjectStorageQueueSource::FileIterator::next()
                 size_t num_successful_objects = 0;
                 for (size_t i = 0; i < new_batch.size(); ++i)
                 {
-                    const auto & object = new_batch[i];
                     file_metadatas[i] = metadata->getFileMetadata(
-                        object->relative_path,
+                        new_batch[i]->relative_path,
                         /* bucket_info */{}); /// No buckets for Unordered mode.
 
                     auto set_processing_result = file_metadatas[i]->prepareSetProcessingRequests(requests);
@@ -206,6 +205,7 @@ ObjectStorageQueueSource::FileIterator::next()
                     else
                     {
                         new_batch[i] = nullptr;
+                        file_metadatas[i] = nullptr;
                     }
                 }
 
@@ -215,6 +215,7 @@ ObjectStorageQueueSource::FileIterator::next()
                 if (code == Coordination::Error::ZOK)
                 {
                     LOG_TEST(log, "Successfully set {} files as processing", new_batch.size());
+
                     for (size_t i = 0; i < new_batch.size(); ++i)
                     {
                         if (!new_batch[i])
@@ -239,16 +240,28 @@ ObjectStorageQueueSource::FileIterator::next()
 
                 if (num_successful_objects != new_batch.size())
                 {
-                    Source::ObjectInfos new_batch_copy;
-                    new_batch_copy.reserve(num_successful_objects);
-
-                    for (auto & object : new_batch)
+                    size_t batch_i = 0;
+                    for (size_t i = 0; i < num_successful_objects; ++i, ++batch_i)
                     {
-                        if (object)
-                            new_batch_copy.push_back(std::move(object));
+                        while (batch_i < new_batch.size() && !new_batch[batch_i])
+                            ++batch_i;
+
+                        if (batch_i == new_batch.size())
+                        {
+                            throw Exception(
+                                ErrorCodes::LOGICAL_ERROR,
+                                "Mismatch num_successful_objects ({}) is less than the number of valid objects",
+                                num_successful_objects);
+                        }
+
+                        new_batch[i] = new_batch[batch_i];
+                        file_metadatas[i] = file_metadatas[batch_i];
                     }
-                    new_batch = std::move(new_batch_copy);
+                    new_batch.resize(num_successful_objects);
+                    file_metadatas.resize(num_successful_objects);
                 }
+
+                chassert(new_batch.size() == file_metadatas.size());
             }
         }
 
@@ -268,10 +281,12 @@ ObjectStorageQueueSource::FileIterator::next()
         object_infos[index],
         file_metadatas.empty() ? nullptr : file_metadatas[index]);
 
-    if (result.second)
-        chassert(
-            result.first->getPath() == result.second->getPath(),
-            fmt::format("Mismatch {} vs {}", result.first->getPath(), result.second->getPath()));
+    if (result.second && result.first->getPath() != result.second->getPath())
+    {
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Mismatch {} and {}", result.first->getPath(), result.second->getPath());
+    }
 
     ++index;
     return result;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -261,7 +261,7 @@ ObjectStorageQueueSource::FileIterator::next()
                     file_metadatas.resize(num_successful_objects);
                 }
 
-                chassert(new_batch.size() == file_metadatas.size());
+                chassert(file_metadatas.empty() || new_batch.size() == file_metadatas.size());
             }
         }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Continues fix from https://github.com/ClickHouse/ClickHouse/pull/74715

Closes https://github.com/ClickHouse/ClickHouse/issues/75044

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [x] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).

