### PR TITLE
Stricter validation of ASTs passed to fuzzJSON

### DIFF
--- a/src/Storages/NamedCollectionsHelpers.cpp
+++ b/src/Storages/NamedCollectionsHelpers.cpp
@@ -38,7 +38,8 @@ namespace
         return identifier->name();
     }
 
-    std::optional<std::pair<std::string, std::variant<Field, ASTPtr>>> getKeyValueFromAST(ASTPtr ast, bool fallback_to_ast_value, ContextPtr context)
+    std::optional<std::pair<std::string, std::variant<Field, ASTPtr>>>
+    getKeyValueFromASTImpl(ASTPtr ast, bool fallback_to_ast_value, ContextPtr context)
     {
         const auto * function = ast->as<ASTFunction>();
         if (!function || function->name != "equals")
@@ -71,16 +72,16 @@ namespace
         auto value = literal_value->as<ASTLiteral>()->value;
         return std::pair{key, Field(value)};
     }
+}
 
-    std::pair<String, Field> getKeyValueFromAST(ASTPtr ast, ContextPtr context)
-    {
-        auto res = getKeyValueFromAST(ast, true, context);
+std::pair<String, Field> getKeyValueFromAST(ASTPtr ast, ContextPtr context)
+{
+    auto res = getKeyValueFromASTImpl(ast, true, context);
 
-        if (!res || !std::holds_alternative<Field>(res->second))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failed to get key value from ast '{}'", queryToString(ast));
+    if (!res || !std::holds_alternative<Field>(res->second))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failed to get key value from ast '{}'", queryToString(ast));
 
-        return {res->first, std::get<Field>(res->second)};
-    }
+    return {res->first, std::get<Field>(res->second)};
 }
 
 std::map<String, Field> getParamsMapFromAST(ASTs asts, ContextPtr context)
@@ -129,7 +130,7 @@ MutableNamedCollectionPtr tryGetNamedCollectionWithOverrides(
 
     for (auto * it = std::next(asts.begin()); it != asts.end(); ++it)
     {
-        auto value_override = getKeyValueFromAST(*it, /* fallback_to_ast_value */complex_args != nullptr, context);
+        auto value_override = getKeyValueFromASTImpl(*it, /* fallback_to_ast_value */ complex_args != nullptr, context);
 
         if (!value_override)
         {

--- a/src/Storages/NamedCollectionsHelpers.h
+++ b/src/Storages/NamedCollectionsHelpers.h
@@ -26,9 +26,13 @@ MutableNamedCollectionPtr tryGetNamedCollectionWithOverrides(
 /// Dictionaries have collection name as name argument of dict configuration and other arguments are overrides.
 MutableNamedCollectionPtr tryGetNamedCollectionWithOverrides(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, ContextPtr context);
 
+/// Parses the ast as a key-value pair.
+/// Throws an exception if the key cannot be parsed as a string literal.
+/// If the value cannot be parsed as a literal or interpreted as a constant expression,
+/// falls back to the AST value.
+std::pair<std::string, Field> getKeyValueFromAST(ASTPtr ast, ContextPtr context);
+
 /// Parses asts as key value pairs and returns a map of them.
-/// If key or value cannot be parsed as literal or interpreted
-/// as constant expression throws an exception.
 std::map<String, Field> getParamsMapFromAST(ASTs asts, ContextPtr context);
 
 HTTPHeaderEntries getHeadersFromNamedCollection(const NamedCollection & collection);

--- a/src/Storages/StorageFuzzJSON.cpp
+++ b/src/Storages/StorageFuzzJSON.cpp
@@ -680,6 +680,10 @@ StorageFuzzJSON::Configuration StorageFuzzJSON::getConfiguration(ASTs & engine_a
 
     if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, local_context))
     {
+        /// Perform strict validation of ASTs in addition to name collection extraction.
+        for (auto * args_it = std::next(engine_args.begin()); args_it != engine_args.end(); ++args_it)
+            getKeyValueFromAST(*args_it, local_context);
+
         StorageFuzzJSON::processNamedCollectionResult(configuration, *named_collection);
     }
     else

--- a/tests/queries/0_stateless/02918_fuzzjson_table_function.sql
+++ b/tests/queries/0_stateless/02918_fuzzjson_table_function.sql
@@ -90,6 +90,7 @@ SELECT * FROM fuzzJSON(02918_json_fuzzer, max_string_value_length=65537) LIMIT 1
 SELECT * FROM fuzzJSON(02918_json_fuzzer, max_key_length=65537) LIMIT 10; -- { serverError BAD_ARGUMENTS }
 SELECT * FROM fuzzJSON(02918_json_fuzzer, max_key_length=10, min_key_length=0) LIMIT 10; -- { serverError BAD_ARGUMENTS }
 SELECT * FROM fuzzJSON(02918_json_fuzzer, max_key_length=10, min_key_length=11) LIMIT 10; -- { serverError BAD_ARGUMENTS }
+SELECT * FROM fuzzJSON(02918_json_fuzzer, equals(random_seed, viewExplain('EXPLAIN', 'actions = 1', (SELECT count(*) FROM numbers(10))), 54321)) LIMIT 10; -- { serverError BAD_ARGUMENTS }
 
 --
 DROP TABLE IF EXISTS 02918_table_obj1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Expressions should be allowed to pass only if they follow the `key=value` pattern, where both the key and the value satisfy `evaluateConstantExpressionOrIdentifierAsLiteral`.
`allow_override_by_default` setting bypasses this validation in `tryGetNamedCollectionWithOverrides`.
Perform a stricter check afterward.
Alternative fix: explicitly set `allow_override_by_default` to `false` for this table function.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/65231
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
