### PR TITLE
Add default disk properly in stress tests

### DIFF
--- a/tests/config/config.d/azure_storage_conf.xml
+++ b/tests/config/config.d/azure_storage_conf.xml
@@ -20,9 +20,7 @@
         <policies>
             <azure_cache>
                 <volumes>
-                    <main>
-                        <disk>cached_azure</disk>
-                    </main>
+                    <main><disk>cached_azure</disk></main>
                 </volumes>
             </azure_cache>
         </policies>

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -229,7 +229,7 @@ configure
 if [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
     # But we still need default disk because some tables loaded only into it
     sudo cat /etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml \
-      | sed "s|<main><disk>s3</disk></main>|<main><disk>s3</disk></main><default><disk>default</disk></default>|" \
+      | sed "s|<main><disk>cached_s3</disk></main>|<main><disk>cached_s3</disk></main><default><disk>default</disk></default>|" \
       > /etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml.tmp
     mv /etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml.tmp /etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml
     sudo chown clickhouse /etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml
@@ -237,7 +237,7 @@ if [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
 elif [[ "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
     # But we still need default disk because some tables loaded only into it
     sudo cat /etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml \
-      | sed "s|<main><disk>azure</disk></main>|<main><disk>azure</disk></main><default><disk>default</disk></default>|" \
+      | sed "s|<main><disk>cached_azure</disk></main>|<main><disk>cached_azure</disk></main><default><disk>default</disk></default>|" \
       > /etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml.tmp
     mv /etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml.tmp /etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml
     sudo chown clickhouse /etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


We didn't replace anything with `sed` because the disks we use have `cached_` prefix.
Not sure how it went unnoticed for so long, maybe we don't need default disk :thinking: 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
