### PR TITLE
Docs: Codeblock languages followup

### DIFF
--- a/docs/en/getting-started/example-datasets/laion.md
+++ b/docs/en/getting-started/example-datasets/laion.md
@@ -157,7 +157,7 @@ SELECT url, caption FROM laion_annoy ORDER BY l2Distance(image_embedding, {targe
 
 **Result**
 
-```text
+```response
 ┌─url──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─caption──────────────────────────────────────────────────────────────┐
 │ http://tse1.mm.bing.net/th?id=OIP.R1CUoYp_4hbeFSHBaaB5-gHaFj                                                                                                                         │ bed bugs and pets can cats carry bed bugs pets adviser               │
 │ http://pet-uploads.adoptapet.com/1/9/c/1963194.jpg?336w                                                                                                                              │ Domestic Longhair Cat for adoption in Quincy, Massachusetts - Ashley │

--- a/docs/en/interfaces/schema-inference.md
+++ b/docs/en/interfaces/schema-inference.md
@@ -531,7 +531,7 @@ DESC format(JSONEachRow, '{"obj" : {"a" : 42, "b" : "Hello"}}, {"obj" : {"a" : 4
 
 Result:
 
-```text
+```response
 ┌─name─┬─type───────────────────────────────────────────────────────────────────────────────────────────────┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
 │ obj  │ Tuple(a Nullable(Int64), b Nullable(String), c Array(Nullable(Int64)), d Tuple(e Nullable(Int64))) │              │                    │         │                  │                │
 └──────┴────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘
@@ -567,7 +567,7 @@ DESC format(JSONEachRow, '{"obj" : {"a" : 42}}, {"obj" : {"a" : {"b" : "Hello"}}
 ```
 Result:
 
-```text
+```response
 Code: 636. DB::Exception: The table structure cannot be extracted from a JSONEachRow format file. Error:
 Code: 117. DB::Exception: JSON objects have ambiguous data: in some objects path 'a' has type 'Int64' and in some - 'Tuple(b String)'. You can enable setting input_format_json_use_string_type_for_ambiguous_paths_in_named_tuples_inference_from_objects to use String type for path 'a'. (INCORRECT_DATA) (version 24.3.1.1).
 You can specify the structure manually. (CANNOT_EXTRACT_TABLE_STRUCTURE)
@@ -582,7 +582,7 @@ SELECT * FROM format(JSONEachRow, '{"obj" : {"a" : 42}}, {"obj" : {"a" : {"b" : 
 ```
 
 Result:
-```text
+```response
 ┌─name─┬─type──────────────────────────┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
 │ obj  │ Tuple(a Nullable(String))     │              │                    │         │                  │                │
 └──────┴───────────────────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘
@@ -1289,6 +1289,7 @@ ${data}<result_after_delimiter>
 ```
 
 And a file `row_format` with the next content:
+
 ```text
 <row_before_delimiter>${column_1:CSV}<field_delimiter_1>${column_2:Quoted}<field_delimiter_2>${column_3:JSON}<row_after_delimiter>
 ```
@@ -1569,7 +1570,7 @@ DESC format(JSONEachRow, $$
                          $$)
 ```
 
-```text
+```response
 ┌─name───────┬─type────────────────────┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
 │ datetime   │ Nullable(DateTime64(9)) │              │                    │         │                  │                │
 │ datetime64 │ Nullable(DateTime64(9)) │              │                    │         │                  │                │
@@ -2020,7 +2021,8 @@ Let's try to use schema inference on these 3 files:
 ```
 
 Result:
-```text
+
+```response
 ┌─name───┬─type─────────────┐
 │ field1 │ Nullable(Int64)  │
 │ field2 │ Nullable(String) │
@@ -2064,7 +2066,8 @@ Let's try to use schema inference on these 3 files:
 ```
 
 Result:
-```text
+
+```response
 ┌─name───┬─type───────────────────┐
 │ field1 │ Nullable(Int64)        │
 │ field2 │ Nullable(String)       │
@@ -2099,7 +2102,7 @@ We can inspect and query this file without specifying format or structure:
 :) desc file(data);
 ```
 
-```text
+```repsonse
 ┌─name─┬─type─────────────┐
 │ a    │ Nullable(Int64)  │
 │ b    │ Nullable(String) │
@@ -2110,7 +2113,7 @@ We can inspect and query this file without specifying format or structure:
 :) select * from file(data);
 ```
 
-```text
+```response
 ┌─a─┬─b─────┐
 │ 1 │ Data1 │
 │ 2 │ Data2 │

--- a/docs/en/operations/cluster-discovery.md
+++ b/docs/en/operations/cluster-discovery.md
@@ -159,7 +159,7 @@ INSERT INTO event_table ...
 
 Then, we add a new node to the cluster, starting a new node with the same entry in the `remote_servers` section in a configuration file:
 
-```text
+```response
 ┌─cluster─┬─shard_num─┬─shard_weight─┬─replica_num─┬─host_name────┬─host_address─┬─port─┬─is_local─┬─user─┬─is_active─┐
 │ default │         1 │            1 │           1 │ 92d3c04025e8 │ 172.26.0.5   │ 9000 │        0 │      │      ᴺᵁᴸᴸ │
 │ default │         1 │            1 │           2 │ a6a68731c21b │ 172.26.0.4   │ 9000 │        1 │      │      ᴺᵁᴸᴸ │

--- a/docs/en/operations/system-tables/information_schema.md
+++ b/docs/en/operations/system-tables/information_schema.md
@@ -343,13 +343,7 @@ FORMAT Vertical;
 
 Result:
 
-```yaml
-
-```
-constraint_catalog:            def
-constraint_schema:             default
-constraint_name:               PRIMARY
-```
+```response
 Row 1:
 ──────
 constraint_catalog:            def

--- a/docs/en/sql-reference/functions/encryption-functions.md
+++ b/docs/en/sql-reference/functions/encryption-functions.md
@@ -145,7 +145,7 @@ SELECT encrypt('aes-256-ofb', 'Secret', '12345678910121314151617181920212', 'ivi
 
 Result:
 
-```text
+```response
 ┌─ciphertexts_equal─┐
 │                 1 │
 └───────────────────┘
@@ -176,7 +176,7 @@ SELECT hex(aes_encrypt_mysql('aes-256-ofb', 'Secret', '1234567891012131415161718
 
 Result:
 
-```text
+```response
 ┌─ciphertext───┐
 │ 24E9E4966469 │
 └──────────────┘
@@ -334,7 +334,7 @@ ORDER BY user_id ASC
 
 Result:
 
-```text
+```response
 ┌──────────────────dt─┬─user_id─┬─value──┐
 │ 2022-08-02 00:00:00 │       1 │ ᴺᵁᴸᴸ   │
 │ 2022-09-02 00:00:00 │       2 │ value2 │

--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -738,7 +738,7 @@ Referring to a nested values by passing multiple indices_or_keys parameters:
 SELECT JSONExtract('{"a":{"b":"hello","c":{"d":[1,2,3],"e":[1,3,7]}}}','a','c','Map(String, Array(UInt8))') AS val, toTypeName(val), val['d'];
 ```
 Result:
-```text
+```response
 ┌─val───────────────────────┬─toTypeName(val)───────────┬─arrayElement(val, 'd')─┐
 │ {'d':[1,2,3],'e':[1,3,7]} │ Map(String, Array(UInt8)) │ [1,2,3]                │
 └───────────────────────────┴───────────────────────────┴────────────────────────┘
@@ -1193,7 +1193,7 @@ INSERT INTO test FORMAT JSONEachRow {"json" : {"a" : 42}}, {"json" : {"b" : "Hel
 SELECT json, JSONAllPaths(json) FROM test;
 ```
 
-```text
+```response
 ┌─json─────────────────────────────────┬─JSONAllPaths(json)─┐
 │ {"a":"42"}                           │ ['a']              │
 │ {"b":"Hello"}                        │ ['b']              │
@@ -1227,7 +1227,7 @@ INSERT INTO test FORMAT JSONEachRow {"json" : {"a" : 42}}, {"json" : {"b" : "Hel
 SELECT json, JSONAllPathsWithTypes(json) FROM test;
 ```
 
-```text
+```response
 ┌─json─────────────────────────────────┬─JSONAllPathsWithTypes(json)───────────────┐
 │ {"a":"42"}                           │ {'a':'Int64'}                             │
 │ {"b":"Hello"}                        │ {'b':'String'}                            │
@@ -1261,7 +1261,7 @@ INSERT INTO test FORMAT JSONEachRow {"json" : {"a" : 42}}, {"json" : {"b" : "Hel
 SELECT json, JSONDynamicPaths(json) FROM test;
 ```
 
-```text
+```response
 ┌─json─────────────────────────────────┬─JSONDynamicPaths(json)─┐
 | {"a":"42"}                           │ ['a']                  │
 │ {"b":"Hello"}                        │ []                     │
@@ -1289,13 +1289,13 @@ JSONAllPathsWithTypes(json)
 
 **Example**
 
-``` sql
+```sql
 CREATE TABLE test (json JSON(max_dynamic_paths=1)) ENGINE = Memory;
 INSERT INTO test FORMAT JSONEachRow {"json" : {"a" : 42}}, {"json" : {"b" : "Hello"}}, {"json" : {"a" : [1, 2, 3], "c" : "2020-01-01"}}
 SELECT json, JSONDynamicPathsWithTypes(json) FROM test;
 ```
 
-```text
+```response
 ┌─json─────────────────────────────────┬─JSONDynamicPathsWithTypes(json)─┐
 │ {"a":"42"}                           │ {'a':'Int64'}                   │
 │ {"b":"Hello"}                        │ {}                              │
@@ -1309,7 +1309,7 @@ Returns the list of paths that are stored in shared data structure in [JSON](../
 
 **Syntax**
 
-``` sql
+```sql
 JSONSharedDataPaths(json)
 ```
 
@@ -1323,13 +1323,13 @@ JSONSharedDataPaths(json)
 
 **Example**
 
-``` sql
+```sql
 CREATE TABLE test (json JSON(max_dynamic_paths=1)) ENGINE = Memory;
 INSERT INTO test FORMAT JSONEachRow {"json" : {"a" : 42}}, {"json" : {"b" : "Hello"}}, {"json" : {"a" : [1, 2, 3], "c" : "2020-01-01"}}
 SELECT json, JSONSharedDataPaths(json) FROM test;
 ```
 
-```text
+```response
 ┌─json─────────────────────────────────┬─JSONSharedDataPaths(json)─┐
 │ {"a":"42"}                           │ []                        │
 │ {"b":"Hello"}                        │ ['b']                     │
@@ -1343,7 +1343,7 @@ Returns the map of paths that are stored in shared data structure and their type
 
 **Syntax**
 
-``` sql
+```sql
 JSONSharedDataPathsWithTypes(json)
 ```
 
@@ -1357,13 +1357,13 @@ JSONSharedDataPathsWithTypes(json)
 
 **Example**
 
-``` sql
+```sql
 CREATE TABLE test (json JSON(max_dynamic_paths=1)) ENGINE = Memory;
 INSERT INTO test FORMAT JSONEachRow {"json" : {"a" : 42}}, {"json" : {"b" : "Hello"}}, {"json" : {"a" : [1, 2, 3], "c" : "2020-01-01"}}
 SELECT json, JSONSharedDataPathsWithTypes(json) FROM test;
 ```
 
-```text
+```response
 ┌─json─────────────────────────────────┬─JSONSharedDataPathsWithTypes(json)─┐
 │ {"a":"42"}                           │ {}                                 │
 │ {"b":"Hello"}                        │ {'b':'String'}                     │

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -40,7 +40,7 @@ SELECT floor(123.45, 1) AS rounded
 
 Result:
 
-```text
+```response
 ┌─rounded─┐
 │   123.4 │
 └─────────┘
@@ -54,7 +54,7 @@ SELECT floor(123.45, -1)
 
 Result:
 
-```text
+```response
 ┌─rounded─┐
 │     120 │
 └─────────┘
@@ -131,7 +131,7 @@ Example with `Float` inputs:
 SELECT number / 2 AS x, round(x) FROM system.numbers LIMIT 3;
 ```
 
-```text
+```response
 ┌───x─┬─round(divide(number, 2))─┐
 │   0 │                        0 │
 │ 0.5 │                        0 │
@@ -245,7 +245,7 @@ Query:
 
 Result:
 
-```text
+```response
 ┌───x─┬─b─┐
 │   0 │ 0 │
 │ 0.5 │ 0 │
@@ -262,7 +262,7 @@ Result:
 
 Examples of Banker's rounding:
 
-```text
+```response
 roundBankers(0.4) = 0
 roundBankers(-3.5) = -4
 roundBankers(4.5) = 4

--- a/docs/en/sql-reference/functions/uuid-functions.md
+++ b/docs/en/sql-reference/functions/uuid-functions.md
@@ -819,7 +819,7 @@ SELECT snowflakeIDToDateTime(7204436857747984384) AS res
 
 Result:
 
-```text
+```response
 ┌─────────────────res─┐
 │ 2024-06-06 10:59:58 │
 └─────────────────────┘
@@ -855,7 +855,7 @@ SELECT snowflakeIDToDateTime64(7204436857747984384) AS res
 
 Result:
 
-```text
+```response
 ┌─────────────────res─┐
 │ 2024-06-06 10:59:58 │
 └─────────────────────┘
@@ -890,7 +890,7 @@ SELECT toDateTime('2021-08-15 18:57:56', 'Asia/Shanghai') AS dt, dateTimeToSnowf
 
 Result:
 
-```text
+```response
 ┌──────────────────dt─┬─────────────────res─┐
 │ 2021-08-15 18:57:56 │ 6832626392367104000 │
 └─────────────────────┴─────────────────────┘

--- a/docs/en/sql-reference/statements/optimize.md
+++ b/docs/en/sql-reference/statements/optimize.md
@@ -72,14 +72,17 @@ CREATE TABLE example (
 PARTITION BY partition_key
 ORDER BY (primary_key, secondary_key);
 ```
+
 ``` sql
 INSERT INTO example (primary_key, secondary_key, value, partition_key)
 VALUES (0, 0, 0, 0), (0, 0, 0, 0), (1, 1, 2, 2), (1, 1, 2, 3), (1, 1, 3, 3);
 ```
+
 ``` sql
 SELECT * FROM example;
 ```
 Result:
+
 ```sql
 
 ┌─primary_key─┬─secondary_key─┬─value─┬─partition_key─┐
@@ -94,6 +97,7 @@ Result:
 │           1 │             1 │     3 │             3 │
 └─────────────┴───────────────┴───────┴───────────────┘
 ```
+
 All following examples are executed against this state with 5 rows.
 
 #### `DEDUPLICATE`
@@ -102,11 +106,14 @@ When columns for deduplication are not specified, all of them are taken into acc
 ``` sql
 OPTIMIZE TABLE example FINAL DEDUPLICATE;
 ```
+
 ``` sql
 SELECT * FROM example;
 ```
+
 Result:
-```text
+
+```response
 ┌─primary_key─┬─secondary_key─┬─value─┬─partition_key─┐
 │           1 │             1 │     2 │             2 │
 └─────────────┴───────────────┴───────┴───────────────┘
@@ -118,16 +125,22 @@ Result:
 │           1 │             1 │     3 │             3 │
 └─────────────┴───────────────┴───────┴───────────────┘
 ```
+
 #### `DEDUPLICATE BY *`
+
 When columns are specified implicitly, the table is deduplicated by all columns that are not `ALIAS` or `MATERIALIZED`. Considering the table above, these are `primary_key`, `secondary_key`, `value`, and `partition_key` columns:
+
 ```sql
 OPTIMIZE TABLE example FINAL DEDUPLICATE BY *;
 ```
+
 ``` sql
 SELECT * FROM example;
 ```
+
 Result:
-```text
+
+```response
 ┌─primary_key─┬─secondary_key─┬─value─┬─partition_key─┐
 │           1 │             1 │     2 │             2 │
 └─────────────┴───────────────┴───────┴───────────────┘
@@ -139,17 +152,21 @@ Result:
 │           1 │             1 │     3 │             3 │
 └─────────────┴───────────────┴───────┴───────────────┘
 ```
+
 #### `DEDUPLICATE BY * EXCEPT`
 Deduplicate by all columns that are not `ALIAS` or `MATERIALIZED` and explicitly not `value`: `primary_key`, `secondary_key`, and `partition_key` columns.
 
 ``` sql
 OPTIMIZE TABLE example FINAL DEDUPLICATE BY * EXCEPT value;
 ```
+
 ``` sql
 SELECT * FROM example;
 ```
+
 Result:
-```text
+
+```response
 ┌─primary_key─┬─secondary_key─┬─value─┬─partition_key─┐
 │           1 │             1 │     2 │             2 │
 └─────────────┴───────────────┴───────┴───────────────┘
@@ -160,16 +177,21 @@ Result:
 │           1 │             1 │     2 │             3 │
 └─────────────┴───────────────┴───────┴───────────────┘
 ```
+
 #### `DEDUPLICATE BY <list of columns>`
+
 Deduplicate explicitly by `primary_key`, `secondary_key`, and `partition_key` columns:
+
 ```sql
 OPTIMIZE TABLE example FINAL DEDUPLICATE BY primary_key, secondary_key, partition_key;
 ```
+
 ``` sql
 SELECT * FROM example;
 ```
 Result:
-```text
+
+```response
 ┌─primary_key─┬─secondary_key─┬─value─┬─partition_key─┐
 │           1 │             1 │     2 │             2 │
 └─────────────┴───────────────┴───────┴───────────────┘
@@ -180,16 +202,22 @@ Result:
 │           1 │             1 │     2 │             3 │
 └─────────────┴───────────────┴───────┴───────────────┘
 ```
+
 #### `DEDUPLICATE BY COLUMNS(<regex>)`
+
 Deduplicate by all columns matching a regex: `primary_key`, `secondary_key`, and `partition_key` columns:
+
 ```sql
 OPTIMIZE TABLE example FINAL DEDUPLICATE BY COLUMNS('.*_key');
 ```
+
 ``` sql
 SELECT * FROM example;
 ```
+
 Result:
-```text
+
+```response
 ┌─primary_key─┬─secondary_key─┬─value─┬─partition_key─┐
 │           0 │             0 │     0 │             0 │
 └─────────────┴───────────────┴───────┴───────────────┘

--- a/docs/en/sql-reference/statements/select/index.md
+++ b/docs/en/sql-reference/statements/select/index.md
@@ -181,19 +181,19 @@ Allows you to invoke some function for each row returned by an outer table expre
 
 **Syntax:**
 
-``` sql
+```sql
 SELECT <expr> APPLY( <func> ) FROM [db.]table_name
 ```
 
 **Example:**
 
-``` sql
+```sql
 CREATE TABLE columns_transformers (i Int64, j Int16, k Int64) ENGINE = MergeTree ORDER by (i);
 INSERT INTO columns_transformers VALUES (100, 10, 324), (120, 8, 23);
 SELECT * APPLY(sum) FROM columns_transformers;
 ```
 
-```text
+```response
 ┌─sum(i)─┬─sum(j)─┬─sum(k)─┐
 │    220 │     18 │    347 │
 └────────┴────────┴────────┘
@@ -211,11 +211,11 @@ SELECT <expr> EXCEPT ( col_name1 [, col_name2, col_name3, ...] ) FROM [db.]table
 
 **Example:**
 
-``` sql
+```sql
 SELECT * EXCEPT (i) from columns_transformers;
 ```
 
-```text
+```response
 ┌──j─┬───k─┐
 │ 10 │ 324 │
 │  8 │  23 │
@@ -236,11 +236,11 @@ SELECT <expr> REPLACE( <expr> AS col_name) from [db.]table_name
 
 **Example:**
 
-``` sql
+```sql
 SELECT * REPLACE(i + 1 AS i) from columns_transformers;
 ```
 
-```text
+```response
 ┌───i─┬──j─┬───k─┐
 │ 101 │ 10 │ 324 │
 │ 121 │  8 │  23 │
@@ -255,11 +255,11 @@ You can use each modifier separately or combine them.
 
 Using the same modifier multiple times.
 
-``` sql
+```sql
 SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) from columns_transformers;
 ```
 
-```text
+```response
 ┌─max(length(toString(j)))─┬─max(length(toString(k)))─┐
 │                        2 │                        3 │
 └──────────────────────────┴──────────────────────────┘
@@ -267,11 +267,11 @@ SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) from columns_tra
 
 Using multiple modifiers in a single query.
 
-``` sql
+```sql
 SELECT * REPLACE(i + 1 AS i) EXCEPT (j) APPLY(sum) from columns_transformers;
 ```
 
-```text
+```response
 ┌─sum(plus(i, 1))─┬─sum(k)─┐
 │             222 │    347 │
 └─────────────────┴────────┘
@@ -285,6 +285,6 @@ Other ways to make settings see [here](../../../operations/settings/index.md).
 
 **Example**
 
-``` sql
+```sql
 SELECT * FROM some_table SETTINGS optimize_read_in_order=1, cast_keep_nullable=1;
 ```

--- a/docs/en/sql-reference/statements/select/join.md
+++ b/docs/en/sql-reference/statements/select/join.md
@@ -84,7 +84,7 @@ If a condition refers columns from different tables, then only the equality oper
 
 Consider `table_1` and `table_2`:
 
-```text
+```response
 ┌─Id─┬─name─┐     ┌─Id─┬─text───────────┬─scores─┐
 │  1 │ A    │     │  1 │ Text A         │     10 │
 │  2 │ B    │     │  1 │ Another text A │     12 │
@@ -101,7 +101,7 @@ SELECT name, text FROM table_1 LEFT OUTER JOIN table_2
 
 Note that the result contains the row with the name `C` and the empty text column. It is included into the result because an `OUTER` type of a join is used.
 
-```text
+```response
 ┌─name─┬─text───┐
 │ A    │ Text A │
 │ B    │ Text B │
@@ -139,7 +139,7 @@ SELECT a, b, val FROM t1 INNER JOIN t2 ON t1.a = t2.key OR t1.b = t2.key;
 
 Result:
 
-```text
+```response
 ┌─a─┬──b─┬─val─┐
 │ 0 │  0 │   0 │
 │ 1 │ -1 │   1 │
@@ -165,7 +165,7 @@ SELECT a, b, val FROM t1 INNER JOIN t2 ON t1.a = t2.key OR t1.b = t2.key AND t2.
 
 Result:
 
-```text
+```response
 ┌─a─┬──b─┬─val─┐
 │ 0 │  0 │   0 │
 │ 2 │ -2 │   2 │
@@ -181,7 +181,7 @@ Clickhouse currently supports `ALL/ANY/SEMI/ANTI INNER/LEFT/RIGHT/FULL JOIN` wit
 
 Table `t1`:
 
-```text
+```response
 ┌─key──┬─attr─┬─a─┬─b─┬─c─┐
 │ key1 │ a    │ 1 │ 1 │ 2 │
 │ key1 │ b    │ 2 │ 3 │ 2 │
@@ -195,7 +195,7 @@ Table `t1`:
 
 Table `t2`
 
-```text
+```response
 ┌─key──┬─attr─┬─a─┬─b─┬─c─┐
 │ key1 │ A    │ 1 │ 2 │ 1 │
 │ key1 │ B    │ 2 │ 1 │ 2 │
@@ -210,7 +210,7 @@ Table `t2`
 SELECT t1.*, t2.* from t1 LEFT JOIN t2 ON t1.key = t2.key and (t1.a < t2.a) ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
 ```
 
-```text
+```response
 key1	a	1	1	2	key1	B	2	1	2
 key1	a	1	1	2	key1	C	3	4	5
 key1	a	1	1	2	key1	D	4	1	6
@@ -232,7 +232,7 @@ The NULL is not equal to any value, including itself. It means that if a JOIN ke
 
 Table `A`:
 
-```text
+```response
 ┌───id─┬─name────┐
 │    1 │ Alice   │
 │    2 │ Bob     │
@@ -242,7 +242,7 @@ Table `A`:
 
 Table `B`:
 
-```text
+```response
 ┌───id─┬─score─┐
 │    1 │    90 │
 │    3 │    85 │
@@ -254,7 +254,7 @@ Table `B`:
 SELECT A.name, B.score FROM A LEFT JOIN B ON A.id = B.id
 ```
 
-```text
+```response
 ┌─name────┬─score─┐
 │ Alice   │    90 │
 │ Bob     │     0 │
@@ -401,14 +401,14 @@ Be careful when using `GLOBAL`. For more information, see the [Distributed subqu
 **Example**
 
 Consider the table `t_1`:
-```text
+```response
 ┌─a─┬─b─┬─toTypeName(a)─┬─toTypeName(b)─┐
 │ 1 │ 1 │ UInt16        │ UInt8         │
 │ 2 │ 2 │ UInt16        │ UInt8         │
 └───┴───┴───────────────┴───────────────┘
 ```
 and the table `t_2`:
-```text
+```response
 ┌──a─┬────b─┬─toTypeName(a)─┬─toTypeName(b)───┐
 │ -1 │    1 │ Int16         │ Nullable(Int64) │
 │  1 │   -1 │ Int16         │ Nullable(Int64) │
@@ -421,7 +421,7 @@ The query
 SELECT a, b, toTypeName(a), toTypeName(b) FROM t_1 FULL JOIN t_2 USING (a, b);
 ```
 returns the set:
-```text
+```response
 ┌──a─┬────b─┬─toTypeName(a)─┬─toTypeName(b)───┐
 │  1 │    1 │ Int32         │ Nullable(Int64) │
 │  2 │    2 │ Int32         │ Nullable(Int64) │

--- a/docs/en/sql-reference/statements/select/order-by.md
+++ b/docs/en/sql-reference/statements/select/order-by.md
@@ -185,7 +185,7 @@ Example with [LowCardinality](../../../sql-reference/data-types/lowcardinality.m
 
 Input table:
 
-```text
+```response
 ┌─x─┬─s───┐
 │ 1 │ Z   │
 │ 2 │ z   │
@@ -205,7 +205,7 @@ SELECT * FROM collate_test ORDER BY s ASC COLLATE 'en';
 
 Result:
 
-```text
+```response
 ┌─x─┬─s───┐
 │ 7 │     │
 │ 3 │ a   │
@@ -219,7 +219,7 @@ Result:
 
 Example with [Tuple](../../../sql-reference/data-types/tuple.md):
 
-```text
+```response
 ┌─x─┬─s───────┐
 │ 1 │ (1,'Z') │
 │ 2 │ (1,'z') │
@@ -239,7 +239,7 @@ SELECT * FROM collate_test ORDER BY s ASC COLLATE 'en';
 
 Result:
 
-```text
+```response
 ┌─x─┬─s───────┐
 │ 3 │ (1,'a') │
 │ 5 │ (1,'A') │
@@ -432,7 +432,7 @@ ORDER BY
 ```
 
 Result:
-```text
+```response
 ┌─────────d1─┬─────────d2─┬─source───┐
 │ 1970-01-11 │ 1970-01-02 │ original │
 │ 1970-01-12 │ 1970-01-01 │          │

--- a/docs/en/sql-reference/table-functions/fileCluster.md
+++ b/docs/en/sql-reference/table-functions/fileCluster.md
@@ -62,7 +62,7 @@ Now, read data contents of `test1.csv` and `test2.csv` via `fileCluster` table f
 SELECT * FROM fileCluster('my_cluster', 'file{1,2}.csv', 'CSV', 'i UInt32, s String') ORDER BY i, s
 ```
 
-```text
+```response
 ┌──i─┬─s──────┐
 │  1 │ file1  │
 │ 11 │ file11 │

--- a/docs/en/sql-reference/table-functions/fuzzQuery.md
+++ b/docs/en/sql-reference/table-functions/fuzzQuery.md
@@ -24,11 +24,11 @@ A table object with a single column containing perturbed query strings.
 
 ## Usage Example
 
-``` sql
+```sql
 SELECT * FROM fuzzQuery('SELECT materialize(\'a\' AS key) GROUP BY key') LIMIT 2;
 ```
 
-```sql
+```response
    ┌─query──────────────────────────────────────────────────────────┐
 1. │ SELECT 'a' AS key GROUP BY key                                 │
 2. │ EXPLAIN PIPELINE compact = true SELECT 'a' AS key GROUP BY key │

--- a/docs/en/sql-reference/table-functions/zeros.md
+++ b/docs/en/sql-reference/table-functions/zeros.md
@@ -20,7 +20,7 @@ SELECT * FROM zeros_mt(10);
 SELECT * FROM system.zeros_mt LIMIT 10;
 ```
 
-```text
+```response
 ┌─zero─┐
 │    0 │
 │    0 │

--- a/docs/en/sql-reference/transactions.md
+++ b/docs/en/sql-reference/transactions.md
@@ -145,22 +145,26 @@ Ok.
 
 :::tip
 If you see the following error, then check your configuration file to make sure that `allow_experimental_transactions` is set to `1` (or any value other than `0` or `false`).
-```sql
+
+```response
 Code: 48. DB::Exception: Received from localhost:9000.
 DB::Exception: Transactions are not supported.
 (NOT_IMPLEMENTED)
 ```
 
 You can also check ClickHouse Keeper by issuing
+
 ```bash
 echo ruok | nc localhost 9181
 ```
+
 ClickHouse Keeper should respond with `imok`.
 :::
 
 ```sql
 ROLLBACK
 ```
+
 ```response
 Ok.
 ```
@@ -179,6 +183,7 @@ CREATE TABLE mergetree_table
 ENGINE = MergeTree
 ORDER BY n
 ```
+
 ```response
 Ok.
 ```
@@ -188,6 +193,7 @@ Ok.
 ```sql
 BEGIN TRANSACTION
 ```
+
 ```response
 Ok.
 ```
@@ -195,6 +201,7 @@ Ok.
 ```sql
 INSERT INTO mergetree_table FORMAT Values (10)
 ```
+
 ```response
 Ok.
 ```
@@ -203,11 +210,13 @@ Ok.
 SELECT *
 FROM mergetree_table
 ```
+
 ```response
 ┌──n─┐
 │ 10 │
 └────┘
 ```
+
 :::note
 You can query the table from within a transaction and see that the row was inserted even though it has not yet been committed.
 :::
@@ -215,12 +224,15 @@ You can query the table from within a transaction and see that the row was inser
 #### Rollback the transaction, and query the table again
 
 Verify that the transaction is rolled back:
+
 ```sql
 ROLLBACK
 ```
+
 ```response
 Ok.
 ```
+
 ```sql
 SELECT *
 FROM mergetree_table
@@ -243,6 +255,7 @@ Ok.
 ```sql
 INSERT INTO mergetree_table FORMAT Values (42)
 ```
+
 ```response
 Ok.
 ```
@@ -250,6 +263,7 @@ Ok.
 ```sql
 COMMIT
 ```
+
 ```response
 Ok. Elapsed: 0.002 sec.
 ```
@@ -258,6 +272,7 @@ Ok. Elapsed: 0.002 sec.
 SELECT *
 FROM mergetree_table
 ```
+
 ```response
 ┌──n─┐
 │ 42 │
@@ -274,6 +289,7 @@ SELECT *
 FROM system.transactions
 FORMAT Vertical
 ```
+
 ```response
 Row 1:
 ──────


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Follow up to #76278 which added languages to code blocks missing one using an LLM. It got it wrong in a few places, 
plus we should use response rather than text for consistency.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
