### PR TITLE
Close old issue with parallel replicas

### DIFF
--- a/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
+++ b/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
@@ -1,0 +1,9 @@
+-- There are no settings to enable parallel replicas explicitly, because
+-- we have a separate test run with them and they will be enabled automatically.
+
+SELECT
+    count(materialize(toLowCardinality(1))) IGNORE NULLS AS num,
+    hostName() AS hostName
+FROM system.query_log AS a
+INNER JOIN system.processes AS b ON (type = toFixedString(toNullable('QueryStart'), 10)) AND (dateDiff('second', event_time, now()) > 5) AND (current_database = currentDatabase())
+FORMAT `Null`;

--- a/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
+++ b/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
@@ -1,6 +1,8 @@
 -- There are no settings to enable parallel replicas explicitly, because
 -- we have a separate test run with them and they will be enabled automatically.
 
+SET enable_analyzer=1;
+
 SELECT
     count(materialize(toLowCardinality(1))) IGNORE NULLS AS num,
     hostName() AS hostName


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The issue no longer reproduces. This closes: https://github.com/ClickHouse/ClickHouse/issues/68533

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
