### PR TITLE
ci: avoid relying on internal AWS DNS

### DIFF
--- a/.github/actions/common_setup/action.yml
+++ b/.github/actions/common_setup/action.yml
@@ -35,3 +35,12 @@ runs:
           # https://github.com/google/sanitizers/issues/856
           echo "Tune vm.mmap_rnd_bits for sanitizers"
           sudo sysctl vm.mmap_rnd_bits=28
+    - name: Avoid relying on internal AWS DNS
+      shell: bash
+      run: |
+          fqdn=$(hostname --fqdn)
+          echo "Current FQDN: $fqdn"
+          echo "127.0.0.1 $fqdn" | sudo tee -a /etc/hosts
+          resolvectl flush-caches
+          resolvectl query "$fqdn"
+          host "$fqdn"


### PR DESCRIPTION
On one of CI runs [1] I found that the internal AWS DNS zone was not available, which leads to broken replication:

    2025.02.05 18:19:13.431922 [ 162438 ] {} <Debug> Application: Configuration parameter 'interserver_http_host' doesn't exist or exists and empty. Will use 'ip-172-31-29-196.ec2.internal' as replica host.
    2025.02.05 18:20:50.304586 [ 163080 ] {} <Debug> ReadWriteBufferFromHTTP: Failed to make request to 'http://ip-172-31-29-196.ec2.internal:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Ftest%2Ftest_l4uzrgcm%2F02438%2Freplicas%2F1&part=all_0_0_0&client_protocol_version=8&compress=false'. Error: 'DB::HTTPException: Received error from remote server http://ip-172-31-29-196.ec2.internal:9009/?endpoint=DataPartsExchange%3Adefault%3A%2Ftest%2Ftest_l4uzrgcm%2F02438%2Freplicas%2F1&part=all_0_0_0&client_protocol_version=8&compress=false. HTTP status code: 500 'Internal Server Error', body length: 99 bytes, body: 'Code: 236. DB::Exception: Transferring part to replica was cancelled. (ABORTED) (version 25.2.1.1)
    2025.02.05 18:21:28.777674 [ 162665 ] {} <Warning> DNSResolver: Cannot resolve host (ip-172-31-29-196.ec2.internal), error 0: Host not found.
    2025.02.05 18:21:28.777783 [ 162665 ] {} <Information> DNSResolver: Cached hosts not found: ip-172-31-29-196.ec2.internal

At first it works, but at some point it became broken.

Also note, that in theory, this should not change anything, since `isLocalAddress` will return `true` for the `172.x` address as well.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/9c47f4ed936ef252a8ac460cbb85527a56b2ab53/fast_test.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI
- [x] <!---no_ci_cache--> Disable CI cache