### PR TITLE
Fix 03326_parallel_replicas_out_of_range.sql

### DIFF
--- a/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
+++ b/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
@@ -3,6 +3,8 @@
 
 SET enable_analyzer=1;
 
+SYSTEM FLUSH LOGS;
+
 SELECT
     count(materialize(toLowCardinality(1))) IGNORE NULLS AS num,
     hostName() AS hostName


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix 03326_parallel_replicas_out_of_range.sql

An error is triggered if the test is executed before system.query_log is flushed for the first time:

```
2025-02-12 18:36:29 Reason: return code: 60
2025-02-12 18:36:29 [ip-172-31-21-150] 2025.02.12 18:36:29.335158 [ 164028 ] {07bd4100-d41f-467f-bb8c-add80fbd6266} executeQuery: Code: 60. DB::Exception: Unknown table expression identifier 'system.query_log' in scope SELECT count(materialize(toLowCardinality(1))) IGNORE NULLS AS num, hostName() AS hostName FROM system.query_log AS a INNER JOIN system.processes AS b ON (type = toFixedString(toNullable('QueryStart'), 10)) AND (dateDiff('second', event_time, now()) > 5) AND (current_database = currentDatabase()). (UNKNOWN_TABLE) (version 25.2.1.1) (from [::ffff:127.0.0.1]:57104) (comment: 03326_parallel_replicas_out_of_range.sql) (query 2, line 6) (in query: SELECT count(materialize(toLowCardinality(1))) IGNORE NULLS AS num, hostName() AS hostName FROM system.query_log AS a INNER JOIN system.processes AS b ON (type = toFixedString(toNullable('QueryStart'), 10)) AND (dateDiff('second', event_time, now()) > 5) AND (current_database = currentDatabase()) FORMAT `Null`;), Stack trace (when copying this message, always include the lines below):
2025-02-12 18:36:29
2025-02-12 18:36:29 0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:106: Poco::Exception::Exception(String const&, int) @ 0x000000000facc20b
2025-02-12 18:36:29 1. /fasttest-workspace/build/./src/Common/Exception.cpp:106: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000849dd59
2025-02-12 18:36:29 2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000003443f0c
2025-02-12 18:36:29 3. DB::Exception::Exception(int, FormatStringHelperImpl::type, std::type_identity::type>, String const&, String&&) @ 0x0000000003a13dab
2025-02-12 18:36:29 4. /fasttest-workspace/build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:4348: DB::QueryAnalyzer::initializeQueryJoinTreeNode(std::shared_ptr&, DB::IdentifierResolveScope&) @ 0x000000000cbc48ab
2025-02-12 18:36:29 5. /fasttest-workspace/build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5551: DB::QueryAnalyzer::resolveQuery(std::shared_ptr const&, DB::IdentifierResolveScope&) @ 0x000000000cb9927c
2025-02-12 18:36:29 6. /fasttest-workspace/build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:175: DB::QueryAnalyzer::resolve(std::shared_ptr&, std::shared_ptr const&, std::shared_ptr) @ 0x000000000cb9876c
2025-02-12 18:36:29 7. /fasttest-workspace/build/./src/Analyzer/Resolve/QueryAnalysisPass.cpp:18: DB::QueryAnalysisPass::run(std::shared_ptr&, std::shared_ptr) @ 0x000000000cb97f76
2025-02-12 18:36:29 8. /fasttest-workspace/build/./src/Analyzer/QueryTreePassManager.cpp:184: DB::QueryTreePassManager::run(std::shared_ptr) @ 0x000000000d2078b6
2025-02-12 18:36:29 9. /fasttest-workspace/build/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:149: DB::(anonymous namespace)::buildQueryTreeAndRunPasses(std::shared_ptr const&, DB::SelectQueryOptions const&, std::shared_ptr const&, std::shared_ptr const&) @ 0x000000000d469e43
2025-02-12 18:36:29 10. /fasttest-workspace/build/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:167: DB::InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(std::shared_ptr const&, std::shared_ptr const&, DB::SelectQueryOptions const&, std::vector> const&) @ 0x000000000d4685da
2025-02-12 18:36:29 11. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:597: std::unique_ptr> std::__function::__policy_invoker> (DB::InterpreterFactory::Arguments const&)>::__call_impl[abi:ne180100]> (DB::InterpreterFactory::Arguments const&)>>(std::__function::__policy_storage const*, DB::InterpreterFactory::Arguments const&) @ 0x000000000d46b4a2
2025-02-12 18:36:29 12. ./contrib/llvm-project/libcxx/include/__functional/function.h:714: ? @ 0x000000000d412591
2025-02-12 18:36:29 13. /fasttest-workspace/build/./src/Interpreters/executeQuery.cpp:1388: DB::executeQueryImpl(char const*, char const*, std::shared_ptr, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*, std::shared_ptr&) @ 0x000000000d7acf16
2025-02-12 18:36:29 14. /fasttest-workspace/build/./src/Interpreters/executeQuery.cpp:1622: DB::executeQuery(String const&, std::shared_ptr, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x000000000d7a96a2
2025-02-12 18:36:29 15. /fasttest-workspace/build/./src/Server/TCPHandler.cpp:663: DB::TCPHandler::runImpl() @ 0x000000000f19495a
2025-02-12 18:36:29 16. /fasttest-workspace/build/./src/Server/TCPHandler.cpp:2626: DB::TCPHandler::run() @ 0x000000000f1acff8
2025-02-12 18:36:29 17. /fasttest-workspace/build/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x000000000fb725a7
2025-02-12 18:36:29 18. /fasttest-workspace/build/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x000000000fb72a7a
2025-02-12 18:36:29 19. /fasttest-workspace/build/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x000000000fb1c932
2025-02-12 18:36:29 20. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x000000000fb1a423
2025-02-12 18:36:29 21. src/thread/pthread_create.c:207: start @ 0x000000000feb080d
2025-02-12 18:36:29 22. src/thread/x86_64/clone.s:22: ? @ 0x000000000feb245d
2025-02-12 18:36:29
2025-02-12 18:36:29 Received exception from server (version 25.2.1):
2025-02-12 18:36:29 Code: 60. DB::Exception: Received from localhost:9000. DB::Exception: Unknown table expression identifier 'system.query_log' in scope SELECT count(materialize(toLowCardinality(1))) IGNORE NULLS AS num, hostName() AS hostName FROM system.query_log AS a INNER JOIN system.processes AS b ON (type = toFixedString(toNullable('QueryStart'), 10)) AND (dateDiff('second', event_time, now()) > 5) AND (current_database = currentDatabase()). (UNKNOWN_TABLE)
2025-02-12 18:36:29 (query: SELECT
2025-02-12 18:36:29 count(materialize(toLowCardinality(1))) IGNORE NULLS AS num,
2025-02-12 18:36:29 hostName() AS hostName
2025-02-12 18:36:29 FROM system.query_log AS a
2025-02-12 18:36:29 INNER JOIN system.processes AS b ON (type = toFixedString(toNullable('QueryStart'), 10)) AND (dateDiff('second', event_time, now()) > 5) AND (current_database = currentDatabase())
2025-02-12 18:36:29 FORMAT `Null`;)
2025-02-12 18:36:29 , result:
2025-02-12 18:36:29
2025-02-12 18:36:29
2025-02-12 18:36:29
2025-02-12 18:36:29 stdout:
2025-02-12 18:36:29
2025-02-12 18:36:29
2025-02-12 18:36:29
2025-02-12 18:36:29 Database: test_glkrntsz
```

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=76012&sha=1f597c5c076bb4d2a229b84568a7b98f489b7d76&name_0=PR&name_1=Fast%20test

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
