### PR TITLE
Add More Info for 01852_dictionary_found_rate_long

### DIFF
--- a/tests/queries/0_stateless/01852_dictionary_found_rate_long.reference
+++ b/tests/queries/0_stateless/01852_dictionary_found_rate_long.reference
@@ -1,33 +1,33 @@
-simple_key_flat_dictionary_01862	1
-simple_key_flat_dictionary_01862	1
-simple_key_flat_dictionary_01862	0.67
-simple_key_direct_dictionary_01862	0
-simple_key_direct_dictionary_01862	0
-simple_key_direct_dictionary_01862	1
-simple_key_direct_dictionary_01862	0.5
-simple_key_hashed_dictionary_01862	0
-simple_key_hashed_dictionary_01862	1
-simple_key_hashed_dictionary_01862	0.5
-simple_key_sparse_hashed_dictionary_01862	0
-simple_key_sparse_hashed_dictionary_01862	1
-simple_key_sparse_hashed_dictionary_01862	0.5
-simple_key_cache_dictionary_01862	0
-simple_key_cache_dictionary_01862	1
-simple_key_cache_dictionary_01862	0.5
-complex_key_hashed_dictionary_01862	0
-complex_key_hashed_dictionary_01862	1
-complex_key_hashed_dictionary_01862	0.5
-complex_key_direct_dictionary_01862	0
-complex_key_direct_dictionary_01862	1
-complex_key_direct_dictionary_01862	0.5
-complex_key_cache_dictionary_01862	0
-complex_key_cache_dictionary_01862	1
-complex_key_cache_dictionary_01862	0.5
-simple_key_range_hashed_dictionary_01862	0
-simple_key_range_hashed_dictionary_01862	1
-simple_key_range_hashed_dictionary_01862	0.5
-ip_trie_dictionary_01862	0
-ip_trie_dictionary_01862	1
-ip_trie_dictionary_01862	0.5
-polygon_dictionary_01862	0
-polygon_dictionary_01862	0.8
+simple_key_flat_dictionary_01862	1	LOADED	
+simple_key_flat_dictionary_01862	1	LOADED	
+simple_key_flat_dictionary_01862	0.67	LOADED	
+simple_key_direct_dictionary_01862	0	NOT_LOADED	
+simple_key_direct_dictionary_01862	0	LOADED	
+simple_key_direct_dictionary_01862	1	LOADED	
+simple_key_direct_dictionary_01862	0.5	LOADED	
+simple_key_hashed_dictionary_01862	0	NOT_LOADED	
+simple_key_hashed_dictionary_01862	1	LOADED	
+simple_key_hashed_dictionary_01862	0.5	LOADED	
+simple_key_sparse_hashed_dictionary_01862	0	NOT_LOADED	
+simple_key_sparse_hashed_dictionary_01862	1	LOADED	
+simple_key_sparse_hashed_dictionary_01862	0.5	LOADED	
+simple_key_cache_dictionary_01862	0	NOT_LOADED	
+simple_key_cache_dictionary_01862	1	LOADED	
+simple_key_cache_dictionary_01862	0.5	LOADED	
+complex_key_hashed_dictionary_01862	0	NOT_LOADED	
+complex_key_hashed_dictionary_01862	1	LOADED	
+complex_key_hashed_dictionary_01862	0.5	LOADED	
+complex_key_direct_dictionary_01862	0	NOT_LOADED	
+complex_key_direct_dictionary_01862	1	LOADED	
+complex_key_direct_dictionary_01862	0.5	LOADED	
+complex_key_cache_dictionary_01862	0	NOT_LOADED	
+complex_key_cache_dictionary_01862	1	LOADED	
+complex_key_cache_dictionary_01862	0.5	LOADED	
+simple_key_range_hashed_dictionary_01862	0	NOT_LOADED	
+simple_key_range_hashed_dictionary_01862	1	LOADED	
+simple_key_range_hashed_dictionary_01862	0.5	LOADED	
+ip_trie_dictionary_01862	0	NOT_LOADED	
+ip_trie_dictionary_01862	1	LOADED	
+ip_trie_dictionary_01862	0.5	LOADED	
+polygon_dictionary_01862	0	NOT_LOADED	
+polygon_dictionary_01862	0.8	LOADED	

--- a/tests/queries/0_stateless/01852_dictionary_found_rate_long.sql
+++ b/tests/queries/0_stateless/01852_dictionary_found_rate_long.sql
@@ -27,11 +27,11 @@ LAYOUT(FLAT())
 LIFETIME(MIN 0 MAX 1000);
 
 SELECT * FROM simple_key_flat_dictionary_01862 FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_flat_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_flat_dictionary_01862';
 SELECT * FROM simple_key_flat_dictionary_01862 WHERE id = 0 FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_flat_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_flat_dictionary_01862';
 SELECT dictGet('simple_key_flat_dictionary_01862', 'value', toUInt64(2)) FORMAT Null;
-SELECT name, round(found_rate, 2) FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_flat_dictionary_01862';
+SELECT name, round(found_rate, 2), status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_flat_dictionary_01862';
 
 DROP DICTIONARY simple_key_flat_dictionary_01862;
 
@@ -47,13 +47,13 @@ SOURCE(CLICKHOUSE(TABLE 'simple_key_source_table_01862'))
 LAYOUT(DIRECT());
 
 -- check that found_rate is 0, not nan
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
 SELECT * FROM simple_key_direct_dictionary_01862 FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
 SELECT dictGet('simple_key_direct_dictionary_01862', 'value', toUInt64(1)) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
 SELECT dictGet('simple_key_direct_dictionary_01862', 'value', toUInt64(2)) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_direct_dictionary_01862';
 
 DROP DICTIONARY simple_key_direct_dictionary_01862;
 
@@ -69,11 +69,11 @@ SOURCE(CLICKHOUSE(TABLE 'simple_key_source_table_01862'))
 LAYOUT(HASHED())
 LIFETIME(MIN 0 MAX 1000);
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_hashed_dictionary_01862';
 SELECT dictGet('simple_key_hashed_dictionary_01862', 'value', toUInt64(1)) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_hashed_dictionary_01862';
 SELECT dictGet('simple_key_hashed_dictionary_01862', 'value', toUInt64(2)) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_hashed_dictionary_01862';
 
 DROP DICTIONARY simple_key_hashed_dictionary_01862;
 
@@ -89,11 +89,11 @@ SOURCE(CLICKHOUSE(TABLE 'simple_key_source_table_01862'))
 LAYOUT(SPARSE_HASHED())
 LIFETIME(MIN 0 MAX 1000);
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_sparse_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_sparse_hashed_dictionary_01862';
 SELECT dictGet('simple_key_sparse_hashed_dictionary_01862', 'value', toUInt64(1)) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_sparse_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_sparse_hashed_dictionary_01862';
 SELECT dictGet('simple_key_sparse_hashed_dictionary_01862', 'value', toUInt64(2)) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_sparse_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_sparse_hashed_dictionary_01862';
 
 DROP DICTIONARY simple_key_sparse_hashed_dictionary_01862;
 
@@ -109,11 +109,11 @@ SOURCE(CLICKHOUSE(TABLE 'simple_key_source_table_01862'))
 LAYOUT(CACHE(SIZE_IN_CELLS 100000))
 LIFETIME(MIN 0 MAX 1000);
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_cache_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_cache_dictionary_01862';
 SELECT toUInt64(1) as key, dictGet('simple_key_cache_dictionary_01862', 'value', key) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_cache_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_cache_dictionary_01862';
 SELECT toUInt64(2) as key, dictGet('simple_key_cache_dictionary_01862', 'value', key) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_cache_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_cache_dictionary_01862';
 
 DROP DICTIONARY simple_key_cache_dictionary_01862;
 
@@ -147,11 +147,11 @@ SOURCE(CLICKHOUSE(TABLE 'complex_key_source_table_01862'))
 LAYOUT(COMPLEX_KEY_HASHED())
 LIFETIME(MIN 0 MAX 1000);
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_hashed_dictionary_01862';
 SELECT dictGet('complex_key_hashed_dictionary_01862', 'value', (toUInt64(1), 'FirstKey')) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_hashed_dictionary_01862';
 SELECT dictGet('complex_key_hashed_dictionary_01862', 'value', (toUInt64(2), 'FirstKey')) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_hashed_dictionary_01862';
 
 DROP DICTIONARY complex_key_hashed_dictionary_01862;
 
@@ -167,11 +167,11 @@ PRIMARY KEY id, id_key
 SOURCE(CLICKHOUSE(TABLE 'complex_key_source_table_01862'))
 LAYOUT(COMPLEX_KEY_DIRECT());
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_direct_dictionary_01862';
 SELECT dictGet('complex_key_direct_dictionary_01862', 'value', (toUInt64(1), 'FirstKey')) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_direct_dictionary_01862';
 SELECT dictGet('complex_key_direct_dictionary_01862', 'value', (toUInt64(2), 'FirstKey')) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_direct_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_direct_dictionary_01862';
 
 DROP DICTIONARY complex_key_direct_dictionary_01862;
 
@@ -188,11 +188,11 @@ SOURCE(CLICKHOUSE(TABLE 'complex_key_source_table_01862'))
 LAYOUT(COMPLEX_KEY_CACHE(SIZE_IN_CELLS 100000))
 LIFETIME(MIN 0 MAX 1000);
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_cache_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_cache_dictionary_01862';
 SELECT dictGet('complex_key_cache_dictionary_01862', 'value', (toUInt64(1), 'FirstKey')) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_cache_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_cache_dictionary_01862';
 SELECT dictGet('complex_key_cache_dictionary_01862', 'value', (toUInt64(2), 'FirstKey')) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_cache_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'complex_key_cache_dictionary_01862';
 
 DROP DICTIONARY complex_key_cache_dictionary_01862;
 
@@ -228,11 +228,11 @@ LAYOUT(RANGE_HASHED())
 RANGE(MIN first MAX last)
 LIFETIME(MIN 0 MAX 1000);
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_range_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_range_hashed_dictionary_01862';
 SELECT dictGet('simple_key_range_hashed_dictionary_01862', 'value', toUInt64(1), today()) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_range_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_range_hashed_dictionary_01862';
 SELECT dictGet('simple_key_range_hashed_dictionary_01862', 'value', toUInt64(2), today()) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_range_hashed_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'simple_key_range_hashed_dictionary_01862';
 
 DROP DICTIONARY simple_key_range_hashed_dictionary_01862;
 
@@ -264,13 +264,13 @@ LAYOUT(IP_TRIE())
 LIFETIME(MIN 0 MAX 1000);
 
 -- found_rate = 0, because we didn't make any searches.
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'ip_trie_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'ip_trie_dictionary_01862';
 -- found_rate = 1, because the dictionary covers the 127.0.0.1 address.
 SELECT dictGet('ip_trie_dictionary_01862', 'value', tuple(toIPv4('127.0.0.1'))) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'ip_trie_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'ip_trie_dictionary_01862';
 -- found_rate = 0.5, because the dictionary does not cover 1.1.1.1 and we have two lookups in total as of now.
 SELECT dictGet('ip_trie_dictionary_01862', 'value', tuple(toIPv4('1.1.1.1'))) FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'ip_trie_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'ip_trie_dictionary_01862';
 
 DROP DICTIONARY ip_trie_dictionary_01862;
 
@@ -306,9 +306,9 @@ SOURCE(CLICKHOUSE(USER 'default' TABLE 'polygons_01862'))
 LIFETIME(0)
 LAYOUT(POLYGON());
 
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'polygon_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'polygon_dictionary_01862';
 SELECT tuple(x, y) as key, dictGet('polygon_dictionary_01862', 'name', key) FROM points_01862 FORMAT Null;
-SELECT name, found_rate FROM system.dictionaries WHERE database = currentDatabase() AND name = 'polygon_dictionary_01862';
+SELECT name, found_rate, status, last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'polygon_dictionary_01862';
 
 DROP DICTIONARY polygon_dictionary_01862;
 DROP TABLE polygons_01862;


### PR DESCRIPTION
For debug purpose of [01852_dictionary_found_rate_long](https://github.com/ClickHouse/ClickHouse/issues/75169) add more outoup here. Runs a thousand times locally, haven't reproduced. It is suspected related to dict status, so output it with last_exception. If fails in the future, we can have more context. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache

<!--
GitHub Actions can run CI on a PR in one of two ways:
1. Run CI on the branch HEAD.
2. Merge master into the branch HEAD and run CI on the ephemeral merge commit.
Option 2. is safer than 1. but also slower since incoming C++ changes from master typically trash the build artifact cache.
The default in CI is 1. If you like to go for 2. remove the following line:
#no_merge_commit
-->
