### PR TITLE
Fix flaky 03047_on_fly_mutations_multiple_updates_rmt when PR is enabled

### DIFF
--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
@@ -1,4 +1,5 @@
--- Tags: no-random-merge-tree-settings, no-random-settings, no-fasttest
+-- Tags: no-random-merge-tree-settings, no-random-settings, no-fasttest, no-parallel-replicas
+-- no-parallel-replicas: reading from s3 ('S3GetObject' event) can happened on any "replica", so we can see no 'S3GetObject' on initiator
 
 DROP TABLE IF EXISTS t_lightweight_mut_5;
 


### PR DESCRIPTION
Stateless tests (release, ParallelReplicas, s3 storage)
https://s3.amazonaws.com/clickhouse-test-reports/0/96ccc078f52522a22ebf4a4af76ba8a3aabf0ce8/stateless_tests__release__parallelreplicas__s3_storage_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
