### PR TITLE
Backport #74844 to 25.1: keeper: fix LOGICAL_ERROR when the connection had been terminated before establishing

### DIFF
--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -622,8 +622,8 @@ void KeeperTCPHandler::cancelWriteBuffer() noexcept
 {
     if (compressed_out)
         compressed_out->cancel();
-    chassert(out);
-    out->cancel();
+    if (out)
+        out->cancel();
 }
 
 ReadBuffer & KeeperTCPHandler::getReadBuffer()


### PR DESCRIPTION
Original pull-request https://github.com/ClickHouse/ClickHouse/pull/74844
Cherry-pick pull-request **manual backport**