### PR TITLE
Fix bad test `03286_reverse_sorting_key_final`

### DIFF
--- a/tests/queries/0_stateless/03286_reverse_sorting_key_final.sql
+++ b/tests/queries/0_stateless/03286_reverse_sorting_key_final.sql
@@ -4,6 +4,9 @@ INSERT INTO t0 (c0.c1) VALUES ([1]), ([2]);
 SELECT 1 FROM t0 FINAL;
 DROP TABLE t0;
 
+-- For consistency of the EXPLAIN output:
+SET allow_prefetched_read_pool_for_remote_filesystem = 0;
+
 -- PartsSplitter should work for reverse keys.
 CREATE TABLE t0(a Int, b Int) Engine=ReplacingMergeTree order by (a desc, b desc) SETTINGS allow_experimental_reverse_key = 1, allow_nullable_key = 1, index_granularity = 8192, index_granularity_bytes = '10Mi';
 INSERT INTO t0 select number, number from numbers(5);
@@ -19,4 +22,3 @@ INSERT INTO t0 select number, number from numbers(5,2);
 set max_threads = 2;
 explain pipeline select * from t0 final SETTINGS enable_vertical_final = 0;
 DROP TABLE t0;
-


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/75770/13f8edc9c566309921c8607a4d7127cc6ac2c0ad/stateless_tests__release__parallelreplicas__s3_storage_.html