### PR TITLE
Add documentation for MongoDB Table and dictionary named collection examples

### DIFF
--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -573,7 +573,7 @@ BACKUP TABLE default.test to S3(named_collection_s3_backups, 'directory')
 
 ## Named collections for accessing MongoDB Table and Dictionary
 
-The description of parameters see [mongodb](../sql-reference/table-functions/mongodb.md).
+For the description of parameters see [mongodb](../sql-reference/table-functions/mongodb.md).
 
 ### DDL example
 

--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -570,3 +570,77 @@ BACKUP TABLE default.test to S3(named_collection_s3_backups, 'directory')
     </named_collections>
 </clickhouse>
 ```
+
+## Named collections for accessing MongoDB Table and Dictionary
+
+The description of parameters see [mongodb](../sql-reference/table-functions/mongodb.md).
+
+### DDL example
+
+```sql
+CREATE NAMED COLLECTION mymongo AS
+user = '',
+password = '',
+host = '127.0.0.1',
+port = 27017,
+database = 'test',
+collection = 'my_collection',
+options = 'connectTimeoutMS=10000'
+```
+
+### XML example
+
+```xml
+<clickhouse>
+    <named_collections>
+        <mymongo>
+            <user></user>
+            <password></password>
+            <host>127.0.0.1</host>
+            <port>27017</port>
+            <database>test</database>
+            <collection>my_collection</collection>
+            <options>connectTimeoutMS=10000</options>
+        </mymongo>
+    </named_collections>
+</clickhouse>
+```
+
+#### MongoDB table
+
+```sql
+CREATE TABLE mytable(log_type VARCHAR, host VARCHAR, command VARCHAR) ENGINE = MongoDB(mymongo, options='connectTimeoutMS=10000&compressors=zstd')
+SELECT count() FROM mytable;
+
+┌─count()─┐
+│       2 │
+└─────────┘
+```
+
+:::note
+The DDL overrides the named collection setting for options.
+:::
+
+#### MongoDB Dictionary
+
+```sql
+CREATE DICTIONARY dict
+(
+    `a` Int64,
+    `b` String
+)
+PRIMARY KEY a
+SOURCE(MONGODB(NAME mymongo COLLECTION my_dict))
+LIFETIME(MIN 1 MAX 2)
+LAYOUT(HASHED())
+
+SELECT dictGet('dict', 'b', 2);
+
+┌─dictGet('dict', 'b', 2)─┐
+│ two                     │
+└─────────────────────────┘
+```
+
+:::note
+The named collection specify `my_collection` for the collection name. In the function call it is overwritten by `collection = 'my_dict'` to select another collection.
+:::

--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -642,5 +642,5 @@ SELECT dictGet('dict', 'b', 2);
 ```
 
 :::note
-The named collection specify `my_collection` for the collection name. In the function call it is overwritten by `collection = 'my_dict'` to select another collection.
+The named collection specifies `my_collection` for the collection name. In the function call it is overwritten by `collection = 'my_dict'` to select another collection.
 :::


### PR DESCRIPTION
In response to https://github.com/ClickHouse/clickhouse-docs/issues/1084 to show examples of named collections for MongoDB Table and Dictionary

**Changelog category (leave one):**
Documentation (changelog entry is not required)