### PR TITLE
better test for system drop replica permissions

### DIFF
--- a/tests/integration/test_permissions_drop_replica/configs/remote_servers.xml
+++ b/tests/integration/test_permissions_drop_replica/configs/remote_servers.xml
@@ -2,6 +2,7 @@
     <remote_servers>
         <test_cluster>
             <shard>
+                <internal_replication>true</internal_replication>
                 <replica>
                     <host>node1</host>
                     <port>9000</port>

--- a/tests/integration/test_permissions_drop_replica/configs/remote_servers.xml
+++ b/tests/integration/test_permissions_drop_replica/configs/remote_servers.xml
@@ -1,6 +1,6 @@
 <clickhouse>
     <remote_servers>
-        <cluster>
+        <test_cluster>
             <shard>
                 <replica>
                     <host>node1</host>
@@ -11,6 +11,6 @@
                     <port>9000</port>
                 </replica>
             </shard>
-        </cluster>
+        </test_cluster>
     </remote_servers>
 </clickhouse>

--- a/tests/integration/test_permissions_drop_replica/test.py
+++ b/tests/integration/test_permissions_drop_replica/test.py
@@ -44,16 +44,6 @@ def fill_nodes(nodes, shard):
         )
 
 
-def clean_up(nodes):
-    for node in nodes:
-        node.query(
-            """
-                DROP DATABASE IF EXISTS test SYNC;
-                DROP USER IF EXISTS test_user_xnhds;
-            """
-        )
-
-
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -119,4 +109,6 @@ def test_drop_permissions(start_cluster):
         node2.start_clickhouse()
 
     finally:
-        clean_up(nodes)
+        for node in nodes:
+            node.query("DROP DATABASE IF EXISTS test SYNC;")
+            node.query("DROP USER IF EXISTS test_user_xnhds;")

--- a/tests/integration/test_permissions_drop_replica/test.py
+++ b/tests/integration/test_permissions_drop_replica/test.py
@@ -20,46 +20,85 @@ node2 = cluster.add_instance(
     main_configs=main_configs,
     macros={"replica": "node2", "shard": "shard2"},
     with_zookeeper=True,
+    stay_alive=True,
 )
+
+
+def setup_nodes(nodes, shard):
+    for node in nodes:
+        node.query(
+            """
+                DROP TABLE IF EXISTS test.test_table;
+                DROP DATABASE IF EXISTS test;
+                DROP USER IF EXISTS test_user_xnhds;
+                CREATE DATABASE test;
+                SET database_replicated_allow_replicated_engine_arguments=2;  
+                CREATE TABLE test.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date);
+            """.format(
+                shard=shard, replica=node.name
+            )
+        )
 
 
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
         cluster.start()
+        setup_nodes([node1, node2], 1)
         yield cluster
     finally:
         cluster.shutdown()
 
 
 def test_drop_permissions(start_cluster):
-    node1.query("DROP DATABASE IF EXISTS r")
     node1.query(
-        f"CREATE DATABASE r ENGINE=Replicated('/clickhouse/databases/r', '{{shard}}', '{{replica}}')"
+        "INSERT INTO test.test_table SELECT number, toString(number) FROM numbers(100)"
     )
-    node1.query(
-        "CREATE TABLE r.t1 (x UInt8, y String) ENGINE=ReplicatedMergeTree ORDER BY x"
+
+    # check metadata for replica node2 in keeper
+    # this the node replica that we are going to drop later on
+    zk = cluster.get_kazoo_client("zoo1")
+    # check that the path from zk exists for the replica node2
+    assert (
+        zk.exists("/clickhouse/tables/test/1/replicated/test_table/replicas/node2")
+        is not None
     )
+
     # create user without any permissions
-    node1.query("CREATE USER foo;")
-    node1.query("REVOKE ALL ON *.* FROM foo;")
-    # try dropping replica using this user without any permissions
-    got_error = node1.query_and_get_error("SYSTEM DROP REPLICA 'node2'", user="foo")
+    node1.query("CREATE USER test_user_xnhds;")
+    node1.query("REVOKE ALL ON *.* FROM test_user_xnhds;")
+
+    # we won't be able to drop an active replica
+    assert (
+        "DB::Exception: Can't drop replica: node2, because it's active."
+        in node1.query_and_get_error("SYSTEM DROP REPLICA 'node2'")
+    )
+
+    # stop the server on replica node2 and assume it's gone forever
+    # this will allow us to drop this replica
+    node2.stop_clickhouse()
+
+    # drop replica node2 from replica node1 using user without privileges
+    got_error = node1.query_and_get_error(
+        "SYSTEM DROP REPLICA 'node2'", user="test_user_xnhds"
+    )
     # this operation should not fail silently
     assert (
         "DB::Exception: Access denied for SYSTEM DROP REPLICA. Not enough permissions to drop these databases:"
         in got_error
     )
-    # assert that the replica still exists
+
+    # drop replica node2 from replica node1 but using user with privileges
+    # this will remove all replicated table metadata belonging to node2 from keeper
+    node1.query("SYSTEM DROP REPLICA 'node2'")
+
+    # check that the metadata for replica node2 was removed from keeper
     assert (
-        node1.query("SELECT host_name FROM system.clusters WHERE replica_num=1") != ""
+        zk.exists(" /clickhouse/tables/test/1/replicated/test_table/replicas/node2")
+        is None
     )
-    # now query using default user (should have necessary permissions)
-    node1.query("SYSTEM DROP REPLICA 'node2'", user="default")
-    # assert that the replica was dropped successfully
-    assert (
-        node1.query("SELECT host_name FROM system.clusters WHERE replica_num=3").strip()
-        == ""
-    )
-    node1.query("DROP USER foo;")
-    node1.query("DROP DATABASE r")
+
+    node1.query("DROP USER test_user_xnhds;")
+    node1.query("DROP TABLE test.test_table;")
+    node1.query("DROP DATABASE test;")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Improve the test that was added earlier in #75377

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
