### PR TITLE
ci: some cleanup and retries for dpkg -i

### DIFF
--- a/docker/test/base/Dockerfile
+++ b/docker/test/base/Dockerfile
@@ -50,5 +50,6 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezo
 
 # This script is used to setup realtime export of server logs from the CI into external ClickHouse cluster:
 COPY setup_export_logs.sh /
+COPY basic_helpers.sh /
 
 CMD sleep 1

--- a/docker/test/base/basic_helpers.sh
+++ b/docker/test/base/basic_helpers.sh
@@ -1,0 +1,23 @@
+#
+# Basic helpers
+#
+
+# Usage: run_with_retry RETRIES ...
+function run_with_retry()
+{
+    local retries="$1" && shift
+
+    local retry=0
+    until [ "$retry" -ge "$retries" ]; do
+        if "$@"; then
+            return
+        else
+            retry=$((retry + 1))
+            sleep 5
+        fi
+    done
+
+    echo "Command '$*' failed after $retries retries, exiting" >&2
+    return 1
+}
+

--- a/docker/test/clickbench/run.sh
+++ b/docker/test/clickbench/run.sh
@@ -5,13 +5,15 @@ SCRIPT_PID=$!
 
 # shellcheck disable=SC1091
 source /setup_export_logs.sh
+# shellcheck disable=SC1091
+source /basic_helpers.sh
 
 # fail on errors, verbose and export all env variables
 set -e -x -a
 
-dpkg -i package_folder/clickhouse-common-static_*.deb
-dpkg -i package_folder/clickhouse-server_*.deb
-dpkg -i package_folder/clickhouse-client_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-common-static_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-server_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-client_*.deb
 
 # A directory for cache
 mkdir /dev/shm/clickhouse

--- a/tests/docker_scripts/attach_gdb.lib
+++ b/tests/docker_scripts/attach_gdb.lib
@@ -2,6 +2,8 @@
 
 # shellcheck source=./utils.lib
 source /repo/tests/docker_scripts/utils.lib
+# shellcheck disable=SC1091
+source /basic_helpers.sh
 
 function attach_gdb_to_clickhouse()
 {

--- a/tests/docker_scripts/sqllogic_runner.sh
+++ b/tests/docker_scripts/sqllogic_runner.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
+source /basic_helpers.sh
+
 set -exu
 trap "exit" INT TERM
 
@@ -26,10 +29,10 @@ ls -la /test_output
 echo "File in /sqllogictest"
 ls -la /sqllogictest
 
-dpkg -i package_folder/clickhouse-common-static_*.deb
-dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
-dpkg -i package_folder/clickhouse-server_*.deb
-dpkg -i package_folder/clickhouse-client_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-common-static_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-server_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-client_*.deb
 
 # install test configs
 # /clickhouse-tests/config/install.sh

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -28,12 +28,12 @@ TZ="$(rg -v '#' /usr/share/zoneinfo/zone.tab  | awk '{print $3}' | shuf | head -
 echo "Chosen random timezone $TZ"
 ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
 
-dpkg -i package_folder/clickhouse-common-static_*.deb
-dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
-dpkg -i package_folder/clickhouse-odbc-bridge_*.deb
-dpkg -i package_folder/clickhouse-library-bridge_*.deb
-dpkg -i package_folder/clickhouse-server_*.deb
-dpkg -i package_folder/clickhouse-client_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-common-static_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-odbc-bridge_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-library-bridge_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-server_*.deb
+run_with_retry 3 dpkg -i package_folder/clickhouse-client_*.deb
 
 echo "$BUGFIX_VALIDATE_CHECK"
 

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -5,6 +5,8 @@ set -e -x -a
 
 # shellcheck disable=SC1091
 source /setup_export_logs.sh
+# shellcheck disable=SC1091
+source /basic_helpers.sh
 
 # shellcheck source=../stateless/stress_tests.lib
 source /repo/tests/docker_scripts/stress_tests.lib

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -260,10 +260,6 @@ function prepare_stateful_data() {
     clickhouse-client --query "SELECT count() FROM test.visits"
 }
 
-function fn_exists() {
-    declare -F "$1" > /dev/null;
-}
-
 function run_tests()
 {
     set -x

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -6,6 +6,9 @@ FAIL="\tFAIL\t\\N\t"
 FAILURE_CONTEXT_LINES=100
 FAILURE_CONTEXT_MAX_LINE_WIDTH=3000
 
+# shellcheck disable=SC1091
+source /basic_helpers.sh
+
 function escaped()
 {
     # That's the simplest way I found to escape a string in bash. Yep, bash is the most convenient programming language.
@@ -31,10 +34,10 @@ function trim_server_logs()
 
 function install_packages()
 {
-    dpkg -i "$1"/clickhouse-common-static_*.deb
-    dpkg -i "$1"/clickhouse-common-static-dbg_*.deb
-    dpkg -i "$1"/clickhouse-server_*.deb
-    dpkg -i "$1"/clickhouse-client_*.deb
+    run_with_retry 3 dpkg -i "$1"/clickhouse-common-static_*.deb
+    run_with_retry 3 dpkg -i "$1"/clickhouse-common-static-dbg_*.deb
+    run_with_retry 3 dpkg -i "$1"/clickhouse-server_*.deb
+    run_with_retry 3 dpkg -i "$1"/clickhouse-client_*.deb
 }
 
 function configure()

--- a/tests/docker_scripts/utils.lib
+++ b/tests/docker_scripts/utils.lib
@@ -36,10 +36,6 @@ function run_with_retry()
     return 1
 }
 
-function fn_exists() {
-    declare -F "$1" > /dev/null;
-}
-
 function collect_core_dumps()
 {
   find . -type f -maxdepth 1 -name 'core.*' | while read -r core; do

--- a/tests/docker_scripts/utils.lib
+++ b/tests/docker_scripts/utils.lib
@@ -5,37 +5,6 @@ sysctl kernel.core_pattern='core.%e.%p-%P'
 # ASAN doesn't work with suid_dumpable=2
 sysctl fs.suid_dumpable=1
 
-function run_with_retry()
-{
-    if [[ $- =~ e ]]; then
-      set_e=true
-    else
-      set_e=false
-    fi
-    set +e
-
-    local total_retries="$1"
-    shift
-
-    local retry=0
-
-    until [ "$retry" -ge "$total_retries" ]
-    do
-        if "$@"; then
-            if $set_e; then
-              set -e
-            fi
-            return
-        else
-            retry=$((retry + 1))
-            sleep 5
-        fi
-    done
-
-    echo "Command '$*' failed after $total_retries retries, exiting"
-    return 1
-}
-
 function collect_core_dumps()
 {
   find . -type f -maxdepth 1 -name 'core.*' | while read -r core; do


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Should help with

```
dpkg-deb (subprocess): cannot copy archive member from 'package_folder/clickhouse-library-bridge_24.8.1.2294_amd64.deb' to decompressor pipe: unexpected end of file or stream
dpkg-deb (subprocess): decompressing archive 'package_folder/clickhouse-library-bridge_24.8.1.2294_amd64.deb' (size=167772160) member 'data.tar': internal gzip read error: buffer error
dpkg-deb: error: <decompress> subprocess returned error exit status 2
```

Fixes: https://github.com/ClickHouse/ClickHouse/issues/68137