### PR TITLE
ci: fix errors due to "unable to read tree" in performance tests

### DIFF
--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1318,7 +1318,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
             insert into query_metrics_v2
             select
                 toDate(event_time) event_date,
-                toDateTime('$(cd right/ch && git show -s --format=%ci "$SHA_TO_TEST" | cut -d' ' -f-2)') event_time,
+                toDateTime('$(git -C right/ch log -1 --format=%cd --date=iso "$SHA_TO_TEST" | cut -d' ' -f-2)') event_time,
                 $PR_TO_TEST pr_number,
                 '$REF_SHA' old_sha,
                 '$SHA_TO_TEST' new_sha,

--- a/docker/packager/binary-builder/build.sh
+++ b/docker/packager/binary-builder/build.sh
@@ -175,6 +175,8 @@ then
     git -C "$PERF_OUTPUT"/ch tag | xargs git -C "$PERF_OUTPUT"/ch tag -d >/dev/null
     git -C "$PERF_OUTPUT"/ch reset --soft pr
     git -C "$PERF_OUTPUT"/ch log -5
+    # Unlike git log, git show requires trees
+    git -C "$PERF_OUTPUT"/ch show -s
     (
         cd "$PERF_OUTPUT"/..
         tar -cv --zstd -f /output/performance.tar.zst output

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -101,6 +101,14 @@ def run_docker_image_with_env(
     subprocess.check_call(cmd, shell=True)
 
 
+def is_release_build(
+    debug_build: bool, package_type: str, sanitizer: str, coverage: bool
+) -> bool:
+    return (
+        not debug_build and package_type == "deb" and sanitizer == "" and not coverage
+    )
+
+
 def parse_env_variables(
     debug_build: bool,
     coverage: bool,
@@ -119,7 +127,6 @@ def parse_env_variables(
     with_coverage: bool,
     with_binaries: str,
     with_buzzhouse: bool,
-    with_performance_artifacts: bool,
 ) -> List[str]:
     DARWIN_SUFFIX = "-darwin"
     DARWIN_ARM_SUFFIX = "-darwin-aarch64"
@@ -249,17 +256,16 @@ def parse_env_variables(
         cmake_flags.append("-DCMAKE_INSTALL_LOCALSTATEDIR=/var")
         # Reduce linking and building time by avoid *install/all dependencies
         cmake_flags.append("-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON")
+        if is_release_build(debug_build, package_type, sanitizer, coverage):
+            cmake_flags.append("-DSPLIT_DEBUG_SYMBOLS=ON")
+            result.append("WITH_PERFORMANCE=1")
+            cmake_flags.append("-DBUILD_STANDALONE_KEEPER=1")
     elif package_type == "fuzzers":
         cmake_flags.append("-DENABLE_FUZZING=1")
         cmake_flags.append("-DENABLE_PROTOBUF=1")
         cmake_flags.append("-DWITH_COVERAGE=1")
         # Reduce linking and building time by avoid *install/all dependencies
         cmake_flags.append("-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON")
-
-    if with_performance_artifacts:
-        cmake_flags.append("-DSPLIT_DEBUG_SYMBOLS=ON")
-        result.append("WITH_PERFORMANCE=1")
-        cmake_flags.append("-DBUILD_STANDALONE_KEEPER=1")
 
     result.append(f"CC={cc}")
     result.append(f"CXX={cxx}")
@@ -457,7 +463,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--with-profiler", action="store_true")
     parser.add_argument("--with-coverage", action="store_true")
     parser.add_argument("--with-buzzhouse", action="store_true")
-    parser.add_argument("--with-performance-artifacts", action="store_true")
     parser.add_argument(
         "--with-binaries", choices=("programs", "tests", ""), default=""
     )
@@ -525,7 +530,6 @@ def main() -> None:
         args.with_coverage,
         args.with_binaries,
         args.with_buzzhouse,
-        args.with_performance_artifacts,
     )
 
     pre_build(args.clickhouse_repo_path, env_prepared)

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -101,14 +101,6 @@ def run_docker_image_with_env(
     subprocess.check_call(cmd, shell=True)
 
 
-def is_release_build(
-    debug_build: bool, package_type: str, sanitizer: str, coverage: bool
-) -> bool:
-    return (
-        not debug_build and package_type == "deb" and sanitizer == "" and not coverage
-    )
-
-
 def parse_env_variables(
     debug_build: bool,
     coverage: bool,
@@ -127,6 +119,7 @@ def parse_env_variables(
     with_coverage: bool,
     with_binaries: str,
     with_buzzhouse: bool,
+    with_performance_artifacts: bool,
 ) -> List[str]:
     DARWIN_SUFFIX = "-darwin"
     DARWIN_ARM_SUFFIX = "-darwin-aarch64"
@@ -256,16 +249,17 @@ def parse_env_variables(
         cmake_flags.append("-DCMAKE_INSTALL_LOCALSTATEDIR=/var")
         # Reduce linking and building time by avoid *install/all dependencies
         cmake_flags.append("-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON")
-        if is_release_build(debug_build, package_type, sanitizer, coverage):
-            cmake_flags.append("-DSPLIT_DEBUG_SYMBOLS=ON")
-            result.append("WITH_PERFORMANCE=1")
-            cmake_flags.append("-DBUILD_STANDALONE_KEEPER=1")
     elif package_type == "fuzzers":
         cmake_flags.append("-DENABLE_FUZZING=1")
         cmake_flags.append("-DENABLE_PROTOBUF=1")
         cmake_flags.append("-DWITH_COVERAGE=1")
         # Reduce linking and building time by avoid *install/all dependencies
         cmake_flags.append("-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON")
+
+    if with_performance_artifacts:
+        cmake_flags.append("-DSPLIT_DEBUG_SYMBOLS=ON")
+        result.append("WITH_PERFORMANCE=1")
+        cmake_flags.append("-DBUILD_STANDALONE_KEEPER=1")
 
     result.append(f"CC={cc}")
     result.append(f"CXX={cxx}")
@@ -463,6 +457,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--with-profiler", action="store_true")
     parser.add_argument("--with-coverage", action="store_true")
     parser.add_argument("--with-buzzhouse", action="store_true")
+    parser.add_argument("--with-performance-artifacts", action="store_true")
     parser.add_argument(
         "--with-binaries", choices=("programs", "tests", ""), default=""
     )
@@ -530,6 +525,7 @@ def main() -> None:
         args.with_coverage,
         args.with_binaries,
         args.with_buzzhouse,
+        args.with_performance_artifacts,
     )
 
     pre_build(args.clickhouse_repo_path, env_prepared)

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -39,6 +39,7 @@ def _can_export_binaries(build_config: CI.BuildConfig) -> bool:
     return False
 
 
+# Copy of packager.is_release_build()
 def with_performance_artifacts(build_config: CI.BuildConfig) -> bool:
     return (
         not build_config.debug_build
@@ -84,9 +85,6 @@ def get_packager_cmd(
     cmd += " --with-profiler"
     cmd += " --with-buzzhouse"
     cmd += f" --version={build_version}"
-
-    if with_performance_artifacts(build_config):
-        cmd += " --with-performance-artifacts"
 
     if _can_export_binaries(build_config):
         cmd += " --with-binaries=tests"

--- a/tests/performance/scripts/compare.sh
+++ b/tests/performance/scripts/compare.sh
@@ -1311,7 +1311,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
             insert into query_metrics_v2
             select
                 toDate(event_time) event_date,
-                toDateTime('$(cd right/ch && git show -s --format=%ci "$SHA_TO_TEST" | cut -d' ' -f-2)') event_time,
+                toDateTime('$(git -C right/ch log -1 --format=%cd --date=iso "$SHA_TO_TEST" | cut -d' ' -f-2)') event_time,
                 $PR_TO_TEST pr_number,
                 '$REF_SHA' old_sha,
                 '$SHA_TO_TEST' new_sha,

--- a/tests/performance/scripts/entrypoint.sh
+++ b/tests/performance/scripts/entrypoint.sh
@@ -29,6 +29,11 @@ function find_reference_sha
 {
     git -C right/ch log -1 origin/master
     git -C right/ch log -1 pr
+
+    # Ensure that trees are available
+    git -C right/ch show -s origin/master
+    git -C right/ch show -s pr
+
     # Go back from the revision to be tested, trying to find the closest published
     # testing release. The PR branch may be either pull/*/head which is the
     # author's branch, or pull/*/merge, which is head merged with some master
@@ -121,9 +126,12 @@ then
     # tests for use by compare.sh. Compare to merge base, because master might be
     # far in the future and have unrelated test changes.
     base=$(git -C right/ch merge-base pr origin/master)
+
+    set -o pipefail
     git -C right/ch diff --name-only "$base" pr -- . | tee all-changed-files.txt
     git -C right/ch diff --name-only --diff-filter=d "$base" pr -- tests/performance/*.xml | tee changed-test-definitions.txt
     git -C right/ch diff --name-only "$base" pr -- :!tests/performance/*.xml :!docker/test/performance-comparison | tee other-changed-files.txt
+    set +o pipefail
 fi
 
 # Set python output encoding so that we can print queries with non-ASCII letters.


### PR DESCRIPTION
### Changes
- unable to parse date from commit - replace `git show` with `git log`
- unable to collect diff (add some sanity checks to ensure that it works correctly) - proper unshallow (without limit for tree)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #75103 (cc @maxknv)