### PR TITLE
Store start_time/end_time for Backups with microseconds

### DIFF
--- a/src/Backups/BackupOperationInfo.h
+++ b/src/Backups/BackupOperationInfo.h
@@ -59,8 +59,8 @@ struct BackupOperationInfo
     /// Profile events collected during the backup.
     std::shared_ptr<ProfileEvents::Counters::Snapshot> profile_counters = nullptr;
 
-    std::chrono::system_clock::time_point start_time;
-    std::chrono::system_clock::time_point end_time;
+    UInt64 start_time_us = 0;
+    UInt64 end_time_us = 0;
 };
 
 }

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -21,6 +21,7 @@
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Parsers/ASTBackupQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Common/DateLUT.h>
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/Macros.h>
@@ -1059,7 +1060,7 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
     info.query_id = query_id;
     info.internal = internal;
     info.status = status;
-    info.start_time = std::chrono::system_clock::now();
+    info.start_time_us = timeInMicroseconds(std::chrono::system_clock::now());
 
     bool is_final_status = isFinalStatus(status);
 
@@ -1071,7 +1072,7 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
     }
 
     if (is_final_status)
-        info.end_time = info.start_time;
+        info.end_time_us = info.start_time_us;
 
     std::lock_guard lock{infos_mutex};
 
@@ -1120,7 +1121,7 @@ void BackupsWorker::setStatus(const String & id, BackupStatus status, bool throw
     }
 
     if (is_final_status)
-        info.end_time = std::chrono::system_clock::now();
+        info.end_time_us = timeInMicroseconds(std::chrono::system_clock::now());
 
     if (isFailedOrCancelled(status))
     {

--- a/src/Interpreters/BackupLog.cpp
+++ b/src/Interpreters/BackupLog.cpp
@@ -32,8 +32,8 @@ ColumnsDescription BackupLogElement::getColumnsDescription()
         {"query_id", std::make_shared<DataTypeString>(), "The ID of a query associated with a backup operation."},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues()), "Operation status."},
         {"error", std::make_shared<DataTypeString>(), "Error message of the failed operation (empty string for successful operations)."},
-        {"start_time", std::make_shared<DataTypeDateTime>(), "Start time of the operation."},
-        {"end_time", std::make_shared<DataTypeDateTime>(), "End time of the operation."},
+        {"start_time", std::make_shared<DataTypeDateTime64>(6), "Start time of the operation."},
+        {"end_time", std::make_shared<DataTypeDateTime64>(6), "End time of the operation."},
         {"num_files", std::make_shared<DataTypeUInt64>(), "Number of files stored in the backup."},
         {"total_size", std::make_shared<DataTypeUInt64>(), "Total size of files stored in the backup."},
         {"num_entries", std::make_shared<DataTypeUInt64>(), "Number of entries in the backup, i.e. the number of files inside the folder if the backup is stored as a folder, or the number of files inside the archive if the backup is stored as an archive. It is not the same as num_files if it's an incremental backup or if it contains empty files or duplicates. The following is always true: num_entries <= num_files."},
@@ -57,8 +57,8 @@ void BackupLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(info.query_id);
     columns[i++]->insert(static_cast<Int8>(info.status));
     columns[i++]->insert(info.error_message);
-    columns[i++]->insert(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.start_time)));
-    columns[i++]->insert(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.end_time)));
+    columns[i++]->insert(static_cast<Decimal64>(info.start_time_us));
+    columns[i++]->insert(static_cast<Decimal64>(info.end_time_us));
     columns[i++]->insert(info.num_files);
     columns[i++]->insert(info.total_size);
     columns[i++]->insert(info.num_entries);

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -11,6 +11,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ProfileEventsExt.h>
+#include "Columns/ColumnsDateTime.h"
 
 
 namespace DB
@@ -26,8 +27,8 @@ ColumnsDescription StorageSystemBackups::getColumnsDescription()
         {"query_id", std::make_shared<DataTypeString>(), "Query ID of a query that started backup."},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues()), "Status of backup or restore operation."},
         {"error", std::make_shared<DataTypeString>(), "The error message if any."},
-        {"start_time", std::make_shared<DataTypeDateTime>(), "The time when operation started."},
-        {"end_time", std::make_shared<DataTypeDateTime>(), "The time when operation finished."},
+        {"start_time", std::make_shared<DataTypeDateTime64>(6), "The time when operation started."},
+        {"end_time", std::make_shared<DataTypeDateTime64>(6), "The time when operation finished."},
         {"num_files", std::make_shared<DataTypeUInt64>(), "The number of files stored in the backup."},
         {"total_size", std::make_shared<DataTypeUInt64>(), "The total size of files stored in the backup."},
         {"num_entries", std::make_shared<DataTypeUInt64>(), "The number of entries in the backup, i.e. the number of files inside the folder if the backup is stored as a folder."},
@@ -49,8 +50,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_query_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
-    auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
-    auto & column_end_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
+    auto & column_start_time = assert_cast<ColumnDateTime64 &>(*res_columns[column_index++]);
+    auto & column_end_time = assert_cast<ColumnDateTime64 &>(*res_columns[column_index++]);
     auto & column_num_files = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
     auto & column_total_size = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
     auto & column_num_entries = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
@@ -68,8 +69,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
         column_query_id.insertData(info.query_id.data(), info.query_id.size());
         column_status.insertValue(static_cast<Int8>(info.status));
         column_error.insertData(info.error_message.data(), info.error_message.size());
-        column_start_time.insertValue(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.start_time)));
-        column_end_time.insertValue(static_cast<UInt32>(std::chrono::system_clock::to_time_t(info.end_time)));
+        column_start_time.insertValue(static_cast<Decimal64>(info.start_time_us));
+        column_end_time.insertValue(static_cast<Decimal64>(info.end_time_us));
         column_num_files.insertValue(info.num_files);
         column_total_size.insertValue(info.total_size);
         column_num_entries.insertValue(info.num_entries);

--- a/tests/integration/test_backup_log/test.py
+++ b/tests/integration/test_backup_log/test.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
@@ -64,7 +65,8 @@ def test_backup_log():
     instance.query("SYSTEM FLUSH LOGS")
     instance.query("DROP TABLE IF EXISTS system.backup_log SYNC")
 
-    backup_name = "File('/backups/test_backup/')"
+    backup_id = uuid.uuid4().hex
+    backup_name = f"File('/backups/test_backup_{backup_id}/')"
     assert instance.query("SELECT * FROM system.tables WHERE name = 'backup_log'") == ""
 
     backup_id = backup_table(backup_name)

--- a/tests/integration/test_backup_log/test.py
+++ b/tests/integration/test_backup_log/test.py
@@ -22,8 +22,8 @@ def start_cluster():
 
 
 def backup_table(backup_name):
-    instance.query("CREATE DATABASE test")
-    instance.query("CREATE TABLE test.table(x UInt32) ENGINE=MergeTree ORDER BY x")
+    instance.query("CREATE DATABASE IF NOT EXISTS test")
+    instance.query("CREATE TABLE IF NOT EXISTS test.table(x UInt32) ENGINE=MergeTree ORDER BY x")
     instance.query("INSERT INTO test.table SELECT number FROM numbers(10)")
     return instance.query(f"BACKUP TABLE test.table TO {backup_name}").split("\t")[0]
 
@@ -62,7 +62,7 @@ def test_backup_log():
         )
 
     instance.query("SYSTEM FLUSH LOGS")
-    instance.query("drop table system.backup_log")
+    instance.query("DROP TABLE IF EXISTS system.backup_log SYNC")
 
     backup_name = "File('/backups/test_backup/')"
     assert instance.query("SELECT * FROM system.tables WHERE name = 'backup_log'") == ""
@@ -73,7 +73,7 @@ def test_backup_log():
         [["CREATING_BACKUP", 0, 0, 0, ""], ["BACKUP_CREATED", 0, 0, 0, ""]]
     )
 
-    instance.query("DROP TABLE test.table SYNC")
+    instance.query("DROP TABLE IF EXISTS test.table SYNC")
 
     restore_id = restore_table(backup_name)
     instance.query("SYSTEM FLUSH LOGS")

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import glob
 import os.path
 import random
@@ -118,10 +119,19 @@ def get_events_for_query(query_id: str) -> Dict[str, int]:
     return result
 
 
-BackupInfo = namedtuple(
-    "BackupInfo",
-    "name id status error num_files total_size num_entries uncompressed_size compressed_size files_read bytes_read",
-)
+@dataclass
+class BackupInfo:
+    name: str
+    id: int
+    status: str
+    error: str
+    num_files: int
+    total_size: int
+    num_entries: int
+    uncompressed_size: int
+    compressed_size: int
+    files_read: int
+    bytes_read: int
 
 
 def get_backup_info_from_system_backups(by_id=None, by_name=None):

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -7,6 +7,7 @@ import sys
 import uuid
 from collections import namedtuple
 from typing import Dict
+from datetime import datetime
 
 import pytest
 
@@ -123,6 +124,8 @@ def get_events_for_query(query_id: str) -> Dict[str, int]:
 class BackupInfo:
     name: str
     id: int
+    start_time: datetime
+    end_time: datetime
     status: str
     error: str
     num_files: int
@@ -144,6 +147,8 @@ def get_backup_info_from_system_backups(by_id=None, by_name=None):
     [
         name,
         id,
+        start_time,
+        end_time,
         status,
         error,
         num_files,
@@ -155,7 +160,7 @@ def get_backup_info_from_system_backups(by_id=None, by_name=None):
         bytes_read,
     ] = (
         instance.query(
-            f"SELECT name, id, status, error, num_files, total_size, num_entries, uncompressed_size, compressed_size, files_read, bytes_read "
+            f"SELECT name, id, start_time, end_time, status, error, num_files, total_size, num_entries, uncompressed_size, compressed_size, files_read, bytes_read "
             f"FROM system.backups WHERE {where_condition} LIMIT 1"
         )
         .strip("\n")
@@ -173,6 +178,8 @@ def get_backup_info_from_system_backups(by_id=None, by_name=None):
     return BackupInfo(
         name=name,
         id=id,
+        start_time=start_time,
+        end_time=end_time,
         status=status,
         error=error,
         num_files=num_files,
@@ -393,6 +400,7 @@ def test_increment_backup_without_changes():
     assert backup_info.error == ""
     assert backup_info.num_files > 0
     assert backup_info.total_size > 0
+    assert backup_info.start_time < backup_info.end_time
     assert (
         0 < backup_info.num_entries and backup_info.num_entries <= backup_info.num_files
     )
@@ -410,6 +418,8 @@ def test_increment_backup_without_changes():
     assert backup2_info.error == ""
     assert backup2_info.num_files == backup_info.num_files
     assert backup2_info.total_size == backup_info.total_size
+    assert backup2_info.start_time > backup_info.end_time
+    assert backup2_info.start_time < backup2_info.end_time
     assert backup2_info.num_entries == 0
     assert backup2_info.uncompressed_size > 0
     assert backup2_info.compressed_size == backup2_info.uncompressed_size
@@ -434,6 +444,7 @@ def test_increment_backup_without_changes():
     assert restore_info.num_files == backup2_info.num_files
     assert restore_info.total_size == backup2_info.total_size
     assert restore_info.num_entries == backup2_info.num_entries
+    assert restore_info.start_time < restore_info.end_time
     assert restore_info.uncompressed_size == backup2_info.uncompressed_size
     assert restore_info.compressed_size == backup2_info.compressed_size
     assert (
@@ -1760,6 +1771,7 @@ def test_system_backups():
     assert info.error == ""
     assert info.num_files > 0
     assert info.total_size > 0
+    assert info.start_time < info.end_time
     assert 0 < info.num_entries and info.num_entries <= info.num_files
     assert info.uncompressed_size > 0
     assert info.compressed_size == info.uncompressed_size
@@ -1791,6 +1803,7 @@ def test_system_backups():
     assert restore_info.name == escaped_backup_name
     assert restore_info.status == "RESTORED"
     assert restore_info.error == ""
+    assert restore_info.start_time < restore_info.end_time
     assert restore_info.num_files == info.num_files
     assert restore_info.total_size == info.total_size
     assert restore_info.num_entries == info.num_entries

--- a/tests/integration/test_backup_restore_new/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_new/test_cancel_backup.py
@@ -72,7 +72,7 @@ def wait_backup(backup_id):
         sleep_time=5,
     )
 
-    backup_duration = int(
+    backup_duration = float(
         node.query(
             f"SELECT end_time - start_time FROM system.backups WHERE id='{backup_id}'"
         )
@@ -136,7 +136,7 @@ def wait_restore(restore_id):
         sleep_time=5,
     )
 
-    restore_duration = int(
+    restore_duration = float(
         node.query(
             f"SELECT end_time - start_time FROM system.backups WHERE id='{restore_id}'"
         )


### PR DESCRIPTION
Before start_time and end_time can't be used to analyze backup/restore
order if these backups were launched with high rate.

Storing microseconds should improve post-analysis with system.backups and
system.backup_log

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Store start_time/end_time for Backups with microseconds

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
