### PR TITLE
Docs: add `remote_url_allow_hosts` setting

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -3176,7 +3176,6 @@ For example:
 </remote_url_allow_hosts>
 ```
 
-
 ## timezone
 
 The server's time zone.

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -3162,9 +3162,9 @@ For the value of the `incl` attribute, see the section "[Configuration files](..
 List of hosts which are allowed to be used in URL-related storage engines and table functions.
 
 When adding a host with the `\<host\>` xml tag:
-- it should be specified exactly as in the URL as the name is checked before DNS resolution.
-- if the port is explicitly specified in the URL, then host:port is checked as a whole.
-- if the host is specified without a port, then any port of the host is allowed.
+- it should be specified exactly as in the URL, as the name is checked before DNS resolution. For example: `<host>clickhouse.com</host>`
+- if the port is explicitly specified in the URL, then host:port is checked as a whole. For example: `<host>clickhouse.com:80</host>`
+- if the host is specified without a port, then any port of the host is allowed. For example: if `<host>clickhouse.com</host>` is specified then `clickhouse.com:20` (FTP), `clickhouse.com:80` (HTTP), `clickhouse.com:443` (HTTPS) etc are allowed.
 - if the host is specified as an IP address, then it is checked as specified in the URL. For example: `[2a02:6b8:a::a]`.
 - if there are redirects and support for redirects is enabled, then every redirect (the location field) is checked.
 
@@ -3175,6 +3175,8 @@ For example:
     <host>clickhouse.com</host>
 </remote_url_allow_hosts>
 ```
+
+
 ## timezone
 
 The server's time zone.

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -3157,6 +3157,24 @@ For the value of the `incl` attribute, see the section "[Configuration files](..
 - [Cluster Discovery](../../operations/cluster-discovery.md)
 - [Replicated database engine](../../engines/database-engines/replicated.md)
 
+## remote_url_allow_hosts
+
+List of hosts which are allowed to be used in URL-related storage engines and table functions.
+
+When adding a host with the `\<host\>` xml tag:
+- it should be specified exactly as in the URL as the name is checked before DNS resolution.
+- if the port is explicitly specified in the URL, then host:port is checked as a whole.
+- if the host is specified without a port, then any port of the host is allowed.
+- if the host is specified as an IP address, then it is checked as specified in the URL. For example: `[2a02:6b8:a::a]`.
+- if there are redirects and support for redirects is enabled, then every redirect (the location field) is checked.
+
+For example: 
+
+```sql
+<remote_url_allow_hosts>
+    <host>clickhouse.com</host>
+</remote_url_allow_hosts>
+```
 ## timezone
 
 The server's time zone.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Adds missing `remote_url_allow_hosts` setting to docs. Closes https://github.com/ClickHouse/clickhouse-docs/issues/3293.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
