### PR TITLE
Fast path support for resizes

### DIFF
--- a/src/Processors/ResizeProcessor.cpp
+++ b/src/Processors/ResizeProcessor.cpp
@@ -9,47 +9,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-namespace
-{
-    template <typename In, typename Out, typename InGetter, typename OutGetter> /// For 1-to-1 case during resize
-    IProcessor::Status fastPathProcess(In & in, Out & out, InGetter getIn, OutGetter getOut)
-    {
-        InputPort * in_port = getIn(in);
-        OutputPort * out_port = getOut(out);
-
-        if (out_port->isFinished())
-        {
-            in_port->close();
-            return IProcessor::Status::Finished;
-        }
-
-        if (!out_port->canPush())
-            return IProcessor::Status::PortFull;
-
-        if (in_port->isFinished())
-        {
-            out_port->finish();
-            return IProcessor::Status::Finished;
-        }
-
-        if (!in_port->hasData())
-        {
-            in_port->setNeeded();
-            return IProcessor::Status::NeedData;
-        }
-
-        out_port->pushData(in_port->pullData(/* set_not_needed = */ true));
-
-        if (in_port->isFinished())
-        {
-            out_port->finish();
-            return IProcessor::Status::Finished;
-        }
-
-        return IProcessor::Status::PortFull;
-    }
-}
-
 /// TODO Check that there is non zero number of inputs and outputs.
 ResizeProcessor::ResizeProcessor(const Block & header, size_t num_inputs, size_t num_outputs)
     : IProcessor(InputPorts(num_inputs, header), OutputPorts(num_outputs, header))
@@ -219,17 +178,6 @@ IProcessor::Status ResizeProcessor::prepare(const PortNumbers & updated_inputs, 
         for (auto & output : outputs)
             output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
     }
-    /// Fast-path for the 1-to-1 case.
-    if (inputs.size() == 1 && outputs.size() == 1)
-    {
-        // Using lambdas that return the address of the port.
-        return fastPathProcess(
-            inputs.front(), outputs.front(),
-            [](auto &port) -> InputPort* { return &port; },
-            [](auto &port) -> OutputPort* { return &port; });
-    }
-
-    /// --- General processing for >1 ports ---
     for (const auto & output_number : updated_outputs)
     {
         auto & output = output_ports[output_number];
@@ -340,16 +288,6 @@ IProcessor::Status StrictResizeProcessor::prepare(const PortNumbers & updated_in
         for (auto & output : outputs)
             output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
     }
-    /// --- Fast-path for the 1-to-1 case ---
-    if (inputs.size() == 1 && outputs.size() == 1)
-    {
-        return fastPathProcess(
-            input_ports[0], output_ports[0],
-            [](auto &wrapper) -> InputPort* { return wrapper.port; },
-            [](auto &wrapper) -> OutputPort* { return wrapper.port; });
-    }
-
-    /// --- General processing for >1 ports ---
     for (const auto & output_number : updated_outputs)
     {
         auto & output = output_ports[output_number];

--- a/src/Processors/ResizeProcessor.cpp
+++ b/src/Processors/ResizeProcessor.cpp
@@ -14,8 +14,8 @@ ResizeProcessor::ResizeProcessor(const Block & header, size_t num_inputs, size_t
     : IProcessor(InputPorts(num_inputs, header), OutputPorts(num_outputs, header))
     , current_input(inputs.begin())
     , current_output(outputs.begin())
-        {
-            }
+{
+}
 
 ResizeProcessor::Status ResizeProcessor::prepare()
 {
@@ -178,6 +178,7 @@ IProcessor::Status ResizeProcessor::prepare(const PortNumbers & updated_inputs, 
         for (auto & output : outputs)
             output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
     }
+
     for (const auto & output_number : updated_outputs)
     {
         auto & output = output_ports[output_number];
@@ -288,6 +289,7 @@ IProcessor::Status StrictResizeProcessor::prepare(const PortNumbers & updated_in
         for (auto & output : outputs)
             output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
     }
+
     for (const auto & output_number : updated_outputs)
     {
         auto & output = output_ports[output_number];

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -690,6 +690,10 @@ void Pipe::resize(size_t num_streams, bool force, bool strict)
     if (!force && num_streams == numOutputPorts())
         return;
 
+    /// We need to not add the resize in case of 1-1 because in case
+    /// it is not force resize and we have n outputs (look at the code above),
+    /// and one of the outputs is dead, we can push all data to n-1 outputs,
+    /// which doesn't make sense for 1-1 scenario
     if (numOutputPorts() == 1 && num_streams == 1)
         return;
 

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -690,6 +690,9 @@ void Pipe::resize(size_t num_streams, bool force, bool strict)
     if (!force && num_streams == numOutputPorts())
         return;
 
+    if (numOutputPorts() == 1 && num_streams == 1)
+        return;
+
     ProcessorPtr resize;
 
     if (strict)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In the case of the 1-1 resize processing, a fast path is enabled, which allows data to go through resize without redundant operations.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
