### PR TITLE
Fix reinterpretAs with FixedString on big-endian architecture

### DIFF
--- a/src/Functions/reinterpretAs.cpp
+++ b/src/Functions/reinterpretAs.cpp
@@ -226,7 +226,7 @@ public:
                         else
                         {
                             size_t offset_to = sizeof(ToFieldType) > copy_size ? sizeof(ToFieldType) - copy_size : 0;
-                            memcpy(reinterpret_cast<char*>(&vec_res[i]) + offset_to, &data_from[index - offset], copy_size);
+                            reverseMemcpy(reinterpret_cast<char*>(&vec_res[i]) + offset_to, &data_from[index - offset], copy_size);
                         }
                         offset += step;
                     }

--- a/src/Functions/reinterpretAs.cpp
+++ b/src/Functions/reinterpretAs.cpp
@@ -314,11 +314,11 @@ private:
         {
             std::string_view data = src.getDataAt(i).toView();
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-            memcpy(&data_to[offset], data.data(), std::min(n, data.size()));
-#else
-            reverseMemcpy(&data_to[offset], data.data(), std::min(n, data.size()));
-#endif
+            if constexpr (std::endian::native == std::endian::little)
+                memcpy(&data_to[offset], data.data(), std::min(n, data.size()));
+            else
+                reverseMemcpy(&data_to[offset], data.data(), std::min(n, data.size()));
+
             offset += n;
         }
     }
@@ -328,11 +328,10 @@ private:
         ColumnFixedString::Chars & data_to = dst.getChars();
         data_to.resize(n * input_rows_count);
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-        memcpy(data_to.data(), src.getRawData().data(), data_to.size());
-#else
-        reverseMemcpy(data_to.data(), src.getRawData().data(), data_to.size());
-#endif
+        if constexpr (std::endian::native == std::endian::little)
+            memcpy(data_to.data(), src.getRawData().data(), data_to.size());
+        else
+            reverseMemcpy(data_to.data(), src.getRawData().data(), data_to.size());
     }
 
     static void NO_INLINE executeToString(const IColumn & src, ColumnString & dst, size_t input_rows_count)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix reinterpretAs with FixedString on big-endian architecture

I came across this while reviewing documentation changes #76022 (that was actually a bad translation from Russian - #16688)

### Example

reinterpretAsUUID(x)         | LE                                   | BE
-|-|-
`'AABBCCDD'`                   | `44444343-4242-4141-0000-000000000000` | `44444343-4242-4141-0000-000000000000`
`toFixedString('AABBCCDD', 8)` | `44444343-4242-4141-0000-000000000000` | **`41414242-4343-4444-0000-000000000000`**

AFAICS all other cases interpret FixedString/String correctly for BE, i.e. copy in reverse order.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/49198 (cc @SuzyWangIBMer)
Refs: https://github.com/ClickHouse/ClickHouse/pull/53556 (cc @kothiga)