### PR TITLE
Fix flaky test 03272_json_to_json_cast_2

### DIFF
--- a/tests/queries/0_stateless/03272_json_to_json_cast_2.sql
+++ b/tests/queries/0_stateless/03272_json_to_json_cast_2.sql
@@ -24,6 +24,7 @@ select json::JSON(max_dynamic_paths=0) as json2, JSONDynamicPaths(json2), JSONSh
 drop table test;
 
 set max_block_size=10000;
+set max_threads=1;
 create table test (id UInt64, json JSON(max_dynamic_paths=4)) engine=MergeTree order by id;
 insert into test select number, multiIf(number < 10000, '{"k2" : 42}', number < 30000, '{"k3" : 42}', number < 60000, '{"k4" : 42}', number < 100000, '{"k1" : 42}', '{"k1" : 42, "k2" : 42, "k3" : 42, "k4" : 42}') from numbers(150000);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flaky test 03272_json_to_json_cast_2. Closes https://github.com/ClickHouse/ClickHouse/issues/74624

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
