### PR TITLE
Add fault injection for PostgreSQL replication on CI

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3248,6 +3248,9 @@ Connection pool push/pop retries number for PostgreSQL table engine and database
     DECLARE(Bool, postgresql_connection_pool_auto_close_connection, false, R"(
 Close connection before returning connection to the pool.
 )", 0) \
+    DECLARE(Float, postgresql_fault_injection_probability, 0.0f, R"(
+Approximate probability of failing internal (for replication) PostgreSQL queries. Valid value is in interval [0.0f, 1.0f]
+)", 0) \
     DECLARE(UInt64, glob_expansion_max_elements, 1000, R"(
 Maximum number of allowed addresses (For external storages, table functions, etc).
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -67,6 +67,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "25.2",
         {
             {"query_plan_use_new_logical_join_step", false, true, "Enable new step"},
+            {"postgresql_fault_injection_probability", 0., 0., "New setting"},
         });
         addSettingsChanges(settings_changes_history, "25.1",
         {

--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.h
@@ -106,6 +106,8 @@ private:
 
     void assertInitialized() const;
 
+    void execWithRetryAndFaultInjection(postgres::Connection & connection, const std::function<void(pqxx::nontransaction &)> & exec) const;
+
     LoggerPtr log;
 
     /// If it is not attach, i.e. a create query, then if publication already exists - always drop it.
@@ -157,6 +159,8 @@ private:
     MaterializedStorages materialized_storages;
 
     bool replication_handler_initialized = false;
+
+    float fault_injection_probability = 0.;
 };
 
 }

--- a/tests/integration/test_postgresql_replica_database_engine_1/configs/users.xml
+++ b/tests/integration/test_postgresql_replica_database_engine_1/configs/users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <allow_experimental_database_materialized_postgresql>1</allow_experimental_database_materialized_postgresql>
+            <postgresql_fault_injection_probability>0.1</postgresql_fault_injection_probability>
         </default>
     </profiles>
 </clickhouse>

--- a/tests/integration/test_postgresql_replica_database_engine_2/configs/users.xml
+++ b/tests/integration/test_postgresql_replica_database_engine_2/configs/users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <allow_experimental_database_materialized_postgresql>1</allow_experimental_database_materialized_postgresql>
+            <postgresql_fault_injection_probability>0.1</postgresql_fault_injection_probability>
         </default>
     </profiles>
     <users>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This is a follow up for https://github.com/ClickHouse/ClickHouse/pull/75062 to catch such issues earlier