### PR TITLE
Remove trace_id from default ORDER BY for system.opentelemetry_span_log

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1278,7 +1278,7 @@
         <engine>
             engine MergeTree
             partition by toYYYYMM(finish_date)
-            order by (finish_date, finish_time_us, trace_id)
+            order by (finish_date, finish_time_us)
         </engine>
         <database>system</database>
         <table>opentelemetry_span_log</table>

--- a/src/Interpreters/OpenTelemetrySpanLog.h
+++ b/src/Interpreters/OpenTelemetrySpanLog.h
@@ -30,7 +30,7 @@ public:
     using SystemLog<OpenTelemetrySpanLogElement>::SystemLog;
 
     static const char * getDefaultPartitionBy() { return "toYYYYMM(finish_date)"; }
-    static const char * getDefaultOrderBy() { return "finish_date, finish_time_us, trace_id"; }
+    static const char * getDefaultOrderBy() { return "finish_date, finish_time_us"; }
 };
 
 }


### PR DESCRIPTION
As @qoega correctly mentioned here [1]:

    "Actually trace_id looks useless as there will be no 8k rows with the same finish_time_us"

  [1]: https://github.com/ClickHouse/ClickHouse/pull/75784#discussion_r1948900911

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove trace_id from default ORDER BY for system.opentelemetry_span_log