### PR TITLE
tests: suppress "/etc/timezone is deprecated on Debian" in 03279_with_clickhouse_driver

### DIFF
--- a/tests/queries/0_stateless/03279_with_clickhouse_driver.py
+++ b/tests/queries/0_stateless/03279_with_clickhouse_driver.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
 # Tags: no-fasttest
 
+import logging
 import os
-
 from clickhouse_driver import Client
+
+
+# Suppress https://github.com/regebro/tzlocal/blob/79da66645f8ce15c1b2d84a5cf350775c2ff81b3/tzlocal/unix.py#L142
+class SuppressTimezoneWarning(logging.Filter):
+    def filter(self, record):
+        return "/etc/timezone is deprecated on Debian" not in record.getMessage()
+
+
+logger = logging.getLogger("tzlocal")
+logger.addFilter(SuppressTimezoneWarning())
 
 
 def run(database):


### PR DESCRIPTION
CI found [1]:

    2025-02-18 20:21:01 Reason: having stderror:
    2025-02-18 20:21:01 /etc/timezone is deprecated on Debian, and no longer reliable. Ignoring.

The error likely came from - https://github.com/regebro/tzlocal/blob/79da66645f8ce15c1b2d84a5cf350775c2ff81b3/tzlocal/unix.py#L142

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=76308&sha=8504d7a7d875771dd97c22b50af10d1242cdb978&name_0=PR&name_1=Stateless%20tests%20%28asan%2C%202%2F2%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)