### PR TITLE
Fix docs on DateTime64 -> Arrow type

### DIFF
--- a/docs/en/interfaces/formats/Arrow/Arrow.md
+++ b/docs/en/interfaces/formats/Arrow/Arrow.md
@@ -35,7 +35,7 @@ The table below shows the supported data types and how they correspond to ClickH
 | `DOUBLE`                                | [Float64](/sql-reference/data-types/float.md)                                                      | `FLOAT64`                  |
 | `DATE32`                                | [Date32](/sql-reference/data-types/date32.md)                                                      | `UINT16`                   |
 | `DATE64`                                | [DateTime](/sql-reference/data-types/datetime.md)                                                  | `UINT32`                   |
-| `TIMESTAMP`, `TIME32`, `TIME64`         | [DateTime64](/sql-reference/data-types/datetime64.md)                                              | `UINT32`                   |
+| `TIMESTAMP`, `TIME32`, `TIME64`         | [DateTime64](/sql-reference/data-types/datetime64.md)                                              | `TIMESTAMP`                |
 | `STRING`, `BINARY`                      | [String](/sql-reference/data-types/string.md)                                                      | `BINARY`                   |
 | `STRING`, `BINARY`, `FIXED_SIZE_BINARY` | [FixedString](/sql-reference/data-types/fixedstring.md)                                            | `FIXED_SIZE_BINARY`        |
 | `DECIMAL`                               | [Decimal](/sql-reference/data-types/decimal.md)                                                    | `DECIMAL`                  |


### PR DESCRIPTION
ClickHouse DateTime64 values are actually exported as Arrow timestamp values: https://github.com/ClickHouse/ClickHouse/blob/707083cd6c1b312caccdb02b7536134296071b25/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp#L177

### Changelog category (leave one):
- Documentation (changelog entry is not required)