### PR TITLE
Fix `ALTER RENAME` requires `CREATE USER` privilege

### DIFF
--- a/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
@@ -53,7 +53,7 @@ BlockIO InterpreterCreateRoleQuery::execute()
     for (const auto & name : query.names)
         getContext()->checkAccess(access_type, name);
 
-    if (!query.new_name.empty())
+    if (!query.new_name.empty() && !query.alter)
         getContext()->checkAccess(AccessType::CREATE_ROLE, query.new_name);
 
     std::optional<AlterSettingsProfileElements> settings_from_query;

--- a/src/Interpreters/Access/InterpreterCreateUserQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateUserQuery.cpp
@@ -196,7 +196,7 @@ BlockIO InterpreterCreateUserQuery::execute()
     for (const auto & name : *query.names)
         access->checkAccess(query.alter ? AccessType::ALTER_USER : AccessType::CREATE_USER, name->toString());
 
-    if (query.new_name)
+    if (query.new_name && !query.alter)
         access->checkAccess(AccessType::CREATE_USER, *query.new_name);
 
     bool implicit_no_password_allowed = access_control.isImplicitNoPasswordAllowed();

--- a/tests/queries/0_stateless/03274_precise_alter_user_grants.sh
+++ b/tests/queries/0_stateless/03274_precise_alter_user_grants.sh
@@ -9,6 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 user1="user03247_1_${CLICKHOUSE_DATABASE}_$RANDOM"
 user2="user03247_2_${CLICKHOUSE_DATABASE}_$RANDOM"
 user3="user03247_3_${CLICKHOUSE_DATABASE}_$RANDOM"
+user4="user03247_4_${CLICKHOUSE_DATABASE}_$RANDOM"
 
 ${CLICKHOUSE_CLIENT} <<EOF
 DROP USER IF EXISTS $user1, $user2, $user3;
@@ -21,6 +22,11 @@ ${CLICKHOUSE_CLIENT} --user $user1 --query "CREATE USER $user3"
 (( $(${CLICKHOUSE_CLIENT} --user $user1 --query "CREATE USER foobar" 2>&1 | grep -c "Not enough privileges") >= 1 )) && echo "Not enough privileges" || echo "UNEXPECTED"
 
 ${CLICKHOUSE_CLIENT} --query "GRANT ALTER USER ON $user2 TO $user2"
-${CLICKHOUSE_CLIENT} --user $user2 --query "ALTER USER $user2 IDENTIFIED BY 'bar';"
-(( $(${CLICKHOUSE_CLIENT} --user $user3 --query "ALTER USER $user2 IDENTIFIED BY 'bar';" 2>&1 | grep -c "Not enough privileges") >= 1 )) && echo "Not enough privileges" || echo "UNEXPECTED"
-(( $(${CLICKHOUSE_CLIENT} --user $user3 --query "ALTER USER $user3 IDENTIFIED BY 'bar';" 2>&1 | grep -c "Not enough privileges") >= 1 )) && echo "Not enough privileges" || echo "UNEXPECTED"
+(( $(${CLICKHOUSE_CLIENT} --user $user2 --query "ALTER USER $user3 IDENTIFIED BY 'bar'" 2>&1 | grep -c "Not enough privileges") >= 1 )) && echo "Not enough privileges" || echo "UNEXPECTED"
+${CLICKHOUSE_CLIENT} --user $user2 --query "ALTER USER $user2 IDENTIFIED BY 'bar'"
+(( $(${CLICKHOUSE_CLIENT} --user $user3 --query "ALTER USER $user2 IDENTIFIED BY 'bar'" 2>&1 | grep -c "Not enough privileges") >= 1 )) && echo "Not enough privileges" || echo "UNEXPECTED"
+
+${CLICKHOUSE_CLIENT} --query "GRANT ALTER USER ON * TO $user3"
+${CLICKHOUSE_CLIENT} --user $user3 --query "ALTER USER $user3 RENAME TO $user4"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user1, $user2, $user3, $user4;"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect permission check where `ALTER RENAME` required `CREATE USER` grant. 
Closes https://github.com/ClickHouse/ClickHouse/issues/74372

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
