### PR TITLE
Change default send_settings_to_client to false

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -900,7 +900,7 @@ namespace DB
     DECLARE(Bool, use_legacy_mongodb_integration, false, R"(
     Use the legacy MongoDB integration implementation. Note: it's highly recommended to set this option to false, since legacy implementation will be removed in the future. Please submit any issues you encounter with the new implementation.
     )", 0) \
-    DECLARE(Bool, send_settings_to_client, true, R"(
+    DECLARE(Bool, send_settings_to_client, false, R"(
     Send user settings from server configuration to clients (in the server Hello message).
     )", 0) \
     \

--- a/tests/integration/test_settings_from_server/configs/config.d/send.xml
+++ b/tests/integration/test_settings_from_server/configs/config.d/send.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <send_settings_to_client>true</send_settings_to_client>
+</clickhouse>

--- a/tests/integration/test_settings_from_server/test.py
+++ b/tests/integration/test_settings_from_server/test.py
@@ -7,7 +7,7 @@ from helpers.network import PartitionManager
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
-    main_configs=[],
+    main_configs=["configs/config.d/send.xml"],
     user_configs=["configs/users.d/users.xml"],
 )
 node_no_send = cluster.add_instance(


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable sending settings from server to client (`send_settings_to_client=false`) for compatibility (This feature will be re-implemented as client setting later for better usability)

The plan is to backport this to 24.12 and 25.1, then merge https://github.com/ClickHouse/ClickHouse/pull/75478 , then change the default back to true.