### PR TITLE
fix docs build for server-configuration-parameters/settings.md

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -8,7 +8,7 @@ keywords: [global server settings]
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import SystemLogParameters from '_snippets/_system-log-parameters.md'
+import SystemLogParameters from './_snippets/_system-log-parameters.md'
 
 # Global Server Settings
 

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1619,7 +1619,7 @@ The following settings can be configured by sub-tags:
 | `url`              | A location for redirect                                                                                                                                               |
 | `type`             | Supported types: static, dynamic_query_handler, predefined_query_handler, redirect                                                                                    | 
 | `status`           | Use with static type, response status code                                                                                                                            |
-| `query_param_name` | Use with dynamic_query_handler type, extracts and executes the value corresponding to the <query_param_name> value in HTTP request params                             |
+| `query_param_name` | Use with dynamic_query_handler type, extracts and executes the value corresponding to the `<query_param_name>` value in HTTP request params                             |
 | `query`            | Use with predefined_query_handler type, executes query when the handler is called                                                                                     |
 | `content_type`     | Use with static type, response content-type                                                                                                                           |
 | `response_content` | Use with static type, Response content sent to client, when using the prefix 'file://' or 'config://', find the content from the file or configuration send to client |


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Looks like docs check started failing for [example](https://s3.amazonaws.com/clickhouse-test-reports/PRs/76181/555fdea9064d662e4b77ec94ce3e59bfd0776cda//docs_check/job.log).

Issue seems to be with the xml tag in markdown `<query_param_name>`.

Looks related to #75613.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
