### PR TITLE
Add more test logs for decompressing

### DIFF
--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -7,6 +7,7 @@
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Exception.h>
+#include <base/demangle.h>
 #include <base/hex.h>
 #include <Compression/ICompressionCodec.h>
 #include <Compression/CompressionFactory.h>
@@ -14,6 +15,7 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/BufferWithOwnMemory.h>
 #include <Compression/CompressionInfo.h>
+#include <IO/WithFileName.h>
 #include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
 
@@ -325,6 +327,23 @@ void CompressedReadBufferBase::decompress(BufferBase::Buffer & to, size_t size_d
     }
     else
         codec->decompress(compressed_buffer, static_cast<UInt32>(size_compressed_without_checksum), to.begin());
+}
+
+void CompressedReadBufferBase::addDiagnostics(Exception & e) const
+{
+    /// Error messages can look really scary when we can't decompress something.
+    /// It makes sense to give more information to help debugging such issues.
+    std::optional<off_t> current_pos;
+    if (auto * seekable_in = dynamic_cast<SeekableReadBuffer *>(compressed_in))
+        current_pos = seekable_in->tryGetPosition();
+    UInt8 header_size = ICompressionCodec::getHeaderSize();
+    String header_hex = hexString(own_compressed_buffer.data(), std::min(own_compressed_buffer.size(), sizeof(Checksum) + header_size));
+
+    e.addMessage("While reading or decompressing {} (position: {}, typename: {}, compressed data header: {})",
+                 getFileNameFromReadBuffer(*compressed_in),
+                 (current_pos ? std::to_string(*current_pos) : "?"),
+                 demangle(typeid(*compressed_in).name()),
+                 header_hex);
 }
 
 /// 'compressed_in' could be initialized lazily, but before first call of 'readCompressedData'.

--- a/src/Compression/CompressedReadBufferBase.h
+++ b/src/Compression/CompressedReadBufferBase.h
@@ -9,6 +9,7 @@
 namespace DB
 {
 
+class Exception;
 class ReadBuffer;
 
 /** Basic functionality for implementation of
@@ -63,6 +64,9 @@ protected:
     /// This method can change location of `to` to avoid unnecessary copy if data is uncompressed.
     /// It is more efficient for compression codec NONE but not suitable if you want to decompress into specific location.
     void decompress(BufferBase::Buffer & to, size_t size_decompressed, size_t size_compressed_without_checksum);
+
+    /// Adds diagnostics to the error message.
+    void addDiagnostics(Exception & e) const;
 
 public:
     /// 'compressed_in' could be initialized lazily, but before first call of 'readCompressedData'.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add more test logs for decompressing