### PR TITLE
Fix distributed request with described structure

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -193,6 +193,13 @@ void StorageObjectStorage::Configuration::update(ObjectStoragePtr object_storage
 {
     IObjectStorage::ApplyNewSettingsOptions options{.allow_client_change = !isStaticConfiguration()};
     object_storage_ptr->applyNewSettings(context->getConfigRef(), getTypeName() + ".", context, options);
+    updated = true;
+}
+
+void StorageObjectStorage::Configuration::updateIfRequired(ObjectStoragePtr object_storage_ptr, ContextPtr local_context)
+{
+    if (!updated)
+        update(object_storage_ptr, local_context);
 }
 
 bool StorageObjectStorage::hasExternalDynamicMetadata() const

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -252,6 +252,7 @@ public:
     String structure = "auto";
 
     virtual void update(ObjectStoragePtr object_storage, ContextPtr local_context);
+    void updateIfRequired(ObjectStoragePtr object_storage, ContextPtr local_context);
 
 
 protected:
@@ -261,6 +262,7 @@ protected:
     void assertInitialized() const;
 
     bool initialized = false;
+    std::atomic<bool> updated = false;
 
     bool allow_dynamic_metadata_for_data_lakes = false;
     bool allow_experimental_delta_kernel_rs = false;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -138,6 +138,8 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
 
     const bool is_archive = configuration->isArchive();
 
+    configuration->updateIfRequired(object_storage, local_context);
+
     std::unique_ptr<IObjectIterator> iterator;
     if (configuration->isPathWithGlobs())
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segmentation fault in distributed requests to Iceberg table with described structure

### Documentation entry for user-facing changes
Distributed request to Iceberg table with described structure fails with error in versions 25.1 and older and causes an segmentation fault in master branch.

This works:
```
SELECT * FROM icebergS3Cluster('cluster', 'http://minio:9000/warehouse/data/', 'minio', 'minio123', 'Parquet')

   ┌───────────────────datetime─┬─symbol─┬────bid─┬────ask─┐
1. │ 2019-08-07 08:35:00.000000 │ AAPL   │ 195.23 │ 195.28 │
2. │ 2019-08-07 08:35:00.000000 │ AAPL   │ 195.22 │ 195.28 │
   └────────────────────────────┴────────┴────────┴────────┘
   ┌───────────────────datetime─┬─symbol─┬────bid─┬────ask─┐
3. │ 2019-08-09 08:35:00.000000 │ AAPL   │ 198.23 │ 195.45 │
4. │ 2019-08-09 08:35:00.000000 │ AAPL   │ 198.25 │  198.5 │
   └────────────────────────────┴────────┴────────┴────────┘
```

This in 25.1, 24,12, etc.:
```
SELECT * FROM icebergS3Cluster('cluster', 'http://minio:9000/warehouse/data/', 'minio', 'minio123', 'Parquet', '`datetime` Nullable(DateTime64(6)), `symbol` Nullable(String), `bid` Nullable(Float64), `ask` Nullable(Float64)')

Received exception from server (version 24.12.2):
Code: 499. DB::Exception: Received from localhost:9000. DB::Exception: Failed to get object info: No response body.. HTTP response code: 404: while reading data/: While executing Remote. (S3_ERROR)
```

In master branch:
```
SELECT * FROM icebergS3Cluster('cluster', 'http://minio:9000/warehouse/data/', 'minio', 'minio123', 'Parquet', '`datetime` Nullable(DateTime64(6)), `symbol` Nullable(String), `bid` Nullable(Float64), `ask` Nullable(Float64)')

[dd40d731b8b0] 2025.02.28 09:58:25.735038 [ 770 ] <Fatal> BaseDaemon: ########################################
[dd40d731b8b0] 2025.02.28 09:58:25.735173 [ 770 ] <Fatal> BaseDaemon: (version 25.3.1.1, build id: BAD58D323C8BBD2947EEED8DBBCC28FB16545759, git hash: 8f043cbadffe20d0479e9aa463e6b4ff34f7b876) (from thread 82) (query_id: c128310e-720a-4dd4-be98-af695a43a3cf) (query: select * from icebergS3Cluster('ch-cluster', s3_conn, url='http://minio:9000/warehouse/data/', format='Parquet', structure = '`datetime` Nullable(DateTime64(6)), `symbol` Nullable(String), `bid` Nullable(Float64), `ask` Nullable(Float64)')) Received signal Segmentation fault (11)
[dd40d731b8b0] 2025.02.28 09:58:25.735198 [ 770 ] <Fatal> BaseDaemon: Address: NULL pointer. Access: read. Address not mapped to object.
[dd40d731b8b0] 2025.02.28 09:58:25.735212 [ 770 ] <Fatal> BaseDaemon: Stack trace: 0x0000556eca269208 0x0000556eca54ea4d 0x00007f66131be520 0x0000556ecc0a9668 0x0000556ecd9549b7 0x0000556ecd909b4f 0x0000556ecd90a0c6 0x0000556ecc0d858f 0x0000556ecc0dbbdd 0x0000556ecd825457 0x0000556ece8d821c 0x0000556ece4ebd57 0x0000556ece50ebba 0x0000556ece4e104e 0x0000556ece4e043f 0x0000556ece4dfc36 0x0000556ece5378b6 0x0000556ecedb90d4 0x0000556ecedb7801 0x0000556ecedba400 0x0000556eced616c9 0x0000556ecf11dafe 0x0000556ecf11a342 0x0000556ed0d0e44b 0x0000556ed0d2a2f8 0x0000556ed3a72e87 0x0000556ed3a7337e 0x0000556ed3a1f0d2 0x0000556ed3a1cb8f 0x00007f6613210ac3 0x00007f66132a2850
[dd40d731b8b0] 2025.02.28 09:58:25.741882 [ 770 ] <Fatal> BaseDaemon: 0.0. inlined from /home/iantonspb/ch-build/./src/Common/StackTrace.cpp:381: StackTrace::tryCapture()
[dd40d731b8b0] 2025.02.28 09:58:25.741947 [ 770 ] <Fatal> BaseDaemon: 0. /home/iantonspb/ch-build/./src/Common/StackTrace.cpp:350: StackTrace::StackTrace(ucontext_t const&) @ 0x000000000cc4e208
[dd40d731b8b0] 2025.02.28 09:58:25.750042 [ 770 ] <Fatal> BaseDaemon: 1. /home/iantonspb/ch-build/./src/Common/SignalHandlers.cpp:106: signalHandler(int, siginfo_t*, void*) @ 0x000000000cf33a4d
[dd40d731b8b0] 2025.02.28 09:58:25.750113 [ 770 ] <Fatal> BaseDaemon: 2. ? @ 0x00007f66131be520
[dd40d731b8b0] 2025.02.28 09:58:25.784536 [ 770 ] <Fatal> BaseDaemon: 3. ./src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h:120: DB::DataLakeConfiguration<DB::StorageS3Configuration, DB::IcebergMetadata>::supportsFileIterator() const @ 0x000000000ea8e668
[dd40d731b8b0] 2025.02.28 09:58:25.810257 [ 770 ] <Fatal> BaseDaemon: 4. /home/iantonspb/ch-build/./src/Storages/ObjectStorage/StorageObjectStorageSource.cpp:164: DB::StorageObjectStorageSource::createFileIterator(std::shared_ptr<DB::StorageObjectStorage::Configuration>, DB::StorageObjectStorage::QuerySettings const&, std::shared_ptr<DB::IObjectStorage>, bool, std::shared_ptr<DB::Context const> const&, DB::ActionsDAG::Node const*, DB::NamesAndTypesList const&, std::vector<std::shared_ptr<DB::RelativePathWithMetadata>, std::allocator<std::shared_ptr<DB::RelativePathWithMetadata>>>*, std::function<void (DB::FileProgress)>) @ 0x00000000103399b7
[dd40d731b8b0] 2025.02.28 09:58:25.825345 [ 770 ] <Fatal> BaseDaemon: 5. /home/iantonspb/ch-build/./src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp:33: DB::StorageObjectStorageCluster::getPathSample(DB::StorageInMemoryMetadata, std::shared_ptr<DB::Context const>) @ 0x00000000102eeb4f
[dd40d731b8b0] 2025.02.28 09:58:25.840322 [ 770 ] <Fatal> BaseDaemon: 6. /home/iantonspb/ch-build/./src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp:73: DB::StorageObjectStorageCluster::StorageObjectStorageCluster(String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>, std::shared_ptr<DB::IObjectStorage>, DB::StorageID const&, DB::ColumnsDescription const&, DB::ConstraintsDescription const&, std::shared_ptr<DB::Context const>) @ 0x00000000102ef0c6
[dd40d731b8b0] 2025.02.28 09:58:25.857547 [ 770 ] <Fatal> BaseDaemon: 7.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:41: DB::StorageObjectStorageCluster* std::construct_at[abi:ne190107]<DB::StorageObjectStorageCluster, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID, DB::ColumnsDescription&, DB::ConstraintsDescription, std::shared_ptr<DB::Context const>&, DB::StorageObjectStorageCluster*>(DB::StorageObjectStorageCluster*, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID&&, DB::ColumnsDescription&, DB::ConstraintsDescription&&, std::shared_ptr<DB::Context const>&)
[dd40d731b8b0] 2025.02.28 09:58:25.857612 [ 770 ] <Fatal> BaseDaemon: 7.1. inlined from ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:49: DB::StorageObjectStorageCluster* std::__construct_at[abi:ne190107]<DB::StorageObjectStorageCluster, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID, DB::ColumnsDescription&, DB::ConstraintsDescription, std::shared_ptr<DB::Context const>&, DB::StorageObjectStorageCluster*>(DB::StorageObjectStorageCluster*, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID&&, DB::ColumnsDescription&, DB::ConstraintsDescription&&, std::shared_ptr<DB::Context const>&)
[dd40d731b8b0] 2025.02.28 09:58:25.857636 [ 770 ] <Fatal> BaseDaemon: 7.2. inlined from ./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:328: void std::allocator_traits<std::allocator<DB::StorageObjectStorageCluster>>::construct[abi:ne190107]<DB::StorageObjectStorageCluster, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID, DB::ColumnsDescription&, DB::ConstraintsDescription, std::shared_ptr<DB::Context const>&, void, 0>(std::allocator<DB::StorageObjectStorageCluster>&, DB::StorageObjectStorageCluster*, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID&&, DB::ColumnsDescription&, DB::ConstraintsDescription&&, std::shared_ptr<DB::Context const>&)
[dd40d731b8b0] 2025.02.28 09:58:25.857651 [ 770 ] <Fatal> BaseDaemon: 7.3. inlined from ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:264: __shared_ptr_emplace<const std::basic_string<char, std::char_traits<char>, std::allocator<char> > &, std::shared_ptr<DB::StorageObjectStorage::Configuration> &, std::shared_ptr<DB::IObjectStorage> &, DB::StorageID, DB::ColumnsDescription &, DB::ConstraintsDescription, std::shared_ptr<const DB::Context> &, std::allocator<DB::StorageObjectStorageCluster>, 0>
[dd40d731b8b0] 2025.02.28 09:58:25.857712 [ 770 ] <Fatal> BaseDaemon: 7. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:843: std::shared_ptr<DB::StorageObjectStorageCluster> std::allocate_shared[abi:ne190107]<DB::StorageObjectStorageCluster, std::allocator<DB::StorageObjectStorageCluster>, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID, DB::ColumnsDescription&, DB::ConstraintsDescription, std::shared_ptr<DB::Context const>&, 0>(std::allocator<DB::StorageObjectStorageCluster> const&, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID&&, DB::ColumnsDescription&, DB::ConstraintsDescription&&, std::shared_ptr<DB::Context const>&) @ 0x000000000eabd58f
[dd40d731b8b0] 2025.02.28 09:58:25.873630 [ 770 ] <Fatal> BaseDaemon: 8.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:851: std::shared_ptr<DB::StorageObjectStorageCluster> std::make_shared[abi:ne190107]<DB::StorageObjectStorageCluster, String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID, DB::ColumnsDescription&, DB::ConstraintsDescription, std::shared_ptr<DB::Context const>&, 0>(String const&, std::shared_ptr<DB::StorageObjectStorage::Configuration>&, std::shared_ptr<DB::IObjectStorage>&, DB::StorageID&&, DB::ColumnsDescription&, DB::ConstraintsDescription&&, std::shared_ptr<DB::Context const>&)
[dd40d731b8b0] 2025.02.28 09:58:25.873679 [ 770 ] <Fatal> BaseDaemon: 8. /home/iantonspb/ch-build/./src/TableFunctions/TableFunctionObjectStorageCluster.cpp:52: DB::TableFunctionObjectStorageCluster<DB::IcebergS3ClusterDefinition, DB::DataLakeConfiguration<DB::StorageS3Configuration, DB::IcebergMetadata>>::executeImpl(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::Context const>, String const&, DB::ColumnsDescription, bool) const @ 0x000000000eac0bdd
[dd40d731b8b0] 2025.02.28 09:58:25.887796 [ 770 ] <Fatal> BaseDaemon: 9. /home/iantonspb/ch-build/./src/TableFunctions/ITableFunction.cpp:36: DB::ITableFunction::execute(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::Context const>, String const&, DB::ColumnsDescription, bool, bool) const @ 0x000000001020a457
[dd40d731b8b0] 2025.02.28 09:58:25.951450 [ 770 ] <Fatal> BaseDaemon: 10. /home/iantonspb/ch-build/./src/Interpreters/Context.cpp:2472: DB::Context::executeTableFunction(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::ITableFunction> const&) @ 0x00000000112bd21c
[dd40d731b8b0] 2025.02.28 09:58:25.994730 [ 770 ] <Fatal> BaseDaemon: 11. /home/iantonspb/ch-build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:4964: DB::QueryAnalyzer::resolveTableFunction(std::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, DB::QueryExpressionsAliasVisitor&, bool) @ 0x0000000010ed0d57
[dd40d731b8b0] 2025.02.28 09:58:26.041447 [ 770 ] <Fatal> BaseDaemon: 12. /home/iantonspb/ch-build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5317: DB::QueryAnalyzer::resolveQueryJoinTreeNode(std::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, DB::QueryExpressionsAliasVisitor&) @ 0x0000000010ef3bba
[dd40d731b8b0] 2025.02.28 09:58:26.083676 [ 770 ] <Fatal> BaseDaemon: 13. /home/iantonspb/ch-build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5570: DB::QueryAnalyzer::resolveQuery(std::shared_ptr<DB::IQueryTreeNode> const&, DB::IdentifierResolveScope&) @ 0x0000000010ec604e
[dd40d731b8b0] 2025.02.28 09:58:26.122421 [ 770 ] <Fatal> BaseDaemon: 14. /home/iantonspb/ch-build/./src/Analyzer/Resolve/QueryAnalyzer.cpp:176: DB::QueryAnalyzer::resolve(std::shared_ptr<DB::IQueryTreeNode>&, std::shared_ptr<DB::IQueryTreeNode> const&, std::shared_ptr<DB::Context const>) @ 0x0000000010ec543f
[dd40d731b8b0] 2025.02.28 09:58:26.123526 [ 770 ] <Fatal> BaseDaemon: 15. /home/iantonspb/ch-build/./src/Analyzer/Resolve/QueryAnalysisPass.cpp:18: DB::QueryAnalysisPass::run(std::shared_ptr<DB::IQueryTreeNode>&, std::shared_ptr<DB::Context const>) @ 0x0000000010ec4c36
[dd40d731b8b0] 2025.02.28 09:58:26.127835 [ 770 ] <Fatal> BaseDaemon: 16. /home/iantonspb/ch-build/./src/Analyzer/QueryTreePassManager.cpp:184: DB::QueryTreePassManager::run(std::shared_ptr<DB::IQueryTreeNode>) @ 0x0000000010f1c8b6
[dd40d731b8b0] 2025.02.28 09:58:26.140907 [ 770 ] <Fatal> BaseDaemon: 17. /home/iantonspb/ch-build/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:151: DB::buildQueryTreeAndRunPasses(std::shared_ptr<DB::IAST> const&, DB::SelectQueryOptions const&, std::shared_ptr<DB::Context const> const&, std::shared_ptr<DB::IStorage> const&) @ 0x000000001179e0d4
[dd40d731b8b0] 2025.02.28 09:58:26.150682 [ 770 ] <Fatal> BaseDaemon: 18. /home/iantonspb/ch-build/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:168: DB::InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(std::shared_ptr<DB::IAST> const&, std::shared_ptr<DB::Context const> const&, DB::SelectQueryOptions const&, std::vector<String, std::allocator<String>> const&) @ 0x000000001179c801
[dd40d731b8b0] 2025.02.28 09:58:26.163084 [ 770 ] <Fatal> BaseDaemon: 19. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:634: std::__unique_if<DB::InterpreterSelectQueryAnalyzer>::__unique_single std::make_unique[abi:ne190107]<DB::InterpreterSelectQueryAnalyzer, std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&>(std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&) @ 0x000000001179f400
[dd40d731b8b0] 2025.02.28 09:58:26.167293 [ 770 ] <Fatal> BaseDaemon: 20.0. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
[dd40d731b8b0] 2025.02.28 09:58:26.167338 [ 770 ] <Fatal> BaseDaemon: 20.1. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:989: ?
[dd40d731b8b0] 2025.02.28 09:58:26.167361 [ 770 ] <Fatal> BaseDaemon: 20. /home/iantonspb/ch-build/./src/Interpreters/InterpreterFactory.cpp:392: DB::InterpreterFactory::get(std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::Context>, DB::SelectQueryOptions const&) @ 0x00000000117466c9
[dd40d731b8b0] 2025.02.28 09:58:26.195049 [ 770 ] <Fatal> BaseDaemon: 21. /home/iantonspb/ch-build/./src/Interpreters/executeQuery.cpp:1391: DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*, std::shared_ptr<DB::IAST>&) @ 0x0000000011b02afe
[dd40d731b8b0] 2025.02.28 09:58:26.226585 [ 770 ] <Fatal> BaseDaemon: 22. /home/iantonspb/ch-build/./src/Interpreters/executeQuery.cpp:1625: DB::executeQuery(String const&, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x0000000011aff342
[dd40d731b8b0] 2025.02.28 09:58:26.247174 [ 770 ] <Fatal> BaseDaemon: 23. /home/iantonspb/ch-build/./src/Server/TCPHandler.cpp:664: DB::TCPHandler::runImpl() @ 0x00000000136f344b
[dd40d731b8b0] 2025.02.28 09:58:26.280842 [ 770 ] <Fatal> BaseDaemon: 24. /home/iantonspb/ch-build/./src/Server/TCPHandler.cpp:2629: DB::TCPHandler::run() @ 0x000000001370f2f8
[dd40d731b8b0] 2025.02.28 09:58:26.282166 [ 770 ] <Fatal> BaseDaemon: 25. /home/iantonspb/ch-build/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x0000000016457e87
[dd40d731b8b0] 2025.02.28 09:58:26.284680 [ 770 ] <Fatal> BaseDaemon: 26. /home/iantonspb/ch-build/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x000000001645837e
[dd40d731b8b0] 2025.02.28 09:58:26.286649 [ 770 ] <Fatal> BaseDaemon: 27. /home/iantonspb/ch-build/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x00000000164040d2
[dd40d731b8b0] 2025.02.28 09:58:26.288424 [ 770 ] <Fatal> BaseDaemon: 28. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000016401b8f
[dd40d731b8b0] 2025.02.28 09:58:26.288444 [ 770 ] <Fatal> BaseDaemon: 29. ? @ 0x00007f6613210ac3
[dd40d731b8b0] 2025.02.28 09:58:26.288468 [ 770 ] <Fatal> BaseDaemon: 30. ? @ 0x00007f66132a2850
[dd40d731b8b0] 2025.02.28 09:58:26.288520 [ 770 ] <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read.
[dd40d731b8b0] 2025.02.28 09:58:26.828171 [ 770 ] <Fatal> BaseDaemon: This ClickHouse version is not official and should be upgraded to the official build.
[dd40d731b8b0] 2025.02.28 09:58:26.828336 [ 770 ] <Fatal> BaseDaemon: No settings were changed
```

Reason - when structure is not described, ClickHouse reads samples from object storage and during that process initializes and fills table metadata,
When structure is described in query, ClickHouse doesn't do it and calls StorageObjectStorageSource::createFileIterator with uninitialized metadata. In 25.1 and older version it try to use root path (http://minio:9000/warehouse/data/) instead of object paths and gets 404 error from S3 storage, in master branch after https://github.com/ClickHouse/ClickHouse/pull/74884 is uses unitialized `current_metadata` in `supportsFileIterator` method.