### PR TITLE
Add possibility to set intentional sleeping period after move

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -806,6 +806,10 @@ Tags:
   * If only _some_ volumes are tagged, those without the tag have the lowest priority, and they are prioritized in the order they are defined in config.
   * If _no_ volumes are tagged, their priority is set correspondingly to their order they are declared in configuration.
   * Two volumes cannot have the same priority value.
+- `min_wait_after_move_ms` — Minimal waiting period after moving a part to the volume before making it active. Actual value is picked randomly between `min_wait_after_move_ms` and `max_wait_after_move_ms`. Default is `0`.
+It makes sense for storages not providing strong read-after-write guarantee.
+- `max_wait_after_move_ms` — Maximal waiting period after move to the volume before making part active. See `min_wait_after_move_ms`. Default is `0`.
+
 
 Configuration examples:
 

--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -54,6 +54,8 @@ public:
         , max_data_part_size(max_data_part_size_)
         , perform_ttl_move_on_insert(perform_ttl_move_on_insert_)
         , load_balancing(load_balancing_)
+        , max_wait_after_move_ms(0)
+        , min_wait_after_move_ms(0)
     {
     }
 
@@ -103,6 +105,11 @@ public:
     /// - ROUND_ROBIN
     /// - LEAST_USED
     const VolumeLoadBalancing load_balancing;
+    /// Waiting period after moving a part to the volume before making it active.
+    /// Actual value is picked randomly between min and max.
+    /// It makes sense for storages not providing strong read-after-write guarantee.
+    const UInt64 max_wait_after_move_ms;
+    const UInt64 min_wait_after_move_ms;
 };
 
 }

--- a/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
@@ -119,6 +119,19 @@
             </volumes>
         </special_warning_policy>
 
+        <policy_with_waiting>
+            <volumes>
+                <main>
+                    <disk>jbod1</disk>
+                </main>
+                <waiting>
+                    <disk>jbod2</disk>
+                    <min_wait_after_move_ms>250</min_wait_after_move_ms>
+                    <max_wait_after_move_ms>500</max_wait_after_move_ms>
+                </waiting>
+            </volumes>
+        </policy_with_waiting>
+
     </policies>
 
 </storage_configuration>

--- a/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
@@ -130,6 +130,7 @@
                     <max_wait_after_move_ms>500</max_wait_after_move_ms>
                 </waiting>
             </volumes>
+            <move_factor>0.0</move_factor>
         </policy_with_waiting>
 
     </policies>

--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -2123,4 +2123,3 @@ def test_waiting_after_move(start_cluster):
     assert node1.contains_in_log(f"Sleeping [0-9]\+ ms after cloning part {first_part}")
 
     node1.query(f"DROP TABLE IF EXISTS {table}")
-


### PR DESCRIPTION
Most of our clusters have the hybrid storage configuration (local disk and S3 disk) with parts moving from local disk to S3 by TTL or move_factor.

Our S3 storage does not provide strong read-after-write guarantee (it has some lag). Therefore sometimes we have an error like below. When ClickHouse tries to read from S3 immediately after cloning.

```
2025.01.14 08:02:59.432178 [ 678725 ] {} <Error> MergeTreeBackgroundExecutor: Exception while executing background task {9439ab61-2151-4ee6-8abe-0b0190ed3228::lambda}: Code: 499. DB::Exception: The specified key does not exist.
: while reading key: cloud_storage/mdb64ld0gkh8kk0hrdrt/shard29/nla/iaudqyffgsmccyrdvbndnanniyhmw, from bucket: cloud-storage-mdb64ld0gkh8kk0hrdrt: Cache info: Buffer path: cloud_storage/mdb64ld0gkh8kk0hrdrt/shard29/nla/iaudqyf
fgsmccyrdvbndnanniyhmw, hash key: 55f1df89b0874514a5224106d3cda3f8, file_offset_of_buffer_end: 0, read_until_position: 192, internal buffer end: 0, read_type: REMOTE_FS_READ_AND_PUT_IN_CACHE, last caller: None:Move:678725, file
 segment info: File segment: [0, 191], key: 55f1df89b0874514a5224106d3cda3f8, state: DOWNLOADING, downloaded size: 0, reserved size: 0, downloader id: None:Move:678725, current write offset: 0, caller id: None:Move:678725, kind
: Regular, unbound: 0. (S3_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c89dadb
1. DB::S3Exception::S3Exception(String const&, Aws::S3::S3Errors) @ 0x000000000f699b6d
2. DB::ReadBufferFromS3::sendRequest(unsigned long, unsigned long, std::optional<unsigned long>) const @ 0x000000000f6987a8
3. DB::ReadBufferFromS3::nextImpl() @ 0x000000000f695679
4. DB::CachedOnDiskReadBufferFromFile::nextImplStep() @ 0x000000000f7192b3
5. DB::CachedOnDiskReadBufferFromFile::nextImpl() @ 0x000000000f71880c
6. DB::ReadBufferFromRemoteFSGather::readImpl() @ 0x000000000f70d510
7. DB::ReadBufferFromRemoteFSGather::nextImpl() @ 0x000000000f70cbd8
8. DB::ThreadPoolRemoteFSReader::execute(DB::IAsynchronousReader::Request, bool) @ 0x000000000f581b2e
9. DB::ThreadPoolRemoteFSReader::execute(DB::IAsynchronousReader::Request) @ 0x000000000f5824c4
10. DB::AsynchronousBoundedReadBuffer::nextImpl() @ 0x000000000f72a28a
11. DB::IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool, bool) @ 0x0000000011987ef4
12. DB::MergeTreePartsMover::clonePart(DB::MergeTreeMoveEntry const&, DB::ReadSettings const&, DB::WriteSettings const&) const @ 0x0000000011bbd025
13. DB::MergeTreeData::moveParts(std::shared_ptr<DB::MergeTreeData::CurrentlyMovingPartsTagger> const&, DB::ReadSettings const&, DB::WriteSettings const&, bool) @ 0x0000000011aadd74
14. bool std::__function::__policy_invoker<bool ()>::__call_impl<std::__function::__default_alloc_func<DB::MergeTreeData::scheduleDataMovingJob(DB::BackgroundJobsAssignee&)::$_0, bool ()>>(std::__function::__policy_storage const*) @ 0x0000000011acb479
15. DB::ExecutableLambdaAdapter::executeStep() @ 0x00000000116622b2
16. DB::MergeTreeBackgroundExecutor<DB::RoundRobinRuntimeQueue>::threadFunction() @ 0x0000000011a0b750
17. ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x000000000c94a139
18. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x000000000c94d99a
19. void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000c94c7ad
20. ? @ 0x00007f16c2a7bac3
21. ? @ 0x00007f16c2b0d850
 (version 24.3.14.35 (official build))
```

This PR adds possibility to set intentional waiting period (picked randomly within the boundaries) after cloning part to the disk without strong read-after-write guarantee. This will mitigate the described error for our case.

An alternative solution would be to check existence of the created blobs in a retry loop but this would create undesirable load to the object storage and still will be limited by some timeout.

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add intentional random waiting period after moving a part. It makes sense for object storages that do not provide strong read-after-write guarantee. (max_wait_after_move_ms and min_wait_after_move_ms volume config parameters).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
