### PR TITLE
Optimize arraySort

### DIFF
--- a/src/Functions/array/arraySort.cpp
+++ b/src/Functions/array/arraySort.cpp
@@ -53,26 +53,15 @@ struct NullableLess
         bool lhs_is_null = null_map[lhs];
         bool rhs_is_null = null_map[rhs];
 
+        if (lhs_is_null) [[unlikely]]
+            return false;
+        if (rhs_is_null) [[unlikely]]
+            return true;
+
         if constexpr (positive)
-        {
-            if (lhs_is_null) [[unlikely]]
-                return false;
-
-            if (rhs_is_null) [[unlikely]]
-                return true;
-
             return nested_column.compareAt(lhs, rhs, nested_column, 1) < 0;
-        }
         else
-        {
-            if (rhs_is_null) [[unlikely]]
-                return false;
-
-            if (lhs_is_null) [[unlikely]]
-                return true;
-
             return nested_column.compareAt(lhs, rhs, nested_column, -1) > 0;
-        }
     }
 };
 

--- a/src/Functions/array/arraySort.cpp
+++ b/src/Functions/array/arraySort.cpp
@@ -1,3 +1,7 @@
+#include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsDateTime.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/array/arraySort.h>
 #include <Common/iota.h>
@@ -13,12 +17,72 @@ namespace ErrorCodes
 namespace
 {
 
-template <bool positive>
+template <bool positive, typename ColumnType>
 struct Less
+{
+    const ColumnType & column;
+
+    explicit Less(const IColumn & column_)
+        : column(assert_cast<const ColumnType &>(column_))
+    {
+    }
+
+    bool operator()(size_t lhs, size_t rhs) const
+    {
+        if constexpr (positive)
+            return column.compareAt(lhs, rhs, column, 1) < 0;
+        else
+            return column.compareAt(lhs, rhs, column, -1) > 0;
+    }
+};
+
+template <bool positive, typename ColumnType>
+struct NullableLess
+{
+    const ColumnType & nested_column;
+    const NullMap & null_map;
+
+    explicit NullableLess(const IColumn & nested_column_, const NullMap & null_map_)
+        : nested_column(assert_cast<const ColumnType &>(nested_column_))
+        , null_map(null_map_)
+    {
+    }
+
+    bool operator()(size_t lhs, size_t rhs) const
+    {
+        bool lhs_is_null = null_map[lhs];
+        bool rhs_is_null = null_map[rhs];
+
+        if constexpr (positive)
+        {
+            if (lhs_is_null) [[unlikely]]
+                return false;
+
+            if (rhs_is_null) [[unlikely]]
+                return true;
+
+            return nested_column.compareAt(lhs, rhs, nested_column, 1) < 0;
+        }
+        else
+        {
+            if (rhs_is_null) [[unlikely]]
+                return false;
+
+            if (lhs_is_null) [[unlikely]]
+                return true;
+
+            return nested_column.compareAt(lhs, rhs, nested_column, -1) > 0;
+        }
+    }
+};
+
+
+template <bool positive>
+struct GenericLess
 {
     const IColumn & column;
 
-    explicit Less(const IColumn & column_) : column(column_) { }
+    explicit GenericLess(const IColumn & column_) : column(column_) { }
 
     bool operator()(size_t lhs, size_t rhs) const
     {
@@ -62,23 +126,97 @@ ColumnPtr ArraySortImpl<positive, is_partial>::execute(
     iota(permutation.data(), nested_size, IColumn::Permutation::value_type(0));
 
     ColumnArray::Offset current_offset = 0;
-    for (size_t i = 0; i < size; ++i)
-    {
-        auto next_offset = offsets[i];
-        if constexpr (is_partial)
-        {
-            if (limit)
-            {
-                const auto effective_limit = std::min<size_t>(limit, next_offset - current_offset);
-                ::partial_sort(&permutation[current_offset], &permutation[current_offset + effective_limit], &permutation[next_offset], Less<positive>(*mapped));
-            }
-            else
-                ::sort(&permutation[current_offset], &permutation[next_offset], Less<positive>(*mapped));
-        }
-        else
-            ::sort(&permutation[current_offset], &permutation[next_offset], Less<positive>(*mapped));
-        current_offset = next_offset;
+
+#define APPLY_COMPARATOR(CMP) \
+    for (size_t i = 0; i < size; ++i) \
+    { \
+        auto next_offset = offsets[i]; \
+        if constexpr (is_partial) \
+        { \
+            if (limit) \
+            { \
+                const auto effective_limit = std::min<size_t>(limit, next_offset - current_offset); \
+                ::partial_sort(&permutation[current_offset], &permutation[current_offset + effective_limit], &permutation[next_offset], CMP); \
+            } \
+            else \
+                ::sort(&permutation[current_offset], &permutation[next_offset], CMP); \
+        } \
+        else \
+            ::sort(&permutation[current_offset], &permutation[next_offset], CMP); \
+        current_offset = next_offset; \
     }
+
+#define DISPATCH_FOR_NONNULLABLE_COLUMN(TYPE) \
+    else if (checkAndGetColumn<TYPE>(mapped.get())) \
+    { \
+        Less<positive, TYPE> cmp(*mapped); \
+        APPLY_COMPARATOR(cmp) \
+    }
+
+    if (false)
+        ;
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnUInt8)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnUInt16)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnUInt32)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnUInt64)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnInt8)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnInt16)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnInt32)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnInt64)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnFloat32)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnFloat64)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnDateTime64)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnDecimal<Decimal32>)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnDecimal<Decimal64>)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnDecimal<Decimal128>)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnDecimal<Decimal256>)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnString)
+    DISPATCH_FOR_NONNULLABLE_COLUMN(ColumnFixedString)
+#undef DISPATCH_FOR_NONNULLABLE_COLUMN
+
+    else if (const auto * nullable = checkAndGetColumn<ColumnNullable>(mapped.get()))
+    {
+        const auto & null_map = nullable->getNullMapData();
+
+#define DISPATCH_FOR_NULLABLE_COLUMN(TYPE) \
+    else if (checkAndGetColumn<TYPE>(&nullable->getNestedColumn())) \
+    { \
+        NullableLess<positive, TYPE> cmp(nullable->getNestedColumn(), null_map); \
+        APPLY_COMPARATOR(cmp) \
+    }
+
+        if (false)
+            ;
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnUInt8)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnUInt16)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnUInt32)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnUInt64)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnInt8)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnInt16)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnInt32)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnInt64)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnFloat32)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnFloat64)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnDateTime64)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnDecimal<Decimal32>)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnDecimal<Decimal64>)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnDecimal<Decimal128>)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnDecimal<Decimal256>)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnString)
+        DISPATCH_FOR_NULLABLE_COLUMN(ColumnFixedString)
+        else
+        {
+            GenericLess<positive> cmp(*mapped);
+            APPLY_COMPARATOR(cmp)
+        }
+#undef DISPATCH_FOR_NULLABLE_COLUMN
+    }
+    else
+    {
+        GenericLess<positive> cmp(*mapped);
+        APPLY_COMPARATOR(cmp)
+    }
+#undef APPLY_COMPARATOR
 
     return ColumnArray::create(array.getData().permute(permutation, 0), array.getOffsetsPtr());
 }

--- a/tests/performance/array_sort.xml
+++ b/tests/performance/array_sort.xml
@@ -1,0 +1,4 @@
+<test>
+    <query>select arraySort(array(rand(), rand(), rand(), rand(), rand())) from numbers(100000000) format Null</query>
+    <query>select arraySort(array(if(number % 2 = 0, rand(), null), rand(), rand(), rand(), rand())) from numbers(100000000) format Null</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize arraySort

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

``` sql
select arraySort(array(rand(), rand(), rand(), rand(), rand())) from numbers(100000000) format Null; 
Before
0 rows in set. Elapsed: 3.706 sec. Processed 100.00 million rows, 800.00 MB (26.98 million rows/s., 215.85 MB/s.)
0 rows in set. Elapsed: 3.903 sec. Processed 100.00 million rows, 800.00 MB (25.62 million rows/s., 204.94 MB/s.)
0 rows in set. Elapsed: 3.600 sec. Processed 100.00 million rows, 800.00 MB (27.78 million rows/s., 222.25 MB/s.)
After
0 rows in set. Elapsed: 2.846 sec. Processed 100.00 million rows, 800.00 MB (35.14 million rows/s., 281.14 MB/s.)
0 rows in set. Elapsed: 2.883 sec. Processed 100.00 million rows, 800.00 MB (34.68 million rows/s., 277.47 MB/s.)
0 rows in set. Elapsed: 2.827 sec. Processed 100.00 million rows, 800.00 MB (35.38 million rows/s., 283.03 MB/s.)

select arraySort(array(if(number = 0, rand(), null), rand(), rand(), rand(), rand())) from numbers(100000000) format Null; 
Before
0 rows in set. Elapsed: 7.064 sec. Processed 100.00 million rows, 800.00 MB (14.16 million rows/s., 113.24 MB/s.)
0 rows in set. Elapsed: 6.831 sec. Processed 100.00 million rows, 800.00 MB (14.64 million rows/s., 117.12 MB/s.)
0 rows in set. Elapsed: 6.871 sec. Processed 100.00 million rows, 800.00 MB (14.55 million rows/s., 116.43 MB/s.)
After
0 rows in set. Elapsed: 4.847 sec. Processed 100.00 million rows, 800.00 MB (20.63 million rows/s., 165.05 MB/s.)
0 rows in set. Elapsed: 4.929 sec. Processed 100.00 million rows, 800.00 MB (20.29 million rows/s., 162.30 MB/s.)
0 rows in set. Elapsed: 4.896 sec. Processed 100.00 million rows, 800.00 MB (20.42 million rows/s., 163.39 MB/s.)
```
