### PR TITLE
Optimize transitive includes of TableExpressionData.h

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -1,6 +1,8 @@
 #include <Interpreters/ProcessorsProfileLog.h>
 #include <Common/FieldVisitorToString.h>
 
+#include <Columns/ColumnNullable.h>
+
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeNullable.h>

--- a/src/Planner/CollectSets.cpp
+++ b/src/Planner/CollectSets.cpp
@@ -5,17 +5,18 @@
 
 #include <Storages/StorageSet.h>
 
-#include <Analyzer/Utils.h>
-#include <Analyzer/SetUtils.h>
-#include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/ColumnNode.h>
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
+#include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/SetUtils.h>
 #include <Analyzer/TableNode.h>
+#include <Analyzer/Utils.h>
 #include <Core/Settings.h>
-#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <Planner/Planner.h>
+#include <Planner/PlannerContext.h>
 
 namespace DB
 {

--- a/src/Planner/CollectSets.h
+++ b/src/Planner/CollectSets.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <Planner/PlannerContext.h>
-
-#include <Analyzer/IQueryTreeNode.h>
+#include <memory>
 
 namespace DB
 {
 
+class IQueryTreeNode;
+using QueryTreeNodePtr = std::shared_ptr<IQueryTreeNode>;
+class PlannerContext;
 struct SelectQueryOptions;
 
 /** Collect prepared sets and sets for subqueries that are necessary to execute IN function and its variations.

--- a/src/Planner/Planner.h
+++ b/src/Planner/Planner.h
@@ -3,13 +3,13 @@
 #include <Interpreters/IInterpreter.h>
 #include <Interpreters/SelectQueryOptions.h>
 
-#include <Analyzer/QueryTreePassManager.h>
 #include <Processors/QueryPlan/QueryPlan.h>
-#include <Interpreters/Context_fwd.h>
 #include <Storages/SelectQueryInfo.h>
 
 namespace DB
 {
+
+class QueryNode;
 
 class GlobalPlannerContext;
 using GlobalPlannerContextPtr = std::shared_ptr<GlobalPlannerContext>;

--- a/src/Planner/PlannerContext.h
+++ b/src/Planner/PlannerContext.h
@@ -7,8 +7,6 @@
 #include <Interpreters/Set.h>
 #include <Interpreters/PreparedSets.h>
 
-#include <Analyzer/IQueryTreeNode.h>
-
 #include <Planner/TableExpressionData.h>
 #include <Interpreters/SelectQueryOptions.h>
 

--- a/src/Planner/PlannerWindowFunctions.h
+++ b/src/Planner/PlannerWindowFunctions.h
@@ -1,10 +1,9 @@
 #pragma once
 
+#include <Analyzer/QueryNode.h>
 #include <Core/SortDescription.h>
-
-#include <Planner/PlannerContext.h>
-
 #include <Interpreters/WindowDescription.h>
+#include <Planner/PlannerContext.h>
 
 namespace DB
 {

--- a/src/Storages/KVStorageUtils.h
+++ b/src/Storages/KVStorageUtils.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Storages/SelectQueryInfo.h>
-
-#include <Interpreters/PreparedSets.h>
+#include <Core/Block.h>
 #include <Core/Field.h>
-
 #include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/PreparedSets.h>
+#include <Storages/SelectQueryInfo.h>
 
 namespace DB
 {

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -1,16 +1,17 @@
-#include <Storages/MergeTree/MergeTreeDataPartWriterWide.h>
-#include <Interpreters/Context.h>
-#include <Compression/CompressionFactory.h>
-#include <Compression/CompressedReadBufferFromFile.h>
-#include <DataTypes/Serializations/ISerialization.h>
-#include <Common/escapeForFileName.h>
 #include <Columns/ColumnSparse.h>
+#include <Compression/CompressedReadBufferFromFile.h>
+#include <Compression/CompressionFactory.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <Interpreters/Context.h>
+#include <Storages/ColumnsDescription.h>
+#include <Storages/MarkCache.h>
+#include <Storages/MergeTree/MergeTreeDataPartWriterWide.h>
+#include <Storages/MergeTree/MergeTreeMarksLoader.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Common/SipHash.h>
+#include <Common/escapeForFileName.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
-#include <Storages/MergeTree/MergeTreeMarksLoader.h>
-#include <Storages/MarkCache.h>
-#include <Storages/ColumnsDescription.h>
-#include <Storages/MergeTree/MergeTreeSettings.h>
 
 namespace DB
 {

--- a/src/Storages/SelectQueryInfo.cpp
+++ b/src/Storages/SelectQueryInfo.cpp
@@ -1,5 +1,6 @@
-#include <Storages/SelectQueryInfo.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Planner/PlannerContext.h>
+#include <Storages/SelectQueryInfo.h>
 
 namespace DB
 {

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -2,12 +2,10 @@
 
 #include <Analyzer/IQueryTreeNode.h>
 #include <Analyzer/TableExpressionModifiers.h>
-#include <Core/Names.h>
 #include <Core/SortDescription.h>
-#include <Interpreters/AggregateDescription.h>
+#include <Interpreters/ActionsDAG.h>
 #include <Interpreters/DatabaseAndTableWithAlias.h>
 #include <Interpreters/PreparedSets.h>
-#include <Planner/PlannerContext.h>
 #include <QueryPipeline/StreamLocalLimits.h>
 
 #include <memory>
@@ -35,6 +33,9 @@ using ReadInOrderOptimizerPtr = std::shared_ptr<const ReadInOrderOptimizer>;
 
 class Cluster;
 using ClusterPtr = std::shared_ptr<Cluster>;
+
+class PlannerContext;
+using PlannerContextPtr = std::shared_ptr<PlannerContext>;
 
 struct PrewhereInfo
 {

--- a/src/Storages/System/StorageSystemDatabases.cpp
+++ b/src/Storages/System/StorageSystemDatabases.cpp
@@ -1,16 +1,17 @@
-#include <Databases/IDatabase.h>
+#include <Access/ContextAccess.h>
+#include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeUUID.h>
+#include <Databases/IDatabase.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/formatWithPossiblyHidingSecrets.h>
-#include <Access/ContextAccess.h>
-#include <Storages/System/StorageSystemDatabases.h>
-#include <Storages/SelectQueryInfo.h>
-#include <Storages/VirtualColumnUtils.h>
 #include <Parsers/ASTCreateQuery.h>
-#include <Common/logger_useful.h>
 #include <Parsers/formatAST.h>
+#include <Storages/SelectQueryInfo.h>
+#include <Storages/System/StorageSystemDatabases.h>
+#include <Storages/VirtualColumnUtils.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB

--- a/src/Storages/VirtualColumnUtils.h
+++ b/src/Storages/VirtualColumnUtils.h
@@ -13,8 +13,8 @@
 namespace DB
 {
 
+class Chunk;
 class NamesAndTypesList;
-
 
 namespace VirtualColumnUtils
 {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize transitive includes of TableExpressionData.h

Another simple change:
```
 34. │ DB::TableExpressionData                           │     6903 │    814994060 │
 35. │ /build/src/Planner/TableExpressionData.h:46:1     │     6090 │    796869679 │
```

Affected tasks when changing `TableExpressionData.h`:
* Before: 449
* Now: 29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
