### PR TITLE
Miscellaneous change for merges

### DIFF
--- a/src/Processors/Merges/Algorithms/MergedData.cpp
+++ b/src/Processors/Merges/Algorithms/MergedData.cpp
@@ -142,9 +142,11 @@ bool MergedData::hasEnoughRows() const
     {
         size_t merged_bytes = 0;
         for (const auto & column : columns)
+        {
             merged_bytes += column->byteSize();
-        if (merged_bytes >= max_block_size_bytes)
-            return true;
+            if (merged_bytes >= max_block_size_bytes)
+                return true;
+        }
     }
 
     if (!use_average_block_size)

--- a/tests/queries/0_stateless/03286_reverse_sorting_key_final.sql
+++ b/tests/queries/0_stateless/03286_reverse_sorting_key_final.sql
@@ -4,6 +4,9 @@ INSERT INTO t0 (c0.c1) VALUES ([1]), ([2]);
 SELECT 1 FROM t0 FINAL;
 DROP TABLE t0;
 
+-- For consistency of the EXPLAIN output:
+SET allow_prefetched_read_pool_for_remote_filesystem = 0;
+
 -- PartsSplitter should work for reverse keys.
 CREATE TABLE t0(a Int, b Int) Engine=ReplacingMergeTree order by (a desc, b desc) SETTINGS allow_experimental_reverse_key = 1, allow_nullable_key = 1, index_granularity = 8192, index_granularity_bytes = '10Mi';
 INSERT INTO t0 select number, number from numbers(5);
@@ -19,4 +22,3 @@ INSERT INTO t0 select number, number from numbers(5,2);
 set max_threads = 2;
 explain pipeline select * from t0 final SETTINGS enable_vertical_final = 0;
 DROP TABLE t0;
-


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I noticed that calling `byteSize` for every row can be slow, but this change does not address it.