### PR TITLE
Add test with .sql file for incremental backup

### DIFF
--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -147,7 +147,8 @@ BackupFileInfo buildFileInfoForBackupEntry(
             info.checksum = checksums.full_checksum;
 
             /// We have prefix of this file in backup with the same checksum.
-            /// In ClickHouse this can happen for StorageLog for example.
+            /// In ClickHouse this can happen for StorageLog for example,
+            /// or for .sql files that store DDL if only last part of the query was changed.
             if (checksums.prefix_checksum == base_backup_file_info->second)
             {
                 LOG_TRACE(log, "Found prefix of file {} in the base backup, will write rest of the file to current backup", adjusted_path);

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -305,6 +305,67 @@ def test_incremental_backup():
     assert instance.query("SELECT count(), sum(x) FROM test.table2") == "102\t5081\n"
 
 
+def test_incremental_backup_after_settings_change():
+    def get_table_ddl(tablename: str):
+        """
+        Return single-line DDL
+        """
+        ddl = instance.query(
+            f"SELECT create_table_query FROM system.tables WHERE name = '{tablename}' AND database = 'test' SETTINGS show_table_uuid_in_table_create_query_if_not_nil=1, show_create_query_identifier_quoting_rule='when_necessary', show_create_query_identifier_quoting_style='Backticks'"
+        )
+        return re.sub(
+            r"[\\\n]", "", ddl
+        )  # remove quoted backslash and the last end of line, the same format in test/table.sql file in a backup
+
+    backup_name = new_backup_name()
+    increment_backup_name = new_backup_name()
+    increment_backup_name2 = new_backup_name()
+    create_and_fill_table(n=1)
+
+    assert instance.query("SELECT count(), sum(x) FROM test.table") == TSV([["1", "0"]])
+    instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    metadata_path = os.path.join(
+        get_path_to_backup(backup_name), "metadata/test/table.sql"
+    )
+
+    with open(metadata_path) as metadata:
+        ddl = metadata.read()
+
+        assert ddl == get_table_ddl("table")
+
+    instance.query("ALTER TABLE test.table ADD COLUMN new_col String")
+
+    instance.query(
+        f"BACKUP TABLE test.table TO {increment_backup_name} SETTINGS base_backup = {backup_name}"
+    )
+
+    increment_backup_metadata_path = os.path.join(
+        get_path_to_backup(increment_backup_name), "metadata/test/table.sql"
+    )
+
+    with open(increment_backup_metadata_path) as metadata:
+        ddl = metadata.read()
+        assert ddl == get_table_ddl("table")
+
+    instance.query(
+        "ALTER TABLE test.table MODIFY SETTING non_replicated_deduplication_window = 0"
+    )
+
+    instance.query(
+        f"BACKUP TABLE test.table TO {increment_backup_name2} SETTINGS base_backup = {increment_backup_name}"
+    )
+
+    increment_backup_metadata_path2 = os.path.join(
+        get_path_to_backup(increment_backup_name2), "metadata/test/table.sql"
+    )
+
+    with open(increment_backup_metadata_path2) as metadata:
+        ddl = metadata.read()
+        # If checksums for the first part of the files are equal only the diff will be written
+        assert ddl == ", non_replicated_deduplication_window = 0"
+
+
 def test_increment_backup_without_changes():
     backup_name = new_backup_name()
     incremental_backup_name = new_backup_name()


### PR DESCRIPTION
With the test, it becomes clearer why incremental backups can contain only the latest pieces of data.

Additionally, a small comment has been added to the source code.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
