### PR TITLE
ci: add clickhouse binary into fasttest artifacts

### DIFF
--- a/ci/workflows/defs.py
+++ b/ci/workflows/defs.py
@@ -447,14 +447,10 @@ ARTIFACTS = [
             ArtifactNames.CH_LOONGARCH64,
         ]
     ),
-    *Artifact.Config(
-        name="...",
+    Artifact.Config(
+        name=ArtifactNames.FAST_TEST,
         type=Artifact.Type.S3,
         path=f"{TEMP_DIR}/fasttest-output/build/*",
-    ).parametrize(
-        names=[
-            ArtifactNames.FAST_TEST,
-        ]
     ),
     *Artifact.Config(
         name="...",

--- a/ci/workflows/defs.py
+++ b/ci/workflows/defs.py
@@ -580,7 +580,7 @@ class Jobs:
                 "./src",
             ],
         ),
-        provides=ArtifactNames.FAST_TEST,
+        provides=[ArtifactNames.FAST_TEST],
     )
 
     build_jobs = Job.Config(

--- a/ci/workflows/defs.py
+++ b/ci/workflows/defs.py
@@ -445,22 +445,12 @@ ARTIFACTS = [
             ArtifactNames.CH_RISCV64,
             ArtifactNames.CH_S390X,
             ArtifactNames.CH_LOONGARCH64,
-            ArtifactNames.FAST_TEST,
         ]
     ),
     *Artifact.Config(
         name="...",
         type=Artifact.Type.S3,
-        path=f"{TEMP_DIR}/fasttest-output/clickhouse-stripped.zst",
-    ).parametrize(
-        names=[
-            ArtifactNames.FAST_TEST,
-        ]
-    ),
-    *Artifact.Config(
-        name="...",
-        type=Artifact.Type.S3,
-        path=f"{TEMP_DIR}/fasttest-output/clickhouse",
+        path=f"{TEMP_DIR}/fasttest-output/build/*",
     ).parametrize(
         names=[
             ArtifactNames.FAST_TEST,

--- a/ci/workflows/defs.py
+++ b/ci/workflows/defs.py
@@ -450,7 +450,7 @@ ARTIFACTS = [
     Artifact.Config(
         name=ArtifactNames.FAST_TEST,
         type=Artifact.Type.S3,
-        path=f"{TEMP_DIR}/fasttest-output/build/*",
+        path=f"{TEMP_DIR}/build/*",
     ),
     *Artifact.Config(
         name="...",

--- a/ci/workflows/defs.py
+++ b/ci/workflows/defs.py
@@ -367,6 +367,7 @@ class ArtifactNames:
     CH_ODBC_B_ARM_RELEASE = "CH_ODBC_B_ARM_RELEASE"
     CH_ODBC_B_ARM_ASAN = "CH_ODBC_B_ARM_ASAN"
 
+    FAST_TEST = "FAST_TEST"
     UNITTEST_AMD_ASAN = "UNITTEST_AMD_ASAN"
     UNITTEST_AMD_TSAN = "UNITTEST_AMD_TSAN"
     UNITTEST_AMD_MSAN = "UNITTEST_AMD_MSAN"
@@ -444,6 +445,25 @@ ARTIFACTS = [
             ArtifactNames.CH_RISCV64,
             ArtifactNames.CH_S390X,
             ArtifactNames.CH_LOONGARCH64,
+            ArtifactNames.FAST_TEST,
+        ]
+    ),
+    *Artifact.Config(
+        name="...",
+        type=Artifact.Type.S3,
+        path=f"{TEMP_DIR}/fasttest-output/clickhouse-stripped.zst",
+    ).parametrize(
+        names=[
+            ArtifactNames.FAST_TEST,
+        ]
+    ),
+    *Artifact.Config(
+        name="...",
+        type=Artifact.Type.S3,
+        path=f"{TEMP_DIR}/fasttest-output/clickhouse",
+    ).parametrize(
+        names=[
+            ArtifactNames.FAST_TEST,
         ]
     ),
     *Artifact.Config(
@@ -574,6 +594,7 @@ class Jobs:
                 "./src",
             ],
         ),
+        provides=ArtifactNames.FAST_TEST,
     )
 
     build_jobs = Job.Config(

--- a/ci/workflows/job_configs.py
+++ b/ci/workflows/job_configs.py
@@ -59,6 +59,7 @@ class JobConfigs:
         requires=[JobNames.DOCKER_BUILDS_AMD],
         timeout=3000,
         command="cd ./tests/ci && python3 ci.py --run-from-praktika",
+        provides=[ArtifactNames.FAST_TEST],
     )
     build_jobs = Job.Config(
         name=JobNames.BUILD,

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -94,7 +94,7 @@ def main():
 
     build_output_temp_path = repo_path / "ci" / "tmp"
     build_output_temp_path.mkdir(parents=True, exist_ok=True)
-    build_output_path = temp_path / "build"
+    build_output_path = build_output_temp_path / "build"
     build_output_path.mkdir(parents=True, exist_ok=True)
 
     run_cmd = get_fasttest_cmd(

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -115,8 +115,8 @@ def main():
     subprocess.check_call(f"sudo chown -R ubuntu:ubuntu {temp_path}", shell=True)
 
     test_output_files = os.listdir(output_path)
-    additional_logs = [f for f in output_path.iterdir() if f.is_file()]
-    additional_logs.append(run_log_path)
+    additional_files = [f for f in output_path.iterdir() if f.is_file()]
+    additional_files.append(run_log_path)
 
     test_log_exists = (
         "test_log.txt" in test_output_files or "test_result.txt" in test_output_files
@@ -147,7 +147,7 @@ def main():
         status=state,
         start_time=stopwatch.start_time_str,
         duration=stopwatch.duration_seconds,
-        additional_files=additional_logs,
+        additional_files=additional_files,
         build_dir_for_upload=str(output_path / "binaries"),
     ).dump()
 

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -115,7 +115,7 @@ def main():
     subprocess.check_call(f"sudo chown -R ubuntu:ubuntu {temp_path}", shell=True)
 
     test_output_files = os.listdir(output_path)
-    additional_files = [f for f in output_path.iterdir() if f.is_file()]
+    additional_files = [f for f in output_path.glob('**/*') if f.is_file()]
     additional_files.append(run_log_path)
 
     test_log_exists = (

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -21,6 +21,7 @@ csv.field_size_limit(sys.maxsize)
 def get_fasttest_cmd(
     workspace: Path,
     output_path: Path,
+    build_output_path: Path,
     repo_path: Path,
     pr_number: int,
     commit_sha: str,
@@ -39,6 +40,7 @@ def get_fasttest_cmd(
         "-e stage=clone_submodules "
         "--tmpfs /tmp/clickhouse "
         f"--volume={workspace}:/fasttest-workspace --volume={repo_path}:/repo "
+        f"--volume={build_output_path}:/build "
         f"--volume={output_path}:/test_output {image} /repo/tests/docker_scripts/fasttest_runner.sh"
     )
 
@@ -90,9 +92,15 @@ def main():
 
     repo_path = Path(REPO_COPY)
 
+    build_output_temp_path = repo_path / "ci" / "tmp"
+    build_output_temp_path.mkdir(parents=True, exist_ok=True)
+    build_output_path = temp_path / "build"
+    build_output_path.mkdir(parents=True, exist_ok=True)
+
     run_cmd = get_fasttest_cmd(
         workspace,
         output_path,
+        build_output_path,
         repo_path,
         pr_info.number,
         pr_info.sha,

--- a/tests/docker_scripts/fasttest_runner.sh
+++ b/tests/docker_scripts/fasttest_runner.sh
@@ -233,10 +233,8 @@ function build
         ) | ts '%Y-%m-%d %H:%M:%S' | tee -a "$FASTTEST_OUTPUT/test_result.txt"
 
         if [ "$COPY_CLICKHOUSE_BINARY_TO_OUTPUT" -eq "1" ]; then
-            mkdir -p "$FASTTEST_OUTPUT/binaries/"
-            cp programs/clickhouse "$FASTTEST_OUTPUT/binaries/clickhouse"
-
-            zstd --threads=0 programs/clickhouse-stripped -o "$FASTTEST_OUTPUT/binaries/clickhouse-stripped.zst"
+            cp programs/clickhouse "$FASTTEST_OUTPUT/clickhouse"
+            zstd --threads=0 programs/clickhouse-stripped -o "$FASTTEST_OUTPUT/clickhouse-stripped.zst"
         fi
         ccache_status
         ccache --evict-older-than 1d ||:

--- a/tests/docker_scripts/fasttest_runner.sh
+++ b/tests/docker_scripts/fasttest_runner.sh
@@ -233,9 +233,8 @@ function build
         ) | ts '%Y-%m-%d %H:%M:%S' | tee -a "$FASTTEST_OUTPUT/test_result.txt"
 
         if [ "$COPY_CLICKHOUSE_BINARY_TO_OUTPUT" -eq "1" ]; then
-            mkdir -p "$FASTTEST_OUTPUT/build"
-            cp programs/clickhouse "$FASTTEST_OUTPUT/build/clickhouse"
-            zstd --threads=0 programs/clickhouse-stripped -o "$FASTTEST_OUTPUT/build/clickhouse-stripped.zst"
+            cp programs/clickhouse /build/clickhouse
+            zstd --threads=0 programs/clickhouse-stripped -o /build/clickhouse-stripped.zst
         fi
         ccache_status
         ccache --evict-older-than 1d ||:

--- a/tests/docker_scripts/fasttest_runner.sh
+++ b/tests/docker_scripts/fasttest_runner.sh
@@ -233,8 +233,9 @@ function build
         ) | ts '%Y-%m-%d %H:%M:%S' | tee -a "$FASTTEST_OUTPUT/test_result.txt"
 
         if [ "$COPY_CLICKHOUSE_BINARY_TO_OUTPUT" -eq "1" ]; then
-            cp programs/clickhouse "$FASTTEST_OUTPUT/clickhouse"
-            zstd --threads=0 programs/clickhouse-stripped -o "$FASTTEST_OUTPUT/clickhouse-stripped.zst"
+            mkdir -p "$FASTTEST_OUTPUT/build"
+            cp programs/clickhouse "$FASTTEST_OUTPUT/build/clickhouse"
+            zstd --threads=0 programs/clickhouse-stripped -o "$FASTTEST_OUTPUT/build/clickhouse-stripped.zst"
         fi
         ccache_status
         ccache --evict-older-than 1d ||:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)