### PR TITLE
tests: fix 02122_4letter_words_stress_zookeeper (previously 4LW was ignored)

### DIFF
--- a/tests/config/config.d/keeper_port.xml
+++ b/tests/config/config.d/keeper_port.xml
@@ -2,6 +2,7 @@
     <keeper_server>
         <tcp_port>9181</tcp_port>
         <server_id>1</server_id>
+        <four_letter_word_allow_list>*</four_letter_word_allow_list>
 
         <create_snapshot_on_exit>0</create_snapshot_on_exit>
         <digest_enabled>1</digest_enabled>

--- a/tests/queries/0_stateless/02122_4letter_words_stress_zookeeper.sh
+++ b/tests/queries/0_stateless/02122_4letter_words_stress_zookeeper.sh
@@ -11,7 +11,7 @@ function four_letter_thread()
     declare -a FOUR_LETTER_COMMANDS=("conf" "cons" "crst" "envi" "ruok" "srst" "srvr" "stat" "wchc" "wchs" "dirs" "mntr" "isro")
     while true; do
         command=${FOUR_LETTER_COMMANDS[$RANDOM % ${#FOUR_LETTER_COMMANDS[@]} ]}
-        echo $command | nc ${CLICKHOUSE_HOST} ${CLICKHOUSE_PORT_KEEPER} 1>/dev/null
+        $CLICKHOUSE_KEEPER_CLIENT -q "$command" 1>/dev/null
     done
 
 }
@@ -31,10 +31,10 @@ export -f create_drop_thread;
 
 TIMEOUT=15
 
-timeout $TIMEOUT bash -c four_letter_thread 2> /dev/null &
-timeout $TIMEOUT bash -c four_letter_thread 2> /dev/null &
-timeout $TIMEOUT bash -c four_letter_thread 2> /dev/null &
-timeout $TIMEOUT bash -c four_letter_thread 2> /dev/null &
+timeout $TIMEOUT bash -c four_letter_thread &
+timeout $TIMEOUT bash -c four_letter_thread &
+timeout $TIMEOUT bash -c four_letter_thread &
+timeout $TIMEOUT bash -c four_letter_thread &
 
 timeout $TIMEOUT bash -c create_drop_thread 2> /dev/null &
 timeout $TIMEOUT bash -c create_drop_thread 2> /dev/null &


### PR DESCRIPTION
- allow 4LW commands for Keeper on CI - four_letter_word_allow_list
- use clickhouse-keeper-client over nc (at least my env does not have it)
- do not hide stderr (hides problems of non existing command)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)