### PR TITLE
Don't allow creating EmbeddedRocksDB table with subcolumn in primary key

### DIFF
--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -714,6 +714,10 @@ static StoragePtr create(const StorageFactory::Arguments & args)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "StorageEmbeddedRocksDB must require one column in primary key");
     }
+
+    if (metadata.getColumns().hasSubcolumn(primary_key_names[0]))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "StorageEmbeddedRocksDB doesn't support subcolumns in primary key");
+
     auto settings = std::make_unique<RocksDBSettings>();
     settings->loadFromQuery(*args.storage_def);
     if (args.storage_def->settings)

--- a/tests/queries/0_stateless/03370_rocks_db_engine_subcolumn_in_pk.sql
+++ b/tests/queries/0_stateless/03370_rocks_db_engine_subcolumn_in_pk.sql
@@ -1,2 +1,4 @@
+-- Tags: no-fasttest
+
 CREATE TABLE test (t Tuple(a Int32)) ENGINE = EmbeddedRocksDB() PRIMARY KEY (t.a); -- {serverError BAD_ARGUMENTS}
 

--- a/tests/queries/0_stateless/03370_rocks_db_engine_subcolumn_in_pk.sql
+++ b/tests/queries/0_stateless/03370_rocks_db_engine_subcolumn_in_pk.sql
@@ -1,0 +1,2 @@
+CREATE TABLE test (t Tuple(a Int32)) ENGINE = EmbeddedRocksDB() PRIMARY KEY (t.a); -- {serverError BAD_ARGUMENTS}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't allow creating EmbeddedRocksDB table with subcolumn in primary key. Previosly such table could be created but select queries were failing.

Closes https://github.com/ClickHouse/ClickHouse/issues/74570

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
