### PR TITLE
Bump black (some distributions have 25 already)

### DIFF
--- a/docker/test/style/requirements.txt
+++ b/docker/test/style/requirements.txt
@@ -3,7 +3,7 @@ aiosignal==1.3.1
 astroid==3.1.0
 async-timeout==4.0.3
 attrs==23.2.0
-black==24.4.2
+black==25.1.0
 boto3==1.34.131
 botocore==1.34.131
 certifi==2024.07.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ profile = "black"
 src_paths = ["src", "tests/ci", "tests/sqllogic", "tests/queries", "tests/integration"]
 
 [tool.black]
-required-version = 24
+required-version = 25
 
 [tool.pylint.SIMILARITIES]
 # due to SQL


### PR DESCRIPTION
Otherwise you need to manually allow 25 version:

    $ black tests/integration/test_merge_tree_s3/test.py
    Oh no! 💥 💔 💥 The required version `24` does not match the running version `25.1.0`!

But, maybe someone will dislike this?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)