### PR TITLE
test_backup_restore_on_cluster: Use logging instead of print

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import time


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
test_backup_restore_on_cluster: Use logging instead of print

When it [fails](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=76745&sha=latest&name_0=PR&name_1=Integration+tests+%28release%2C+3%2F4%29) you don't get any prints, so they are useless for debugging.

```
2025-02-26 15:02:33 [ 675 ] DEBUG : Executing query SELECT name FROM system.errors WHERE last_error_time >= toDateTime('2025-02-26 15:01:34') AND NOT ((name == 'KEEPER_EXCEPTION') AND (last_error_message LIKE '%Fault injection%')) AND NOT (name == 'NO_ELEMENTS_IN_CONFIG') on node1 (cluster.py:3536, query)
2025-02-26 15:02:33 [ 675 ] DEBUG : Executing query SELECT name, last_error_message FROM system.errors WHERE last_error_time >= toDateTime('2025-02-26 15:01:34') on node1 (cluster.py:3536, query)
2025-02-26 15:02:33 [ 675 ] DEBUG : Executing query SELECT name FROM system.errors WHERE last_error_time >= toDateTime('2025-02-26 15:01:34') AND NOT ((name == 'KEEPER_EXCEPTION') AND (last_error_message LIKE '%Fault injection%')) AND NOT (name == 'NO_ELEMENTS_IN_CONFIG') on node2 (cluster.py:3536, query)
2025-02-26 15:02:33 [ 675 ] DEBUG : Executing query SELECT name, last_error_message FROM system.errors WHERE last_error_time >= toDateTime('2025-02-26 15:01:34') on node2 (cluster.py:3536, query)
```

^ This is missing the `Found errors:` messages which would help debugging why and where the `ABORTED` error appeared.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
