### PR TITLE
Update run.sh

### DIFF
--- a/docker/docs/builder/run.sh
+++ b/docker/docs/builder/run.sh
@@ -31,7 +31,7 @@ sed -i '/onBrokenMarkdownLinks:/ s/ignore/error/g' docusaurus.config.js
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   export CI=true
-  exec yarn build_docs_check "$@"
+  exec yarn build-docs-check "$@"
   exec yarn build-swagger
 fi
 

--- a/docker/docs/builder/run.sh
+++ b/docker/docs/builder/run.sh
@@ -31,7 +31,8 @@ sed -i '/onBrokenMarkdownLinks:/ s/ignore/error/g' docusaurus.config.js
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   export CI=true
-  exec yarn build "$@"
+  exec yarn build_docs_check "$@"
+  exec yarn build-swagger
 fi
 
 exec "$@"

--- a/docker/docs/builder/run.sh
+++ b/docker/docs/builder/run.sh
@@ -31,8 +31,7 @@ sed -i '/onBrokenMarkdownLinks:/ s/ignore/error/g' docusaurus.config.js
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   export CI=true
-  exec yarn build-docs-check "$@"
-  exec yarn build-swagger
+  exec yarn build
 fi
 
 exec "$@"

--- a/docker/docs/builder/run.sh
+++ b/docker/docs/builder/run.sh
@@ -31,7 +31,8 @@ sed -i '/onBrokenMarkdownLinks:/ s/ignore/error/g' docusaurus.config.js
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   export CI=true
-  exec yarn build
+  exec yarn build "$@"
+  exec yarn build-swagger
 fi
 
 exec "$@"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
<!--
https://clickhouse.com/docs/en/cloud/manage/api/swagger is broken. Issue is that build swagger is running before docusaurus build so docusaurus build seems to overwrite the swagger.html file output from build swagger.

This leads back to this error on docs check: 

```
Unknown argument: out-dir
error Command failed with exit code 1.
```
In https://github.com/ClickHouse/clickhouse-docs/pull/3255 I separate out build-swagger from build (by adding build-docs-check). Then in run.sh we will call `yarn build_docs_check` followed by `yarn build-swagger` to make sure docusaurus build doesn't overwrite swagger.html. 
-->

Testing if we need `$@` argument after `yarn build` as it ties us to having to call `docusaurus build` last. Not even sure if it's getting used or not.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
