### PR TITLE
Make now() use the same clock as now64

### DIFF
--- a/src/Functions/now.cpp
+++ b/src/Functions/now.cpp
@@ -19,6 +19,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int CANNOT_CLOCK_GETTIME;
 }
 
 namespace

--- a/src/Functions/now.cpp
+++ b/src/Functions/now.cpp
@@ -128,12 +128,17 @@ public:
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Arguments of function {} should be String or FixedString",
                 getName());
         }
+
+        timespec spec{};
+        if (clock_gettime(CLOCK_REALTIME, &spec))
+            throw ErrnoException(ErrorCodes::CANNOT_CLOCK_GETTIME, "Cannot clock_gettime");
+
         if (arguments.size() == 1)
             return std::make_unique<FunctionBaseNow>(
-                time(nullptr), DataTypes{arguments.front().type},
+                spec.tv_sec, DataTypes{arguments.front().type},
                 std::make_shared<DataTypeDateTime>(extractTimeZoneNameFromFunctionArguments(arguments, 0, 0, allow_nonconst_timezone_arguments)));
 
-        return std::make_unique<FunctionBaseNow>(time(nullptr), DataTypes(), std::make_shared<DataTypeDateTime>());
+        return std::make_unique<FunctionBaseNow>(spec.tv_sec, DataTypes(), std::make_shared<DataTypeDateTime>());
     }
 private:
     const bool allow_nonconst_timezone_arguments;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/73685

Before this PR, `now()` uses `time(0)`, which is usually implemented as `clock_gettime(CLOCK_REALTIME_COARSE)`, which usually lags behind `CLOCK_REALTIME` by a few ms. So, for the first few milliseconds of every second (6.3ms on my machine), `now()` returns the previous second. I.e. `now() != now64(0)` ~0.6% of the time.

This PR switches `now()` to `CLOCK_REALTIME`.

It doesn't matter for performance because it's only called at query analysis time, not for each row, not even for each block.

It may matter for refreshable MVs because people will often (?) want to use rounded `now()` as an estimate of the refresh timeslot. E.g. consider `REFRESH EVERY 1 MINUTE APPEND ... SELECT ... WHERE timestamp BETWEEN (toStartOfMinute(now()) as timeslot_end) - INTERVAL 1 MINUTE AND timeslot_end`. Without this PR, `timeslot_end` would usually be in the previous minute, but if there's a 7ms hiccup in query analysis it'll be in the next minute. With this PR it'll be in the current minute semi-reliably (unless there's a 1 minute hiccup in query analysis).