### PR TITLE
fix: remove subqueries from CTE after substition when analyzer disabled

### DIFF
--- a/tests/queries/0_stateless/03357_cte_subquery_without_analyzer.reference
+++ b/tests/queries/0_stateless/03357_cte_subquery_without_analyzer.reference
@@ -1,0 +1,19 @@
+-- Check subqueries are not propagated to remote
+20
+
+1	0
+
+-- Check scalar subqueries are propagated to remote
+1
+
+1	1
+
+-- Check expressions are propagated to remote
+2
+
+1	1
+
+-- Check only subqueries are not propagated to remote
+11
+
+1	0	1

--- a/tests/queries/0_stateless/03357_cte_subquery_without_analyzer.sql
+++ b/tests/queries/0_stateless/03357_cte_subquery_without_analyzer.sql
@@ -1,0 +1,117 @@
+set enable_analyzer = 0;
+
+create table data (id Int32) engine = MergeTree order by id;
+insert into data select number from numbers(100);
+
+create table filters (id Int32) engine = MergeTree order by id;
+insert into filters select number from numbers(20);
+
+select '-- Check subqueries are not propagated to remote';
+
+with
+    flt as (select id from filters)
+select count()
+from remote('127.0.0.1:9000', currentDatabase(), 'data')
+where id global in (flt)
+settings prefer_localhost_replica = 0,
+         log_comment = '03357_global_in_subquery';
+
+select '';
+system flush logs;
+
+with (
+    select query_id from system.query_log
+    where log_comment = '03357_global_in_subquery'
+      and type = 'QueryStart'
+      and current_database = currentDatabase()
+      and is_initial_query
+) as initial_id
+select count(), countIf(startsWith(lower(query), 'with flt'))
+from system.query_log
+where initial_query_id = initial_id
+  and type = 'QueryStart'
+  and query_id != initial_query_id;
+
+select '';
+select '-- Check scalar subqueries are propagated to remote';
+
+with
+    (select count() from filters) as flt
+select count()
+from remote('127.0.0.1:9000', currentDatabase(), 'data')
+where id global in (flt)
+settings prefer_localhost_replica = 0,
+         log_comment = '03357_global_in_scalar';
+
+select '';
+system flush logs;
+
+with (
+    select query_id from system.query_log
+    where log_comment = '03357_global_in_scalar'
+      and type = 'QueryStart'
+      and current_database = currentDatabase()
+      and is_initial_query
+) as initial_id
+select count(), countIf(startsWith(lower(query), 'with _cast(20,'))
+from system.query_log
+where initial_query_id = initial_id
+  and type = 'QueryStart'
+  and query_id != initial_query_id;
+
+select '';
+select '-- Check expressions are propagated to remote';
+
+with count() as expr
+select expr
+from remote('127.0.0.1:9000', currentDatabase(), 'data')
+where id in (10, 20)
+settings prefer_localhost_replica = 0,
+         log_comment = '03357_expressions';
+
+select '';
+system flush logs;
+
+with (
+    select query_id from system.query_log
+    where log_comment = '03357_expressions'
+      and type = 'QueryStart'
+      and current_database = currentDatabase()
+      and is_initial_query
+) as initial_id
+select count(), countIf(startsWith(lower(query), 'with count() as `expr`'))
+from system.query_log
+where initial_query_id = initial_id
+  and type = 'QueryStart'
+  and query_id != initial_query_id;
+
+select '';
+select '-- Check only subqueries are not propagated to remote';
+
+with count() as expr,
+     (select count() from filters where id in (5, 15)) as sclr,
+     sub as (select * from filters where id >= 10)
+select expr
+from remote('127.0.0.1:9000', currentDatabase(), 'data')
+where id global in (sclr)
+   or id global in (sub)
+settings prefer_localhost_replica = 0,
+         log_comment = '03357_mixed';
+
+select '';
+system flush logs;
+
+with (
+    select query_id from system.query_log
+    where log_comment = '03357_mixed'
+      and type = 'QueryStart'
+      and current_database = currentDatabase()
+      and is_initial_query
+) as initial_id
+select count(),
+       countIf(lower(query) like '%(select * from filters where id < 10)%'),
+       countIf(startsWith(lower(query), 'with'))
+from system.query_log
+where initial_query_id = initial_id
+  and type = 'QueryStart'
+  and query_id != initial_query_id;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove subqueries from CTE after their substitution into the query to prevent sending them on remote nodes in case of disabled analyzer. In case WITH subquery is sent on remote node, in case of subquery counter match, its alias (`_subqueryXXX`) may be resolved there to original query, which leads to the subquery execution on remote.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
