### PR TITLE
Fix `used_flag` initialization in parallel hash

### DIFF
--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -592,46 +592,43 @@ UInt64 calculateCacheKey(std::shared_ptr<TableJoin> & table_join, IQueryTreeNode
 
 void ConcurrentHashJoin::onBuildPhaseFinish()
 {
-    for (auto & hash_join : hash_joins)
+    if (hash_joins[0]->data->twoLevelMapIsUsed())
     {
-        // `onBuildPhaseFinish` cannot be called concurrently with other IJoin methods, so we don't need a lock to access internal joins.
-        hash_join->data->onBuildPhaseFinish();
-    }
-
-    if (!hash_joins[0]->data->twoLevelMapIsUsed())
-        return;
-
-    // At this point, the build phase is finished. We need to build a shared common hash map to be used in the probe phase.
-    // It is done in two steps:
-    //     1. Merge hash maps into a single one. For that, we iterate over all sub-maps and move buckets from the current `HashJoin` instance to the common map.
-    for (size_t i = 1; i < slots; ++i)
-    {
-        auto move_buckets = [&](auto & lhs_maps, HashJoin::Type type, auto & rhs_maps, size_t idx)
+        // At this point, the build phase is finished. We need to build a shared common hash map to be used in the probe phase.
+        // It is done in two steps:
+        //     1. Merge hash maps into a single one. For that, we iterate over all sub-maps and move buckets from the current `HashJoin` instance to the common map.
+        for (size_t i = 1; i < slots; ++i)
         {
-            APPLY_TO_MAP(
-                INVOKE_WITH_MAPS,
-                type,
-                lhs_maps,
-                rhs_maps,
-                [&](auto & lhs_map, auto & rhs_map)
-                {
-                    for (size_t j = idx; j < lhs_map.NUM_BUCKETS; j += slots)
-                    {
-                        if (!lhs_map.impls[j].empty())
-                            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected non-empty map");
-                        lhs_map.impls[j] = std::move(rhs_map.impls[j]);
-                    }
-                })
-        };
-
-        std::visit(
-            [&](auto & lhs_map)
+            auto move_buckets = [&](auto & lhs_maps, HashJoin::Type type, auto & rhs_maps, size_t idx)
             {
-                using T = std::decay_t<decltype(lhs_map)>;
-                move_buckets(lhs_map, getData(hash_joins[0])->type, std::get<T>(getData(hash_joins[i])->maps.at(0)), i);
-            },
-            getData(hash_joins[0])->maps.at(0));
+                APPLY_TO_MAP(
+                    INVOKE_WITH_MAPS,
+                    type,
+                    lhs_maps,
+                    rhs_maps,
+                    [&](auto & lhs_map, auto & rhs_map)
+                    {
+                        for (size_t j = idx; j < lhs_map.NUM_BUCKETS; j += slots)
+                        {
+                            if (!lhs_map.impls[j].empty())
+                                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected non-empty map");
+                            lhs_map.impls[j] = std::move(rhs_map.impls[j]);
+                        }
+                    })
+            };
+
+            std::visit(
+                [&](auto & lhs_map)
+                {
+                    using T = std::decay_t<decltype(lhs_map)>;
+                    move_buckets(lhs_map, getData(hash_joins[0])->type, std::get<T>(getData(hash_joins[i])->maps.at(0)), i);
+                },
+                getData(hash_joins[0])->maps.at(0));
+        }
     }
+
+    // `onBuildPhaseFinish` cannot be called concurrently with other IJoin methods, so we don't need a lock to access internal joins.
+    hash_joins[0]->data->onBuildPhaseFinish();
 
     //     2. Copy this common map to all the `HashJoin` instances along with the `used_flags` data structure.
     for (size_t i = 1; i < slots; ++i)

--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -628,6 +628,7 @@ void ConcurrentHashJoin::onBuildPhaseFinish()
     }
 
     // `onBuildPhaseFinish` cannot be called concurrently with other IJoin methods, so we don't need a lock to access internal joins.
+    // The following calls must be done after the final common map is constructed, otherwise we will incorrectly initialize `used_flags`.
     for (const auto & hash_join : hash_joins)
         hash_join->data->onBuildPhaseFinish();
 

--- a/tests/queries/0_stateless/03360_any_join_parallel_hash_bug.sql
+++ b/tests/queries/0_stateless/03360_any_join_parallel_hash_bug.sql
@@ -1,5 +1,6 @@
 -- Previously, due to a bug in `ConcurrentHashJoin::onBuildPhaseFinish()` we reserved much less space in `used_flags` than needed.
 -- This test just checks that we won't crash.
+SET enable_analyzer=1;
 SELECT
     number,
     number
@@ -7,4 +8,5 @@ FROM system.numbers
 ANY INNER JOIN system.numbers AS alias277 ON number = alias277.number
 LIMIT 102400
 FORMAT `Null`
-SETTINGS join_algorithm = 'parallel_hash'
+SETTINGS join_algorithm = 'parallel_hash';
+

--- a/tests/queries/0_stateless/03360_any_join_parallel_hash_bug.sql
+++ b/tests/queries/0_stateless/03360_any_join_parallel_hash_bug.sql
@@ -1,0 +1,10 @@
+-- Previously, due to a bug in `ConcurrentHashJoin::onBuildPhaseFinish()` we reserved much less space in `used_flags` than needed.
+-- This test just checks that we won't crash.
+SELECT
+    number,
+    number
+FROM system.numbers
+ANY INNER JOIN system.numbers AS alias277 ON number = alias277.number
+LIMIT 1024000
+FORMAT `Null`
+SETTINGS join_algorithm = 'parallel_hash'

--- a/tests/queries/0_stateless/03360_any_join_parallel_hash_bug.sql
+++ b/tests/queries/0_stateless/03360_any_join_parallel_hash_bug.sql
@@ -5,6 +5,6 @@ SELECT
     number
 FROM system.numbers
 ANY INNER JOIN system.numbers AS alias277 ON number = alias277.number
-LIMIT 1024000
+LIMIT 102400
 FORMAT `Null`
 SETTINGS join_algorithm = 'parallel_hash'


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `used_flag` initialization in parallel hash. It might cause a server crash.


Closes: #75649 #76292 


