### PR TITLE
CI: Fix concurrent report update

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -2,7 +2,9 @@ import copy
 import dataclasses
 import datetime
 import json
+import random
 import sys
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -501,65 +503,6 @@ class _ResultS3:
             print("Failed to put non-versioned Result")
         return True
 
-    # @classmethod
-    # def lock(cls, s3_path, level=0):
-    #     env = _Environment.get()
-    #     s3_path_lock = s3_path + f".lock"
-    #     file_path_lock = f"{Settings.TEMP_DIR}/{Path(s3_path_lock).name}"
-    #     assert Shell.check(
-    #         f"echo '''{env.JOB_NAME}''' > {file_path_lock}", verbose=True
-    #     ), "Never"
-    #
-    #     i = 20
-    #     meta = S3.head_object(s3_path_lock)
-    #     while meta:
-    #         locked_by_job = meta.get("Metadata", {"job": ""}).get("job", "")
-    #         if locked_by_job:
-    #             decoded_bytes = base64.b64decode(locked_by_job)
-    #             locked_by_job = decoded_bytes.decode("utf-8")
-    #         print(
-    #             f"WARNING: Failed to acquire lock, meta [{meta}], job [{locked_by_job}] - wait"
-    #         )
-    #         i -= 5
-    #         if i < 0:
-    #             info = f"ERROR: lock acquire failure - unlock forcefully"
-    #             print(info)
-    #             env.add_info(info)
-    #             break
-    #         time.sleep(5)
-    #
-    #     metadata = {"job": Utils.to_base64(env.JOB_NAME)}
-    #     S3.put(
-    #         s3_path=s3_path_lock,
-    #         local_path=file_path_lock,
-    #         metadata=metadata,
-    #         if_none_matched=True,
-    #     )
-    #     time.sleep(1)
-    #     obj = S3.head_object(s3_path_lock)
-    #     if not obj or not obj.has_tags(tags=metadata):
-    #         print(f"WARNING: locked by another job [{obj}]")
-    #         env.add_info("S3 lock file failure")
-    #         cls.lock(s3_path, level=level + 1)
-    #     print("INFO: lock acquired")
-    #
-    # @classmethod
-    # def unlock(cls, s3_path):
-    #     s3_path_lock = s3_path + ".lock"
-    #     env = _Environment.get()
-    #     obj = S3.head_object(s3_path_lock)
-    #     if not obj:
-    #         print("ERROR: lock file is removed")
-    #         assert False  # investigate
-    #     elif not obj.has_tags({"job": Utils.to_base64(env.JOB_NAME)}):
-    #         print("ERROR: lock file was acquired by another job")
-    #         assert False  # investigate
-    #
-    #     if not S3.delete(s3_path_lock):
-    #         print(f"ERROR: File [{s3_path_lock}] delete failure")
-    #     print("INFO: lock released")
-    #     return True
-
     @classmethod
     def upload_result_files_to_s3(
         cls, result: Result, s3_subprefix="", _uploaded_file_link=None
@@ -613,7 +556,7 @@ class _ResultS3:
         prev_status = ""
         new_status = ""
         done = False
-        while attempt < 20:
+        while attempt < 50:
             version = cls.copy_result_from_s3_with_version(
                 Result.file_name_static(workflow_name)
             )
@@ -632,6 +575,9 @@ class _ResultS3:
                 break
             print(f"Attempt [{attempt}] to upload workflow result failed")
             attempt += 1
+            # random delay (0-2s) to reduce contention and minimize race conditions
+            # when multiple concurrent jobs attempt to update the workflow report
+            time.sleep(random.uniform(0, 2))
         assert done
 
         if prev_status != new_status:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
