### PR TITLE
Avoid unnecessary contention in `parallel_hash` when `max_rows_in_join = max_bytes_in_join = 0`

### DIFF
--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -327,7 +327,7 @@ bool ConcurrentHashJoin::addBlockToJoin(const Block & right_block_, bool check_l
         }
     }
 
-    if (check_limits)
+    if (check_limits && table_join->sizeLimits().hasLimits())
         return table_join->sizeLimits().check(getTotalRowCount(), getTotalByteCount(), "JOIN", ErrorCodes::SET_SIZE_LIMIT_EXCEEDED);
     return true;
 }

--- a/tests/performance/parallel_hash_build_phase.xml
+++ b/tests/performance/parallel_hash_build_phase.xml
@@ -1,7 +1,8 @@
 <test>
   <settings>
     <query_plan_join_swap_table>0</query_plan_join_swap_table>
+    <max_threads>8</max_threads>
   </settings>
 
-  <query>select * from numbers_mt(100) t1 inner join numbers_mt(2e8) t2 using (number) format Null</query>
+  <query>select * from numbers_mt(100) t1 inner join numbers_mt(1e8) t2 using (number) format Null</query>
 </test>

--- a/tests/performance/parallel_hash_build_phase.xml
+++ b/tests/performance/parallel_hash_build_phase.xml
@@ -1,0 +1,7 @@
+<test>
+  <settings>
+    <query_plan_join_swap_table>0</query_plan_join_swap_table>
+  </settings>
+
+  <query>select * from numbers_mt(100) t1 inner join numbers_mt(2e8) t2 using (number) format Null</query>
+</test>

--- a/tests/performance/parallel_hash_build_phase.xml
+++ b/tests/performance/parallel_hash_build_phase.xml
@@ -1,5 +1,6 @@
 <test>
   <settings>
+    <join_algorithm>parallel_hash</join_algorithm>
     <query_plan_join_swap_table>0</query_plan_join_swap_table>
     <max_threads>8</max_threads>
   </settings>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed unnecessary contention in `parallel_hash` when `max_rows_in_join = max_bytes_in_join = 0`.


#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
