### PR TITLE
Add libc6-compat to container

### DIFF
--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN CGO_ENABLED=0 go install github.com/wjdp/htmltest@v${HTMLTEST_VERSION} \
 # nodejs 17 prefers ipv6 and is broken in our environment
 FROM node:20-alpine
 
-RUN apk add --no-cache git openssh bash curl
+RUN apk add --no-cache git openssh bash curl libc6-compat
 
 # At this point we want to really update /opt/clickhouse-docs directory
 # So we reset the cache


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

I have PR https://github.com/ClickHouse/clickhouse-docs/pull/3168 failing on docs check build. It runs a shell script which is using curl to download the clickhouse binary (used in generating the markdown for settings), however I always get error: 

```
./clickhouse: cannot execute: required file not found
```

I spent ages trying to see what I did wrong.
- file exists
- it has the correct permissions
- the script runs fine locally and on Vercel (ubuntu based)

Eventually I came across this stack overflow post for people having the same issue:

https://stackoverflow.com/questions/66963068/docker-alpine-executable-binary-not-found-even-if-in-path

I'm hoping this solves the issue

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
