### PR TITLE
Remove the `force` flag for resizes

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -390,7 +390,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
             return processors;
         });
 
-        pipeline.resize(params.max_threads, /* force = */ true);
+        pipeline.resize(params.max_threads);
 
         aggregating = collector.detachProcessors(0);
         return;
@@ -495,7 +495,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
         /// Add resize transform to uniformly distribute data between aggregating streams.
         /// But not if we execute aggregation over partitioned data in which case data streams shouldn't be mixed.
         if (!storage_has_evenly_distributed_read && !skip_merging)
-            pipeline.resize(pipeline.getNumStreams(), true, true);
+            pipeline.resize(pipeline.getNumStreams(), true);
 
         auto many_data = std::make_shared<ManyAggregatedData>(pipeline.getNumStreams());
 
@@ -514,7 +514,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     skip_merging);
             });
 
-        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads, true /* force */);
+        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads);
 
         aggregating = collector.detachProcessors(0);
     }
@@ -522,7 +522,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
     {
         pipeline.addSimpleTransform([&](const Block & header) { return std::make_shared<AggregatingTransform>(header, transform_params); });
 
-        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads, false /* force */);
+        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads);
 
         aggregating = collector.detachProcessors(0);
     }
@@ -677,7 +677,7 @@ QueryPipelineBuilderPtr AggregatingProjectionStep::updatePipeline(
         AggregatingTransformParamsPtr transform_params = std::make_shared<AggregatingTransformParams>(
             pipeline.getHeader(), std::move(params_copy), aggregator_list_ptr, final);
 
-        pipeline.resize(pipeline.getNumStreams(), true, true);
+        pipeline.resize(pipeline.getNumStreams(), true);
 
         pipeline.addSimpleTransform([&](const Block & header)
         {

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -683,13 +683,10 @@ void Pipe::addChains(std::vector<Chain> chains)
     max_parallel_streams = std::max(max_parallel_streams, max_parallel_streams_for_chains);
 }
 
-void Pipe::resize(size_t num_streams, bool force, bool strict)
+void Pipe::resize(size_t num_streams, bool strict)
 {
     if (output_ports.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot resize an empty Pipe");
-
-    if (!force && num_streams == numOutputPorts())
-        return;
 
     /// We need to not add the resize in case of 1-1 because in case
     /// it is not force resize and we have n outputs (look at the code above),

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -688,6 +688,9 @@ void Pipe::resize(size_t num_streams, bool strict)
     if (output_ports.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot resize an empty Pipe");
 
+    if (strict && num_streams == numOutputPorts())
+        return;
+
     /// We need to not add the resize in case of 1-1 because in case
     /// it is not force resize and we have n outputs (look at the code above),
     /// and one of the outputs is dead, we can push all data to n-1 outputs,

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -90,7 +90,7 @@ public:
     void addChains(std::vector<Chain> chains);
 
     /// Changes the number of output ports if needed. Adds (Strict)ResizeProcessor.
-    void resize(size_t num_streams, bool force = false, bool strict = false);
+    void resize(size_t num_streams, bool strict = false);
 
     using Transformer = std::function<Processors(OutputPortRawPtrs ports)>;
 

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -193,10 +193,10 @@ void QueryPipelineBuilder::addMergingAggregatedMemoryEfficientTransform(Aggregat
     DB::addMergingAggregatedMemoryEfficientTransform(pipe, std::move(params), num_merging_processors);
 }
 
-void QueryPipelineBuilder::resize(size_t num_streams, bool force, bool strict)
+void QueryPipelineBuilder::resize(size_t num_streams, bool strict)
 {
     checkInitializedAndNotCompleted();
-    pipe.resize(num_streams, force, strict);
+    pipe.resize(num_streams, strict);
 }
 
 void QueryPipelineBuilder::narrow(size_t size)
@@ -359,8 +359,8 @@ std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesYShaped
     right->pipe.dropExtremes();
     if ((left->getNumStreams() != 1 || right->getNumStreams() != 1) && join->getTableJoin().kind() == JoinKind::Paste)
     {
-        left->pipe.resize(1, true);
-        right->pipe.resize(1, true);
+        left->pipe.resize(1);
+        right->pipe.resize(1);
     }
     else if (left->getNumStreams() != 1 || right->getNumStreams() != 1)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Join is supported only for pipelines with one output port, got {} and {}", left->getNumStreams(), right->getNumStreams());

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -97,7 +97,7 @@ public:
     void addMergingAggregatedMemoryEfficientTransform(AggregatingTransformParamsPtr params, size_t num_merging_processors);
 
     /// Changes the number of output ports if needed. Adds ResizeTransform.
-    void resize(size_t num_streams, bool force = false, bool strict = false);
+    void resize(size_t num_streams, bool strict = false);
 
     /// Concat some ports to have no more then size outputs.
     /// This method is needed for Merge table engine in case of reading from many tables.

--- a/tests/queries/0_stateless/02343_aggregation_pipeline.reference
+++ b/tests/queries/0_stateless/02343_aggregation_pipeline.reference
@@ -6,32 +6,30 @@ ExpressionTransform × 16
   (Aggregating)
   Resize 16 → 16
     AggregatingTransform × 16
-      StrictResize 16 → 16
-        (Expression)
-        ExpressionTransform × 16
-          (Aggregating)
-          Resize 1 → 16
-            AggregatingTransform
-              (Expression)
-              ExpressionTransform
-                (ReadFromSystemNumbers)
-                NumbersRange 0 → 1
+      (Expression)
+      ExpressionTransform × 16
+        (Aggregating)
+        Resize 1 → 16
+          AggregatingTransform
+            (Expression)
+            ExpressionTransform
+              (ReadFromSystemNumbers)
+              NumbersRange 0 → 1
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0;
 (Expression)
 ExpressionTransform × 16
   (Aggregating)
   Resize 16 → 16
     AggregatingTransform × 16
-      StrictResize 16 → 16
-        (Expression)
-        ExpressionTransform × 16
-          (Aggregating)
-          Resize 16 → 16
-            AggregatingTransform × 16
-              (Expression)
-              ExpressionTransform × 16
-                (ReadFromSystemNumbers)
-                NumbersRange × 16 0 → 1
+      (Expression)
+      ExpressionTransform × 16
+        (Aggregating)
+        Resize 16 → 16
+          AggregatingTransform × 16
+            (Expression)
+            ExpressionTransform × 16
+              (ReadFromSystemNumbers)
+              NumbersRange × 16 0 → 1
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0;
 (Expression)
 ExpressionTransform
@@ -139,10 +137,9 @@ ExpressionTransform × 2
                         (Aggregating)
                         Resize 2 → 1
                           AggregatingTransform × 2
-                            StrictResize 2 → 2
-                              (Expression)
-                              ExpressionTransform × 2
-                                (ReadFromMergeTree)
-                                MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                            (Expression)
+                            ExpressionTransform × 2
+                              (ReadFromMergeTree)
+                              MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
                         (ReadFromRemote)
               (ReadFromRemote)

--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
@@ -5,27 +5,45 @@ select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 32
+<<<<<<< HEAD
+        MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+=======
       MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+>>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- Without asynchronous_read, max_streams_for_merge_tree_reading limits max_streams * max_streams_to_max_threads_ratio
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 4
+<<<<<<< HEAD
+        MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+=======
       MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+>>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- With asynchronous_read, read in max_streams_for_merge_tree_reading async streams and resize to max_threads
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 4 → 4
+<<<<<<< HEAD
+        Resize 16 → 4
+          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+=======
       Resize 16 → 4
           MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+>>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading outp[ut streams, resize to max_threads after aggregation
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 4
+<<<<<<< HEAD
+        Resize 32 → 16
+          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
+=======
       Resize 32 → 16
           MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
+>>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- For read-in-order, disable everything
 set query_plan_remove_redundant_sorting=0; -- to keep reading in order
 select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, optimize_read_in_order=1, query_plan_read_in_order=1;

--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
@@ -5,45 +5,27 @@ select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 32
-<<<<<<< HEAD
         MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
-=======
-      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
->>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- Without asynchronous_read, max_streams_for_merge_tree_reading limits max_streams * max_streams_to_max_threads_ratio
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 4
-<<<<<<< HEAD
         MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
-=======
-      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
->>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- With asynchronous_read, read in max_streams_for_merge_tree_reading async streams and resize to max_threads
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 4 → 4
-<<<<<<< HEAD
         Resize 16 → 4
           MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
-=======
-      Resize 16 → 4
-          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
->>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading outp[ut streams, resize to max_threads after aggregation
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 4
-<<<<<<< HEAD
         Resize 32 → 16
           MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
-=======
-      Resize 32 → 16
-          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
->>>>>>> ba82d342bec614293c539a412213b60f82545f47
 -- For read-in-order, disable everything
 set query_plan_remove_redundant_sorting=0; -- to keep reading in order
 select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, optimize_read_in_order=1, query_plan_read_in_order=1;

--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
@@ -5,31 +5,27 @@ select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 32
-      StrictResize 16 → 16
-          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
 -- Without asynchronous_read, max_streams_for_merge_tree_reading limits max_streams * max_streams_to_max_threads_ratio
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 4
-      StrictResize 16 → 16
-          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
 -- With asynchronous_read, read in max_streams_for_merge_tree_reading async streams and resize to max_threads
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 4 → 4
-      StrictResize 4 → 4
-          Resize 16 → 4
-            MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+      Resize 16 → 4
+          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
 -- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading outp[ut streams, resize to max_threads after aggregation
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
   Resize 16 → 4
-      StrictResize 16 → 16
-          Resize 32 → 16
-            MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
+      Resize 32 → 16
+          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
 -- For read-in-order, disable everything
 set query_plan_remove_redundant_sorting=0; -- to keep reading in order
 select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, optimize_read_in_order=1, query_plan_read_in_order=1;

--- a/tests/queries/0_stateless/02521_aggregation_by_partitions.reference
+++ b/tests/queries/0_stateless/02521_aggregation_by_partitions.reference
@@ -153,59 +153,60 @@ explain pipeline select a from t6 group by a settings read_in_order_two_level_me
 (Expression)
 ExpressionTransform × 16
   (Aggregating)
-  FinalizeAggregatedTransform × 16
-    AggregatingInOrderTransform × 16
-      (Expression)
-      ExpressionTransform × 16
-        (ReadFromMergeTree)
-        MergingSortedTransform 2 → 1
-          ExpressionTransform × 2
-            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-              MergingSortedTransform 2 → 1
-                ExpressionTransform × 2
-                  MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                    MergingSortedTransform 2 → 1
-                      ExpressionTransform × 2
-                        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                          MergingSortedTransform 2 → 1
-                            ExpressionTransform × 2
-                              MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                MergingSortedTransform 2 → 1
-                                  ExpressionTransform × 2
-                                    MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                      MergingSortedTransform 2 → 1
-                                        ExpressionTransform × 2
-                                          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                            MergingSortedTransform 2 → 1
-                                              ExpressionTransform × 2
-                                                MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                  MergingSortedTransform 2 → 1
-                                                    ExpressionTransform × 2
-                                                      MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                        MergingSortedTransform 2 → 1
-                                                          ExpressionTransform × 2
-                                                            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                              MergingSortedTransform 2 → 1
-                                                                ExpressionTransform × 2
-                                                                  MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                                    MergingSortedTransform 2 → 1
-                                                                      ExpressionTransform × 2
-                                                                        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                                          MergingSortedTransform 2 → 1
-                                                                            ExpressionTransform × 2
-                                                                              MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                                                MergingSortedTransform 2 → 1
-                                                                                  ExpressionTransform × 2
-                                                                                    MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                                                      MergingSortedTransform 2 → 1
-                                                                                        ExpressionTransform × 2
-                                                                                          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                                                            MergingSortedTransform 2 → 1
-                                                                                              ExpressionTransform × 2
-                                                                                                MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
-                                                                                                  MergingSortedTransform 2 → 1
-                                                                                                    ExpressionTransform × 2
-                                                                                                      MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+  Resize 16 → 16
+    FinalizeAggregatedTransform × 16
+      AggregatingInOrderTransform × 16
+        (Expression)
+        ExpressionTransform × 16
+          (ReadFromMergeTree)
+          MergingSortedTransform 2 → 1
+            ExpressionTransform × 2
+              MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                MergingSortedTransform 2 → 1
+                  ExpressionTransform × 2
+                    MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                      MergingSortedTransform 2 → 1
+                        ExpressionTransform × 2
+                          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                            MergingSortedTransform 2 → 1
+                              ExpressionTransform × 2
+                                MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                  MergingSortedTransform 2 → 1
+                                    ExpressionTransform × 2
+                                      MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                        MergingSortedTransform 2 → 1
+                                          ExpressionTransform × 2
+                                            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                              MergingSortedTransform 2 → 1
+                                                ExpressionTransform × 2
+                                                  MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                    MergingSortedTransform 2 → 1
+                                                      ExpressionTransform × 2
+                                                        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                          MergingSortedTransform 2 → 1
+                                                            ExpressionTransform × 2
+                                                              MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                MergingSortedTransform 2 → 1
+                                                                  ExpressionTransform × 2
+                                                                    MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                      MergingSortedTransform 2 → 1
+                                                                        ExpressionTransform × 2
+                                                                          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                            MergingSortedTransform 2 → 1
+                                                                              ExpressionTransform × 2
+                                                                                MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                                  MergingSortedTransform 2 → 1
+                                                                                    ExpressionTransform × 2
+                                                                                      MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                                        MergingSortedTransform 2 → 1
+                                                                                          ExpressionTransform × 2
+                                                                                            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                                              MergingSortedTransform 2 → 1
+                                                                                                ExpressionTransform × 2
+                                                                                                  MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
+                                                                                                    MergingSortedTransform 2 → 1
+                                                                                                      ExpressionTransform × 2
+                                                                                                        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) × 2 0 → 1
 1000000
 Skip merging: 1
 Skip merging: 1


### PR DESCRIPTION
Motivated by https://github.com/ClickHouse/ClickHouse/pull/76354#issuecomment-2675946990

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
