### PR TITLE
CI: Support setting commit status per job in praktika

### DIFF
--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -48,6 +48,8 @@ class Job:
 
         allow_merge_on_failure: bool = False
 
+        enable_commit_status: bool = False
+
         parameter: Any = None
 
         def parametrize(

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -414,10 +414,10 @@ def _finish_workflow(workflow, job_name):
 
     if failed_results:
         failed_jobs_csv = ",".join(failed_results)
-        if len(failed_jobs_csv) < 50:
+        if len(failed_jobs_csv) < 80:
             ready_for_merge_description = f"Failed: {failed_jobs_csv}"
         else:
-            ready_for_merge_description = f"Failed: {len(failed_results)} jobs"
+            ready_for_merge_description = f"Failed: {len(failed_results)} required jobs"
 
     if workflow.enable_merge_ready_status:
         pem = workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY).get_value()

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -418,7 +418,9 @@ class Runner:
             print(f"Run html report hook")
             HtmlRunnerHooks.post_run(workflow, job, info_errors)
 
-        if workflow.enable_commit_status_on_failure and not result.is_ok():
+        if (
+            workflow.enable_commit_status_on_failure and not result.is_ok()
+        ) or job.enable_commit_status:
             if Settings.USE_CUSTOM_GH_AUTH:
                 from praktika.gh_auth_deprecated import GHAuth
 

--- a/ci/workflows/job_configs.py
+++ b/ci/workflows/job_configs.py
@@ -32,6 +32,7 @@ class JobConfigs:
         runs_on=RunnerLabels.STYLE_CHECK_ARM,
         command="cd ./tests/ci && python3 ci.py --run-from-praktika",
         requires=[JobNames.DOCKER_BUILDS_AMD],
+        enable_commit_status=True,
     )
     fast_test = Job.Config(
         name=JobNames.FAST_TEST,
@@ -721,6 +722,7 @@ class JobConfigs:
             ],
         ),
         allow_merge_on_failure=True,
+        enable_commit_status=True,
     ).parametrize(
         parameter=[
             "release, 1/3",

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1428,21 +1428,7 @@ def main() -> int:
 
         # post
         try:
-            job_report = JobReport.load()
-            gh = GitHub(get_best_robot_token(), per_page=100)
-            commit = get_commit(gh, pr_info.sha)
-            if not job_report.dummy:
-                if "style" in check_name.lower() and job_report.status == "success":
-                    # style status required for sync ...
-                    post_commit_status(
-                        commit,
-                        job_report.status,
-                        "",
-                        "",
-                        check_name,
-                        pr_info,
-                    )
-            else:
+            if JobReport.load().dummy:
                 print("ERROR: Job was killed - generate evidence")
                 job_report.duration = (
                     start_time - datetime.now(timezone.utc)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* praktika to support job-level setting to enable GH commit status
* enables commit status for Performance Comparison job

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
