### PR TITLE
Fix undefined behaviour in exception_cast

### DIFF
--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -337,11 +337,11 @@ std::string getExceptionMessage(std::exception_ptr e, bool with_stacktrace, bool
 
 template <typename T>
 requires std::is_pointer_v<T>
-T exception_cast(std::exception_ptr e)
+T current_exception_cast()
 {
     try
     {
-        std::rethrow_exception(e);
+        throw;
     }
     catch (std::remove_pointer_t<T> & concrete)
     {

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -246,7 +246,7 @@ bool ReadBufferFromS3::processException(size_t read_offset, size_t attempt) cons
         getCurrentExceptionMessage(/* with_stacktrace = */ false));
 
 
-    if (auto * s3_exception = exception_cast<S3Exception *>(std::current_exception()))
+    if (auto * s3_exception = current_exception_cast<S3Exception *>())
     {
         /// It doesn't make sense to retry Access Denied or No Such Key
         if (!s3_exception->isRetryableError())

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -882,7 +882,7 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
             LOG_ERROR(storage.log, "Part {} is broken and needs manual correction. Reason: {}",
                 getDataPartStorage().getFullPath(), message);
 
-            if (Exception * e = exception_cast<Exception *>(std::current_exception()))
+            if (Exception * e = current_exception_cast<Exception *>())
             {
                 /// Probably there is something wrong with files of this part.
                 /// So it can be helpful to add to the error message some information about those files.

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6177,9 +6177,16 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::loadPartRestoredFromBackup(cons
 
         if (!retryable || (try_no + 1 == loading_parts_max_tries))
         {
-            if (Exception * e = exception_cast<Exception *>(error))
-                e->addMessage("while restoring part {} of table {}", part_name, getStorageID());
-            std::rethrow_exception(error);
+            try
+            {
+                std::rethrow_exception(error);
+            }
+            catch (...)
+            {
+                if (Exception * e = current_exception_cast<Exception *>())
+                    e->addMessage("while restoring part {} of table {}", part_name, getStorageID());
+                throw;
+            }
         }
 
         tryLogException(error, log,


### PR DESCRIPTION
[7.6.18](https://eel.is/c++draft/expr.compound#expr.throw) Throwing an exception[[expr.throw]](https://eel.is/c++draft/expr.throw)

> A [throw-expression](https://eel.is/c++draft/expr.throw#nt:throw-expression) with no operand rethrows the currently handled exception ([[except.handle]](https://eel.is/c++draft/except.handle))[.](https://eel.is/c++draft/expr.throw#3.sentence-1) If no exception is presently being handled, the function std​::​terminate is invoked ([[except.terminate]](https://eel.is/c++draft/except.terminate))[.](https://eel.is/c++draft/expr.throw#3.sentence-2) **Otherwise, the exception is reactivated with the existing exception object; no new exception object is created**[.](https://eel.is/c++draft/expr.throw#3.sentence-3) The exception is no longer considered to be caught[.](https://eel.is/c++draft/expr.throw#3.sentence-4)


But `std::rethrow_exception` can rethrow copy of the exception, which is destroyed after leaving `catch` block:

[17.9.7](https://eel.is/c++draft/support.exception#propagation) Exception propagation [[propagation]](https://eel.is/c++draft/propagation)

> *[[noreturn]] constexpr void rethrow_exception(exception_ptr p);*
Effects: Let u be the exception object to which p refers, or a copy of that exception object[.](https://eel.is/c++draft/propagation#11.sentence-1) **It is unspecified whether a copy is made**, and memory for the copy is allocated in an unspecified way[.](https://eel.is/c++draft/propagation#11.sentence-2)
> - If allocating memory to form u fails, throws an instance of bad_alloc;
> - otherwise, if copying the exception to which p refers to form u throws an exception, throws that exception;
> - otherwise, throws u.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix undefined behaviour while exception casting.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
