### PR TITLE
Add various profile events for CHECKSUM_DOESNT_MATCH

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -43,6 +43,9 @@
     M(ReadCompressedBytes, "Number of bytes (the number of bytes before decompression) read from compressed sources (files, network).", ValueType::Bytes) \
     M(CompressedReadBufferBlocks, "Number of compressed blocks (the blocks of data that are compressed independent of each other) read from compressed sources (files, network).", ValueType::Number) \
     M(CompressedReadBufferBytes, "Number of uncompressed bytes (the number of bytes after decompression) read from compressed sources (files, network).", ValueType::Bytes) \
+    M(CompressedReadBufferChecksumDoesntMatch, "Number of times the compressed block checksum did not match.", ValueType::Number) \
+    M(CompressedReadBufferChecksumDoesntMatchSingleBitMismatch, "Number of times a compressed block checksum mismatch was caused by a single-bit difference.", ValueType::Number) \
+    M(CompressedReadBufferChecksumDoesntMatchMicroseconds, "Total time spent detecting bit-flips due to compressed block checksum mismatches.", ValueType::Microseconds) \
     M(UncompressedCacheHits, "Number of times a block of data has been found in the uncompressed cache (and decompression was avoided).", ValueType::Number) \
     M(UncompressedCacheMisses, "Number of times a block of data has not been found in the uncompressed cache (and required decompression).", ValueType::Number) \
     M(UncompressedCacheWeightLost, "Number of bytes evicted from the uncompressed cache.", ValueType::Bytes) \

--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <cassert>
 #include <city.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Exception.h>
 #include <base/hex.h>
@@ -22,6 +23,10 @@ namespace ProfileEvents
     extern const Event ReadCompressedBytes;
     extern const Event CompressedReadBufferBlocks;
     extern const Event CompressedReadBufferBytes;
+
+    extern const Event CompressedReadBufferChecksumDoesntMatch;
+    extern const Event CompressedReadBufferChecksumDoesntMatchSingleBitMismatch;
+    extern const Event CompressedReadBufferChecksumDoesntMatchMicroseconds;
 }
 
 namespace DB
@@ -44,6 +49,9 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
     auto calculated_checksum = CityHash_v1_0_2::CityHash128(data, size);
     if (expected_checksum == calculated_checksum)
         return;
+
+    ProfileEvents::increment(ProfileEvents::CompressedReadBufferChecksumDoesntMatch);
+    ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::CompressedReadBufferChecksumDoesntMatchMicroseconds);
 
     WriteBufferFromOwnString message;
 
@@ -87,6 +95,7 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
             auto checksum_of_data_with_flipped_bit = CityHash_v1_0_2::CityHash128(tmp_data, size);
             if (expected_checksum == checksum_of_data_with_flipped_bit)
             {
+                ProfileEvents::increment(ProfileEvents::CompressedReadBufferChecksumDoesntMatchSingleBitMismatch);
                 message << ". The mismatch is caused by single bit flip in data block at byte " << (bit_pos / 8) << ", bit " << (bit_pos % 8) << ". "
                     << message_hardware_failure;
                 throw Exception::createDeprecated(message.str(), error_code);
@@ -102,6 +111,7 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
 
     if (difference == 1)
     {
+        ProfileEvents::increment(ProfileEvents::CompressedReadBufferChecksumDoesntMatchSingleBitMismatch);
         message << ". The mismatch is caused by single bit flip in checksum. "
             << message_hardware_failure;
         throw Exception::createDeprecated(message.str(), error_code);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

While digging into some `CHECKSUM_DOESNT_MATCH` errors, I was struggling to understand why it takes > 300sec for the query to fail. Besides counters allows to track the errors more easily.