### PR TITLE
[RFC] Decrease maximum block size for verifying bit flip in case of checksum mismatch

### DIFF
--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -73,7 +73,7 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
 
     /// If size is too huge, then this may be caused by corruption.
     /// And anyway this is pretty heavy, so avoid burning too much CPU here.
-    if (size < (1ULL << 20))
+    if (size < (512ULL << 10))
     {
         /// We need to copy data from ReadBuffer to flip bits as ReadBuffer should be immutable
         PODArray<char> tmp_buffer(data, data + size);


### PR DESCRIPTION
The reason for this change is speed:
- validating bit flip for 1MiB   block: 420sec
- validating bit flip for 512KiB block: 104sec

And when this takes > 300 sec, it exceeds default
`send_timeout`/`receive_timeout`, and will lead to connection resets.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

_Note: I want to gather some statistics first, hence - draft._

Refs: #5347 (cc @alexey-milovidov )