### PR TITLE
Add ClickHouse to docs dockerfile

### DIFF
--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -6,10 +6,23 @@ ARG HTMLTEST_VERSION=0.17.0
 RUN CGO_ENABLED=0 go install github.com/wjdp/htmltest@v${HTMLTEST_VERSION} \
     && mv "${GOPATH}/bin/htmltest" /usr/bin/htmltest
 
+# we need clickhouse for running of the settings autogeneration script
+FROM clickhouse/clickhouse-server AS clickhouse-provider
+
 # nodejs 17 prefers ipv6 and is broken in our environment
 FROM node:20-alpine
 
-RUN apk add --no-cache git openssh bash curl libc6-compat sudo
+RUN apk add --no-cache git openssh bash curl libc6-compat
+
+# Copy ClickHouse binary from the clickhouse-provider stage
+COPY --from=clickhouse-provider /usr/bin/clickhouse /usr/bin/clickhouse
+ENV PATH=$PATH:/usr/bin
+
+# Despite using libc6-compat we are still missing some files
+# See https://github.com/ClickHouse/ClickHouse/issues/26350
+RUN git clone https://github.com/ClickHouse/libc-blobs.git -b master --depth=1
+RUN mv /lib/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1.bak
+RUN cp -r libc-blobs/aarch64/lib/* /lib/
 
 # At this point we want to really update /opt/clickhouse-docs directory
 # So we reset the cache
@@ -24,7 +37,7 @@ RUN yarn config set registry https://registry.npmjs.org \
     && yarn install \
     && yarn cache clean
 
-ENV HOME /opt/clickhouse-docs
+ENV HOME=/opt/clickhouse-docs
 
 RUN mkdir /output_path \
   && chmod -R a+w . /output_path \

--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -6,22 +6,13 @@ ARG HTMLTEST_VERSION=0.17.0
 RUN CGO_ENABLED=0 go install github.com/wjdp/htmltest@v${HTMLTEST_VERSION} \
     && mv "${GOPATH}/bin/htmltest" /usr/bin/htmltest
 
-# we need clickhouse for running of the settings autogeneration script
-FROM clickhouse/clickhouse-server AS clickhouse-provider
+FROM node:20-bookworm-slim
 
-# nodejs 17 prefers ipv6 and is broken in our environment
-FROM node:20-alpine
+RUN apt-get update && \
+    apt install -y --no-install-recommends git openssh-server bash ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*:
 
-RUN apk add --no-cache git openssh bash curl libc6-compat
-
-# Copy ClickHouse binary from the clickhouse-provider stage
-COPY --from=clickhouse-provider /usr/bin/clickhouse /usr/bin/clickhouse
-ENV PATH=$PATH:/usr/bin
-
-# Despite using libc6-compat we are still missing some files
-# See https://github.com/ClickHouse/ClickHouse/issues/26350
-RUN git clone https://github.com/ClickHouse/libc-blobs.git -b master --depth=1
-RUN cp -r libc-blobs/aarch64/lib/* /lib/
+RUN curl https://clickhouse.com/ | sh
 
 # At this point we want to really update /opt/clickhouse-docs directory
 # So we reset the cache

--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -21,7 +21,6 @@ ENV PATH=$PATH:/usr/bin
 # Despite using libc6-compat we are still missing some files
 # See https://github.com/ClickHouse/ClickHouse/issues/26350
 RUN git clone https://github.com/ClickHouse/libc-blobs.git -b master --depth=1
-RUN mv /lib/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1.bak
 RUN cp -r libc-blobs/aarch64/lib/* /lib/
 
 # At this point we want to really update /opt/clickhouse-docs directory

--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update && \
     apt install -y --no-install-recommends git openssh-server bash ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*:
 
-RUN curl https://clickhouse.com/ | sh
-
 # At this point we want to really update /opt/clickhouse-docs directory
 # So we reset the cache
 ARG CACHE_INVALIDATOR=0


### PR DESCRIPTION
Trying to get clickhouse-local working in the docs container, as it is needed to run a script for autogenerating documentation from source code for settings.

Maybe there is a better way to do it, happy to receive suggestions.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes.

Not sure if this is the best way to do this, open to suggestions if there is a more efficient way.

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
