### PR TITLE
ci: Fix Logical error: Ephemeral node still exists after 90s in DatabaseReplicated

### DIFF
--- a/tests/queries/0_stateless/02447_drop_database_replica.sh
+++ b/tests/queries/0_stateless/02447_drop_database_replica.sh
@@ -48,7 +48,8 @@ echo 'timeout on active'
 db9="${db}_9"
 REPLICA_UUID=$($CLICKHOUSE_CLIENT -q "select serverUUID()")
 if ! [[ $REPLICA_UUID =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-  echo "Weird UUID ${REPLICA_UUID}"
+    echo "Weird UUID ${REPLICA_UUID}"
+    exit 1
 fi
 $CLICKHOUSE_CLIENT -q "create database $db9 engine=Replicated('/test/${CLICKHOUSE_DATABASE}/rdb', 's9', 'r9')"
 $CLICKHOUSE_CLIENT -q "detach database $db9"


### PR DESCRIPTION
The problem is caused by the 02447_drop_database_replica test, that in case of CANNOT_SCHEDULE_TASK can get empty UUID and lead to.

Here is an example from CI [1]:

    2024.10.30 14:48:51.317477 [ 5100 ] {eeecc0f7-c2ee-41bf-9214-45d5bb19ef94} <Debug> executeQuery: (from [::1]:56758) (comment: 02447_drop_database_replica.sh) select serverUUID() (stage: Complete)
    2024.10.30 14:48:51.341250 [ 5100 ] {eeecc0f7-c2ee-41bf-9214-45d5bb19ef94} <Error> executeQuery: Code: 439. DB::Exception: Cannot schedule a task: fault injected (threads=804, jobs=776). (CANNOT_SCHEDULE_TASK) (version 24.11.1.388) (from [::1]:56758) (comment: 02447_drop_database_replica.sh) (in query: select serverUUID()), Stack trace (when copying this message, always include the lines below):
    ...
    2024.10.30 15:38:37.688997 [ 61116 ] {} <Fatal> : Logical error: 'Ephemeral node /test/test_5/rdb/replicas/s9|r9/active still exists after 90s, probably it's owned by someone else. Either session_timeout_ms in client's config is different from server's config or it's a bug. Node data: '''.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/71176/623b2f11d30af6ff0d00caa56bffbd4590bc4fff/stress_test__debug_.html

Note, that it does not make sense to retry in case of CANNOT_SCHEDULE_TASK, since it is possible only in stress tests.

And yes, this will the issue completelly, since the problem is that this test does not creates ephemeral nodes, so node will not dissapears.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/68570

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)