### PR TITLE
Fix compiler error in ClientInfo

### DIFF
--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -32,7 +32,7 @@ std::optional<Poco::Net::SocketAddress> ClientInfo::getLastForwardedFor() const
     if (last[0] == '[')
         return Poco::Net::SocketAddress{Poco::Net::AddressFamily::IPv6, last};
 
-    int colons = std::count(last.begin(), last.end(), ':');
+    const auto colons = std::count(last.begin(), last.end(), ':');
 
     /// IPv6 address without port
     if (colons > 1)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not sure why it fails for me locally, maybe clang version

```
/home/ubuntu/ClickHouse2/src/Interpreters/ClientInfo.cpp:35:18: error: implicit conversion loses integer precision: '__iter_diff_t<__wrap_iter<char *>>' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
   35 |     int colons = std::count(last.begin(), last.end(), ':');
      |         ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```