### PR TITLE
Groom more IColumn headers

### DIFF
--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -37,6 +37,8 @@ class WeakHash32;
 class ColumnConst;
 class IDataType;
 using DataTypePtr = std::shared_ptr<const IDataType>;
+using IColumnPermutation = PaddedPODArray<size_t>;
+using IColumnFilter = PaddedPODArray<UInt8>;
 
 /// A range of column values between row indexes `from` and `to`. The name "equal range" is due to table sorting as its main use case: With
 /// a PRIMARY KEY (c_pk1, c_pk2, ...), the first PK column is fully sorted. The second PK column is sorted within equal-value runs of the
@@ -348,7 +350,7 @@ public:
       * if 0, then don't makes reserve(),
       * otherwise (i.e. < 0), makes reserve() using size of source column.
       */
-    using Filter = PaddedPODArray<UInt8>;
+    using Filter = IColumnFilter;
     [[nodiscard]] virtual Ptr filter(const Filter & filt, ssize_t result_size_hint) const = 0;
 
     /** Expand column by mask inplace. After expanding column will
@@ -361,7 +363,7 @@ public:
 
     /// Permutes elements using specified permutation. Is used in sorting.
     /// limit - if it isn't 0, puts only first limit elements in the result.
-    using Permutation = PaddedPODArray<size_t>;
+    using Permutation = IColumnPermutation;
     [[nodiscard]] virtual Ptr permute(const Permutation & perm, size_t limit) const = 0;
 
     /// Creates new column with values column[indexes[:limit]]. If limit is 0, all indexes are used.

--- a/src/Functions/FunctionDateOrDateTimeToSomething.h
+++ b/src/Functions/FunctionDateOrDateTimeToSomething.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <DataTypes/DataTypeNullable.h>
 #include <Functions/IFunctionDateOrDateTime.h>
 
 namespace DB

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -41,7 +41,6 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadHelpers.h>
 
-#include <limits>
 #include <type_traits>
 
 namespace DB

--- a/src/Functions/array/FunctionArrayMapped.h
+++ b/src/Functions/array/FunctionArrayMapped.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <type_traits>
-
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnFunction.h>

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -17,8 +17,6 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnTuple.h>
 #include "Common/FieldVisitors.h"
-#include "Common/Logger.h"
-#include "Common/logger_useful.h"
 #include <Common/FieldVisitorsAccurateComparison.h>
 #include <Common/memcmpSmall.h>
 #include <Common/assert_cast.h>

--- a/src/Interpreters/AggregationMethod.h
+++ b/src/Interpreters/AggregationMethod.h
@@ -5,11 +5,6 @@
 #include <Interpreters/AggregatedData.h>
 
 #include <Columns/ColumnString.h>
-#include <Columns/ColumnFixedString.h>
-#include <Columns/ColumnVector.h>
-#include <Columns/ColumnNullable.h>
-#include <Columns/ColumnLowCardinality.h>
-
 namespace DB
 {
 class IColumn;

--- a/src/Interpreters/RowRefs.h
+++ b/src/Interpreters/RowRefs.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <algorithm>
-#include <list>
-#include <mutex>
 #include <optional>
 
 #include <Columns/IColumn_fwd.h>

--- a/src/Interpreters/sortBlock.h
+++ b/src/Interpreters/sortBlock.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <Columns/IColumn.h>
+#include <base/types.h>
+#include <Common/PODArray_fwd.h>
 
 namespace DB
 {
 
 class Block;
 class SortDescription;
+using IColumnPermutation = PaddedPODArray<size_t>;
 
 /// Sort one block by `description`. If limit != 0, then the partial sort of the first `limit` rows is produced.
 void sortBlock(Block & block, const SortDescription & description, UInt64 limit = 0);
@@ -17,7 +19,7 @@ void sortBlock(Block & block, const SortDescription & description, UInt64 limit 
   *  - because based on the order of rows it is determined whether to delete or leave groups of rows when collapsing.
   * Used only in StorageMergeTree to sort the data with INSERT.
   */
-void stableGetPermutation(const Block & block, const SortDescription & description, IColumn::Permutation & out_permutation);
+void stableGetPermutation(const Block & block, const SortDescription & description, IColumnPermutation & out_permutation);
 
 /** Quickly check whether the block is already sorted. If the block is not sorted - returns false as fast as possible.
   */

--- a/src/Processors/Formats/Impl/NpyOutputFormat.h
+++ b/src/Processors/Formats/Impl/NpyOutputFormat.h
@@ -7,7 +7,6 @@
 #include <Columns/IColumn_fwd.h>
 
 #include <vector>
-#include <string>
 
 
 namespace DB

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithm.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <Processors/Chunk.h>
-#include <Columns/IColumn.h>
+#include <Common/PODArray_fwd.h>
 #include <Common/ProfileEvents.h>
 
 namespace DB
 {
+
+using IColumnPermutation = PaddedPODArray<size_t>;
 
 class IMergingAlgorithm
 {
@@ -30,7 +32,7 @@ public:
         /// between different algorithm objects in parallel FINAL.
         bool skip_last_row = false;
 
-        IColumn::Permutation * permutation = nullptr;
+        IColumnPermutation * permutation = nullptr;
 
         void swap(Input & other) noexcept
         {

--- a/src/Processors/Transforms/ColumnGathererTransform.cpp
+++ b/src/Processors/Transforms/ColumnGathererTransform.cpp
@@ -21,6 +21,13 @@ namespace ErrorCodes
     extern const int RECEIVED_EMPTY_DATA;
 }
 
+void ColumnGathererStream::Source::update(ColumnPtr column_)
+{
+    column = std::move(column_);
+    size = column->size();
+    pos = 0;
+}
+
 ColumnGathererStream::ColumnGathererStream(
     size_t num_inputs,
     ReadBuffer & row_sources_buf_,

--- a/src/Processors/Transforms/ColumnGathererTransform.h
+++ b/src/Processors/Transforms/ColumnGathererTransform.h
@@ -84,12 +84,7 @@ private:
         size_t pos = 0;
         size_t size = 0;
 
-        void update(ColumnPtr column_)
-        {
-            column = std::move(column_);
-            size = column->size();
-            pos = 0;
-        }
+        void update(ColumnPtr column_);
     };
 
     MutableColumnPtr result_column;

--- a/src/Processors/Transforms/TotalsHavingTransform.h
+++ b/src/Processors/Transforms/TotalsHavingTransform.h
@@ -9,6 +9,7 @@ namespace DB
 
 class ExpressionActions;
 using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
+using IColumnFilter = PaddedPODArray<UInt8>;
 
 class ActionsDAG;
 
@@ -51,7 +52,7 @@ protected:
     Chunk totals;
 
 private:
-    void addToTotals(const Chunk & chunk, const IColumn::Filter * filter);
+    void addToTotals(const Chunk & chunk, const IColumnFilter * filter);
     void prepareTotals();
 
     /// Params


### PR DESCRIPTION
- Remove unused includes
- Use `using` to alias types passed by reference

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
