### PR TITLE
Adding TLS Log system table.

### DIFF
--- a/docs/en/operations/system-tables/tls_log.md
+++ b/docs/en/operations/system-tables/tls_log.md
@@ -1,0 +1,48 @@
+---
+slug: /en/operations/system-tables/tls_log
+---
+# tls_log
+
+Contains information about client certificates received by ClickHouse server as part of TLS handshake (both valid and invalid). Useful for observability of cert-based authentication.
+
+Columns:
+
+- `type` ([Enum8](../../sql-reference/data-types/enum.md)) — Certificate validation result. Possible values:
+    - `failure` — Certificate was invalid.
+    - `success` — Certificate was validated successfully.
+- `event_date` ([Date](../../sql-reference/data-types/date.md)) — Connection date.
+- `event_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — Connection time.
+- `event_time_microseconds` ([DateTime64](../../sql-reference/data-types/datetime64.md)) — Connection time with microseconds precision.
+- `certificate_subjects` ([Array](../../sql-reference/data-types/array.md)([LowCardinality(String)](../../sql-reference/data-types/lowcardinality.md))) - The list of certificate [subjects](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6) stored in CN or SAN fields of the certificate.
+- `certificate_not_before` ([DateTime](../../sql-reference/data-types/datetime.md)) — date and time when certificate becomes valid ([rfc](https://datatracker.ietf.org/doc/html/rfc6487#section-4.6.1))
+- `certificate_not_after` ([DateTime](../../sql-reference/data-types/datetime.md)) — date and time when certificate expires ([rfc](https://datatracker.ietf.org/doc/html/rfc6487#section-4.6.2))
+- `certificate_serial` [LowCardinality(String)](../../sql-reference/data-types/lowcardinality.md) — [serial number](https://datatracker.ietf.org/doc/html/rfc6487#section-4.2) of the certificate.
+- `certificate_issuer` [LowCardinality(String)](../../sql-reference/data-types/lowcardinality.md) — [Certificate Authority](https://datatracker.ietf.org/doc/html/rfc6487#section-4.4) that issued the certificate.
+- `user` ([String](../../sql-reference/data-types/string.md)) — User name.
+- `failure_reason` ([String](../../sql-reference/data-types/string.md)) — The exception message containing the reason for certificate validation failure.
+- `failure_count` ([UInt64](../../sql-reference/data-types/int-uint.md)) — Count of failures since the last event for this certificate.
+
+**Example**
+
+Query:
+
+``` sql
+SELECT * FROM system.tls_log LIMIT 1 FORMAT Vertical;
+```
+
+Result:
+
+``` text
+Row 1:
+──────
+type:                    success
+event_date:              2024-10-15
+event_time:              2024-10-15 10:15:26
+event_time_microseconds: 2024-10-15 10:15:26.081684
+certificate_subjects:    ['CN:client1']
+certificate_not_before:  2024-06-06 12:48:46
+certificate_not_after:   2034-06-04 12:48:46
+certificate_serial:      05F10C67567FE30795D77AF2540F6AC8D4CF2468
+certificate_issuer:      /C=RU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=ca
+failure_reason:
+```

--- a/docs/ru/operations/system-tables/tls_log.md
+++ b/docs/ru/operations/system-tables/tls_log.md
@@ -1,0 +1,47 @@
+---
+slug: /ru/operations/system-tables/tls_log
+---
+# system.tls_log {#system_tables-tls_log}
+
+Содержит информацию о клиентских сертификатах, полученных сервером ClickHouse в ходе TLS-рукопожатия (как действительных, так и недействительных). Полезно для наблюдения за аутентификацией на основе сертификатов.
+
+Столбцы:
+
+- `type` ([Enum8](../../sql-reference/data-types/enum.md)) — Результат проверки сертификата. Возможные значения:
+    - `failure` — Сертификат недействителен.
+    - `success` — Сертификат успешно проверен.
+- `event_date` ([Date](../../sql-reference/data-types/date.md)) — Дата подключения.
+- `event_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — Время подключения.
+- `event_time_microseconds` ([DateTime64](../../sql-reference/data-types/datetime64.md)) — Время подключения с точностью до микросекунд.
+- `certificate_subjects` ([Array](../../sql-reference/data-types/array.md)([LowCardinality(String)](../../sql-reference/data-types/lowcardinality.md))) — Список [субъектов](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6) сертификата, сохраненных в полях CN или SAN сертификата.
+- `certificate_not_before` ([DateTime](../../sql-reference/data-types/datetime.md)) — Дата и время, когда сертификат становится действительным ([rfc](https://datatracker.ietf.org/doc/html/rfc6487#section-4.6.1))
+- `certificate_not_after` ([DateTime](../../sql-reference/data-types/datetime.md)) — Дата и время, когда сертификат перестает действовать ([rfc](https://datatracker.ietf.org/doc/html/rfc6487#section-4.6.2))
+- `certificate_serial` [LowCardinality(String)](../../sql-reference/data-types/lowcardinality.md) — [Серийный номер](https://datatracker.ietf.org/doc/html/rfc6487#section-4.2) сертификата.
+- `certificate_issuer` [LowCardinality(String)](../../sql-reference/data-types/lowcardinality.md) — [CA](https://datatracker.ietf.org/doc/html/rfc6487#section-4.4), который выдал сертификат.
+- `user` ([String](../../sql-reference/data-types/string.md)) — Имя пользователя.
+- `failure_reason` ([String](../../sql-reference/data-types/string.md)) — Сообщение об ошибке, возникшее при проверке сертификата.
+- `failure_count` ([UInt64](../../sql-reference/data-types/int-uint.md)) — Количество ошибок с момента последнего события для этого сертификата.
+
+**Пример**
+
+Запрос:
+
+``` sql
+SELECT * FROM system.tls_log LIMIT 1 FORMAT Vertical;
+```
+
+Результат:
+``` text
+Row 1:
+──────
+type:                    success
+event_date:              2024-10-15
+event_time:              2024-10-15 10:15:26
+event_time_microseconds: 2024-10-15 10:15:26.081684
+certificate_subjects:    ['CN:client1']
+certificate_not_before:  2024-06-06 12:48:46
+certificate_not_after:   2034-06-04 12:48:46
+certificate_serial:      05F10C67567FE30795D77AF2540F6AC8D4CF2468
+certificate_issuer:      /C=RU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=ca
+failure_reason:
+```

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1368,6 +1368,16 @@
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </s3queue_log>
 
+    <!-- Log of client certificates seen by the server
+        (only if built with openssl support)
+    -->
+    <tls_log>
+        <database>system</database>
+        <table>tls_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </tls_log>
+
     <!-- Blob storage object operations log.
     -->
     <blob_storage_log>

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -10,6 +10,7 @@
 #include <Interpreters/QueryThreadLog.h>
 #include <Interpreters/QueryViewsLog.h>
 #include <Interpreters/SessionLog.h>
+#include <Interpreters/TLSLog.h>
 #include <Interpreters/TextLog.h>
 #include <Interpreters/TraceLog.h>
 #include <Interpreters/FilesystemCacheLog.h>
@@ -265,6 +266,7 @@ void SystemLogBase<LogElement>::notifyFlush(Index expected_flushed_index, bool s
 template <typename LogElement>
 void SystemLogBase<LogElement>::flush(Index expected_flushed_index, bool should_prepare_tables_anyway)
 {
+    onFlushNotification();
     queue->waitFlush(expected_flushed_index, should_prepare_tables_anyway);
 }
 

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -31,7 +31,8 @@
     M(AsynchronousInsertLogElement) \
     M(BackupLogElement) \
     M(BlobStorageLogElement) \
-    M(QueryMetricLogElement)
+    M(QueryMetricLogElement) \
+    M(TLSLogElement)
 
 namespace Poco
 {
@@ -216,6 +217,8 @@ public:
     static consteval bool shouldTurnOffLogger() { return false; }
 
 protected:
+    // Allow subclasses to flush accumulated data
+    virtual void onFlushNotification() {}
     void stopFlushThread() final;
 
     std::shared_ptr<SystemLogQueue<LogElement>> queue;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -88,6 +88,7 @@
 #include <Interpreters/DDLTask.h>
 #include <Interpreters/Session.h>
 #include <Interpreters/TraceCollector.h>
+#include <Interpreters/TLSLog.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
 #include <IO/UncompressedCache.h>
@@ -4628,6 +4629,15 @@ std::shared_ptr<SessionLog> Context::getSessionLog() const
     return shared->system_logs->session_log;
 }
 
+std::shared_ptr<TLSLog> Context::getTLSLog() const
+{
+    SharedLockGuard lock(shared->mutex);
+
+    if (!shared->system_logs)
+        return {};
+
+    return shared->system_logs->tls_log;
+}
 
 std::shared_ptr<ZooKeeperLog> Context::getZooKeeperLog() const
 {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -117,6 +117,7 @@ class AsynchronousMetricLog;
 class OpenTelemetrySpanLog;
 class ZooKeeperLog;
 class SessionLog;
+class TLSLog;
 class BackupsWorker;
 class TransactionsInfoLog;
 class ProcessorsProfileLog;
@@ -1197,6 +1198,7 @@ public:
     std::shared_ptr<OpenTelemetrySpanLog> getOpenTelemetrySpanLog() const;
     std::shared_ptr<ZooKeeperLog> getZooKeeperLog() const;
     std::shared_ptr<SessionLog> getSessionLog() const;
+    std::shared_ptr<TLSLog> getTLSLog() const;
     std::shared_ptr<TransactionsInfoLog> getTransactionsInfoLog() const;
     std::shared_ptr<ProcessorsProfileLog> getProcessorsProfileLog() const;
     std::shared_ptr<FilesystemCacheLog> getFilesystemCacheLog() const;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -30,6 +30,7 @@
 #include <Interpreters/TraceLog.h>
 #include <Interpreters/TextLog.h>
 #include <Interpreters/MetricLog.h>
+#include <Interpreters/TLSLog.h>
 #include <Interpreters/AsynchronousMetricLog.h>
 #include <Interpreters/OpenTelemetrySpanLog.h>
 #include <Interpreters/ZooKeeperLog.h>

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -36,6 +36,7 @@
 #include <Interpreters/TraceLog.h>
 #include <Interpreters/TransactionsInfoLog.h>
 #include <Interpreters/ZooKeeperLog.h>
+#include <Interpreters/TLSLog.h>
 #include <IO/WriteHelpers.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -31,6 +31,7 @@
     M(BackupLog,             backup_log,           "Contains logging entries with the information about BACKUP and RESTORE operations.") \
     M(BlobStorageLog,        blob_storage_log,     "Contains logging entries with information about various blob storage operations such as uploads and deletes.") \
     M(QueryMetricLog,        query_metric_log,     "Contains history of memory and metric values from table system.events for individual queries, periodically flushed to disk.") \
+    M(TLSLog,                tls_log,               "Contains information about TLS Certificates used for authentication.") \
 
 
 namespace DB

--- a/src/Interpreters/TLSLog.cpp
+++ b/src/Interpreters/TLSLog.cpp
@@ -1,0 +1,234 @@
+#include <Interpreters/TLSLog.h>
+
+#include <chrono>
+#include <memory>
+#include <Columns/ColumnArray.h>
+#include <Common/DateLUT.h>
+#include <Common/Exception.h>
+#include <Common/SipHash.h>
+#include <Core/NamesAndTypes.h>
+#include <Core/Types.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeEnum.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/SystemLog.h>
+#include <Poco/Delegate.h>
+#include <base/scope_guard.h>
+#if USE_SSL
+#include <Poco/Net/X509Certificate.h>
+#include <Poco/Net/SSLManager.h>
+#include <Access/Common/SSLCertificateSubjects.h>
+#include <Poco/Net/VerificationErrorArgs.h>
+#endif
+
+namespace
+{
+using namespace DB;
+
+void fillColumnArray(const Strings & data, IColumn & column)
+{
+    auto & array = typeid_cast<ColumnArray &>(column);
+    size_t size = 0;
+    auto & data_col = array.getData();
+    for (const auto & name : data)
+    {
+        data_col.insertData(name.data(), name.size());
+        ++size;
+    }
+    auto & offsets = array.getOffsets();
+    offsets.push_back(offsets.back() + size);
+}
+
+}
+
+namespace DB
+{
+
+#if USE_SSL
+UInt128 X509CertificateHash(const Poco::Net::X509Certificate &cert)
+{
+    BIO * bio = BIO_new(BIO_s_mem());
+    SCOPE_EXIT({ BIO_free(bio); });
+
+    PEM_write_bio_X509(bio, cert.certificate());
+
+    char * cert_data = nullptr;
+    auto size = BIO_get_mem_data(bio, &cert_data);
+    return sipHash128(cert_data, size);
+}
+#endif
+
+
+TLSLogElement::TLSLogElement(const String &failure_reason_, uint64_t failure_count_)
+    : type(failure_reason_.empty() ? TLSLogElementType::SESSION_SUCCESS : TLSLogElementType::SESSION_FAILURE)
+    , event_time(std::chrono::system_clock::now())
+    , failure_reason(failure_reason_)
+    , failure_count(failure_count_)
+{
+}
+
+#if USE_SSL
+void TLSLog::onInvalidCertificate(const void *, Poco::Net::VerificationErrorArgs & errorCert)
+{
+    // Don't put every certificate failure into the log to save disk space and protect from misbehaving clients.
+    // Instead, produce a log per certificate hash once in `TLSLogErrorFlushIntervalSeconds` seconds.
+    std::unique_lock lock{tls_failure_stats_mutex};
+    const UInt128 &cert_hash = X509CertificateHash(errorCert.certificate());
+    if (!tls_failure_stats.contains(cert_hash))
+        tls_failure_stats[cert_hash] = std::make_unique<CertStats>(errorCert.certificate());
+
+    auto &stats = tls_failure_stats[cert_hash];
+    ++stats->count;
+    stats->last_error_message = errorCert.errorMessage();
+    stats->last_error_time = std::chrono::system_clock::now();
+}
+
+void TLSLog::logTLSConnection(const Poco::Net::X509Certificate &tls_certificate, const String &user)
+{
+    add(TLSLogElement(tls_certificate, user, std::chrono::system_clock::now()));
+}
+
+void TLSLog::onFlushNotification()
+{
+    try
+    {
+        auto tls_failure_stats_tmp = decltype(tls_failure_stats){};
+        {
+            std::unique_lock lock{tls_failure_stats_mutex};
+            tls_failure_stats_tmp = std::move(tls_failure_stats);
+            tls_failure_stats.clear();
+        }
+        for (auto &cert_stat : tls_failure_stats_tmp)
+        {
+            auto &stat = cert_stat.second;
+            add(TLSLogElement(*stat->certificate, "", stat->last_error_time, stat->last_error_message, stat->count));
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
+TLSLog::CertStats::CertStats(const Poco::Net::X509Certificate &tls_certificate) :
+    certificate(std::make_unique<Poco::Net::X509Certificate>(tls_certificate))
+{
+
+}
+#endif
+
+TLSLog::TLSLog(ContextPtr context_, const SystemLogSettings & settings) : SystemLog<TLSLogElement>(context_, settings)
+{
+#if USE_SSL
+    Poco::Net::SSLManager::instance().ServerVerificationError += Poco::Delegate<TLSLog, Poco::Net::VerificationErrorArgs>(this, &TLSLog::onInvalidCertificate);
+#endif
+}
+
+TLSLog::~TLSLog()
+{
+#if USE_SSL
+    Poco::Net::SSLManager::instance().ServerVerificationError -= Poco::Delegate<TLSLog, Poco::Net::VerificationErrorArgs>(this, &TLSLog::onInvalidCertificate);
+#endif
+}
+
+#if USE_SSL
+TLSLogElement::TLSLogElement(const Poco::Net::X509Certificate &tls_certificate, const String &user_, const TimePoint &event_time_, const String &failure_reason_, uint64_t failure_count_)
+    : TLSLogElement(failure_reason_, failure_count_)
+{
+    event_time = event_time_;
+    certificate_validity_period = {tls_certificate.validFrom().timestamp().epochTime(), tls_certificate.expiresOn().timestamp().epochTime()};
+    using SubjectType = SSLCertificateSubjects::Type;
+    SSLCertificateSubjects cert_subjects = extractSSLCertificateSubjects(tls_certificate);
+    for (auto subject_type : {SubjectType::CN, SubjectType::SAN})
+        for (const auto & subject : cert_subjects.at(subject_type))
+            certificate_subjects.push_back(toString(subject_type) + ":" + subject);
+
+    user = user_;
+    certificate_serial = tls_certificate.serialNumber();
+    certificate_issuer = tls_certificate.issuerName();
+}
+#endif
+
+NamesAndTypesList TLSLogElement::getNamesAndTypes()
+{
+    auto event_type = std::make_shared<DataTypeEnum8>(
+        DataTypeEnum8::Values
+        {
+            {"failure",           static_cast<Int8>(TLSLogElementType::SESSION_FAILURE)},
+            {"success",           static_cast<Int8>(TLSLogElementType::SESSION_SUCCESS)},
+        });
+
+    auto lc_string_datatype = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
+
+    return
+    {
+        {"type", std::move(event_type)},
+        {"event_date", std::make_shared<DataTypeDate>()},
+        {"event_time", std::make_shared<DataTypeDateTime>()},
+        {"event_time_microseconds", std::make_shared<DataTypeDateTime64>(6)},
+        {"certificate_subjects", std::make_shared<DataTypeArray>(lc_string_datatype)},
+        {"certificate_not_before", std::make_shared<DataTypeDateTime>()},
+        {"certificate_not_after", std::make_shared<DataTypeDateTime>()},
+        {"certificate_serial", lc_string_datatype},
+        {"certificate_issuer", lc_string_datatype},
+        {"user", lc_string_datatype},
+        {"failure_reason", std::make_shared<DataTypeString>()},
+        {"failure_count", std::make_shared<DataTypeUInt64>()},
+    };
+}
+
+ColumnsDescription TLSLogElement::getColumnsDescription()
+{
+    auto event_type = std::make_shared<DataTypeEnum8>(
+    DataTypeEnum8::Values
+    {
+        {"failure",           static_cast<Int8>(TLSLogElementType::SESSION_FAILURE)},
+        {"success",           static_cast<Int8>(TLSLogElementType::SESSION_SUCCESS)},
+    });
+
+    auto lc_string_datatype = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
+
+    return ColumnsDescription
+    {
+        {"type", std::move(event_type), "Type of event, can either be FAILURE or SUCCESS."},
+        {"event_date", std::make_shared<DataTypeDate>(), "Date of the event."},
+        {"event_time", std::make_shared<DataTypeDateTime>(), "Time of the event"},
+        {"event_time_microseconds", std::make_shared<DataTypeDateTime64>(6), "Time of the event in microseconds."},
+        {"certificate_subjects", std::make_shared<DataTypeArray>(lc_string_datatype), "The list of subjects in the certificate."},
+        {"certificate_not_before", std::make_shared<DataTypeDateTime>(), "Certificate is valid only after this time."},
+        {"certificate_not_after", std::make_shared<DataTypeDateTime>(), "Certificate is not valid after this time."},
+        {"certificate_serial", lc_string_datatype, "Certificate serial number."},
+        {"certificate_issuer", lc_string_datatype, "Certificate issuer."},
+        {"user", lc_string_datatype, "Connecting user."},
+        {"failure_reason", std::make_shared<DataTypeString>(), "In case type of event is FAILURE, provides the motive of failure."},
+        {"failure_count", std::make_shared<DataTypeUInt64>(), "Number of times the error repeated since the last event"},
+    };
+}
+
+
+void TLSLogElement::appendToBlock(MutableColumns & columns) const
+{
+    size_t i = 0;
+
+    time_t event_time_seconds = timeInSeconds(event_time);
+    Decimal64 event_time_microseconds = timeInMicroseconds(event_time);
+    columns[i++]->insert(type);
+    columns[i++]->insert(static_cast<DayNum>(DateLUT::instance().toDayNum(event_time_seconds).toUnderType()));
+    columns[i++]->insert(event_time_seconds);
+    columns[i++]->insert(event_time_microseconds);
+    fillColumnArray(certificate_subjects, *columns[i++]);
+    columns[i++]->insert(certificate_validity_period.first);
+    columns[i++]->insert(certificate_validity_period.second);
+    columns[i++]->insert(certificate_serial);
+    columns[i++]->insert(certificate_issuer);
+    columns[i++]->insert(user);
+    columns[i++]->insertData(failure_reason.data(), failure_reason.length());
+    columns[i++]->insert(failure_count);
+}
+
+}

--- a/src/Interpreters/TLSLog.h
+++ b/src/Interpreters/TLSLog.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <Interpreters/SystemLog.h>
+#include <Core/NamesAndTypes.h>
+#include <Core/NamesAndAliases.h>
+#include <Columns/IColumn.h>
+#include <Storages/ColumnsDescription.h>
+#include "base/extended_types.h"
+
+namespace Poco
+{
+namespace Net
+{
+class Socket;
+class X509Certificate;
+class VerificationErrorArgs;
+}
+}
+
+namespace DB
+{
+
+
+constexpr int64_t TLSLogErrorFlushIntervalSeconds = 10;
+enum class TLSLogElementType : int8_t
+{
+    SESSION_FAILURE = 0,
+    SESSION_SUCCESS = 1,
+};
+
+/**
+A struct which will be inserted as row into tls_log table.
+*/
+struct TLSLogElement
+{
+    using Type = TLSLogElementType;
+    using TimePoint = std::chrono::system_clock::time_point;
+
+    explicit TLSLogElement(const String &failure_reason = "", uint64_t failure_count = 0);
+#if USE_SSL
+    explicit TLSLogElement(const Poco::Net::X509Certificate &tls_certificate, const String &user, const TimePoint &event_time, const String &failure_reason = "", uint64_t failure_count = 0);
+#endif
+
+    TLSLogElementType type;
+    // time_t event_time{};
+    // Decimal64 event_time_microseconds{};
+    TimePoint event_time;
+    Strings certificate_subjects;
+    std::pair<time_t, time_t> certificate_validity_period;
+    String certificate_serial;
+    String certificate_issuer;
+    String user;
+    String failure_reason;
+    uint64_t failure_count = 0;
+
+    static std::string name() { return "TLSLog"; }
+
+    static NamesAndTypesList getNamesAndTypes();
+    static NamesAndAliases getNamesAndAliases() { return {}; }
+    static ColumnsDescription getColumnsDescription();
+    static const char * getCustomColumnList() { return nullptr; }
+
+    void appendToBlock(MutableColumns & columns) const;
+};
+
+/** TLSLog contains information about client certificates received
+by ClickHouse server during TLS handshakes.*/
+class TLSLog : public SystemLog<TLSLogElement>
+{
+    struct CertStats
+    {
+        explicit CertStats(const Poco::Net::X509Certificate &);
+        std::unique_ptr<Poco::Net::X509Certificate> certificate;
+        int64_t count = 0;
+        String last_error_message;
+        TLSLogElement::TimePoint last_error_time;
+    };
+
+    using SystemLog<TLSLogElement>::SystemLog;
+public:
+    explicit TLSLog(ContextPtr context_, const SystemLogSettings & settings);
+    ~TLSLog() override;
+#if USE_SSL
+    void logTLSConnection(const Poco::Net::X509Certificate &tls_certificate, const String &user);
+    void onInvalidCertificate(const void *, Poco::Net::VerificationErrorArgs & errorCert);
+private:
+    void onFlushNotification() override;
+    std::unordered_map<UInt128, std::unique_ptr<CertStats>> tls_failure_stats;
+    std::mutex tls_failure_stats_mutex;
+#endif
+};
+
+}

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -13,6 +13,8 @@
 #include <Poco/Net/NetException.h>
 
 #include <Common/logger_useful.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/TLSLog.h>
 
 #if USE_SSL
 #include <Poco/Net/SecureStreamSocketImpl.h>

--- a/src/Server/HTTP/authenticateUserByHTTP.cpp
+++ b/src/Server/HTTP/authenticateUserByHTTP.cpp
@@ -12,6 +12,7 @@
 #include <Server/HTTP/HTTPServerResponse.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/Session.h>
+#include <Interpreters/TLSLog.h>
 
 #include <Poco/Net/HTTPBasicCredentials.h>
 
@@ -104,7 +105,11 @@ bool authenticateUserByHTTP(
             throwMultipleAuthenticationMethods("SSL certificate authentication", "authentication via parameters");
 
         if (request.havePeerCertificate())
+        {
             certificate_subjects = extractSSLCertificateSubjects(request.peerCertificate());
+            if (auto tls_log = global_context->getTLSLog(); tls_log != nullptr)
+                tls_log->logTLSConnection(request.peerCertificate(), user);
+        }
 
         if (certificate_subjects.empty())
             throw Exception(ErrorCodes::AUTHENTICATION_FAILED,

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -32,6 +32,7 @@
 #include <Interpreters/Squashing.h>
 #include <Interpreters/TablesStatus.h>
 #include <Interpreters/executeQuery.h>
+#include <Interpreters/TLSLog.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Server/TCPServer.h>
 #include <Storages/MergeTree/MergeTreeDataPartUUID.h>
@@ -1717,6 +1718,8 @@ void TCPHandler::receiveHello()
         Poco::Net::SecureStreamSocket secure_socket(socket());
         if (secure_socket.havePeerCertificate())
         {
+            if (auto tls_log = server.context()->getTLSLog(); tls_log != nullptr)
+                tls_log->logTLSConnection(secure_socket.peerCertificate(), user);
             try
             {
                 session->authenticate(

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
@@ -13,6 +13,7 @@
     <trace_log remove="remove"/>
     <asynchronous_metric_log remove="remove" />
     <session_log remove="remove" />
+    <tls_log remove="remove" />
     <part_log remove="remove" />
     <crash_log remove="remove" />
     <opentelemetry_span_log remove="remove" />

--- a/tests/integration/test_memory_limit/configs/async_metrics_no.xml
+++ b/tests/integration/test_memory_limit/configs/async_metrics_no.xml
@@ -14,6 +14,7 @@
     <trace_log remove="remove"/>
     <asynchronous_metric_log remove="remove" />
     <session_log remove="remove" />
+    <tls_log remove="remove" />
     <part_log remove="remove" />
     <crash_log remove="remove" />
     <opentelemetry_span_log remove="remove" />

--- a/tests/integration/test_ssl_cert_authentication/configs/ssl_config.xml
+++ b/tests/integration/test_ssl_cert_authentication/configs/ssl_config.xml
@@ -1,4 +1,10 @@
 <clickhouse>
+    <tls_log>
+        <database>system</database>
+        <table>tls_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </tls_log>
     <!-- HTTP API with TLS (HTTPS).
          You have to configure certificate to enable this interface.
          See the openSSL section below.
@@ -19,7 +25,6 @@
             <caConfig>/etc/clickhouse-server/config.d/ca-cert.pem</caConfig>
             <verificationMode>relaxed</verificationMode>
         </server>
-
         <client> <!-- Used for connecting to https dictionary source and secured Zookeeper communication -->
             <loadDefaultCAFile>true</loadDefaultCAFile>
             <cacheSessions>true</cacheSessions>

--- a/tests/performance/scripts/config/config.d/zzz-perf-comparison-tweaks-config.xml
+++ b/tests/performance/scripts/config/config.d/zzz-perf-comparison-tweaks-config.xml
@@ -15,6 +15,7 @@
     <part_log remove="remove"/>
     <opentelemetry_span_log remove="remove"/>
     <session_log remove="remove"/>
+    <tls_log remove="remove"/>
 
     <uncompressed_cache_size>1000000000</uncompressed_cache_size>
 


### PR DESCRIPTION
system.tls_log contains information about client certificates received by ClickHouse server during TLS handshakes. Useful for improving observability of certificate-based authentication.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added a new table system.tls_log to improve observability of certificates used by clients.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

#### CI Settings (Only check the boxes if you know what you are doing)

All builds in Builds_1 and Builds_2 stages are always mandatory and will run independently of the checks below:
- [ ] <!---ci_include_stateless--> Only: Stateless tests
- [ ] <!---ci_include_integration--> Only: Integration tests
- [ ] <!---ci_include_performance--> Only: Performance tests
---
- [ ] <!---ci_exclude_style--> Skip: Style check
- [ ] <!---ci_exclude_fast--> Skip: Fast test
---
- [ ] <!---woolen_wolfdog--> Run all checks ignoring all possible failures (Resource-intensive. All test jobs execute in parallel).
- [ ] <!---no_ci_cache--> Disable CI cache
