### PR TITLE
move images to static folder

### DIFF
--- a/docs/en/getting-started/example-datasets/cell-towers.md
+++ b/docs/en/getting-started/example-datasets/cell-towers.md
@@ -14,6 +14,7 @@ import CodeBlock from '@theme/CodeBlock';
 import ActionsMenu from '@site/docs/_snippets/_service_actions_menu.md';
 import SQLConsoleDetail from '@site/docs/_snippets/_launch_sql_console.md';
 import SupersetDocker from '@site/docs/_snippets/_add_superset_detail.md';
+import cloud_load_data_sample from '@site/static/images/_snippets/cloud-load-data-sample.png';
 
 ## Goal {#goal}
 
@@ -44,7 +45,7 @@ ClickHouse Cloud provides an easy-button for uploading this dataset from S3.  Lo
 
 Choose the **Cell Towers** dataset from the **Sample data** tab, and **Load data**:
 
-![Load cell towers dataset](@site/docs/_snippets/images/cloud-load-data-sample.png)
+<img src={cloud_load_data_sample} class="image" alt="Load cell towers dataset" />
 
 ### Examine the schema of the cell_towers table {#examine-the-schema-of-the-cell_towers-table}
 ```sql

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -5,6 +5,9 @@ sidebar_label: ClickHouse Client
 title: ClickHouse Client
 ---
 
+import cloud_connect_button from '@site/static/images/_snippets/cloud-connect-button.png';
+import connection_details_native from '@site/static/images/_snippets/connection-details-native.png'
+
 ClickHouse provides a native command-line client for executing SQL queries directly against a ClickHouse server. It supports both interactive mode (for live query execution) and batch mode (for scripting and automation). Query results can be displayed in the terminal or exported to a file, with support for all ClickHouse output [formats](formats.md), such as Pretty, CSV, JSON, and more.
 
 The client provides real-time feedback on query execution with a progress bar and the number of rows read, bytes processed and query execution time. It supports both [command-line options](#command-line-options) and [configuration files](#configuration_files).
@@ -67,7 +70,7 @@ For a complete list of command-line options, see [Command Line Options](#command
 
 The details for your ClickHouse Cloud service are available in the ClickHouse Cloud console. Select the service that you want to connect to and click **Connect**:
 
-<img src={require('../_snippets/images/cloud-connect-button.png').default}
+<img src={cloud_connect_button}
   class="image"
   alt="ClickHouse Cloud service connect button"
   style={{width: '30em'}} />
@@ -76,7 +79,7 @@ The details for your ClickHouse Cloud service are available in the ClickHouse Cl
 
 Choose **Native**, and the details are shown with an example `clickhouse-client` command:
 
-<img src={require('../_snippets/images/connection-details-native.png').default}
+<img src={connection_details_native}
   class="image"
   alt="ClickHouse Cloud Native TCP connection details"
   style={{width: '40em'}} />

--- a/docs/zh/getting-started/example-datasets/cell-towers.mdx
+++ b/docs/zh/getting-started/example-datasets/cell-towers.mdx
@@ -10,6 +10,8 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import ActionsMenu from '@site/docs/_snippets/_service_actions_menu.md';
 import SQLConsoleDetail from '@site/docs/_snippets/_launch_sql_console.md';
+import cloud_load_data_sample from '@site/static/images/_snippets/cloud-load-data-sample.png';
+
 
 该数据集来自 [OpenCellid](https://www.opencellid.org/) - 世界上最大的蜂窝信号塔的开放数据库。
 
@@ -27,7 +29,7 @@ OpenCelliD 项目在 `Creative Commons Attribution-ShareAlike 4.0 International 
 
 从 **Sample data** 选项卡中选择 **Cell Towers** 数据集，然后选择 **Load data**：
 
-![加载数据集](@site/docs/_snippets/images/cloud-load-data-sample.png)
+<img src={cloud_load_data_sample} class="image" alt="加载数据集" />
 
 检查 cell_towers 的表结构：
 


### PR DESCRIPTION
Moves images to use static folder. Depends on https://github.com/ClickHouse/clickhouse-docs/pull/3406

### Changelog category (leave one):

- Documentation (changelog entry is not required)

