### PR TITLE
CMake: Make messages about keeper-data-dumper and keeper-bench less noisy

### DIFF
--- a/programs/keeper-bench/CMakeLists.txt
+++ b/programs/keeper-bench/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET ch_contrib::rapidjson OR NOT TARGET ch_contrib::nuraft)
-    message (WARNING "Not building keeper-bench due to rapidjson or nuraft is disabled")
+    message (STATUS "Not building keeper-bench because RapidJSON or NuRaft is disabled")
     return()
 endif ()
 

--- a/programs/keeper-data-dumper/CMakeLists.txt
+++ b/programs/keeper-data-dumper/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET ch_contrib::nuraft)
-    message (WARNING "Not building keeper-data-dumper due to nuraft is disabled")
+    message (STATUS "Not building keeper-data-dumper because NuRaft is disabled")
     return ()
 endif ()
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)