### PR TITLE
Faster ClickHouse Servers shutdown (get rid of 2.5sec delay)

### DIFF
--- a/base/poco/Net/include/Poco/Net/Socket.h
+++ b/base/poco/Net/include/Poco/Net/Socket.h
@@ -87,6 +87,16 @@ namespace Net
         bool operator>=(const Socket & socket) const;
         /// Compares the SocketImpl pointers.
 
+        void shutdownReceive();
+        /// Shuts down the receiving part of the socket connection.
+
+        void shutdownSend();
+        /// Shuts down the sending part of the socket connection.
+
+        void shutdown();
+        /// Shuts down both the receiving and the sending part
+        /// of the socket connection.
+
         void close();
         /// Closes the socket.
 
@@ -362,6 +372,21 @@ namespace Net
         return _pImpl >= socket._pImpl;
     }
 
+
+    inline void Socket::shutdownReceive()
+    {
+        _pImpl->shutdownReceive();
+    }
+
+    inline void Socket::shutdownSend()
+    {
+        _pImpl->shutdownSend();
+    }
+
+    inline void Socket::shutdown()
+    {
+        _pImpl->shutdown();
+    }
 
     inline void Socket::close()
     {

--- a/base/poco/Net/src/TCPServer.cpp
+++ b/base/poco/Net/src/TCPServer.cpp
@@ -152,6 +152,11 @@ void TCPServer::run()
                         ErrorHandler::logMessage(Message::PRIO_WARNING, "Filtered out connection from " + ss.peerAddress().toString());
                     }
                 }
+                // Termination request
+                catch (Poco::InvalidArgumentException&)
+                {
+                    break;
+                }
                 catch (Poco::Exception& exc)
                 {
                     ErrorHandler::handle(exc);

--- a/src/Server/TCPServer.h
+++ b/src/Server/TCPServer.h
@@ -22,6 +22,9 @@ public:
     /// Close the socket and ask existing connections to stop serving queries
     void stop()
     {
+        if (!is_open)
+            return;
+
         // Shutdown the listen socket before stopping tcp server to avoid 2.5second delay
         socket.shutdownReceive();
 

--- a/src/Server/TCPServer.h
+++ b/src/Server/TCPServer.h
@@ -22,6 +22,9 @@ public:
     /// Close the socket and ask existing connections to stop serving queries
     void stop()
     {
+        // Shutdown the listen socket before stopping tcp server to avoid 2.5second delay
+        socket.shutdownReceive();
+
         Poco::Net::TCPServer::stop();
         // This notifies already established connections that they should stop serving
         // queries and close their socket as soon as they can.

--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -346,13 +346,14 @@ def test_reload_via_client(cluster, zk):
         instance.docker_id,
     ] + localhost_client.command
 
-    # NOTE: reload via zookeeper is too fast, but 100 iterations was enough, even for debug build.
-    for i in range(0, 100):
+    listen_config = "/etc/clickhouse-server/config.d/99-listen.yaml"
+    # NOTE: this test cannot use ZooKeeper since it uses watches to subscribe to changes and they are very fast
+    for i in range(0, 10):
         try:
-            client = get_client(cluster, port=9000)
-            zk.set("/clickhouse/listen_hosts", b"<listen_host>127.0.0.1</listen_host>")
+            instance.replace_config(listen_config, "listen_host: 127.0.0.1")
+
             query_id = f"reload_config_{i}"
-            client.query("SYSTEM RELOAD CONFIG", query_id=query_id)
+            instance.query("SYSTEM RELOAD CONFIG", query_id=query_id)
             assert int(localhost_client.query("SELECT 1")) == 1
             localhost_client.query("SYSTEM FLUSH LOGS")
             MainConfigLoads = int(
@@ -372,14 +373,21 @@ def test_reload_via_client(cluster, zk):
             logging.exception("Retry %s", i)
             exception = e
         finally:
-            while True:
+            instance.replace_config(listen_config, "")
+
+            reset_config_exception = None
+            for i in range(1, 10):
                 try:
-                    with sync_loaded_config(localhost_client.query):
-                        configure_from_zk(zk)
+                    instance.query("SYSTEM RELOAD CONFIG")
+                    reset_config_exception = None
                     break
-                except QueryRuntimeException:
+                except QueryRuntimeException as e:
                     logging.exception("The new socket is not bound yet")
                     time.sleep(0.1)
+                    reset_config_exception = e
+
+            if reset_config_exception is not None:
+                raise reset_config_exception
 
     if exception:
         raise exception


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Faster ClickHouse Servers shutdown (get rid of 2.5sec delay)

The I was looking at has nothing related to server shutdown, it was a problem that for local development due to server takes at least 2.5 second [1] to shutdown I constantly pressing C-C multiple times, and this leaves the ephemeral nodes (obviously I'm using embedded keeper for local development).

 [1]: https://github.com/ClickHouse/ClickHouse/blob/2eded0e18c29dfc1dcf3a3cdb8d34c1cf369d53e/base/poco/Net/src/TCPServer.cpp#L130-L133

https://github.com/ClickHouse/ClickHouse/blob/2eded0e18c29dfc1dcf3a3cdb8d34c1cf369d53e/base/poco/Net/src/TCPServer.cpp#L130-L133