### PR TITLE
Disable tests which consume tens of gigs of memory with sanitizers

### DIFF
--- a/tests/integration/test_rename_column/test.py
+++ b/tests/integration/test_rename_column/test.py
@@ -293,6 +293,9 @@ def alter_move(node, table_name, iterations=1, ignore_exception=False):
 
 
 def test_rename_parallel_same_node(started_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     table_name = "test_rename_parallel_same_node"
     drop_table(nodes, table_name)
     try:
@@ -331,6 +334,9 @@ def test_rename_parallel_same_node(started_cluster):
 
 
 def test_rename_parallel(started_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     table_name = "test_rename_parallel"
     drop_table(nodes, table_name)
     try:
@@ -370,6 +376,9 @@ def test_rename_parallel(started_cluster):
 
 def test_rename_with_parallel_select(started_cluster):
     table_name = "test_rename_with_parallel_select"
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     drop_table(nodes, table_name)
     try:
         create_table(nodes, table_name)
@@ -420,6 +429,9 @@ def test_rename_with_parallel_select(started_cluster):
 
 
 def test_rename_with_parallel_insert(started_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     table_name = "test_rename_with_parallel_insert"
     drop_table(nodes, table_name)
     try:
@@ -473,6 +485,9 @@ def test_rename_with_parallel_insert(started_cluster):
 
 
 def test_rename_with_parallel_merges(started_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     table_name = "test_rename_with_parallel_merges"
     drop_table(nodes, table_name)
     try:
@@ -536,6 +551,9 @@ def test_rename_with_parallel_merges(started_cluster):
 
 
 def test_rename_with_parallel_slow_insert(started_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     table_name = "test_rename_with_parallel_slow_insert"
     drop_table(nodes, table_name)
     try:
@@ -574,6 +592,9 @@ def test_rename_with_parallel_slow_insert(started_cluster):
 
 
 def test_rename_with_parallel_ttl_move(started_cluster):
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     table_name = "test_rename_with_parallel_ttl_move"
     try:
         create_table(
@@ -645,6 +666,9 @@ def test_rename_with_parallel_ttl_move(started_cluster):
 
 def test_rename_with_parallel_ttl_delete(started_cluster):
     table_name = "test_rename_with_parallel_ttl_delete"
+    if node1.is_built_with_sanitizer():
+        pytest.skip("Consume tons of memory with sanitizer")
+
     try:
         create_table(nodes, table_name, with_time_column=True, with_ttl_delete=True)
         rename_column(node1, table_name, "time", "time2", 1, False)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable tests `test_rename_column` with sanitizers because they consume 10-40 gigabytes of memory. Fixes #49399.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
