### PR TITLE
Precalculate number of output rows and reserve mem for them

### DIFF
--- a/src/Interpreters/HashJoin/AddedColumns.cpp
+++ b/src/Interpreters/HashJoin/AddedColumns.cpp
@@ -3,6 +3,12 @@
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 JoinOnKeyColumns::JoinOnKeyColumns(
     const ScatteredBlock & block_, const Names & key_names_, const String & cond_column_name, const Sizes & key_sizes_)
     : block(block_)
@@ -194,7 +200,7 @@ void AddedColumns<false>::appendFromBlock(const RowRef * row_ref, const bool has
 }
 
 template <>
-__attribute__((noreturn)) void AddedColumns<false>::appendFromBlock(const RowRefList *, bool) 
+__attribute__((noreturn)) void AddedColumns<false>::appendFromBlock(const RowRefList *, bool)
 {
     throw Exception(ErrorCodes::LOGICAL_ERROR, "AddedColumns are not implemented for RowRefList in non-lazy mode");
 }

--- a/src/Interpreters/HashJoin/AddedColumns.h
+++ b/src/Interpreters/HashJoin/AddedColumns.h
@@ -57,9 +57,34 @@ public:
         }
     };
 
-    struct LazyOutput
+    class LazyOutput
     {
         PaddedPODArray<UInt64> row_refs;
+        size_t row_count = 0;   /// Total number of rows in all RowRef-s and RowRefList-s
+
+    public:
+        const PaddedPODArray<UInt64> & getRowRefs() const { return row_refs; }
+        size_t getRowCount() const { return row_count; }
+
+        void reserve(size_t size) { row_refs.reserve(size); }
+
+        void addRowRef(const RowRef * row_ref)
+        {
+            row_refs.emplace_back(reinterpret_cast<UInt64>(row_ref));
+            ++row_count;
+        }
+
+        void addRowRefList(const RowRefList * row_ref_list)
+        {
+            row_refs.emplace_back(reinterpret_cast<UInt64>(row_ref_list));
+            row_count += row_ref_list->rows;
+        }
+
+        void addDefault()
+        {
+            row_refs.emplace_back(0);
+            ++row_count;
+        }
     };
 
     AddedColumns(
@@ -88,7 +113,7 @@ public:
         if constexpr (lazy)
         {
             has_columns_to_add = num_columns_to_add > 0;
-            lazy_output.row_refs.reserve(rows_to_add);
+            lazy_output.reserve(rows_to_add);
         }
 
         columns.reserve(num_columns_to_add);
@@ -139,6 +164,7 @@ public:
         return ColumnWithTypeAndName(std::move(columns[i]), type_name[i].type, type_name[i].qualified_name);
     }
 
+    void appendFromBlock(const RowRefList * row_ref_list, bool has_default);
     void appendFromBlock(const RowRef * row_ref, bool has_default);
 
     void appendDefaultRow();
@@ -238,6 +264,9 @@ private:
      */
     template<bool from_row_list>
     void buildOutputFromBlocks();
+
+    template<bool join_data_sorted>
+    void buildOutputFromRowRefLists();
 };
 
 /// Adapter class to pass into addFoundRowAll


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Slight improvement in some join scenarios: precalculate number of output rows and reserve memory for them.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
