### PR TITLE
Fix `TOO_MANY_ROWS` error in `01158_zookeeper_log_long`

### DIFF
--- a/tests/queries/0_stateless/01158_zookeeper_log_long.sql
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.sql
@@ -26,22 +26,36 @@ from system.zookeeper_log where path like '/test/01158/' || currentDatabase() ||
 order by xid, type, request_idx;
 
 select 'parts';
+with now() - interval 1 hour as cutoff_time,
+query_ids as
+(
+    select query_id from system.query_log where current_database=currentDatabase() and event_time>=cutoff_time
+)
 select type, has_watch, op_num, replace(path, toString(serverUUID()), '<uuid>'), is_ephemeral, is_sequential, if(startsWith(path, '/clickhouse/sessions'), 1, version), requests_size, request_idx, error, watch_type,
        watch_state, path_created, stat_version, stat_cversion, stat_dataLength, stat_numChildren
 from system.zookeeper_log
-where (session_id, xid) in (
-    select session_id, xid from system.zookeeper_log where path='/test/01158/' || currentDatabase() || '/rmt/replicas/1/parts/all_0_0_0'
-    and (query_id='' or query_id in (select query_id from system.query_log where current_database=currentDatabase() and event_date>=yesterday()))
+where event_time>=cutoff_time and (session_id, xid) in (
+    select session_id, xid from system.zookeeper_log where event_time>=cutoff_time
+    and path='/test/01158/' || currentDatabase() || '/rmt/replicas/1/parts/all_0_0_0'
+    and (query_id='' or query_id in query_ids)
 )
 order by xid, type, request_idx;
 
 select 'blocks';
+
+with now() - interval 1 hour as cutoff_time,
+query_ids as
+(
+    select query_id from system.query_log where current_database=currentDatabase() and event_time>=cutoff_time
+)
 select type, has_watch, op_num, path, is_ephemeral, is_sequential, version, requests_size, request_idx, error, watch_type,
        watch_state, path_created, stat_version, stat_cversion, stat_dataLength, stat_numChildren
 from system.zookeeper_log
-where (session_id, xid) in (
-    select session_id, xid from system.zookeeper_log where path like '/test/01158/' || currentDatabase() || '/rmt/blocks/%' and op_num not in (1, 12, 500)
-    and (query_id='' or query_id in (select query_id from system.query_log where current_database=currentDatabase() and event_date>=yesterday()))
+where event_time>=cutoff_time and (session_id, xid) in (
+    select session_id, xid from system.zookeeper_log where event_time>=cutoff_time
+    and path like '/test/01158/' || currentDatabase() || '/rmt/blocks/%'
+    and op_num not in (1, 12, 500)
+    and (query_id='' or query_id in query_ids)
 )
 order by xid, type, request_idx;
 


### PR DESCRIPTION
Limit the number of rows processed by the inner query.
```
2024-12-16 16:44:22 [c60341892f5f] 2024.12.16 15:44:22.097193 [ 250910 ] {110d1ee7-64e6-4f95-be68-2102660dfbf0} <Error> executeQuery: Code: 158. DB::Exception: Limit for rows or bytes to read exceeded, max rows: 20.00 million, current rows: 20.85 million: While executing MergeTreeSelect(pool: ReadPool, algorithm: Thread). (TOO_MANY_ROWS) (version 24.9.1.6127) (from [::1]:55202) (comment: 01158_zookeeper_log_long.sql) (in query: select type, has_watch, op_num, replace(path, toString(serverUUID()), '<uuid>'), is_ephemeral, is_sequential, if(startsWith(path, '/clickhouse/sessions'), 1, version), requests_size, request_idx, error, watch_type, watch_state, path_created, stat_version, stat_cversion, stat_dataLength, stat_numChildren from system.zookeeper_log where (session_id, xid) in ( select session_id, xid from system.zookeeper_log where path='/test/01158/' || currentDatabase() || '/rmt/replicas/1/parts/all_0_0_0' and (query_id='' or query_id in (select query_id from system.query_log where current_database=currentDatabase() and event_date>=yesterday())) ) order by xid, type, request_idx;), Stack trace (when copying this message, always include the lines below):
2024-12-16 16:44:22 
2024-12-16 16:44:22 0. ./build_docker/./src/Common/Exception.cpp:111: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000cf5541b
2024-12-16 16:44:22 1. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000007f7c74c
2024-12-16 16:44:22 2. ./src/Common/Exception.h:128: DB::Exception::Exception<char const*&, String, String>(int, FormatStringHelperImpl<std::type_identity<char const*&>::type, std::type_identity<String>::type, std::type_identity<String>::type>, char const*&, String&&, String&&) @ 0x000000001083048e
2024-12-16 16:44:22 3. ./build_docker/./src/QueryPipeline/SizeLimits.cpp:24: DB::SizeLimits::check(unsigned long, unsigned long, char const*, int, int) const @ 0x00000000108300c7
2024-12-16 16:44:22 4. ./build_docker/./src/QueryPipeline/ReadProgressCallback.cpp:109: DB::ReadProgressCallback::onProgress(unsigned long, unsigned long, std::list<DB::StorageLimits, std::allocator<DB::StorageLimits>> const&) @ 0x0000000010818833
2024-12-16 16:44:22 5. ./build_docker/./src/Processors/Executors/ExecutionThreadContext.cpp:62: DB::ExecutionThreadContext::executeTask() @ 0x0000000012fff726
2024-12-16 16:44:22 6. ./build_docker/./src/Processors/Executors/PipelineExecutor.cpp:288: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x0000000012ff30d0
2024-12-16 16:44:22 7. ./build_docker/./src/Processors/Executors/PipelineExecutor.cpp:254: DB::PipelineExecutor::execute(unsigned long, bool) @ 0x0000000012ff2544
2024-12-16 16:44:22 8. ./build_docker/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:83: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x00000000130031aa
2024-12-16 16:44:22 9. ./contrib/llvm-project/libcxx/include/__functional/function.h:848: ? @ 0x000000000d032fbf
2024-12-16 16:44:22 10. ? @ 0x00007fe886620ac3
2024-12-16 16:44:22 11. ? @ 0x00007fe8866b2850
2024-12-16 16:44:22
```
https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/21809/9596a25c9be215ad6ce33974c12871b27a382c24/stateless_tests__release__s3_storage_.html

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
