### PR TITLE
tests: disable flaky query in 03040_recursive_cte_postgres_6

### DIFF
--- a/tests/queries/0_stateless/03040_recursive_cte_postgres_6.reference
+++ b/tests/queries/0_stateless/03040_recursive_cte_postgres_6.reference
@@ -84,12 +84,14 @@ WITH RECURSIVE x AS (SELECT 1 AS n UNION ALL SELECT sum(n) FROM x)
 -- ORDER BY
 WITH RECURSIVE x AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM x ORDER BY 1)
   SELECT * FROM x FORMAT NULL SETTINGS max_recursive_cte_evaluation_depth = 5; -- { serverError TOO_DEEP_RECURSION }
+-- FIXME: indeterministic results
+--
 -- target list has a recursive query name
-WITH RECURSIVE x AS (SELECT 1 AS id
-    UNION ALL
-    SELECT (SELECT * FROM x) FROM x WHERE id < 5
-) SELECT * FROM x; -- { serverError UNKNOWN_TABLE, CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
-1
+-- WITH RECURSIVE x AS (SELECT 1 AS id
+--     UNION ALL
+--     SELECT (SELECT * FROM x) FROM x WHERE id < 5
+-- ) SELECT * FROM x; -- { serverError UNKNOWN_TABLE, CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+
 -- mutual recursive query (not implemented)
 WITH RECURSIVE
   x AS (SELECT 1 AS id UNION ALL SELECT id+1 FROM y WHERE id < 5),

--- a/tests/queries/0_stateless/03040_recursive_cte_postgres_6.sql
+++ b/tests/queries/0_stateless/03040_recursive_cte_postgres_6.sql
@@ -99,11 +99,13 @@ WITH RECURSIVE x AS (SELECT 1 AS n UNION ALL SELECT sum(n) FROM x)
 WITH RECURSIVE x AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM x ORDER BY 1)
   SELECT * FROM x FORMAT NULL SETTINGS max_recursive_cte_evaluation_depth = 5; -- { serverError TOO_DEEP_RECURSION }
 
+-- FIXME: indeterministic results
+--
 -- target list has a recursive query name
-WITH RECURSIVE x AS (SELECT 1 AS id
-    UNION ALL
-    SELECT (SELECT * FROM x) FROM x WHERE id < 5
-) SELECT * FROM x; -- { serverError UNKNOWN_TABLE, CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+-- WITH RECURSIVE x AS (SELECT 1 AS id
+--     UNION ALL
+--     SELECT (SELECT * FROM x) FROM x WHERE id < 5
+-- ) SELECT * FROM x; -- { serverError UNKNOWN_TABLE, CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
 
 -- mutual recursive query (not implemented)
 WITH RECURSIVE


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The behavior became non deterministic after https://github.com/ClickHouse/ClickHouse/pull/75732#discussion_r1957063847 (cc @KochetovNicolai )