### PR TITLE
Add -n flag to clickhouse client

### DIFF
--- a/tests/queries/0_stateless/02473_optimize_old_parts.sh
+++ b/tests/queries/0_stateless/02473_optimize_old_parts.sh
@@ -68,7 +68,7 @@ SELECT (now() - modification_time) > 5 FROM system.parts WHERE database = curren
 DROP TABLE test_with_merge;"
 
 # Partition 2 will ignore max_bytes_to_merge_at_max_space_in_pool
-$CLICKHOUSE_CLIENT -mq "
+$CLICKHOUSE_CLIENT -nmq "
 SELECT 'With merge partition only and disable limit';
 
 CREATE TABLE test_with_merge_limit (i Int64) ENGINE = MergeTree ORDER BY i PARTITION BY i
@@ -80,7 +80,7 @@ INSERT INTO test_with_merge_limit SELECT 2 SETTINGS insert_deduplicate = 0;"
 wait_for_number_of_parts 'test_with_merge_limit' 2 100
 
 # Partition 2 will limit by max_bytes_to_merge_at_max_space_in_pool
-$CLICKHOUSE_CLIENT -mq "
+$CLICKHOUSE_CLIENT -nmq "
 DROP TABLE test_with_merge_limit;
 
 SELECT 'With merge partition only and enable limit';
@@ -93,5 +93,5 @@ INSERT INTO test_with_merge_limit SELECT 2 SETTINGS insert_deduplicate = 0;"
 
 wait_for_number_of_parts 'test_with_merge_limit' 3 100
 
-$CLICKHOUSE_CLIENT -mq "
+$CLICKHOUSE_CLIENT -nmq "
 DROP TABLE test_with_merge_limit;"

--- a/tests/queries/0_stateless/02676_optimize_old_parts_replicated.sh
+++ b/tests/queries/0_stateless/02676_optimize_old_parts_replicated.sh
@@ -70,7 +70,7 @@ SELECT (now() - modification_time) > 5 FROM system.parts WHERE database = curren
 DROP TABLE test_replicated;"
 
 # Partition 2 will ignore max_bytes_to_merge_at_max_space_in_pool
-$CLICKHOUSE_CLIENT -mq "
+$CLICKHOUSE_CLIENT -nmq "
 SELECT 'With merge replicated partition only and disable limit';
 
 CREATE TABLE test_replicated_limit (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only_limit', 'node')  ORDER BY i
@@ -84,7 +84,7 @@ INSERT INTO test_replicated_limit SELECT 2 SETTINGS insert_deduplicate = 0;"
 wait_for_number_of_parts 'test_replicated_limit' 2 100
 
 # Partition 2 will limit by max_bytes_to_merge_at_max_space_in_pool
-$CLICKHOUSE_CLIENT -mq "
+$CLICKHOUSE_CLIENT -nmq "
 DROP TABLE test_replicated_limit SYNC;
 
 SELECT 'With merge replicated partition only and enable limit';
@@ -99,5 +99,5 @@ INSERT INTO test_replicated_limit SELECT 2 SETTINGS insert_deduplicate = 0;"
 
 wait_for_number_of_parts 'test_replicated_limit' 3 100
 
-$CLICKHOUSE_CLIENT -mq "
+$CLICKHOUSE_CLIENT -nmq "
 DROP TABLE test_replicated_limit;"


### PR DESCRIPTION
See the errors [here](https://s3.amazonaws.com/clickhouse-test-reports/75116/dce48485b93e4f691ac0d167439fc5232e7c3fd2/stateless_tests__asan__[2_4].html)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
