### PR TITLE
Docs: add section for `CLUSTER` privilege

### DIFF
--- a/docs/en/sql-reference/statements/grant.md
+++ b/docs/en/sql-reference/statements/grant.md
@@ -233,7 +233,7 @@ Hierarchy of privileges:
     - `SYSTEM FLUSH`
         - `SYSTEM FLUSH DISTRIBUTED`
         - `SYSTEM FLUSH LOGS`
-    - `CLUSTER` (see also `access_control_improvements.on_cluster_queries_require_cluster_grant` configuration directive)
+- [CLUSTER](#cluster)
 - [INTROSPECTION](#introspection)
     - `addressToLine`
     - `addressToLineWithInlines`
@@ -402,6 +402,30 @@ Allows executing [CREATE](../../sql-reference/statements/create/index.md) and [A
 **Notes**
 
 - To delete the created table, a user needs [DROP](#drop).
+
+### CLUSTER
+
+Allows executing `ON CLUSTER` queries.
+
+```sql title="Syntax"
+GRANT CLUSTER ON *.* TO <username>
+```
+
+By default, queries with `ON CLUSTER` require the user to have the `CLUSTER` grant.
+You will get the following error if you to try to use `ON CLUSTER` in a query without first granting the `CLUSTER` privilege:
+
+```text
+Not enough privileges. To execute this query, it's necessary to have the grant CLUSTER ON *.*. 
+```
+
+The default behavior can be changed by setting the `on_cluster_queries_require_cluster_grant` setting,
+located in the `access_control_improvements` section of `config.xml` (see below), to `false`.
+
+```yaml title="config.xml"
+<access_control_improvements>
+    <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
+</access_control_improvements>
+```
 
 ### DROP
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Addresses [#2996](https://github.com/ClickHouse/clickhouse-docs/issues/2996). 
- Moves `CLUSTER` out from underneath `SYSTEM` as it is of type `GLOBAL`.
- Adds a section for `CLUSTER` privilege, including where to find the relevant setting.  

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
