### PR TITLE
`Core settings` --> `Session settings`

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -576,7 +576,7 @@ Query settings can be specified as command-line options in the client, for examp
 $ clickhouse-client --max_threads 1
 ```
 
-See [Core Settings](../operations/settings/settings.md) for a list of settings.
+See [Settings](../operations/settings/settings.md) for a list of settings.
 
 ### Formatting Options {#command-line-options-formatting}
 

--- a/docs/en/operations/settings/index.md
+++ b/docs/en/operations/settings/index.md
@@ -13,13 +13,13 @@ XML-based Settings Profiles and [configuration files](https://clickhouse.com/doc
 There are two main groups of ClickHouse settings:
 
 - Global server settings
-- Query-level settings
+- Session settings
 
-The main distinction between global server settings and query-level settings is that global server settings must be set in configuration files, while query-level settings can be set in configuration files or with SQL queries.
+The main distinction between both is that global server settings apply globally for the ClickHouse server, while session settings apply to user sessions or even individual queries.
 
 Read about [global server settings](/docs/en/operations/server-configuration-parameters/settings.md) to learn more about configuring your ClickHouse server at the global server level.
 
-Read about [query-level settings](/docs/en/operations/settings/settings-query-level.md) to learn more about configuring your ClickHouse server at the query level.
+Read about [session settings](/docs/en/operations/settings/settings-query-level.md) to learn more about configuring your ClickHouse server at the session level.
 
 ## See non-default settings
 

--- a/docs/en/operations/settings/settings-query-level.md
+++ b/docs/en/operations/settings/settings-query-level.md
@@ -1,10 +1,11 @@
 ---
-sidebar_label: Query-level Settings
-title: Query-level Settings
+sidebar_label: Query-level Session Settings
+title: Query-level Session Settings
 slug: /en/operations/settings/query-level
 ---
 
-There are multiple ways to set ClickHouse query-level settings. Settings are configured in layers, and each subsequent layer redefines the previous values of a setting.
+There are multiple ways to run statements with specific settings.
+Settings are configured in layers, and each subsequent layer redefines the previous values of a setting.
 
 The order of priority for defining a setting is:
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1,6 +1,6 @@
 ---
-title: Core Settings
-sidebar_label: Core Settings
+title: Session Settings
+sidebar_label: Session Settings
 slug: /en/operations/settings/settings
 toc_max_heading_level: 2
 --- 

--- a/src/Storages/System/StorageSystemSettingsChanges.cpp
+++ b/src/Storages/System/StorageSystemSettingsChanges.cpp
@@ -28,7 +28,7 @@ ColumnsDescription StorageSystemSettingsChanges::getColumnsDescription()
     /// TODO: Fill in all the comments
     return ColumnsDescription
     {
-        {"type", getSettingsTypeEnum(), "The group of settings (Core, MergeTree...)"},
+        {"type", getSettingsTypeEnum(), "The group of settings (Session, MergeTree...)"},
         {"version", std::make_shared<DataTypeString>(), "The ClickHouse server version."},
         {"changes",
          std::make_shared<DataTypeArray>(std::make_shared<DataTypeTuple>(

--- a/src/Storages/System/StorageSystemSettingsChanges.cpp
+++ b/src/Storages/System/StorageSystemSettingsChanges.cpp
@@ -16,7 +16,7 @@ DataTypePtr getSettingsTypeEnum()
     return std::make_shared<DataTypeEnum8>(
     DataTypeEnum8::Values
         {
-            {"Core", 0},
+            {"Session", 0},
             {"MergeTree", 1},
         });
 }

--- a/tests/queries/0_stateless/02326_settings_changes_system_table.reference
+++ b/tests/queries/0_stateless/02326_settings_changes_system_table.reference
@@ -1,4 +1,4 @@
-type	Enum8(\'Core\' = 0, \'MergeTree\' = 1)			The group of settings (Core, MergeTree...)		
+type	Enum8(\'Session\' = 0, \'MergeTree\' = 1)			The group of settings (Session, MergeTree...)		
 version	String			The ClickHouse server version.		
 changes	Array(Tuple(\n    name String,\n    previous_value String,\n    new_value String,\n    reason String))			The list of changes in settings which changed the behaviour of ClickHouse.		
-Core	22.5	[('memory_overcommit_ratio_denominator','0','1073741824','Enable memory overcommit feature by default'),('memory_overcommit_ratio_denominator_for_user','0','1073741824','Enable memory overcommit feature by default')]
+Session	22.5	[('memory_overcommit_ratio_denominator','0','1073741824','Enable memory overcommit feature by default'),('memory_overcommit_ratio_denominator_for_user','0','1073741824','Enable memory overcommit feature by default')]

--- a/tests/queries/0_stateless/02995_new_settings_history.sh
+++ b/tests/queries/0_stateless/02995_new_settings_history.sh
@@ -52,7 +52,7 @@ $CLICKHOUSE_LOCAL --query "
         )) AND (name NOT IN (
             SELECT arrayJoin(tupleElement(changes, 'name'))
             FROM system.settings_changes
-            WHERE type = 'Core' AND splitByChar('.', version)[1]::UInt64 >= 25 AND splitByChar('.', version)[2]::UInt64 > 1
+            WHERE type = 'Session' AND splitByChar('.', version)[1]::UInt64 >= 25 AND splitByChar('.', version)[2]::UInt64 > 1
         ))
         UNION ALL
         (
@@ -75,7 +75,7 @@ $CLICKHOUSE_LOCAL --query "
             WHERE (new_settings.default != old_settings.default) AND (name NOT IN (
                 SELECT arrayJoin(tupleElement(changes, 'name'))
                 FROM system.settings_changes
-                WHERE type = 'Core' AND splitByChar('.', version)[1]::UInt64 >= 25 AND splitByChar('.', version)[2]::UInt64 > 1
+                WHERE type = 'Session' AND splitByChar('.', version)[1]::UInt64 >= 25 AND splitByChar('.', version)[2]::UInt64 > 1
             )) AND ${IGNORE_SETTINGS_FOR_SANITIZERS}
         )
         UNION ALL


### PR DESCRIPTION
Terms "core settings" and "session settings" were used interchangeably. This was slightly confusing. This PR changes naming to the latter (which was afaik historically earlier term).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CC @Blargian 
CC @Algunenano 