### PR TITLE
Enable ICU and GRPC when cross-compiling for Darwin

### DIFF
--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -36,8 +36,6 @@ endif ()
 
 if (CMAKE_CROSSCOMPILING)
     if (OS_DARWIN)
-        # FIXME: broken dependencies
-        set (ENABLE_GRPC OFF CACHE INTERNAL "") # no protobuf -> no grpc
         set (ENABLE_FASTOPS OFF CACHE INTERNAL "")
     elseif (OS_LINUX OR OS_ANDROID)
         if (ARCH_PPC64LE)

--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -38,7 +38,6 @@ if (CMAKE_CROSSCOMPILING)
     if (OS_DARWIN)
         # FIXME: broken dependencies
         set (ENABLE_GRPC OFF CACHE INTERNAL "") # no protobuf -> no grpc
-        set (ENABLE_ICU OFF CACHE INTERNAL "")
         set (ENABLE_FASTOPS OFF CACHE INTERNAL "")
     elseif (OS_LINUX OR OS_ANDROID)
         if (ARCH_PPC64LE)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable ICU and GRPC when cross-compiling for Darwin

It currently works locally, so I'd expect it to work in cross-compilation too.

Closes https://github.com/ClickHouse/ClickHouse/issues/75898

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
