### PR TITLE
Allow to combine read-only and read-write disks - COW policy

### DIFF
--- a/src/Disks/SingleDiskVolume.h
+++ b/src/Disks/SingleDiskVolume.h
@@ -14,6 +14,8 @@ public:
 
     ReservationPtr reserve(UInt64 bytes) override
     {
+        if (disks[0]->isReadOnly())
+            return {};
         return disks[0]->reserve(bytes);
     }
 

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -81,6 +81,10 @@ private:
 
         bool operator<(const DiskWithSize & rhs) const
         {
+            if (disk->isReadOnly())
+                return true;
+            if (rhs.disk->isReadOnly())
+                return false;
             return free_size < rhs.free_size;
         }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3247,6 +3247,8 @@ void MergeTreeData::dropAllData()
     DataPartsVector all_parts;
     for (auto it = data_parts_by_info.begin(); it != data_parts_by_info.end(); ++it)
     {
+        if ((*it)->isStoredOnReadonlyDisk())
+            continue;
         modifyPartState(it, DataPartState::Deleting);
         all_parts.push_back(*it);
     }
@@ -3309,6 +3311,8 @@ void MergeTreeData::dropAllData()
     for (const auto & disk : getDisks())
     {
         if (disk->isBroken())
+            continue;
+        if (disk->isReadOnly())
             continue;
 
         /// It can naturally happen if we cannot drop table from the first time

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7731,7 +7731,6 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::cloneAn
     String tmp_dst_part_name = tmp_part_prefix + dst_part_name;
     auto temporary_directory_lock = getTemporaryPartDirectoryHolder(tmp_dst_part_name);
 
-    auto reservation = src_part->getDataPartStorage().reserve(src_part->getBytesOnDisk());
     auto src_part_storage = src_part->getDataPartStoragePtr();
 
     scope_guard src_flushed_tmp_dir_lock;

--- a/tests/integration/test_cow_policy/configs/overrides.yaml
+++ b/tests/integration/test_cow_policy/configs/overrides.yaml
@@ -4,9 +4,17 @@ storage_configuration:
       type: web
       endpoint: https://raw.githubusercontent.com/ClickHouse/web-tables-demo/main/web/
   policies:
-    cow_policy:
+    cow_policy_multi_disk:
       volumes:
         disks:
           disk:
           - web
+          - default
+    cow_policy_multi_volume:
+      volumes:
+        disks_web:
+          disk:
+          - web
+        disks_local:
+          disk:
           - default

--- a/tests/integration/test_cow_policy/configs/overrides.yaml
+++ b/tests/integration/test_cow_policy/configs/overrides.yaml
@@ -1,0 +1,12 @@
+storage_configuration:
+  disks:
+    web:
+      type: web
+      endpoint: https://raw.githubusercontent.com/ClickHouse/web-tables-demo/main/web/
+  policies:
+    cow_policy:
+      volumes:
+        disks:
+          disk:
+          - web
+          - default

--- a/tests/integration/test_cow_policy/test.py
+++ b/tests/integration/test_cow_policy/test.py
@@ -1,0 +1,54 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance("node", main_configs=["configs/overrides.yaml"])
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    except Exception as ex:
+        print(ex)
+    finally:
+        cluster.shutdown()
+
+
+def test_cow_policy(start_cluster):
+    try:
+        node.query_with_retry(
+            """
+            ATTACH TABLE uk_price_paid UUID 'cf712b4f-2ca8-435c-ac23-c4393efe52f7'
+            (
+                price UInt32,
+                date Date,
+                postcode1 LowCardinality(String),
+                postcode2 LowCardinality(String),
+                type Enum8('other' = 0, 'terraced' = 1, 'semi-detached' = 2, 'detached' = 3, 'flat' = 4),
+                is_new UInt8,
+                duration Enum8('unknown' = 0, 'freehold' = 1, 'leasehold' = 2),
+                addr1 String,
+                addr2 String,
+                street LowCardinality(String),
+                locality LowCardinality(String),
+                town LowCardinality(String),
+                district LowCardinality(String),
+                county LowCardinality(String)
+            )
+            ENGINE = MergeTree
+            ORDER BY (postcode1, postcode2, addr1, addr2)
+            SETTINGS storage_policy = 'cow_policy'
+            """
+        )
+        prev_count = int(node.query("SELECT count() FROM uk_price_paid"))
+        assert prev_count > 0
+        for _ in range(0, 10):
+            node.query("INSERT INTO uk_price_paid (price) VALUES (1000)")
+        new_count = int(node.query("SELECT count() FROM uk_price_paid"))
+        assert new_count == prev_count + 10
+    finally:
+        node.query("DROP TABLE IF EXISTS uk_price_paid")


### PR DESCRIPTION
It was possible before, but it was not deterministic, since new data could be inserted into the read-only disk and this will fail.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to combine read-only and read-write disks in storage policy (as multiple volumes, or multiple disks). This allows to read data from the entire volume, while inserts will prefer the writable disk (i.e. Copy-on-Write storage policy)