### PR TITLE
Fix error message during accessing https in case of ClickHouse built without SSL

### DIFF
--- a/src/Common/HTTPConnectionPool.cpp
+++ b/src/Common/HTTPConnectionPool.cpp
@@ -790,7 +790,7 @@ createConnectionPool(ConnectionGroup::Ptr group, std::string host, UInt16 port, 
             group, std::move(host), port, secure, std::move(proxy_configuration));
 #else
         throw Exception(
-            ErrorCodes::SUPPORT_IS_DISABLED, "Inter-server secret support is disabled, because ClickHouse was built without SSL library");
+            ErrorCodes::SUPPORT_IS_DISABLED, "HTTPS support is disabled, because ClickHouse was built without SSL library");
 #endif
     }
     else


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error message during accessing https in case of ClickHouse built without SSL