### PR TITLE
Do not truncate the SQLite int to 32 bit

### DIFF
--- a/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
+++ b/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
@@ -31,13 +31,18 @@ static DataTypePtr convertSQLiteDataType(String type)
     DataTypePtr res;
     type = Poco::toLower(type);
 
+    /// The SQLite columns get the INTEGER affinity if the type name contains "int". This means variable-length integers up to 8 bytes. The bit width is not really enforced even
+    /// in a STRICT table, so in general we should treat these columns as Int64. Besides that, we allow some common fixed-width int specifiers for applications to select a 
+    /// particular width, even though it's not enforced in any way by SQLite itself.
+    /// Docs: https://www.sqlite.org/datatype3.html
+    /// The most insane quote from there: Note that a declared type of "FLOATING POINT" would give INTEGER affinity, not REAL affinity, due to the "INT" at the end of "POINT". 
     if (type == "tinyint")
         res = std::make_shared<DataTypeInt8>();
-    else if (type == "smallint")
+    else if (type == "smallint" || type == "int2")
         res = std::make_shared<DataTypeInt16>();
-    else if ((type.starts_with("int") && type != "int8") || type == "mediumint")
+    else if (type == "mediumint" || type == "int4")
         res = std::make_shared<DataTypeInt32>();
-    else if (type == "bigint" || type == "int8")
+    else if (type.contains("int"))
         res = std::make_shared<DataTypeInt64>();
     else if (type == "float")
         res = std::make_shared<DataTypeFloat32>();

--- a/tests/queries/0_stateless/01889_sqlite_read_write.reference
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.reference
@@ -7,11 +7,11 @@ table4
 table5
 show creare table:
 CREATE TABLE SQLite.table1\n(\n    `col1` Nullable(String),\n    `col2` Nullable(Int16)\n)\nENGINE = SQLite
-CREATE TABLE SQLite.table2\n(\n    `col1` Nullable(Int32),\n    `col2` Nullable(String)\n)\nENGINE = SQLite
+CREATE TABLE SQLite.table2\n(\n    `col1` Nullable(Int64),\n    `col2` Nullable(String)\n)\nENGINE = SQLite
 describe table:
 col1	Nullable(String)					
 col2	Nullable(Int16)					
-col1	Nullable(Int32)					
+col1	Nullable(Int64)					
 col2	Nullable(String)					
 select *:
 line1	1
@@ -21,7 +21,7 @@ line3	3
 2	text2
 3	text3
 test types
-CREATE TABLE SQLite.table4\n(\n    `a` Nullable(Int32),\n    `b` Nullable(Int32),\n    `c` Nullable(Int8),\n    `d` Nullable(Int16),\n    `e` Nullable(Int32),\n    `f` Nullable(Int64),\n    `g` Nullable(Int32),\n    `h` Nullable(Int64)\n)\nENGINE = SQLite
+CREATE TABLE SQLite.table4\n(\n    `a` Nullable(Int64),\n    `b` Nullable(Int64),\n    `c` Nullable(Int8),\n    `d` Nullable(Int16),\n    `e` Nullable(Int32),\n    `f` Nullable(Int64),\n    `g` Nullable(Int16),\n    `h` Nullable(Int64)\n)\nENGINE = SQLite
 CREATE TABLE SQLite.table5\n(\n    `a` Nullable(String),\n    `b` Nullable(String),\n    `c` Nullable(Float64),\n    `d` Nullable(Float64),\n    `e` Nullable(Float64),\n    `f` Nullable(Float32)\n)\nENGINE = SQLite
 create table engine with table3
 CREATE TABLE default.sqlite_table3\n(\n    `col1` String,\n    `col2` Int32\n)\nENGINE = SQLite
@@ -38,9 +38,9 @@ line3	3
 line4	4
 test schema inference
 col1	Nullable(String)					
-col2	Nullable(Int32)					
+col2	Nullable(Int64)					
 col1	Nullable(String)					
-col2	Nullable(Int32)					
+col2	Nullable(Int64)					
 test path in clickhouse-local
 line1	1
 line2	2


### PR DESCRIPTION
The integer in SQLite is a 8-byte type with variable length storage. When an application specifies "int" or "integer" as a column type, it is not reasonable to assume intent to truncate it to 4 bytes.  The current behavior makes the ClickHouse SQLite integration unusable for timestamps which are normally stored as integer.

The old behavior of truncating to narrower types when the column name explicitly specifies something like 'smallint' is preserved.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not truncate the SQLite integer columns to 4 bytes.


Fixes https://github.com/ClickHouse/ClickHouse/issues/73141