### PR TITLE
tests: use compact output for skip reason in clickhouse-test launcher

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1750,7 +1750,7 @@ class TestCase:
         description_full = messages[result.status]
         description_full += self.print_test_time(result.total_time)
         if result.reason is not None:
-            description_full += f"\nReason: {result.reason.value} "
+            description_full += f" (reason: {result.reason.value})"
 
         description_full += result.description
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)