### PR TITLE
Adjust a few old tests to flush individual logs

### DIFF
--- a/tests/queries/0_stateless/01158_zookeeper_log_long.sql
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.sql
@@ -17,7 +17,7 @@ system sync replica rmt;
 insert into rmt values (1);
 insert into rmt values (1);
 system sync replica rmt;
-system flush logs;
+system flush logs zookeeper_log, query_log;
 
 select 'log';
 select address, type, has_watch, op_num, path, is_ephemeral, is_sequential, version, requests_size, request_idx, error, watch_type,
@@ -61,6 +61,6 @@ order by xid, type, request_idx;
 
 drop table rmt sync;
 
-system flush logs;
+system flush logs zookeeper_log;
 select 'duration_microseconds';
 select count()>0 from system.zookeeper_log where path like '/test/01158/' || currentDatabase() || '/rmt%' and duration_microseconds > 0;

--- a/tests/queries/0_stateless/01165_lost_part_empty_partition.sql
+++ b/tests/queries/0_stateless/01165_lost_part_empty_partition.sql
@@ -15,7 +15,7 @@ drop table rmt1;
 system sync replica rmt2;
 select lost_part_count from system.replicas where database = currentDatabase() and table = 'rmt2';
 drop table rmt2;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS text_log;
 select count() from system.text_log where logger_name like '%' || currentDatabase() || '%' and message ilike '%table with non-zero lost_part_count equal to%';
 
 
@@ -29,7 +29,7 @@ drop table rmt1;
 system sync replica rmt2;
 select lost_part_count from system.replicas where database = currentDatabase() and table = 'rmt2';
 drop table rmt2;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS text_log;
 select count() from system.text_log where logger_name like '%' || currentDatabase() || '%' and message ilike '%table with non-zero lost_part_count equal to%';
 
 

--- a/tests/queries/0_stateless/01200_mutations_memory_consumption.sql
+++ b/tests/queries/0_stateless/01200_mutations_memory_consumption.sql
@@ -16,7 +16,7 @@ INSERT INTO table_with_single_pk SELECT number, toString(number % 10) FROM numbe
 
 ALTER TABLE table_with_single_pk DELETE WHERE key % 77 = 0 SETTINGS mutations_sync = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 -- Memory usage for all mutations must be almost constant and less than
 -- read_bytes
@@ -45,7 +45,7 @@ INSERT INTO table_with_multi_pk SELECT number % 32, number, toDateTime('2019-10-
 
 ALTER TABLE table_with_multi_pk DELETE WHERE key1 % 77 = 0 SETTINGS mutations_sync = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 -- Memory usage for all mutations must be almost constant and less than
 -- read_bytes
@@ -76,7 +76,7 @@ INSERT INTO table_with_function_pk SELECT number % 32, number, toDateTime('2019-
 
 ALTER TABLE table_with_function_pk DELETE WHERE key1 % 77 = 0 SETTINGS mutations_sync = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 -- Memory usage for all mutations must be almost constant and less than
 -- read_bytes
@@ -105,7 +105,7 @@ INSERT INTO table_without_pk SELECT number % 32, number, toDateTime('2019-10-01 
 
 ALTER TABLE table_without_pk DELETE WHERE key1 % 77 = 0 SETTINGS mutations_sync = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 -- Memory usage for all mutations must be almost constant and less than
 -- read_bytes

--- a/tests/queries/0_stateless/01231_log_queries_min_type.sql
+++ b/tests/queries/0_stateless/01231_log_queries_min_type.sql
@@ -1,14 +1,14 @@
 set log_queries=1;
 
 select '01231_log_queries_min_type/QUERY_START';
-system flush logs;
+system flush logs query_log;
 select count() from system.query_log where current_database = currentDatabase()
     and query like 'select \'01231_log_queries_min_type/QUERY_START%'
     and event_date >= yesterday();
 
 set log_queries_min_type='EXCEPTION_BEFORE_START';
 select '01231_log_queries_min_type/EXCEPTION_BEFORE_START';
-system flush logs;
+system flush logs query_log;
 select count() from system.query_log where current_database = currentDatabase()
     and query like 'select \'01231_log_queries_min_type/EXCEPTION_BEFORE_START%'
     and event_date >= yesterday();
@@ -17,14 +17,14 @@ set max_rows_to_read='100K';
 set log_queries_min_type='EXCEPTION_WHILE_PROCESSING';
 select '01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING', max(number) from system.numbers limit 1e6; -- { serverError TOO_MANY_ROWS }
 set max_rows_to_read=0;
-system flush logs;
+system flush logs query_log;
 select count() from system.query_log where current_database = currentDatabase()
     and query like 'select \'01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING%'
     and event_date >= yesterday() and type = 'ExceptionWhileProcessing';
 
 set max_rows_to_read='100K';
 select '01231_log_queries_min_type w/ Settings/EXCEPTION_WHILE_PROCESSING', max(number) from system.numbers limit 1e6; -- { serverError TOO_MANY_ROWS }
-system flush logs;
+system flush logs query_log;
 set max_rows_to_read=0;
 select count() from system.query_log where
     current_database = currentDatabase() and

--- a/tests/queries/0_stateless/01275_parallel_mv.reference
+++ b/tests/queries/0_stateless/01275_parallel_mv.reference
@@ -14,7 +14,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=0,
     optimize_trivial_insert_select=0,
     max_insert_threads=0;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -38,7 +38,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=0,
     optimize_trivial_insert_select=0,
     max_insert_threads=5;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -62,7 +62,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=0,
     optimize_trivial_insert_select=1,
     max_insert_threads=0;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -86,7 +86,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=0,
     optimize_trivial_insert_select=1,
     max_insert_threads=5;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -110,7 +110,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=1,
     optimize_trivial_insert_select=0,
     max_insert_threads=0;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -134,7 +134,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=1,
     optimize_trivial_insert_select=0,
     max_insert_threads=5;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -158,7 +158,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=1,
     optimize_trivial_insert_select=1,
     max_insert_threads=0;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and
@@ -182,7 +182,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing=1,
     optimize_trivial_insert_select=1,
     max_insert_threads=5;
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and

--- a/tests/queries/0_stateless/01275_parallel_mv.sql.j2
+++ b/tests/queries/0_stateless/01275_parallel_mv.sql.j2
@@ -41,7 +41,7 @@ insert into testX select number from numbers(200) settings
     parallel_view_processing={{ parallel_view_processing }},
     optimize_trivial_insert_select={{ optimize_trivial_insert_select }},
     max_insert_threads={{ max_insert_threads }};
-system flush logs;
+system flush logs system.query_log;
 select peak_threads_usage from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and

--- a/tests/queries/0_stateless/01290_max_execution_speed_distributed.sql
+++ b/tests/queries/0_stateless/01290_max_execution_speed_distributed.sql
@@ -25,7 +25,7 @@ INSERT INTO times SELECT now();
 SELECT max(t) - min(t) >= 1 FROM times;
 
 -- Check that the query was also throttled on "remote" servers.
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT DISTINCT query_duration_ms >= 500
 FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/01292_create_user.sql
+++ b/tests/queries/0_stateless/01292_create_user.sql
@@ -240,7 +240,7 @@ SELECT name, auth_type, auth_params FROM system.users WHERE name = 'u1_01292' OR
 DROP USER u1_01292;
 
 SELECT '-- no passwords or hashes in query_log';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT query
 FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/01319_query_formatting_in_server_log.sql
+++ b/tests/queries/0_stateless/01319_query_formatting_in_server_log.sql
@@ -3,5 +3,5 @@ cd' /* hello */ -- world
 , 1;
 
 SET max_rows_to_read = 0; -- system.text_log can be really big
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS text_log;
 SELECT extract(message, 'SeL.+?;') FROM system.text_log WHERE event_date >= yesterday() AND message LIKE '%SeLeCt \'ab\n%' and logger_name = 'executeQuery' ORDER BY event_time DESC LIMIT 1 FORMAT TSVRaw;

--- a/tests/queries/0_stateless/01323_too_many_threads_bug.sql
+++ b/tests/queries/0_stateless/01323_too_many_threads_bug.sql
@@ -13,12 +13,12 @@ set max_threads = 16;
 set log_queries = 1;
 select x from table_01323_many_parts limit 10 format Null;
 
-system flush logs;
+system flush logs query_log;
 select peak_threads_usage <= 4 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 select x from table_01323_many_parts order by x limit 10 format Null;
 
-system flush logs;
+system flush logs query_log;
 select peak_threads_usage <= 36 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01323_many_parts;

--- a/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.sql
+++ b/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.sql
@@ -6,7 +6,7 @@ INSERT INTO test_01343 VALUES ('Hello, world');
 SET local_filesystem_read_method = 'mmap', min_bytes_to_use_mmap_io = 1;
 SELECT * FROM test_01343;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['CreatedReadBufferMMap'] AS value FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 300 AND query LIKE 'SELECT * FROM test_01343%' AND type = 2 ORDER BY event_time DESC LIMIT 1;
 
 DROP TABLE test_01343;

--- a/tests/queries/0_stateless/01344_min_bytes_to_use_mmap_io_index.sql
+++ b/tests/queries/0_stateless/01344_min_bytes_to_use_mmap_io_index.sql
@@ -6,7 +6,7 @@ INSERT INTO test_01344 VALUES ('Hello, world');
 SET local_filesystem_read_method = 'mmap', min_bytes_to_use_mmap_io = 1;
 SELECT * FROM test_01344 WHERE x = 'Hello, world';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['CreatedReadBufferMMap'] as value FROM system.query_log
     WHERE current_database = currentDatabase() AND event_date >= yesterday() AND query LIKE 'SELECT * FROM test_01344 WHERE x = ''Hello, world''%' AND type = 2 ORDER BY event_time DESC LIMIT 1;
 

--- a/tests/queries/0_stateless/01356_view_threads.sql
+++ b/tests/queries/0_stateless/01356_view_threads.sql
@@ -9,7 +9,7 @@ set log_queries = 1;
 set max_threads = 16;
 select g % 2 as gg, sum(s) from table_01356_view_threads group by gg order by gg;
 
-system flush logs;
+system flush logs query_log;
 select length(thread_ids) >= 1 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and lower(query) like '%select g % 2 as gg, sum(s) from table_01356_view_threads group by gg order by gg%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01356_view_threads;

--- a/tests/queries/0_stateless/01357_result_rows.sql
+++ b/tests/queries/0_stateless/01357_result_rows.sql
@@ -1,5 +1,5 @@
 set log_queries = 1;
 select count() > 0 from system.settings;
 
-system flush logs;
+system flush logs query_log;
 select result_rows, result_bytes >= 8 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and lower(query) like '%select count() > 0 from system.settings%' and type = 'QueryFinish' order by query_start_time desc limit 1;

--- a/tests/queries/0_stateless/01358_union_threads_bug.sql
+++ b/tests/queries/0_stateless/01358_union_threads_bug.sql
@@ -6,5 +6,5 @@ set max_threads = 16;
 
 SELECT count() FROM (SELECT number FROM numbers_mt(1000000) ORDER BY number DESC LIMIT 100 UNION ALL SELECT number FROM numbers_mt(1000000) ORDER BY number DESC LIMIT 100 UNION ALL SELECT number FROM numbers_mt(1000000) ORDER BY number DESC LIMIT 100);
 
-system flush logs;
+system flush logs query_log;
 select length(thread_ids) >= 1 from system.query_log where current_database = currentDatabase() AND event_date >= today() - 1 and query like '%SELECT count() FROM (SELECT number FROM numbers_mt(1000000) ORDER BY number DESC LIMIT 100 UNION ALL SELECT number FROM numbers_mt(1000000) ORDER BY number DESC LIMIT 100 UNION ALL SELECT number FROM numbers_mt(1000000) ORDER BY number DESC LIMIT 100)%' and type = 'QueryFinish' order by query_start_time desc limit 1;

--- a/tests/queries/0_stateless/01360_materialized_view_with_join_on_query_log.sql
+++ b/tests/queries/0_stateless/01360_materialized_view_with_join_on_query_log.sql
@@ -9,7 +9,7 @@ INSERT INTO expected_times VALUES('main_dashboard_top_query', 500), ('main_dashb
 
 SET log_queries=1;
 SELECT 1;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 
 -- NOTE: can be rewritten using log_queries_min_query_duration_ms
@@ -35,7 +35,7 @@ SELECT 1 WHERE not ignore(sleep(0.520)) /* QUERY_GROUP_ID:main_dashboard_top_que
 SELECT 1 WHERE not ignore(sleep(0.520)) /* QUERY_GROUP_ID:main_dashboard_bottom_query */;
 
 SET log_queries=0;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT '=== system.query_log ===';
 

--- a/tests/queries/0_stateless/01413_rows_events.sql
+++ b/tests/queries/0_stateless/01413_rows_events.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS rows_events_test;
 CREATE TABLE rows_events_test (k UInt32, v UInt32) ENGINE = MergeTree ORDER BY k;
 
 INSERT INTO /* test 01413, query 1 */ rows_events_test VALUES (1,1);
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT written_rows FROM system.query_log WHERE current_database = currentDatabase() AND query LIKE 'INSERT INTO /* test 01413, query 1 */ rows_events_test%' AND type = 2 AND event_date >= yesterday() ORDER BY event_time DESC LIMIT 1;
 
@@ -10,7 +10,7 @@ SELECT ProfileEvents['InsertedRows'] as value FROM system.query_log WHERE curren
 
 
 INSERT INTO /* test 01413, query 2 */ rows_events_test VALUES (2,2), (3,3);
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT written_rows FROM system.query_log WHERE current_database = currentDatabase() AND query LIKE 'INSERT INTO /* test 01413, query 2 */ rows_events_test%' AND type = 2 AND event_date >= yesterday() ORDER BY event_time DESC LIMIT 1;
 
@@ -18,7 +18,7 @@ SELECT ProfileEvents['InsertedRows'] as value FROM system.query_log WHERE curren
 
 
 SELECT * FROM /* test 01413, query 3 */ rows_events_test WHERE v = 2;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows FROM system.query_log WHERE current_database = currentDatabase() AND query LIKE 'SELECT * FROM /* test 01413, query 3 */ rows_events_test%' AND type = 2 AND event_date >= yesterday() ORDER BY event_time DESC LIMIT 1;
 

--- a/tests/queries/0_stateless/01415_overlimiting_threads_for_repica_bug.sql
+++ b/tests/queries/0_stateless/01415_overlimiting_threads_for_repica_bug.sql
@@ -7,5 +7,5 @@ set prefer_localhost_replica = 1;
 
 select sum(number) from remote('127.0.0.{1|2}', numbers_mt(1000000)) group by number % 2 order by number % 2;
 
-system flush logs;
+system flush logs query_log;
 select length(thread_ids) >= 1 from system.query_log where current_database = currentDatabase() and event_date >= today() - 1 and lower(query) like '%select sum(number) from remote(_127.0.0.{1|2}_, numbers_mt(1000000)) group by number %' and type = 'QueryFinish' order by query_start_time desc limit 1;

--- a/tests/queries/0_stateless/01461_query_start_time_microseconds.sql
+++ b/tests/queries/0_stateless/01461_query_start_time_microseconds.sql
@@ -1,6 +1,6 @@
 SET log_queries = 1;
 SELECT '01461_query_log_query_start_time_milliseconds_test';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 -- assumes that the query_start_time field is already accurate.
 WITH (
       (
@@ -25,7 +25,7 @@ SELECT if(dateDiff('second', toDateTime(time_with_microseconds), toDateTime(t)) 
 
 SET log_query_threads = 1;
 SELECT '01461_query_thread_log_query_start_time_milliseconds_test';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_thread_log;
 -- assumes that the query_start_time field is already accurate.
 WITH (
       (

--- a/tests/queries/0_stateless/01473_event_time_microseconds.reference
+++ b/tests/queries/0_stateless/01473_event_time_microseconds.reference
@@ -6,5 +6,3 @@ ok
 ok
 01473_query_thread_log_table_event_start_time_microseconds_test
 ok
-01473_text_log_table_event_start_time_microseconds_test
-ok

--- a/tests/queries/0_stateless/01473_event_time_microseconds.sql
+++ b/tests/queries/0_stateless/01473_event_time_microseconds.sql
@@ -11,7 +11,7 @@ SET query_profiler_real_time_period_ns = 100000000;
 -- a long enough query to trigger the query profiler and to record trace log
 SELECT sleep(2) FORMAT Null;
 SET query_profiler_real_time_period_ns = 1000000000;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS metric_log, trace_log, query_log, query_thread_log;
 
 SELECT '01473_metric_log_table_event_start_time_microseconds_test';
 -- query assumes that the event_time field is accurate.
@@ -50,14 +50,4 @@ WITH (
         ORDER BY event_time DESC
         LIMIT 1
     ) AS time
-SELECT if(dateDiff('second', toDateTime(time.1), toDateTime(time.2)) = 0, 'ok', toString(time));
-
-SELECT '01473_text_log_table_event_start_time_microseconds_test';
-WITH (
-          SELECT event_time_microseconds, event_time
-          FROM system.query_thread_log
-          WHERE current_database = currentDatabase()
-          ORDER BY event_time DESC
-          LIMIT 1
-      ) AS time
 SELECT if(dateDiff('second', toDateTime(time.1), toDateTime(time.2)) = 0, 'ok', toString(time));

--- a/tests/queries/0_stateless/01475_read_subcolumns.sql
+++ b/tests/queries/0_stateless/01475_read_subcolumns.sql
@@ -10,7 +10,7 @@ INSERT INTO t_arr VALUES ([1]) ([]) ([1, 2, 3]) ([1, 2]);
 SYSTEM DROP MARK CACHE;
 SELECT a.size0 FROM t_arr;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FileOpen']
 FROM system.query_log
 WHERE (type = 'QueryFinish') AND (lower(query) LIKE lower('SELECT a.size0 FROM %t_arr%'))
@@ -27,7 +27,7 @@ SELECT t.s FROM t_tup;
 SYSTEM DROP MARK CACHE;
 SELECT t.u FROM t_tup;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FileOpen']
 FROM system.query_log
 WHERE (type = 'QueryFinish') AND (lower(query) LIKE lower('SELECT t._ FROM %t_tup%'))
@@ -41,7 +41,7 @@ INSERT INTO t_nul VALUES (1) (NULL) (2) (NULL);
 SYSTEM DROP MARK CACHE;
 SELECT n.null FROM t_nul;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FileOpen']
 FROM system.query_log
 WHERE (type = 'QueryFinish') AND (lower(query) LIKE lower('SELECT n.null FROM %t_nul%'))
@@ -59,7 +59,7 @@ SELECT m.keys FROM t_map;
 SYSTEM DROP MARK CACHE;
 SELECT m.values FROM t_map;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FileOpen']
 FROM system.query_log
 WHERE (type = 'QueryFinish') AND (lower(query) LIKE lower('SELECT m.% FROM %t_map%'))

--- a/tests/queries/0_stateless/01531_query_log_query_comment.sql
+++ b/tests/queries/0_stateless/01531_query_log_query_comment.sql
@@ -3,7 +3,7 @@ set log_queries_min_type='QUERY_FINISH';
 
 set enable_global_with_statement=0;
 select /* test=01531, enable_global_with_statement=0 */ 2;
-system flush logs;
+system flush logs query_log;
 select count() from system.query_log
 where event_date >= yesterday()
     and query like 'select /* test=01531, enable_global_with_statement=0 */ 2%'
@@ -12,7 +12,7 @@ where event_date >= yesterday()
 
 set enable_global_with_statement=1;
 select /* test=01531, enable_global_with_statement=1 */ 2;
-system flush logs;
+system flush logs query_log;
 select count() from system.query_log
 where event_date >= yesterday()
     and query like 'select /* test=01531, enable_global_with_statement=1 */ 2%'

--- a/tests/queries/0_stateless/01532_execute_merges_on_single_replica_long.sql
+++ b/tests/queries/0_stateless/01532_execute_merges_on_single_replica_long.sql
@@ -112,7 +112,7 @@ OPTIMIZE TABLE execute_on_single_replica_r1 FINAL;
 SYSTEM SYNC REPLICA execute_on_single_replica_r1;
 SYSTEM SYNC REPLICA execute_on_single_replica_r2;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT '****************************';
 SELECT '*** part_log';

--- a/tests/queries/0_stateless/01533_multiple_nested.sql
+++ b/tests/queries/0_stateless/01533_multiple_nested.sql
@@ -36,7 +36,7 @@ SYSTEM DROP MARK CACHE;
 SELECT col1.a FROM nested FORMAT Null;
 
 -- 4 files: (col1.size0, col1.a) x2
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FileOpen'] - ProfileEvents['CreatedReadBufferDirectIOFailed']
 FROM system.query_log
 WHERE (type = 'QueryFinish') AND (lower(query) LIKE lower('SELECT col1.a FROM %nested%'))
@@ -46,7 +46,7 @@ SYSTEM DROP MARK CACHE;
 SELECT col3.n2.s FROM nested FORMAT Null;
 
 -- 6 files: (col3.size0, col3.n2.size1, col3.n2.s) x2
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FileOpen'] - ProfileEvents['CreatedReadBufferDirectIOFailed']
 FROM system.query_log
 WHERE (type = 'QueryFinish') AND (lower(query) LIKE lower('SELECT col3.n2.s FROM %nested%'))

--- a/tests/queries/0_stateless/01546_log_queries_min_query_duration_ms.sql
+++ b/tests/queries/0_stateless/01546_log_queries_min_query_duration_ms.sql
@@ -6,7 +6,7 @@ set log_queries=1;
 -- fast -- no logging
 --
 select '01546_log_queries_min_query_duration_ms-fast' format Null;
-system flush logs;
+system flush logs query_log, query_thread_log;
 
 -- No logging, since the query is fast enough.
 select count()
@@ -27,7 +27,7 @@ where
 --
 set log_queries_min_query_duration_ms=300;
 select '01546_log_queries_min_query_duration_ms-slow', sleep(0.4) format Null;
-system flush logs;
+system flush logs query_log, query_thread_log;
 
 -- With the limit on minimum execution time, "query start" and "exception before start" events are not logged, only query finish.
 select count()

--- a/tests/queries/0_stateless/01547_query_log_current_database.sql
+++ b/tests/queries/0_stateless/01547_query_log_current_database.sql
@@ -16,7 +16,7 @@ select '01547_query_log_current_database' from system.one format Null;
 set log_queries=0;
 set log_query_threads=0;
 
-system flush logs;
+system flush logs query_log, query_thread_log;
 
 select count()
 from system.query_log

--- a/tests/queries/0_stateless/01560_crash_in_agg_empty_arglist.sql
+++ b/tests/queries/0_stateless/01560_crash_in_agg_empty_arglist.sql
@@ -1,5 +1,5 @@
 -- make sure the system.query_log table is created
 SELECT 1;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT any() as t, substring(query, 1, 70) AS query, avg(memory_usage) usage, count() count FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= toDate(1604295323) AND event_time >= toDateTime(1604295323) AND type in (1,2,3,4) and initial_user in ('') and('all' = 'all' or(positionCaseInsensitive(query, 'all') = 1)) GROUP BY query ORDER BY usage desc LIMIT 5; -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/01651_bugs_from_15889.sql
+++ b/tests/queries/0_stateless/01651_bugs_from_15889.sql
@@ -40,7 +40,7 @@ INSERT INTO trace_log values ('2020-10-06','2020-10-06 13:43:39','2020-10-06 13:
 set allow_introspection_functions = 1;
 
 -- make sure query_log exists
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 WITH concat(addressToLine(arrayJoin(trace) AS addr), '#') AS symbol
 SELECT count() > 7
@@ -73,7 +73,7 @@ WHERE greaterOrEquals(event_date, ignore(ignore(ignore(NULL, '')), 256), yesterd
 
 DROP TABLE IF EXISTS trace_log;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 WITH
     (

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
@@ -24,7 +24,7 @@ FORMAT Null; -- { serverError MEMORY_LIMIT_EXCEEDED }
 
 SELECT '';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT arraySort(used_aggregate_functions)
 FROM system.query_log WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND (query LIKE '%toDate(\'2000-12-05\')%')
@@ -61,7 +61,7 @@ SELECT '';
 DROP database IF EXISTS test_query_log_factories_info1;
 CREATE database test_query_log_factories_info1 ENGINE=Atomic;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT used_database_engines
 FROM system.query_log
 WHERE current_database = currentDatabase() AND type == 'QueryFinish' AND (query LIKE '%database test_query_log_factories_info%')
@@ -70,7 +70,7 @@ SELECT '';
 
 CREATE OR REPLACE TABLE test_query_log_factories_info1.memory_table (id BIGINT, date DATETIME) ENGINE=Memory();
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT arraySort(used_data_type_families), used_storages
 FROM system.query_log
 WHERE current_database = currentDatabase() AND type == 'QueryFinish' AND (query LIKE '%TABLE test%')

--- a/tests/queries/0_stateless/01670_log_comment.sql
+++ b/tests/queries/0_stateless/01670_log_comment.sql
@@ -1,5 +1,5 @@
 SET log_comment = 'log_comment test', log_queries = 1;
 SELECT 1;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT type, query FROM system.query_log WHERE current_database = currentDatabase() AND log_comment = 'log_comment test' AND query LIKE 'SELECT 1%' AND event_date >= yesterday() AND type = 1 ORDER BY event_time_microseconds DESC LIMIT 1;
 SELECT type, query FROM system.query_log WHERE current_database = currentDatabase() AND log_comment = 'log_comment test' AND query LIKE 'SELECT 1%' AND event_date >= yesterday() AND type = 2 ORDER BY event_time_microseconds DESC LIMIT 1;

--- a/tests/queries/0_stateless/01702_system_query_log.reference
+++ b/tests/queries/0_stateless/01702_system_query_log.reference
@@ -42,7 +42,7 @@ Alter	ALTER TABLE sqllt.table DROP COLUMN the_new_col;
 Alter	ALTER TABLE sqllt.table UPDATE i = i + 1 WHERE 1;
 Alter	ALTER TABLE sqllt.table DELETE WHERE i > 65535;
 Select	-- not done, seems to hard, so I\'ve skipped queries of ALTER-X, where X is:\n-- PARTITION\n-- ORDER BY\n-- SAMPLE BY\n-- INDEX\n-- CONSTRAINT\n-- TTL\n-- USER\n-- QUOTA\n-- ROLE\n-- ROW POLICY\n-- SETTINGS PROFILE\n\nSELECT \'SYSTEM queries\';
-System	SYSTEM FLUSH LOGS;
+System	SYSTEM FLUSH LOGS query_log;
 System	SYSTEM STOP MERGES sqllt.table;
 System	SYSTEM START MERGES sqllt.table;
 System	SYSTEM STOP TTL MERGES sqllt.table;

--- a/tests/queries/0_stateless/01702_system_query_log.sql
+++ b/tests/queries/0_stateless/01702_system_query_log.sql
@@ -66,7 +66,7 @@ ALTER TABLE sqllt.table DELETE WHERE i > 65535;
 -- SETTINGS PROFILE
 
 SELECT 'SYSTEM queries';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SYSTEM STOP MERGES sqllt.table;
 SYSTEM START MERGES sqllt.table;
 SYSTEM STOP TTL MERGES sqllt.table;
@@ -126,7 +126,7 @@ SET log_comment='';
 -- Now get all logs related to this test
 ---------------------------------------------------------------------------------------------------
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'ACTUAL LOG CONTENT:';
 
 -- Try to filter out all possible previous junk events by excluding old log entries,

--- a/tests/queries/0_stateless/01710_query_log_with_projection_info.sql
+++ b/tests/queries/0_stateless/01710_query_log_with_projection_info.sql
@@ -37,7 +37,7 @@ SELECT * FROM t WHERE id2 = 3 FORMAT Null;
 SELECT sum(id3) FROM t GROUP BY id2 FORMAT Null;
 SELECT min(id) FROM t FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     --Remove the prefix string which is a mutable database name.

--- a/tests/queries/0_stateless/01747_system_session_log_long.sh
+++ b/tests/queries/0_stateless/01747_system_session_log_long.sh
@@ -358,7 +358,7 @@ testAsUserIdentifiedBy "sha256_password"
 testAsUserIdentifiedBy "double_sha1_password"
 
 executeQuery <<EOF
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS session_log;
 
 WITH
     now64(6) as n,

--- a/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.reference
+++ b/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.reference
@@ -15,7 +15,7 @@ select '(0, 2)';
 with (select currentDatabase()) as id_no select *, ignore(id_no) from dist_01756 where dummy in (0, 2);
 0	0
 0	0
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -36,7 +36,7 @@ select 'optimize_skip_unused_shards_rewrite_in(0, 2)';
 optimize_skip_unused_shards_rewrite_in(0, 2)
 with (select currentDatabase()) as id_02 select *, ignore(id_02) from dist_01756 where dummy in (0, 2);
 0	0
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -50,7 +50,7 @@ order by query;
 select 'optimize_skip_unused_shards_rewrite_in(2,)';
 optimize_skip_unused_shards_rewrite_in(2,)
 with (select currentDatabase()) as id_2 select *, ignore(id_2) from dist_01756 where dummy in (2);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -64,7 +64,7 @@ select 'optimize_skip_unused_shards_rewrite_in(0,)';
 optimize_skip_unused_shards_rewrite_in(0,)
 with (select currentDatabase()) as id_00 select *, ignore(id_00) from dist_01756 where dummy in (0);
 0	0
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -79,7 +79,7 @@ select 'signed column';
 signed column
 create table data_01756_signed (key Int) engine=Null;
 with (select currentDatabase()) as key_signed select *, ignore(key_signed) from cluster(test_cluster_two_shards, currentDatabase(), data_01756_signed, key) where key in (-1, -2);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and

--- a/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.sql
+++ b/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.sql
@@ -33,7 +33,7 @@ create table dist_01756 as system.one engine=Distributed(test_cluster_two_shards
 --
 select '(0, 2)';
 with (select currentDatabase()) as id_no select *, ignore(id_no) from dist_01756 where dummy in (0, 2);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -52,7 +52,7 @@ set optimize_skip_unused_shards_rewrite_in=1;
 -- detailed coverage for realistic examples
 select 'optimize_skip_unused_shards_rewrite_in(0, 2)';
 with (select currentDatabase()) as id_02 select *, ignore(id_02) from dist_01756 where dummy in (0, 2);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -64,7 +64,7 @@ order by query;
 
 select 'optimize_skip_unused_shards_rewrite_in(2,)';
 with (select currentDatabase()) as id_2 select *, ignore(id_2) from dist_01756 where dummy in (2);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -76,7 +76,7 @@ order by query;
 
 select 'optimize_skip_unused_shards_rewrite_in(0,)';
 with (select currentDatabase()) as id_00 select *, ignore(id_00) from dist_01756 where dummy in (0);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and
@@ -90,7 +90,7 @@ order by query;
 select 'signed column';
 create table data_01756_signed (key Int) engine=Null;
 with (select currentDatabase()) as key_signed select *, ignore(key_signed) from cluster(test_cluster_two_shards, currentDatabase(), data_01756_signed, key) where key in (-1, -2);
-system flush logs;
+system flush logs query_log;
 select splitByString('IN', query)[-1] from system.query_log where
     event_date >= yesterday() and
     event_time > now() - interval 1 hour and

--- a/tests/queries/0_stateless/01882_check_max_parts_to_merge_at_once.sql
+++ b/tests/queries/0_stateless/01882_check_max_parts_to_merge_at_once.sql
@@ -20,7 +20,7 @@ SYSTEM START MERGES limited_merge_table;
 
 OPTIMIZE TABLE limited_merge_table FINAL;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT COUNT() FROM limited_merge_table;
 

--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -17,7 +17,7 @@ SETTINGS max_memory_usage = '400M';
 SELECT s FROM order_by_desc ORDER BY u LIMIT 10 FORMAT Null
 SETTINGS max_memory_usage = '400M';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows < 110000 FROM system.query_log
 WHERE type = 'QueryFinish' AND current_database = currentDatabase()

--- a/tests/queries/0_stateless/01927_query_views_log_current_database.sql
+++ b/tests/queries/0_stateless/01927_query_views_log_current_database.sql
@@ -27,7 +27,7 @@ INSERT INTO table_a SELECT '111', * FROM numbers(100);
 -- INSERT 2
 INSERT INTO table_d SELECT 0.5, * FROM numbers(50);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log, query_views_log;
 
 
 -- CHECK LOGS OF INSERT 1

--- a/tests/queries/0_stateless/01943_query_id_check.sql
+++ b/tests/queries/0_stateless/01943_query_id_check.sql
@@ -6,12 +6,12 @@ SET prefer_localhost_replica = 1;
 DROP TABLE IF EXISTS tmp;
 
 CREATE TABLE tmp ENGINE = TinyLog AS SELECT queryID();
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT query FROM system.query_log WHERE query_id = (SELECT * FROM tmp) AND current_database = currentDatabase() LIMIT 1;
 DROP TABLE tmp;
 
 CREATE TABLE tmp ENGINE = TinyLog AS SELECT initialQueryID();
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT query FROM system.query_log WHERE initial_query_id = (SELECT * FROM tmp) AND current_database = currentDatabase() LIMIT 1;
 DROP TABLE tmp;
 

--- a/tests/queries/0_stateless/01946_profile_sleep.sql
+++ b/tests/queries/0_stateless/01946_profile_sleep.sql
@@ -2,7 +2,7 @@ SET log_queries=1;
 SET log_profile_events=true;
 
 SELECT 'SLEEP #1 TEST', sleep(0.001) FORMAT Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'SLEEP #1 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
 FROM system.query_log
 WHERE query like '%SELECT ''SLEEP #1 TEST''%'
@@ -12,7 +12,7 @@ WHERE query like '%SELECT ''SLEEP #1 TEST''%'
     FORMAT JSONEachRow;
 
 SELECT 'SLEEP #2 TEST', sleep(0.001) FROM numbers(2) FORMAT Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'SLEEP #2 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
 FROM system.query_log
 WHERE query like '%SELECT ''SLEEP #2 TEST''%'
@@ -22,7 +22,7 @@ WHERE query like '%SELECT ''SLEEP #2 TEST''%'
     FORMAT JSONEachRow;
 
 SELECT 'SLEEP #3 TEST', sleepEachRow(0.001) FORMAT Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'SLEEP #3 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
 FROM system.query_log
 WHERE query like '%SELECT ''SLEEP #3 TEST''%'
@@ -32,7 +32,7 @@ WHERE query like '%SELECT ''SLEEP #3 TEST''%'
     FORMAT JSONEachRow;
 
 SELECT 'SLEEP #4 TEST', sleepEachRow(0.001) FROM numbers(2) FORMAT Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'SLEEP #4 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
 FROM system.query_log
 WHERE query like '%SELECT ''SLEEP #4 TEST''%'
@@ -43,7 +43,7 @@ WHERE query like '%SELECT ''SLEEP #4 TEST''%'
 
 
 CREATE VIEW sleep_view AS SELECT sleepEachRow(0.001) FROM system.numbers;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'SLEEP #5 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
 FROM system.query_log
 WHERE query like '%CREATE VIEW sleep_view AS%'
@@ -53,7 +53,7 @@ WHERE query like '%CREATE VIEW sleep_view AS%'
     FORMAT JSONEachRow;
 
 SELECT 'SLEEP #6 TEST', sleepEachRow(0.001) FROM sleep_view LIMIT 10 FORMAT Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT 'SLEEP #6 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
 FROM system.query_log
 WHERE query like '%SELECT ''SLEEP #6 TEST''%'

--- a/tests/queries/0_stateless/01947_mv_subquery.sql
+++ b/tests/queries/0_stateless/01947_mv_subquery.sql
@@ -38,7 +38,7 @@ DESCRIBE ( SELECT '1947 #3 QUERY - TRUE',
     ) FORMAT Null;
 
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT '1947 #1 CHECK - TRUE' as test,
        ProfileEvents['SleepFunctionCalls'] as sleep_calls,
@@ -107,7 +107,7 @@ DESCRIBE ( SELECT '1947 #3 QUERY - FALSE',
             USING (id)
     ) FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT '1947 #1 CHECK - FALSE' as test,
        ProfileEvents['SleepFunctionCalls'] as sleep_calls,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adjust a few old tests to flush individual logs

Makes them more lightweight. Related https://github.com/ClickHouse/ClickHouse/issues/57984

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
