### PR TITLE
Fix codecs_int_select perf test flakiness

### DIFF
--- a/tests/performance/codecs_int_select.xml
+++ b/tests/performance/codecs_int_select.xml
@@ -39,10 +39,11 @@
 
     <create_query>CREATE TABLE IF NOT EXISTS codec_{seq_type}_{type}_{codec} (n {type} CODEC({codec})) ENGINE = MergeTree PARTITION BY tuple() ORDER BY tuple();</create_query>
 
+    <fill_query>SYSTEM STOP MERGES codec_seq_{type}_{codec}</fill_query>
     <fill_query>INSERT INTO codec_seq_{type}_{codec} (n) SELECT number FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>INSERT INTO codec_mon_{type}_{codec} (n) SELECT number*512+(intHash64(number)%512) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>INSERT INTO codec_rnd_{type}_{codec} (n) SELECT intHash64(number) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
-    <fill_query>optimize table codec_{seq_type}_{type}_{codec} settings optimize_throw_if_noop = 1</fill_query>
+    <fill_query>OPTIMIZE TABLE codec_{seq_type}_{type}_{codec} SETTINGS optimize_throw_if_noop = 1</fill_query>
 
     <query>SELECT count(n) FROM codec_{seq_type}_{type}_{codec} WHERE ignore(n) == 0 LIMIT {num_rows} SETTINGS max_threads=1</query>
 

--- a/tests/performance/codecs_int_select.xml
+++ b/tests/performance/codecs_int_select.xml
@@ -37,9 +37,14 @@
         </substitution>
     </substitutions>
 
-    <create_query>CREATE TABLE IF NOT EXISTS codec_{seq_type}_{type}_{codec} (n {type} CODEC({codec})) ENGINE = MergeTree PARTITION BY tuple() ORDER BY tuple();</create_query>
+    <create_query>
+        CREATE TABLE IF NOT EXISTS codec_{seq_type}_{type}_{codec}
+        (n {type} CODEC({codec}))
+        ENGINE = MergeTree
+        ORDER BY tuple()
+        SETTINGS merge_selector_base=1000
+    </create_query>
 
-    <fill_query>SYSTEM STOP MERGES codec_seq_{type}_{codec}</fill_query>
     <fill_query>INSERT INTO codec_seq_{type}_{codec} (n) SELECT number FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>INSERT INTO codec_mon_{type}_{codec} (n) SELECT number*512+(intHash64(number)%512) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>INSERT INTO codec_rnd_{type}_{codec} (n) SELECT intHash64(number) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>


### PR DESCRIPTION
CI found [1], in `codecs_int_select-err.log`:

    clickhouse_driver.errors.ServerException: Code: 388.
    DB::Exception: Cannot OPTIMIZE table: There is no need to merge parts according to merge selector algorithm. Stack trace:

In server log:

    2025.02.04 10:10:01.628389 [ 1327 ] {45e50980-0cef-408f-8def-cd03c745a048} <Debug> executeQuery: (from [::1]:58140) INSERT INTO codec_seq_UInt64_DoubleDelta (n) SELECT number FROM system.numbers LIMIT 20000000 SETTINGS max_threads=1 (stage: Complete)
    2025.02.04 10:10:01.735464 [ 1327 ] {45e50980-0cef-408f-8def-cd03c745a048} <Debug> TCPHandler: Processed in 0.107449617 sec.
    # last insert finished here, and then it has been merged
    2025.02.04 10:10:02.234161 [ 2636 ] {default.codec_seq_UInt64_DoubleDelta::all_1_18_2} <Information> default.codec_seq_UInt64_DoubleDelta (MergerMutator): Merged 7 parts: [all_1_6_1, all_18_18_0] -> all_1_18_2
    # and after it fails
    2025.02.04 10:10:09.018244 [ 1327 ] {7e610e53-f883-4017-9560-96fbbfe4db74} <Debug> executeQuery: (from [::1]:58140) optimize table codec_seq_UInt64_DoubleDelta settings optimize_throw_if_noop = 1 (stage: Complete)
    2025.02.04 10:10:09.018348 [ 1327 ] {7e610e53-f883-4017-9560-96fbbfe4db74} <Information> default.codec_seq_UInt64_DoubleDelta: Cannot OPTIMIZE table: There is no need to merge parts according to merge selector algorithm
    2025.02.04 10:10:09.024092 [ 1327 ] {7e610e53-f883-4017-9560-96fbbfe4db74} <Error> executeQuery: Code: 388. DB::Exception: Cannot OPTIMIZE table: There is no need to merge parts according to merge selector algorithm. (CANNOT_ASSIGN_OPTIMIZE) (version 25.2.1.920 (official build)) (from [::1]:58140) (in query: optimize table codec_seq_UInt64_DoubleDelta settings optimize_throw_if_noop = 1), Stack trace (when copying this message, always include the lines below):

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/75477/afa954c96fabecda711a9cfabe77fd43229e6519/performance_comparison__release__[3_4]/report.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
