### PR TITLE
Fix test `03237_insert_sparse_columns_mem`

### DIFF
--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates.sql
@@ -1,4 +1,5 @@
 -- Tags: no-random-merge-tree-settings, no-random-settings, no-parallel
+-- no-parallel: SYSTEM DROP MARK CACHE is used.
 
 DROP TABLE IF EXISTS t_lightweight_mut_5;
 

--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-merge-tree-settings, no-random-settings
+-- Tags: no-random-merge-tree-settings, no-random-settings, no-parallel
 
 DROP TABLE IF EXISTS t_lightweight_mut_5;
 

--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-merge-tree-settings, no-random-settings, no-fasttest, no-parallel-replicas
+-- Tags: no-random-merge-tree-settings, no-random-settings, no-fasttest, no-parallel-replicas, no-parallel
 -- no-parallel-replicas: reading from s3 ('S3GetObject' event) can happened on any "replica", so we can see no 'S3GetObject' on initiator
 
 DROP TABLE IF EXISTS t_lightweight_mut_5;

--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
@@ -1,5 +1,6 @@
 -- Tags: no-random-merge-tree-settings, no-random-settings, no-fasttest, no-parallel-replicas, no-parallel
 -- no-parallel-replicas: reading from s3 ('S3GetObject' event) can happened on any "replica", so we can see no 'S3GetObject' on initiator
+-- no-parallel: SYSTEM DROP MARK CACHE is used.
 
 DROP TABLE IF EXISTS t_lightweight_mut_5;
 

--- a/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
+++ b/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
@@ -5,6 +5,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+set -e
+
 table_structure="id UInt64"
 
 for i in {1..250}; do
@@ -17,7 +19,10 @@ $MY_CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS t_insert_mem;
     DROP TABLE IF EXISTS t_reference;
 
-    CREATE TABLE t_insert_mem ($table_structure) ENGINE = MergeTree ORDER BY id SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+    CREATE TABLE t_insert_mem ($table_structure)
+    ENGINE = MergeTree ORDER BY id
+    SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9, index_granularity = 8192, index_granularity_bytes = '10M';
+
     CREATE TABLE t_reference ($table_structure) ENGINE = Log;
 
     SYSTEM STOP MERGES t_insert_mem;

--- a/tests/queries/0_stateless/03272_prewarm_mark_cache_add_column.sql
+++ b/tests/queries/0_stateless/03272_prewarm_mark_cache_add_column.sql
@@ -1,5 +1,5 @@
 -- Tags: no-parallel
--- no-parallel: if mark cache is dropped concurrently LoadedMarksCount event will be incorrect.
+-- no-parallel: SYSTEM DROP MARK CACHE is used.
 
 DROP TABLE IF EXISTS t_prewarm_add_column;
 
@@ -7,6 +7,7 @@ CREATE TABLE t_prewarm_add_column (a UInt64)
 ENGINE = MergeTree ORDER BY a
 SETTINGS prewarm_mark_cache = 1, min_bytes_for_wide_part = 0;
 
+-- Drop mark cache because it may be full and we will fail to add new entries to it.
 SYSTEM DROP MARK CACHE;
 SYSTEM STOP MERGES t_prewarm_add_column;
 

--- a/tests/queries/0_stateless/03272_prewarm_mark_cache_add_column.sql
+++ b/tests/queries/0_stateless/03272_prewarm_mark_cache_add_column.sql
@@ -1,9 +1,13 @@
+-- Tags: no-parallel
+-- no-parallel: if mark cache is dropped concurrently LoadedMarksCount event will be incorrect.
+
 DROP TABLE IF EXISTS t_prewarm_add_column;
 
 CREATE TABLE t_prewarm_add_column (a UInt64)
 ENGINE = MergeTree ORDER BY a
 SETTINGS prewarm_mark_cache = 1, min_bytes_for_wide_part = 0;
 
+SYSTEM DROP MARK CACHE;
 SYSTEM STOP MERGES t_prewarm_add_column;
 
 INSERT INTO t_prewarm_add_column VALUES (1);


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Fixes #73047.

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
