### PR TITLE
Add option to skip user setup in entrypoint.sh

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
 CLICKHOUSE_DB="${CLICKHOUSE_DB:-}"
 CLICKHOUSE_ACCESS_MANAGEMENT="${CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT:-0}"
-CLICKHOUSE_SKIP_USER_SETUP="${$CLICKHOUSE_SKIP_USER_SETUP:-0}"
+CLICKHOUSE_SKIP_USER_SETUP="${CLICKHOUSE_SKIP_USER_SETUP:-0}"
 
 function create_directory_and_do_chown() {
     local dir=$1
@@ -106,7 +106,7 @@ do
 done
 
 if [ "$CLICKHOUSE_SKIP_USER_SETUP" == "1" ]; then
-    echo "$0: explicitly skip user changing user 'default'"
+    echo "$0: explicitly skip changing user 'default'"
 # if clickhouse user is defined - create it (user "default" already exists out of box)
 elif [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ] || [ "$CLICKHOUSE_ACCESS_MANAGEMENT" != "0" ]; then
     echo "$0: create new user '$CLICKHOUSE_USER' instead 'default'"

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -106,10 +106,11 @@ do
 done
 
 if [ "$CLICKHOUSE_SKIP_USER_SETUP" == "1" ]; then
-  # if clickhouse user is defined - create it (user "default" already exists out of box)
-  if [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ] || [ "$CLICKHOUSE_ACCESS_MANAGEMENT" != "0" ]; then
-      echo "$0: create new user '$CLICKHOUSE_USER' instead 'default'"
-      cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
+    echo "$0: explicitly skip user changing user 'default'"
+# if clickhouse user is defined - create it (user "default" already exists out of box)
+elif [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ] || [ "$CLICKHOUSE_ACCESS_MANAGEMENT" != "0" ]; then
+    echo "$0: create new user '$CLICKHOUSE_USER' instead 'default'"
+    cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
 <clickhouse>
   <!-- Docs: <https://clickhouse.com/docs/en/operations/settings/settings_users/> -->
   <users>
@@ -129,9 +130,9 @@ if [ "$CLICKHOUSE_SKIP_USER_SETUP" == "1" ]; then
   </users>
 </clickhouse>
 EOT
-  else
-      echo "$0: neither CLICKHOUSE_USER nor CLICKHOUSE_PASSWORD is set, disabling network access for user '$CLICKHOUSE_USER'"
-      cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
+else
+    echo "$0: neither CLICKHOUSE_USER nor CLICKHOUSE_PASSWORD is set, disabling network access for user '$CLICKHOUSE_USER'"
+    cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
 <clickhouse>
   <!-- Docs: <https://clickhouse.com/docs/en/operations/settings/settings_users/> -->
   <users>
@@ -145,7 +146,6 @@ EOT
   </users>
 </clickhouse>
 EOT
-  fi
 fi
 
 CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS="${CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS:-}"


### PR DESCRIPTION
Some internal scripts are failing when attempting to write to `/etc/clickhouse-server/users.d/default-user.xml` after https://github.com/ClickHouse/ClickHouse/pull/75259, because some containers are mounted with read-only volumes.
Add an environment variable to skip the block that creates the default user, as it can be added from configuration files instead.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
