### PR TITLE
Fix errors and flakiness in test_broken_projections

### DIFF
--- a/tests/integration/test_broken_projections/test.py
+++ b/tests/integration/test_broken_projections/test.py
@@ -2,6 +2,7 @@ import logging
 import random
 import string
 import time
+import uuid
 from multiprocessing.dummy import Pool
 
 import pytest
@@ -236,29 +237,19 @@ def check(
             f"SELECT c FROM '{table}' WHERE d == 12 ORDER BY c SETTINGS force_optimize_projection_name = 'proj1'"
         )
     else:
-        query_id = node.query(
-            f"SELECT queryID() FROM (SELECT c FROM '{table}' WHERE d == 12 ORDER BY c SETTINGS force_optimize_projection_name = 'proj1')"
+        query_id = uuid.uuid4().hex
+        node.query(
+            f"SELECT c FROM '{table}' WHERE d == 12 ORDER BY c SETTINGS force_optimize_projection_name = 'proj1'",
+            query_id=query_id,
         ).strip()
-        for _ in range(10):
-            node.query("SYSTEM FLUSH LOGS")
-            res = node.query(
-                f"""
-            SELECT query, splitByChar('.', arrayJoin(projections))[-1]
-            FROM system.query_log
-            WHERE query_id='{query_id}' AND type='QueryFinish'
-            """
-            )
-            if res != "":
-                break
-        if res == "":
-            res = node.query(
-                """
-                SELECT query_id, query, splitByChar('.', arrayJoin(projections))[-1]
-                FROM system.query_log ORDER BY query_start_time_microseconds DESC
-            """
-            )
-            print(f"Looked for query id {query_id}, but to no avail: {res}")
-            assert False
+        node.query("SYSTEM FLUSH LOGS")
+        res = node.query(
+            f"""
+        SELECT splitByChar('.', arrayJoin(projections))[-1]
+        FROM system.query_log
+        WHERE query_id='{query_id}' AND type='QueryFinish'
+        """
+        )
         assert "proj1" in res
 
     if expect_broken_part == "proj2":
@@ -266,29 +257,19 @@ def check(
             f"SELECT d FROM '{table}' WHERE c == 12 ORDER BY d SETTINGS force_optimize_projection_name = 'proj2'"
         )
     else:
-        query_id = node.query(
-            f"SELECT queryID() FROM (SELECT d FROM '{table}' WHERE c == 12 ORDER BY d SETTINGS force_optimize_projection_name = 'proj2')"
+        query_id = uuid.uuid4().hex
+        node.query(
+            f"SELECT queryID() FROM (SELECT d FROM '{table}' WHERE c == 12 ORDER BY d SETTINGS force_optimize_projection_name = 'proj2')",
+            query_id=query_id,
         ).strip()
-        for _ in range(10):
-            node.query("SYSTEM FLUSH LOGS")
-            res = node.query(
-                f"""
-            SELECT query, splitByChar('.', arrayJoin(projections))[-1]
-            FROM system.query_log
-            WHERE query_id='{query_id}' AND type='QueryFinish'
-            """
-            )
-            if res != "":
-                break
-        if res == "":
-            res = node.query(
-                """
-                SELECT query_id, query, splitByChar('.', arrayJoin(projections))[-1]
-                FROM system.query_log ORDER BY query_start_time_microseconds DESC
-            """
-            )
-            print(f"Looked for query id {query_id}, but to no avail: {res}")
-            assert False
+        node.query("SYSTEM FLUSH LOGS")
+        res = node.query(
+            f"""
+        SELECT splitByChar('.', arrayJoin(projections))[-1]
+        FROM system.query_log
+        WHERE query_id='{query_id}' AND type='QueryFinish'
+        """
+        )
         assert "proj2" in res
 
     if do_check_command:


### PR DESCRIPTION
Recently CI found one more failure for
test_broken_projections/test.py::test_broken_ignored_replicated [1], but this time, we have more details:

    Looked for query id , but to no avail: 408ff27f-4d8d-4328-8099-c89c4aeee8ce	SELECT queryID() FROM (SELECT c FROM \'test3_replica\' WHERE d == 12 ORDER BY c SETTINGS force_optimize_projection_name = \'proj1\')	proj1

                      ^^^ - query_id is empty!

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=75973&sha=bb72b6d9b56327982e2366d962be00888790bdb9&name_0=PR&name_1=Integration%20tests%20%28aarch64%2C%202%2F4%29

So:
- flakiness is due to buggy queryID() function, so revet #61932 (retrying querying query_log), the issue with queryID() will be fixed separately
- errors due to query included into the "res" so it always match

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)