### PR TITLE
Fix "Part <...> does not contain in snapshot of previous virtual parts. (PART_IS_TEMPORARILY_LOCKED)" during DETACH PART

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergePredicates/ReplicatedMergeTreeMergePredicate.cpp
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/ReplicatedMergeTreeMergePredicate.cpp
@@ -61,6 +61,14 @@ ReplicatedMergeTreeZooKeeperMergePredicate::ReplicatedMergeTreeZooKeeperMergePre
     /// Order of actions is important, DO NOT CHANGE.
     /// For explanation check DistributedMergePredicate.
 
+    /// We want to ensure that the predicate uses the most recent state of the queue
+    /// (in particular the list of virtual parts). Because in some cases the race condition
+    /// takes place between creating the predicate to use it for some parts and placing this parts
+    /// in the list of virtual parts during pulling queue.
+    /// The second call to pullLogsToQueue() below is used for preserving the invariant,
+    /// see DistributedMergePredicate
+    queue_.pullLogsToQueue(zookeeper, {}, ReplicatedMergeTreeQueue::MERGE_PREDICATE);
+
     {
         std::lock_guard lock(queue.state_mutex);
         prev_virtual_parts = std::make_shared<ActiveDataPartSet>(queue.virtual_parts);

--- a/src/Storages/MergeTree/Compaction/MergePredicates/ReplicatedMergeTreeMergePredicate.cpp
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/ReplicatedMergeTreeMergePredicate.cpp
@@ -61,14 +61,6 @@ ReplicatedMergeTreeZooKeeperMergePredicate::ReplicatedMergeTreeZooKeeperMergePre
     /// Order of actions is important, DO NOT CHANGE.
     /// For explanation check DistributedMergePredicate.
 
-    /// We want to ensure that the predicate uses the most recent state of the queue
-    /// (in particular the list of virtual parts). Because in some cases the race condition
-    /// takes place between creating the predicate to use it for some parts and placing this parts
-    /// in the list of virtual parts during pulling queue.
-    /// The second call to pullLogsToQueue() below is used for preserving the invariant,
-    /// see DistributedMergePredicate
-    queue_.pullLogsToQueue(zookeeper, {}, ReplicatedMergeTreeQueue::MERGE_PREDICATE);
-
     {
         std::lock_guard lock(queue.state_mutex);
         prev_virtual_parts = std::make_shared<ActiveDataPartSet>(queue.virtual_parts);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9221,6 +9221,10 @@ bool StorageReplicatedMergeTree::dropPartImpl(
         if (shutdown_called || partial_shutdown_called)
             throw Exception(ErrorCodes::ABORTED, "Cannot drop part because shutdown called");
 
+        /// Ensure that the merge predicate will use the most recent state of the queue
+        /// (in particular the list of virtual parts).
+        queue.pullLogsToQueue(zookeeper, {}, ReplicatedMergeTreeQueue::MERGE_PREDICATE);
+
         auto merge_predicate = queue.getMergePredicate(zookeeper, PartitionIdsHint{part_info.partition_id});
 
         auto part = getPartIfExists(part_info, {MergeTreeDataPartState::Active});

--- a/tests/queries/0_stateless/03356_pull_entry_before_detach_part.sql
+++ b/tests/queries/0_stateless/03356_pull_entry_before_detach_part.sql
@@ -1,0 +1,13 @@
+-- Tags: no-fasttest
+
+DROP TABLE IF EXISTS t1 SYNC;
+
+CREATE TABLE t1 (x UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_03356/t1', '1') ORDER BY tuple();
+
+SYSTEM STOP PULLING REPLICATION LOG t1;
+
+INSERT INTO t1 VALUES (1);
+
+SYSTEM START PULLING REPLICATION LOG t1;
+
+ALTER TABLE t1 DETACH PART 'all_0_0_0';

--- a/tests/queries/0_stateless/03356_pull_entry_before_detach_part.sql
+++ b/tests/queries/0_stateless/03356_pull_entry_before_detach_part.sql
@@ -1,5 +1,8 @@
 -- Tags: no-fasttest, no-parallel
 
+-- Forbid fault injection to avoid part name randomization, since we rely on it
+SET insert_keeper_fault_injection_probability=0;
+
 DROP TABLE IF EXISTS t1 SYNC;
 
 CREATE TABLE t1 (x UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_03356/t1', '1') ORDER BY tuple();

--- a/tests/queries/0_stateless/03356_pull_entry_before_detach_part.sql
+++ b/tests/queries/0_stateless/03356_pull_entry_before_detach_part.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-parallel
 
 DROP TABLE IF EXISTS t1 SYNC;
 


### PR DESCRIPTION
The race condition leading to the error below can be easily reproduced for the test lines:
```
INSERT INTO test1 SELECT toDate('2023-01-01') + toIntervalDay(number), number + 1000 from system.numbers limit 20
ALTER TABLE test1 DETACH PART 'all_0_0_0'"
```
By adding sleep in any place of `ReplicatedMergeTreeQueue::pullLogsToQueue()` before [this](https://github.com/ClickHouse/ClickHouse/blob/09a73b311c7d22e4d5126a0c4c18ed063b17e34c/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp#L752) line.

Error:
```
2025.02.11 11:50:40.000593 [ 9 ] {061d749d-1ae0-4dca-8b71-50f2ce366ddf} <Debug> executeQuery: (from 172.16.1.1:62162) (query 1, line 1) ALTER TABLE test1 DETACH PART 'all_0_0_0' (stage: Complete)
2025.02.11 11:50:40.000742 [ 9 ] {061d749d-1ae0-4dca-8b71-50f2ce366ddf} <Test> CancellationChecker: Did not add the task because the timeout is 0. Query: ALTER TABLE test1 DETACH PART 'all_0_0_0'
2025.02.11 11:50:40.001213 [ 9 ] {061d749d-1ae0-4dca-8b71-50f2ce366ddf} <Trace> default.test1 (240a67b9-3ffc-44e0-8c18-1e9ad21281f8): Will try to insert a log entry to DROP_PART for part all_0_0_0
2025.02.11 11:50:40.234026 [ 27 ] {} <Trace> default.test1 (ReplicatedMergeTreeQueue): Insert entry queue-0000000000 to queue with type GET_PART with virtual parts [all_0_0_0]
2025.02.11 11:50:40.234112 [ 27 ] {} <Test> default.test1 (ReplicatedMergeTreeQueue): Adding part all_0_0_0 to mutations
2025.02.11 11:50:40.234152 [ 27 ] {} <Debug> default.test1 (ReplicatedMergeTreeQueue): Pulled 1 entries to queue.
2025.02.11 11:50:40.234186 [ 27 ] {} <Debug> default.test1 (240a67b9-3ffc-44e0-8c18-1e9ad21281f8): Updating strategy picker state
2025.02.11 11:50:40.235400 [ 27 ] {} <Trace> default.test1 (StorageReplicatedMergeTree::queueUpdatingTask): Execution took 507 ms.
2025.02.11 11:50:40.236458 [ 603 ] {} <Test> default.test1 (ReplicatedMergeTreeQueue): Removing successful entry queue-0000000000 from queue with type GET_PART with virtual parts [all_0_0_0]
2025.02.11 11:50:40.236580 [ 603 ] {} <Test> default.test1 (ReplicatedMergeTreeQueue): Adding parts [all_0_0_0] to current parts
2025.02.11 11:50:40.236664 [ 603 ] {} <Test> default.test1 (ReplicatedMergeTreeQueue): Removing part all_0_0_0 from mutations (remove_part: false, remove_covered_parts: true)
2025.02.11 11:50:40.351288 [ 9 ] {061d749d-1ae0-4dca-8b71-50f2ce366ddf} <Error> executeQuery: Code: 384. DB::Exception: Part all_0_0_0 does not contain in snapshot of previous virtual parts. (PART_IS_TEMPORARILY_LOCKED) (version 25.2.1.1812 (official build)) (from 172.16.1.1:62162) (query 1, line 1) (in query: ALTER TABLE test1 DETACH PART 'all_0_0_0'), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:106: Poco::Exception::Exception(String const&, int) @ 0x0000000021eae400
1. ./build_docker/./src/Common/Exception.cpp:106: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x00000000103f8e18
2. ./src/Common/Exception.h:104: DB::Exception::Exception(PreformattedMessage const&, int) @ 0x00000000135d543e
3. ./build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:9248: DB::StorageReplicatedMergeTree::dropPartImpl(std::shared_ptr<zkutil::ZooKeeper>&, String, DB::ReplicatedMergeTreeLogEntry&, bool, bool) @ 0x000000001c0cb589
4. ./build_docker/./src/Storages/StorageReplicatedMergeTree.cpp:6863: DB::StorageReplicatedMergeTree::dropPart(String const&, bool, std::shared_ptr<DB::Context const>) @ 0x000000001c0cc0ee
5. ./build_docker/./src/Storages/MergeTree/MergeTreeData.cpp:5630: DB::MergeTreeData::alterPartition(std::shared_ptr<DB::StorageInMemoryMetadata const> const&, std::vector<DB::PartitionCommand, std::allocator<DB::PartitionCommand>> const&, std::shared_ptr<DB::Context const>) @ 0x000000001c7026da
6. ./build_docker/./src/Interpreters/InterpreterAlterQuery.cpp:245: DB::InterpreterAlterQuery::executeToTable(DB::ASTAlterQuery const&) @ 0x00000000197afea3
7. ./build_docker/./src/Interpreters/InterpreterAlterQuery.cpp:80: DB::InterpreterAlterQuery::execute() @ 0x00000000197ad0a3
8. ./build_docker/./src/Interpreters/executeQuery.cpp:1455: DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*, std::shared_ptr<DB::IAST>&) @ 0x000000001a17e8a9
9. ./build_docker/./src/Interpreters/executeQuery.cpp:1622: DB::executeQuery(String const&, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x000000001a1795ce
10. ./build_docker/./src/Server/TCPHandler.cpp:662: DB::TCPHandler::runImpl() @ 0x000000001cf7bf05
11. ./build_docker/./src/Server/TCPHandler.cpp:2625: DB::TCPHandler::run() @ 0x000000001cfa2c88
12. ./build_docker/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x0000000021fc4503
13. ./build_docker/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x0000000021fc4d72
14. ./build_docker/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x0000000021f3dc43
15. ./build_docker/./base/poco/Foundation/src/Thread.cpp:45: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x0000000021f3bf50
16. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000021f3a30a
17. __tsan_thread_start_func @ 0x0000000007f43428
18. ? @ 0x00007f17b8a53ac3
19. ? @ 0x00007f17b8ae5850
```

Failure [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=11991bb3cfaa57042ecb5a1fb428631136cf2d35&name_0=MasterCI&name_1=Integration%20tests%20%28tsan%2C%205%2F6%29)

Race condition takes place between creating of merge predicate (actually [saving](https://github.com/ClickHouse/ClickHouse/blob/09a73b311c7d22e4d5126a0c4c18ed063b17e34c/src/Storages/MergeTree/Compaction/MergePredicates/ReplicatedMergeTreeMergePredicate.cpp#L66) `prev_virtual_parts`) and the pulling of new log entries to queue with subsequent updating `queue.virtual_parts`.

I implemented the simplest fix without conditional logic for now. 
Alternatives would be pulling preliminary only for some checking (for example, for `dropPart`) or use `virtual_parts` instead of `prev_virtual_parts` while working `DistributedMergePredicate::CanUsePartInMerges() -> checkCanMergePartsPreconditions()` [link](https://github.com/ClickHouse/ClickHouse/blob/09a73b311c7d22e4d5126a0c4c18ed063b17e34c/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h#L132)


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "Part <...> does not contain in snapshot of previous virtual parts. (PART_IS_TEMPORARILY_LOCKED)" during DETACH PART

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
