### PR TITLE
Fix crap in function `translate`

### DIFF
--- a/src/Functions/translate.cpp
+++ b/src/Functions/translate.cpp
@@ -80,12 +80,14 @@ struct TranslateImpl
             {
                 if (*src <= ascii_upper_bound && map[*src] != ascii_upper_bound + 1)
                 {
-                    *dst++ = map[*src];
+                    *dst = map[*src];
+                    ++dst;
                     ++data_size;
                 }
                 else if (*src > ascii_upper_bound)
                 {
-                    *dst++ = *src;
+                    *dst = *src;
+                    ++dst;
                     ++data_size;
                 }
 
@@ -94,9 +96,13 @@ struct TranslateImpl
 
             /// Technically '\0' can be mapped into other character,
             ///  so we need to process '\0' delimiter separately
-            *dst++ = 0;
-            res_offsets[i] = ++data_size;
+            *dst = 0;
+            ++dst;
+            ++data_size;
+            res_offsets[i] = data_size;
         }
+
+        res_data.resize(data_size);
     }
 
     static void vectorFixed(
@@ -282,7 +288,8 @@ struct TranslateUTF8Impl
 
             /// Technically '\0' can be mapped into other character,
             ///  so we need to process '\0' delimiter separately
-            *dst++ = 0;
+            *dst = 0;
+            ++dst;
 
             ++data_size;
             res_offsets[i] = data_size;
@@ -337,12 +344,7 @@ public:
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of third argument of function {}",
                 arguments[2]->getName(), getName());
 
-        if (isString(arguments[0]))
-            return std::make_shared<DataTypeString>();
-
-        const auto * ptr = checkAndGetDataType<DataTypeFixedString>(arguments[0].get());
-        chassert(ptr);
-        return std::make_shared<DataTypeFixedString>(ptr->getN());
+        return arguments[0];
     }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
@@ -361,9 +363,18 @@ public:
         String map_from = c1_const->getValue<String>();
         String map_to = c2_const->getValue<String>();
 
-        auto map_from_size = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(map_from.data()), map_from.size());
-        auto map_to_size = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(map_to.data()), map_to.size());
-
+        size_t map_from_size;
+        size_t map_to_size;
+        if constexpr (std::is_same_v<Impl, TranslateUTF8Impl>)
+        {
+            map_from_size = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(map_from.data()), map_from.size());
+            map_to_size = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(map_to.data()), map_to.size());
+        }
+        else
+        {
+            map_from_size = map_from.size();
+            map_to_size = map_to.size();
+        }
         if (map_from_size < map_to_size)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument of function {} must not be shorter than the third argument. Size of the second argument: {}, size of the third argument: {}", getName(), map_from.size(), map_to.size());
 

--- a/tests/queries/0_stateless/03354_translate_crap.reference
+++ b/tests/queries/0_stateless/03354_translate_crap.reference
@@ -1,0 +1,1 @@
+1A2BC	String

--- a/tests/queries/0_stateless/03354_translate_crap.sql
+++ b/tests/queries/0_stateless/03354_translate_crap.sql
@@ -1,0 +1,1 @@
+SELECT translate('aAbBcC', 'abc', toFixedString('12', 2)) AS a, toTypeName(a);


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix uninitialized memory read in function `translate`. This closes #75592.
