### PR TITLE
Ignore some jemalloc messages

### DIFF
--- a/programs/keeper/keeper_main.cpp
+++ b/programs/keeper/keeper_main.cpp
@@ -143,7 +143,7 @@ __attribute__((constructor(0))) void init_je_malloc_message()
             return;
 
 #    if defined(SYS_write)
-        syscall(SYS_write, fd, message_view.data(), message_view.size());
+        syscall(SYS_write, 2 /*stderr*/, message_view.data(), message_view.size());
 #    else
         write(STDERR_FILENO, message_view.data(), message_view.size());
 #    endif

--- a/programs/keeper/keeper_main.cpp
+++ b/programs/keeper/keeper_main.cpp
@@ -126,6 +126,29 @@ extern "C"
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
 extern "C" void (*malloc_message)(void *, const char *s);
 __attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
+#elif USE_JEMALLOC
+#include <unordered_set>
+/// Ignore messages which can be safely ignored, e.g. EAGAIN on pthread_create
+extern "C" void (*malloc_message)(void *, const char * s);
+__attribute__((constructor(0))) void init_je_malloc_message()
+{
+    malloc_message = [](void *, const char * str)
+    {
+        using namespace std::literals;
+        static const std::unordered_set<std::string_view> ignore_messages{
+            "<jemalloc>: background thread creation failed (11)\n"sv};
+
+        std::string_view message_view{str};
+        if (ignore_messages.contains(message_view))
+            return;
+
+#    if defined(SYS_write)
+        syscall(SYS_write, fd, message_view.data(), message_view.size());
+#    else
+        write(STDERR_FILENO, message_view.data(), message_view.size());
+#    endif
+    };
+}
 #endif
 
 /// This allows to implement assert to forbid initialization of a class in static constructors.

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -220,7 +220,7 @@ __attribute__((constructor(0))) void init_je_malloc_message()
             return;
 
 #    if defined(SYS_write)
-        syscall(SYS_write, fd, message_view.data(), message_view.size());
+        syscall(SYS_write, 2 /*stderr*/, message_view.data(), message_view.size());
 #    else
         write(STDERR_FILENO, message_view.data(), message_view.size());
 #    endif

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -11,6 +11,8 @@
 #include "config.h"
 #include "config_tools.h"
 
+#include <unistd.h>
+
 #include <filesystem>
 #include <iostream>
 #include <new>
@@ -201,6 +203,29 @@ extern "C"
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
 extern "C" void (*malloc_message)(void *, const char *s);
 __attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
+#elif USE_JEMALLOC
+#include <unordered_set>
+/// Ignore messages which can be safely ignored, e.g. EAGAIN on pthread_create
+extern "C" void (*malloc_message)(void *, const char * s);
+__attribute__((constructor(0))) void init_je_malloc_message()
+{
+    malloc_message = [](void *, const char * str)
+    {
+        using namespace std::literals;
+        static const std::unordered_set<std::string_view> ignore_messages{
+            "<jemalloc>: background thread creation failed (11)\n"sv};
+
+        std::string_view message_view{str};
+        if (ignore_messages.contains(message_view))
+            return;
+
+#    if defined(SYS_write)
+        syscall(SYS_write, fd, message_view.data(), message_view.size());
+#    else
+        write(STDERR_FILENO, message_view.data(), message_view.size());
+#    endif
+    };
+}
 #endif
 
 /// This allows to implement assert to forbid initialization of a class in static constructors.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Jemalloc can print out some messages to stderr, sometimes warnings and sometimes errors.
We can safely ignore some of those messages, e.g. `<jemalloc>: background thread creation failed (11)`. 
It is printed when pthread_create for background thread returns `EAGAIN`. It will be simply retried again.

Fix https://github.com/ClickHouse/ClickHouse/issues/74941
I could've ignored message in that test only but it could easily happen for some other random test.
These messages are only printed in nonrelease builds.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
