### PR TITLE
Try stabilize stateless runner

### DIFF
--- a/ci/jobs/functional_stateless_tests.py
+++ b/ci/jobs/functional_stateless_tests.py
@@ -41,7 +41,7 @@ def run_stateless_test(
     if batch_num and batch_total:
         aux = f"--run-by-hash-total {batch_total} --run-by-hash-num {batch_num-1}"
     statless_test_command = f"clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --hung-check --print-time \
-                --no-drop-if-fail --capture-client-stacktrace --queries /repo/tests/queries --test-runs 1 --hung-check \
+                --capture-client-stacktrace --queries /repo/tests/queries --test-runs 1 --hung-check \
                 {'--no-parallel' if no_parallel else ''}  {'--no-sequential' if no_sequiential else ''} \
                 --print-time --jobs {nproc} --report-coverage --report-logs-stats {aux} \
                 --queries ./tests/queries -- '{test}' | ts '%Y-%m-%d %H:%M:%S' \

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2125,6 +2125,7 @@ class TestCase:
         drop_database_query = f"DROP DATABASE IF EXISTS {database}"
         if args.replicated_database:
             drop_database_query += " ON CLUSTER test_cluster_database_replicated"
+        drop_database_query += " SYNC"
 
         # It's possible to get an error "New table appeared in database being dropped or detached. Try again."
         for _ in range(1, 60):

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -368,7 +368,6 @@ function run_tests()
         --check-zookeeper-session
         --hung-check
         --print-time
-        --no-drop-if-fail
         --capture-client-stacktrace
         --queries "/repo/tests/queries"
         --test-runs "$NUM_TRIES"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Drop the database after each test run, regardless of its status, and do so in sync mode.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
