### PR TITLE
Explicit instantiation of LowCardinalityDictionaryCache::cache

### DIFF
--- a/src/Common/ColumnsHashing.cpp
+++ b/src/Common/ColumnsHashing.cpp
@@ -1,0 +1,10 @@
+#include <Common/CacheBase.h>
+#include <Common/ColumnsHashing.h>
+
+namespace DB
+{
+template class CacheBase<
+    ColumnsHashing::LowCardinalityDictionaryCache::DictionaryKey,
+    ColumnsHashing::LowCardinalityDictionaryCache::CachedValues,
+    ColumnsHashing::LowCardinalityDictionaryCache::DictionaryKeyHash>;
+}

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -242,7 +242,6 @@ private:
     Cache cache;
 };
 
-
 /// Single low cardinality column.
 template <typename SingleColumnMethod, typename Mapped, bool use_cache>
 struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
@@ -797,4 +796,10 @@ struct HashMethodHashed
 };
 
 }
+
+/// Explicit instantiation of LowCardinalityDictionaryCache::cache which is a really heavy template
+extern template class CacheBase<
+    ColumnsHashing::LowCardinalityDictionaryCache::DictionaryKey,
+    ColumnsHashing::LowCardinalityDictionaryCache::CachedValues,
+    ColumnsHashing::LowCardinalityDictionaryCache::DictionaryKeyHash>;
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Explicit instantiation of LowCardinalityDictionaryCache::cache

Today's most expensive instantiation:

```
SELECT
    detail,
    count(),
    sum(dur)
FROM build_time_trace
WHERE (date = today()) AND (NOT is_total)
GROUP BY detail
ORDER BY sum(dur) DESC
LIMIT 10

Query id: dbda55bb-bc62-415f-90f7-8c5db1b01388

    ┌─detail────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬───count()─┬──────sum(dur)─┐
 1. │                                                                                                                                                                                                                                   │ 162253475 │ 4485345487754 │
 2. │ [module]                                                                                                                                                                                                                          │   3056681 │  465104704848 │
 3. │ X86 DAG->DAG Instruction Selection                                                                                                                                                                                                │  10364404 │   29880672476 │
 4. │ DB::CacheBase<DB::ColumnsHashing::LowCardinalityDictionaryCache::DictionaryKey, DB::ColumnsHashing::LowCardinalityDictionaryCache::CachedValues, DB::ColumnsHashing::LowCardinalityDictionaryCache::DictionaryKeyHash>::CacheBase │     74881 │   19930506276 │
 5. │ Live DEBUG_VALUE analysis                                                                                                                                                                                                         │   5859943 │   15795033743 │
 6. │ LinkerDriver::Link                                                                                                                                                                                                                │      2213 │   15034479813 │
 7. │ DB::ContextData                                                                                                                                                                                                                   │     86504 │   10489107442 │
 8. │ DB::Field                                                                                                                                                                                                                         │    103821 │   10031148390 │
 9. │ /build/src/Common/intExp.h:148:1                                                                                                                                                                                                  │     85360 │    9927987736 │
10. │ exp10_i256                                                                                                                                                                                                                        │     85360 │    9925677446 │
    └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────┴───────────────┘
```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
