### PR TITLE
Use vertical merge for merge tree in integration tests

### DIFF
--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -30,6 +30,13 @@
 
     <custom_cached_disks_base_directory replace="replace">/</custom_cached_disks_base_directory>
 
+    <!-- Reduce memory consumption a lot, especially make sense for wide system tables and santizier builds -->
+    <!-- Simple merge of dozen of rows of system.metric_log can consume gigabytes of memory -->
+    <merge_tree>
+        <vertical_merge_algorithm_min_rows_to_activate>1</vertical_merge_algorithm_min_rows_to_activate>
+        <vertical_merge_algorithm_min_columns_to_activate>1</vertical_merge_algorithm_min_columns_to_activate>
+    </merge_tree>
+
     <!-- Remove the default remote server to avoid people depending on its hardcoded config -->
     <remote_servers remove="remove"></remote_servers>
 </clickhouse>

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -160,6 +160,8 @@
         <disable_freeze_partition_for_zero_copy_replication>0</disable_freeze_partition_for_zero_copy_replication>
         <disable_detach_partition_for_zero_copy_replication>0</disable_detach_partition_for_zero_copy_replication>
         <disable_fetch_partition_for_zero_copy_replication>0</disable_fetch_partition_for_zero_copy_replication>
+        <vertical_merge_algorithm_min_rows_to_activate>131072</vertical_merge_algorithm_min_rows_to_activate>
+        <vertical_merge_algorithm_min_columns_to_activate>11</vertical_merge_algorithm_min_columns_to_activate>
     </merge_tree>
 
     <database_catalog_unused_dir_hide_timeout_sec>0</database_catalog_unused_dir_hide_timeout_sec>

--- a/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
@@ -33,7 +33,7 @@
 </merge_tree>
 <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
 
-<!-- consume huge amout of memory in sanitizers builds -->
+<!-- consume huge amout of memory in sanitizers builds when min_bytes_for_wide_part=0 -->
 <query_metric_log remove="remove"/>
 <metric_log remove="remove"/>
 

--- a/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_rename_column/configs/config.d/storage_configuration.xml
@@ -28,7 +28,13 @@
 <merge_tree>
     <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
     <temporary_directories_lifetime>1</temporary_directories_lifetime>
+    <vertical_merge_algorithm_min_rows_to_activate>1</vertical_merge_algorithm_min_rows_to_activate>
+    <vertical_merge_algorithm_min_columns_to_activate>1</vertical_merge_algorithm_min_columns_to_activate>
 </merge_tree>
 <allow_remove_stale_moving_parts>true</allow_remove_stale_moving_parts>
+
+<!-- consume huge amout of memory in sanitizers builds -->
+<query_metric_log remove="remove"/>
+<metric_log remove="remove"/>
 
 </clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Example of huge memory consumption: https://pastila.nl/?00c71791/9d38194748974c011c7183e0d554b6f1#FO0nldzVRCZMVIywj7kHaw==. Integration tests are the not place where we test merge algorithm, so I thing "vertical" by default is okay. For stateless test is more complex. Potentially helps #49399. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [x] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
