### PR TITLE
CI: Decouple Sync and Mergeable check statuses

### DIFF
--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -609,7 +609,6 @@ class CommonJobConfigs:
 
 REQUIRED_CHECKS = [
     StatusNames.PR_CHECK,
-    StatusNames.SYNC,
     JobNames.BUILD_CHECK,
     JobNames.DOCS_CHECK,
     JobNames.FAST_TEST,

--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -462,7 +462,6 @@ def set_mergeable_check(
 def trigger_mergeable_check(
     commit: Commit,
     statuses: CommitStatuses,
-    set_from_sync: bool = False,
     workflow_failed: bool = False,
 ) -> StatusType:
     """calculate and update CI.StatusNames.MERGEABLE"""
@@ -502,12 +501,7 @@ def trigger_mergeable_check(
 
     description = format_description(description)
 
-    if set_from_sync:
-        # update Mergeable Check from sync WF only if its status already present or its new status is FAILURE
-        #   to avoid false-positives
-        if mergeable_status or state == FAILURE:
-            set_mergeable_check(commit, description, state)
-    elif mergeable_status is None or mergeable_status.description != description:
+    if mergeable_status is None or mergeable_status.description != description:
         set_mergeable_check(commit, description, state)
 
     return state
@@ -536,11 +530,6 @@ def update_upstream_sync_status(
         "",
         description,
         CI.StatusNames.SYNC,
-    )
-    trigger_mergeable_check(
-        last_synced_upstream_commit,
-        get_commit_filtered_statuses(last_synced_upstream_commit),
-        set_from_sync=True,
     )
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
As _Mergeable check_ and _Sync_ are now two separate _required for merge_ statuses - dependency one on another can be removed from code

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
