### PR TITLE
ci: add some comments about differences in artifacts paths

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -1,7 +1,8 @@
 from praktika import Artifact, Docker, Job, Secret
 from praktika.utils import MetaClasses, Utils
 
-TEMP_DIR = f"{Utils.cwd()}/ci/tmp"  # == Settings.TEMP_DIR
+# i.e. "ClickHouse/ci/tmp"
+TEMP_DIR = f"{Utils.cwd()}/ci/tmp"  # == _Settings.TEMP_DIR != env_helper.TEMP_PATH
 
 
 class RunnerLabels:

--- a/tests/ci/env_helper.py
+++ b/tests/ci/env_helper.py
@@ -9,6 +9,7 @@ git_root = p.abspath(p.join(module_dir, "..", ".."))
 ROOT_DIR = git_root
 IS_CI = bool(os.getenv("CI"))
 IS_NEW_CI = bool(int(os.getenv("PRAKTIKA", "0")))
+# i.e. "ClickHouse/tests/ci/tmp"
 TEMP_PATH = os.getenv("TEMP_PATH", p.abspath(p.join(module_dir, "./tmp")))
 REPORT_PATH = f"{TEMP_PATH}/reports"
 # FIXME: latest should not be used in CI, set temporary for transition to "docker with digest as a tag"

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -92,6 +92,11 @@ def main():
 
     repo_path = Path(REPO_COPY)
 
+    # i.e. "ClickHouse/ci/tmp"
+    #
+    # Note, it is not the same as "TEMP_PATH", since we want to upload binaries
+    # to the "clickhouse-builds" bucket from the Runner::_post_run, not the
+    # "S3_REPORT_BUCKET_NAME" via HtmlRunnerHooks::post_run
     build_output_temp_path = repo_path / "ci" / "tmp"
     build_output_temp_path.mkdir(parents=True, exist_ok=True)
     build_output_path = build_output_temp_path / "build"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There are lots of odd things in CI code right now, this PR tries to add some comments around, but long-term goal should be to make code cleaner