### PR TITLE
Fix pretty print of Bool values in JSON format

### DIFF
--- a/src/DataTypes/Serializations/SerializationBool.cpp
+++ b/src/DataTypes/Serializations/SerializationBool.cpp
@@ -266,6 +266,11 @@ void SerializationBool::serializeTextJSON(const IColumn &column, size_t row_num,
     serializeSimple(column, row_num, ostr, settings);
 }
 
+void SerializationBool::serializeTextJSONPretty(const IColumn &column, size_t row_num, WriteBuffer &ostr, const FormatSettings &settings, size_t) const
+{
+    serializeSimple(column, row_num, ostr, settings);
+}
+
 void SerializationBool::deserializeTextJSON(IColumn &column, ReadBuffer &istr, const FormatSettings &) const
 {
     if (istr.eof())

--- a/src/DataTypes/Serializations/SerializationBool.h
+++ b/src/DataTypes/Serializations/SerializationBool.h
@@ -21,6 +21,7 @@ public:
     bool tryDeserializeTextEscaped(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
 
     void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const override;
+    void serializeTextJSONPretty(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings, size_t) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings &) const override;
     bool tryDeserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings &) const override;
 

--- a/tests/queries/0_stateless/03364_pretty_json_bool.reference
+++ b/tests/queries/0_stateless/03364_pretty_json_bool.reference
@@ -1,0 +1,23 @@
+{
+	"meta":
+	[
+		{
+			"name": "a",
+			"type": "Bool"
+		},
+		{
+			"name": "b",
+			"type": "Bool"
+		}
+	],
+
+	"data":
+	[
+		{
+			"a": true,
+			"b": false
+		}
+	],
+
+	"rows": 1
+}

--- a/tests/queries/0_stateless/03364_pretty_json_bool.sql
+++ b/tests/queries/0_stateless/03364_pretty_json_bool.sql
@@ -1,0 +1,2 @@
+select true as a, false as b format JSON settings output_format_write_statistics=0;
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix pretty print of Bool values in JSON format.

Closes https://github.com/ClickHouse/ClickHouse/issues/76769
Closes https://github.com/ClickHouse/ClickHouse/issues/75681

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
