### PR TITLE
add a test for SYSTEM_VIEWS grant

### DIFF
--- a/tests/queries/0_stateless/03327_permissions_on_refresh_mv.sh
+++ b/tests/queries/0_stateless/03327_permissions_on_refresh_mv.sh
@@ -10,12 +10,14 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT="`echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g'`"
 CLICKHOUSE_CLIENT="`echo "$CLICKHOUSE_CLIENT --allow_materialized_view_with_bad_select=0 --session_timezone Etc/UTC"`"
 db=$CLICKHOUSE_DATABASE
+user_1="user_${CLICKHOUSE_TEST_UNIQUE_NAME}_1"
+user_2="user_${CLICKHOUSE_TEST_UNIQUE_NAME}_2"
 
 $CLICKHOUSE_CLIENT -q "
 drop view if exists mv_test_03327;
 drop table if exists test_03327;
-drop user if exists test_03327_user_1;
-drop user if exists test_03327_user_2;
+drop user if exists $user_1;
+drop user if exists $user_2;
 "
 
 $CLICKHOUSE_CLIENT -q "
@@ -28,29 +30,34 @@ create materialized view mv_test_03327 refresh every 10 minute append (x Int64) 
 
 # user with missing system views grant
 $CLICKHOUSE_CLIENT -q "
-create user test_03327_user_1;
-revoke all on *.* from test_03327_user_1;
-GRANT SHOW ON $db to test_03327_user_1;
+create user if not exists $user_1;
+revoke all on *.* from $user_1;
+grant select on $db.mv_test_03327 to $user_1;
+GRANT SHOW ON $db to $user_1;
 "
 
 # this should not work
-$CLICKHOUSE_CLIENT -u 'test_03327_user_1' -q "
+$CLICKHOUSE_CLIENT -u $user_1 -q "
 use $db;
 system refresh view mv_test_03327; -- { serverError ACCESS_DENIED }
+system start view mv_test_03327; -- { serverError ACCESS_DENIED }
+select * from mv_test_03327 format null;
+system wait view mv_test_03327; -- { serverError ACCESS_DENIED }
+system stop view mv_test_03327; -- { serverError ACCESS_DENIED }
+system cancel view mv_test_03327; -- { serverError ACCESS_DENIED }
 "
 
 # user with system views grant
 $CLICKHOUSE_CLIENT -q "
-create user test_03327_user_2;
-revoke all on *.* from test_03327_user_2;
-grant select on $db.test_03327 to test_03327_user_2;
-grant select on $db.mv_test_03327 to test_03327_user_2;
-grant show on $db to test_03327_user_2;
-grant system views on $db.* to test_03327_user_2;
+create user if not exists $user_2;
+revoke all on *.* from $user_2;
+grant select on $db.mv_test_03327 to $user_2;
+grant show on $db to $user_2;
+grant system views on $db.* to $user_2;
 "
 
 # all these operations should work
-$CLICKHOUSE_CLIENT -u 'test_03327_user_2' -q "
+$CLICKHOUSE_CLIENT -u $user_2 -q "
 use $db;
 system refresh view mv_test_03327;
 system start view mv_test_03327;
@@ -63,6 +70,6 @@ system cancel view mv_test_03327;
 $CLICKHOUSE_CLIENT -q "
 drop view mv_test_03327;
 drop table test_03327;
-drop user test_03327_user_1;
-drop user test_03327_user_2;
+drop user $user_1;
+drop user $user_2;
 "

--- a/tests/queries/0_stateless/03327_permissions_on_refresh_mv.sh
+++ b/tests/queries/0_stateless/03327_permissions_on_refresh_mv.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tags: atomic-database
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Set session timezone to UTC to make all DateTime formatting and parsing use UTC, because refresh
+# scheduling is done in UTC.
+CLICKHOUSE_CLIENT="`echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g'`"
+CLICKHOUSE_CLIENT="`echo "$CLICKHOUSE_CLIENT --allow_materialized_view_with_bad_select=0 --session_timezone Etc/UTC"`"
+db=$CLICKHOUSE_DATABASE
+
+$CLICKHOUSE_CLIENT -q "
+drop view if exists mv_test_03327;
+drop table if exists test_03327;
+drop user if exists test_03327_user_1;
+drop user if exists test_03327_user_2;
+"
+
+$CLICKHOUSE_CLIENT -q "
+use $db;
+create table test_03327 (x Int64) engine MergeTree order by x;
+insert into test_03327 select number from numbers(1000);
+-- create materialized view mv_test_03327 (x Int64) refresh every 1 minute as select x*10 as x from test_03327;
+create materialized view mv_test_03327 refresh every 10 minute append (x Int64) engine Memory empty as select x*10 as x from test_03327;
+"
+
+# user with missing system views grant
+$CLICKHOUSE_CLIENT -q "
+create user test_03327_user_1;
+revoke all on *.* from test_03327_user_1;
+GRANT SHOW ON $db to test_03327_user_1;
+"
+
+# this should not work
+$CLICKHOUSE_CLIENT -u 'test_03327_user_1' -q "
+use $db;
+system refresh view mv_test_03327; -- { serverError ACCESS_DENIED }
+"
+
+# user with system views grant
+$CLICKHOUSE_CLIENT -q "
+create user test_03327_user_2;
+revoke all on *.* from test_03327_user_2;
+grant select on $db.test_03327 to test_03327_user_2;
+grant select on $db.mv_test_03327 to test_03327_user_2;
+grant show on $db to test_03327_user_2;
+grant system views on $db.* to test_03327_user_2;
+"
+
+# all these operations should work
+$CLICKHOUSE_CLIENT -u 'test_03327_user_2' -q "
+use $db;
+system refresh view mv_test_03327;
+system start view mv_test_03327;
+select * from mv_test_03327 format null;
+system wait view mv_test_03327;
+system stop view mv_test_03327;
+system cancel view mv_test_03327;
+"
+
+$CLICKHOUSE_CLIENT -q "
+drop view mv_test_03327;
+drop table test_03327;
+drop user test_03327_user_1;
+drop user test_03327_user_2;
+"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Add a test for #74789

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
