### PR TITLE
Fix `chcache` reporting on compiler failure

### DIFF
--- a/rust/chcache/src/main.rs
+++ b/rust/chcache/src/main.rs
@@ -197,12 +197,16 @@ fn hash_preprocessed_compiler_output(compiler: String, args: &Vec<String>) -> St
         .args(preprocess_args)
         .output()
         .expect("Failed to execute command");
-    let output = String::from_utf8_lossy(&output.stdout);
 
-    assert!(output.len() > 0);
+    let stdout_output = String::from_utf8_lossy(&output.stdout);
+    let stderr_output = String::from_utf8_lossy(&output.stderr);
+
+    if stdout_output.is_empty() {
+        panic!("{}", stderr_output);
+    }
 
     let mut hasher = Hasher::new();
-    hasher.update(output.as_bytes());
+    hasher.update(stdout_output.as_bytes());
 
     let hash = hasher.finalize();
     hash.to_hex().to_string()
@@ -417,7 +421,7 @@ async fn compiler_cache_entrypoint(config: &Config) {
                         if !output.status.success() {
                             println!("{}", String::from_utf8_lossy(&output.stdout));
                             eprintln!("{}", String::from_utf8_lossy(&output.stderr));
-                            return;
+                            std::process::exit(output.status.code().unwrap_or(1));
                         }
                         fs::read(get_output_from_args(&rest_of_args)).expect("Unable to read file")
                     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
