### PR TITLE
tests: fix 01720_country_intersection flakiness

### DIFF
--- a/tests/queries/0_stateless/01720_country_intersection.sh
+++ b/tests/queries/0_stateless/01720_country_intersection.sh
@@ -5,14 +5,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 ${CLICKHOUSE_CLIENT} -q "drop table if exists country_polygons;"
-${CLICKHOUSE_CLIENT} -q "create table country_polygons(name String, p Array(Array(Tuple(Float64, Float64)))) engine=MergeTree() order by tuple();"
+${CLICKHOUSE_CLIENT} -q "create table country_polygons(name String, p Array(Array(Tuple(Float64, Float64)))) engine=Memory()"
 cat ${CURDIR}/country_polygons.tsv | ${CLICKHOUSE_CLIENT} -q "insert into country_polygons format TSV"
 ${CLICKHOUSE_CLIENT} -q "SELECT c, d, polygonsIntersectionSpherical(a, b) FROM (SELECT first.p AS a, second.p AS b, first.name AS c, second.name AS d FROM country_polygons AS first CROSS JOIN country_polygons AS second LIMIT 100) format TSV"
 ${CLICKHOUSE_CLIENT} -q "drop table if exists country_polygons;"
 
 
 ${CLICKHOUSE_CLIENT} -q "drop table if exists country_rings;"
-${CLICKHOUSE_CLIENT} -q "create table country_rings(name String, p Array(Tuple(Float64, Float64))) engine=MergeTree() order by tuple();"
+${CLICKHOUSE_CLIENT} -q "create table country_rings(name String, p Array(Tuple(Float64, Float64))) engine=Memory()"
 cat ${CURDIR}/country_rings.tsv | ${CLICKHOUSE_CLIENT} -q "insert into country_rings format TSV"
 ${CLICKHOUSE_CLIENT} -q "SELECT c, d, polygonsIntersectionSpherical(a, b) FROM (SELECT first.p AS a, second.p AS b, first.name AS c, second.name AS d FROM country_rings AS first CROSS JOIN country_rings AS second LIMIT 100) format TSV"
 ${CLICKHOUSE_CLIENT} -q "drop table if exists country_rings;"


### PR DESCRIPTION
Minimal repro, add the following to the beginning of the test:

    CLICKHOUSE_CLIENT+=" --storage_policy=remote_policy" # this is requried to trigger parallel read in ReadFromMergeTree::read() (checkAllPartsOnRemoteFS())
    CLICKHOUSE_CLIENT+=" --index_granularity_bytes 20121 "
    CLICKHOUSE_CLIENT+=" --max_threads 3 "

ORDER BY will require adjusting the .reference file, changing engine to Memory be enough to fix the flakiness and keep .reference as-is.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)