### PR TITLE
Fix flaky stress tests due to RESTORE of V0-format tables

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreePartInfo.cpp
@@ -182,7 +182,11 @@ String MergeTreePartInfo::getPartNameAndCheckFormat(MergeTreeDataFormatVersion f
         return getPartNameV1();
 
     /// We cannot just call getPartNameV0 because it requires extra arguments, but at least we can warn about it.
-    chassert(false);  /// Catch it in CI. Feel free to remove this line.
+    /// It is tempting to add chassert(false) here to catch it in CI.
+    /// But it turns out that in stress tests a common database could be used by multiple tests, and there are tests that create
+    /// tables with V0 format using `allow_deprecated_syntax_for_merge_tree` and tests that do BACKUP are RESOURCE of a db containing
+    /// such tables. Current implementation of RESTORE do not support V0 in MergeTreeData::restorePartFromBackup().
+    /// So this creates flaky combination of tests.
     throw Exception(ErrorCodes::BAD_DATA_PART_NAME, "Trying to get part name in new format for old format version. "
                     "Either some new feature is incompatible with deprecated *MergeTree definition syntax or it's a bug.");
 }


### PR DESCRIPTION
In stress tests, we have a common database used for multiple tests (I don't know why). Test `00584_view_union_all.sql` have created table in old format:
```
set allow_deprecated_syntax_for_merge_tree=1;
CREATE TABLE Test_00584 (
    createdDate Date,
    str String,
    key Enum8('A' = 0, 'B' = 1, 'ALL' = 2),
    a Int64
)
ENGINE = MergeTree(createdDate, str, 8192);

INSERT INTO Test_00584 VALUES ('2000-01-01', 'hello', 'A', 123);
```
then test `03001_backup_matview_after_modify_query` makes the following on the same database:
```
BACKUP DATABASE test_9 TO Disk('backups', 'test_9_backup')
RESTORE DATABASE test_9 AS test_9_2 FROM Disk('backups', 'test_9_backup')
```

The current implementation of RESTORE does not support such an old table. It calls `MergeTreePartInfo::getPartNameAndCheckFormat` directly from `MergeTreeData::restorePartFromBackup`. This leads to `chassert(false);` which triggered the issue in CI. Afterwards `BAD_DATA_PART_NAME` should have been thrown, but it did not happen.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
