### PR TITLE
Fix: test test_background_dictionary_reconnect

### DIFF
--- a/tests/integration/helpers/port_forward.py
+++ b/tests/integration/helpers/port_forward.py
@@ -1,0 +1,103 @@
+import socket
+import threading
+
+
+# simple port forwarding
+class PortForward:
+    def __init__(self):
+        self._clients_lock = threading.Lock()
+        self._clients = {}
+
+    def _run(self):
+        while True:
+            try:
+                connection, addr = self._sock.accept()
+            except socket.timeout:
+                continue
+            except Exception:
+                break
+
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client.bind(("", 0))
+            client.connect(self._address)
+
+            connection.settimeout(1)
+            client.settimeout(1)
+
+            def forward(source: socket.socket, destination: socket.socket, terminate):
+                while True:
+                    try:
+                        data = source.recv(4096)
+                        if not data:
+                            destination.shutdown(socket.SHUT_WR)
+                            source.shutdown(socket.SHUT_RD)
+                            break
+                        sent = 0
+                        while sent < len(data):
+                            try:
+                                sent += destination.send(data[sent:])
+                            except socket.timeout:
+                                continue
+                    except socket.timeout:
+                        continue
+                    except Exception:
+                        break
+
+                terminate()
+
+            def termination(connection: socket.socket, idx: int):
+                client = None
+                with self._clients_lock:
+                    client = self._clients.pop(connection, None)
+                if client is not None:
+                    client[idx].join()
+                    connection.close()
+                    client[0].close()
+
+            client_to_server_thread = threading.Thread(
+                target=forward, args=(connection, client, lambda: termination(connection, 2))
+            )
+            server_to_client_thread = threading.Thread(
+                target=forward, args=(client, connection, lambda: termination(connection, 1))
+            )
+
+            with self._clients_lock:
+                self._clients[connection] = (client, client_to_server_thread, server_to_client_thread)
+
+            client_to_server_thread.start()
+            server_to_client_thread.start()
+
+    def start(self, address, listen_port=0):
+        self._address = address
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("", listen_port))
+        self._sock.listen()
+        self._sock.settimeout(1)
+        self._runner = threading.Thread(target=self._run)
+        self._runner.start()
+        return self._sock.getsockname()[1]
+
+    def stop(self, force = False):
+        if self._sock:
+            self._sock.close()
+
+        if not force:
+            return
+
+        if self._runner:
+            self._runner.join()
+
+        while True:
+            item = None
+            with self._clients_lock:
+                try:
+                    item = self._clients.popitem()
+                except KeyError:
+                    break
+            
+            (connection, (client, client_to_server_thread, server_to_client_thread)) = item
+
+            connection.close()
+            client.close()
+            client_to_server_thread.join()
+            server_to_client_thread.join()

--- a/tests/integration/test_dictionaries_mysql/test.py
+++ b/tests/integration/test_dictionaries_mysql/test.py
@@ -486,7 +486,7 @@ def test_background_dictionary_reconnect(started_cluster):
             DB 'test'
             QUERY $doc$SELECT * FROM test.dict;$doc$
             BACKGROUND_RECONNECT 'true'
-            REPLICA(HOST '{socket.gethostname()}' PORT 3336 PRIORITY 1)))
+            REPLICA(HOST '{socket.gethostbyname(socket.gethostname())}' PORT 3336 PRIORITY 1)))
         """
         )
 

--- a/tests/integration/test_dictionaries_mysql/test.py
+++ b/tests/integration/test_dictionaries_mysql/test.py
@@ -458,7 +458,7 @@ def test_background_dictionary_reconnect(started_cluster):
     )
 
     port_forward = PortForward()
-    port_forward.start((started_cluster.mysql8_ip, started_cluster.mysql8_port), 3336)
+    port = port_forward.start((started_cluster.mysql8_ip, started_cluster.mysql8_port))
 
     @contextmanager
     def port_forward_manager():
@@ -486,7 +486,7 @@ def test_background_dictionary_reconnect(started_cluster):
             DB 'test'
             QUERY $doc$SELECT * FROM test.dict;$doc$
             BACKGROUND_RECONNECT 'true'
-            REPLICA(HOST '{socket.gethostbyname(socket.gethostname())}' PORT 3336 PRIORITY 1)))
+            REPLICA(HOST '{socket.gethostbyname(socket.gethostname())}' PORT {port} PRIORITY 1)))
         """
         )
 
@@ -514,7 +514,7 @@ def test_background_dictionary_reconnect(started_cluster):
         time.sleep(5)
 
         # Restore connection to mysql server
-        port_forward.start((started_cluster.mysql8_ip, started_cluster.mysql8_port), 3336)
+        port_forward.start((started_cluster.mysql8_ip, started_cluster.mysql8_port), port)
 
         time.sleep(5)
 

--- a/tests/integration/test_dictionaries_mysql/test.py
+++ b/tests/integration/test_dictionaries_mysql/test.py
@@ -1,5 +1,7 @@
 ## sudo -H pip install PyMySQL
+from contextlib import contextmanager
 import logging
+import socket
 import time
 import warnings
 
@@ -7,7 +9,7 @@ import pymysql.cursors
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
+from helpers.port_forward import PortForward
 
 DICTS = ["configs/dictionaries/mysql_dict1.xml", "configs/dictionaries/mysql_dict2.xml"]
 CONFIG_FILES = [
@@ -455,43 +457,52 @@ def test_background_dictionary_reconnect(started_cluster):
         mysql_connection, "INSERT INTO test.dict VALUES (1, 'Value_1');"
     )
 
-    query = instance.query
-    query(
-        f"""
-    DROP DICTIONARY IF EXISTS dict;
-    CREATE DICTIONARY dict
-    (
-        id UInt64,
-        value String
-    )
-    PRIMARY KEY id
-    LAYOUT(DIRECT())
-    SOURCE(MYSQL(
-        USER 'root'
-        PASSWORD 'clickhouse'
-        DB 'test'
-        QUERY $doc$SELECT * FROM test.dict;$doc$
-        BACKGROUND_RECONNECT 'true'
-        REPLICA(HOST 'mysql80' PORT 3306 PRIORITY 1)))
-    """
-    )
+    port_forward = PortForward()
+    port_forward.start((started_cluster.mysql8_ip, started_cluster.mysql8_port), 3336)
 
-    result = query("SELECT value FROM dict WHERE id = 1")
-    assert result == "Value_1\n"
+    @contextmanager
+    def port_forward_manager():
+        try:
+            yield
+        finally:
+            port_forward.stop(True)
 
-    class MySQL_Instance:
-        pass
+    with port_forward_manager():
 
-    mysql_instance = MySQL_Instance()
-    mysql_instance.ip_address = started_cluster.mysql8_ip
-
-    query("TRUNCATE TABLE IF EXISTS system.text_log")
-
-    with PartitionManager() as pm:
-        # Break connection to mysql server
-        pm.partition_instances(
-            instance, mysql_instance, action="REJECT --reject-with tcp-reset"
+        query = instance.query
+        query(
+            f"""
+        DROP DICTIONARY IF EXISTS dict;
+        CREATE DICTIONARY dict
+        (
+            id UInt64,
+            value String
         )
+        PRIMARY KEY id
+        LAYOUT(DIRECT())
+        SOURCE(MYSQL(
+            USER 'root'
+            PASSWORD 'clickhouse'
+            DB 'test'
+            QUERY $doc$SELECT * FROM test.dict;$doc$
+            BACKGROUND_RECONNECT 'true'
+            REPLICA(HOST '{socket.gethostname()}' PORT 3336 PRIORITY 1)))
+        """
+        )
+
+        result = query("SELECT value FROM dict WHERE id = 1")
+        assert result == "Value_1\n"
+
+        class MySQL_Instance:
+            pass
+
+        mysql_instance = MySQL_Instance()
+        mysql_instance.ip_address = started_cluster.mysql8_ip
+
+        query("TRUNCATE TABLE IF EXISTS system.text_log")
+
+        # Break connection to mysql server
+        port_forward.stop(force=True)
 
         # Exhaust possible connection pool and initiate reconnection attempts
         for _ in range(5):
@@ -502,30 +513,33 @@ def test_background_dictionary_reconnect(started_cluster):
 
         time.sleep(5)
 
-    time.sleep(5)
+        # Restore connection to mysql server
+        port_forward.start((started_cluster.mysql8_ip, started_cluster.mysql8_port), 3336)
 
-    query("SYSTEM FLUSH LOGS")
-    assert (
-        int(
-            query(
-                "SELECT count() FROM system.text_log WHERE message like 'Failed to connect to MySQL %: mysqlxx::ConnectionFailed'"
+        time.sleep(5)
+
+        query("SYSTEM FLUSH LOGS")
+        assert (
+            int(
+                query(
+                    "SELECT count() FROM system.text_log WHERE message like 'Failed to connect to MySQL %: mysqlxx::ConnectionFailed'"
+                )
             )
+            > 0
         )
-        > 0
-    )
-    assert (
-        int(
-            query(
-                "SELECT count() FROM system.text_log WHERE message like 'Reestablishing connection to % has succeeded.'"
+        assert (
+            int(
+                query(
+                    "SELECT count() FROM system.text_log WHERE message like 'Reestablishing connection to % has succeeded.'"
+                )
             )
+            > 0
         )
-        > 0
-    )
-    assert (
-        int(
-            query(
-                "SELECT count() FROM system.text_log WHERE message like '%Reestablishing connection to % has failed: mysqlxx::ConnectionFailed: Can\\'t connect to MySQL server on %'"
+        assert (
+            int(
+                query(
+                    "SELECT count() FROM system.text_log WHERE message like '%Reestablishing connection to % has failed: mysqlxx::ConnectionFailed: Can\\'t connect to MySQL server on %'"
+                )
             )
+            > 0
         )
-        > 0
-    )

--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -611,7 +611,7 @@ def test_background_dictionary_reconnect(started_cluster):
     postgres_conn.cursor().execute("INSERT INTO dict VALUES (1, 'Value_1')")
 
     port_forward = PortForward()
-    port_forward.start((started_cluster.postgres_ip, started_cluster.postgres_port), 5532)
+    port = port_forward.start((started_cluster.postgres_ip, started_cluster.postgres_port))
 
     @contextmanager
     def port_forward_manager():
@@ -639,7 +639,7 @@ def test_background_dictionary_reconnect(started_cluster):
             DB 'postgres_database'
             QUERY $doc$SELECT * FROM dict;$doc$
             BACKGROUND_RECONNECT 'true'
-            REPLICA(HOST '{socket.gethostbyname(socket.gethostname())}' PORT 5532 PRIORITY 1)))
+            REPLICA(HOST '{socket.gethostbyname(socket.gethostname())}' PORT {port} PRIORITY 1)))
         """
         )
 
@@ -667,7 +667,7 @@ def test_background_dictionary_reconnect(started_cluster):
         time.sleep(5)
 
         # Restore connection to postgresql server
-        port_forward.start((started_cluster.postgres_ip, started_cluster.postgres_port), 5532)
+        port_forward.start((started_cluster.postgres_ip, started_cluster.postgres_port), port)
 
         time.sleep(5)
 

--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -1,5 +1,7 @@
 import logging
 import time
+import socket
+from contextlib import contextmanager
 from multiprocessing.dummy import Pool
 
 import psycopg2
@@ -9,6 +11,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.postgres_utility import get_postgres_conn
+from helpers.port_forward import PortForward
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -607,43 +610,52 @@ def test_background_dictionary_reconnect(started_cluster):
 
     postgres_conn.cursor().execute("INSERT INTO dict VALUES (1, 'Value_1')")
 
-    query = node1.query
-    query(
-        f"""
-    DROP DICTIONARY IF EXISTS dict;
-    CREATE DICTIONARY dict
-    (
-        id UInt64,
-        value String
-    )
-    PRIMARY KEY id
-    LAYOUT(DIRECT())
-    SOURCE(POSTGRESQL(
-        USER 'postgres'
-        PASSWORD 'mysecretpassword'
-        DB 'postgres_database'
-        QUERY $doc$SELECT * FROM dict;$doc$
-        BACKGROUND_RECONNECT 'true'
-        REPLICA(HOST '{started_cluster.postgres_ip}' PORT {started_cluster.postgres_port} PRIORITY 1)))
-    """
-    )
+    port_forward = PortForward()
+    port_forward.start((started_cluster.postgres_ip, started_cluster.postgres_port), 5532)
 
-    result = query("SELECT value FROM dict WHERE id = 1")
-    assert result == "Value_1\n"
+    @contextmanager
+    def port_forward_manager():
+        try:
+            yield
+        finally:
+            port_forward.stop(True)
 
-    class PostgreSQL_Instance:
-        pass
+    with port_forward_manager():
 
-    postgres_instance = PostgreSQL_Instance()
-    postgres_instance.ip_address = started_cluster.postgres_ip
-
-    query("TRUNCATE TABLE IF EXISTS system.text_log")
-
-    with PartitionManager() as pm:
-        # Break connection to mysql server
-        pm.partition_instances(
-            node1, postgres_instance, action="REJECT --reject-with tcp-reset"
+        query = node1.query
+        query(
+            f"""
+        DROP DICTIONARY IF EXISTS dict;
+        CREATE DICTIONARY dict
+        (
+            id UInt64,
+            value String
         )
+        PRIMARY KEY id
+        LAYOUT(DIRECT())
+        SOURCE(POSTGRESQL(
+            USER 'postgres'
+            PASSWORD 'mysecretpassword'
+            DB 'postgres_database'
+            QUERY $doc$SELECT * FROM dict;$doc$
+            BACKGROUND_RECONNECT 'true'
+            REPLICA(HOST '{socket.gethostname()}' PORT 5532 PRIORITY 1)))
+        """
+        )
+
+        result = query("SELECT value FROM dict WHERE id = 1")
+        assert result == "Value_1\n"
+
+        class PostgreSQL_Instance:
+            pass
+
+        postgres_instance = PostgreSQL_Instance()
+        postgres_instance.ip_address = started_cluster.postgres_ip
+
+        query("TRUNCATE TABLE IF EXISTS system.text_log")
+
+        # Break connection to postgresql server
+        port_forward.stop(force=True)
 
         # Exhaust possible connection pool and initiate reconnection attempts
         for _ in range(5):
@@ -651,28 +663,32 @@ def test_background_dictionary_reconnect(started_cluster):
                 result = query("SELECT value FROM dict WHERE id = 1")
             except Exception as e:
                 pass
+
         time.sleep(5)
 
-    time.sleep(5)
+        # Restore connection to postgresql server
+        port_forward.start((started_cluster.postgres_ip, started_cluster.postgres_port), 5532)
 
-    query("SYSTEM FLUSH LOGS")
+        time.sleep(5)
 
-    assert (
-        int(
-            query(
-                "SELECT count() FROM system.text_log WHERE message like 'Reestablishing connection to % has failed: %'"
+        query("SYSTEM FLUSH LOGS")
+
+        assert (
+            int(
+                query(
+                    "SELECT count() FROM system.text_log WHERE message like 'Reestablishing connection to % has failed: %'"
+                )
             )
+            > 0
         )
-        > 0
-    )
-    assert (
-        int(
-            query(
-                "SELECT count() FROM system.text_log WHERE message like 'Reestablishing connection to % has succeeded.'"
+        assert (
+            int(
+                query(
+                    "SELECT count() FROM system.text_log WHERE message like 'Reestablishing connection to % has succeeded.'"
+                )
             )
+            > 0
         )
-        > 0
-    )
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -639,7 +639,7 @@ def test_background_dictionary_reconnect(started_cluster):
             DB 'postgres_database'
             QUERY $doc$SELECT * FROM dict;$doc$
             BACKGROUND_RECONNECT 'true'
-            REPLICA(HOST '{socket.gethostname()}' PORT 5532 PRIORITY 1)))
+            REPLICA(HOST '{socket.gethostbyname(socket.gethostname())}' PORT 5532 PRIORITY 1)))
         """
         )
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

closes #73885

Description:
PartitionManager seems to be not 100% reliable way to break connection between instances - on very rare occasions connection may be spontaneously restored (maybe by some other process). So use port forwarding instead.