### PR TITLE
Preserve bool literal naming and value in distributed queries.

### DIFF
--- a/src/Analyzer/ConstantNode.cpp
+++ b/src/Analyzer/ConstantNode.cpp
@@ -232,6 +232,9 @@ ASTPtr ConstantNode::toASTImpl(const ConvertToASTOptions & options) const
         return makeASTFunction("_CAST", std::move(constant_value_ast), std::move(constant_type_name_ast));
     }
 
+    if (isBool(constant_value_type))
+        constant_value_ast->custom_type = constant_value_type;
+
     return constant_value_ast;
 }
 

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -619,8 +619,10 @@ QueryTreeNodePtr QueryTreeBuilder::buildExpression(const ASTPtr & expression, co
     }
     else if (const auto * ast_literal = expression->as<ASTLiteral>())
     {
-        if (context->getSettingsRef()[Setting::allow_experimental_variant_type] && context->getSettingsRef()[Setting::use_variant_as_common_type])
-            result = std::make_shared<ConstantNode>(ast_literal->value, applyVisitor(FieldToDataType<LeastSupertypeOnError::Variant>(), ast_literal->value));
+        if (ast_literal->custom_type)
+            result = std::make_shared<ConstantNode>(ast_literal->value, ast_literal->custom_type);
+        else if (context->getSettingsRef()[Setting::allow_experimental_variant_type] && context->getSettingsRef()[Setting::use_variant_as_common_type])
+            result = std::make_shared<ConstantNode>(ast_literal->value, ast_literal->custom_type ? ast_literal->custom_type : applyVisitor(FieldToDataType<LeastSupertypeOnError::Variant>(), ast_literal->value));
         else
             result = std::make_shared<ConstantNode>(ast_literal->value);
     }

--- a/src/Parsers/ASTLiteral.cpp
+++ b/src/Parsers/ASTLiteral.cpp
@@ -1,6 +1,7 @@
 #include <Common/SipHash.h>
 #include <Common/FieldVisitorToString.h>
 #include <Common/FieldVisitorHash.h>
+#include <DataTypes/IDataType.h>
 #include <Parsers/ASTLiteral.h>
 #include <IO/WriteHelpers.h>
 #include <IO/WriteBufferFromString.h>
@@ -152,7 +153,9 @@ String FieldVisitorToStringPostgreSQL::operator() (const String & x) const
 
 void ASTLiteral::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSettings & settings, IAST::FormatState &, IAST::FormatStateStacked) const
 {
-    if (settings.literal_escaping_style == LiteralEscapingStyle::Regular)
+    if (custom_type && isBool(custom_type) && isInt64OrUInt64FieldType(value.getType()))
+        ostr << applyVisitor(FieldVisitorToString(), Field(value.safeGet<UInt64>() != 0));
+    else if (settings.literal_escaping_style == LiteralEscapingStyle::Regular)
         ostr << applyVisitor(FieldVisitorToString(), value);
     else
         ostr << applyVisitor(FieldVisitorToStringPostgreSQL(), value);

--- a/tests/queries/0_stateless/03360_bool_remote.reference
+++ b/tests/queries/0_stateless/03360_bool_remote.reference
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/tests/queries/0_stateless/03360_bool_remote.sql
+++ b/tests/queries/0_stateless/03360_bool_remote.sql
@@ -1,0 +1,3 @@
+SELECT true AS x FROM remote('127.0.0.{1,2}', system.one) LIMIT 1;
+SELECT materialize(true) AS x FROM remote('127.0.0.{1,2}', system.one) LIMIT 1;
+SELECT true AS x FROM remote('127.0.0.{1,2}', system.one) GROUP BY x;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix THERE_IS_NO_COLUMN exception when selecting boolean literal from distributed tables.

closes #72238
closes #75696
