### PR TITLE
Fix `02350_views_max_insert_threads`

### DIFF
--- a/tests/queries/0_stateless/02350_views_max_insert_threads.sql
+++ b/tests/queries/0_stateless/02350_views_max_insert_threads.sql
@@ -7,10 +7,10 @@ drop table if exists t_mv;
 create table t (a UInt64) Engine = Null;
 create materialized view t_mv Engine = Null AS select now() as ts, max(a) from t group by ts;
 
-insert into t select * from numbers_mt(10e7) settings max_threads = 16, max_insert_threads=16, max_block_size=100000, parallel_view_processing=1;
+insert into t select * from numbers_mt(10e6) settings max_threads = 10, max_insert_threads=10, max_block_size=100000, parallel_view_processing=1;
 system flush logs;
 
-select peak_threads_usage>=16 from system.query_log where
+select peak_threads_usage>=10 from system.query_log where
     event_date >= yesterday() and
     current_database = currentDatabase() and
     type = 'QueryFinish' and

--- a/tests/queries/0_stateless/02350_views_max_insert_threads.sql
+++ b/tests/queries/0_stateless/02350_views_max_insert_threads.sql
@@ -7,7 +7,7 @@ drop table if exists t_mv;
 create table t (a UInt64) Engine = Null;
 create materialized view t_mv Engine = Null AS select now() as ts, max(a) from t group by ts;
 
-insert into t select * from numbers_mt(10e6) settings max_threads = 16, max_insert_threads=16, max_block_size=100000, parallel_view_processing=1;
+insert into t select * from numbers_mt(10e7) settings max_threads = 16, max_insert_threads=16, max_block_size=100000, parallel_view_processing=1;
 system flush logs;
 
 select peak_threads_usage>=16 from system.query_log where


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/75174

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
