### PR TITLE
keeper: fix data-race for latest_snapshot_{info,meta,buf}

### DIFF
--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -128,6 +128,8 @@ void KeeperStateMachine<Storage>::init()
     {
         try
         {
+            std::lock_guard lock(snapshots_lock);
+
             latest_snapshot_buf = snapshot_manager.deserializeSnapshotBufferFromDisk(latest_log_index);
             auto snapshot_deserialization_result = snapshot_manager.deserializeSnapshotFromBuffer(latest_snapshot_buf);
             latest_snapshot_info = snapshot_manager.getLatestSnapshotInfo();
@@ -653,6 +655,8 @@ bool KeeperStateMachine<Storage>::apply_snapshot(nuraft::snapshot & s)
     }
 
     { /// deserialize and apply snapshot to storage
+        std::lock_guard lock(snapshots_lock);
+
         SnapshotDeserializationResult<Storage> snapshot_deserialization_result;
         if (latest_snapshot_ptr)
             snapshot_deserialization_result = snapshot_manager.deserializeSnapshotFromBuffer(latest_snapshot_ptr);
@@ -800,6 +804,7 @@ void KeeperStateMachine<Storage>::create_snapshot(nuraft::snapshot & s, nuraft::
 
         when_done(ret, exception);
 
+        std::lock_guard lock(snapshots_lock);
         return ret ? latest_snapshot_info : nullptr;
     };
 

--- a/src/Coordination/KeeperStateMachine.h
+++ b/src/Coordination/KeeperStateMachine.h
@@ -5,6 +5,7 @@
 #include <Coordination/KeeperContext.h>
 #include <Common/SharedMutex.h>
 
+#include <base/defines.h>
 #include <libnuraft/nuraft.hxx>
 #include <Common/ConcurrentBoundedQueue.h>
 
@@ -122,9 +123,9 @@ protected:
     CommitCallback commit_callback;
     /// In our state machine we always have a single snapshot which is stored
     /// in memory in compressed (serialized) format.
-    SnapshotMetadataPtr latest_snapshot_meta = nullptr;
-    std::shared_ptr<SnapshotFileInfo> latest_snapshot_info;
-    nuraft::ptr<nuraft::buffer> latest_snapshot_buf = nullptr;
+    SnapshotMetadataPtr latest_snapshot_meta TSA_GUARDED_BY(snapshots_lock) = nullptr;
+    std::shared_ptr<SnapshotFileInfo> latest_snapshot_info TSA_GUARDED_BY(snapshots_lock);
+    nuraft::ptr<nuraft::buffer> latest_snapshot_buf TSA_GUARDED_BY(snapshots_lock) = nullptr;
 
     CoordinationSettingsPtr coordination_settings;
 


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/75848/479ca9b0a40fa32074501bea7d9eb7d369f3ddd4/integration_tests__tsan__2_6_.html

<details>

<summary>Race</summary>

```
E           Exception: Sanitizer assert found for instance ==================
E           WARNING: ThreadSanitizer: data race (pid=8)
E             Write of size 8 at 0x726000005c78 by thread T585 (mutexes: write M0, write M1):
E               #0 std::__1::enable_if<is_move_constructible<DB::SnapshotFileInfo*>::value && is_move_assignable<DB::SnapshotFileInfo*>::value, void>::type std::__1::swap[abi:ne180100]<DB::SnapshotFileInfo*>(DB::SnapshotFileInfo*&, DB::SnapshotFileInfo*&) build_docker/./contrib/llvm-project/libcxx/include/__utility/swap.h:44:7 (clickhouse+0x1dad0fb6) (BuildId: eb398fb9d76a60d418ba7222d10f730fae2208dc)
E               #1 std::__1::shared_ptr<DB::SnapshotFileInfo>::swap[abi:ne180100](std::__1::shared_ptr<DB::SnapshotFileInfo>&) build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:694:5 (clickhouse+0x1dad0fb6)
E               #2 std::__1::shared_ptr<DB::SnapshotFileInfo>::operator=[abi:ne180100](std::__1::shared_ptr<DB::SnapshotFileInfo>&&) build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:663:32 (clickhouse+0x1dad0fb6)
E               #3 DB::KeeperStateMachine<DB::KeeperStorage<DB::SnapshotableHashTable<DB::KeeperMemNode>>>::save_logical_snp_obj(nuraft::snapshot&, unsigned long&, nuraft::buffer&, bool, bool) build_docker/./src/Coordination/KeeperStateMachine.cpp:846:30 (clickhouse+0x1dad0fb6)

E             Previous read of size 8 at 0x726000005c78 by thread T572:
E               #0 std::__1::shared_ptr<DB::SnapshotFileInfo>::shared_ptr[abi:ne180100](std::__1::shared_ptr<DB::SnapshotFileInfo> const&) build_docker/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:565:82 (clickhouse+0x1daea9b2) (BuildId: eb398fb9d76a60d418ba7222d10f730fae2208dc)
E               #1 DB::KeeperStateMachine<DB::KeeperStorage<DB::SnapshotableHashTable<DB::KeeperMemNode>>>::create_snapshot(nuraft::snapshot&, std::__1::function<void (bool&, std::__1::shared_ptr<std::exception>&)>&)::'lambda'(std::__1::variant<std::__1::shared_ptr<DB::KeeperStorageSnapshot<DB::KeeperStorage<DB::SnapshotableHashTable<DB::KeeperMemNode>>>>, std::__1::shared_ptr<DB::KeeperStorageSnapshot<DB::KeeperStorage<DB::RocksDBContainer<DB::KeeperRocksNode>>>>>&&, bool)::operator()(std::__1::variant<std::__1::shared_ptr<DB::KeeperStorageSnapshot<DB::KeeperStorage<DB::SnapshotableHashTable<DB::KeeperMemNode>>>>, std::__1::shared_ptr<DB::KeeperStorageSnapshot<DB::KeeperStorage<DB::RocksDBContainer<DB::KeeperRocksNode>>>>>&&, bool) const build_docker/./src/Coordination/KeeperStateMachine.cpp:803:22 (clickhouse+0x1daea9b2)

```

</details>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)