### PR TITLE
Fix build

### DIFF
--- a/src/IO/ReadBufferFromEncryptedFile.cpp
+++ b/src/IO/ReadBufferFromEncryptedFile.cpp
@@ -27,7 +27,7 @@ ReadBufferFromEncryptedFile::ReadBufferFromEncryptedFile(
 {
     offset = offset_;
     need_seek = true;
-    LOG_TEST(log, "Decrypting {}: version={}, algorithm={}", getFileName(), header_.version, toString(header_.algorithm));
+    LOG_TEST(log, "Decrypting {}: version={}, algorithm={}", in->getFileName(), header_.version, toString(header_.algorithm));
 }
 
 off_t ReadBufferFromEncryptedFile::seek(off_t off, int whence)


### PR DESCRIPTION
```
Feb 10 18:49:24 /build/src/IO/ReadBufferFromEncryptedFile.cpp:30:62: error: Call to virtual method 'ReadBufferFromEncryptedFile::getFileName' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall,-warnings-as-errors]
Feb 10 18:49:24    30 |     LOG_TEST(log, "Decrypting {}: version={}, algorithm={}", getFileName(), header_.version, toString(header_.algorithm));
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

