### PR TITLE
tests: avoid relying on existing order in 01257_dictionary_mismatch_types

### DIFF
--- a/tests/queries/0_stateless/01257_dictionary_mismatch_types.sql
+++ b/tests/queries/0_stateless/01257_dictionary_mismatch_types.sql
@@ -106,6 +106,7 @@ SELECT
     dictGet('test_dict_db.table1_dict', 'col8', (col1, col2, col3, col4, col5)),
     dictGet('test_dict_db.table1_dict', 'col9', (col1, col2, col3, col4, col5))
 FROM test_dict_db.table1
-WHERE dictHas('test_dict_db.table1_dict', (col1, col2, col3, col4, col5));
+WHERE dictHas('test_dict_db.table1_dict', (col1, col2, col3, col4, col5))
+ORDER BY col1, col2, col3, col4, col5, col14, col17;
 
 DROP DATABASE IF EXISTS test_dict_db;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)