### PR TITLE
ci: remove useless store/metadata.tar artifacts to reduce cost

### DIFF
--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -527,8 +527,6 @@ fi
 tar -chf /test_output/coordination.tar /var/lib/clickhouse/coordination ||:
 
 rm -rf /var/lib/clickhouse/data/system/*/
-tar -chf /test_output/store.tar /var/lib/clickhouse/store ||:
-tar -chf /test_output/metadata.tar /var/lib/clickhouse/metadata/*.sql ||:
 
 
 if [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then


### PR DESCRIPTION
The problem with store is that it almost useless, for the following reasons:
- After #75594 it does not contains any databases for failed tests so it can contain only some system/service tables
- But the system database is removed before creating it
- There is actually MinIO logs, but they are available as a separate artifacts
- Plus, there is public datasets that are converted from table with S3 disk to a plain MergeTree

**So to summarize we store ~500MiB for each build of useless stuff.**

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)