### PR TITLE
s3queue: do not throw exception about duplicated settings on attach

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -123,7 +123,7 @@ void ObjectStorageQueueSettings::applyChanges(const SettingsChanges & changes)
     impl->applyChanges(changes);
 }
 
-void ObjectStorageQueueSettings::loadFromQuery(ASTStorage & storage_def)
+void ObjectStorageQueueSettings::loadFromQuery(ASTStorage & storage_def, bool is_attach, const StorageID & storage_id)
 {
     if (storage_def.settings)
     {
@@ -151,7 +151,22 @@ void ObjectStorageQueueSettings::loadFromQuery(ASTStorage & storage_def)
                 {
                     bool inserted = names.insert(change.name).second;
                     if (!inserted)
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is duplicated", change.name);
+                    {
+                        if (is_attach)
+                        {
+                            LOG_WARNING(
+                                getLogger("StorageObjectStorageQueue"),
+                                "Storage {} has a duplicated setting {}. "
+                                "Will use the first declared setting's value",
+                                storage_id.getNameForLogs(), change.name);
+                        }
+                        else
+                        {
+                            throw Exception(
+                                ErrorCodes::BAD_ARGUMENTS,
+                                "Setting {} is duplicated", change.name);
+                        }
+                    }
                 }
             }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -164,7 +164,7 @@ void ObjectStorageQueueSettings::loadFromQuery(ASTStorage & storage_def, bool is
                         {
                             throw Exception(
                                 ErrorCodes::BAD_ARGUMENTS,
-                                "Setting {} is duplicated", change.name);
+                                "Setting {} is defined multiple times", change.name);
                         }
                     }
                 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h
@@ -13,6 +13,7 @@ struct ObjectStorageQueueSettingsImpl;
 struct MutableColumnsAndConstraints;
 class StorageObjectStorageQueue;
 class SettingsChanges;
+struct StorageID;
 
 /// List of available types supported in ObjectStorageQueueSettings object
 #define OBJECT_STORAGE_QUEUE_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
@@ -60,7 +61,7 @@ struct ObjectStorageQueueSettings
         const std::string & database_name,
         const StorageObjectStorageQueue & storage) const;
 
-    void loadFromQuery(ASTStorage & storage_def);
+    void loadFromQuery(ASTStorage & storage_def, bool is_attach, const StorageID & storage_id);
 
     void applyChanges(const SettingsChanges & changes);
 

--- a/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
+++ b/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
@@ -42,7 +42,8 @@ StoragePtr createQueueStorage(const StorageFactory::Arguments & args)
     auto queue_settings = std::make_unique<ObjectStorageQueueSettings>();
     if (args.storage_def->settings)
     {
-        queue_settings->loadFromQuery(*args.storage_def);
+        const bool is_attach = args.mode > LoadingStrictnessLevel::CREATE;
+        queue_settings->loadFromQuery(*args.storage_def, is_attach, args.table_id);
 
         Settings settings = args.getContext()->getSettingsCopy();
         settings.applyChanges(args.storage_def->settings->changes);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
