### PR TITLE
Right count() in SummingMergeTree order by tuple()

### DIFF
--- a/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.reference
+++ b/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.reference
@@ -1,7 +1,2 @@
--- { echoOn }
-CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = SummingMergeTree() ORDER BY tuple() PARTITION BY (c0) SETTINGS allow_nullable_key = 1;
-INSERT INTO TABLE t0 (c0) VALUES (NULL);
-SELECT * FROM t0 FINAL;
 \N
-SELECT count() FROM t0 FINAL WHERE ((t0.c0 IS NULL) = TRUE);
 1

--- a/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.reference
+++ b/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.reference
@@ -1,0 +1,7 @@
+-- { echoOn }
+CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = SummingMergeTree() ORDER BY tuple() PARTITION BY (c0) SETTINGS allow_nullable_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (NULL);
+SELECT * FROM t0 FINAL;
+\N
+SELECT count() FROM t0 FINAL WHERE ((t0.c0 IS NULL) = TRUE);
+1

--- a/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
+++ b/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
@@ -1,0 +1,5 @@
+-- { echoOn }
+CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = SummingMergeTree() ORDER BY tuple() PARTITION BY (c0) SETTINGS allow_nullable_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (NULL);
+SELECT * FROM t0 FINAL;
+SELECT count() FROM t0 FINAL WHERE ((t0.c0 IS NULL) = TRUE);

--- a/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
+++ b/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
@@ -1,4 +1,4 @@
--- { echoOn }
+SET enable_analyzer = 1;
 CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = SummingMergeTree() ORDER BY tuple() PARTITION BY (c0) SETTINGS allow_nullable_key = 1;
 INSERT INTO TABLE t0 (c0) VALUES (NULL);
 SELECT * FROM t0 FINAL;


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Doesn't reproduce on master. This closes: https://github.com/ClickHouse/ClickHouse/issues/70895

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
