### PR TITLE
Refactoring of zero-copy code

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -208,6 +208,7 @@ void Service::processQuery(const HTMLForm & params, ReadBuffer & /*body*/, Write
             writeBinary(projections.size(), out);
         }
 
+        // TODO ZeroCopy: Move to virtual method
         if ((*data_settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication] &&
             client_protocol_version >= REPLICATION_PROTOCOL_VERSION_WITH_PARTS_ZERO_COPY)
         {
@@ -371,6 +372,7 @@ MergeTreeData::DataPartPtr Service::findPart(const String & name)
     if (!part)
         throw Exception(ErrorCodes::NO_SUCH_DATA_PART, "No part {} in table", name);
 
+    // TODO ZeroCopy: move all below to virtual method
     bool zero_copy_enabled = (*data.getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication];
     if (!zero_copy_enabled)
         return part;
@@ -417,7 +419,7 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> Fetcher::fetchSelected
     bool to_detached,
     const String & tmp_prefix_,
     std::optional<CurrentlySubmergingEmergingTagger> * tagger_ptr,
-    bool try_zero_copy,
+    bool try_zero_copy,  // Make method virtual and try without explicit flag
     DiskPtr disk)
 {
     if (blocker.isCancelled())
@@ -796,7 +798,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             throw Exception(ErrorCodes::ZERO_COPY_REPLICATION_ERROR, "Part {} unique id {} doesn't exist on {} (with type {}).", part_name, part_id, disk->getName(), disk->getDataSourceDescription().toString());
 
         LOG_DEBUG(log, "Downloading part {} unique id {} metadata onto disk {}.", part_name, part_id, disk->getName());
-        zero_copy_temporary_lock_holder = data.lockSharedDataTemporary(part_name, part_id, disk);
+        zero_copy_temporary_lock_holder = data.lockSharedDataTemporary(part_name, part_id, disk); // TODO: ZeroCopy fetcher with factory function
     }
     else
     {

--- a/src/Storages/MergeTree/DataPartsExchange.h
+++ b/src/Storages/MergeTree/DataPartsExchange.h
@@ -57,7 +57,7 @@ private:
 
 /** Client for getting the parts from the table *MergeTree.
   */
-class Fetcher final : private boost::noncopyable
+class Fetcher: private boost::noncopyable
 {
 public:
     explicit Fetcher(StorageReplicatedMergeTree & data_);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5028,10 +5028,6 @@ void MergeTreeData::swapActivePart(MergeTreeData::DataPartPtr part_copy, DataPar
             ssize_t diff_rows = part_copy->rows_count - original_active_part->rows_count;
             increaseDataVolume(diff_bytes, diff_rows, /* parts= */ 0);
 
-            /// Move parts are non replicated operations, so we take lock here.
-            /// All other locks are taken in StorageReplicatedMergeTree
-            lockSharedData(*part_copy, /* replace_existing_lock */ true);
-
             return;
         }
     }
@@ -7980,7 +7976,7 @@ PartitionCommandsResultInfo MergeTreeData::freezePartitionsByMatcher(
         {
             // Store metadata for replicated table.
             // Do nothing for non-replicated.
-            createAndStoreFreezeMetadata(disk, part, fs::path(backup_part_path) / part->getDataPartStorage().getPartDirectory());
+            createAndStoreFreezeMetadata(disk, part, fs::path(backup_part_path) / part->getDataPartStorage().getPartDirectory()); // TODO leave as virtual
         };
 
         IDataPartStorage::ClonePartParams params

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -255,16 +255,16 @@ public:
     public:
         Transaction(MergeTreeData & data_, MergeTreeTransaction * txn_);
 
-        DataPartsVector commit(DataPartsLock * acquired_parts_lock = nullptr);
+        virtual DataPartsVector commit(DataPartsLock * acquired_parts_lock = nullptr);
 
         /// Rename should be done explicitly, before calling commit(), to
         /// guarantee that no lock held during rename (since rename is IO
         /// bound, while data parts lock is the bottleneck)
         void renameParts();
 
-        void addPart(MutableDataPartPtr & part, bool need_rename);
+        virtual void addPart(MutableDataPartPtr & part, bool need_rename);
 
-        void rollback(DataPartsLock * lock = nullptr);
+        virtual void rollback(DataPartsLock * lock = nullptr);
 
         /// Immediately remove parts from table's data_parts set and change part
         /// state to temporary. Useful for new parts which not present in table.
@@ -273,7 +273,7 @@ public:
         size_t size() const { return precommitted_parts.size(); }
         bool isEmpty() const { return precommitted_parts.empty(); }
 
-        ~Transaction()
+        virtual ~Transaction()
         {
             try
             {
@@ -1102,15 +1102,6 @@ public:
     /// Schedules job to move parts between disks/volumes and so on.
     bool scheduleDataMovingJob(BackgroundJobsAssignee & assignee);
     bool areBackgroundMovesNeeded() const;
-
-
-    /// Lock part in zookeeper for shared data in several nodes
-    /// Overridden in StorageReplicatedMergeTree
-    virtual void lockSharedData(const IMergeTreeDataPart &, bool = false, std::optional<HardlinkedFiles> = {}) const {} /// NOLINT
-
-    /// Unlock shared data part in zookeeper
-    /// Overridden in StorageReplicatedMergeTree
-    virtual std::pair<bool, NameSet> unlockSharedData(const IMergeTreeDataPart &) const { return std::make_pair(true, NameSet{}); }
 
     /// Fetch part only if some replica has it on shared storage like S3
     /// Overridden in StorageReplicatedMergeTree

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -261,7 +261,7 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
         disk->createDirectories(path_to_clone);
 
         /// TODO: Make it possible to fetch only zero-copy part without fallback to fetching a full-copy one
-        auto zero_copy_part = data->tryToFetchIfShared(*part, disk, fs::path(path_to_clone) / part->name);
+        auto zero_copy_part = data->tryToFetchIfShared(*part, disk, fs::path(path_to_clone) / part->name); // TODO: make ZeroCopyPartsMover
 
         if (zero_copy_part)
         {

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -227,6 +227,7 @@ namespace ErrorCodes
     DECLARE(UInt64, part_moves_between_shards_delay_seconds, 30, "Time to wait before/after moving parts between shards.", EXPERIMENTAL) \
     DECLARE(Bool, allow_remote_fs_zero_copy_replication, false, "Don't use this setting in production, because it is not ready.", BETA) \
     DECLARE(String, remote_fs_zero_copy_zookeeper_path, "/clickhouse/zero_copy", "ZooKeeper path for zero-copy table-independent info.", EXPERIMENTAL) \
+    DECLARE(String, old_remote_fs_zero_copy_zookeeper_path, "", "Old ZooKeeper path for zero-copy table-independent info used in compatibility mode", EXPERIMENTAL) \
     DECLARE(Bool, remote_fs_zero_copy_path_compatible_mode, false, "Run zero-copy in compatible mode during conversion process.", EXPERIMENTAL) \
     DECLARE(Bool, cache_populated_by_fetch, false, "Only available in ClickHouse Cloud", EXPERIMENTAL) \
     DECLARE(Bool, force_read_through_cache_for_merges, false, "Force read-through filesystem cache for merges", EXPERIMENTAL) \

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -130,91 +130,22 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
     reserved_space = StorageReplicatedMergeTree::reserveSpace(estimated_space_for_result, source_part->getDataPartStorage());
     future_mutated_part->updatePath(storage, reserved_space.get());
 
+    // Created prepareAfterReservation because we cannot get IDisk object from source_part
+    // to acquire zero-copy lock
+    // TODO: make zero-copy part derived class
+    if (!prepareAfterReservation(source_part_name, source_part, estimated_space_for_result, need_to_check_missing_part_in_fetch))
+        return PrepareResult{
+            .prepared_successfully = false,
+            .need_to_check_missing_part_in_fetch = need_to_check_missing_part_in_fetch,
+            .part_log_writer = part_log_writer,
+        };
+
+
     table_lock_holder = storage.lockForShare(
             RWLockImpl::NO_QUERY, (*storage_settings_ptr)[MergeTreeSetting::lock_acquire_timeout_for_background_operations]);
     StorageMetadataPtr metadata_snapshot = storage.getInMemoryMetadataPtr();
 
     transaction_ptr = std::make_unique<MergeTreeData::Transaction>(storage, NO_TRANSACTION_RAW);
-
-    if ((*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-    {
-        if (auto disk = reserved_space->getDisk(); disk->supportZeroCopyReplication())
-        {
-            if (storage.findReplicaHavingCoveringPart(entry.new_part_name, true))
-            {
-                LOG_DEBUG(log, "Mutation of part {} finished by some other replica, will download mutated part", entry.new_part_name);
-                return PrepareResult{
-                    .prepared_successfully = false,
-                    .need_to_check_missing_part_in_fetch = true,
-                    .part_log_writer = part_log_writer,
-                };
-            }
-
-            if ((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock] != 0 &&
-                estimated_space_for_result >= (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock])
-            {
-                /// In zero copy replication only one replica execute merge/mutation, others just download merged parts metadata.
-                /// Here we are trying to metigate the skew of merges execution because of faster/slower replicas.
-                /// Replicas can be slow because of different reasons like bigger latency for ZooKeeper or just slight step behind because of bigger queue.
-                /// In this case faster replica can pick up all merges execution, especially large merges while other replicas can just idle. And even in this case
-                /// the fast replica is not overloaded because amount of executing merges don't affect the ability to aquite locks for new merges.
-                ///
-                /// So here we trying to solve it with the simplest solution -- sleep random time up to 500ms for 1GB part and up to 7 seconds for 300GB part.
-                /// It can sound too much, but we are trying to acquire these locks in background tasks which can be scheduled each 5 seconds or so.
-                double start_to_sleep_seconds = std::logf((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value);
-                uint64_t right_border_to_sleep_ms = static_cast<uint64_t>((std::log(estimated_space_for_result) - start_to_sleep_seconds + 0.5) * 1000);
-                uint64_t time_to_sleep_milliseconds = std::min<uint64_t>(10000UL, std::uniform_int_distribution<uint64_t>(1, 1 + right_border_to_sleep_ms)(rng));
-
-                LOG_INFO(log, "Mutation size is {} bytes (it's more than sleep threshold {}) so will intentionally sleep for {} ms to allow other replicas to took this big mutation",
-                    estimated_space_for_result, (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock], time_to_sleep_milliseconds);
-
-                std::this_thread::sleep_for(std::chrono::milliseconds(time_to_sleep_milliseconds));
-            }
-
-            zero_copy_lock = storage.tryCreateZeroCopyExclusiveLock(entry.new_part_name, disk);
-
-            if (!zero_copy_lock || !zero_copy_lock->isLocked())
-            {
-                LOG_DEBUG(
-                    log,
-                    "Mutation of part {} started by some other replica, will wait for it and mutated merged part. Number of tries {}",
-                    entry.new_part_name,
-                    entry.num_tries);
-                storage.watchZeroCopyLock(entry.new_part_name, disk);
-
-                return PrepareResult{
-                    .prepared_successfully = false,
-                    .need_to_check_missing_part_in_fetch = false,
-                    .part_log_writer = part_log_writer,
-                };
-            }
-            if (storage.findReplicaHavingCoveringPart(entry.new_part_name, /* active */ false))
-            {
-                /// Why this if still needed? We can check for part in zookeeper, don't find it and sleep for any amount of time. During this sleep part will be actually committed from other replica
-                /// and exclusive zero copy lock will be released. We will take the lock and execute mutation one more time, while it was possible just to download the part from other replica.
-                ///
-                /// It's also possible just because reads in [Zoo]Keeper are not lineariazable.
-                ///
-                /// NOTE: In case of mutation and hardlinks it can even lead to extremely rare dataloss (we will produce new part with the same hardlinks, don't fetch the same from other replica), so this check is important.
-                ///
-                /// In case of DROP_RANGE on fast replica and stale replica we can have some failed select queries in case of zero copy replication.
-                zero_copy_lock->lock->unlock();
-
-                LOG_DEBUG(
-                    log,
-                    "We took zero copy lock, but mutation of part {} finished by some other replica, will release lock and download "
-                    "mutated part to avoid data duplication",
-                    entry.new_part_name);
-                return PrepareResult{
-                    .prepared_successfully = false,
-                    .need_to_check_missing_part_in_fetch = true,
-                    .part_log_writer = part_log_writer,
-                };
-            }
-
-            LOG_DEBUG(log, "Zero copy lock taken, will mutate part {}", entry.new_part_name);
-        }
-    }
 
     task_context = Context::createCopy(storage.getContext());
     task_context->makeQueryContextForMutate(*storage.getSettings());
@@ -288,11 +219,12 @@ bool MutateFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrit
         throw;
     }
 
-    if (zero_copy_lock)
-    {
-        LOG_DEBUG(log, "Removing zero-copy lock");
-        zero_copy_lock->lock->unlock();
-    }
+    // Move to MutateZeroCopyFromLogEntryTask
+    // if (zero_copy_lock)
+    // {
+    //     LOG_DEBUG(log, "Removing zero-copy lock");
+    //     zero_copy_lock->lock->unlock();
+    // }
 
     /** With `ZSESSIONEXPIRED` or `ZOPERATIONTIMEOUT`, we can inadvertently roll back local changes to the parts.
          * This is not a problem, because in this case the entry will remain in the queue, and we will try again.
@@ -305,5 +237,102 @@ bool MutateFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrit
     return true;
 }
 
+
+bool MutateZeroCopyFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWriter write_part_log)
+{
+    MutateFromLogEntryTask::finalize(write_part_log);
+
+    if (zero_copy_lock)
+    {
+        LOG_DEBUG(log, "Removing zero-copy lock");
+        zero_copy_lock->lock->unlock();
+    }
+}
+
+bool MutateZeroCopyFromLogEntryTask::prepareAfterReservation(
+        const String & source_part_name,
+        MergeTreeData::DataPartPtr active_containing_part,
+        size_t estimated_space_for_result,
+        bool & need_to_check_missing_part_in_fetch)
+{
+    if (!(*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+        return true;
+    
+    if (auto disk = reserved_space->getDisk(); disk->supportZeroCopyReplication())
+    {
+        if (storage.findReplicaHavingCoveringPart(entry.new_part_name, true))
+        {
+            LOG_DEBUG(log, "Mutation of part {} finished by some other replica, will download mutated part", entry.new_part_name);
+            need_to_check_missing_part_in_fetch = true;
+            return false;
+        }
+
+        if ((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock] != 0 &&
+            estimated_space_for_result >= (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock])
+        {
+            /// In zero copy replication only one replica execute merge/mutation, others just download merged parts metadata.
+            /// Here we are trying to metigate the skew of merges execution because of faster/slower replicas.
+            /// Replicas can be slow because of different reasons like bigger latency for ZooKeeper or just slight step behind because of bigger queue.
+            /// In this case faster replica can pick up all merges execution, especially large merges while other replicas can just idle. And even in this case
+            /// the fast replica is not overloaded because amount of executing merges don't affect the ability to aquite locks for new merges.
+            ///
+            /// So here we trying to solve it with the simplest solution -- sleep random time up to 500ms for 1GB part and up to 7 seconds for 300GB part.
+            /// It can sound too much, but we are trying to acquire these locks in background tasks which can be scheduled each 5 seconds or so.
+            double start_to_sleep_seconds = std::logf((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value);
+            uint64_t right_border_to_sleep_ms = static_cast<uint64_t>((std::log(estimated_space_for_result) - start_to_sleep_seconds + 0.5) * 1000);
+            uint64_t time_to_sleep_milliseconds = std::min<uint64_t>(10000UL, std::uniform_int_distribution<uint64_t>(1, 1 + right_border_to_sleep_ms)(rng));
+
+            LOG_INFO(log, "Mutation size is {} bytes (it's more than sleep threshold {}) so will intentionally sleep for {} ms to allow other replicas to took this big mutation",
+                estimated_space_for_result, (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock], time_to_sleep_milliseconds);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(time_to_sleep_milliseconds));
+        }
+
+        zero_copy_lock = storage.tryCreateZeroCopyExclusiveLock(entry.new_part_name, disk);
+
+        if (!zero_copy_lock || !zero_copy_lock->isLocked())
+        {
+            LOG_DEBUG(
+                log,
+                "Mutation of part {} started by some other replica, will wait for it and mutated merged part. Number of tries {}",
+                entry.new_part_name,
+                entry.num_tries);
+            storage.watchZeroCopyLock(entry.new_part_name, disk);
+
+            return PrepareResult{
+                .prepared_successfully = false,
+                .need_to_check_missing_part_in_fetch = false,
+                .part_log_writer = part_log_writer,
+            };
+        }
+        if (storage.findReplicaHavingCoveringPart(entry.new_part_name, /* active */ false))
+        {
+            /// Why this if still needed? We can check for part in zookeeper, don't find it and sleep for any amount of time. During this sleep part will be actually committed from other replica
+            /// and exclusive zero copy lock will be released. We will take the lock and execute mutation one more time, while it was possible just to download the part from other replica.
+            ///
+            /// It's also possible just because reads in [Zoo]Keeper are not lineariazable.
+            ///
+            /// NOTE: In case of mutation and hardlinks it can even lead to extremely rare dataloss (we will produce new part with the same hardlinks, don't fetch the same from other replica), so this check is important.
+            ///
+            /// In case of DROP_RANGE on fast replica and stale replica we can have some failed select queries in case of zero copy replication.
+            zero_copy_lock->lock->unlock();
+
+            LOG_DEBUG(
+                log,
+                "We took zero copy lock, but mutation of part {} finished by some other replica, will release lock and download "
+                "mutated part to avoid data duplication",
+                entry.new_part_name);
+            return PrepareResult{
+                .prepared_successfully = false,
+                .need_to_check_missing_part_in_fetch = true,
+                .part_log_writer = part_log_writer,
+            };
+        }
+
+        LOG_DEBUG(log, "Zero copy lock taken, will mutate part {}", entry.new_part_name);
+    }
+    
+    return true;
+}
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -942,7 +942,7 @@ std::pair<std::vector<String>, bool> ReplicatedMergeTreeSinkImpl<async_insert>::
         storage.getLockSharedDataOps(*part, zookeeper, /*replace_zero_copy_lock*/ false, {}, ops);
         size_t shared_lock_op_id_end = ops.size();
 
-        storage.getCommitPartOps(ops, part, block_id_path);
+        storage.getCommitPartOps(ops, part, block_id_path); // TODO: make virtual
 
         /// It's important to create it outside of lock scope because
         /// otherwise it can lock parts in destructor and deadlock is possible.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -860,25 +860,7 @@ void StorageReplicatedMergeTree::createNewZooKeeperNodesAttempt() const
     futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/quorum/failed_parts", String(), zkutil::CreateMode::Persistent));
     futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/mutations", String(), zkutil::CreateMode::Persistent));
 
-
     futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/quorum/parallel", String(), zkutil::CreateMode::Persistent));
-    /// Nodes for remote fs zero-copy replication
-    const auto settings = getSettings();
-    if ((*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-    {
-        for (const auto & zero_copy_locks_root : getZookeeperZeroCopyLockPaths())
-        {
-            for (const auto & ancestor : getAncestors(zero_copy_locks_root))
-            {
-                futures.push_back(zookeeper->asyncTryCreateNoThrow(ancestor, String(), zkutil::CreateMode::Persistent));
-            }
-        }
-
-        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_s3", String(), zkutil::CreateMode::Persistent));
-        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_s3/shared", String(), zkutil::CreateMode::Persistent));
-        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_hdfs", String(), zkutil::CreateMode::Persistent));
-        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_hdfs/shared", String(), zkutil::CreateMode::Persistent));
-    }
 
     /// Part movement.
     futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/part_moves_shard", String(), zkutil::CreateMode::Persistent));
@@ -1260,62 +1242,6 @@ zkutil::ZooKeeperPtr StorageReplicatedMergeTree::getZooKeeperIfTableShutDown() c
     return maybe_new_zookeeper;
 }
 
-std::vector<String> StorageReplicatedMergeTree::getZookeeperZeroCopyLockPaths() const
-{
-    const auto settings = getSettings();
-    if (!(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-    {
-        return {};
-    }
-
-    const auto & disks = getStoragePolicy()->getDisks();
-    std::set<String> disk_types_with_zero_copy;
-    for (const auto & disk : disks)
-    {
-        if (!disk->supportZeroCopyReplication())
-            continue;
-
-        disk_types_with_zero_copy.insert(disk->getDataSourceDescription().toString());
-    }
-
-    const auto actual_table_shared_id = getTableSharedID();
-
-    std::vector<String> result;
-    result.reserve(disk_types_with_zero_copy.size());
-
-    for (const auto & disk_type: disk_types_with_zero_copy)
-    {
-        auto zero_copy = fmt::format("zero_copy_{}", disk_type);
-        auto zero_copy_path = fs::path((*settings)[MergeTreeSetting::remote_fs_zero_copy_zookeeper_path].toString()) / zero_copy;
-
-        result.push_back(zero_copy_path / actual_table_shared_id);
-    }
-
-    return result;
-}
-
-void StorageReplicatedMergeTree::dropZookeeperZeroCopyLockPaths(zkutil::ZooKeeperPtr zookeeper, std::vector<String> zero_copy_locks_paths,
-                                                                LoggerPtr logger)
-{
-    for (const auto & zero_copy_locks_root : zero_copy_locks_paths)
-    {
-        auto code = zookeeper->tryRemove(zero_copy_locks_root);
-        if (code == Coordination::Error::ZNOTEMPTY)
-        {
-            LOG_WARNING(logger, "Zero copy locks are not empty for {}. There are some lost locks inside."
-                              "Removing them all.", zero_copy_locks_root);
-            zookeeper->tryRemoveRecursive(zero_copy_locks_root);
-        }
-        else if (code == Coordination::Error::ZNONODE)
-        {
-            LOG_INFO(logger, "Zero copy locks directory {} is absent on ZooKeeper.", zero_copy_locks_root);
-        }
-        else
-        {
-            chassert(code == Coordination::Error::ZOK);
-        }
-    }
-}
 
 void StorageReplicatedMergeTree::drop()
 {
@@ -1338,20 +1264,21 @@ void StorageReplicatedMergeTree::drop()
             throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Can't drop readonly replicated table (need to drop data in ZooKeeper as well)");
     }
 
-    /// Wait for loading of all outdated parts because
-    /// in case of zero copy recursive removal of directory
-    /// is not supported and table cannot be dropped.
-    if (canUseZeroCopyReplication())
-    {
-        /// Load remaining parts synchronously because task
-        /// for loading is already cancelled in shutdown().
-        loadOutdatedDataParts(/*is_async=*/ false);
-    }
+    prepareDrop();
 
+    // /// Wait for loading of all outdated parts because
+    // /// in case of zero copy recursive removal of directory
+    // /// is not supported and table cannot be dropped.
+    // if (canUseZeroCopyReplication() /*isLoadingOutadatedPartsNeeded()*/)
+    // {
+    //     /// Load remaining parts synchronously because task
+    //     /// for loading is already cancelled in shutdown().
+    //     loadOutdatedDataParts(/*is_async=*/ false);
+    // }
 
-    /// getZookeeperZeroCopyLockPaths has to be called before dropAllData
-    /// otherwise table_shared_id is unknown
-    auto zero_copy_locks_paths = getZookeeperZeroCopyLockPaths();
+    // /// getZookeeperZeroCopyLockPaths has to be called before dropAllData
+    // /// otherwise table_shared_id is unknown
+    // auto zero_copy_locks_paths = getZookeeperZeroCopyLockPaths();
 
     dropAllData();
 
@@ -1373,7 +1300,8 @@ void StorageReplicatedMergeTree::drop()
         bool last_replica_dropped = dropReplica(zookeeper, zookeeper_info, log.load(), getSettings(), &has_metadata_in_zookeeper);
         if (last_replica_dropped)
         {
-            dropZookeeperZeroCopyLockPaths(zookeeper, zero_copy_locks_paths, log.load());
+            onLastReplicaDropped();
+           // dropZookeeperZeroCopyLockPaths(zookeeper, zero_copy_locks_paths, log.load());
         }
     }
 }
@@ -2108,7 +2036,8 @@ bool StorageReplicatedMergeTree::getOpsToCheckPartChecksumsAndCommit(const ZooKe
     NameSet absent_part_paths_on_replicas;
 
     size_t prev_ops_size = ops.size();
-    getLockSharedDataOps(*part, zookeeper, replace_zero_copy_lock, hardlinked_files, ops);
+    // Moved to StorageZeroCopyReplicatedMergeTree::checkPartChecksumsAndAddCommitOps
+    // getLockSharedDataOps(*part, zookeeper, replace_zero_copy_lock, hardlinked_files, ops);
 
     /// Checksums are checked here and `ops` is filled. In fact, the part is added to ZK just below, when executing `multi`.
     bool part_found = checkPartChecksumsAndAddCommitOps(zookeeper, part, ops, part->name, absent_part_paths_on_replicas);
@@ -2508,8 +2437,7 @@ bool StorageReplicatedMergeTree::executeFetch(LogEntry & entry, bool need_to_che
                 source_replica_path,
                 /* to_detached= */ false,
                 entry.quorum,
-                /* zookeeper_ */ nullptr,
-                /* try_fetch_shared= */ true))
+                /* zookeeper_ */ nullptr))
             {
                 return false;
             }
@@ -2694,6 +2622,111 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
 }
 
 
+bool StorageReplicatedMergeTree::isCloneNeededForReplaceRange(const MergeTreeData::DataPartPtr & part, const PartDescriptionPtr & part_desc)
+{
+    if (!src_part)
+    {
+        LOG_DEBUG(log, "There is no part {} in {}", part_desc->src_part_name, source_table_id.getNameForLogs());
+        return false;
+    }
+
+    String checksum_hex = src_part->checksums.getTotalChecksumHex();
+
+    if (checksum_hex != part_desc->checksum_hex)
+    {
+        LOG_DEBUG(log, "Part {} of {} has inappropriate checksum", part_desc->src_part_name, source_table_id.getNameForLogs());
+        /// TODO: check version
+        return false;
+    }
+
+    return true;
+}
+
+bool StorageReplicatedMergeTree::isPreferredFetchFromOtherReplicaForReplaceRange(PartDescriptionPtr & part_desc)
+{
+    return false;
+}
+
+bool StorageReplicatedMergeTree::shouldUseCopyInsteadOfHardlinksForReplaceRange()
+{
+    return (*storage_settings_ptr)[MergeTreeSetting::always_use_copy_instead_of_hardlinks];
+}
+
+
+
+void StorageReplicatedMergeTree::obtainPartForReplaceRange(PartDescriptionPtr & part_desc)
+{
+    if (part_desc->src_table_part && !isPreferredFetchFromOtherReplicaForReplaceRange(part_desc);)
+    {
+        if (part_desc->checksum_hex != part_desc->src_table_part->checksums.getTotalChecksumHex())
+            throw Exception(ErrorCodes::UNFINISHED, "Checksums of {} is suddenly changed", part_desc->src_table_part->name);
+
+        /// Don't do hardlinks in case of zero-copy at any side (defensive programming)
+        bool source_zero_copy_enabled = (*dynamic_cast<const MergeTreeData *>(source_table.get())
+                                              ->getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication];
+        bool our_zero_copy_enabled = (*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication];
+
+        IDataPartStorage::ClonePartParams clone_params{
+            .copy_instead_of_hardlink = (*storage_settings_ptr)[MergeTreeSetting::always_use_copy_instead_of_hardlinks]
+                || ((our_zero_copy_enabled || source_zero_copy_enabled)
+                    && part_desc->src_table_part->isStoredOnRemoteDiskWithZeroCopySupport()),
+            .metadata_version_to_write = metadata_snapshot->getMetadataVersion()};
+        auto [res_part, temporary_part_lock] = cloneAndLoadDataPart(
+            part_desc->src_table_part,
+            TMP_PREFIX + "clone_",
+            part_desc->new_part_info,
+            metadata_snapshot,
+            clone_params,
+            getContext()->getReadSettings(),
+            getContext()->getWriteSettings(),
+            true /*must_on_same_disk*/);
+        part_desc->res_part = std::move(res_part);
+        part_desc->temporary_part_lock = std::move(temporary_part_lock);
+    }
+    else if (!part_desc->replica.empty())
+    {
+        String source_replica_path = fs::path(zookeeper_path) / "replicas" / part_desc->replica;
+        ReplicatedMergeTreeAddress address(getZooKeeper()->get(fs::path(source_replica_path) / "host"));
+        auto timeouts = ConnectionTimeouts::getFetchPartHTTPTimeouts(getContext()->getServerSettings(), getContext()->getSettingsRef());
+
+        auto credentials = getContext()->getInterserverCredentials();
+        String interserver_scheme = getContext()->getInterserverScheme();
+        scope_guard part_temp_directory_lock;
+
+        if (interserver_scheme != address.scheme)
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Interserver schemas are different '{}' != '{}', can't fetch part from {}",
+                interserver_scheme,
+                address.scheme,
+                address.host);
+
+        auto [fetched_part, lock] = fetcher.fetchSelectedPart(
+            metadata_snapshot,
+            getContext(),
+            part_desc->found_new_part_name,
+            zookeeper_info.zookeeper_name,
+            source_replica_path,
+            address.host,
+            address.replication_port,
+            timeouts,
+            credentials->getUser(),
+            credentials->getPassword(),
+            interserver_scheme,
+            replicated_fetches_throttler,
+            false,
+            TMP_PREFIX + "fetch_");
+        part_desc->res_part = fetched_part;
+        part_temp_directory_lock = std::move(lock);
+
+        /// TODO: check columns_version of fetched part
+
+        ProfileEvents::increment(ProfileEvents::ReplicatedPartFetches);
+    }
+    else
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "There is no receipt to produce part {}. This is bug", part_desc->new_part_name);
+}
+
 bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
 {
     Stopwatch watch;
@@ -2809,7 +2842,7 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
                 parts_to_remove_str += part.getPartName();
                 parts_to_remove_str += " ";
             }
-            LOG_TRACE(log, "Replacing {} parts {}with empty set", parts_to_remove.size(), parts_to_remove_str);
+            LOG_TRACE(log, "Replacing {} parts {} with empty set", parts_to_remove.size(), parts_to_remove_str);
         }
     }
 
@@ -2863,28 +2896,9 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
         for (PartDescriptionPtr & part_desc : parts_to_add)
         {
             auto src_part = src_data->getPartIfExists(part_desc->src_part_info, valid_states);
-            if (!src_part)
-            {
-                LOG_DEBUG(log, "There is no part {} in {}", part_desc->src_part_name, source_table_id.getNameForLogs());
+            
+            if (!isCloneNeededForReplaceRange(src_part, part_desc))
                 continue;
-            }
-
-            bool avoid_copy_local_part = (*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication] && src_part->isStoredOnRemoteDiskWithZeroCopySupport();
-
-            if (avoid_copy_local_part)
-            {
-                LOG_DEBUG(log, "Avoid copy local part {} from table {} because of zero-copy replication", part_desc->src_part_name, source_table_id.getNameForLogs());
-                continue;
-            }
-
-            String checksum_hex  = src_part->checksums.getTotalChecksumHex();
-
-            if (checksum_hex != part_desc->checksum_hex)
-            {
-                LOG_DEBUG(log, "Part {} of {} has inappropriate checksum", part_desc->src_part_name, source_table_id.getNameForLogs());
-                /// TODO: check version
-                continue;
-            }
 
             part_desc->found_new_part_name = part_desc->new_part_name;
             part_desc->found_new_part_info = part_desc->new_part_info;
@@ -3018,73 +3032,10 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
 
     static const String TMP_PREFIX = "tmp_replace_from_";
 
-    auto obtain_part = [&] (PartDescriptionPtr & part_desc)
-    {
-        /// Fetches with zero-copy-replication are cheap, but cloneAndLoadDataPart(must_on_same_disk=true) will do full copy.
-        /// It's okay to check the setting for current table and disk for the source table, because src and dst part are on the same disk.
-        bool prefer_fetch_from_other_replica = !part_desc->replica.empty() && (*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication]
-            && part_desc->src_table_part && part_desc->src_table_part->isStoredOnRemoteDiskWithZeroCopySupport();
-
-        if (part_desc->src_table_part && !prefer_fetch_from_other_replica)
-        {
-            if (part_desc->checksum_hex != part_desc->src_table_part->checksums.getTotalChecksumHex())
-                throw Exception(ErrorCodes::UNFINISHED, "Checksums of {} is suddenly changed", part_desc->src_table_part->name);
-
-            /// Don't do hardlinks in case of zero-copy at any side (defensive programming)
-            bool source_zero_copy_enabled = (*dynamic_cast<const MergeTreeData *>(source_table.get())->getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication];
-            bool our_zero_copy_enabled = (*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication];
-
-            IDataPartStorage::ClonePartParams clone_params
-            {
-                .copy_instead_of_hardlink = (*storage_settings_ptr)[MergeTreeSetting::always_use_copy_instead_of_hardlinks] || ((our_zero_copy_enabled || source_zero_copy_enabled) && part_desc->src_table_part->isStoredOnRemoteDiskWithZeroCopySupport()),
-                .metadata_version_to_write = metadata_snapshot->getMetadataVersion()
-            };
-            auto [res_part, temporary_part_lock] = cloneAndLoadDataPart(
-                part_desc->src_table_part,
-                TMP_PREFIX + "clone_",
-                part_desc->new_part_info,
-                metadata_snapshot,
-                clone_params,
-                getContext()->getReadSettings(),
-                getContext()->getWriteSettings(),
-                true/*must_on_same_disk*/);
-            part_desc->res_part = std::move(res_part);
-            part_desc->temporary_part_lock = std::move(temporary_part_lock);
-        }
-        else if (!part_desc->replica.empty())
-        {
-            String source_replica_path = fs::path(zookeeper_path) / "replicas" / part_desc->replica;
-            ReplicatedMergeTreeAddress address(getZooKeeper()->get(fs::path(source_replica_path) / "host"));
-            auto timeouts = ConnectionTimeouts::getFetchPartHTTPTimeouts(getContext()->getServerSettings(), getContext()->getSettingsRef());
-
-            auto credentials = getContext()->getInterserverCredentials();
-            String interserver_scheme = getContext()->getInterserverScheme();
-            scope_guard part_temp_directory_lock;
-
-            if (interserver_scheme != address.scheme)
-                throw Exception(ErrorCodes::LOGICAL_ERROR,
-                                "Interserver schemas are different '{}' != '{}', can't fetch part from {}",
-                                interserver_scheme, address.scheme, address.host);
-
-            auto [fetched_part, lock] = fetcher.fetchSelectedPart(
-                metadata_snapshot, getContext(), part_desc->found_new_part_name, zookeeper_info.zookeeper_name, source_replica_path,
-                address.host, address.replication_port, timeouts, credentials->getUser(), credentials->getPassword(),
-                interserver_scheme, replicated_fetches_throttler, false, TMP_PREFIX + "fetch_");
-            part_desc->res_part = fetched_part;
-            part_temp_directory_lock = std::move(lock);
-
-            /// TODO: check columns_version of fetched part
-
-            ProfileEvents::increment(ProfileEvents::ReplicatedPartFetches);
-        }
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "There is no receipt to produce part {}. This is bug", part_desc->new_part_name);
-    };
-
     /// Download or clone parts
     /// TODO: make it in parallel
     for (PartDescriptionPtr & part_desc : final_parts)
-        obtain_part(part_desc);
+        obtainPartForReplaceRange(part_desc);
 
     MutableDataPartsVector res_parts;
     for (PartDescriptionPtr & part_desc : final_parts)
@@ -3094,20 +3045,23 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
     {
         /// Commit parts
         auto zookeeper = getZooKeeper();
+        auto keeper_commit_part_txn = getKeeperCommitPartTransaction();
         Transaction transaction(*this, NO_TRANSACTION_RAW);
 
         Coordination::Requests ops;
         for (PartDescriptionPtr & part_desc : final_parts)
-        {
+        {            
             renameTempPartAndReplace(part_desc->res_part, transaction, /*rename_in_transaction=*/ true);
-            getCommitPartOps(ops, part_desc->res_part);
-            lockSharedData(*part_desc->res_part, /*replace_existing_lock=*/ true, part_desc->hardlinked_files);
+            //getCommitPartOps(ops, part_desc->res_part); // make virtual
+            keeper_commit_part_txn->addPart(part_desc->res_part);
+            // lockSharedData(*part_desc->res_part, /*replace_existing_lock=*/ true, part_desc->hardlinked_files);
         }
         transaction.renameParts();
 
 
-        if (!ops.empty())
-            zookeeper->multi(ops);
+        // if (!ops.empty())
+        //     zookeeper->multi(ops);
+        keeper_commit_part_txn->execute();
 
         {
             auto data_parts_lock = lockParts();
@@ -3128,13 +3082,14 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
         }
 
         PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(res_parts, watch.elapsed(), profile_events_scope.getSnapshot()));
+        keeper_commit_part_txn->commit();
     }
     catch (...)
     {
         PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(res_parts, watch.elapsed()), ExecutionStatus::fromCurrentException("", true));
 
-        for (const auto & res_part : res_parts)
-            unlockSharedData(*res_part);
+        // for (const auto & res_part : res_parts)
+        //     unlockSharedData(*res_part);
 
         throw;
     }
@@ -3935,7 +3890,8 @@ bool StorageReplicatedMergeTree::scheduleDataProcessingJob(BackgroundJobsAssigne
     }
     if (job_type == LogEntry::MUTATE_PART)
     {
-        auto task = std::make_shared<MutateFromLogEntryTask>(selected_entry, *this, common_assignee_trigger);
+        //auto task = std::make_shared<MutateFromLogEntryTask>(selected_entry, *this, common_assignee_trigger);
+        auto task = makeMutateFromLogEntryTask(selected_entry);
         assignee.scheduleMergeMutateTask(task);
         return true;
     }
@@ -3945,6 +3901,11 @@ bool StorageReplicatedMergeTree::scheduleDataProcessingJob(BackgroundJobsAssigne
             [this, selected_entry]() mutable { return processQueueEntry(selected_entry); }, common_assignee_trigger, getStorageID()),
         /* need_trigger */ true);
     return true;
+}
+
+ExecutableTaskPtr StorageReplicatedMergeTree::makeMutateFromLogEntryTask(const SelectedEntryPtr & selected_entry) const
+{
+    return std::make_shared<MutateFromLogEntryTask>(selected_entry, *this, common_assignee_trigger);
 }
 
 
@@ -5011,6 +4972,19 @@ bool StorageReplicatedMergeTree::partIsLastQuorumPart(const MergeTreePartInfo & 
     return partition_it->second == part_info.getPartNameAndCheckFormat(format_version);
 }
 
+// bool StorageReplicatedMergeTree::fetchPart(
+//     const String & part_name,
+//     const StorageMetadataPtr & metadata_snapshot,
+//     const String & source_zookeeper_name,
+//     const String & source_replica_path,
+//     bool to_detached,
+//     size_t quorum,
+//     zkutil::ZooKeeper::Ptr zookeeper_
+//     /*bool try_fetch_shared*/)
+// {
+//     return fetchPartImpl(
+//         part_name, metadata_snapshot, metadata_snapshot, source_zookeeper_name, source_replica_path, to_detached, quorum, zookeeper_)
+// }
 
 bool StorageReplicatedMergeTree::fetchPart(
     const String & part_name,
@@ -5019,8 +4993,8 @@ bool StorageReplicatedMergeTree::fetchPart(
     const String & source_replica_path,
     bool to_detached,
     size_t quorum,
-    zkutil::ZooKeeper::Ptr zookeeper_,
-    bool try_fetch_shared)
+    zkutil::ZooKeeper::Ptr zookeeper_
+    /*bool try_fetch_shared*/)
 {
     if (isStaticStorage())
         throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Table is in readonly mode due to static storage");
@@ -5075,10 +5049,12 @@ bool StorageReplicatedMergeTree::fetchPart(
             profile_events_scope.getSnapshot());
     };
 
+    /*
     auto is_zero_copy_part = [&settings_ptr](const auto & data_part)
     {
         return (*settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication] && data_part->isStoredOnRemoteDiskWithZeroCopySupport();
     };
+    */
 
     DataPartPtr part_to_clone;
     {
@@ -5091,7 +5067,7 @@ bool StorageReplicatedMergeTree::fetchPart(
         auto source_part = getActiveContainingPart(covered_part_info);
 
         /// Fetch for zero-copy replication is cheap and straightforward, so we don't use local clone here
-        if (source_part && !is_zero_copy_part(source_part))
+        if (source_part /*&& !is_zero_copy_part(source_part)*/)
         {
             auto source_part_header = ReplicatedMergeTreePartHeader::fromColumnsAndChecksums(
                 source_part->getColumns(), source_part->checksums);
@@ -5146,7 +5122,7 @@ bool StorageReplicatedMergeTree::fetchPart(
     {
         get_part = [&, part_to_clone]()
         {
-            chassert(!is_zero_copy_part(part_to_clone));
+            // chassert(!is_zero_copy_part(part_to_clone)); // TODO ZeroCopy: remove
             IDataPartStorage::ClonePartParams clone_params
             {
                 .copy_instead_of_hardlink = (*getSettings())[MergeTreeSetting::always_use_copy_instead_of_hardlinks],
@@ -5181,7 +5157,7 @@ bool StorageReplicatedMergeTree::fetchPart(
                 throw Exception(ErrorCodes::INTERSERVER_SCHEME_DOESNT_MATCH, "Interserver schemes are different: "
                     "'{}' != '{}', can't fetch part from {}", interserver_scheme, address.scheme, address.host);
 
-            auto [fetched_part, lock] =  fetcher.fetchSelectedPart(
+            auto [fetched_part, lock] = fetchSelectedPart(  // TODO ZeroCopy: make fetcher zero-copy
                 metadata_snapshot,
                 getContext(),
                 part_name,
@@ -5196,8 +5172,7 @@ bool StorageReplicatedMergeTree::fetchPart(
                 replicated_fetches_throttler,
                 to_detached,
                 "",
-                &tagger_ptr,
-                try_fetch_shared);
+                &tagger_ptr);
             part_directory_lock = std::move(lock);
             return fetched_part;
         };
@@ -5298,6 +5273,44 @@ bool StorageReplicatedMergeTree::fetchPart(
         LOG_DEBUG(log, "Fetched part {} from {}:{}{}", part_name, source_zookeeper_name, source_replica_path, to_detached ? " (to 'detached' directory)" : "");
 
     return true;
+}
+
+std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> fetchSelectedPart(
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        const String & part_name,
+        const String & zookeeper_name,
+        const String & replica_path,
+        const String & host,
+        int port,
+        const ConnectionTimeouts & timeouts,
+        const String & user,
+        const String & password,
+        const String & interserver_scheme,
+        ThrottlerPtr throttler,
+        bool to_detached,
+        const String & tmp_prefix_,
+        std::optional<CurrentlySubmergingEmergingTagger> * tagger_ptr,
+        DiskPtr disk)
+{
+    // TODO ZeroCopy: make fetcher polymorphic and return it from factory
+    return fetchSelectedPart(
+                metadata_snapshot,
+                getContext(),
+                part_name,
+                source_zookeeper_name,
+                source_replica_path,
+                address.host,
+                address.replication_port,
+                timeouts,
+                credentials->getUser(),
+                credentials->getPassword(),
+                interserver_scheme,
+                replicated_fetches_throttler,
+                to_detached,
+                "",
+                &tagger_ptr,
+                /* try_zero_copy = */ false);
 }
 
 
@@ -7556,7 +7569,7 @@ void StorageReplicatedMergeTree::fetchPartition(
         try
         {
             /// part name, metadata, part_path, true, 0, zookeeper
-            if (!fetchPart(part_name, metadata_snapshot, from_zookeeper_name, part_path, true, 0, zookeeper, /* try_fetch_shared = */ false))
+            if (!fetchPart(part_name, metadata_snapshot, from_zookeeper_name, part_path, true, 0, zookeeper))
                 throw Exception(ErrorCodes::UNFINISHED, "Failed to fetch part {} from {}", part_name, from_);
         }
         catch (const DB::Exception & e)
@@ -7695,7 +7708,7 @@ void StorageReplicatedMergeTree::fetchPartition(
 
             try
             {
-                fetched = fetchPart(part, metadata_snapshot, from_zookeeper_name, best_replica_path, true, 0, zookeeper, /* try_fetch_shared = */ false);
+                fetched = fetchPart(part, metadata_snapshot, from_zookeeper_name, best_replica_path, true, 0, zookeeper);
             }
             catch (const DB::Exception & e)
             {
@@ -8372,7 +8385,7 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
     const String & partition_id,
     const ZooKeeperPtr & zookeeper,
     bool replace,
-    const bool & zero_copy_enabled,
+    /*const bool & zero_copy_enabled,*/
     const bool & always_use_copy_instead_of_hardlinks,
     const ContextPtr & query_context)
 {
@@ -8546,22 +8559,24 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
 
         try
         {
-            Coordination::Requests ops;
+            // Coordination::Requests ops;
+            auto keeper_commit_part_txn = getKeeperCommitPartTransaction();
             for (size_t i = 0; i < dst_parts.size(); ++i)
             {
-                getCommitPartOps(ops, dst_parts[i], block_id_paths[i]);
-                ephemeral_locks[i].getUnlockOp(ops);
+                //getCommitPartOps(ops, dst_parts[i], block_id_paths[i]);
+                keeper_commit_part_txn->addPart(dst_parts[i], block_id_paths[i]);                
+                ephemeral_locks[i].getUnlockOp(keeper_commit_part_txn.getOps());
             }
 
             if (txn)
-                txn->moveOpsTo(ops);
+                txn->moveOpsTo(keeper_commit_part_txn.getOps());
 
-            delimiting_block_lock->getUnlockOp(ops);
+            delimiting_block_lock->getUnlockOp(keeper_commit_part_txn.getOps());
             /// Check and update version to avoid race with DROP_RANGE
-            ops.emplace_back(zkutil::makeSetRequest(alter_partition_version_path, "", alter_partition_version_stat.version));
+            keeper_commit_part_txn.getOps().emplace_back(zkutil::makeSetRequest(alter_partition_version_path, "", alter_partition_version_stat.version));
             /// Just update version, because merges assignment relies on it
-            ops.emplace_back(zkutil::makeSetRequest(fs::path(zookeeper_path) / "log", "", -1));
-            ops.emplace_back(zkutil::makeCreateRequest(fs::path(zookeeper_path) / "log/log-", entry->toString(), zkutil::CreateMode::PersistentSequential));
+            keeper_commit_part_txn.getOps().emplace_back(zkutil::makeSetRequest(fs::path(zookeeper_path) / "log", "", -1));
+            keeper_commit_part_txn.getOps().emplace_back(zkutil::makeCreateRequest(fs::path(zookeeper_path) / "log/log-", entry->toString(), zkutil::CreateMode::PersistentSequential));
 
             Transaction transaction(*this, NO_TRANSACTION_RAW);
             {
@@ -8571,10 +8586,12 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
             }
             transaction.renameParts();
 
-            for (const auto & dst_part : dst_parts)
-                lockSharedData(*dst_part, false, /*hardlinked_files*/ {});
+            // Done in keeper_commit_part_txn
+            // for (const auto & dst_part : dst_parts)
+            //     lockSharedData(*dst_part, false, /*hardlinked_files*/ {});
 
-            Coordination::Error code = zookeeper->tryMulti(ops, op_results);
+            //Coordination::Error code = zookeeper->tryMulti(ops, op_results);
+            Coordination::Error code = keeper_commit_part_txn->execute();
             if (code == Coordination::Error::ZOK)
                 delimiting_block_lock->assumeUnlocked();
             else if (code == Coordination::Error::ZBADVERSION)
@@ -8601,12 +8618,15 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
             }
 
             PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(dst_parts, watch.elapsed(), profile_events_scope.getSnapshot()));
+            keeper_commit_part_txn->commit();
         }
         catch (...)
         {
             PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(dst_parts, watch.elapsed()), ExecutionStatus::fromCurrentException("", true));
-            for (const auto & dst_part : dst_parts)
-                unlockSharedData(*dst_part);
+
+            // Done in keeper_commit_part_txn dtr
+            // for (const auto & dst_part : dst_parts)
+            //     unlockSharedData(*dst_part);
 
             throw;
         }
@@ -8817,18 +8837,20 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
         DataPartsVector parts_holder;
         try
         {
-            Coordination::Requests ops;
+            // Coordination::Requests ops;
+            auto keeper_commit_part_txn = dest_table_storage->getKeeperCommitPartTransaction();
             for (size_t i = 0; i < dst_parts.size(); ++i)
             {
-                dest_table_storage->getCommitPartOps(ops, dst_parts[i], block_id_paths[i]);
-                ephemeral_locks[i].getUnlockOp(ops);
+                // dest_table_storage->getCommitPartOps(ops, dst_parts[i], block_id_paths[i]);
+                keeper_commit_part_txn->addPart(dst_parts[i], block_id_paths[i]);
+                ephemeral_locks[i].getUnlockOp(keeper_commit_part_txn->getOps());
             }
 
             /// Check and update version to avoid race with DROP_RANGE
-            ops.emplace_back(zkutil::makeSetRequest(dest_alter_partition_version_path, "", dest_alter_partition_version_stat.version));
+            keeper_commit_part_txn->getOps().emplace_back(zkutil::makeSetRequest(dest_alter_partition_version_path, "", dest_alter_partition_version_stat.version));
             /// Just update version, because merges assignment relies on it
-            ops.emplace_back(zkutil::makeSetRequest(fs::path(dest_table_storage->zookeeper_path) / "log", "", -1));
-            ops.emplace_back(zkutil::makeCreateRequest(fs::path(dest_table_storage->zookeeper_path) / "log/log-",
+            keeper_commit_part_txn->getOps().emplace_back(zkutil::makeSetRequest(fs::path(dest_table_storage->zookeeper_path) / "log", "", -1));
+            keeper_commit_part_txn->getOps().emplace_back(zkutil::makeCreateRequest(fs::path(dest_table_storage->zookeeper_path) / "log/log-",
                                                        entry.toString(), zkutil::CreateMode::PersistentSequential));
 
             {
@@ -8840,13 +8862,15 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
                 for (auto & part : dst_parts)
                     dest_table_storage->renameTempPartAndReplaceUnlocked(part, transaction, dest_data_parts_lock, /*rename_in_transaction=*/ false);
 
-                for (const auto & dst_part : dst_parts)
-                    dest_table_storage->lockSharedData(*dst_part, false, /*hardlinked_files*/ {});
+                // Done in keeper_commit_part_txn
+                // for (const auto & dst_part : dst_parts)
+                //     dest_table_storage->lockSharedData(*dst_part, false, /*hardlinked_files*/ {}); // TODO: the same as for executeReplaceRang
 
-                Coordination::Error code = zookeeper->tryMulti(ops, op_results);
+                // Coordination::Error code = zookeeper->tryMulti(ops, op_results);
+                Coordination::Error code = keeper_commit_part_txn->execute();
                 if (code == Coordination::Error::ZBADVERSION)
                     continue;
-                zkutil::KeeperMultiException::check(code, ops, op_results);
+                zkutil::KeeperMultiException::check(code, keeper_commit_part_txn.getOps(), keeper_commit_part_txn.getResults());
 
                 parts_holder = getDataPartsVectorInPartitionForInternalUsage(MergeTreeDataPartState::Active, drop_range.partition_id, &src_data_parts_lock);
                 /// We ignore the list of parts returned from the function below because we cannot remove them from zk
@@ -8861,8 +8885,9 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
         {
             PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(dst_parts, watch.elapsed()), ExecutionStatus::fromCurrentException("", true));
 
-            for (const auto & dst_part : dst_parts)
-                dest_table_storage->unlockSharedData(*dst_part);
+            // Done in keeper_commit_part_txn
+            // for (const auto & dst_part : dst_parts)
+            //     dest_table_storage->unlockSharedData(*dst_part);
 
             throw;
         }
@@ -9470,21 +9495,6 @@ std::optional<CheckResult> StorageReplicatedMergeTree::checkDataNext(DataValidat
 }
 
 
-bool StorageReplicatedMergeTree::canUseZeroCopyReplication() const
-{
-    auto settings_ptr = getSettings();
-    if (!(*settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-        return false;
-
-    auto disks = getStoragePolicy()->getDisks();
-    for (const auto & disk : disks)
-    {
-        if (disk->supportZeroCopyReplication())
-            return true;
-    }
-    return false;
-}
-
 void StorageReplicatedMergeTree::checkBrokenDisks()
 {
     auto disks = getStoragePolicy()->getDisks();
@@ -9643,765 +9653,6 @@ void StorageReplicatedMergeTree::createTableSharedIDAttempt() const
 }
 
 
-zkutil::EphemeralNodeHolderPtr StorageReplicatedMergeTree::lockSharedDataTemporary(const String & part_name, const String & part_id, const DiskPtr & disk) const
-{
-    auto settings = getSettings();
-
-    if (!disk || !disk->supportZeroCopyReplication() || !(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-        return {};
-
-    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
-    if (!zookeeper)
-        return {};
-
-    String id = part_id;
-    boost::replace_all(id, "/", "_");
-
-    String zc_zookeeper_path = getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().toString(), getTableSharedID(),
-        part_name, zookeeper_path)[0];
-
-    String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
-
-    LOG_TRACE(log, "Set zookeeper temporary ephemeral lock {}", zookeeper_node);
-    createZeroCopyLockNode(
-        std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), zookeeper_node, zkutil::CreateMode::Ephemeral, false);
-
-    LOG_TRACE(log, "Zookeeper temporary ephemeral lock {} created", zookeeper_node);
-    return zkutil::EphemeralNodeHolder::existing(zookeeper_node, *zookeeper);
-}
-
-void StorageReplicatedMergeTree::lockSharedData(
-    const IMergeTreeDataPart & part,
-    bool replace_existing_lock,
-    std::optional<HardlinkedFiles> hardlinked_files) const
-{
-    LOG_DEBUG(log, "Trying to create zero-copy lock for part {}", part.name);
-    auto zookeeper = tryGetZooKeeper();
-    if (zookeeper)
-        lockSharedData(part, std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), replace_existing_lock, hardlinked_files);
-}
-
-void StorageReplicatedMergeTree::getLockSharedDataOps(
-    const IMergeTreeDataPart & part,
-    const ZooKeeperWithFaultInjectionPtr & zookeeper,
-    bool replace_existing_lock,
-    std::optional<HardlinkedFiles> hardlinked_files,
-    Coordination::Requests & requests) const
-{
-    auto settings = getSettings();
-
-    if (!part.isStoredOnDisk() || !(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-        return;
-
-    if (!part.getDataPartStorage().supportZeroCopyReplication())
-        return;
-
-    if (zookeeper->isNull())
-        return;
-
-    String id = part.getUniqueId();
-    boost::replace_all(id, "/", "_");
-
-    Strings zc_zookeeper_paths = getZeroCopyPartPath(
-        *getSettings(), part.getDataPartStorage().getDiskType(), getTableSharedID(),
-        part.name, zookeeper_path);
-
-    String path_to_set_hardlinked_files;
-    NameSet hardlinks;
-
-    if (hardlinked_files.has_value() && !hardlinked_files->hardlinks_from_source_part.empty())
-    {
-        path_to_set_hardlinked_files = getZeroCopyPartPath(
-            *getSettings(), part.getDataPartStorage().getDiskType(), hardlinked_files->source_table_shared_id,
-            hardlinked_files->source_part_name, zookeeper_path)[0];
-
-        hardlinks = hardlinked_files->hardlinks_from_source_part;
-    }
-
-    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
-    {
-        String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
-
-        if (!path_to_set_hardlinked_files.empty() && !hardlinks.empty())
-        {
-            LOG_DEBUG(log, "Locking shared node {} with hardlinks from the other shared node {}, "
-                           "hardlinks: [{}]",
-                      zookeeper_node, path_to_set_hardlinked_files,
-                      boost::algorithm::join(hardlinks, ","));
-        }
-
-        getZeroCopyLockNodeCreateOps(
-            zookeeper, zookeeper_node, requests, zkutil::CreateMode::Persistent,
-            replace_existing_lock, path_to_set_hardlinked_files, hardlinks);
-    }
-}
-
-
-void StorageReplicatedMergeTree::lockSharedData(
-    const IMergeTreeDataPart & part,
-    const ZooKeeperWithFaultInjectionPtr & zookeeper,
-    bool replace_existing_lock,
-    std::optional<HardlinkedFiles> hardlinked_files) const
-{
-    auto settings = getSettings();
-
-    if (!part.isStoredOnDisk() || !(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-        return;
-
-    if (!part.getDataPartStorage().supportZeroCopyReplication())
-        return;
-
-    if (zookeeper->isNull())
-        return;
-
-    String id = part.getUniqueId();
-    boost::replace_all(id, "/", "_");
-
-    Strings zc_zookeeper_paths = getZeroCopyPartPath(
-        *getSettings(), part.getDataPartStorage().getDiskType(), getTableSharedID(),
-        part.name, zookeeper_path);
-
-    String path_to_set_hardlinked_files;
-    NameSet hardlinks;
-
-    if (hardlinked_files.has_value() && !hardlinked_files->hardlinks_from_source_part.empty())
-    {
-        path_to_set_hardlinked_files = getZeroCopyPartPath(
-            *getSettings(), part.getDataPartStorage().getDiskType(), hardlinked_files->source_table_shared_id,
-            hardlinked_files->source_part_name, zookeeper_path)[0];
-
-        hardlinks = hardlinked_files->hardlinks_from_source_part;
-    }
-
-    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
-    {
-        String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
-
-        LOG_TRACE(log, "Trying to create zookeeper persistent lock {} with hardlinks [{}]", zookeeper_node, fmt::join(hardlinks, ", "));
-
-        createZeroCopyLockNode(
-            zookeeper, zookeeper_node, zkutil::CreateMode::Persistent,
-            replace_existing_lock, path_to_set_hardlinked_files, hardlinks);
-
-        LOG_TRACE(log, "Zookeeper persistent lock {} created", zookeeper_node);
-    }
-}
-
-std::pair<bool, NameSet>
-StorageReplicatedMergeTree::unlockSharedData(const IMergeTreeDataPart & part) const
-{
-    return unlockSharedData(part, std::make_shared<ZooKeeperWithFaultInjection>(nullptr));
-}
-
-std::pair<bool, NameSet>
-StorageReplicatedMergeTree::unlockSharedData(const IMergeTreeDataPart & part, const ZooKeeperWithFaultInjectionPtr & zookeeper) const
-{
-    auto settings = getSettings();
-    if (!(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-        return std::make_pair(true, NameSet{});
-
-    if (!part.isStoredOnDisk())
-    {
-        LOG_TRACE(log, "Part {} is not stored on disk, blobs can be removed", part.name);
-        return std::make_pair(true, NameSet{});
-    }
-
-    if (!part.getDataPartStorage().supportZeroCopyReplication())
-    {
-        LOG_TRACE(log, "Part {} is not stored on zero-copy replicated disk, blobs can be removed", part.name);
-        return std::make_pair(true, NameSet{});
-    }
-
-    auto shared_id = getTableSharedID();
-    if (shared_id == toString(UUIDHelpers::Nil))
-    {
-        if (zookeeper->exists(zookeeper_path))
-        {
-            LOG_WARNING(log, "Not removing shared data for part {} because replica does not have metadata in ZooKeeper, "
-                             "but table path exist and other replicas may exist. It may leave some garbage on S3", part.name);
-            return std::make_pair(false, NameSet{});
-        }
-        LOG_TRACE(log, "Part {} blobs can be removed, because table {} completely dropped", part.name, getStorageID().getNameForLogs());
-        return std::make_pair(true, NameSet{});
-    }
-
-    /// If part is temporary refcount file may be absent
-    if (part.getDataPartStorage().existsFile(IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK))
-    {
-        auto ref_count = part.getDataPartStorage().getRefCount(IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK);
-        if (ref_count > 0) /// Keep part shard info for frozen backups
-        {
-            LOG_TRACE(log, "Part {} has more than zero local references ({}), blobs cannot be removed", part.name, ref_count);
-            return std::make_pair(false, NameSet{});
-        }
-
-        LOG_TRACE(log, "Part {} local references is zero, will check blobs can be removed in zookeeper", part.name);
-    }
-    else
-    {
-        LOG_TRACE(log, "Part {} looks temporary, because {} file doesn't exists, blobs can be removed", part.name, IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK);
-        /// Temporary part with some absent file cannot be locked in shared mode
-        return std::make_pair(true, NameSet{});
-    }
-
-    if (part.getState() == MergeTreeDataPartState::Temporary && part.is_temp)
-    {
-        /// Part {} is in temporary state and has it_temp flag. it means that it is under construction.
-        /// That path hasn't been added to active set, no commit procedure has begun.
-        /// The metadata files is about to delete now. Clichouse has to make a decision remove or preserve blobs on remote FS.
-        /// In general remote data might be shared and has to be unlocked in the keeper before removing.
-        /// However there are some cases when decision is clear without asking keeper:
-        /// When the part has been fetched then remote data has to be preserved, part doesn't own it.
-        /// When the part has been merged then remote data can be removed, part owns it.
-        /// In opposition, when the part has been mutated in generally it hardlinks the files from source part.
-        /// Therefore remote data could be shared, it has to be unlocked in the keeper.
-        /// In order to track all that cases remove_tmp_policy is used.
-        /// Clickhouse set that field as REMOVE_BLOBS or PRESERVE_BLOBS when it sure about the decision without asking keeper.
-
-        if (part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS
-            || part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::PRESERVE_BLOBS)
-        {
-            bool can_remove_blobs = part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS;
-            LOG_INFO(log, "Looks like CH knows the origin of that part. "
-                          "Part {} can be deleted without unlocking shared data in zookeeper. "
-                          "Part blobs {}.",
-                     part.name,
-                     can_remove_blobs ? "will be removed" : "have to be preserved");
-            return std::make_pair(can_remove_blobs, NameSet{});
-        }
-    }
-
-    if (part.rows_count == 0 && part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS_OF_NOT_TEMPORARY)
-    {
-        /// It's a non-replicated empty part that was created to avoid unexpected parts after DROP_RANGE
-        LOG_INFO(log, "Looks like {} is a non-replicated empty part that was created to avoid unexpected parts after DROP_RANGE, "
-                      "blobs can be removed", part.name);
-        return std::make_pair(true, NameSet{});
-    }
-
-    if (has_metadata_in_zookeeper.has_value() && !has_metadata_in_zookeeper)
-    {
-        if (zookeeper->exists(zookeeper_path))
-        {
-            LOG_WARNING(log, "Not removing shared data for part {} because replica does not have metadata in ZooKeeper, "
-                             "but table path exist and other replicas may exist. It may leave some garbage on S3", part.name);
-            return std::make_pair(false, NameSet{});
-        }
-
-        /// If table was completely dropped (no meta in zookeeper) we can safely remove parts
-        return std::make_pair(true, NameSet{});
-    }
-
-    /// We remove parts during table shutdown. If exception happen, restarting thread will be already turned
-    /// off and nobody will reconnect our zookeeper connection. In this case we use zookeeper connection from
-    /// context.
-    if (shutdown_called.load())
-        zookeeper->setKeeper(getZooKeeperIfTableShutDown());
-    else
-        zookeeper->setKeeper(getZooKeeper());
-
-    /// It can happen that we didn't had the connection to zookeeper during table creation, but actually
-    /// table is completely dropped, so we can drop it without any additional checks.
-    if (!has_metadata_in_zookeeper.has_value() && !zookeeper->exists(zookeeper_path))
-        return std::make_pair(true, NameSet{});
-
-    return unlockSharedDataByID(
-        part.getUniqueId(), shared_id, part.info, replica_name,
-        part.getDataPartStorage().getDiskType(), zookeeper, *getSettings(), log.load(), zookeeper_path, format_version);
-}
-
-namespace
-{
-
-/// What is going on here?
-/// Actually we need this code because of flaws in hardlinks tracking. When we create child part during mutation we can hardlink some files from parent part, like
-/// all_0_0_0:
-///                     a.bin a.mrk2 columns.txt ...
-/// all_0_0_0_1:          ^     ^
-///                     a.bin a.mrk2 columns.txt
-/// So when we deleting all_0_0_0 it doesn't remove blobs for a.bin and a.mrk2 because all_0_0_0_1 use them.
-/// But sometimes we need an opposite. When we deleting all_0_0_0_1 it can be non replicated to other replicas, so we are the only owner of this part.
-/// In this case when we will drop all_0_0_0_1 we will drop blobs for all_0_0_0. But it will lead to dataloss. For such case we need to check that other replicas
-/// still need parent part.
-std::pair<bool, NameSet> getParentLockedBlobs(const ZooKeeperWithFaultInjectionPtr & zookeeper_ptr, const std::string & zero_copy_part_path_prefix, const MergeTreePartInfo & part_info, MergeTreeDataFormatVersion format_version, LoggerPtr log)
-{
-    NameSet files_not_to_remove;
-
-    /// No mutations -- no hardlinks -- no issues
-    if (part_info.mutation == 0)
-        return {false, files_not_to_remove};
-
-    /// Getting all zero copy parts
-    Strings parts_str;
-    zookeeper_ptr->tryGetChildren(zero_copy_part_path_prefix, parts_str);
-
-    /// Parsing infos. It's hard to convert info -> string for old-format merge tree
-    /// so storing string as is.
-    std::vector<std::pair<MergeTreePartInfo, std::string>> parts_infos;
-    for (const auto & part_str : parts_str)
-    {
-        MergeTreePartInfo parent_candidate_info = MergeTreePartInfo::fromPartName(part_str, format_version);
-        parts_infos.emplace_back(parent_candidate_info, part_str);
-    }
-
-    /// Sort is important. We need to find our closest parent, like:
-    /// for part all_0_0_0_64 we can have parents
-    /// all_0_0_0_6 < we need the closest parent, not others
-    /// all_0_0_0_1
-    /// all_0_0_0
-    std::sort(parts_infos.begin(), parts_infos.end());
-    std::string part_info_str = part_info.getPartNameV1();
-
-    /// In reverse order to process from bigger to smaller
-    for (const auto & [parent_candidate_info, part_candidate_info_str] : parts_infos | std::views::reverse)
-    {
-        if (parent_candidate_info == part_info)
-            continue;
-
-        /// We are mutation child of this parent
-        if (part_info.isMutationChildOf(parent_candidate_info))
-        {
-            LOG_TRACE(log, "Found mutation parent {} for part {}", part_candidate_info_str, part_info_str);
-            /// Get hardlinked files
-            String files_not_to_remove_str;
-            Coordination::Error code;
-            zookeeper_ptr->tryGet(fs::path(zero_copy_part_path_prefix) / part_candidate_info_str, files_not_to_remove_str, nullptr, nullptr, &code);
-            if (code != Coordination::Error::ZOK)
-            {
-                LOG_INFO(log, "Cannot get parent files from ZooKeeper on path ({}), error {}, assuming the parent was removed concurrently",
-                            (fs::path(zero_copy_part_path_prefix) / part_candidate_info_str).string(), code);
-                continue;
-            }
-
-            if (!files_not_to_remove_str.empty())
-            {
-                boost::split(files_not_to_remove, files_not_to_remove_str, boost::is_any_of("\n "));
-                LOG_TRACE(log, "Found files not to remove from parent part {}: [{}]", part_candidate_info_str, fmt::join(files_not_to_remove, ", "));
-            }
-            else
-            {
-                std::vector<std::string> children;
-                code = zookeeper_ptr->tryGetChildren(fs::path(zero_copy_part_path_prefix) / part_candidate_info_str, children);
-                if (code != Coordination::Error::ZOK)
-                {
-                    LOG_INFO(log, "Cannot get parent locks in ZooKeeper on path ({}), error {}, assuming the parent was removed concurrently",
-                              (fs::path(zero_copy_part_path_prefix) / part_candidate_info_str).string(), errorMessage(code));
-                    continue;
-                }
-
-                if (children.size() > 1 || (children.size() == 1 && children[0] != ZeroCopyLock::ZERO_COPY_LOCK_NAME))
-                {
-                    LOG_TRACE(log, "No files not to remove found for part {} from parent {}", part_info_str, part_candidate_info_str);
-                }
-                else
-                {
-                    /// The case when part is actually removed, but some stale replica trying to execute merge/mutation.
-                    /// We shouldn't use the part to check hardlinked blobs, it just doesn't exist.
-                    LOG_TRACE(log, "Part {} is not parent (only merge/mutation locks exist), refusing to use as parent", part_candidate_info_str);
-                    continue;
-                }
-            }
-
-            return {true, files_not_to_remove};
-        }
-    }
-    LOG_TRACE(log, "No mutation parent found for part {}", part_info_str);
-    return {false, files_not_to_remove};
-}
-
-}
-
-std::pair<bool, NameSet> StorageReplicatedMergeTree::unlockSharedDataByID(
-        String part_id, const String & table_uuid, const MergeTreePartInfo & part_info,
-        const String & replica_name_, const std::string & disk_type, const ZooKeeperWithFaultInjectionPtr & zookeeper_ptr, const MergeTreeSettings & settings,
-        LoggerPtr logger, const String & zookeeper_path_old, MergeTreeDataFormatVersion data_format_version)
-{
-    boost::replace_all(part_id, "/", "_");
-
-    auto part_name = part_info.getPartNameV1();
-
-    Strings zc_zookeeper_paths = getZeroCopyPartPath(settings, disk_type, table_uuid, part_name, zookeeper_path_old);
-
-    bool part_has_no_more_locks = true;
-    NameSet files_not_to_remove;
-
-    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
-    {
-        String files_not_to_remove_str;
-        zookeeper_ptr->tryGet(zc_zookeeper_path, files_not_to_remove_str);
-
-        files_not_to_remove.clear();
-        if (!files_not_to_remove_str.empty())
-            boost::split(files_not_to_remove, files_not_to_remove_str, boost::is_any_of("\n "));
-
-        String zookeeper_part_uniq_node = fs::path(zc_zookeeper_path) / part_id;
-
-        /// Delete our replica node for part from zookeeper (we are not interested in it anymore)
-        String zookeeper_part_replica_node = fs::path(zookeeper_part_uniq_node) / replica_name_;
-
-        auto [has_parent, parent_not_to_remove] = getParentLockedBlobs(
-            zookeeper_ptr, fs::path(zc_zookeeper_path).parent_path(), part_info, data_format_version, logger);
-
-        files_not_to_remove.insert(parent_not_to_remove.begin(), parent_not_to_remove.end());
-
-        LOG_TRACE(logger, "Removing zookeeper lock {} for part {} (files to keep: [{}])", zookeeper_part_replica_node, part_name, fmt::join(files_not_to_remove, ", "));
-
-        fiu_do_on(FailPoints::zero_copy_unlock_zk_fail_before_op, { zookeeper_ptr->forceFailureBeforeOperation(); });
-        fiu_do_on(FailPoints::zero_copy_unlock_zk_fail_after_op, { zookeeper_ptr->forceFailureAfterOperation(); });
-
-        if (auto ec = zookeeper_ptr->tryRemove(zookeeper_part_replica_node); ec != Coordination::Error::ZOK)
-        {
-            /// Very complex case. It means that lock already doesn't exist when we tried to remove it.
-            /// So we don't know are we owner of this part or not. Maybe we just mutated it, renamed on disk and failed to lock in ZK.
-            /// But during mutation we can have hardlinks to another part. So it's not Ok to remove blobs of this part if it was mutated.
-            if (ec == Coordination::Error::ZNONODE)
-            {
-                if (has_parent)
-                {
-                    LOG_INFO(logger, "Lock on path {} for part {} doesn't exist, refuse to remove blobs", zookeeper_part_replica_node, part_name);
-                    return {false, {}};
-                }
-
-                LOG_INFO(
-                    logger,
-                    "Lock on path {} for part {} doesn't exist, but we don't have mutation parent, can remove blobs",
-                    zookeeper_part_replica_node,
-                    part_name);
-            }
-            else
-            {
-                throw zkutil::KeeperException::fromPath(ec, zookeeper_part_replica_node);
-            }
-        }
-
-        /// Check, maybe we were the last replica and can remove part forever
-        Strings children;
-        zookeeper_ptr->tryGetChildren(zookeeper_part_uniq_node, children);
-
-        if (!children.empty())
-        {
-            LOG_TRACE(logger, "Found {} ({}) zookeeper locks for {}", children.size(), fmt::join(children, ", "), zookeeper_part_uniq_node);
-            part_has_no_more_locks = false;
-            continue;
-        }
-
-        LOG_TRACE(logger, "No more children left for {}, will try to remove the whole node", zookeeper_part_uniq_node);
-
-
-        auto error_code = zookeeper_ptr->tryRemove(zookeeper_part_uniq_node);
-
-        if (error_code == Coordination::Error::ZOK)
-        {
-            LOG_TRACE(logger, "Removed last parent zookeeper lock {} for part {} with id {}", zookeeper_part_uniq_node, part_name, part_id);
-        }
-        else if (error_code == Coordination::Error::ZNOTEMPTY)
-        {
-            LOG_TRACE(
-                logger,
-                "Cannot remove last parent zookeeper lock {} for part {} with id {}, another replica locked part concurrently",
-                zookeeper_part_uniq_node,
-                part_name,
-                part_id);
-            part_has_no_more_locks = false;
-            continue;
-        }
-        else if (error_code == Coordination::Error::ZNONODE)
-        {
-            LOG_TRACE(logger, "Node with parent zookeeper lock {} for part {} with id {} doesn't exist", zookeeper_part_uniq_node, part_name, part_id);
-        }
-        else
-        {
-            throw zkutil::KeeperException::fromPath(error_code, zookeeper_part_uniq_node);
-        }
-
-
-        /// Even when we have lock with same part name, but with different uniq, we can remove files on S3
-        children.clear();
-        String zookeeper_part_node = fs::path(zookeeper_part_uniq_node).parent_path();
-        zookeeper_ptr->tryGetChildren(zookeeper_part_node, children);
-
-        if (children.empty())
-        {
-            /// Cleanup after last uniq removing
-            error_code = zookeeper_ptr->tryRemove(zookeeper_part_node);
-
-            if (error_code == Coordination::Error::ZOK)
-            {
-                LOG_TRACE(logger, "Removed last parent zookeeper lock {} for part {} (part is finally unlocked)", zookeeper_part_node, part_name);
-            }
-            else if (error_code == Coordination::Error::ZNOTEMPTY)
-            {
-                LOG_TRACE(logger, "Cannot remove last parent zookeeper lock {} for part {}, another replica locked part concurrently", zookeeper_part_uniq_node, part_name);
-            }
-            else if (error_code == Coordination::Error::ZNONODE)
-            {
-                /// We don't know what to do, because this part can be mutation part
-                /// with hardlinked columns. Since we don't have this information (about blobs not to remove)
-                /// we refuse to remove blobs.
-                LOG_WARNING(logger, "Node with parent zookeeper lock {} for part {} doesn't exist (part was unlocked before), refuse to remove blobs", zookeeper_part_uniq_node, part_name);
-                return {false, {}};
-            }
-            else
-            {
-                throw zkutil::KeeperException::fromPath(error_code, zookeeper_part_uniq_node);
-            }
-        }
-        else
-        {
-            /// It's possible that we have two instances of the same part with different blob names of
-            /// FILE_FOR_REFERENCES_CHECK aka checksums.txt aka part_unique_id,
-            /// and other files in both parts are hardlinks (the same blobs are shared between part instances).
-            /// It's possible after unsuccessful attempts to commit a mutated part to zk.
-            /// It's not a problem if we have found the mutation parent (so we have files_not_to_remove).
-            /// But in rare cases mutations parents could have been already removed (so we don't have the list of hardlinks).
-
-            /// I'm not 100% sure that parent_not_to_remove list cannot be incomplete (when we've found a parent)
-            if (part_info.mutation && !has_parent)
-                part_has_no_more_locks = false;
-
-            LOG_TRACE(logger, "Can't remove parent zookeeper lock {} for part {}, because children {} ({}) exists (can remove blobs: {})",
-                zookeeper_part_node, part_name, children.size(), fmt::join(children, ", "), part_has_no_more_locks);
-        }
-    }
-
-    return std::make_pair(part_has_no_more_locks, files_not_to_remove);
-}
-
-
-MergeTreeData::MutableDataPartPtr StorageReplicatedMergeTree::tryToFetchIfShared(
-    const IMergeTreeDataPart & part,
-    const DiskPtr & disk,
-    const String & path)
-{
-    const auto settings = getSettings();
-    auto data_source_description = disk->getDataSourceDescription();
-    if (!(disk->supportZeroCopyReplication() && (*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication]))
-        return nullptr;
-
-    String replica = getSharedDataReplica(part, data_source_description);
-
-    /// We can't fetch part when none replicas have this part on a same type remote disk
-    if (replica.empty())
-        return nullptr;
-
-    return executeFetchShared(replica, part.name, disk, path);
-}
-
-String StorageReplicatedMergeTree::getSharedDataReplica(
-    const IMergeTreeDataPart & part, const DataSourceDescription & data_source_description) const
-{
-    String best_replica;
-
-    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
-    if (!zookeeper)
-        return "";
-
-    Strings zc_zookeeper_paths = getZeroCopyPartPath(*getSettings(), data_source_description.toString(), getTableSharedID(), part.name,
-            zookeeper_path);
-
-    std::set<String> replicas;
-
-    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
-    {
-        Strings ids;
-        zookeeper->tryGetChildren(zc_zookeeper_path, ids);
-
-        for (const auto & id : ids)
-        {
-            String zookeeper_part_uniq_node = fs::path(zc_zookeeper_path) / id;
-            Strings id_replicas;
-            zookeeper->tryGetChildren(zookeeper_part_uniq_node, id_replicas);
-            LOG_TRACE(log, "Found zookeeper replicas for {}: {}", zookeeper_part_uniq_node, id_replicas.size());
-            replicas.insert(id_replicas.begin(), id_replicas.end());
-        }
-    }
-
-    LOG_TRACE(log, "Found zookeeper replicas for part {}: {}", part.name, replicas.size());
-
-    Strings active_replicas;
-
-    /// TODO: Move best replica choose in common method (here is the same code as in StorageReplicatedMergeTree::fetchPartition)
-
-    /// Leave only active replicas.
-    active_replicas.reserve(replicas.size());
-
-    for (const String & replica : replicas)
-        if ((replica != replica_name) && (zookeeper->exists(fs::path(zookeeper_path) / "replicas" / replica / "is_active")))
-            active_replicas.push_back(replica);
-
-    LOG_TRACE(log, "Found zookeeper active replicas for part {}: {}", part.name, active_replicas.size());
-
-    if (active_replicas.empty())
-        return "";
-
-    /** You must select the best (most relevant) replica.
-    * This is a replica with the maximum `log_pointer`, then with the minimum `queue` size.
-    * NOTE This is not exactly the best criteria. It does not make sense to download old partitions,
-    *  and it would be nice to be able to choose the replica closest by network.
-    * NOTE Of course, there are data races here. You can solve it by retrying.
-    */
-    Int64 max_log_pointer = -1;
-    UInt64 min_queue_size = std::numeric_limits<UInt64>::max();
-
-    for (const String & replica : active_replicas)
-    {
-        String current_replica_path = fs::path(zookeeper_path) / "replicas" / replica;
-
-        String log_pointer_str = zookeeper->get(fs::path(current_replica_path) / "log_pointer");
-        Int64 log_pointer = log_pointer_str.empty() ? 0 : parse<UInt64>(log_pointer_str);
-
-        Coordination::Stat stat;
-        zookeeper->get(fs::path(current_replica_path) / "queue", &stat);
-        size_t queue_size = stat.numChildren;
-
-        if (log_pointer > max_log_pointer
-            || (log_pointer == max_log_pointer && queue_size < min_queue_size))
-        {
-            max_log_pointer = log_pointer;
-            min_queue_size = queue_size;
-            best_replica = replica;
-        }
-    }
-
-    return best_replica;
-}
-
-Strings StorageReplicatedMergeTree::getZeroCopyPartPath(
-    const MergeTreeSettings & settings, const std::string & disk_type, const String & table_uuid,
-    const String & part_name, const String & zookeeper_path_old)
-{
-    Strings res;
-
-    String zero_copy = fmt::format("zero_copy_{}", disk_type);
-
-    String new_path = fs::path(settings[MergeTreeSetting::remote_fs_zero_copy_zookeeper_path].toString()) / zero_copy / table_uuid / part_name;
-    res.push_back(std::move(new_path));
-    if (settings[MergeTreeSetting::remote_fs_zero_copy_path_compatible_mode] && !zookeeper_path_old.empty())
-    { /// Compatibility mode for cluster with old and new versions
-        String old_path = fs::path(zookeeper_path_old) / zero_copy / "shared" / part_name;
-        res.push_back(std::move(old_path));
-    }
-
-    return res;
-}
-
-void StorageReplicatedMergeTree::watchZeroCopyLock(const String & part_name, const DiskPtr & disk)
-{
-    auto path = getZeroCopyPartPath(part_name, disk);
-    if (path)
-    {
-        auto zookeeper = getZooKeeper();
-        auto lock_path = fs::path(*path) / "part_exclusive_lock";
-        LOG_TEST(log, "Adding zero-copy lock on {}", lock_path);
-        /// Looks ugly, but we cannot touch any storage fields inside Watch callback
-        /// because it could lead to use-after-free (storage dropped and watch triggered)
-        std::shared_ptr<std::atomic<bool>> flag = std::make_shared<std::atomic<bool>>(true);
-        std::string replica;
-        bool exists = zookeeper->tryGetWatch(lock_path, replica, nullptr, [flag] (const Coordination::WatchResponse &)
-        {
-            *flag = false;
-        });
-
-        if (exists)
-        {
-            std::lock_guard lock(existing_zero_copy_locks_mutex);
-            existing_zero_copy_locks[lock_path] = ZeroCopyLockDescription{replica, flag};
-        }
-    }
-}
-
-bool StorageReplicatedMergeTree::checkZeroCopyLockExists(const String & part_name, const DiskPtr & disk, String & lock_replica)
-{
-    auto path = getZeroCopyPartPath(part_name, disk);
-
-    std::lock_guard lock(existing_zero_copy_locks_mutex);
-    /// Cleanup abandoned locks during each check. The set of locks is small and this is quite fast loop.
-    /// Also it's hard to properly remove locks because we can execute replication queue
-    /// in arbitrary order and some parts can be replaced by covering parts without merges.
-    for (auto it = existing_zero_copy_locks.begin(); it != existing_zero_copy_locks.end();)
-    {
-        if (*it->second.exists)
-            ++it;
-        else
-        {
-            LOG_TEST(log, "Removing zero-copy lock on {}", it->first);
-            it = existing_zero_copy_locks.erase(it);
-        }
-    }
-
-    if (path)
-    {
-        auto lock_path = fs::path(*path) / "part_exclusive_lock";
-        if (auto it = existing_zero_copy_locks.find(lock_path); it != existing_zero_copy_locks.end())
-        {
-            lock_replica = it->second.replica;
-            if (*it->second.exists)
-            {
-                LOG_TEST(log, "Zero-copy lock on path {} exists", it->first);
-                return true;
-            }
-        }
-
-        LOG_TEST(log, "Zero-copy lock on path {} doesn't exist", lock_path);
-    }
-
-    return false;
-}
-
-std::optional<String> StorageReplicatedMergeTree::getZeroCopyPartPath(const String & part_name, const DiskPtr & disk)
-{
-    if (!disk || !disk->supportZeroCopyReplication())
-        return std::nullopt;
-
-    return getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().toString(), getTableSharedID(), part_name, zookeeper_path)[0];
-}
-
-bool StorageReplicatedMergeTree::waitZeroCopyLockToDisappear(const ZeroCopyLock & lock, size_t milliseconds_to_wait)
-{
-    if (lock.isLocked())
-        return true;
-
-    if (partial_shutdown_called.load(std::memory_order_relaxed))
-        return true;
-
-    auto lock_path = lock.lock->getLockPath();
-    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
-    if (!zookeeper)
-        return true;
-
-    Stopwatch time_waiting;
-    const auto & stop_waiting = [&]()
-    {
-        bool timeout_exceeded = milliseconds_to_wait < time_waiting.elapsedMilliseconds();
-        return partial_shutdown_called.load(std::memory_order_relaxed) || is_readonly.load(std::memory_order_relaxed) || timeout_exceeded;
-    };
-
-    return zookeeper->waitForDisappear(lock_path, stop_waiting);
-}
-
-std::optional<ZeroCopyLock> StorageReplicatedMergeTree::tryCreateZeroCopyExclusiveLock(const String & part_name, const DiskPtr & disk)
-{
-    if (!disk || !disk->supportZeroCopyReplication())
-        return std::nullopt;
-
-    if (partial_shutdown_called.load(std::memory_order_relaxed) || is_readonly.load(std::memory_order_relaxed))
-        return std::nullopt;
-
-    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
-    if (!zookeeper)
-        return std::nullopt;
-
-    String zc_zookeeper_path = *getZeroCopyPartPath(part_name, disk);
-
-    /// Just recursively create ancestors for lock
-    zookeeper->createAncestors(zc_zookeeper_path + "/");
-
-    /// Create actual lock
-    ZeroCopyLock lock(zookeeper, zc_zookeeper_path, replica_name);
-    lock.lock->tryLock();
-    return lock;
-}
-
 String StorageReplicatedMergeTree::findReplicaHavingPart(
     const String & part_name, const String & zookeeper_path_, zkutil::ZooKeeper::Ptr zookeeper_ptr)
 {
@@ -10509,7 +9760,7 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
                             lost_part_name, fmt::join(part_names, ", "));
         }
 
-        lockSharedData(*new_data_part, false, {});
+        // lockSharedData(*new_data_part, false, {});
 
         while (true)
         {
@@ -10537,15 +9788,17 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
                 return false;
             }
 
-            Coordination::Requests ops;
+            // Coordination::Requests ops;
+            auto keeper_commit_part_txn = dest_table_storage->getKeeperCommitPartTransaction();
+
             Coordination::Stat replicas_stat;
             auto replicas_path = fs::path(zookeeper_path) / "replicas";
             Strings replicas = zookeeper->getChildren(replicas_path, &replicas_stat);
 
-            ops.emplace_back(zkutil::makeCheckRequest(zookeeper_path + "/log", pred.getVersion()));
+            keeper_commit_part_txn.getOps().emplace_back(zkutil::makeCheckRequest(zookeeper_path + "/log", pred.getVersion()));
 
             /// In rare cases new replica can appear during check
-            ops.emplace_back(zkutil::makeCheckRequest(replicas_path, replicas_stat.version));
+            keeper_commit_part_txn.getOps().emplace_back(zkutil::makeCheckRequest(replicas_path, replicas_stat.version));
 
             for (const String & replica : replicas)
             {
@@ -10568,7 +9821,7 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
             /// Ensure that we are the first replica who commits that part.
             size_t num_check_ops_unused;
             bool part_found = getOpsToCheckPartChecksumsAndCommit(std::make_shared<ZooKeeperWithFaultInjection>(zookeeper),
-                new_data_part, /*hardlinked_files*/ {}, /*replace_zero_copy_lock*/ true, ops, num_check_ops_unused);
+                new_data_part, /*hardlinked_files*/ {}, /*replace_zero_copy_lock*/ true, keeper_commit_part_txn.getOps(), num_check_ops_unused);
             if (part_found)
                 throw Exception(ErrorCodes::DUPLICATE_DATA_PART, "Found part on another replica, probably it was already replaced");
 
@@ -10579,17 +9832,18 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
             if (zookeeper->tryGet(lost_part_count_path, lost_part_count_str, &lost_part_count_stat))
             {
                 UInt64 lost_part_count = lost_part_count_str.empty() ? 0 : parse<UInt64>(lost_part_count_str);
-                ops.emplace_back(zkutil::makeSetRequest(lost_part_count_path, toString(lost_part_count + 1), lost_part_count_stat.version));
+                keeper_commit_part_txn.getOps().emplace_back(zkutil::makeSetRequest(lost_part_count_path, toString(lost_part_count + 1), lost_part_count_stat.version));
             }
             else
             {
-                ops.emplace_back(zkutil::makeCreateRequest(lost_part_count_path, "1", zkutil::CreateMode::Persistent));
+                keeper_commit_part_txn.getOps().emplace_back(zkutil::makeCreateRequest(lost_part_count_path, "1", zkutil::CreateMode::Persistent));
             }
 
             ThreadFuzzer::maybeInjectSleep();
 
             Coordination::Responses responses;
-            auto code = zookeeper->tryMulti(ops, responses, /* check_session_valid */ true);
+            // auto code = zookeeper->tryMulti(ops, responses, /* check_session_valid */ true);
+            auto code = keeper_commit_part_txn->execute();
             if (code == Coordination::Error::ZOK)
             {
                 transaction.commit();
@@ -10603,6 +9857,7 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
             {
                 zkutil::KeeperMultiException::check(code, ops, responses);
             }
+            keeper_commit_part_txn->commit();
         }
     }
     catch (const Exception & ex)
@@ -10616,193 +9871,11 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
     return true;
 }
 
-void StorageReplicatedMergeTree::getZeroCopyLockNodeCreateOps(
-    const ZooKeeperWithFaultInjectionPtr & zookeeper, const String & zookeeper_node, Coordination::Requests & requests,
-    int32_t mode, bool replace_existing_lock,
-    const String & path_to_set_hardlinked_files, const NameSet & hardlinked_files)
-{
-
-    /// Ephemeral locks can be created only when we fetch shared data.
-    /// So it never require to create ancestors. If we create them
-    /// race condition with source replica drop is possible.
-    if (mode == zkutil::CreateMode::Persistent)
-        zookeeper->checkExistsAndGetCreateAncestorsOps(zookeeper_node, requests);
-
-    if (replace_existing_lock && zookeeper->exists(zookeeper_node))
-    {
-        requests.emplace_back(zkutil::makeRemoveRequest(zookeeper_node, -1));
-        requests.emplace_back(zkutil::makeCreateRequest(zookeeper_node, "", mode));
-        if (!path_to_set_hardlinked_files.empty() && !hardlinked_files.empty())
-        {
-            std::string data = boost::algorithm::join(hardlinked_files, "\n");
-            /// List of files used to detect hardlinks. path_to_set_hardlinked_files --
-            /// is a path to source part zero copy node. During part removal hardlinked
-            /// files will be left for source part.
-            requests.emplace_back(zkutil::makeSetRequest(path_to_set_hardlinked_files, data, -1));
-        }
-    }
-    else
-    {
-        Coordination::Requests ops;
-        if (!path_to_set_hardlinked_files.empty() && !hardlinked_files.empty())
-        {
-            std::string data = boost::algorithm::join(hardlinked_files, "\n");
-            /// List of files used to detect hardlinks. path_to_set_hardlinked_files --
-            /// is a path to source part zero copy node. During part removal hardlinked
-            /// files will be left for source part.
-            requests.emplace_back(zkutil::makeSetRequest(path_to_set_hardlinked_files, data, -1));
-        }
-        requests.emplace_back(zkutil::makeCreateRequest(zookeeper_node, "", mode));
-    }
-}
-
-
-void StorageReplicatedMergeTree::createZeroCopyLockNode(
-    const ZooKeeperWithFaultInjectionPtr & zookeeper, const String & zookeeper_node, int32_t mode,
-    bool replace_existing_lock, const String & path_to_set_hardlinked_files, const NameSet & hardlinked_files)
-{
-    /// In rare case other replica can remove path between createAncestors and createIfNotExists
-    /// So we make up to 5 attempts
-
-    auto is_ephemeral = [&](const String & node_path) -> bool
-    {
-        String dummy_res;
-        Coordination::Stat node_stat;
-        if (zookeeper->tryGet(node_path, dummy_res, &node_stat))
-            return node_stat.ephemeralOwner;
-        return false;
-    };
-
-    bool created = false;
-    for (int attempts = 5; attempts > 0; --attempts)
-    {
-        Coordination::Requests ops;
-        Coordination::Responses responses;
-        getZeroCopyLockNodeCreateOps(zookeeper, zookeeper_node, ops, mode, replace_existing_lock, path_to_set_hardlinked_files, hardlinked_files);
-
-        fiu_do_on(FailPoints::zero_copy_lock_zk_fail_before_op, { zookeeper->forceFailureBeforeOperation(); });
-        fiu_do_on(FailPoints::zero_copy_lock_zk_fail_after_op, { zookeeper->forceFailureAfterOperation(); });
-
-        auto error = zookeeper->tryMulti(ops, responses);
-        if (error == Coordination::Error::ZOK)
-        {
-            created = true;
-            break;
-        }
-        if (mode == zkutil::CreateMode::Persistent)
-        {
-            if (error == Coordination::Error::ZNONODE)
-                continue;
-
-            if (error == Coordination::Error::ZNODEEXISTS)
-            {
-                if (is_ephemeral(zookeeper_node))
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Node {} already exists, but it is ephemeral", zookeeper_node);
-
-                size_t failed_op = zkutil::getFailedOpIndex(error, responses);
-                /// Part was locked before, unfortunately it's possible during moves
-                if (ops[failed_op]->getPath() == zookeeper_node)
-                {
-                    created = true;
-                    break;
-                }
-                continue;
-            }
-        }
-        else if (mode == zkutil::CreateMode::Ephemeral)
-        {
-            /// It is super rare case when we had part, but it was lost and we were unable to unlock it from keeper.
-            /// Now we are trying to fetch it from other replica and unlocking.
-            if (error == Coordination::Error::ZNODEEXISTS)
-            {
-                size_t failed_op = zkutil::getFailedOpIndex(error, responses);
-                if (ops[failed_op]->getPath() == zookeeper_node)
-                {
-                    LOG_WARNING(
-                        getLogger("ZeroCopyLocks"),
-                        "Replacing persistent lock with ephemeral for path {}. It can happen only in case of local part loss",
-                        zookeeper_node);
-                    replace_existing_lock = true;
-                    continue;
-                }
-            }
-        }
-
-        zkutil::KeeperMultiException::check(error, ops, responses);
-    }
-
-    if (!created)
-    {
-        String mode_str = mode == zkutil::CreateMode::Persistent ? "persistent" : "ephemeral";
-        throw Exception(ErrorCodes::NOT_FOUND_NODE,
-                        "Cannot create {} zero copy lock {} because part was unlocked from zookeeper",
-                        mode_str, zookeeper_node);
-    }
-}
 
 bool StorageReplicatedMergeTree::removeDetachedPart(DiskPtr disk, const String & path, const String & part_name)
 {
-    auto settings_ptr = getSettings();
-    if (disk->supportZeroCopyReplication() && (*settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
-    {
-        String table_id = getTableSharedID();
-        return removeSharedDetachedPart(disk, path, part_name, table_id, replica_name, zookeeper_path, getContext(), current_zookeeper);
-    }
-
     disk->removeRecursive(path);
-
     return false;
-}
-
-
-bool StorageReplicatedMergeTree::removeSharedDetachedPart(DiskPtr disk, const String & path, const String & part_name, const String & table_uuid,
-    const String & detached_replica_name, const String & detached_zookeeper_path, const ContextPtr & local_context, const zkutil::ZooKeeperPtr & zookeeper)
-{
-    bool keep_shared = false;
-
-    NameSet files_not_to_remove;
-
-    // zero copy replication is only available since format version 1 so we can safely use it here
-    auto part_info = DetachedPartInfo::parseDetachedPartName(disk, part_name, MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING);
-    if (!part_info.valid_name)
-        throw Exception(ErrorCodes::BAD_DATA_PART_NAME, "Invalid detached part name {} on disk {}", path, disk->getName());
-
-    fs::path checksums = fs::path(path) / IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK;
-    if (disk->existsFile(checksums))
-    {
-        if (disk->getRefCount(checksums) == 0)
-        {
-            String id = disk->getUniqueId(checksums);
-            bool can_remove = false;
-            std::tie(can_remove, files_not_to_remove) = StorageReplicatedMergeTree::unlockSharedDataByID(
-                id, table_uuid, part_info,
-                detached_replica_name,
-                disk->getDataSourceDescription().toString(),
-                std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), local_context->getReplicatedMergeTreeSettings(),
-                getLogger("StorageReplicatedMergeTree"),
-                detached_zookeeper_path,
-                MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING);
-
-            keep_shared = !can_remove;
-        }
-        else
-            keep_shared = true;
-    }
-
-    disk->removeSharedRecursive(path, keep_shared, files_not_to_remove);
-
-    return keep_shared;
-}
-
-
-void StorageReplicatedMergeTree::createAndStoreFreezeMetadata(DiskPtr disk, DataPartPtr, String backup_part_path) const
-{
-    if (disk->supportZeroCopyReplication())
-    {
-        FreezeMetaData meta;
-        meta.fill(*this);
-        meta.save(disk, backup_part_path);
-    }
 }
 
 
@@ -10982,6 +10055,11 @@ void StorageReplicatedMergeTree::attachRestoredParts(MutableDataPartsVector && p
 
     for (auto part : parts)
         sink->writeExistingPart(part);
+}
+
+MutateFromLogEntryTask StorageReplicatedMergeTree::createMutateFromLogEntryTask(const ReplicatedMergeTreeQueue::SelectedEntryPtr & entry)
+{
+    return std::make_shared<MutateFromLogEntryTask>(entry, *this, common_assignee_trigger);    
 }
 
 template std::optional<EphemeralLockInZooKeeper> StorageReplicatedMergeTree::allocateBlockNumber<String>(

--- a/src/Storages/StorageZeroCopyReplicatedMergeTree.cpp
+++ b/src/Storages/StorageZeroCopyReplicatedMergeTree.cpp
@@ -1,0 +1,1182 @@
+#include <Storages/StorageZeroCopyReplicatedMergeTree.h>
+
+namespace DB
+{
+
+MergeTreeData::MutableDataPartPtr StorageZeroCopyReplicatedMergeTree::executeFetchShared(
+const String & source_replica,
+const String & new_part_name,
+const DiskPtr & disk,
+const String & path)
+{
+    if (source_replica.empty())
+    {
+        LOG_INFO(log, "No active replica has part {} on shared storage.", new_part_name);
+        return nullptr;
+    }
+
+    const auto storage_settings_ptr = getSettings();
+    auto metadata_snapshot = getInMemoryMetadataPtr();
+
+    try
+    {
+        return fetchExistsPart(new_part_name, metadata_snapshot, fs::path(zookeeper_path) / "replicas" / source_replica, disk, path);
+    }
+    catch (Exception & e)
+    {
+        if (e.code() == ErrorCodes::RECEIVED_ERROR_TOO_MANY_REQUESTS)
+            e.addMessage("Too busy replica. Will try later.");
+        tryLogCurrentException(log, __PRETTY_FUNCTION__);
+        throw;
+    }
+}
+
+void StorageZeroCopyReplicatedMergeTree::lockSharedData(
+    const IMergeTreeDataPart & part,
+    bool replace_existing_lock,
+    std::optional<HardlinkedFiles> hardlinked_files) const
+{
+    LOG_DEBUG(log, "Trying to create zero-copy lock for part {}", part.name);
+    auto zookeeper = tryGetZooKeeper();
+    if (zookeeper)
+        lockSharedData(part, std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), replace_existing_lock, hardlinked_files);
+}
+
+void StorageZeroCopyReplicatedMergeTree::getLockSharedDataOps(
+    const IMergeTreeDataPart & part,
+    const ZooKeeperWithFaultInjectionPtr & zookeeper,
+    bool replace_existing_lock,
+    std::optional<HardlinkedFiles> hardlinked_files,
+    Coordination::Requests & requests) const
+{
+    auto settings = getSettings();
+
+    if (!part.isStoredOnDisk() || !(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+        return;
+
+    if (!part.getDataPartStorage().supportZeroCopyReplication())
+        return;
+
+    if (zookeeper->isNull())
+        return;
+
+    String id = part.getUniqueId();
+    boost::replace_all(id, "/", "_");
+
+    Strings zc_zookeeper_paths = getZeroCopyPartPath(
+        *getSettings(), part.getDataPartStorage().getDiskType(), getTableSharedID(),
+        part.name, zookeeper_path);
+
+    String path_to_set_hardlinked_files;
+    NameSet hardlinks;
+
+    if (hardlinked_files.has_value() && !hardlinked_files->hardlinks_from_source_part.empty())
+    {
+        path_to_set_hardlinked_files = getZeroCopyPartPath(
+            *getSettings(), part.getDataPartStorage().getDiskType(), hardlinked_files->source_table_shared_id,
+            hardlinked_files->source_part_name, zookeeper_path)[0];
+
+        hardlinks = hardlinked_files->hardlinks_from_source_part;
+    }
+
+    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
+    {
+        String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
+
+        if (!path_to_set_hardlinked_files.empty() && !hardlinks.empty())
+        {
+            LOG_DEBUG(log, "Locking shared node {} with hardlinks from the other shared node {}, "
+                           "hardlinks: [{}]",
+                      zookeeper_node, path_to_set_hardlinked_files,
+                      boost::algorithm::join(hardlinks, ","));
+        }
+
+        getZeroCopyLockNodeCreateOps(
+            zookeeper, zookeeper_node, requests, zkutil::CreateMode::Persistent,
+            replace_existing_lock, path_to_set_hardlinked_files, hardlinks);
+    }
+}
+
+
+void StorageZeroCopyReplicatedMergeTree::lockSharedData(
+    const IMergeTreeDataPart & part,
+    const ZooKeeperWithFaultInjectionPtr & zookeeper,
+    bool replace_existing_lock,
+    std::optional<HardlinkedFiles> hardlinked_files) const
+{
+    auto settings = getSettings();
+
+    if (!part.isStoredOnDisk() || !(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+        return;
+
+    if (!part.getDataPartStorage().supportZeroCopyReplication())
+        return;
+
+    if (zookeeper->isNull())
+        return;
+
+    String id = part.getUniqueId();
+    boost::replace_all(id, "/", "_");
+
+    Strings zc_zookeeper_paths = getZeroCopyPartPath(
+        *getSettings(), part.getDataPartStorage().getDiskType(), getTableSharedID(),
+        part.name, zookeeper_path);
+
+    String path_to_set_hardlinked_files;
+    NameSet hardlinks;
+
+    if (hardlinked_files.has_value() && !hardlinked_files->hardlinks_from_source_part.empty())
+    {
+        path_to_set_hardlinked_files = getZeroCopyPartPath(
+            *getSettings(), part.getDataPartStorage().getDiskType(), hardlinked_files->source_table_shared_id,
+            hardlinked_files->source_part_name, zookeeper_path)[0];
+
+        hardlinks = hardlinked_files->hardlinks_from_source_part;
+    }
+
+    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
+    {
+        String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
+
+        LOG_TRACE(log, "Trying to create zookeeper persistent lock {} with hardlinks [{}]", zookeeper_node, fmt::join(hardlinks, ", "));
+
+        createZeroCopyLockNode(
+            zookeeper, zookeeper_node, zkutil::CreateMode::Persistent,
+            replace_existing_lock, path_to_set_hardlinked_files, hardlinks);
+
+        LOG_TRACE(log, "Zookeeper persistent lock {} created", zookeeper_node);
+    }
+}
+
+std::pair<bool, NameSet>
+StorageZeroCopyReplicatedMergeTree::unlockSharedData(const IMergeTreeDataPart & part) const
+{
+    return unlockSharedData(part, std::make_shared<ZooKeeperWithFaultInjection>(nullptr));
+}
+
+std::pair<bool, NameSet>
+StorageZeroCopyReplicatedMergeTree::unlockSharedData(const IMergeTreeDataPart & part, const ZooKeeperWithFaultInjectionPtr & zookeeper) const
+{
+    auto settings = getSettings();
+    if (!(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+        return std::make_pair(true, NameSet{});
+
+    if (!part.isStoredOnDisk())
+    {
+        LOG_TRACE(log, "Part {} is not stored on disk, blobs can be removed", part.name);
+        return std::make_pair(true, NameSet{});
+    }
+
+    if (!part.getDataPartStorage().supportZeroCopyReplication())
+    {
+        LOG_TRACE(log, "Part {} is not stored on zero-copy replicated disk, blobs can be removed", part.name);
+        return std::make_pair(true, NameSet{});
+    }
+
+    auto shared_id = getTableSharedID();
+    if (shared_id == toString(UUIDHelpers::Nil))
+    {
+        if (zookeeper->exists(zookeeper_path))
+        {
+            LOG_WARNING(log, "Not removing shared data for part {} because replica does not have metadata in ZooKeeper, "
+                             "but table path exist and other replicas may exist. It may leave some garbage on S3", part.name);
+            return std::make_pair(false, NameSet{});
+        }
+        LOG_TRACE(log, "Part {} blobs can be removed, because table {} completely dropped", part.name, getStorageID().getNameForLogs());
+        return std::make_pair(true, NameSet{});
+    }
+
+    /// If part is temporary refcount file may be absent
+    if (part.getDataPartStorage().existsFile(IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK))
+    {
+        auto ref_count = part.getDataPartStorage().getRefCount(IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK);
+        if (ref_count > 0) /// Keep part shard info for frozen backups
+        {
+            LOG_TRACE(log, "Part {} has more than zero local references ({}), blobs cannot be removed", part.name, ref_count);
+            return std::make_pair(false, NameSet{});
+        }
+
+        LOG_TRACE(log, "Part {} local references is zero, will check blobs can be removed in zookeeper", part.name);
+    }
+    else
+    {
+        LOG_TRACE(log, "Part {} looks temporary, because {} file doesn't exists, blobs can be removed", part.name, IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK);
+        /// Temporary part with some absent file cannot be locked in shared mode
+        return std::make_pair(true, NameSet{});
+    }
+
+    if (part.getState() == MergeTreeDataPartState::Temporary && part.is_temp)
+    {
+        /// Part {} is in temporary state and has it_temp flag. it means that it is under construction.
+        /// That path hasn't been added to active set, no commit procedure has begun.
+        /// The metadata files is about to delete now. Clichouse has to make a decision remove or preserve blobs on remote FS.
+        /// In general remote data might be shared and has to be unlocked in the keeper before removing.
+        /// However there are some cases when decision is clear without asking keeper:
+        /// When the part has been fetched then remote data has to be preserved, part doesn't own it.
+        /// When the part has been merged then remote data can be removed, part owns it.
+        /// In opposition, when the part has been mutated in generally it hardlinks the files from source part.
+        /// Therefore remote data could be shared, it has to be unlocked in the keeper.
+        /// In order to track all that cases remove_tmp_policy is used.
+        /// Clickhouse set that field as REMOVE_BLOBS or PRESERVE_BLOBS when it sure about the decision without asking keeper.
+
+        if (part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS
+            || part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::PRESERVE_BLOBS)
+        {
+            bool can_remove_blobs = part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS;
+            LOG_INFO(log, "Looks like CH knows the origin of that part. "
+                          "Part {} can be deleted without unlocking shared data in zookeeper. "
+                          "Part blobs {}.",
+                     part.name,
+                     can_remove_blobs ? "will be removed" : "have to be preserved");
+            return std::make_pair(can_remove_blobs, NameSet{});
+        }
+    }
+
+    if (part.rows_count == 0 && part.remove_tmp_policy == IMergeTreeDataPart::BlobsRemovalPolicyForTemporaryParts::REMOVE_BLOBS_OF_NOT_TEMPORARY)
+    {
+        /// It's a non-replicated empty part that was created to avoid unexpected parts after DROP_RANGE
+        LOG_INFO(log, "Looks like {} is a non-replicated empty part that was created to avoid unexpected parts after DROP_RANGE, "
+                      "blobs can be removed", part.name);
+        return std::make_pair(true, NameSet{});
+    }
+
+    if (has_metadata_in_zookeeper.has_value() && !has_metadata_in_zookeeper)
+    {
+        if (zookeeper->exists(zookeeper_path))
+        {
+            LOG_WARNING(log, "Not removing shared data for part {} because replica does not have metadata in ZooKeeper, "
+                             "but table path exist and other replicas may exist. It may leave some garbage on S3", part.name);
+            return std::make_pair(false, NameSet{});
+        }
+
+        /// If table was completely dropped (no meta in zookeeper) we can safely remove parts
+        return std::make_pair(true, NameSet{});
+    }
+
+    /// We remove parts during table shutdown. If exception happen, restarting thread will be already turned
+    /// off and nobody will reconnect our zookeeper connection. In this case we use zookeeper connection from
+    /// context.
+    if (shutdown_called.load())
+        zookeeper->setKeeper(getZooKeeperIfTableShutDown());
+    else
+        zookeeper->setKeeper(getZooKeeper());
+
+    /// It can happen that we didn't had the connection to zookeeper during table creation, but actually
+    /// table is completely dropped, so we can drop it without any additional checks.
+    if (!has_metadata_in_zookeeper.has_value() && !zookeeper->exists(zookeeper_path))
+        return std::make_pair(true, NameSet{});
+
+    return unlockSharedDataByID(
+        part.getUniqueId(), shared_id, part.info, replica_name,
+        part.getDataPartStorage().getDiskType(), zookeeper, *getSettings(), log.load(), zookeeper_path, format_version);
+}
+
+namespace
+{
+
+/// What is going on here?
+/// Actually we need this code because of flaws in hardlinks tracking. When we create child part during mutation we can hardlink some files from parent part, like
+/// all_0_0_0:
+///                     a.bin a.mrk2 columns.txt ...
+/// all_0_0_0_1:          ^     ^
+///                     a.bin a.mrk2 columns.txt
+/// So when we deleting all_0_0_0 it doesn't remove blobs for a.bin and a.mrk2 because all_0_0_0_1 use them.
+/// But sometimes we need an opposite. When we deleting all_0_0_0_1 it can be non replicated to other replicas, so we are the only owner of this part.
+/// In this case when we will drop all_0_0_0_1 we will drop blobs for all_0_0_0. But it will lead to dataloss. For such case we need to check that other replicas
+/// still need parent part.
+std::pair<bool, NameSet> getParentLockedBlobs(const ZooKeeperWithFaultInjectionPtr & zookeeper_ptr, const std::string & zero_copy_part_path_prefix, const MergeTreePartInfo & part_info, MergeTreeDataFormatVersion format_version, LoggerPtr log)
+{
+    NameSet files_not_to_remove;
+
+    /// No mutations -- no hardlinks -- no issues
+    if (part_info.mutation == 0)
+        return {false, files_not_to_remove};
+
+    /// Getting all zero copy parts
+    Strings parts_str;
+    zookeeper_ptr->tryGetChildren(zero_copy_part_path_prefix, parts_str);
+
+    /// Parsing infos. It's hard to convert info -> string for old-format merge tree
+    /// so storing string as is.
+    std::vector<std::pair<MergeTreePartInfo, std::string>> parts_infos;
+    for (const auto & part_str : parts_str)
+    {
+        MergeTreePartInfo parent_candidate_info = MergeTreePartInfo::fromPartName(part_str, format_version);
+        parts_infos.emplace_back(parent_candidate_info, part_str);
+    }
+
+    /// Sort is important. We need to find our closest parent, like:
+    /// for part all_0_0_0_64 we can have parents
+    /// all_0_0_0_6 < we need the closest parent, not others
+    /// all_0_0_0_1
+    /// all_0_0_0
+    std::sort(parts_infos.begin(), parts_infos.end());
+    std::string part_info_str = part_info.getPartNameV1();
+
+    /// In reverse order to process from bigger to smaller
+    for (const auto & [parent_candidate_info, part_candidate_info_str] : parts_infos | std::views::reverse)
+    {
+        if (parent_candidate_info == part_info)
+            continue;
+
+        /// We are mutation child of this parent
+        if (part_info.isMutationChildOf(parent_candidate_info))
+        {
+            LOG_TRACE(log, "Found mutation parent {} for part {}", part_candidate_info_str, part_info_str);
+            /// Get hardlinked files
+            String files_not_to_remove_str;
+            Coordination::Error code;
+            zookeeper_ptr->tryGet(fs::path(zero_copy_part_path_prefix) / part_candidate_info_str, files_not_to_remove_str, nullptr, nullptr, &code);
+            if (code != Coordination::Error::ZOK)
+            {
+                LOG_INFO(log, "Cannot get parent files from ZooKeeper on path ({}), error {}, assuming the parent was removed concurrently",
+                            (fs::path(zero_copy_part_path_prefix) / part_candidate_info_str).string(), code);
+                continue;
+            }
+
+            if (!files_not_to_remove_str.empty())
+            {
+                boost::split(files_not_to_remove, files_not_to_remove_str, boost::is_any_of("\n "));
+                LOG_TRACE(log, "Found files not to remove from parent part {}: [{}]", part_candidate_info_str, fmt::join(files_not_to_remove, ", "));
+            }
+            else
+            {
+                std::vector<std::string> children;
+                code = zookeeper_ptr->tryGetChildren(fs::path(zero_copy_part_path_prefix) / part_candidate_info_str, children);
+                if (code != Coordination::Error::ZOK)
+                {
+                    LOG_INFO(log, "Cannot get parent locks in ZooKeeper on path ({}), error {}, assuming the parent was removed concurrently",
+                              (fs::path(zero_copy_part_path_prefix) / part_candidate_info_str).string(), errorMessage(code));
+                    continue;
+                }
+
+                if (children.size() > 1 || (children.size() == 1 && children[0] != ZeroCopyLock::ZERO_COPY_LOCK_NAME))
+                {
+                    LOG_TRACE(log, "No files not to remove found for part {} from parent {}", part_info_str, part_candidate_info_str);
+                }
+                else
+                {
+                    /// The case when part is actually removed, but some stale replica trying to execute merge/mutation.
+                    /// We shouldn't use the part to check hardlinked blobs, it just doesn't exist.
+                    LOG_TRACE(log, "Part {} is not parent (only merge/mutation locks exist), refusing to use as parent", part_candidate_info_str);
+                    continue;
+                }
+            }
+
+            return {true, files_not_to_remove};
+        }
+    }
+    LOG_TRACE(log, "No mutation parent found for part {}", part_info_str);
+    return {false, files_not_to_remove};
+}
+
+}
+
+std::pair<bool, NameSet> StorageZeroCopyReplicatedMergeTree::unlockSharedDataByID(
+        String part_id, const String & table_uuid, const MergeTreePartInfo & part_info,
+        const String & replica_name_, const std::string & disk_type, const ZooKeeperWithFaultInjectionPtr & zookeeper_ptr, const MergeTreeSettings & settings,
+        LoggerPtr logger, const String & zookeeper_path_old, MergeTreeDataFormatVersion data_format_version)
+{
+    boost::replace_all(part_id, "/", "_");
+
+    auto part_name = part_info.getPartNameV1();
+
+    Strings zc_zookeeper_paths = getZeroCopyPartPath(settings, disk_type, table_uuid, part_name, zookeeper_path_old);
+
+    bool part_has_no_more_locks = true;
+    NameSet files_not_to_remove;
+
+    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
+    {
+        String files_not_to_remove_str;
+        zookeeper_ptr->tryGet(zc_zookeeper_path, files_not_to_remove_str);
+
+        files_not_to_remove.clear();
+        if (!files_not_to_remove_str.empty())
+            boost::split(files_not_to_remove, files_not_to_remove_str, boost::is_any_of("\n "));
+
+        String zookeeper_part_uniq_node = fs::path(zc_zookeeper_path) / part_id;
+
+        /// Delete our replica node for part from zookeeper (we are not interested in it anymore)
+        String zookeeper_part_replica_node = fs::path(zookeeper_part_uniq_node) / replica_name_;
+
+        auto [has_parent, parent_not_to_remove] = getParentLockedBlobs(
+            zookeeper_ptr, fs::path(zc_zookeeper_path).parent_path(), part_info, data_format_version, logger);
+
+        files_not_to_remove.insert(parent_not_to_remove.begin(), parent_not_to_remove.end());
+
+        LOG_TRACE(logger, "Removing zookeeper lock {} for part {} (files to keep: [{}])", zookeeper_part_replica_node, part_name, fmt::join(files_not_to_remove, ", "));
+
+        fiu_do_on(FailPoints::zero_copy_unlock_zk_fail_before_op, { zookeeper_ptr->forceFailureBeforeOperation(); });
+        fiu_do_on(FailPoints::zero_copy_unlock_zk_fail_after_op, { zookeeper_ptr->forceFailureAfterOperation(); });
+
+        if (auto ec = zookeeper_ptr->tryRemove(zookeeper_part_replica_node); ec != Coordination::Error::ZOK)
+        {
+            /// Very complex case. It means that lock already doesn't exist when we tried to remove it.
+            /// So we don't know are we owner of this part or not. Maybe we just mutated it, renamed on disk and failed to lock in ZK.
+            /// But during mutation we can have hardlinks to another part. So it's not Ok to remove blobs of this part if it was mutated.
+            if (ec == Coordination::Error::ZNONODE)
+            {
+                if (has_parent)
+                {
+                    LOG_INFO(logger, "Lock on path {} for part {} doesn't exist, refuse to remove blobs", zookeeper_part_replica_node, part_name);
+                    return {false, {}};
+                }
+
+                LOG_INFO(
+                    logger,
+                    "Lock on path {} for part {} doesn't exist, but we don't have mutation parent, can remove blobs",
+                    zookeeper_part_replica_node,
+                    part_name);
+            }
+            else
+            {
+                throw zkutil::KeeperException::fromPath(ec, zookeeper_part_replica_node);
+            }
+        }
+
+        /// Check, maybe we were the last replica and can remove part forever
+        Strings children;
+        zookeeper_ptr->tryGetChildren(zookeeper_part_uniq_node, children);
+
+        if (!children.empty())
+        {
+            LOG_TRACE(logger, "Found {} ({}) zookeeper locks for {}", children.size(), fmt::join(children, ", "), zookeeper_part_uniq_node);
+            part_has_no_more_locks = false;
+            continue;
+        }
+
+        LOG_TRACE(logger, "No more children left for {}, will try to remove the whole node", zookeeper_part_uniq_node);
+
+
+        auto error_code = zookeeper_ptr->tryRemove(zookeeper_part_uniq_node);
+
+        if (error_code == Coordination::Error::ZOK)
+        {
+            LOG_TRACE(logger, "Removed last parent zookeeper lock {} for part {} with id {}", zookeeper_part_uniq_node, part_name, part_id);
+        }
+        else if (error_code == Coordination::Error::ZNOTEMPTY)
+        {
+            LOG_TRACE(
+                logger,
+                "Cannot remove last parent zookeeper lock {} for part {} with id {}, another replica locked part concurrently",
+                zookeeper_part_uniq_node,
+                part_name,
+                part_id);
+            part_has_no_more_locks = false;
+            continue;
+        }
+        else if (error_code == Coordination::Error::ZNONODE)
+        {
+            LOG_TRACE(logger, "Node with parent zookeeper lock {} for part {} with id {} doesn't exist", zookeeper_part_uniq_node, part_name, part_id);
+        }
+        else
+        {
+            throw zkutil::KeeperException::fromPath(error_code, zookeeper_part_uniq_node);
+        }
+
+
+        /// Even when we have lock with same part name, but with different uniq, we can remove files on S3
+        children.clear();
+        String zookeeper_part_node = fs::path(zookeeper_part_uniq_node).parent_path();
+        zookeeper_ptr->tryGetChildren(zookeeper_part_node, children);
+
+        if (children.empty())
+        {
+            /// Cleanup after last uniq removing
+            error_code = zookeeper_ptr->tryRemove(zookeeper_part_node);
+
+            if (error_code == Coordination::Error::ZOK)
+            {
+                LOG_TRACE(logger, "Removed last parent zookeeper lock {} for part {} (part is finally unlocked)", zookeeper_part_node, part_name);
+            }
+            else if (error_code == Coordination::Error::ZNOTEMPTY)
+            {
+                LOG_TRACE(logger, "Cannot remove last parent zookeeper lock {} for part {}, another replica locked part concurrently", zookeeper_part_uniq_node, part_name);
+            }
+            else if (error_code == Coordination::Error::ZNONODE)
+            {
+                /// We don't know what to do, because this part can be mutation part
+                /// with hardlinked columns. Since we don't have this information (about blobs not to remove)
+                /// we refuse to remove blobs.
+                LOG_WARNING(logger, "Node with parent zookeeper lock {} for part {} doesn't exist (part was unlocked before), refuse to remove blobs", zookeeper_part_uniq_node, part_name);
+                return {false, {}};
+            }
+            else
+            {
+                throw zkutil::KeeperException::fromPath(error_code, zookeeper_part_uniq_node);
+            }
+        }
+        else
+        {
+            /// It's possible that we have two instances of the same part with different blob names of
+            /// FILE_FOR_REFERENCES_CHECK aka checksums.txt aka part_unique_id,
+            /// and other files in both parts are hardlinks (the same blobs are shared between part instances).
+            /// It's possible after unsuccessful attempts to commit a mutated part to zk.
+            /// It's not a problem if we have found the mutation parent (so we have files_not_to_remove).
+            /// But in rare cases mutations parents could have been already removed (so we don't have the list of hardlinks).
+
+            /// I'm not 100% sure that parent_not_to_remove list cannot be incomplete (when we've found a parent)
+            if (part_info.mutation && !has_parent)
+                part_has_no_more_locks = false;
+
+            LOG_TRACE(logger, "Can't remove parent zookeeper lock {} for part {}, because children {} ({}) exists (can remove blobs: {})",
+                zookeeper_part_node, part_name, children.size(), fmt::join(children, ", "), part_has_no_more_locks);
+        }
+    }
+
+    return std::make_pair(part_has_no_more_locks, files_not_to_remove);
+}
+
+
+MergeTreeData::MutableDataPartPtr StorageZeroCopyReplicatedMergeTree::tryToFetchIfShared(
+    const IMergeTreeDataPart & part,
+    const DiskPtr & disk,
+    const String & path)
+{
+    const auto settings = getSettings();
+    auto data_source_description = disk->getDataSourceDescription();
+    if (!(disk->supportZeroCopyReplication() && (*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication]))
+        return nullptr;
+
+    String replica = getSharedDataReplica(part, data_source_description);
+
+    /// We can't fetch part when none replicas have this part on a same type remote disk
+    if (replica.empty())
+        return nullptr;
+
+    return executeFetchShared(replica, part.name, disk, path);
+}
+
+String StorageZeroCopyReplicatedMergeTree::getSharedDataReplica(
+    const IMergeTreeDataPart & part, const DataSourceDescription & data_source_description) const
+{
+    String best_replica;
+
+    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
+    if (!zookeeper)
+        return "";
+
+    Strings zc_zookeeper_paths = getZeroCopyPartPath(*getSettings(), data_source_description.toString(), getTableSharedID(), part.name,
+            zookeeper_path);
+
+    std::set<String> replicas;
+
+    for (const auto & zc_zookeeper_path : zc_zookeeper_paths)
+    {
+        Strings ids;
+        zookeeper->tryGetChildren(zc_zookeeper_path, ids);
+
+        for (const auto & id : ids)
+        {
+            String zookeeper_part_uniq_node = fs::path(zc_zookeeper_path) / id;
+            Strings id_replicas;
+            zookeeper->tryGetChildren(zookeeper_part_uniq_node, id_replicas);
+            LOG_TRACE(log, "Found zookeeper replicas for {}: {}", zookeeper_part_uniq_node, id_replicas.size());
+            replicas.insert(id_replicas.begin(), id_replicas.end());
+        }
+    }
+
+    LOG_TRACE(log, "Found zookeeper replicas for part {}: {}", part.name, replicas.size());
+
+    Strings active_replicas;
+
+    /// TODO: Move best replica choose in common method (here is the same code as in StorageReplicatedMergeTree::fetchPartition)
+
+    /// Leave only active replicas.
+    active_replicas.reserve(replicas.size());
+
+    for (const String & replica : replicas)
+        if ((replica != replica_name) && (zookeeper->exists(fs::path(zookeeper_path) / "replicas" / replica / "is_active")))
+            active_replicas.push_back(replica);
+
+    LOG_TRACE(log, "Found zookeeper active replicas for part {}: {}", part.name, active_replicas.size());
+
+    if (active_replicas.empty())
+        return "";
+
+    /** You must select the best (most relevant) replica.
+    * This is a replica with the maximum `log_pointer`, then with the minimum `queue` size.
+    * NOTE This is not exactly the best criteria. It does not make sense to download old partitions,
+    *  and it would be nice to be able to choose the replica closest by network.
+    * NOTE Of course, there are data races here. You can solve it by retrying.
+    */
+    Int64 max_log_pointer = -1;
+    UInt64 min_queue_size = std::numeric_limits<UInt64>::max();
+
+    for (const String & replica : active_replicas)
+    {
+        String current_replica_path = fs::path(zookeeper_path) / "replicas" / replica;
+
+        String log_pointer_str = zookeeper->get(fs::path(current_replica_path) / "log_pointer");
+        Int64 log_pointer = log_pointer_str.empty() ? 0 : parse<UInt64>(log_pointer_str);
+
+        Coordination::Stat stat;
+        zookeeper->get(fs::path(current_replica_path) / "queue", &stat);
+        size_t queue_size = stat.numChildren;
+
+        if (log_pointer > max_log_pointer
+            || (log_pointer == max_log_pointer && queue_size < min_queue_size))
+        {
+            max_log_pointer = log_pointer;
+            min_queue_size = queue_size;
+            best_replica = replica;
+        }
+    }
+
+    return best_replica;
+}
+
+Strings StorageZeroCopyReplicatedMergeTree::getZeroCopyPartPath(
+    const MergeTreeSettings & settings, const std::string & disk_type, const String & table_uuid,
+    const String & part_name, const String & zookeeper_path_old)
+{
+    Strings res;
+
+    String zero_copy = fmt::format("zero_copy_{}", disk_type);
+
+    String new_path = fs::path(settings[MergeTreeSetting::remote_fs_zero_copy_zookeeper_path].toString()) / zero_copy / table_uuid / part_name;
+    res.push_back(std::move(new_path));
+    if (settings[MergeTreeSetting::remote_fs_zero_copy_path_compatible_mode] && !zookeeper_path_old.empty())
+    { /// Compatibility mode for cluster with old and new versions
+        String old_path = fs::path(zookeeper_path_old) / zero_copy / "shared" / part_name;
+        res.push_back(std::move(old_path));
+    }
+
+    return res;
+}
+
+void StorageZeroCopyReplicatedMergeTree::watchZeroCopyLock(const String & part_name, const DiskPtr & disk)
+{
+    auto path = getZeroCopyPartPath(part_name, disk);
+    if (path)
+    {
+        auto zookeeper = getZooKeeper();
+        auto lock_path = fs::path(*path) / "part_exclusive_lock";
+        LOG_TEST(log, "Adding zero-copy lock on {}", lock_path);
+        /// Looks ugly, but we cannot touch any storage fields inside Watch callback
+        /// because it could lead to use-after-free (storage dropped and watch triggered)
+        std::shared_ptr<std::atomic<bool>> flag = std::make_shared<std::atomic<bool>>(true);
+        std::string replica;
+        bool exists = zookeeper->tryGetWatch(lock_path, replica, nullptr, [flag] (const Coordination::WatchResponse &)
+        {
+            *flag = false;
+        });
+
+        if (exists)
+        {
+            std::lock_guard lock(existing_zero_copy_locks_mutex);
+            existing_zero_copy_locks[lock_path] = ZeroCopyLockDescription{replica, flag};
+        }
+    }
+}
+
+bool StorageZeroCopyReplicatedMergeTree::checkZeroCopyLockExists(const String & part_name, const DiskPtr & disk, String & lock_replica)
+{
+    auto path = getZeroCopyPartPath(part_name, disk);
+
+    std::lock_guard lock(existing_zero_copy_locks_mutex);
+    /// Cleanup abandoned locks during each check. The set of locks is small and this is quite fast loop.
+    /// Also it's hard to properly remove locks because we can execute replication queue
+    /// in arbitrary order and some parts can be replaced by covering parts without merges.
+    for (auto it = existing_zero_copy_locks.begin(); it != existing_zero_copy_locks.end();)
+    {
+        if (*it->second.exists)
+            ++it;
+        else
+        {
+            LOG_TEST(log, "Removing zero-copy lock on {}", it->first);
+            it = existing_zero_copy_locks.erase(it);
+        }
+    }
+
+    if (path)
+    {
+        auto lock_path = fs::path(*path) / "part_exclusive_lock";
+        if (auto it = existing_zero_copy_locks.find(lock_path); it != existing_zero_copy_locks.end())
+        {
+            lock_replica = it->second.replica;
+            if (*it->second.exists)
+            {
+                LOG_TEST(log, "Zero-copy lock on path {} exists", it->first);
+                return true;
+            }
+        }
+
+        LOG_TEST(log, "Zero-copy lock on path {} doesn't exist", lock_path);
+    }
+
+    return false;
+}
+
+std::optional<String> StorageZeroCopyReplicatedMergeTree::getZeroCopyPartPath(const String & part_name, const DiskPtr & disk)
+{
+    if (!disk || !disk->supportZeroCopyReplication())
+        return std::nullopt;
+
+    return getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().toString(), getTableSharedID(), part_name, zookeeper_path)[0];
+}
+
+bool StorageZeroCopyReplicatedMergeTree::waitZeroCopyLockToDisappear(const ZeroCopyLock & lock, size_t milliseconds_to_wait)
+{
+    if (lock.isLocked())
+        return true;
+
+    if (partial_shutdown_called.load(std::memory_order_relaxed))
+        return true;
+
+    auto lock_path = lock.lock->getLockPath();
+    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
+    if (!zookeeper)
+        return true;
+
+    Stopwatch time_waiting;
+    const auto & stop_waiting = [&]()
+    {
+        bool timeout_exceeded = milliseconds_to_wait < time_waiting.elapsedMilliseconds();
+        return partial_shutdown_called.load(std::memory_order_relaxed) || is_readonly.load(std::memory_order_relaxed) || timeout_exceeded;
+    };
+
+    return zookeeper->waitForDisappear(lock_path, stop_waiting);
+}
+
+std::optional<ZeroCopyLock> StorageZeroCopyReplicatedMergeTree::tryCreateZeroCopyExclusiveLock(const String & part_name, const DiskPtr & disk)
+{
+    if (!disk || !disk->supportZeroCopyReplication())
+        return std::nullopt;
+
+    if (partial_shutdown_called.load(std::memory_order_relaxed) || is_readonly.load(std::memory_order_relaxed))
+        return std::nullopt;
+
+    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
+    if (!zookeeper)
+        return std::nullopt;
+
+    String zc_zookeeper_path = *getZeroCopyPartPath(part_name, disk);
+
+    /// Just recursively create ancestors for lock
+    zookeeper->createAncestors(zc_zookeeper_path + "/");
+
+    /// Create actual lock
+    ZeroCopyLock lock(zookeeper, zc_zookeeper_path, replica_name);
+    lock.lock->tryLock();
+    return lock;
+}
+
+std::vector<String> StorageZeroCopyReplicatedMergeTree::getZookeeperZeroCopyLockPaths() const
+{
+    const auto settings = getSettings();
+    if (!(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+    {
+        return {};
+    }
+
+    const auto & disks = getStoragePolicy()->getDisks();
+    std::set<String> disk_types_with_zero_copy;
+    for (const auto & disk : disks)
+    {
+        if (!disk->supportZeroCopyReplication())
+            continue;
+
+        disk_types_with_zero_copy.insert(disk->getDataSourceDescription().toString());
+    }
+
+    const auto actual_table_shared_id = getTableSharedID();
+
+    std::vector<String> result;
+    result.reserve(disk_types_with_zero_copy.size());
+
+    for (const auto & disk_type: disk_types_with_zero_copy)
+    {
+        auto zero_copy = fmt::format("zero_copy_{}", disk_type);
+        auto zero_copy_path = fs::path((*settings)[MergeTreeSetting::remote_fs_zero_copy_zookeeper_path].toString()) / zero_copy;
+
+        result.push_back(zero_copy_path / actual_table_shared_id);
+    }
+
+    return result;
+}
+
+void StorageZeroCopyReplicatedMergeTree::dropZookeeperZeroCopyLockPaths(zkutil::ZooKeeperPtr zookeeper, std::vector<String> zero_copy_locks_paths,
+                                                                LoggerPtr logger)
+{
+    for (const auto & zero_copy_locks_root : zero_copy_locks_paths)
+    {
+        auto code = zookeeper->tryRemove(zero_copy_locks_root);
+        if (code == Coordination::Error::ZNOTEMPTY)
+        {
+            LOG_WARNING(logger, "Zero copy locks are not empty for {}. There are some lost locks inside."
+                              "Removing them all.", zero_copy_locks_root);
+            zookeeper->tryRemoveRecursive(zero_copy_locks_root);
+        }
+        else if (code == Coordination::Error::ZNONODE)
+        {
+            LOG_INFO(logger, "Zero copy locks directory {} is absent on ZooKeeper.", zero_copy_locks_root);
+        }
+        else
+        {
+            chassert(code == Coordination::Error::ZOK);
+        }
+    }
+}
+
+
+void StorageZeroCopyReplicatedMergeTree::createZeroCopyLockNode(
+    const ZooKeeperWithFaultInjectionPtr & zookeeper, const String & zookeeper_node, int32_t mode,
+    bool replace_existing_lock, const String & path_to_set_hardlinked_files, const NameSet & hardlinked_files)
+{
+    /// In rare case other replica can remove path between createAncestors and createIfNotExists
+    /// So we make up to 5 attempts
+
+    auto is_ephemeral = [&](const String & node_path) -> bool
+    {
+        String dummy_res;
+        Coordination::Stat node_stat;
+        if (zookeeper->tryGet(node_path, dummy_res, &node_stat))
+            return node_stat.ephemeralOwner;
+        return false;
+    };
+
+    bool created = false;
+    for (int attempts = 5; attempts > 0; --attempts)
+    {
+        Coordination::Requests ops;
+        Coordination::Responses responses;
+        getZeroCopyLockNodeCreateOps(zookeeper, zookeeper_node, ops, mode, replace_existing_lock, path_to_set_hardlinked_files, hardlinked_files);
+
+        fiu_do_on(FailPoints::zero_copy_lock_zk_fail_before_op, { zookeeper->forceFailureBeforeOperation(); });
+        fiu_do_on(FailPoints::zero_copy_lock_zk_fail_after_op, { zookeeper->forceFailureAfterOperation(); });
+
+        auto error = zookeeper->tryMulti(ops, responses);
+        if (error == Coordination::Error::ZOK)
+        {
+            created = true;
+            break;
+        }
+        if (mode == zkutil::CreateMode::Persistent)
+        {
+            if (error == Coordination::Error::ZNONODE)
+                continue;
+
+            if (error == Coordination::Error::ZNODEEXISTS)
+            {
+                if (is_ephemeral(zookeeper_node))
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Node {} already exists, but it is ephemeral", zookeeper_node);
+
+                size_t failed_op = zkutil::getFailedOpIndex(error, responses);
+                /// Part was locked before, unfortunately it's possible during moves
+                if (ops[failed_op]->getPath() == zookeeper_node)
+                {
+                    created = true;
+                    break;
+                }
+                continue;
+            }
+        }
+        else if (mode == zkutil::CreateMode::Ephemeral)
+        {
+            /// It is super rare case when we had part, but it was lost and we were unable to unlock it from keeper.
+            /// Now we are trying to fetch it from other replica and unlocking.
+            if (error == Coordination::Error::ZNODEEXISTS)
+            {
+                size_t failed_op = zkutil::getFailedOpIndex(error, responses);
+                if (ops[failed_op]->getPath() == zookeeper_node)
+                {
+                    LOG_WARNING(
+                        getLogger("ZeroCopyLocks"),
+                        "Replacing persistent lock with ephemeral for path {}. It can happen only in case of local part loss",
+                        zookeeper_node);
+                    replace_existing_lock = true;
+                    continue;
+                }
+            }
+        }
+
+        zkutil::KeeperMultiException::check(error, ops, responses);
+    }
+
+    if (!created)
+    {
+        String mode_str = mode == zkutil::CreateMode::Persistent ? "persistent" : "ephemeral";
+        throw Exception(ErrorCodes::NOT_FOUND_NODE,
+                        "Cannot create {} zero copy lock {} because part was unlocked from zookeeper",
+                        mode_str, zookeeper_node);
+    }
+}
+
+bool StorageZeroCopyReplicatedMergeTree::removeSharedDetachedPart(DiskPtr disk, const String & path, const String & part_name, const String & table_uuid,
+    const String & detached_replica_name, const String & detached_zookeeper_path, const ContextPtr & local_context, const zkutil::ZooKeeperPtr & zookeeper)
+{
+    bool keep_shared = false;
+
+    NameSet files_not_to_remove;
+
+    // zero copy replication is only available since format version 1 so we can safely use it here
+    auto part_info = DetachedPartInfo::parseDetachedPartName(disk, part_name, MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING);
+    if (!part_info.valid_name)
+        throw Exception(ErrorCodes::BAD_DATA_PART_NAME, "Invalid detached part name {} on disk {}", path, disk->getName());
+
+    fs::path checksums = fs::path(path) / IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK;
+    if (disk->existsFile(checksums))
+    {
+        if (disk->getRefCount(checksums) == 0)
+        {
+            String id = disk->getUniqueId(checksums);
+            bool can_remove = false;
+            std::tie(can_remove, files_not_to_remove) = StorageReplicatedMergeTree::unlockSharedDataByID(
+                id, table_uuid, part_info,
+                detached_replica_name,
+                disk->getDataSourceDescription().toString(),
+                std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), local_context->getReplicatedMergeTreeSettings(),
+                getLogger("StorageReplicatedMergeTree"),
+                detached_zookeeper_path,
+                MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING);
+
+            keep_shared = !can_remove;
+        }
+        else
+            keep_shared = true;
+    }
+
+    disk->removeSharedRecursive(path, keep_shared, files_not_to_remove);
+
+    return keep_shared;
+}
+
+bool StorageZeroCopyReplicatedMergeTree::canUseZeroCopyReplication() const
+{
+    auto settings_ptr = getSettings();
+    if (!(*settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+        return false;
+
+    auto disks = getStoragePolicy()->getDisks();
+    for (const auto & disk : disks)
+    {
+        if (disk->supportZeroCopyReplication())
+            return true;
+    }
+    return false;
+}
+
+zkutil::EphemeralNodeHolderPtr StorageZeroCopyReplicatedMergeTree::lockSharedDataTemporary(const String & part_name, const String & part_id, const DiskPtr & disk) const
+{
+    auto settings = getSettings();
+
+    if (!disk || !disk->supportZeroCopyReplication() || !(*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+        return {};
+
+    zkutil::ZooKeeperPtr zookeeper = tryGetZooKeeper();
+    if (!zookeeper)
+        return {};
+
+    String id = part_id;
+    boost::replace_all(id, "/", "_");
+
+    String zc_zookeeper_path = getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().toString(), getTableSharedID(),
+        part_name, zookeeper_path)[0];
+
+    String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
+
+    LOG_TRACE(log, "Set zookeeper temporary ephemeral lock {}", zookeeper_node);
+    createZeroCopyLockNode(
+        std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), zookeeper_node, zkutil::CreateMode::Ephemeral, false);
+
+    LOG_TRACE(log, "Zookeeper temporary ephemeral lock {} created", zookeeper_node);
+    return zkutil::EphemeralNodeHolder::existing(zookeeper_node, *zookeeper);
+}
+
+void StorageZeroCopyReplicatedMergeTree::getZeroCopyLockNodeCreateOps(
+    const ZooKeeperWithFaultInjectionPtr & zookeeper, const String & zookeeper_node, Coordination::Requests & requests,
+    int32_t mode, bool replace_existing_lock,
+    const String & path_to_set_hardlinked_files, const NameSet & hardlinked_files)
+{
+
+    /// Ephemeral locks can be created only when we fetch shared data.
+    /// So it never require to create ancestors. If we create them
+    /// race condition with source replica drop is possible.
+    if (mode == zkutil::CreateMode::Persistent)
+        zookeeper->checkExistsAndGetCreateAncestorsOps(zookeeper_node, requests);
+
+    if (replace_existing_lock && zookeeper->exists(zookeeper_node))
+    {
+        requests.emplace_back(zkutil::makeRemoveRequest(zookeeper_node, -1));
+        requests.emplace_back(zkutil::makeCreateRequest(zookeeper_node, "", mode));
+        if (!path_to_set_hardlinked_files.empty() && !hardlinked_files.empty())
+        {
+            std::string data = boost::algorithm::join(hardlinked_files, "\n");
+            /// List of files used to detect hardlinks. path_to_set_hardlinked_files --
+            /// is a path to source part zero copy node. During part removal hardlinked
+            /// files will be left for source part.
+            requests.emplace_back(zkutil::makeSetRequest(path_to_set_hardlinked_files, data, -1));
+        }
+    }
+    else
+    {
+        Coordination::Requests ops;
+        if (!path_to_set_hardlinked_files.empty() && !hardlinked_files.empty())
+        {
+            std::string data = boost::algorithm::join(hardlinked_files, "\n");
+            /// List of files used to detect hardlinks. path_to_set_hardlinked_files --
+            /// is a path to source part zero copy node. During part removal hardlinked
+            /// files will be left for source part.
+            requests.emplace_back(zkutil::makeSetRequest(path_to_set_hardlinked_files, data, -1));
+        }
+        requests.emplace_back(zkutil::makeCreateRequest(zookeeper_node, "", mode));
+    }
+}
+
+void StorageZeroCopyReplicatedMergeTree::createAndStoreFreezeMetadata(DiskPtr disk, DataPartPtr, String backup_part_path) const
+{
+    if (disk->supportZeroCopyReplication())
+    {
+        FreezeMetaData meta;
+        meta.fill(*this);
+        meta.save(disk, backup_part_path);
+    }
+}
+
+virtual bool StorageZeroCopyReplicatedMergeTree::checkPartChecksumsAndAddCommitOps(
+    const ZooKeeperWithFaultInjectionPtr & zookeeper,
+    const DataPartPtr & part,
+    Coordination::Requests & ops,
+    String part_name,
+    NameSet & absent_replicas_paths)
+{
+    getLockSharedDataOps(*part, zookeeper, replace_zero_copy_lock, hardlinked_files, ops);
+    StorageReplicatedMergeTree::checkPartChecksumsAndAddCommitOps(zookeeper, part, ops, part_name, absent_replicas_paths);
+}
+
+bool StorageZeroCopyReplicatedMergeTree::isCloneNeededForReplaceRange(const DataPartPtr & part, const PartDescriptionPtr & part_desc)
+{
+    if (!StorageReplicatedMergeTree::isCloneNeededForReplaceRange(part, part_desc))
+        return false;
+
+
+    if ((*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication] && part->isStoredOnRemoteDiskWithZeroCopySupport())
+    {
+        LOG_DEBUG(
+            log,
+            "Avoid copy local part {} from table {} because of zero-copy replication",
+            part_desc->src_part_name,
+            source_table_id.getNameForLogs());
+        return false;
+    }
+
+    return true;
+}
+
+bool StorageZeroCopyReplicatedMergeTree::removeDetachedPart(DiskPtr disk, const String & path, const String & part_name)
+{
+    auto settings = getSettings();
+
+    if (disk->supportZeroCopyReplication() && (settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+    {
+        String table_id = getTableSharedID();
+        return removeSharedDetachedPart(disk, path, part_name, table_id, replica_name, zookeeper_path, getContext(), current_zookeeper);
+    }
+
+    return StorageReplicatedMergeTree::removeDetachedPart(disk, path, part_name);
+}
+
+std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> StorageZeroCopyReplicatedMergeTree::fetchSelectedPart(
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        const String & part_name,
+        const String & zookeeper_name,
+        const String & replica_path,
+        const String & host,
+        int port,
+        const ConnectionTimeouts & timeouts,
+        const String & user,
+        const String & password,
+        const String & interserver_scheme,
+        ThrottlerPtr throttler,
+        bool to_detached,
+        const String & tmp_prefix_,
+        std::optional<CurrentlySubmergingEmergingTagger> * tagger_ptr,
+        DiskPtr disk)
+{
+    // TODO ZeroCopy: make fetcher polymorphic and return it from factory
+    return fetchSelectedPart(
+                metadata_snapshot,
+                getContext(),
+                part_name,
+                source_zookeeper_name,
+                source_replica_path,
+                address.host,
+                address.replication_port,
+                timeouts,
+                credentials->getUser(),
+                credentials->getPassword(),
+                interserver_scheme,
+                replicated_fetches_throttler,
+                to_detached,
+                "",
+                &tagger_ptr,
+                /* try_zero_copy = */ true);
+}
+
+void StorageZeroCopyReplicatedMergeTree::createNewZooKeeperNodesAttempt() const
+{
+
+    StorageReplicatedMergeTree::createNewZooKeeperNodesAttempt();
+
+    /// Nodes for remote fs zero-copy replication
+    const auto settings = getSettings();
+    if ((*settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+    {
+        for (const auto & zero_copy_locks_root : getZookeeperZeroCopyLockPaths())
+        {
+            for (const auto & ancestor : getAncestors(zero_copy_locks_root))
+            {
+                futures.push_back(zookeeper->asyncTryCreateNoThrow(ancestor, String(), zkutil::CreateMode::Persistent));
+            }
+        }
+
+        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_s3", String(), zkutil::CreateMode::Persistent));
+        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_s3/shared", String(), zkutil::CreateMode::Persistent));
+        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_hdfs", String(), zkutil::CreateMode::Persistent));
+        futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/zero_copy_hdfs/shared", String(), zkutil::CreateMode::Persistent));
+    }
+
+}
+
+void StorageZeroCopyReplicatedMergeTree::prepareDrop()
+{
+        /// Wait for loading of all outdated parts because
+    /// in case of zero copy recursive removal of directory
+    /// is not supported and table cannot be dropped.
+    if (canUseZeroCopyReplication() /*isLoadingOutadatedPartsNeeded()*/)
+    {
+        /// Load remaining parts synchronously because task
+        /// for loading is already cancelled in shutdown().
+        loadOutdatedDataParts(/*is_async=*/ false);
+    }
+
+    /// getZookeeperZeroCopyLockPaths has to be called before dropAllData
+    /// otherwise table_shared_id is unknown
+    zero_copy_locks_paths = getZookeeperZeroCopyLockPaths();
+}
+
+void StorageZeroCopyReplicatedMergeTree::onLastReplicaDropped()
+{
+    dropZookeeperZeroCopyLockPaths(getZooKeeper(), zero_copy_locks_paths, log.load());
+}
+
+bool StorageZeroCopyReplicatedMergeTree::isPreferredFetchFromOtherReplicaForReplaceRange(PartDescriptionPtr & part_desc)
+{
+    /// Fetches with zero-copy-replication are cheap, but cloneAndLoadDataPart(must_on_same_disk=true) will do full copy.
+    /// It's okay to check the setting for current table and disk for the source table, because src and dst part are on the same disk.
+    return !part_desc->replica.empty()
+        && (*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication] && part_desc->src_table_part
+        && part_desc->src_table_part->isStoredOnRemoteDiskWithZeroCopySupport();
+}
+
+ExecutableTaskPtr StorageReplicatedMergeTree::makeMutateFromLogEntryTask(const SelectedEntryPtr & selected_entry) const
+{
+    return std::make_shared<MutateZeroCopyFromLogEntryTask>(selected_entry, *this, common_assignee_trigger);
+}
+
+
+
+}

--- a/src/Storages/StorageZeroCopyReplicatedMergeTree.h
+++ b/src/Storages/StorageZeroCopyReplicatedMergeTree.h
@@ -1,0 +1,174 @@
+#pragma once
+#include <Storages/StorageReplicatedMergeTree.h>
+
+namespace DB 
+{
+
+class StorageZeroCopyReplicatedMergeTree: public StorageReplicatedMergeTree
+{
+public:
+    // ctr
+
+
+    class Transaction: public MergeTreeData::Transaction
+    {
+        explicit ZeroCopyTransaction(TransactionUniquePtr transaction)
+        : parent_transaction(std::move(transaction))
+        {
+        }
+
+        virtual DataPartsVector commit(DataPartsLock * acquired_parts_lock = nullptr)
+        {           
+            
+            
+        }
+
+        virtual void addPart(MutableDataPartPtr & part, bool need_rename);
+
+        virtual void rollback(DataPartsLock * lock = nullptr);
+    
+    private:
+        TransactionUniquePtr parent_transaction;
+    };
+
+        /// Fetch part only when it stored on shared storage like S3
+    MutableDataPartPtr executeFetchShared(const String & source_replica, const String & new_part_name, const DiskPtr & disk, const String & path);
+
+    /// Lock part in zookeeper for use shared data in several nodes
+    void lockSharedData(const IMergeTreeDataPart & part, bool replace_existing_lock, std::optional<HardlinkedFiles> hardlinked_files) const override;
+    void lockSharedData(
+        const IMergeTreeDataPart & part,
+        const ZooKeeperWithFaultInjectionPtr & zookeeper,
+        bool replace_existing_lock,
+        std::optional<HardlinkedFiles> hardlinked_files) const;
+
+    void getLockSharedDataOps(
+        const IMergeTreeDataPart & part,
+        const ZooKeeperWithFaultInjectionPtr & zookeeper,
+        bool replace_existing_lock,
+        std::optional<HardlinkedFiles> hardlinked_files,
+        Coordination::Requests & requests) const;
+
+    zkutil::EphemeralNodeHolderPtr lockSharedDataTemporary(const String & part_name, const String & part_id, const DiskPtr & disk) const;
+
+    /// Unlock shared data part in zookeeper
+    /// Return true if data unlocked
+    /// Return false if data is still used by another node
+    std::pair<bool, NameSet> unlockSharedData(const IMergeTreeDataPart & part) const override;
+    std::pair<bool, NameSet>
+    unlockSharedData(const IMergeTreeDataPart & part, const ZooKeeperWithFaultInjectionPtr & zookeeper) const;
+
+    /// Unlock shared data part in zookeeper by part id
+    /// Return true if data unlocked
+    /// Return false if data is still used by another node
+    static std::pair<bool, NameSet> unlockSharedDataByID(
+        String part_id,
+        const String & table_uuid,
+        const MergeTreePartInfo & part_info,
+        const String & replica_name_,
+        const std::string & disk_type,
+        const ZooKeeperWithFaultInjectionPtr & zookeeper_,
+        const MergeTreeSettings & settings,
+        LoggerPtr logger,
+        const String & zookeeper_path_old,
+        MergeTreeDataFormatVersion data_format_version);
+
+    /// Fetch part only if some replica has it on shared storage like S3
+    MutableDataPartPtr tryToFetchIfShared(const IMergeTreeDataPart & part, const DiskPtr & disk, const String & path) override;
+    
+    static bool removeSharedDetachedPart(DiskPtr disk, const String & path, const String & part_name, const String & table_uuid,
+    const String & replica_name, const String & zookeeper_path, const ContextPtr & local_context, const zkutil::ZooKeeperPtr & zookeeper);
+
+    bool canUseZeroCopyReplication() const;
+
+    /// Create freeze metadata for table and save in zookeeper. Required only if zero-copy replication enabled.
+    void createAndStoreFreezeMetadata(DiskPtr disk, DataPartPtr part, String backup_part_path) const override;
+
+    std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> fetchSelectedPart(
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        const String & part_name,
+        const String & zookeeper_name,
+        const String & replica_path,
+        const String & host,
+        int port,
+        const ConnectionTimeouts & timeouts,
+        const String & user,
+        const String & password,
+        const String & interserver_scheme,
+        ThrottlerPtr throttler,
+        bool to_detached,
+        const String & tmp_prefix_,
+        std::optional<CurrentlySubmergingEmergingTagger> * tagger_ptr,
+        DiskPtr disk) override;
+    
+    /// Create freeze metadata for table and save in zookeeper. Required only if zero-copy replication enabled.
+    void createAndStoreFreezeMetadata(DiskPtr disk, DataPartPtr part, String backup_part_path) const override;
+
+private:
+
+    std::mutex existing_zero_copy_locks_mutex;
+
+    struct ZeroCopyLockDescription
+    {
+        std::string replica;
+        std::shared_ptr<std::atomic<bool>> exists;
+    };
+
+    std::unordered_map<String, ZeroCopyLockDescription> existing_zero_copy_locks;
+
+    static Strings getZeroCopyPartPath(const MergeTreeSettings & settings, const std::string & disk_type, const String & table_uuid,
+        const String & part_name, const String & zookeeper_path_old);
+
+    static void createZeroCopyLockNode(
+        const ZooKeeperWithFaultInjectionPtr & zookeeper, const String & zookeeper_node,
+        int32_t mode = zkutil::CreateMode::Persistent, bool replace_existing_lock = false,
+        const String & path_to_set_hardlinked_files = "", const NameSet & hardlinked_files = {});
+
+    static void getZeroCopyLockNodeCreateOps(
+        const ZooKeeperWithFaultInjectionPtr & zookeeper, const String & zookeeper_node, Coordination::Requests & requests,
+        int32_t mode = zkutil::CreateMode::Persistent, bool replace_existing_lock = false,
+        const String & path_to_set_hardlinked_files = "", const NameSet & hardlinked_files = {});
+
+        bool checkZeroCopyLockExists(const String & part_name, const DiskPtr & disk, String & lock_replica);
+    void watchZeroCopyLock(const String & part_name, const DiskPtr & disk);
+
+    std::optional<String> getZeroCopyPartPath(const String & part_name, const DiskPtr & disk);
+
+    /// Create ephemeral lock in zookeeper for part and disk which support zero copy replication.
+    /// If no connection to zookeeper, shutdown, readonly -- return std::nullopt.
+    /// If somebody already holding the lock -- return unlocked ZeroCopyLock object (not std::nullopt).
+    std::optional<ZeroCopyLock> tryCreateZeroCopyExclusiveLock(const String & part_name, const DiskPtr & disk) override;
+
+    /// Wait for ephemral lock to disappear. Return true if table shutdown/readonly/timeout exceeded, etc.
+    /// Or if node actually disappeared.
+    bool waitZeroCopyLockToDisappear(const ZeroCopyLock & lock, size_t milliseconds_to_wait) override;
+
+
+    std::vector<String> getZookeeperZeroCopyLockPaths() const;
+    static void dropZookeeperZeroCopyLockPaths(zkutil::ZooKeeperPtr zookeeper,
+                                               std::vector<String> zero_copy_locks_paths, LoggerPtr logger);
+
+    bool checkPartChecksumsAndAddCommitOps(
+        const ZooKeeperWithFaultInjectionPtr & zookeeper,
+        const DataPartPtr & part,
+        Coordination::Requests & ops,
+        String part_name,
+        NameSet & absent_replicas_paths) override;
+    
+    bool isPreferredFetchFromOtherReplicaForReplaceRange(PartDescriptionPtr & part_desc) override;
+    bool isCloneNeededForReplaceRange(const DataPartPtr & part, const PartDescriptionPtr & part_desc) override;
+
+    void createNewZooKeeperNodesAttempt() const override;
+
+    void prepareDrop() override;
+    void onLastReplicaDropped() override;
+
+    ExecutableTaskPtr makeMutateFromLogEntryTask(const SelectedEntryPtr & selected_entry) const override;
+
+    std::vector<String> zero_copy_lock_paths;
+
+};
+
+};
+


### PR DESCRIPTION
The main goal is to get rid `StorageReplicatedMergeTree` and other important classes of zero-copy related code and move this code to the separate classes by means of inheritance and other means.

Remove most of the conditional code like this wherever possible.
```c++
if (settings[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
...
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
