### PR TITLE
Not too strict parsing of endpoints in table function

### DIFF
--- a/src/Common/parseRemoteDescription.cpp
+++ b/src/Common/parseRemoteDescription.cpp
@@ -206,7 +206,7 @@ std::vector<std::pair<String, uint16_t>> parseRemoteDescriptionForExternalDataba
         }
         else
         {
-            result.emplace_back(std::make_pair(host, DB::parseFromString<UInt16>(address.substr(colon + 1))));
+            result.emplace_back(std::make_pair(host, DB::parseFromStringWithoutAssertEOF<UInt16>(address.substr(colon + 1))));
         }
     }
 

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -1764,8 +1764,8 @@ inline T parse(const char * data, size_t size)
     return res;
 }
 
-/// This function is used in one place where we need to preserve backward compatibility
-/// and allow
+/// This function is used in one place (parseRemoteDescriptionForExternalDataba)
+/// where we need to preserve backward compatibility.
 template <typename T>
 inline T parseWithoutAssertEOF(const char * data, size_t size)
 {

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -1006,11 +1006,19 @@ template <typename T>
 inline T parse(const char * data, size_t size);
 
 template <typename T>
+inline T parseWithoutAssertEOF(const char * data, size_t size);
+
+template <typename T>
 inline T parseFromString(std::string_view str)
 {
     return parse<T>(str.data(), str.size());
 }
 
+template <typename T>
+inline T parseFromStringWithoutAssertEOF(std::string_view str)
+{
+    return parseWithoutAssertEOF<T>(str.data(), str.size());
+}
 
 template <typename ReturnType = void, bool dt64_mode = false>
 ReturnType readDateTimeTextFallback(time_t & datetime, ReadBuffer & buf, const DateLUTImpl & date_lut, const char * allowed_date_delimiters = nullptr, const char * allowed_time_delimiters = nullptr);
@@ -1753,6 +1761,17 @@ inline T parse(const char * data, size_t size)
     ReadBufferFromMemory buf(data, size);
     readText(res, buf);
     assertEOF(buf);
+    return res;
+}
+
+/// This function is used in one place where we need to preserve backward compatibility
+/// and allow
+template <typename T>
+inline T parseWithoutAssertEOF(const char * data, size_t size)
+{
+    T res;
+    ReadBufferFromMemory buf(data, size);
+    readText(res, buf);
     return res;
 }
 

--- a/tests/queries/0_stateless/03356_postgresql_mysql_endpoint_parsing.sql
+++ b/tests/queries/0_stateless/03356_postgresql_mysql_endpoint_parsing.sql
@@ -1,4 +1,6 @@
 -- Tags: no-fasttest
 -- We test only that parsing of the endpoint works in this test.
-CREATE OR REPLACE TABLE tablefunc01 (x int) AS postgresql('localhost:9005/postgresql', 'postgres_db', 'postgres_table', 'postgres_user', '124444');
-CREATE OR REPLACE TABLE tablefunc02 (x int) AS mysql('127.0.0.1:9004/mysql', 'mysql_db', 'mysql_table', 'mysql_user','123123');
+DROP TABLE IF EXISTS tablefunc01;
+DROP TABLE IF EXISTS tablefunc02;
+CREATE TABLE tablefunc01 (x int) AS postgresql('localhost:9005/postgresql', 'postgres_db', 'postgres_table', 'postgres_user', '124444');
+CREATE TABLE tablefunc02 (x int) AS mysql('127.0.0.1:9004/mysql', 'mysql_db', 'mysql_table', 'mysql_user','123123');

--- a/tests/queries/0_stateless/03356_postgresql_mysql_endpoint_parsing.sql
+++ b/tests/queries/0_stateless/03356_postgresql_mysql_endpoint_parsing.sql
@@ -1,3 +1,4 @@
+-- Tags: no-fasttest
 -- We test only that parsing of the endpoint works in this test.
 CREATE OR REPLACE TABLE tablefunc01 (x int) AS postgresql('localhost:9005/postgresql', 'postgres_db', 'postgres_table', 'postgres_user', '124444');
 CREATE OR REPLACE TABLE tablefunc02 (x int) AS mysql('127.0.0.1:9004/mysql', 'mysql_db', 'mysql_table', 'mysql_user','123123');

--- a/tests/queries/0_stateless/03356_postgresql_mysql_endpoint_parsing.sql
+++ b/tests/queries/0_stateless/03356_postgresql_mysql_endpoint_parsing.sql
@@ -1,0 +1,3 @@
+-- We test only that parsing of the endpoint works in this test.
+CREATE OR REPLACE TABLE tablefunc01 (x int) AS postgresql('localhost:9005/postgresql', 'postgres_db', 'postgres_table', 'postgres_user', '124444');
+CREATE OR REPLACE TABLE tablefunc02 (x int) AS mysql('127.0.0.1:9004/mysql', 'mysql_db', 'mysql_table', 'mysql_user','123123');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to parse endpoints like `localhost:1234/handle` in `postgresql` or `mysql` table functions. This fixes a regression introduced in https://github.com/ClickHouse/ClickHouse/pull/52503

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
