### PR TITLE
Improve clickhouse-server entrypoint

### DIFF
--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -125,8 +125,8 @@ RUN clickhouse-local -q 'SELECT * FROM system.build_options' \
     && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
 
 RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV TZ UTC
+ENV LANG=en_US.UTF-8
+ENV TZ=UTC
 
 RUN mkdir /docker-entrypoint-initdb.d
 
@@ -136,6 +136,6 @@ COPY entrypoint.sh /entrypoint.sh
 EXPOSE 9000 8123 9009
 VOLUME /var/lib/clickhouse
 
-ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
+ENV CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -88,12 +88,6 @@ function create_directory_and_do_chown() {
     fi
 }
 
-create_directory_and_do_chown "$DATA_DIR"
-
-# Change working directory to $DATA_DIR in case there're paths relative to $DATA_DIR, also avoids running
-# clickhouse-server at root directory.
-cd "$DATA_DIR"
-
 function manage_clickhouse_directories() {
     for dir in "$ERROR_LOG_DIR" \
       "$LOG_DIR" \
@@ -238,6 +232,12 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     # so the container can't be finished by ctrl+c
     CLICKHOUSE_WATCHDOG_ENABLE=${CLICKHOUSE_WATCHDOG_ENABLE:-0}
     export CLICKHOUSE_WATCHDOG_ENABLE
+
+    create_directory_and_do_chown "$DATA_DIR"
+
+    # Change working directory to $DATA_DIR in case there're paths relative to $DATA_DIR, also avoids running
+    # clickhouse-server at root directory.
+    cd "$DATA_DIR"
 
     # Using functions here to avoid unnecessary work in case of launching other binaries,
     # inspired by postgres, mariadb etc. entrypoints

--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -361,6 +361,7 @@ class Utils:
             (",", "_"),
             ("/", "_"),
             ("-", "_"),
+            (":", "_"),
         ):
             res = res.replace(*r)
         return res

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -249,7 +249,7 @@ def build_and_push_image(
         )
         cmd = " ".join(cmd_args)
         logging.info("Building image %s:%s for arch %s: %s", image.repo, tag, arch, cmd)
-        log_file = temp_path / f"{image.repo.replace('/', '__')}:{tag}-{arch}.log"
+        log_file = temp_path / Utils.normalize_string(f"{image.repo}:{tag}-{arch}.log")
         if retry_popen(cmd, log_file) != 0:
             result.append(
                 TestResult(
@@ -326,6 +326,7 @@ def test_docker_library(test_results: TestResults) -> None:
         run_sh = (repo_path / "test/run.sh").absolute()
         for image in check_images:
             cmd = f"{run_sh} {image}"
+            tag = image.rsplit(":", 1)[-1]
             log_file = (
                 temp_path / f"docker-library-test-{Utils.normalize_string(image)}.log"
             )
@@ -333,7 +334,12 @@ def test_docker_library(test_results: TestResults) -> None:
                 retcode = process.wait()
             status = OK if retcode == 0 else FAIL
             test_results.append(
-                TestResult(test_name, status, stopwatch.duration_seconds, [log_file])
+                TestResult(
+                    f"{test_name} ({tag})",
+                    status,
+                    stopwatch.duration_seconds,
+                    [log_file],
+                )
             )
     except Exception as e:
         logging.error("Failed while testing the docker library image: %s", e)

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -310,8 +310,8 @@ def test_docker_library(test_results: TestResults) -> None:
         return
     test_name = "docker library image test"
     temp_path = Path(TEMP_PATH)
+    stopwatch = Stopwatch()
     try:
-        stopwatch = Stopwatch()
         repo = "docker-library/official-images"
         logging.info("Cloning %s repository to run tests for 'clickhouse' image", repo)
         repo_path = temp_path / repo
@@ -325,6 +325,7 @@ def test_docker_library(test_results: TestResults) -> None:
         )
         run_sh = (repo_path / "test/run.sh").absolute()
         for image in check_images:
+            test_sw = Stopwatch()
             cmd = f"{run_sh} {image}"
             tag = image.rsplit(":", 1)[-1]
             log_file = (
@@ -337,7 +338,7 @@ def test_docker_library(test_results: TestResults) -> None:
                 TestResult(
                     f"{test_name} ({tag})",
                     status,
-                    stopwatch.duration_seconds,
+                    test_sw.duration_seconds,
                     [log_file],
                 )
             )


### PR DESCRIPTION
A change related to the review in https://github.com/docker-library/official-images/pull/18387
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make all clickhouse-server related actions a function, and execute them only when launching the default binary in `entrypoint.sh`. A long-postponed improvement was suggested in #50724. Added switch `--users` to `clickhouse-extract-from-config` to get values from the `users.xml`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
