### PR TITLE
Add `MemoryTrackingUncorrected` metric

### DIFF
--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -243,10 +243,10 @@ void * Allocator<clear_memory_, populate>::realloc(void * buf, size_t old_size, 
                 ReadableSize(new_size));
         }
 
-        buf = new_buf;
         auto trace_free = CurrentMemoryTracker::free(old_size);
         trace_free.onFree(buf, old_size);
-        trace_alloc.onAlloc(buf, new_size);
+        trace_alloc.onAlloc(new_buf, new_size);
+        buf = new_buf;
 
         if constexpr (clear_memory)
             if (new_size > old_size)

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -62,6 +62,7 @@
     M(QueryThread, "Number of query processing threads") \
     M(ReadonlyReplica, "Number of Replicated tables that are currently in readonly state due to re-initialization after ZooKeeper session loss or due to startup without ZooKeeper configured.") \
     M(MemoryTracking, "Total amount of memory (bytes) allocated by the server.") \
+    M(MemoryTrackingUncorrected, "Total amount of memory (bytes) allocated by the server not corrected by RSS.") \
     M(MergesMutationsMemoryTracking, "Total amount of memory (bytes) allocated by background tasks (merges and mutations).") \
     M(EphemeralNode, "Number of ephemeral nodes hold in ZooKeeper.") \
     M(ZooKeeperSession, "Number of sessions (connections) to ZooKeeper. Should be no more than one, because using more than one connection to ZooKeeper may lead to bugs due to lack of linearizability (stale reads) that ZooKeeper consistency model allows.") \

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -5,7 +5,6 @@
 #include <Common/Scheduler/ResourceLink.h>
 
 #include <memory>
-#include <string>
 #include <string_view>
 
 

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -96,6 +96,12 @@ private:
 
     bool isSizeOkForSampling(UInt64 size) const;
 
+    /// helper fields for analyzing MemoryTracker
+    /// amount which is not corrected by external source like RSS
+    int64_t uncorrected_amount = 0;
+    /// last corrected amount we set to memory tracker
+    int64_t last_corrected_amount = 0;
+
     /// allocImpl(...) and free(...) should not be used directly
     friend struct CurrentMemoryTracker;
     [[nodiscard]] AllocationTrace allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryTracker * query_tracker = nullptr, double _sample_probability = -1.0);

--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -119,15 +119,18 @@ void doSettingsSanityCheckClamp(Settings & current_settings, LoggerPtr log)
     }
 
     static constexpr UInt64 max_sane_block_rows_size = 4294967296; // 2^32
-    std::unordered_set<String> block_rows_settings{
-        "max_block_size",
-        "max_insert_block_size",
-        "min_insert_block_size_rows",
-        "min_insert_block_size_bytes_for_materialized_views",
-        "min_external_table_block_size_rows",
-        "max_joined_block_size_rows",
-        "input_format_parquet_max_block_size"};
-    for (auto const & setting : block_rows_settings)
+
+    using namespace std::literals;
+    static constexpr std::array block_rows_settings{
+        "max_block_size"sv,
+        "max_insert_block_size"sv,
+        "min_insert_block_size_rows"sv,
+        "min_insert_block_size_bytes_for_materialized_views"sv,
+        "min_external_table_block_size_rows"sv,
+        "max_joined_block_size_rows"sv,
+        "input_format_parquet_max_block_size"sv};
+
+    for (auto const setting : block_rows_settings)
     {
         if (auto block_size = get_current_value(setting).safeGet<UInt64>();
             block_size > max_sane_block_rows_size)

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -283,7 +283,7 @@ void ThreadStatus::detachFromGroup()
 
     LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
 
-    /// flash untracked memory before resetting memory_tracker parent
+    /// flush untracked memory before resetting memory_tracker parent
     flushUntrackedMemory();
 
     finalizeQueryProfiler();

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -113,6 +113,11 @@ MergeInfo MergeListElement::getInfo() const
     return res;
 }
 
+const MemoryTracker & MergeListElement::getMemoryTracker() const
+{
+    return thread_group->memory_tracker;
+}
+
 MergeListElement::~MergeListElement()
 {
     background_memory_tracker.adjustOnBackgroundTaskEnd(&getMemoryTracker());

--- a/src/Storages/MergeTree/MergeList.h
+++ b/src/Storages/MergeTree/MergeList.h
@@ -4,7 +4,6 @@
 #include <Core/Field.h>
 #include <Common/Stopwatch.h>
 #include <Common/CurrentMetrics.h>
-#include <Common/MemoryTracker.h>
 #include <Common/ThreadStatus.h>
 #include <Storages/MergeTree/MergeType.h>
 #include <Storages/MergeTree/MergeAlgorithm.h>
@@ -13,7 +12,6 @@
 #include <Interpreters/StorageID.h>
 #include <boost/noncopyable.hpp>
 #include <memory>
-#include <list>
 #include <mutex>
 #include <atomic>
 
@@ -22,6 +20,8 @@ namespace CurrentMetrics
 {
     extern const Metric Merge;
 }
+
+class MemoryTracker;
 
 namespace DB
 {
@@ -115,7 +115,7 @@ struct MergeListElement : boost::noncopyable
 
     MergeInfo getInfo() const;
 
-    const MemoryTracker & getMemoryTracker() const { return thread_group->memory_tracker; }
+    const MemoryTracker & getMemoryTracker() const;
 
     MergeListElement * ptr() { return this; }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `MemoryTrackingUncorrected` metric showing value of internal global memory tracker which is not corrected by RSS.

cc @azat 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
