### PR TITLE
ci: enable kernel.task_delayacct for OSIOWaitMicroseconds

### DIFF
--- a/.github/actions/common_setup/action.yml
+++ b/.github/actions/common_setup/action.yml
@@ -28,13 +28,17 @@ runs:
       run: |
           # to remove every leftovers
           sudo rm -fr "$TEMP_PATH" && mkdir -p "$TEMP_PATH"
+    # https://github.com/google/sanitizers/issues/856
     - name: Tune vm.mmap_rnd_bits for sanitizers
       shell: bash
       run: |
           sudo sysctl vm.mmap_rnd_bits
-          # https://github.com/google/sanitizers/issues/856
-          echo "Tune vm.mmap_rnd_bits for sanitizers"
           sudo sysctl vm.mmap_rnd_bits=28
+    - name: Tune kernel.task_delayacct=1 for OSIOWaitMicroseconds
+      shell: bash
+      run: |
+          sudo sysctl kernel.task_delayacct
+          sudo sysctl kernel.task_delayacct=1
     - name: Avoid relying on internal AWS DNS
       shell: bash
       run: |


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)