### PR TITLE
ci: disable 02711_server_uuid_macro for SharedCatalog (breaks some invariants)

### DIFF
--- a/tests/queries/0_stateless/02711_server_uuid_macro.sql
+++ b/tests/queries/0_stateless/02711_server_uuid_macro.sql
@@ -1,3 +1,5 @@
+-- Tags: no-shared-catalog
+
 DROP TABLE IF EXISTS test;
 
 -- You can create a table with the {server_uuid} substituted.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)