### PR TITLE
Fix CMake string replace function usage

### DIFF
--- a/contrib/llvm-project-cmake/CMakeLists.txt
+++ b/contrib/llvm-project-cmake/CMakeLists.txt
@@ -154,7 +154,7 @@ block()
     # to another CMake generator, but expects a value without spaces.
     # We may replace spaces with semicolons to ensure it is unwrapped correctly later.
     if (CMAKE_CXX_COMPILER_LAUNCHER)
-        string(REPLACE " " ";" CMAKE_CXX_COMPILER_LAUNCHER "${LLVM_CMAKE_CXX_COMPILER_LAUNCHER}")
+        string(REPLACE " " ";" LLVM_CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_CXX_COMPILER_LAUNCHER}")
     endif()
     set (CMAKE_CXX_COMPILER_LAUNCHER "${LLVM_CMAKE_CXX_COMPILER_LAUNCHER}")
 


### PR DESCRIPTION
Follow up for https://github.com/ClickHouse/ClickHouse/pull/75148/

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

