### PR TITLE
Fix `setReadUntilPosition` in `AsynchronousBoundedReadBuffer`

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
@@ -131,8 +131,8 @@ void AsynchronousBoundedReadBuffer::setReadUntilPosition(size_t position)
             if (available() >= file_offset_of_buffer_end - position)
             {
                 /// new read until position is after the current position in the working buffer
-                file_offset_of_buffer_end = position;
                 working_buffer.resize(working_buffer.size() - (file_offset_of_buffer_end - position));
+                file_offset_of_buffer_end = position;
                 pos = std::min(pos, working_buffer.end());
             }
             else


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This can lead to incorrect offsets when combined with `seek` in some edge cases.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
