### PR TITLE
Return appropriate error on large query size

### DIFF
--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -318,10 +318,10 @@ ASTPtr tryParseQuery(
     _out_query_end = last_token.end;
 
     // Check if the query length exceeds the max_query_size
-    size_t query_length = _out_query_end - query_begin;
+    size_t query_length = static_cast<size_t>(std::distance(query_begin, _out_query_end));
     if (query_length > max_query_size)
     {
-        out_error_message = "Max query size exceeded";
+        out_error_message = fmt::format("Max query size exceeded: {} > {}", query_length, max_query_size);
         return nullptr;
     }
 

--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -22,6 +22,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int SYNTAX_ERROR;
+    extern const int QUERY_IS_TOO_LARGE;
 }
 
 namespace

--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -267,6 +267,12 @@ ASTPtr tryParseQuery(
     /// NOTE: consider use UInt32 for max_parser_depth setting.
     IParser::Pos token_iterator(tokens, static_cast<uint32_t>(max_parser_depth), static_cast<uint32_t>(max_parser_backtracks));
 
+    if (static_cast<size_t>(all_queries_end - query_begin) > max_query_size)
+    {
+        out_error_message = "Max query size exceeded";
+        return nullptr;
+    }
+
     if (token_iterator->isEnd()
         || token_iterator->type == TokenType::Semicolon)
     {
@@ -401,6 +407,9 @@ ASTPtr parseQueryAndMovePosition(
 
     if (res)
         return res;
+
+    if (error_message == "Max query size exceeded")
+        throw Exception::createDeprecated(error_message, ErrorCodes::QUERY_IS_TOO_LARGE);
 
     throw Exception::createDeprecated(error_message, ErrorCodes::SYNTAX_ERROR);
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Resolves https://github.com/ClickHouse/ClickHouse/issues/75473

### Changelog category (leave one):

- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Earlier when the query size exceeded the `max_query_size`, it used to throw it as `SYNTAX_ERROR` which was misleading. Now it will be throw it as `QUERY_IS_TOO_LARGE` which is appropriate error type.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
