### PR TITLE
fix test_merge_tree_load_parts/test.py::test_merge_tree_load_parts_corrupted

### DIFF
--- a/src/Compression/CompressedReadBufferFromFile.cpp
+++ b/src/Compression/CompressedReadBufferFromFile.cpp
@@ -58,7 +58,7 @@ CompressedReadBufferFromFile::CompressedReadBufferFromFile(std::unique_ptr<ReadB
     : BufferWithOwnMemory<ReadBuffer>(0)
     , p_file_in(std::move(buf))
     , file_in(*p_file_in)
-    , log(getLogger("CompressedReadBufferFromFile"))
+    , log(getLogger("CompressedReadBufferFromFile"), /* allowed_count */ 1, /* interval */ 1)
 {
     compressed_in = &file_in;
     allow_different_codecs = allow_different_codecs_;

--- a/src/Compression/CompressedReadBufferFromFile.h
+++ b/src/Compression/CompressedReadBufferFromFile.h
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <Compression/CompressedReadBufferBase.h>
 #include <IO/ReadBufferFromFileBase.h>
+#include "Common/LoggingFormatStringHelpers.h"
 
 
 namespace DB
@@ -27,7 +28,7 @@ private:
     ReadBufferFromFileBase & file_in;
     size_t size_compressed = 0;
 
-    LoggerPtr log;
+    LogSeriesLimiter log;
 
     /// This field inherited from ReadBuffer. It's used to perform "lazy" seek, so in seek() call we:
     /// 1) actually seek only underlying compressed file_in to offset_in_compressed_file;

--- a/tests/integration/test_merge_tree_load_parts/configs/compat.xml
+++ b/tests/integration/test_merge_tree_load_parts/configs/compat.xml
@@ -1,4 +1,8 @@
 <clickhouse>
     <replicated_merge_tree_paranoid_check_on_drop_range>0</replicated_merge_tree_paranoid_check_on_drop_range>
     <replicated_merge_tree_paranoid_check_on_startup>0</replicated_merge_tree_paranoid_check_on_startup>
+
+    <logger>
+        <level>debug</level>
+    </logger>
 </clickhouse>

--- a/tests/integration/test_merge_tree_load_parts/configs/compat.xml
+++ b/tests/integration/test_merge_tree_load_parts/configs/compat.xml
@@ -3,6 +3,7 @@
     <replicated_merge_tree_paranoid_check_on_startup>0</replicated_merge_tree_paranoid_check_on_startup>
 
     <logger>
-        <level>debug</level>
+        <!-- the test looks at the logs, do not make log level too low like test level -->
+        <level>trace</level>
     </logger>
 </clickhouse>

--- a/tests/integration/test_merge_tree_load_parts/configs/fast_background_pool.xml
+++ b/tests/integration/test_merge_tree_load_parts/configs/fast_background_pool.xml
@@ -8,6 +8,7 @@
     <background_processing_pool_task_sleep_seconds_when_no_work_random_part>0</background_processing_pool_task_sleep_seconds_when_no_work_random_part>
 
     <logger>
-        <level>debug</level>
+        <!-- the test looks at the logs, do not make log level too low like test level -->
+        <level>trace</level>
     </logger>
 </clickhouse>

--- a/tests/integration/test_merge_tree_load_parts/configs/fast_background_pool.xml
+++ b/tests/integration/test_merge_tree_load_parts/configs/fast_background_pool.xml
@@ -6,4 +6,8 @@
     <background_processing_pool_task_sleep_seconds_when_no_work_max>1</background_processing_pool_task_sleep_seconds_when_no_work_max>
     <background_processing_pool_task_sleep_seconds_when_no_work_multiplier>1</background_processing_pool_task_sleep_seconds_when_no_work_multiplier>
     <background_processing_pool_task_sleep_seconds_when_no_work_random_part>0</background_processing_pool_task_sleep_seconds_when_no_work_random_part>
+
+    <logger>
+        <level>debug</level>
+    </logger>
 </clickhouse>


### PR DESCRIPTION
reduce logs, by removing noisy logs.
make log level for the test as debug instead test.

Fixes https://github.com/ClickHouse/ClickHouse/issues/58585

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
