### PR TITLE
Fix flaky test `00612_http_max_query_size`

### DIFF
--- a/tests/queries/0_stateless/00612_http_max_query_size.sh
+++ b/tests/queries/0_stateless/00612_http_max_query_size.sh
@@ -40,11 +40,10 @@ def gen_data(q):
         yield pattern.format(str(i).zfill(1024 - len(pattern) + 2)).encode()
 
 s = requests.Session()
-resp = s.post(url + '&max_query_size={}'.format(1 << 21), timeout=1, data=gen_data(q), stream=True,
+resp = s.post(url + '&max_query_size={}'.format(1 << 21), timeout=60, data=gen_data(q), stream=True,
               headers = {'Connection': 'close'})
 
 for line in resp.iter_lines():
     print(line)
 " | python3 | grep -o "Max query size exceeded"
 echo -
-


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The test has an unreasonable small timeout (one second).