### PR TITLE
Fix crash in template parsing in Values format

### DIFF
--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -564,11 +564,26 @@ bool ConstantExpressionTemplate::parseLiteralAndAssertType(
 
         DataTypes nested_types;
         if (type_info.is_array)
-            nested_types = { assert_cast<const DataTypeArray &>(*collection_type).getNestedType() };
+        {
+            const auto * array_type = typeid_cast<const DataTypeArray *>(collection_type.get());
+            if (!array_type)
+                return false;
+            nested_types = {array_type->getNestedType()};
+        }
         else if (type_info.is_tuple)
-            nested_types = assert_cast<const DataTypeTuple &>(*collection_type).getElements();
+        {
+            const auto * tuple_type = typeid_cast<const DataTypeTuple *>(collection_type.get());
+            if (!tuple_type)
+                return false;
+            nested_types = tuple_type->getElements();
+        }
         else
-            nested_types = assert_cast<const DataTypeMap &>(*collection_type).getKeyValueTypes();
+        {
+            const auto * map_type = typeid_cast<const DataTypeMap *>(collection_type.get());
+            if (!map_type)
+                return false;
+            nested_types = map_type->getKeyValueTypes();
+        }
 
         for (size_t i = 0; i < nested_types.size(); ++i)
         {

--- a/tests/queries/0_stateless/03369_values_template_types_mismatch.sql
+++ b/tests/queries/0_stateless/03369_values_template_types_mismatch.sql
@@ -1,0 +1,3 @@
+CREATE TABLE t0 (c0 String) ENGINE = Memory;
+INSERT INTO TABLE t0 (c0) VALUES ([1, NULL]::Array(Nullable(Int32))), ((1,1));
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in template parsing in Values format in case of types mismatch

Closes https://github.com/ClickHouse/ClickHouse/issues/74326

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
