### PR TITLE
Fix test `01290_max_execution_speed_distributed`

### DIFF
--- a/tests/queries/0_stateless/01290_max_execution_speed_distributed.sql
+++ b/tests/queries/0_stateless/01290_max_execution_speed_distributed.sql
@@ -2,11 +2,24 @@
 
 SET log_queries=1;
 
+DROP TABLE IF EXISTS times;
 CREATE TEMPORARY TABLE times (t DateTime);
 
 INSERT INTO times SELECT now();
-SELECT count('special query for 01290_max_execution_speed_distributed') FROM remote('127.0.0.{2,3}', numbers(100000))
-SETTINGS max_execution_speed = 100000, timeout_before_checking_execution_speed = 0, max_block_size = 100;
+
+SELECT count('special query for 01290_max_execution_speed_distributed')
+FROM
+(
+    SELECT
+        sleep(0.001), -- sleep for each block is needed to make sure the query cannot finish too fast,
+                      -- i.e. before the first timer tick that might take up to 10ms on some platforms including ARM.
+                      -- the timer's resolution is important because we use `CLOCK_MONOTONIC_COARSE` in `ReadProgressCallback`.
+                      -- ATST `sleep` uses more accurate timer, so we won't spend more than 100ms in total sleeping.
+        number
+    FROM remote('127.0.0.{2,3}', numbers(100000))
+)
+SETTINGS max_execution_speed = 100000, timeout_before_checking_execution_speed = 0, max_block_size = 1000;
+
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 1 FROM times;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes: #71366


#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
