### PR TITLE
Correct documentation for reinterpretAsUUID

### DIFF
--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -6178,7 +6178,7 @@ Result:
 In addition to the UUID functions listed here, there is dedicated [UUID function documentation](../functions/uuid-functions.md).
 :::
 
-Accepts a 16 byte string and returns a UUID containing bytes representing the corresponding value in network byte order (big-endian). If the string isn't long enough, the function works as if the string is padded with the necessary number of null bytes to the end. If the string is longer than 16 bytes, the extra bytes at the end are ignored.
+Accepts a 16 byte string and returns a UUID by interpreting each 8-byte half in little-endian byte order. If the string isn't long enough, the function works as if the string is padded with the necessary number of null bytes to the end. If the string is longer than 16 bytes, the extra bytes at the end are ignored.
 
 **Syntax**
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

https://clickhouse.com/docs/en/sql-reference/functions/type-conversion-functions#reinterpretasuuid

The documentation states:

> Accepts a 16 byte string and returns a UUID containing bytes representing the corresponding value in network byte order (big-endian).

However, this isn't the case. For example, let's say we are trying to create a UUID from a Sip128 hash:

base64 of the bytes we are calling this function on:
```
SELECT base64Encode(sipHash128Reference('TESTSTRING'))
FORMAT TabSeparatedRaw

Query id: <omitted>

TPzoaSe7gNjAziB2ynLV4A==
```

The UUID ClickHouse gives:
```
SELECT reinterpretAsUUID(sipHash128Reference('TESTSTRING'))
FORMAT TabSeparatedRaw

Query id: fc86001b-cacb-4657-9668-4dc29072042e

d880bb27-69e8-fc4c-e0d5-72ca7620cec0
```

Here's a Python script that demonstrates that ClickHouse actually interprets the bytes in little-endian order:

```
import base64
import uuid
import struct

# The base64 string we know is correct
base64_str = "TPzoaSe7gNjAziB2ynLV4A=="
bytes_data = base64.b64decode(base64_str)

# Print raw bytes in hex
print("Raw bytes in hex:")
print(' '.join(f'{b:02x}' for b in bytes_data))
print()

print("Different UUID constructions:")

# Using big-endian byte order (network byte order)
msb_be, lsb_be = struct.unpack('>QQ', bytes_data)
uuid_be = uuid.UUID(int=(msb_be << 64) | lsb_be)
print(f"Big-endian interpretation:    {uuid_be}")

# Using little-endian byte order (actual ClickHouse behavior)
msb_le, lsb_le = struct.unpack('<QQ', bytes_data)
uuid_le = uuid.UUID(int=(msb_le << 64) | lsb_le)
print(f"Little-endian interpretation: {uuid_le}")
```

Output:
```
$ python test_uuid.py
Raw bytes in hex:
4c fc e8 69 27 bb 80 d8 c0 ce 20 76 ca 72 d5 e0

Different UUID constructions:
Big-endian interpretation:    4cfce869-27bb-80d8-c0ce-2076ca72d5e0
Little-endian interpretation: d880bb27-69e8-fc4c-e0d5-72ca7620cec0
```