### PR TITLE
Fix incorrect processed_rows value in system.s3queue_log in case file was retried

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -55,6 +55,7 @@ static struct InitFiu
     ONCE(smt_insert_fake_hardware_error) \
     ONCE(smt_sleep_after_hardware_in_insert) \
     ONCE(smt_throw_keeper_exception_after_successful_insert) \
+    REGULAR(object_storage_queue_fail_commit) \
     REGULAR(smt_dont_merge_first_part) \
     REGULAR(smt_sleep_in_schedule_data_processing_job) \
     REGULAR(cache_warmer_stall) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -49,6 +49,8 @@ void ObjectStorageQueueIFileMetadata::FileStatus::onProcessing()
 {
     state = FileStatus::State::Processing;
     processing_start_time = now();
+    processing_end_time = {};
+    processed_rows = 0;
 }
 
 void ObjectStorageQueueIFileMetadata::FileStatus::onProcessed()

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -3085,7 +3085,7 @@ def test_failed_commit(started_cluster):
     for _ in range(100):
         if check_failpoint():
             break
-        time.sleep(50)
+        time.sleep(1)
 
     assert check_failpoint()
 

--- a/tests/integration/test_storage_s3_queue/test.py
+++ b/tests/integration/test_storage_s3_queue/test.py
@@ -3048,3 +3048,87 @@ def test_filtering_files(started_cluster, mode):
     ) or node1.contains_in_log(
         f"StorageS3Queue (r.{table_name}): Skipping file {failed_file}: Failed"
     )
+
+
+def test_failed_commit(started_cluster):
+    node = started_cluster.instances["instance"]
+
+    table_name = f"test_failed_commit"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+    files_to_generate = 1
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+        },
+    )
+    total_values = generate_random_files(
+        started_cluster, files_path, files_to_generate, start_ind=0, row_num=2
+    )
+
+    node.query(f"SYSTEM ENABLE FAILPOINT object_storage_queue_fail_commit")
+
+    create_mv(node, table_name, dst_table_name)
+
+    def check_failpoint():
+        return node.contains_in_log(
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 1002. DB::Exception: Failed to commit processed files. (UNKNOWN_EXCEPTION)"
+        )
+
+    for _ in range(100):
+        if check_failpoint():
+            break
+        time.sleep(50)
+
+    assert check_failpoint()
+
+    node.query("SYSTEM FLUSH LOGS")
+    assert 0 == int(
+        node.query(
+            f"SELECT count() FROM system.s3queue_log WHERE table = '{table_name}' and status = 'Processed'"
+        )
+    )
+
+    def get_count():
+        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+    count_failed = int(
+        node.count_in_log(
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 1002. DB::Exception: Failed to commit processed files. (UNKNOWN_EXCEPTION)"
+        )
+    )
+    count = get_count()
+    expected_rows = 2 * count_failed
+    expected_rows_upper = 2 * (
+        count_failed + 2
+    )  # Could get more in between getting 'count_failed' and getting 'count'
+
+    assert expected_rows <= count and count <= expected_rows_upper
+
+    node.query(f"SYSTEM DISABLE FAILPOINT object_storage_queue_fail_commit")
+
+    processed = False
+    for _ in range(20):
+        node.query("SYSTEM FLUSH LOGS")
+        processed = int(
+            node.query(
+                f"SELECT count() FROM system.s3queue_log WHERE table = '{table_name}' and status = 'Processed'"
+            )
+        )
+        if processed == 1:
+            break
+        time.sleep(1)
+
+    assert processed == 1
+    assert 2 == int(
+        node.query(
+            f"SELECT rows_processed FROM system.s3queue_log WHERE table = '{table_name}' and status = 'Processed'"
+        )
+    )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect processed_rows value in system.s3queue_log in case file was retried 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [x] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [x] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
