### PR TITLE
ci/stress: ensure that the distributed sends will be stopped

### DIFF
--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -280,6 +280,10 @@ mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/c
 # NOTE Disable thread fuzzer before server start with data after stress test.
 # In debug build it can take a lot of time.
 unset "${!THREAD_@}"
+# Also disable cannot_allocate_thread_fault_injection_probability, since this
+# will not allow to load tables asynchronously. Anyway the stress tests was
+# running with fault injection.
+rm /etc/clickhouse-server/config.d/cannot_allocate_thread_injection.xml
 
 start_server
 

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -181,9 +181,18 @@ function stop_server()
     # Preserve the pid, since the server can hung after the PID will be deleted.
     pid="$(cat /var/run/clickhouse-server/clickhouse-server.pid)"
 
-    # FIXME: workaround for slow shutdown of Distributed tables (due to sequential tables shutdown)
+    # FIXME: workaround for slow shutdown of Distributed tables (due to
+    # sequential tables shutdown), since flush_on_detach=0 will not help if the
+    # send is already in progress.
+    #
+    # Also we need to retry it due to cannot_allocate_thread_fault_injection_probability.
+    #
     # Refs: https://github.com/ClickHouse/ClickHouse/issues/72557
-    clickhouse client -q "SYSTEM STOP DISTRIBUTED SENDS" ||:
+    for i in {1..30}; do
+        if clickhouse client -q "SYSTEM STOP DISTRIBUTED SENDS"; then
+            break
+        fi
+    done
     clickhouse stop --max-tries "$max_tries" --do-not-kill && return
 
     if [ "$check_hang" == true ]

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -185,8 +185,6 @@ function stop_server()
     # sequential tables shutdown), since flush_on_detach=0 will not help if the
     # send is already in progress.
     #
-    # Also we need to retry it due to cannot_allocate_thread_fault_injection_probability.
-    #
     # Refs: https://github.com/ClickHouse/ClickHouse/issues/72557
     for i in {1..30}; do
         if clickhouse client -q "SYSTEM STOP DISTRIBUTED SENDS"; then


### PR DESCRIPTION
It is possible that this query will fail, due to `CANNOT_SCHEDULE_TASK` (due to `cannot_allocate_thread_fault_injection_probability`) and increasing it - will not help (even 30 retries failed with async load), so let's simply disable this fault injections for the last server (the one that ensures that the tables are correct after stressing)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/72558