### PR TITLE
url engine does not support partition by

### DIFF
--- a/docs/en/engines/table-engines/special/url.md
+++ b/docs/en/engines/table-engines/special/url.md
@@ -97,12 +97,6 @@ SELECT * FROM url_engine_table
     - Indexes.
     - Replication.
 
-## PARTITION BY
-
-`PARTITION BY` — Optional.  It is possible to create separate files by partitioning the data on a partition key. In most cases, you don't need a partition key, and if it is needed you generally don't need a partition key more granular than by month. Partitioning does not speed up queries (in contrast to the ORDER BY expression). You should never use too granular partitioning. Don't partition your data by client identifiers or names (instead, make client identifier or name the first column in the ORDER BY expression).
-
-For partitioning by month, use the `toYYYYMM(date_column)` expression, where `date_column` is a column with a date of the type [Date](/docs/en/sql-reference/data-types/date.md). The partition names here have the `"YYYYMM"` format.
-
 ## Virtual Columns {#virtual-columns}
 
 - `_path` — Path to the `URL`. Type: `LowCardinality(String)`.

--- a/docs/ja/engines/table-engines/special/url.md
+++ b/docs/ja/engines/table-engines/special/url.md
@@ -94,12 +94,6 @@ SELECT * FROM url_engine_table
     - インデックス。
     - レプリケーション。
 
-## PARTITION BY
-
-`PARTITION BY` — 任意です。パーティションキーに基づいてデータを分割して、別々のファイルを作成することができます。ほとんどの場合、パーティションキーは不要であり、必要な場合でも一般的に月ごと以上に細かいパーティションキーは不要です。パーティション分割はクエリを高速化しません（ORDER BY式とは対照的です）。過度に細かいパーティション分割は避けてください。クライアントの識別子や名前でデータをパーティション分割しないでください（代わりに、クライアント識別子や名前をORDER BY式の最初のカラムにしてください）。
-
-月ごとにパーティション分割するには、`toYYYYMM(date_column)`式を使用します。ここで`date_column`は[Date](/docs/ja/sql-reference/data-types/date.md)型の日付を持つカラムです。パーティション名は`"YYYYMM"`形式になります。
-
 ## 仮想カラム {#virtual-columns}
 
 - `_path` — `URL`へのパスです。型: `LowCardinality(String)`。


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Remove misleading information regarding URL engine from docs. This table engine 
doesn't support `PARTITION BY` and here is the error message I got when using 
`PARTITION BY` with the URL table engine.

```
`Code: 36. DB::Exception: Engine URL doesn't support PARTITION_BY, PRIMARY_KEY, ORDER_BY or SAMPLE_BY clauses. Currently only the following engines have support for the feature: [HDFS, OSS, AzureBlobStorage, KeeperMap, S3, MaterializedPostgreSQL, ReplicatedSummingMergeTree, COSN, Redis, MergeTree, ReplicatedReplacingMergeTree, ReplicatedVersionedCollapsingMergeTree, VersionedCollapsingMergeTree, Hive, ReplacingMergeTree, ReplicatedAggregatingMergeTree, ReplicatedMergeTree, EmbeddedRocksDB, ReplicatedCollapsingMergeTree, ReplicatedGraphiteMergeTree, SummingMergeTree, GraphiteMergeTree, CollapsingMergeTree, AggregatingMergeTree]. (BAD_ARGUMENTS) (version 24.6.2.17 (official build))`
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
