### PR TITLE
ci: tune errors injection and allow replicated database in stress tests

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -74,7 +74,7 @@ def get_options(i: int, upgrade_check: bool) -> str:
     # TODO: After release 24.3 use ignore_drop_queries_probability for both
     #       stress test and upgrade check
     if not upgrade_check:
-        client_options.append("ignore_drop_queries_probability=0.5")
+        client_options.append("ignore_drop_queries_probability=0.2")
 
     if random.random() < 0.2:
         client_options.append("enable_parallel_replicas=1")

--- a/tests/config/config.d/cannot_allocate_thread_injection.xml
+++ b/tests/config/config.d/cannot_allocate_thread_injection.xml
@@ -1,3 +1,3 @@
 <clickhouse>
-    <cannot_allocate_thread_fault_injection_probability>0.0001</cannot_allocate_thread_fault_injection_probability>
+    <cannot_allocate_thread_fault_injection_probability>0.001</cannot_allocate_thread_fault_injection_probability>
 </clickhouse>

--- a/tests/config/config.d/cannot_allocate_thread_injection.xml
+++ b/tests/config/config.d/cannot_allocate_thread_injection.xml
@@ -1,3 +1,3 @@
 <clickhouse>
-    <cannot_allocate_thread_fault_injection_probability>0.01</cannot_allocate_thread_fault_injection_probability>
+    <cannot_allocate_thread_fault_injection_probability>0.0001</cannot_allocate_thread_fault_injection_probability>
 </clickhouse>

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -119,6 +119,7 @@ EOL
 <clickhouse>
     <profiles>
         <default>
+            <database_replicated_allow_replicated_engine_arguments>1</database_replicated_allow_replicated_engine_arguments>
             <max_execution_time>60</max_execution_time>
             <max_memory_usage>10G</max_memory_usage>
             <max_memory_usage_for_user>${max_users_mem}</max_memory_usage_for_user>


### PR DESCRIPTION
Public stress tests either don't work or have limited coverage due to the excessive amount of fault injections (`cannot_allocate_thread_fault_injection_probability=0.01`)

The test logs show huge amounts of the following error:
```DB::Exception: Cannot schedule a task: fault injected (threads=4, jobs=3).```

Also set `database_replicated_allow_replicated_engine_arguments=1` to allow tests with replicated database and tables. 


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
