### PR TITLE
Tests: add 'error' test hint for functional tests

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2539,7 +2539,37 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
                 }
                 else if (have_error)
                 {
-                    if (test_hint.hasServerErrors())
+                    if (test_hint.hasServerErrors() && test_hint.hasClientErrors())
+                    {
+                        if (server_exception)
+                        {
+                            if (!test_hint.hasExpectedServerError(server_exception->code()))
+                            {
+                                error_matches_hint = false;
+                                error_stream << fmt::format(
+                                    "Expected one of the server error codes '{}' but got '{}' (query: {}).\n",
+                                    test_hint.serverErrors(), server_exception->code(), full_query);
+                            }
+                        }
+                        else if (client_exception)
+                        {
+                            if (!test_hint.hasExpectedClientError(client_exception->code()))
+                            {
+                                error_matches_hint = false;
+                                error_stream << fmt::format(
+                                    "Expected one of the client error codes '{}' but got '{}' (query: {}).\n",
+                                    test_hint.clientErrors(), client_exception->code(), full_query);
+                            }
+                        }
+                        else
+                        {
+                            error_matches_hint = false;
+                            error_stream << fmt::format(
+                                "Expected either a server or client error, but got none (query: {}).\n",
+                                full_query);
+                        }
+                    }
+                    else if (test_hint.hasServerErrors())
                     {
                         if (!server_exception)
                         {
@@ -2554,7 +2584,7 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
                                               test_hint.serverErrors(), server_exception->code(), full_query);
                         }
                     }
-                    if (test_hint.hasClientErrors())
+                    else if (test_hint.hasClientErrors())
                     {
                         if (!client_exception)
                         {
@@ -2569,7 +2599,7 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
                                        test_hint.clientErrors(), client_exception->code(), full_query);
                         }
                     }
-                    if (!test_hint.hasClientErrors() && !test_hint.hasServerErrors())
+                    else
                     {
                         // No error was expected but it still occurred. This is the
                         // default case without test hint, doesn't need additional
@@ -2579,14 +2609,21 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
                 }
                 else
                 {
-                    if (test_hint.hasClientErrors())
+                    if (test_hint.hasClientErrors() && test_hint.hasServerErrors())
+                    {
+                        error_matches_hint = false;
+                        error_stream << fmt::format(
+                                   "The query succeeded but server or client errors '{}' were expected (query: {}).\n",
+                                   test_hint.serverErrors(), full_query);
+                    }
+                    else if (test_hint.hasClientErrors())
                     {
                         error_matches_hint = false;
                         error_stream << fmt::format(
                                    "The query succeeded but the client error '{}' was expected (query: {}).\n",
                                    test_hint.clientErrors(), full_query);
                     }
-                    if (test_hint.hasServerErrors())
+                    else if (test_hint.hasServerErrors())
                     {
                         error_matches_hint = false;
                         error_stream << fmt::format(

--- a/src/Client/TestHint.cpp
+++ b/src/Client/TestHint.cpp
@@ -88,6 +88,7 @@ void TestHint::parse(Lexer & comment_lexer, bool is_leading_hint)
     std::unordered_set<std::string_view> command_errors{
         "serverError",
         "clientError",
+        "error",
     };
 
     for (Token token = comment_lexer.nextToken(); !token.isEnd(); token = comment_lexer.nextToken())
@@ -173,9 +174,18 @@ void TestHint::parse(Lexer & comment_lexer, bool is_leading_hint)
             }
 
             if (item == "serverError")
+            {
                 server_errors = error_codes;
-            else
+            }
+            else if (item == "clientError")
+            {
                 client_errors = error_codes;
+            }
+            else
+            {
+                server_errors = error_codes;
+                client_errors = error_codes;
+            }
             break;
         }
     }

--- a/tests/queries/0_stateless/00700_decimal_bounds.sql
+++ b/tests/queries/0_stateless/00700_decimal_bounds.sql
@@ -18,26 +18,26 @@ CREATE TABLE IF NOT EXISTS decimal
     j DECIMAL(1,0)
 ) ENGINE = Memory;
 
-INSERT INTO decimal (a) VALUES (1000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (a) VALUES (-1000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (b) VALUES (1000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (b) VALUES (-1000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (c) VALUES (100000000000000000000000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (c) VALUES (-100000000000000000000000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (d) VALUES (1); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (d) VALUES (-1); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (e) VALUES (1000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (e) VALUES (-1000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (f) VALUES (1); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (f) VALUES (-1); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (g) VALUES (10000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (g) VALUES (-10000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (h) VALUES (1000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (h) VALUES (-1000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (i) VALUES (100000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (i) VALUES (-100000000000000000000); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (j) VALUES (10); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (j) VALUES (-10); -- { clientError ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (a) VALUES (1000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (a) VALUES (-1000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (b) VALUES (1000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (b) VALUES (-1000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (c) VALUES (100000000000000000000000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (c) VALUES (-100000000000000000000000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (d) VALUES (1); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (d) VALUES (-1); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (e) VALUES (1000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (e) VALUES (-1000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (f) VALUES (1); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (f) VALUES (-1); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (g) VALUES (10000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (g) VALUES (-10000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (h) VALUES (1000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (h) VALUES (-1000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (i) VALUES (100000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (i) VALUES (-100000000000000000000); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (j) VALUES (10); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (j) VALUES (-10); -- { error ARGUMENT_OUT_OF_BOUND }
 
 INSERT INTO decimal (a) VALUES (0.1);
 INSERT INTO decimal (a) VALUES (-0.1);
@@ -84,14 +84,14 @@ INSERT INTO decimal (a, b, c, d, e, f, g, h, i, j) VALUES (0.0, 0.0, 0.0, 0.0, 0
 INSERT INTO decimal (a, b, c, d, e, f, g, h, i, j) VALUES (-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0);
 
 INSERT INTO decimal (a, b, g) VALUES ('42.00000', 42.0000000000000000000000000000000, '0.999990');
-INSERT INTO decimal (a) VALUES ('-9x'); -- { clientError CANNOT_PARSE_TEXT }
-INSERT INTO decimal (a) VALUES ('0x1'); -- { clientError CANNOT_PARSE_TEXT }
+INSERT INTO decimal (a) VALUES ('-9x'); -- { error CANNOT_PARSE_TEXT }
+INSERT INTO decimal (a) VALUES ('0x1'); -- { error CANNOT_PARSE_TEXT }
 
 INSERT INTO decimal (a, b, c, d, e, f) VALUES ('0.9e9', '0.9e18', '0.9e38', '9e-9', '9e-18', '9e-38');
 INSERT INTO decimal (a, b, c, d, e, f) VALUES ('-0.9e9', '-0.9e18', '-0.9e38', '-9e-9', '-9e-18', '-9e-38');
 
-INSERT INTO decimal (a, b, c, d, e, f) VALUES ('1e9', '1e18', '1e38', '1e-10', '1e-19', '1e-39'); -- { clientError ARGUMENT_OUT_OF_BOUND }
-INSERT INTO decimal (a, b, c, d, e, f) VALUES ('-1e9', '-1e18', '-1e38', '-1e-10', '-1e-19', '-1e-39'); -- { clientError ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (a, b, c, d, e, f) VALUES ('1e9', '1e18', '1e38', '1e-10', '1e-19', '1e-39'); -- { error ARGUMENT_OUT_OF_BOUND }
+INSERT INTO decimal (a, b, c, d, e, f) VALUES ('-1e9', '-1e18', '-1e38', '-1e-10', '-1e-19', '-1e-39'); -- { error ARGUMENT_OUT_OF_BOUND }
 
 SELECT * FROM decimal ORDER BY a, b, c, d, e, f, g, h, i, j;
 DROP TABLE IF EXISTS decimal;

--- a/tests/queries/0_stateless/00948_values_interpreter_template.sql
+++ b/tests/queries/0_stateless/00948_values_interpreter_template.sql
@@ -23,9 +23,9 @@ INSERT INTO values_template VALUES ((1), lower(replaceAll('Hella', 'a', 'o')), 1
 
 INSERT INTO values_template_nullable VALUES ((1), lower(replaceAll('Hella', 'a', 'o')), 1 + 2 + 3, arraySort(x -> assumeNotNull(x), [null, NULL::Nullable(UInt8)])),   ((2), lower(replaceAll('Warld', 'b', 'o')), 4 - 5 + 6, arraySort(x -> assumeNotNull(x), [+1, -1, Null])),   ((3), lower(replaceAll('Test', 'c', 'o')), 3 + 2 - 1, arraySort(x -> assumeNotNull(x), [1, nUlL, 3.14])),   ((4), lower(replaceAll(null, 'c', 'o')), 6 + 5 - null, arraySort(x -> assumeNotNull(x), [3, 2, 1]));
 
-INSERT INTO values_template_fallback VALUES (1 + x); -- { clientError SYNTAX_ERROR }
-INSERT INTO values_template_fallback VALUES (abs(functionThatDoesNotExists(42))); -- { clientError UNKNOWN_FUNCTION }
-INSERT INTO values_template_fallback VALUES ([1]); -- { clientError ILLEGAL_TYPE_OF_ARGUMENT }
+INSERT INTO values_template_fallback VALUES (1 + x); -- { error SYNTAX_ERROR }
+INSERT INTO values_template_fallback VALUES (abs(functionThatDoesNotExists(42))); -- { error UNKNOWN_FUNCTION }
+INSERT INTO values_template_fallback VALUES ([1]); -- { error ILLEGAL_TYPE_OF_ARGUMENT }
 
 INSERT INTO values_template_fallback VALUES (CAST(1, 'UInt8')), (CAST('2', 'UInt8'));
 SET input_format_values_accurate_types_of_literals = 0;

--- a/tests/queries/0_stateless/01825_type_json_field.sql
+++ b/tests/queries/0_stateless/01825_type_json_field.sql
@@ -22,7 +22,7 @@ INSERT INTO t_json_field VALUES (4, map('a', 30, 'b', 400)), (5, map('s', 'qqq',
 SELECT id, data.a, data.s, data.b, data.t FROM t_json_field ORDER BY id;
 SELECT DISTINCT toTypeName(data) FROM t_json_field;
 
-INSERT INTO t_json_field VALUES (6, map(1, 2, 3, 4)); -- { clientError TYPE_MISMATCH }
-INSERT INTO t_json_field VALUES (6, (1, 2, 3)); -- { clientError TYPE_MISMATCH }
+INSERT INTO t_json_field VALUES (6, map(1, 2, 3, 4)); -- { error TYPE_MISMATCH }
+INSERT INTO t_json_field VALUES (6, (1, 2, 3)); -- { error TYPE_MISMATCH }
 
 DROP TABLE t_json_field;

--- a/tests/queries/0_stateless/02560_agg_state_deserialization_hash_table_crash.sql
+++ b/tests/queries/0_stateless/02560_agg_state_deserialization_hash_table_crash.sql
@@ -1,4 +1,4 @@
 DROP TABLE IF EXISTS tab;
 create table tab (d Int64, s AggregateFunction(groupUniqArrayArray, Array(UInt64)), c SimpleAggregateFunction(groupUniqArrayArray, Array(UInt64))) engine = SummingMergeTree() order by d;
-INSERT INTO tab VALUES (1, 'このコー'); -- { clientError TOO_LARGE_ARRAY_SIZE }
+INSERT INTO tab VALUES (1, 'このコー'); -- { error TOO_LARGE_ARRAY_SIZE }
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02896_leading_zeroes_no_octal.sql
+++ b/tests/queries/0_stateless/02896_leading_zeroes_no_octal.sql
@@ -102,13 +102,13 @@ INSERT INTO t_leading_zeroes_f VALUES (2069, '0x01P-01', 0x01P-01, 0.5, 'Hex sho
 
 -- Binary should not work with input_format_values_interpret_expressions = 0
 
-INSERT INTO t_leading_zeroes_f VALUES (2050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes_f VALUES (2051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes_f VALUES (2052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes_f VALUES (2050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { error SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes_f VALUES (2051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { error SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes_f VALUES (2052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { error SYNTAX_ERROR }
 
-INSERT INTO t_leading_zeroes VALUES (1050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes VALUES (1051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
-INSERT INTO t_leading_zeroes VALUES (1052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { clientError SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes VALUES (1050, '0b10000', 0b10000, 16, 'Binary should not be parsed'); -- { error SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes VALUES (1051, '-0b10000', -0b10000, -16, 'Binary should not be parsed'); -- { error SYNTAX_ERROR }
+INSERT INTO t_leading_zeroes VALUES (1052, '+0b10000', +0b10000, 16, 'Binary should not be parsed'); -- { error SYNTAX_ERROR }
 
 
 


### PR DESCRIPTION
Add an "error" hint that expects both server- and client-side errors. This is required for tests with async inserts enabled because the error might be returned by the server when it’s expected from the client. 
For example, here is an error that occurs with async inserts enabled:
```
2025-01-27 17:12:26 02560_agg_state_deserialization_hash_table_crash:                       [ FAIL ] 1.80 sec.
2025-01-27 17:12:26 Reason: return code:  128
2025-01-27 17:12:26 Expected client error code '128' but got no client error (query: INSERT INTO tab VALUES (1, 'このコー'); -- { clientError TOO_LARGE_ARRAY_SIZE }).
2025-01-27 17:12:26 Received exception from server (version 24.12.1):
2025-01-27 17:12:26 Code: 128. DB::Exception: Received from c-ecru-li-21-server-57izk5b-0.sticky.dykuimk9v5.eu-west-1.aws.clickhouse-staging.com:9440. DB::Exception: The size of serialized hash table is suspiciously large: 12899872220324872419: While executing WaitForAsyncInsert. (TOO_LARGE_ARRAY_SIZE)
2025-01-27 17:12:26 (query: INSERT INTO tab VALUES (1, 'このコー'); -- { clientError TOO_LARGE_ARRAY_SIZE })
```


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
