### PR TITLE
CI: Improve CI report responsiveness

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1067,37 +1067,42 @@
         let hasNewData = false;
 
         if (!runtimeCache.commits || sha === 'latest') {
-            const { data, updated } = await fetchJson(
-                `${baseUrl}/${suffix}/commits.json`,
-            );
+            const { data, updated } = await fetchJson(`${baseUrl}/${suffix}/commits.json`);
             if (updated) {
                 runtimeCache.commits = data ? data : [];
                 hasNewData = true;
             }
         }
 
-        const shaToLoad = (sha === 'latest') ? runtimeCache.commits[runtimeCache.commits.length - 1].sha : sha;
-        if (nameParams.length > 1) {
-            const task = normalizeTaskName(nameParams[1]);
-            const path = `${baseUrl}/${suffix}/${encodeURIComponent(shaToLoad)}/result_${task}.json`;
-            const { data, updated } = await fetchJson(path);
+        const shaToLoad = (sha === 'latest') ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha : sha;
 
+        const fetchTasks = [];
+        if (nameParams.length > 1) {
+            const task1 = normalizeTaskName(nameParams[1]);
+            const path1 = `${baseUrl}/${suffix}/${encodeURIComponent(shaToLoad)}/result_${task1}.json`;
+            fetchTasks.push(fetchJson(path1));
+        }
+
+        const task0 = normalizeTaskName(nameParams[0]);
+        const path0 = `${baseUrl}/${suffix}/${encodeURIComponent(shaToLoad)}/result_${task0}.json`;
+        fetchTasks.push(fetchJson(path0));
+
+        // Run fetchJson calls in parallel
+        const results = await Promise.all(fetchTasks);
+
+        if (nameParams.length > 1) {
+            const { data, updated } = results[0]; // First request result
             if (updated) {
                 runtimeCache.json1 = data;
                 hasNewData = true;
             }
         }
 
-        {
-            const task = normalizeTaskName(nameParams[0]);
-            const path = `${baseUrl}/${suffix}/${encodeURIComponent(shaToLoad)}/result_${task}.json`;
-
-            const { data, updated } = await fetchJson(path);
-            if (updated) {
-                runtimeCache.json0 = data;
-                hasNewData = true;
-                data.links.forEach(storeLink);
-            }
+        const { data, updated } = results[fetchTasks.length - 1]; // Last request result (always task0)
+        if (updated) {
+            runtimeCache.json0 = data;
+            hasNewData = true;
+            data.links.forEach(storeLink);
         }
 
         return hasNewData;

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -419,7 +419,7 @@ class Runner:
             print(f"Run html report hook")
             HtmlRunnerHooks.post_run(workflow, job, info_errors)
 
-        report_url = Info().get_job_report_url()
+        report_url = Info().get_job_report_url(latest=False)
         if (
             workflow.enable_commit_status_on_failure and not result.is_ok()
         ) or job.enable_commit_status:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Parallelize data download for workflow-level data and job level-data
* Fixes report links in commit statuses: Links in commit statuses point to the current sha, link in the PR comment keeps using "latest" alias for sha

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
