### PR TITLE
Fix recursive copy in clickhouse-disks

### DIFF
--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -131,7 +131,6 @@ void asyncCopy(
     IDisk & to_disk,
     String to_path,
     ThreadPoolCallbackRunnerLocal<void> & runner,
-    bool copy_root_dir,
     const ReadSettings & read_settings,
     const WriteSettings & write_settings,
     const std::function<void()> & cancellation_hook)
@@ -141,21 +140,16 @@ void asyncCopy(
         runner(
             [&from_disk, from_path, &to_disk, to_path, &read_settings, &write_settings, &cancellation_hook] {
                 from_disk.copyFile(
-                    from_path, to_disk, fs::path(to_path) / fileName(from_path), read_settings, write_settings, cancellation_hook);
+                    from_path, to_disk, to_path, read_settings, write_settings, cancellation_hook);
             });
     }
-    else
+    else /// Directory
     {
         fs::path dest(to_path);
-        if (copy_root_dir)
-        {
-            fs::path dir_name = fs::path(from_path).parent_path().filename();
-            dest /= dir_name;
-            to_disk.createDirectories(dest);
-        }
+        to_disk.createDirectories(dest);
 
         for (auto it = from_disk.iterateDirectory(from_path); it->isValid(); it->next())
-            asyncCopy(from_disk, it->path(), to_disk, dest, runner, true, read_settings, write_settings, cancellation_hook);
+            asyncCopy(from_disk, it->path(), to_disk, dest / it->name(), runner, read_settings, write_settings, cancellation_hook);
     }
 }
 
@@ -163,7 +157,6 @@ void IDisk::copyThroughBuffers(
     const String & from_path,
     const std::shared_ptr<IDisk> & to_disk,
     const String & to_path,
-    bool copy_root_dir,
     const ReadSettings & read_settings,
     WriteSettings write_settings,
     const std::function<void()> & cancellation_hook)
@@ -175,7 +168,7 @@ void IDisk::copyThroughBuffers(
     write_settings.s3_allow_parallel_part_upload = false;
     write_settings.azure_allow_parallel_part_upload = false;
 
-    asyncCopy(*this, from_path, *to_disk, to_path, runner, copy_root_dir, read_settings, write_settings, cancellation_hook);
+    asyncCopy(*this, from_path, *to_disk, to_path, runner, read_settings, write_settings, cancellation_hook);
 
     runner.waitForAllToFinishAndRethrowFirstError();
 }
@@ -192,7 +185,7 @@ void IDisk::copyDirectoryContent(
     if (!to_disk->existsDirectory(to_dir))
         to_disk->createDirectories(to_dir);
 
-    copyThroughBuffers(from_dir, to_disk, to_dir, /* copy_root_dir= */ false, read_settings, write_settings, cancellation_hook);
+    copyThroughBuffers(from_dir, to_disk, to_dir, read_settings, write_settings, cancellation_hook);
 }
 
 void IDisk::truncateFile(const String &, size_t)

--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -182,9 +182,6 @@ void IDisk::copyDirectoryContent(
     const WriteSettings & write_settings,
     const std::function<void()> & cancellation_hook)
 {
-    if (!to_disk->existsDirectory(to_dir))
-        to_disk->createDirectories(to_dir);
-
     copyThroughBuffers(from_dir, to_disk, to_dir, read_settings, write_settings, cancellation_hook);
 }
 

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -572,7 +572,6 @@ protected:
         const String & from_path,
         const std::shared_ptr<IDisk> & to_disk,
         const String & to_path,
-        bool copy_root_dir,
         const ReadSettings & read_settings,
         WriteSettings write_settings,
         const std::function<void()> & cancellation_hook);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
