### PR TITLE
Make reverse key work with PartsSplitter and explicit primary key

### DIFF
--- a/src/Processors/QueryPlan/PartsSplitter.cpp
+++ b/src/Processors/QueryPlan/PartsSplitter.cpp
@@ -928,6 +928,7 @@ static void reorderColumns(ActionsDAG & dag, const Block & header, const std::st
 
 SplitPartsWithRangesByPrimaryKeyResult splitPartsWithRangesByPrimaryKey(
     const KeyDescription & primary_key,
+    const KeyDescription & sorting_key,
     ExpressionActionsPtr sorting_expr,
     RangesInDataParts parts,
     size_t max_layers,
@@ -962,14 +963,16 @@ SplitPartsWithRangesByPrimaryKeyResult splitPartsWithRangesByPrimaryKey(
     }
 
     bool in_reverse_order = false;
-    if (!primary_key.reverse_flags.empty())
+    size_t num_primary_keys = primary_key.expression_list_ast->children.size();
+    if (!sorting_key.reverse_flags.empty())
     {
-        in_reverse_order = primary_key.reverse_flags[0];
-        for (size_t i = 1; i < primary_key.reverse_flags.size(); ++i)
+        chassert(sorting_key.reverse_flags.size() >= num_primary_keys);
+        in_reverse_order = sorting_key.reverse_flags[0];
+        for (size_t i = 1; i < num_primary_keys; ++i)
         {
             /// It's not possible to split parts when some keys are in ascending
             /// order while others are in descending order.
-            if (in_reverse_order != primary_key.reverse_flags[i])
+            if (in_reverse_order != sorting_key.reverse_flags[i])
             {
                 result.merging_pipes.emplace_back(create_merging_pipe(intersecting_parts_ranges));
                 return result;

--- a/src/Processors/QueryPlan/PartsSplitter.h
+++ b/src/Processors/QueryPlan/PartsSplitter.h
@@ -29,6 +29,7 @@ struct SplitPartsWithRangesByPrimaryKeyResult
   */
 SplitPartsWithRangesByPrimaryKeyResult splitPartsWithRangesByPrimaryKey(
     const KeyDescription & primary_key,
+    const KeyDescription & sorting_key,
     ExpressionActionsPtr sorting_expr,
     RangesInDataParts parts,
     size_t max_layers,

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -890,6 +890,7 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreams(RangesInDataParts && parts_
 
         SplitPartsWithRangesByPrimaryKeyResult split_ranges_result = splitPartsWithRangesByPrimaryKey(
             storage_snapshot->metadata->getPrimaryKey(),
+            storage_snapshot->metadata->getSortingKey(),
             std::move(sorting_expr),
             std::move(parts_with_ranges),
             num_streams,
@@ -1371,6 +1372,7 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
 
                 SplitPartsWithRangesByPrimaryKeyResult split_ranges_result = splitPartsWithRangesByPrimaryKey(
                     storage_snapshot->metadata->getPrimaryKey(),
+                    storage_snapshot->metadata->getSortingKey(),
                     sorting_expr,
                     std::move(new_parts),
                     num_streams,

--- a/tests/queries/0_stateless/03286_reverse_sorting_key_final2.reference
+++ b/tests/queries/0_stateless/03286_reverse_sorting_key_final2.reference
@@ -1,0 +1,17 @@
+-- { echo ON }
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY (c0 DESC) PRIMARY KEY (c0) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1), (2);
+SELECT sum(c0) FROM t0 FINAL;
+3
+DROP TABLE t0;
+CREATE TABLE t0 (c0 Int, c1 Int) ENGINE = SummingMergeTree() ORDER BY (c0 DESC, c1) PRIMARY KEY (c0) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1), (2);
+SELECT sum(c0) FROM t0 FINAL;
+3
+DROP TABLE t0;
+CREATE TABLE t0 (c0 Int, c1 Int) ENGINE = SummingMergeTree() ORDER BY (c0 DESC, c1) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1), (2);
+SELECT sum(c0) FROM t0 FINAL;
+3
+DROP TABLE t0;

--- a/tests/queries/0_stateless/03286_reverse_sorting_key_final2.sql
+++ b/tests/queries/0_stateless/03286_reverse_sorting_key_final2.sql
@@ -1,0 +1,20 @@
+-- { echo ON }
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY (c0 DESC) PRIMARY KEY (c0) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1), (2);
+SELECT sum(c0) FROM t0 FINAL;
+
+DROP TABLE t0;
+
+CREATE TABLE t0 (c0 Int, c1 Int) ENGINE = SummingMergeTree() ORDER BY (c0 DESC, c1) PRIMARY KEY (c0) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1), (2);
+SELECT sum(c0) FROM t0 FINAL;
+
+DROP TABLE t0;
+
+CREATE TABLE t0 (c0 Int, c1 Int) ENGINE = SummingMergeTree() ORDER BY (c0 DESC, c1) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO TABLE t0 (c0) VALUES (1), (2);
+SELECT sum(c0) FROM t0 FINAL;
+
+DROP TABLE t0;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable reverse key support in PartsSplitter. This fixes https://github.com/ClickHouse/ClickHouse/issues/75928.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
