### PR TITLE
Remove dependencies on VersionNumber.h

### DIFF
--- a/programs/odbc-bridge/ODBCPooledConnectionFactory.h
+++ b/programs/odbc-bridge/ODBCPooledConnectionFactory.h
@@ -7,6 +7,8 @@
 #include <base/defines.h>
 #include <unordered_map>
 
+#include <boost/noncopyable.hpp>
+
 
 namespace DB
 {

--- a/src/Access/ContextAccess.h
+++ b/src/Access/ContextAccess.h
@@ -9,7 +9,6 @@
 #include <Access/EnabledRowPolicies.h>
 #include <Access/QuotaUsage.h>
 #include <Core/UUID.h>
-#include <Interpreters/ClientInfo.h>
 #include <base/scope_guard.h>
 #include <Common/SettingsChanges.h>
 

--- a/src/Common/VersionNumber.h
+++ b/src/Common/VersionNumber.h
@@ -14,8 +14,7 @@ struct VersionNumber
     explicit VersionNumber() = default;
 
     VersionNumber(const std::initializer_list<Int64> & init) : components(init) {}
-    explicit VersionNumber(Int64 major, Int64 minor = 0, Int64 patch = 0) : components{major, minor, patch} {}
-    explicit VersionNumber(const std::vector<Int64> & components_) : components(components_) {}
+    explicit VersionNumber(Int64 major, Int64 minor = 0, Int64 patch = 0) : components{major, minor, patch} { }
 
     /// Parse version number from string.
     explicit VersionNumber(std::string version);

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -1,16 +1,16 @@
-#include <Interpreters/ClientInfo.h>
+#include <Core/ProtocolDefines.h>
 #include <IO/ReadBuffer.h>
-#include <IO/WriteBuffer.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
-#include <Core/ProtocolDefines.h>
+#include <Interpreters/ClientInfo.h>
 #include <base/getFQDNOrHostName.h>
 #include <Poco/Net/HTTPRequest.h>
-#include <unistd.h>
 
 #include <Common/config_version.h>
 
 #include <format>
+#include <unistd.h>
+#include <boost/algorithm/string/trim.hpp>
 
 
 namespace DB
@@ -20,6 +20,23 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
 }
+
+std::optional<Poco::Net::SocketAddress> ClientInfo::getLastForwardedFor() const
+{
+    if (forwarded_for.empty())
+        return {};
+    String last = forwarded_for.substr(forwarded_for.find_last_of(',') + 1);
+    boost::trim(last);
+    try
+    {
+        return Poco::Net::SocketAddress{last};
+    }
+    catch (const Poco::InvalidArgumentException &)
+    {
+        return Poco::Net::SocketAddress{last, 0};
+    }
+}
+
 
 void ClientInfo::write(WriteBuffer & out, UInt64 server_protocol_revision) const
 {
@@ -225,11 +242,6 @@ bool ClientInfo::clientVersionEquals(const ClientInfo & other, bool compare_patc
 String ClientInfo::getVersionStr() const
 {
     return std::format("{}.{}.{} ({})", client_version_major, client_version_minor, client_version_patch, client_tcp_protocol_version);
-}
-
-VersionNumber ClientInfo::getVersionNumber() const
-{
-    return VersionNumber(client_version_major, client_version_minor, client_version_patch);
 }
 
 void ClientInfo::fillOSUserHostNameAndVersionInfo()

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <Core/UUID.h>
-#include <Poco/Net/SocketAddress.h>
 #include <base/types.h>
+#include <Poco/Net/SocketAddress.h>
 #include <Common/OpenTelemetryTraceContext.h>
-#include <Common/VersionNumber.h>
-#include <boost/algorithm/string/trim.hpp>
 
 
 namespace Poco::Net
@@ -114,21 +111,7 @@ public:
     /// The element can be trusted only if you trust the corresponding proxy.
     /// NOTE This field can also be reused in future for TCP interface with PROXY v1/v2 protocols.
     String forwarded_for;
-    std::optional<Poco::Net::SocketAddress> getLastForwardedFor() const
-    {
-        if (forwarded_for.empty())
-            return {};
-        String last = forwarded_for.substr(forwarded_for.find_last_of(',') + 1);
-        boost::trim(last);
-        try
-        {
-            return Poco::Net::SocketAddress{last};
-        }
-        catch (const Poco::InvalidArgumentException &)
-        {
-            return Poco::Net::SocketAddress{last, 0};
-        }
-    }
+    std::optional<Poco::Net::SocketAddress> getLastForwardedFor() const;
 
     String getLastForwardedForHost() const
     {
@@ -176,7 +159,6 @@ public:
     bool clientVersionEquals(const ClientInfo & other, bool compare_patch) const;
 
     String getVersionStr() const;
-    VersionNumber getVersionNumber() const;
 
 private:
     void fillOSUserHostNameAndVersionInfo();

--- a/src/Interpreters/SessionTracker.cpp
+++ b/src/Interpreters/SessionTracker.cpp
@@ -1,5 +1,6 @@
 #include "SessionTracker.h"
 
+#include <Core/Field.h>
 #include <Common/Exception.h>
 
 namespace DB

--- a/src/Interpreters/SessionTracker.h
+++ b/src/Interpreters/SessionTracker.h
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "ClientInfo.h"
+#include <Core/Types_fwd.h>
+#include <base/types.h>
 
 #include <list>
-#include <map>
 #include <memory>
 #include <mutex>
+#include <unordered_map>
+
+#include <boost/noncopyable.hpp>
 
 namespace DB
 {

--- a/src/Interpreters/ZooKeeperLog.h
+++ b/src/Interpreters/ZooKeeperLog.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <Core/NamesAndTypes.h>
 #include <Core/NamesAndAliases.h>
+#include <Core/NamesAndTypes.h>
 #include <Interpreters/SystemLog.h>
-#include <Interpreters/ClientInfo.h>
-#include <Common/ZooKeeper/IKeeper.h>
 #include <Storages/ColumnsDescription.h>
+#include <Common/ZooKeeper/IKeeper.h>
 
 
 namespace DB

--- a/src/QueryPipeline/RemoteInserter.h
+++ b/src/QueryPipeline/RemoteInserter.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <Core/Block.h>
-#include <Common/Throttler.h>
 #include <IO/ConnectionTimeouts.h>
-#include <Interpreters/ClientInfo.h>
-
+#include <Common/Throttler.h>
 
 namespace DB
 {
 
+class ClientInfo;
 class Connection;
 class ReadBuffer;
 struct Settings;

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -24,6 +24,8 @@
 #    include <Common/logger_useful.h>
 #    include <Common/setThreadName.h>
 
+#    include <boost/algorithm/string/trim.hpp>
+
 
 #    ifdef POCO_HAVE_FD_EPOLL
 #        include <sys/epoll.h>

--- a/src/Storages/Kafka/StorageKafkaUtils.cpp
+++ b/src/Storages/Kafka/StorageKafkaUtils.cpp
@@ -34,6 +34,7 @@
 #include <Common/setThreadName.h>
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <cppkafka/cppkafka.h>
 #include <librdkafka/rdkafka.h>
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove dependencies on VersionNumber.h


For some reason this popped up as a heavy hitter in compilation times:
```
130. │ DB::VersionNumber                                                                                                                                                                                                                                          │    130984 │    3407021580 │
131. │ _ZNSt3__16vectorINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS4_IS6_EEE18__assign_with_sizeB8ne180100IPS6_SA_EEvT_T0_l                                                                                                                      │    897964 │    3400625124 │
132. │ DB::IProcessor                                                                                                                                                                                                                                             │     94664 │    3400117307 │
133. │ /build/src/Common/VersionNumber.h:12:1                                                                                                                                                                                                                     │    119425 │    3388960620 │
```

Positions 130 and 133, even though it's a pretty simple header and not used much directly. I've removed the helper function from ClientInfo.h and reduce some header dependencies too.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
