### PR TITLE
RMV tests: fix flakiness caused by premature refreshes

### DIFF
--- a/tests/integration/test_refreshable_mat_view/test.py
+++ b/tests/integration/test_refreshable_mat_view/test.py
@@ -198,6 +198,11 @@ def fn_setup_tables():
 )
 @pytest.mark.parametrize("with_append", [True, False])
 @pytest.mark.parametrize("empty", [True, False])
+@pytest.mark.skipif(
+    datetime.now().minute > 57,
+    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
+           'which might trigger it earlier than expected'
+)
 def test_simple_append(
     module_setup_tables,
     fn_setup_tables,
@@ -259,6 +264,11 @@ def test_simple_append(
             "refresh_retry_max_backoff_ms": "20",
         },
     ],
+)
+@pytest.mark.skipif(
+    datetime.now().minute > 57,
+    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
+           'which might trigger it earlier than expected'
 )
 def test_alters(
     module_setup_tables,
@@ -376,6 +386,11 @@ def expect_rows(rows, table="test_rmv"):
     assert len(inserted_data) == rows
 
 
+@pytest.mark.skipif(
+    datetime.now().minute > 57,
+    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
+           'which might trigger it earlier than expected'
+)
 def test_long_query(fn_setup_tables):
     if node.is_built_with_sanitizer():
         pytest.skip("Disabled for sanitizers")

--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -238,6 +238,11 @@ def fn_setup_tables():
     "empty",
     [True, False],
 )
+@pytest.mark.skipif(
+    datetime.now().minute > 57,
+    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
+           'which might trigger it earlier than expected'
+)
 def test_append(
     module_setup_tables,
     fn_setup_tables,
@@ -296,6 +301,11 @@ def test_append(
             "refresh_retry_max_backoff_ms": "20",
         },
     ],
+)
+@pytest.mark.skipif(
+    datetime.now().minute > 57,
+    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
+           'which might trigger it earlier than expected'
 )
 def test_alters(
     module_setup_tables,
@@ -382,7 +392,7 @@ def test_real_wait_refresh(
 
     create_sql = CREATE_RMV.render(
         table_name="test_rmv",
-        refresh_interval="EVERY 10 SECOND",
+        refresh_interval="AFTER 10 SECOND",
         to_clause=to_clause_,
         table_clause=table_clause,
         select_query="SELECT now() as a, b FROM src1 SETTINGS insert_deduplicate=0",


### PR DESCRIPTION
1. Skip tests that can be run close to the end of the hour and fail because of premature scheduled refresh
https://github.com/ClickHouse/ClickHouse/pull/72123#issuecomment-2685949961
2. Try to fix `test_real_wait_refresh`
https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19uYW1lIExJS0UgJ0ludGVncmF0aW9uJScKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMTAyNCBIT1VSCiAgICBBTkQgKGhlYWRfcmVmID0gJ21hc3RlcicgQU5EIHN0YXJ0c1dpdGgoaGVhZF9yZXBvLCAnQ2xpY2tIb3VzZS8nKSkKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIEFORCAodGVzdF9zdGF0dXMgTElLRSAnRiUnIE9SIHRlc3Rfc3RhdHVzIExJS0UgJ0UlJykgCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgYW5kIHRlc3RfbmFtZSBsaWtlICcldGVzdF9yZWZyZXNoYWJsZV9tYXRfdmlldyUnCk9SREVSIEJZIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgY2hlY2tfc3RhcnRfdGltZQ==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
