### PR TITLE
ci: tune threadpool_writer_pool_size (to avoid one test affect another for S3)

### DIFF
--- a/tests/config/config.d/threadpool_writer_pool_size.yaml
+++ b/tests/config/config.d/threadpool_writer_pool_size.yaml
@@ -1,0 +1,3 @@
+---
+# Increase number of threads to avoid one test affect others
+threadpool_writer_pool_size: 500

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -84,6 +84,7 @@ ln -sf $SRC_PATH/config.d/filesystem_caches_path.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/validate_tcp_client_information.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/zero_copy_destructive_operations.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/handlers.yaml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/threadpool_writer_pool_size.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/
 


### PR DESCRIPTION
While reviewing one flaky test [1] I found this:

```
2025.02.11 20:32:37.980244 [ 106730 ] {fe1cd3d8-dafb-4732-9cc6-9653e403fb8e} <Debug> executeQuery: (from [::1]:41148) (comment: 02968_file_log_multiple_read.sh) (query 1, line 1) select count() from table_to_store_data; (stage: Complete)
...
2025.02.11 20:32:38.396915 [ 525 ] {} <Trace> FileLogConsumer 0: Polled batch of 10 records.
...
2025.02.11 20:32:47.870183 [ 106706 ] {cc726be3-3294-4aa9-ab00-554e00d05571} <Debug> executeQuery: (from [::1]:43114) (comment: 02968_file_log_multiple_read.sh) (query 1, line 1) select count() from table_to_store_data; (stage: Complete)
...
2025.02.11 20:32:48.968244 [ 106720 ] {caf46be3-5423-4b03-82ec-a8eb79b3a5e5} <Debug> executeQuery: (from [::1]:43130) (comment: 02968_file_log_multiple_read.sh) (query 1, line 1) SELECT * FROM table_to_store_data ORDER BY id; (stage: Complete)
...
2025.02.11 20:32:49.587001 [ 525 ] {} <Debug> StorageFileLog (file_log): Pushing 10 rows to test_9pfc79ke.file_log (5b73275e-71e1-412d-8c8d-4fb419074adf) took 11200 ms.
```

So writing first part takes 11 seconds, whichi is likely due to S3 storage.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9a12e619a4bce1968e15c40fe4ddd6159130725f&name_0=MasterCI&name_1=Stateless%20tests%20%28debug%2C%20s3%20storage%29

Likely it was waiting for some parallel write, let's increase number of threads on CI to avoid this.

TL;DR;

<details>

<summary>trace_log</summary>

```
Row 3:
──────
arrayStringC⋯bols, '\n'): StackTrace::StackTrace(ucontext_t const&)
DB::(anonymous namespace)::writeTraceInfo(DB::TraceType, int, siginfo_t*, void*)
DB::QueryProfilerReal::signalHandler(int, siginfo_t*, void*)

std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)
std::__1::__assoc_sub_state::copy()
std::__1::future<void>::get()
DB::TaskTracker::waitAll()
DB::WriteBufferFromS3::finalizeImpl()
DB::WriteBuffer::finalize()
DB::WriteBufferFromFileDecorator::finalizeImpl()
DB::WriteBufferWithFinalizeCallback::finalizeImpl()
DB::WriteBuffer::finalize()
DB::MergeTreeDataPartWriterCompact::finish(bool)
DB::MergedBlockOutputStream::Finalizer::Impl::finish()
DB::MergedBlockOutputStream::Finalizer::finish()
DB::MergeTreeDataWriter::TemporaryPart::finalize()
DB::MergeTreeSink::finishDelayedChunk()
DB::runStep(std::__1::function<void ()>, DB::ThreadStatus*, std::__1::atomic<unsigned long>*)
DB::ExceptionKeepingTransform::work()
DB::ExecutionThreadContext::executeTask()
DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*)
DB::PipelineExecutor::executeSingleThread(unsigned long)
DB::PipelineExecutor::executeImpl(unsigned long, bool)
DB::PipelineExecutor::execute(unsigned long, bool)
DB::CompletedPipelineExecutor::execute()
DB::StorageFileLog::streamToViews()
DB::StorageFileLog::threadFunc()
DB::BackgroundSchedulePoolTaskInfo::execute()
DB::BackgroundSchedulePool::threadFunction()
void std::__1::__function::__policy_invoker<void ()>::__call_impl[abi:se180100]<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, StrongTypedef<unsigned long, CurrentMetrics::MetricTag>, char const*)::$_1&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*)
ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker()
void* std::__1::__thread_proxy[abi:se180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*)
```

</details>

<details>

<summary>query_views_log</summary>

```
SELECT
    pe.1,
    pe.2
FROM query_views_log_5585707547072793959
ARRAY JOIN ProfileEvents AS pe
WHERE (event_date IN ('2025-02-11')) AND (pull_request_number = 0) AND (commit_sha = '9a12e619a4bce1968e15c40fe4ddd6159130725f') AND ((event_time >= '2025-02-11 19:32:30') AND (event_time <= '2025-02-11 19:32:49')) AND (check_name = 'Stateless tests (debug, s3 storage)') AND (view_target LIKE 'test_9pfc79ke.%') AND (view_duration_ms = 11183)

Query id: 35d8c9dc-0b99-4735-b291-78429b9645d4

    ┌─tupleElement(pe, 1)──────────────────────────┬─tupleElement(pe, 2)─┐
 1. │ QueriesWithSubqueries                        │                   5 │
 2. │ SelectQueriesWithSubqueries                  │                   4 │
 3. │ InsertQueriesWithSubqueries                  │                   1 │
 4. │ FileOpen                                     │                   9 │
 5. │ WriteBufferFromFileDescriptorWrite           │                   9 │
 6. │ WriteBufferFromFileDescriptorWriteBytes      │                 484 │
 7. │ IOBufferAllocs                               │                  30 │
 8. │ IOBufferAllocBytes                           │            12817489 │
 9. │ FunctionExecute                              │                   3 │
10. │ DiskWriteElapsedMicroseconds                 │                 163 │
11. │ LocalThreadPoolJobs                          │                   9 │
12. │ RemoteWriteThrottlerBytes                    │                 576 │
13. │ InsertedRows                                 │                  10 │
14. │ InsertedBytes                                │                  80 │
15. │ SelectedRows                                 │                  20 │
16. │ SelectedBytes                                │                 160 │
17. │ MergeTreeDataWriterRows                      │                  10 │
18. │ MergeTreeDataWriterUncompressedBytes         │                  80 │
19. │ MergeTreeDataWriterCompressedBytes           │                 259 │
20. │ MergeTreeDataWriterBlocks                    │                   1 │
21. │ MergeTreeDataWriterBlocksAlreadySorted       │                   1 │
22. │ MergeTreeDataWriterSortingBlocksMicroseconds │                   4 │
23. │ MergeTreeDataWriterMergingBlocksMicroseconds │                   2 │
24. │ InsertedCompactParts                         │                   1 │
25. │ ContextLock                                  │                  57 │
26. │ RWLockAcquiredReadLocks                      │                  10 │
27. │ PartsLockHoldMicroseconds                    │                 126 │
28. │ RealTimeMicroseconds                         │            11184993 │
29. │ UserTimeMicroseconds                         │               15431 │
30. │ SoftPageFaults                               │                   4 │
31. │ QueryProfilerRuns                            │                  12 │
32. │ S3ReadMicroseconds                           │               14078 │
33. │ S3ReadRequestsCount                          │                  18 │
34. │ DiskS3ReadMicroseconds                       │               14078 │
35. │ DiskS3ReadRequestsCount                      │                  18 │
36. │ S3HeadObject                                 │                  18 │
37. │ DiskS3HeadObject                             │                  18 │
38. │ WriteBufferFromS3Bytes                       │                 576 │
39. │ LogTrace                                     │                  40 │
40. │ LogDebug                                     │                   2 │
41. │ LoggerElapsedNanoseconds                     │            81725509 │
42. │ DiskConnectionsReused                        │                  18 │
43. │ DiskConnectionsPreserved                     │                  18 │
44. │ ConcurrencyControlSlotsGranted               │                   1 │
45. │ ConcurrencyControlSlotsAcquired              │                   1 │
    └──────────────────────────────────────────────┴─────────────────────┘
```

</details>

<details>

<summary>metric_log</summary>

```
clickhouse-cloud$  :) select event_time, ProfileEvent_WriteBufferFromS3Bytes, ProfileEvent_WriteBufferFromS3Microseconds from metric_log_7777484111524293105 where event_date in '2025-02-11' and pull_request_number = 0 and commit_sha = '9a12e619a4bce1968e15c40fe4ddd6159130725f' and event_time between '2025-02-11 19:32:30' and '2025-02-11 19:32:49' and check_name = 'Stateless tests (debug, s3 storage)' order by 1

SELECT
    event_time,
    ProfileEvent_WriteBufferFromS3Bytes,
    ProfileEvent_WriteBufferFromS3Microseconds
FROM metric_log_7777484111524293105
WHERE (event_date IN ('2025-02-11')) AND (pull_request_number = 0) AND (commit_sha = '9a12e619a4bce1968e15c40fe4ddd6159130725f') AND ((event_time >= '2025-02-11 19:32:30') AND (event_time <= '2025-02-11 19:32:49')) AND (check_name = 'Stateless tests (debug, s3 storage)')
ORDER BY 1 ASC

Query id: 7d97cd7a-6c35-4e27-877b-08e01393f72c

    ┌──────────event_time─┬─ProfileEvent_WriteBufferFromS3Bytes─┬─ProfileEvent_WriteBufferFromS3Microseconds─┐
 1. │ 2025-02-11 19:32:30 │                               11594 │                                    2653873 │
 2. │ 2025-02-11 19:32:31 │                               10023 │                                    2757613 │
 3. │ 2025-02-11 19:32:32 │                             2155399 │                                    4111243 │
 4. │ 2025-02-11 19:32:33 │                             2985854 │                                   26921338 │
 5. │ 2025-02-11 19:32:34 │                                7936 │                                   25422613 │
 6. │ 2025-02-11 19:32:35 │                             3883492 │                                   24801127 │
 7. │ 2025-02-11 19:32:36 │                             5705908 │                                   23786050 │
 8. │ 2025-02-11 19:32:37 │                            13252641 │                                   32368510 │
 9. │ 2025-02-11 19:32:38 │                            19149831 │                                   70738207 │
10. │ 2025-02-11 19:32:39 │                             3515044 │                                   94236723 │
11. │ 2025-02-11 19:32:40 │                                   1 │                                  101089372 │
12. │ 2025-02-11 19:32:41 │                              653213 │                                   97707451 │
13. │ 2025-02-11 19:32:42 │                                   0 │                                   99595743 │
14. │ 2025-02-11 19:32:43 │                             1361957 │                                  102491420 │
15. │ 2025-02-11 19:32:44 │                             1079337 │                                  101388003 │
16. │ 2025-02-11 19:32:45 │                             1197565 │                                   97024436 │
17. │ 2025-02-11 19:32:46 │                                   0 │                                   99589346 │
18. │ 2025-02-11 19:32:47 │                                   0 │                                  102530969 │
19. │ 2025-02-11 19:32:48 │                             1285250 │                                   97393019 │
20. │ 2025-02-11 19:32:49 │                                   0 │                                  101415583 │
    └─────────────────────┴─────────────────────────────────────┴────────────────────────────────────────────┘
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)