### PR TITLE
Improve the `binary` page

### DIFF
--- a/programs/server/binary.html
+++ b/programs/server/binary.html
@@ -105,7 +105,15 @@
 
                     hilbertEncode(x, y) DIV 2 AS addr,
 
-                    extract(demangle(addressToSymbol(addr)), '(?:^| )(?:(?:DB|\\(anonymous namespace\\))::)?(\\w+)') AS name,
+                    replaceOne(
+                        replaceRegexpOne(
+                            demangle(addressToSymbol(addr)),
+                            '^([\\w\\*]+ )+', -- simple return types
+                            ''),
+                        '(anonymous namespace)::',
+                        '') AS full_name,
+
+                    extract(full_name, '(?:(?:DB|std|__1|detail|impl_?)::)?(\\w+)') AS name,
                     (empty(name) ? 0 : sipHash64(name)) AS hash,
                     hash MOD 256 AS r, hash DIV 256 MOD 256 AS g, hash DIV 65536 MOD 256 AS b
 

--- a/programs/server/binary.html
+++ b/programs/server/binary.html
@@ -86,7 +86,7 @@
         let map = L.map('space', {
             crs: L.CRS.Simple,
             center: [-512, 512],
-            maxBounds: [[128, -128], [-1152, 1152]],
+            maxBounds: [[512, -512], [-1536, 1536]],
             zoom: 0,
         });
 
@@ -103,9 +103,9 @@
                     (zoom_factor * (tile_x + {x:UInt16} * 1024))::UInt16 AS x,
                     (zoom_factor * (tile_y + {y:UInt16} * 1024))::UInt16 AS y,
 
-                    mortonEncode(x, y) AS addr,
+                    hilbertEncode(x, y) DIV 2 AS addr,
 
-                    extract(demangle(addressToSymbol(addr)), '^[^<]+') AS name,
+                    extract(demangle(addressToSymbol(addr)), '(?:^| )(?:(?:DB|\\(anonymous namespace\\))::)?(\\w+)') AS name,
                     (empty(name) ? 0 : sipHash64(name)) AS hash,
                     hash MOD 256 AS r, hash DIV 256 MOD 256 AS g, hash DIV 65536 MOD 256 AS b
 
@@ -225,14 +225,33 @@
             }
         }
 
-        function showPopup(x, y) {
-            const xn = BigInt(x);
-            const yn = BigInt(y);
-            let addr_int = 0n;
-            for (let bit = 0n; bit < 16n; ++bit) {
-                addr_int |= ((xn >> bit) & 1n) << (bit * 2n);
-                addr_int |= ((yn >> bit) & 1n) << (1n + bit * 2n);
+        function hilbertEncode(x, y) {
+            let xn = BigInt(x);
+            let yn = BigInt(y);
+
+            let res = 0n;
+
+            for (let shift = 0n; shift < 16n; ++shift) {
+                const mask = 1n << (15n - shift);
+                const x_bit = (xn & mask) > 0n ? 1n : 0n;
+                const y_bit = (yn & mask) > 0n ? 1n : 0n;
+
+                res += mask * mask * ((3n * y_bit) ^ x_bit);
+
+                if (x_bit == 0n) {
+                    if (y_bit == 1n) {
+                        xn = mask - 1n - xn;
+                        yn = mask - 1n - yn;
+                    }
+                    [xn, yn] = [yn, xn];
+                }
             }
+
+            return res;
+        }
+
+        function showPopup(x, y) {
+            let addr_int = hilbertEncode(x, y) / 2n;
 
             current_requested_addr = addr_int;
 

--- a/src/Functions/hilbertEncode.cpp
+++ b/src/Functions/hilbertEncode.cpp
@@ -1,7 +1,5 @@
-#include <limits>
 #include <optional>
 #include <Functions/FunctionFactory.h>
-#include <Common/BitHelpers.h>
 #include "hilbertEncode2DLUT.h"
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved the `/binary` server's page. Using the Hilbert curve instead of the Morton curve. Display 512 MB worth of addresses in the square, which fills the square better (in previous versions, addresses fill only half of the square). Color addresses closer to the library name rather than the function name. Allow scrolling a bit more outside of the area.

Previous:
<img width="785" alt="Screenshot_20250215_075340" src="https://github.com/user-attachments/assets/51d50236-8193-4648-bc93-a3f3b7b3e5fe" />

Current:
<img width="781" alt="Screenshot_20250215_075353" src="https://github.com/user-attachments/assets/a6a05c0d-078d-46ca-91b2-0a2e2ea048b1" />
