### PR TITLE
ci: add chc alias in integration-test image

### DIFF
--- a/ci/docker/integration/integration-test/Dockerfile
+++ b/ci/docker/integration/integration-test/Dockerfile
@@ -100,3 +100,8 @@ maxClientCnxns=80' > /opt/zookeeper/conf/zoo.cfg && \
 
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/ci/docker/integration/integration-test/entrypoint.sh
+++ b/ci/docker/integration/integration-test/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ln -s "$(which clickhouse)" /usr/bin/chc
+ln -s "$(which clickhouse)" /usr/bin/chl
+
+exec "$@"

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3251,7 +3251,7 @@ services:
             {odbc_ini_path}
             {keytab_path}
             {krb5_conf}
-        entrypoint: {entrypoint_cmd}
+        command: {cmd}
         tmpfs: {tmpfs}
         {mem_limit}
         cap_add:
@@ -4786,7 +4786,7 @@ class ClickHouseInstance:
                     odbc_ini_path=odbc_ini_path,
                     keytab_path=self.keytab_path,
                     krb5_conf=self.krb5_conf,
-                    entrypoint_cmd=entrypoint_cmd,
+                    cmd=entrypoint_cmd,
                     networks=networks,
                     app_net=app_net,
                     ipv4_address=ipv4_address,


### PR DESCRIPTION
It is very useful to run a short name instead of a full `clickhouse client` name even during debugging in tests.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
