### PR TITLE
[WIP] Decoupling buffers. Fixes #40222

### DIFF
--- a/src/Columns/BufferFWD.h
+++ b/src/Columns/BufferFWD.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Core/Defines.h>
+#include <base/types.h>
+#include <Common/Allocator_fwd.h>
+
+namespace DB
+{
+
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right, size_t pad_left>
+class PODArrayOwning;
+
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right_, size_t pad_left_> // NOLINT
+class IBuffer;
+
+template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+using PaddedBuffer = IBuffer<T, initial_bytes, TAllocator, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
+
+template<typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+using OwningBuffer = PODArrayOwning<T, initial_bytes, TAllocator, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
+
+}

--- a/src/Columns/BufferFWD.h
+++ b/src/Columns/BufferFWD.h
@@ -10,6 +10,12 @@ namespace DB
 template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right, size_t pad_left>
 class PODArrayOwning;
 
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right, size_t pad_left>
+class PODArrayView;
+
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right, size_t pad_left>
+class PODArrayLimitView;
+
 template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right_, size_t pad_left_> // NOLINT
 class IBuffer;
 
@@ -18,5 +24,11 @@ using PaddedBuffer = IBuffer<T, initial_bytes, TAllocator, PADDING_FOR_SIMD - 1,
 
 template<typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
 using OwningBuffer = PODArrayOwning<T, initial_bytes, TAllocator, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
+
+template<typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+using ViewBuffer = PODArrayView<T, initial_bytes, TAllocator, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
+
+template<typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+using LimitViewBuffer = PODArrayLimitView<T, initial_bytes, TAllocator, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
 
 }

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -161,6 +161,14 @@ public:
 
     UInt32 getScale() const { return scale; }
 
+    void* doGetContainer() override {
+        return static_cast<void*>(&data);
+    }
+
+    const void* doGetContainer() const override {
+        return static_cast<const void*>(&data);
+    }
+
 protected:
     Container data;
     UInt32 scale;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -161,11 +161,11 @@ public:
 
     UInt32 getScale() const { return scale; }
 
-    void* doGetContainer() override {
+    void * doGetContainer() override {
         return static_cast<void*>(&data);
     }
 
-    const void* doGetContainer() const override {
+    const void * doGetContainer() const override {
         return static_cast<const void*>(&data);
     }
 

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -161,11 +161,13 @@ public:
 
     UInt32 getScale() const { return scale; }
 
-    void * doGetContainer() override {
+    void * doGetContainer() override
+    {
         return static_cast<void*>(&data);
     }
 
-    const void * doGetContainer() const override {
+    const void * doGetContainer() const override
+    {
         return static_cast<const void*>(&data);
     }
 

--- a/src/Columns/ColumnFixedSizeHelper.h
+++ b/src/Columns/ColumnFixedSizeHelper.h
@@ -22,19 +22,20 @@ namespace DB
   * To allow functional tests to work under UBSan we have to separate some base class that will present the memory layout in explicit way,
   *  and we will do static_cast to this class.
   */
-  class ColumnFixedSizeHelper : public IColumn
-  {
-  public:
-      template <size_t ELEMENT_SIZE> // NOLINT
-      const char * getRawDataBegin() const
-      {
-          return IColumn::getContainer<ELEMENT_SIZE>()->raw_data();
-      }
+class ColumnFixedSizeHelper : public IColumn
+{
+public:
+    template <size_t ELEMENT_SIZE> // NOLINT
+    const char * getRawDataBegin() const
+    {
+        return IColumn::getContainer<ELEMENT_SIZE>()->raw_data();
+    }
 
-      template <size_t ELEMENT_SIZE> // NOLINT
-      void insertRawData(const char * ptr)
-      {
-          return IColumn::getContainer<ELEMENT_SIZE>()->push_back_raw(ptr);
-      }
-  };
+    template <size_t ELEMENT_SIZE> // NOLINT
+    void insertRawData(const char * ptr)
+    {
+        return IColumn::getContainer<ELEMENT_SIZE>()->push_back_raw(ptr);
+    }
+};
+
 }

--- a/src/Columns/ColumnFixedSizeHelper.h
+++ b/src/Columns/ColumnFixedSizeHelper.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <Columns/IColumn.h>
-// #include <Common/PODArray.h>
-#include <Columns/IBuffer.h>
+#include <Common/PODArray.h>
 
 
 namespace DB
@@ -23,24 +22,24 @@ namespace DB
   * To allow functional tests to work under UBSan we have to separate some base class that will present the memory layout in explicit way,
   *  and we will do static_cast to this class.
   */
-class ColumnFixedSizeHelper : public IColumn
-{
-public:
-    template <typename T>
-    const char * getRawDataBegin() const
-    {
-        return reinterpret_cast<const IBuffer<T, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
-                   reinterpret_cast<const char *>(this) + sizeof(*this))
-            ->raw_data();
-    }
+  class ColumnFixedSizeHelper : public IColumn
+  {
+  public:
+      template <size_t ELEMENT_SIZE>
+      const char * getRawDataBegin() const
+      {
+          return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
+                     reinterpret_cast<const char *>(this) + sizeof(*this))
+              ->raw_data();
+      }
 
-    template <typename T>
-    void insertRawData(const char * ptr)
-    {
-        return reinterpret_cast<IBuffer<T, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
-                   reinterpret_cast<char *>(this) + sizeof(*this))
-            ->push_back_raw(ptr);
-    }
-};
+      template <size_t ELEMENT_SIZE>
+      void insertRawData(const char * ptr)
+      {
+          return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
+                     reinterpret_cast<char *>(this) + sizeof(*this))
+              ->push_back_raw(ptr);
+      }
+  };
 
 }

--- a/src/Columns/ColumnFixedSizeHelper.h
+++ b/src/Columns/ColumnFixedSizeHelper.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <Columns/IColumn.h>
-#include <Common/PODArray.h>
+// #include <Common/PODArray.h>
+#include <Columns/IBuffer.h>
 
 
 namespace DB
@@ -25,18 +26,18 @@ namespace DB
 class ColumnFixedSizeHelper : public IColumn
 {
 public:
-    template <size_t ELEMENT_SIZE>
+    template <typename T>
     const char * getRawDataBegin() const
     {
-        return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
+        return reinterpret_cast<const IBuffer<T, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
                    reinterpret_cast<const char *>(this) + sizeof(*this))
             ->raw_data();
     }
 
-    template <size_t ELEMENT_SIZE>
+    template <typename T>
     void insertRawData(const char * ptr)
     {
-        return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
+        return reinterpret_cast<IBuffer<T, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
                    reinterpret_cast<char *>(this) + sizeof(*this))
             ->push_back_raw(ptr);
     }

--- a/src/Columns/ColumnFixedSizeHelper.h
+++ b/src/Columns/ColumnFixedSizeHelper.h
@@ -25,21 +25,16 @@ namespace DB
   class ColumnFixedSizeHelper : public IColumn
   {
   public:
-      template <size_t ELEMENT_SIZE>
+      template <size_t ELEMENT_SIZE> // NOLINT
       const char * getRawDataBegin() const
       {
-          return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
-                     reinterpret_cast<const char *>(this) + sizeof(*this))
-              ->raw_data();
+          return IColumn::getContainer<ELEMENT_SIZE>()->raw_data();
       }
 
-      template <size_t ELEMENT_SIZE>
+      template <size_t ELEMENT_SIZE> // NOLINT
       void insertRawData(const char * ptr)
       {
-          return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> *>(
-                     reinterpret_cast<char *>(this) + sizeof(*this))
-              ->push_back_raw(ptr);
+          return IColumn::getContainer<ELEMENT_SIZE>()->push_back_raw(ptr);
       }
   };
-
 }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -49,10 +49,12 @@ private:
     ColumnFixedString(const ColumnFixedString & src) : chars(src.chars.begin(), src.chars.end()), n(src.n) {} /// NOLINT
 
 public:
-    void * doGetContainer() override {
+    void * doGetContainer() override
+    {
         return static_cast<void*>(&chars);
     }
-    const void * doGetContainer() const override {
+    const void * doGetContainer() const override
+    {
         return static_cast<const void*>(&chars);
     }
     std::string getName() const override { return "FixedString(" + std::to_string(n) + ")"; }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -49,6 +49,12 @@ private:
     ColumnFixedString(const ColumnFixedString & src) : chars(src.chars.begin(), src.chars.end()), n(src.n) {} /// NOLINT
 
 public:
+    void* doGetContainer() override {
+        return static_cast<void*>(&chars);
+    }
+    const void* doGetContainer() const override {
+        return static_cast<const void*>(&chars);
+    }
     std::string getName() const override { return "FixedString(" + std::to_string(n) + ")"; }
     const char * getFamilyName() const override { return "FixedString"; }
     TypeIndex getDataType() const override { return TypeIndex::FixedString; }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -49,10 +49,10 @@ private:
     ColumnFixedString(const ColumnFixedString & src) : chars(src.chars.begin(), src.chars.end()), n(src.n) {} /// NOLINT
 
 public:
-    void* doGetContainer() override {
+    void * doGetContainer() override {
         return static_cast<void*>(&chars);
     }
-    const void* doGetContainer() const override {
+    const void * doGetContainer() const override {
         return static_cast<const void*>(&chars);
     }
     std::string getName() const override { return "FixedString(" + std::to_string(n) + ")"; }

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -30,6 +30,7 @@
 #include "Columns/BufferFWD.h"
 
 #include <bit>
+#include <cstdio>
 #include <cstring>
 
 #if defined(__SSE2__)
@@ -538,6 +539,7 @@ void ColumnVector<T>::doInsertRangeFrom(const IColumn & src, size_t start, size_
     // TODO: make method for getting owner reallocated buffer and fix this
 
     size_t old_size = data->size();
+    (void)fprintf(stderr, "SOBAKA %zu", old_size);
     auto mutable_data = std::static_pointer_cast<PaddedBuffer<T>>(data)->getOwningBuffer();
     mutable_data->resize(old_size + length);
     memcpy(mutable_data->data() + old_size, &(*src_vec.data)[start], length * sizeof((*data)[0]));

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -8,7 +8,7 @@
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/MaskOperations.h>
-// #include <Columns/PODArrayOwning.h>
+#include <Columns/PODArrayOwning.h>
 #include <Columns/RadixSortHelper.h>
 #include <IO/WriteHelpers.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
@@ -539,7 +539,7 @@ void ColumnVector<T>::doInsertRangeFrom(const IColumn & src, size_t start, size_
     // TODO: make method for getting owner reallocated buffer and fix this
 
     size_t old_size = data->size();
-    (void)fprintf(stderr, "SOBAKA %zu", old_size);
+    (void)fprintf(stderr, "SOBAKA %zu %zu\n", old_size, length);
     auto mutable_data = std::static_pointer_cast<PaddedBuffer<T>>(data)->getOwningBuffer();
     mutable_data->resize(old_size + length);
     memcpy(mutable_data->data() + old_size, &(*src_vec.data)[start], length * sizeof((*data)[0]));

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -104,7 +104,7 @@ WeakHash32 ColumnVector<T>::getWeakHash32() const
 template <typename T>
 void ColumnVector<T>::updateHashFast(SipHash & hash) const
 {
-    hash.update(reinterpret_cast<const char *>(data->data()), size() * sizeof(data[0]));
+    hash.update(reinterpret_cast<const char *>(data->data()), size() * sizeof((*data)[0]));
 }
 
 template <typename T>

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -539,7 +539,6 @@ void ColumnVector<T>::doInsertRangeFrom(const IColumn & src, size_t start, size_
     // TODO: make method for getting owner reallocated buffer and fix this
 
     size_t old_size = data->size();
-    (void)fprintf(stderr, "SOBAKA %zu %zu\n", old_size, length);
     auto mutable_data = std::static_pointer_cast<PaddedBuffer<T>>(data)->getOwningBuffer();
     mutable_data->resize(old_size + length);
     memcpy(mutable_data->data() + old_size, &(*src_vec.data)[start], length * sizeof((*data)[0]));

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -578,7 +578,7 @@ uint8_t suffixToCopy(UInt64 mask)
 }
 
 DECLARE_DEFAULT_CODE(
-template <typename T, typename Container, size_t SIMD_ELEMENTS>
+template <typename T, typename Container, size_t SIMD_ELEMENTS> // NOLINT
 inline void doFilterAligned(const UInt8 *& filt_pos, const UInt8 *& filt_end_aligned, const T *& data_pos, Container & res_data)
 {
     while (filt_pos < filt_end_aligned)
@@ -628,7 +628,7 @@ void resize(Container & res_data, size_t reserve_size)
 }
 
 DECLARE_AVX512VBMI2_SPECIFIC_CODE(
-template <size_t ELEMENT_WIDTH>
+template <size_t ELEMENT_WIDTH> // NOLINT
 inline void compressStoreAVX512(const void *src, void *dst, const UInt64 mask)
 {
     __m512i vsrc = _mm512_loadu_si512(src);
@@ -642,7 +642,7 @@ inline void compressStoreAVX512(const void *src, void *dst, const UInt64 mask)
         _mm512_mask_compressstoreu_epi64(dst, static_cast<__mmask8>(mask), vsrc);
 }
 
-template <typename T, typename Container, size_t SIMD_ELEMENTS>
+template <typename T, typename Container, size_t SIMD_ELEMENTS> // NOLINT
 inline void doFilterAligned(const UInt8 *& filt_pos, const UInt8 *& filt_end_aligned, const T *& data_pos, Container & res_data)
 {
     static constexpr size_t VEC_LEN = 64;   /// AVX512 vector length - 64 bytes

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -9,10 +9,11 @@
 #include <Columns/ColumnConst.h>
 #include <Columns/MaskOperations.h>
 #include <Columns/PODArrayOwning.h>
+#include <Columns/PODArrayView.h>
 #include <Columns/RadixSortHelper.h>
 #include <IO/WriteHelpers.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
-#include "Common/PODArray_fwd.h"
+#include <Common/PODArray_fwd.h>
 #include <Common/Arena.h>
 #include <Common/Exception.h>
 #include <Common/FieldVisitorToString.h>
@@ -27,7 +28,7 @@
 #include <Common/findExtreme.h>
 #include <Common/iota.h>
 #include <DataTypes/FieldToDataType.h>
-#include "Columns/BufferFWD.h"
+#include <Columns/BufferFWD.h>
 
 #include <bit>
 #include <cstdio>

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -322,6 +322,14 @@ public:
         return (*data)[n];
     }
 
+    void* doGetContainer() override {
+        return static_cast<void*>(&(*data));
+    }
+
+    const void* doGetContainer() const override {
+        return static_cast<const void*>(&data);
+    }
+
 protected:
     Container _;
     std::shared_ptr<Buffer> data;

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -323,15 +323,16 @@ public:
     }
 
     void* doGetContainer() override {
-        return static_cast<void*>(&(*data));
+        assert(data != nullptr && "dies from cringe");
+        data = data->getOwningBuffer();
+        return static_cast<void*>(&(*std::static_pointer_cast<Container>(data)));
     }
 
     const void* doGetContainer() const override {
-        return static_cast<const void*>(&data);
+        return static_cast<const void*>(&(*std::static_pointer_cast<Container>(data)));
     }
 
 protected:
-    Container _;
     std::shared_ptr<Buffer> data;
 };
 

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -322,13 +322,15 @@ public:
         return (*data)[n];
     }
 
-    void * doGetContainer() override {
+    void * doGetContainer() override
+    {
         assert(data != nullptr && "dies from cringe");
         data = data->getOwningBuffer();
         return static_cast<void*>(&(*std::static_pointer_cast<Container>(data)));
     }
 
-    const void * doGetContainer() const override {
+    const void * doGetContainer() const override
+    {
         return static_cast<const void*>(&(*std::static_pointer_cast<Container>(data)));
     }
 

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <memory>
 #include <Columns/ColumnFixedSizeHelper.h>
 #include <Columns/IColumn.h>
 #include <Columns/IColumnImpl.h>
+#include <Columns/IBuffer.h>
 #include <Common/TargetSpecific.h>
 #include <Common/assert_cast.h>
 #include <Core/CompareHelper.h>
@@ -42,17 +44,16 @@ private:
 
 public:
     using ValueType = T;
-    using Container = PaddedPODArray<ValueType>;
+    using Container = PaddedBuffer<ValueType>;
 
 private:
     ColumnVector() = default;
-    explicit ColumnVector(const size_t n) : data(n) {}
-    ColumnVector(const size_t n, const ValueType x) : data(n, x) {}
-    ColumnVector(const ColumnVector & src) : data(src.data.begin(), src.data.end()) {}
-    ColumnVector(Container::const_iterator begin, Container::const_iterator end) : data(begin, end) { }
+    explicit ColumnVector(const size_t n) : data(std::make_shared<OwningBuffer<T>>(n)) {}
+    ColumnVector(const size_t n, const ValueType x) : data(std::make_shared<OwningBuffer<T>>(n, x)) {}
+    ColumnVector(const ColumnVector & src) : data(std::make_shared<OwningBuffer<T>>(src.data.begin(), src.data.end())) {}
 
     /// Sugar constructor.
-    ColumnVector(std::initializer_list<T> il) : data{il} {}
+    ColumnVector(std::initializer_list<T> il) : data{std::make_shared<OwningBuffer<T>>(il)} {}
 
 public:
     bool isNumeric() const override { return is_arithmetic_v<T>; }
@@ -260,7 +261,7 @@ public:
     ColumnPtr index(const IColumn & indexes, size_t limit) const override;
 
     template <typename Type>
-    ColumnPtr indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const;
+    ColumnPtr indexImpl(const PaddedBuffer<Type> & indexes, size_t limit) const;
 
     ColumnPtr replicate(const IColumn::Offsets & offsets) const override;
 
@@ -316,8 +317,153 @@ public:
     }
 
 protected:
-    Container data;
+    std::shared_ptr<Container> data;
 };
+
+DECLARE_DEFAULT_CODE(
+template <typename Container, typename Type>
+inline void vectorIndexImpl(const Container & data, const PaddedBuffer<Type> & indexes, size_t limit, Container & res_data)
+{
+    for (size_t i = 0; i < limit; ++i)
+        res_data[i] = data[indexes[i]];
+}
+);
+
+DECLARE_AVX512VBMI_SPECIFIC_CODE(
+template <typename Container, typename Type>
+inline void vectorIndexImpl(const Container & data, const PaddedBuffer<Type> & indexes, size_t limit, Container & res_data)
+{
+    static constexpr UInt64 MASK64 = 0xffffffffffffffff;
+    const size_t limit64 = limit & ~63;
+    size_t pos = 0;
+    size_t data_size = data.size();
+
+    auto data_pos = reinterpret_cast<const UInt8 *>(data.data());
+    auto indexes_pos = reinterpret_cast<const UInt8 *>(indexes.data());
+    auto res_pos = reinterpret_cast<UInt8 *>(res_data.data());
+
+    if (limit == 0)
+        return;   /// nothing to do, just return
+
+    if (data_size <= 64)
+    {
+        /// one single mask load for table size <= 64
+        __mmask64 last_mask = MASK64 >> (64 - data_size);
+        __m512i table1 = _mm512_maskz_loadu_epi8(last_mask, data_pos);
+
+        /// 64 bytes table lookup using one single permutexvar_epi8
+        while (pos < limit64)
+        {
+            __m512i vidx = _mm512_loadu_epi8(indexes_pos + pos);
+            __m512i out = _mm512_permutexvar_epi8(vidx, table1);
+            _mm512_storeu_epi8(res_pos + pos, out);
+            pos += 64;
+        }
+        /// tail handling
+        if (limit > limit64)
+        {
+            __mmask64 tail_mask = MASK64 >> (limit64 + 64 - limit);
+            __m512i vidx = _mm512_maskz_loadu_epi8(tail_mask, indexes_pos + pos);
+            __m512i out = _mm512_permutexvar_epi8(vidx, table1);
+            _mm512_mask_storeu_epi8(res_pos + pos, tail_mask, out);
+        }
+    }
+    else if (data_size <= 128)
+    {
+        /// table size (64, 128] requires 2 zmm load
+        __mmask64 last_mask = MASK64 >> (128 - data_size);
+        __m512i table1 = _mm512_loadu_epi8(data_pos);
+        __m512i table2 = _mm512_maskz_loadu_epi8(last_mask, data_pos + 64);
+
+        /// 128 bytes table lookup using one single permute2xvar_epi8
+        while (pos < limit64)
+        {
+            __m512i vidx = _mm512_loadu_epi8(indexes_pos + pos);
+            __m512i out = _mm512_permutex2var_epi8(table1, vidx, table2);
+            _mm512_storeu_epi8(res_pos + pos, out);
+            pos += 64;
+        }
+        if (limit > limit64)
+        {
+            __mmask64 tail_mask = MASK64 >> (limit64 + 64 - limit);
+            __m512i vidx = _mm512_maskz_loadu_epi8(tail_mask, indexes_pos + pos);
+            __m512i out = _mm512_permutex2var_epi8(table1, vidx, table2);
+            _mm512_mask_storeu_epi8(res_pos + pos, tail_mask, out);
+        }
+    }
+    else
+    {
+        if (data_size > 256)
+        {
+            /// byte index will not exceed 256 boundary.
+            data_size = 256;
+        }
+
+        __m512i table1 = _mm512_loadu_epi8(data_pos);
+        __m512i table2 = _mm512_loadu_epi8(data_pos + 64);
+        __m512i table3, table4;
+        if (data_size <= 192)
+        {
+            /// only 3 tables need to load if size <= 192
+            __mmask64 last_mask = MASK64 >> (192 - data_size);
+            table3 = _mm512_maskz_loadu_epi8(last_mask, data_pos + 128);
+            table4 = _mm512_setzero_si512();
+        }
+        else
+        {
+            __mmask64 last_mask = MASK64 >> (256 - data_size);
+            table3 = _mm512_loadu_epi8(data_pos + 128);
+            table4 = _mm512_maskz_loadu_epi8(last_mask, data_pos + 192);
+        }
+
+        /// 256 bytes table lookup can use: 2 permute2xvar_epi8 plus 1 blender with MSB
+        while (pos < limit64)
+        {
+            __m512i vidx = _mm512_loadu_epi8(indexes_pos + pos);
+            __m512i tmp1 = _mm512_permutex2var_epi8(table1, vidx, table2);
+            __m512i tmp2 = _mm512_permutex2var_epi8(table3, vidx, table4);
+            __mmask64 msb = _mm512_movepi8_mask(vidx);
+            __m512i out = _mm512_mask_blend_epi8(msb, tmp1, tmp2);
+            _mm512_storeu_epi8(res_pos + pos, out);
+            pos += 64;
+        }
+        if (limit > limit64)
+        {
+            __mmask64 tail_mask = MASK64 >> (limit64 + 64 - limit);
+            __m512i vidx = _mm512_maskz_loadu_epi8(tail_mask, indexes_pos + pos);
+            __m512i tmp1 = _mm512_permutex2var_epi8(table1, vidx, table2);
+            __m512i tmp2 = _mm512_permutex2var_epi8(table3, vidx, table4);
+            __mmask64 msb = _mm512_movepi8_mask(vidx);
+            __m512i out = _mm512_mask_blend_epi8(msb, tmp1, tmp2);
+            _mm512_mask_storeu_epi8(res_pos + pos, tail_mask, out);
+        }
+    }
+}
+);
+
+template <typename T>
+template <typename Type>
+ColumnPtr ColumnVector<T>::indexImpl(const PaddedBuffer<Type> & indexes, size_t limit) const
+{
+    assert(limit <= indexes.size());
+
+    auto res = this->create(limit);
+    typename Self::Container & res_data = res->getData();
+#if USE_MULTITARGET_CODE
+    if constexpr (sizeof(T) == 1 && sizeof(Type) == 1)
+    {
+        /// VBMI optimization only applicable for (U)Int8 types
+        if (isArchSupported(TargetArch::AVX512VBMI))
+        {
+            TargetSpecific::AVX512VBMI::vectorIndexImpl<Container, Type>(data, indexes, limit, res_data);
+            return res;
+        }
+    }
+#endif
+    TargetSpecific::Default::vectorIndexImpl<Container, Type>(data, indexes, limit, res_data);
+
+    return res;
+}
 
 template <class TCol>
 concept is_col_vector = std::is_same_v<TCol, ColumnVector<typename TCol::ValueType>>;

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -55,9 +55,10 @@ private:
     explicit ColumnVector(const size_t n) : data(std::make_shared<OwningBuffer<T>>(n)) {}
     ColumnVector(const size_t n, const ValueType x) : data(std::make_shared<OwningBuffer<T>>(n, x)) {}
     ColumnVector(const ColumnVector & src) : data(std::make_shared<OwningBuffer<T>>(src.data->begin(), src.data->end())) {}
+    ColumnVector(Container::const_iterator begin, Container::const_iterator end) : data(std::make_shared<OwningBuffer<T>>(begin, end)) { }
 
     /// Sugar constructor.
-    ColumnVector(std::initializer_list<T> il) : data{std::make_shared<OwningBuffer<T>>(il)} {}
+    ColumnVector(std::initializer_list<T> il) : data{std::make_shared<OwningBuffer<T>>(std::move(il))} {}
 
 public:
     bool isNumeric() const override { return is_arithmetic_v<T>; }
@@ -325,151 +326,6 @@ protected:
     Container _;
     std::shared_ptr<Buffer> data;
 };
-
-DECLARE_DEFAULT_CODE(
-template <typename Container, typename Type>
-inline void vectorIndexImpl(const Container & data, const PaddedPODArray<Type> & indexes, size_t limit, Container & res_data)
-{
-    for (size_t i = 0; i < limit; ++i)
-        res_data[i] = data[indexes[i]];
-}
-);
-
-DECLARE_AVX512VBMI_SPECIFIC_CODE(
-template <typename Container, typename Type>
-inline void vectorIndexImpl(const Container & data, const PaddedPODArray<Type> & indexes, size_t limit, Container & res_data)
-{
-    static constexpr UInt64 MASK64 = 0xffffffffffffffff;
-    const size_t limit64 = limit & ~63;
-    size_t pos = 0;
-    size_t data_size = data.size();
-
-    auto data_pos = reinterpret_cast<const UInt8 *>(data.data());
-    auto indexes_pos = reinterpret_cast<const UInt8 *>(indexes.data());
-    auto res_pos = reinterpret_cast<UInt8 *>(res_data.data());
-
-    if (limit == 0)
-        return;   /// nothing to do, just return
-
-    if (data_size <= 64)
-    {
-        /// one single mask load for table size <= 64
-        __mmask64 last_mask = MASK64 >> (64 - data_size);
-        __m512i table1 = _mm512_maskz_loadu_epi8(last_mask, data_pos);
-
-        /// 64 bytes table lookup using one single permutexvar_epi8
-        while (pos < limit64)
-        {
-            __m512i vidx = _mm512_loadu_epi8(indexes_pos + pos);
-            __m512i out = _mm512_permutexvar_epi8(vidx, table1);
-            _mm512_storeu_epi8(res_pos + pos, out);
-            pos += 64;
-        }
-        /// tail handling
-        if (limit > limit64)
-        {
-            __mmask64 tail_mask = MASK64 >> (limit64 + 64 - limit);
-            __m512i vidx = _mm512_maskz_loadu_epi8(tail_mask, indexes_pos + pos);
-            __m512i out = _mm512_permutexvar_epi8(vidx, table1);
-            _mm512_mask_storeu_epi8(res_pos + pos, tail_mask, out);
-        }
-    }
-    else if (data_size <= 128)
-    {
-        /// table size (64, 128] requires 2 zmm load
-        __mmask64 last_mask = MASK64 >> (128 - data_size);
-        __m512i table1 = _mm512_loadu_epi8(data_pos);
-        __m512i table2 = _mm512_maskz_loadu_epi8(last_mask, data_pos + 64);
-
-        /// 128 bytes table lookup using one single permute2xvar_epi8
-        while (pos < limit64)
-        {
-            __m512i vidx = _mm512_loadu_epi8(indexes_pos + pos);
-            __m512i out = _mm512_permutex2var_epi8(table1, vidx, table2);
-            _mm512_storeu_epi8(res_pos + pos, out);
-            pos += 64;
-        }
-        if (limit > limit64)
-        {
-            __mmask64 tail_mask = MASK64 >> (limit64 + 64 - limit);
-            __m512i vidx = _mm512_maskz_loadu_epi8(tail_mask, indexes_pos + pos);
-            __m512i out = _mm512_permutex2var_epi8(table1, vidx, table2);
-            _mm512_mask_storeu_epi8(res_pos + pos, tail_mask, out);
-        }
-    }
-    else
-    {
-        if (data_size > 256)
-        {
-            /// byte index will not exceed 256 boundary.
-            data_size = 256;
-        }
-
-        __m512i table1 = _mm512_loadu_epi8(data_pos);
-        __m512i table2 = _mm512_loadu_epi8(data_pos + 64);
-        __m512i table3, table4;
-        if (data_size <= 192)
-        {
-            /// only 3 tables need to load if size <= 192
-            __mmask64 last_mask = MASK64 >> (192 - data_size);
-            table3 = _mm512_maskz_loadu_epi8(last_mask, data_pos + 128);
-            table4 = _mm512_setzero_si512();
-        }
-        else
-        {
-            __mmask64 last_mask = MASK64 >> (256 - data_size);
-            table3 = _mm512_loadu_epi8(data_pos + 128);
-            table4 = _mm512_maskz_loadu_epi8(last_mask, data_pos + 192);
-        }
-
-        /// 256 bytes table lookup can use: 2 permute2xvar_epi8 plus 1 blender with MSB
-        while (pos < limit64)
-        {
-            __m512i vidx = _mm512_loadu_epi8(indexes_pos + pos);
-            __m512i tmp1 = _mm512_permutex2var_epi8(table1, vidx, table2);
-            __m512i tmp2 = _mm512_permutex2var_epi8(table3, vidx, table4);
-            __mmask64 msb = _mm512_movepi8_mask(vidx);
-            __m512i out = _mm512_mask_blend_epi8(msb, tmp1, tmp2);
-            _mm512_storeu_epi8(res_pos + pos, out);
-            pos += 64;
-        }
-        if (limit > limit64)
-        {
-            __mmask64 tail_mask = MASK64 >> (limit64 + 64 - limit);
-            __m512i vidx = _mm512_maskz_loadu_epi8(tail_mask, indexes_pos + pos);
-            __m512i tmp1 = _mm512_permutex2var_epi8(table1, vidx, table2);
-            __m512i tmp2 = _mm512_permutex2var_epi8(table3, vidx, table4);
-            __mmask64 msb = _mm512_movepi8_mask(vidx);
-            __m512i out = _mm512_mask_blend_epi8(msb, tmp1, tmp2);
-            _mm512_mask_storeu_epi8(res_pos + pos, tail_mask, out);
-        }
-    }
-}
-);
-
-template <typename T>
-template <typename Type>
-ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const
-{
-    assert(limit <= indexes.size());
-
-    auto res = this->create(limit);
-    typename Self::Container & res_data = res->getData();
-#if USE_MULTITARGET_CODE
-    if constexpr (sizeof(T) == 1 && sizeof(Type) == 1)
-    {
-        /// VBMI optimization only applicable for (U)Int8 types
-        if (isArchSupported(TargetArch::AVX512VBMI))
-        {
-            TargetSpecific::AVX512VBMI::vectorIndexImpl<Container, Type>((*data), indexes, limit, res_data);
-            return res;
-        }
-    }
-#endif
-    TargetSpecific::Default::vectorIndexImpl<Container, Type>((*data), indexes, limit, res_data);
-
-    return res;
-}
 
 template <class TCol>
 concept is_col_vector = std::is_same_v<TCol, ColumnVector<typename TCol::ValueType>>;

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -5,6 +5,7 @@
 #include <Columns/IColumn.h>
 #include <Columns/IColumnImpl.h>
 #include <Columns/IBuffer.h>
+#include <Columns/PODArrayOwning.h>
 #include "Common/PODArray_fwd.h"
 #include <Common/TargetSpecific.h>
 #include <Common/assert_cast.h>
@@ -14,6 +15,7 @@
 #include <base/TypeName.h>
 #include <base/unaligned.h>
 
+#include "Columns/BufferFWD.h"
 #include "config.h"
 
 class SipHash;
@@ -34,6 +36,7 @@ class ColumnVector final : public COWHelper<IColumnHelper<ColumnVector<T>, Colum
     static_assert(!is_decimal<T>);
 
 private:
+    using Buffer = PaddedBuffer<T>;
     using Self = ColumnVector;
     friend class COWHelper<IColumnHelper<Self, ColumnFixedSizeHelper>, Self>;
 
@@ -51,7 +54,7 @@ private:
     ColumnVector() = default;
     explicit ColumnVector(const size_t n) : data(std::make_shared<OwningBuffer<T>>(n)) {}
     ColumnVector(const size_t n, const ValueType x) : data(std::make_shared<OwningBuffer<T>>(n, x)) {}
-    ColumnVector(const ColumnVector & src) : data(std::make_shared<OwningBuffer<T>>(src.data.begin(), src.data.end())) {}
+    ColumnVector(const ColumnVector & src) : data(std::make_shared<OwningBuffer<T>>(src.data->begin(), src.data->end())) {}
 
     /// Sugar constructor.
     ColumnVector(std::initializer_list<T> il) : data{std::make_shared<OwningBuffer<T>>(il)} {}
@@ -61,7 +64,7 @@ public:
 
     size_t size() const override
     {
-        return data.size();
+        return data->size();
     }
 
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
@@ -70,7 +73,7 @@ public:
     void doInsertFrom(const IColumn & src, size_t n) override
 #endif
     {
-        data.push_back(assert_cast<const Self &>(src).getData()[n]);
+        data->push_back(assert_cast<const Self &>(src).getData()[n]);
     }
 
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
@@ -80,32 +83,32 @@ public:
 #endif
     {
         ValueType v = assert_cast<const Self &>(src).getData()[position];
-        data.resize_fill(data.size() + length, v);
+        data->resize_fill(data->size() + length, v);
     }
 
     void insertMany(const Field & field, size_t length) override
     {
-        data.resize_fill(data.size() + length, static_cast<T>(field.safeGet<T>()));
+        data->resize_fill(data->size() + length, static_cast<T>(field.safeGet<T>()));
     }
 
     void insertData(const char * pos, size_t) override
     {
-        data.emplace_back(unalignedLoad<T>(pos));
+        data->emplace_back(unalignedLoad<T>(pos));
     }
 
     void insertDefault() override
     {
-        data.push_back(T());
+        data->push_back(T());
     }
 
     void insertManyDefaults(size_t length) override
     {
-        data.resize_fill(data.size() + length, T());
+        data->resize_fill(data->size() + length, T());
     }
 
     void popBack(size_t n) override
     {
-        data.resize_assume_reserved(data.size() - n);
+        data->resize_assume_reserved(data->size() - n);
     }
 
     const char * deserializeAndInsertFromArena(const char * pos) override;
@@ -120,33 +123,33 @@ public:
 
     size_t byteSize() const override
     {
-        return data.size() * sizeof(data[0]);
+        return data->size() * sizeof((*data)[0]);
     }
 
     size_t byteSizeAt(size_t) const override
     {
-        return sizeof(data[0]);
+        return sizeof((*data)[0]);
     }
 
     size_t allocatedBytes() const override
     {
-        return data.allocated_bytes();
+        return data->allocated_bytes();
     }
 
     void protect() override
     {
-        data.protect();
+        data->protect();
     }
 
     void insertValue(const T value)
     {
-        data.push_back(value);
+        data->push_back(value);
     }
 
     template <class U>
     constexpr int compareAtOther(size_t n, size_t m, const ColumnVector<U> & rhs, int nan_direction_hint) const
     {
-        return CompareHelper<T, U>::compare(data[n], rhs.data[m], nan_direction_hint);
+        return CompareHelper<T, U>::compare((*data)[n], (*rhs.data)[m], nan_direction_hint);
     }
 
     /// This method implemented in header because it could be possibly devirtualized.
@@ -156,7 +159,7 @@ public:
     int doCompareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override
 #endif
     {
-        return CompareHelper<T>::compare(data[n], assert_cast<const Self &>(rhs_).data[m], nan_direction_hint);
+        return CompareHelper<T>::compare((*data)[n], (*assert_cast<const Self &>(rhs_).data)[m], nan_direction_hint);
     }
 
 #if USE_EMBEDDED_COMPILER
@@ -177,17 +180,17 @@ public:
 
     void reserve(size_t n) override
     {
-        data.reserve_exact(n);
+        data->reserve_exact(n);
     }
 
     size_t capacity() const override
     {
-        return data.capacity();
+        return data->capacity();
     }
 
     void shrinkToFit() override
     {
-        data.shrink_to_fit();
+        data->shrink_to_fit();
     }
 
     const char * getFamilyName() const override { return TypeName<T>.data(); }
@@ -197,8 +200,8 @@ public:
 
     Field operator[](size_t n) const override
     {
-        assert(n < data.size()); /// This assert is more strict than the corresponding assert inside PODArray.
-        return data[n];
+        assert(n < data->size()); /// This assert is more strict than the corresponding assert inside PODArray.
+        return (*data)[n];
     }
 
 
@@ -218,7 +221,7 @@ public:
     UInt64 NO_SANITIZE_UNDEFINED getUInt(size_t n) const override
     {
         if constexpr (is_arithmetic_v<T>)
-            return UInt64(data[n]);
+            return UInt64((*data)[n]);
         else
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get the value of {} as UInt", TypeName<T>);
     }
@@ -227,7 +230,7 @@ public:
     Int64 NO_SANITIZE_UNDEFINED getInt(size_t n) const override
     {
         if constexpr (is_arithmetic_v<T>)
-            return Int64(data[n]);
+            return Int64((*data)[n]);
         else
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get the value of {} as Int", TypeName<T>);
     }
@@ -235,14 +238,14 @@ public:
     bool getBool(size_t n) const override
     {
         if constexpr (is_arithmetic_v<T>)
-            return bool(data[n]);
+            return bool((*data)[n]);
         else
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get the value of {} as bool", TypeName<T>);
     }
 
     void insert(const Field & x) override
     {
-        data.push_back(static_cast<T>(x.safeGet<T>()));
+        data->push_back(static_cast<T>(x.safeGet<T>()));
     }
 
     bool tryInsert(const DB::Field & x) override;
@@ -262,7 +265,7 @@ public:
     ColumnPtr index(const IColumn & indexes, size_t limit) const override;
 
     template <typename Type>
-    ColumnPtr indexImpl(const PaddedBuffer<Type> & indexes, size_t limit) const;
+    ColumnPtr indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const;
 
     ColumnPtr replicate(const IColumn::Offsets & offsets) const override;
 
@@ -274,15 +277,15 @@ public:
 
     std::string_view getRawData() const override
     {
-        return {reinterpret_cast<const char*>(data.data()), byteSize()};
+        return {reinterpret_cast<const char*>(data->data()), byteSize()};
     }
 
     StringRef getDataAt(size_t n) const override
     {
-        return StringRef(reinterpret_cast<const char *>(&data[n]), sizeof(data[n]));
+        return StringRef(reinterpret_cast<const char *>(&(*data)[n]), sizeof((*data)[n]));
     }
 
-    bool isDefaultAt(size_t n) const override { return data[n] == T{}; }
+    bool isDefaultAt(size_t n) const override { return (*data)[n] == T{}; }
 
     bool structureEquals(const IColumn & rhs) const override
     {
@@ -299,31 +302,33 @@ public:
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()
     {
-        return *data;
+        data = data->getOwningBuffer();
+        return *std::static_pointer_cast<Container>(data);
     }
 
     const Container & getData() const
     {
-        return *data;
+        return *std::static_pointer_cast<Container>(data);
     }
 
     const T & getElement(size_t n) const
     {
-        return data[n];
+        return (*data)[n];
     }
 
     T & getElement(size_t n)
     {
-        return data[n];
+        return (*data)[n];
     }
 
 protected:
-    std::shared_ptr<Container> data;
+    Container _;
+    std::shared_ptr<Buffer> data;
 };
 
 DECLARE_DEFAULT_CODE(
 template <typename Container, typename Type>
-inline void vectorIndexImpl(const Container & data, const PaddedBuffer<Type> & indexes, size_t limit, Container & res_data)
+inline void vectorIndexImpl(const Container & data, const PaddedPODArray<Type> & indexes, size_t limit, Container & res_data)
 {
     for (size_t i = 0; i < limit; ++i)
         res_data[i] = data[indexes[i]];
@@ -332,7 +337,7 @@ inline void vectorIndexImpl(const Container & data, const PaddedBuffer<Type> & i
 
 DECLARE_AVX512VBMI_SPECIFIC_CODE(
 template <typename Container, typename Type>
-inline void vectorIndexImpl(const Container & data, const PaddedBuffer<Type> & indexes, size_t limit, Container & res_data)
+inline void vectorIndexImpl(const Container & data, const PaddedPODArray<Type> & indexes, size_t limit, Container & res_data)
 {
     static constexpr UInt64 MASK64 = 0xffffffffffffffff;
     const size_t limit64 = limit & ~63;
@@ -444,7 +449,7 @@ inline void vectorIndexImpl(const Container & data, const PaddedBuffer<Type> & i
 
 template <typename T>
 template <typename Type>
-ColumnPtr ColumnVector<T>::indexImpl(const PaddedBuffer<Type> & indexes, size_t limit) const
+ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const
 {
     assert(limit <= indexes.size());
 
@@ -456,12 +461,12 @@ ColumnPtr ColumnVector<T>::indexImpl(const PaddedBuffer<Type> & indexes, size_t 
         /// VBMI optimization only applicable for (U)Int8 types
         if (isArchSupported(TargetArch::AVX512VBMI))
         {
-            TargetSpecific::AVX512VBMI::vectorIndexImpl<Container, Type>(data, indexes, limit, res_data);
+            TargetSpecific::AVX512VBMI::vectorIndexImpl<Container, Type>((*data), indexes, limit, res_data);
             return res;
         }
     }
 #endif
-    TargetSpecific::Default::vectorIndexImpl<Container, Type>(data, indexes, limit, res_data);
+    TargetSpecific::Default::vectorIndexImpl<Container, Type>((*data), indexes, limit, res_data);
 
     return res;
 }

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -5,6 +5,7 @@
 #include <Columns/IColumn.h>
 #include <Columns/IColumnImpl.h>
 #include <Columns/IBuffer.h>
+#include "Common/PODArray_fwd.h"
 #include <Common/TargetSpecific.h>
 #include <Common/assert_cast.h>
 #include <Core/CompareHelper.h>
@@ -44,7 +45,7 @@ private:
 
 public:
     using ValueType = T;
-    using Container = PaddedBuffer<ValueType>;
+    using Container = PaddedPODArray<ValueType>;
 
 private:
     ColumnVector() = default;
@@ -298,12 +299,12 @@ public:
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()
     {
-        return data;
+        return *data;
     }
 
     const Container & getData() const
     {
-        return data;
+        return *data;
     }
 
     const T & getElement(size_t n) const

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -51,7 +51,7 @@ public:
     using Container = PaddedPODArray<ValueType>;
 
 private:
-    ColumnVector() = default;
+    ColumnVector() :data(std::make_shared<OwningBuffer<T>>()) {}
     explicit ColumnVector(const size_t n) : data(std::make_shared<OwningBuffer<T>>(n)) {}
     ColumnVector(const size_t n, const ValueType x) : data(std::make_shared<OwningBuffer<T>>(n, x)) {}
     ColumnVector(const ColumnVector & src) : data(std::make_shared<OwningBuffer<T>>(src.data->begin(), src.data->end())) {}

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -322,13 +322,13 @@ public:
         return (*data)[n];
     }
 
-    void* doGetContainer() override {
+    void * doGetContainer() override {
         assert(data != nullptr && "dies from cringe");
         data = data->getOwningBuffer();
         return static_cast<void*>(&(*std::static_pointer_cast<Container>(data)));
     }
 
-    const void* doGetContainer() const override {
+    const void * doGetContainer() const override {
         return static_cast<const void*>(&(*std::static_pointer_cast<Container>(data)));
     }
 

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -74,6 +74,7 @@ public:
     void doInsertFrom(const IColumn & src, size_t n) override
 #endif
     {
+        data = data->getOwningBuffer();
         data->push_back(assert_cast<const Self &>(src).getData()[n]);
     }
 
@@ -83,32 +84,38 @@ public:
     void doInsertManyFrom(const IColumn & src, size_t position, size_t length) override
 #endif
     {
+        data = data->getOwningBuffer();
         ValueType v = assert_cast<const Self &>(src).getData()[position];
         data->resize_fill(data->size() + length, v);
     }
 
     void insertMany(const Field & field, size_t length) override
     {
+        data = data->getOwningBuffer();
         data->resize_fill(data->size() + length, static_cast<T>(field.safeGet<T>()));
     }
 
     void insertData(const char * pos, size_t) override
     {
+        data = data->getOwningBuffer();
         data->emplace_back(unalignedLoad<T>(pos));
     }
 
     void insertDefault() override
     {
+        data = data->getOwningBuffer();
         data->push_back(T());
     }
 
     void insertManyDefaults(size_t length) override
     {
+        data = data->getOwningBuffer();
         data->resize_fill(data->size() + length, T());
     }
 
     void popBack(size_t n) override
     {
+        data = data->getOwningBuffer();
         data->resize_assume_reserved(data->size() - n);
     }
 
@@ -144,6 +151,7 @@ public:
 
     void insertValue(const T value)
     {
+        data = data->getOwningBuffer();
         data->push_back(value);
     }
 
@@ -181,6 +189,7 @@ public:
 
     void reserve(size_t n) override
     {
+        data = data->getOwningBuffer();
         data->reserve_exact(n);
     }
 
@@ -191,6 +200,7 @@ public:
 
     void shrinkToFit() override
     {
+        data = data->getOwningBuffer();
         data->shrink_to_fit();
     }
 
@@ -324,7 +334,7 @@ public:
 
     void * doGetContainer() override
     {
-        assert(data != nullptr && "dies from cringe");
+        assert(data != nullptr);
         data = data->getOwningBuffer();
         return static_cast<void*>(&(*std::static_pointer_cast<Container>(data)));
     }

--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -1,5 +1,7 @@
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
+#include "Columns/IColumn.h"
+#include "Storages/StorageReplicatedMergeTree.h"
 #include <Columns/FilterDescription.h>
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnsNumber.h>

--- a/src/Columns/IBuffer.cpp
+++ b/src/Columns/IBuffer.cpp
@@ -37,6 +37,4 @@ ALWAYS_INLINE size_t minimum_memory_for_elements(size_t num_elements, size_t ele
 
 }
 
-const char empty_owning_buffer[empty_owning_buffer_size]{};
-
 }

--- a/src/Columns/IBuffer.cpp
+++ b/src/Columns/IBuffer.cpp
@@ -1,0 +1,47 @@
+#include "IBuffer.h"
+
+namespace DB
+{
+    namespace ErrorCodes
+{
+    extern const int CANNOT_MPROTECT;
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
+
+namespace BufferDetails
+{
+
+#ifndef NDEBUG
+void protectMemoryRegion(void * addr, size_t len, int prot)
+{
+    if (0 != mprotect(addr, len, prot))
+        throw ErrnoException(ErrorCodes::CANNOT_MPROTECT, "Cannot mprotect memory region");
+}
+#endif
+
+ALWAYS_INLINE size_t byte_size(size_t num_elements, size_t element_size)
+{
+    size_t amount;
+    if (__builtin_mul_overflow(num_elements, element_size, &amount))
+        throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Amount of memory requested to allocate is more than allowed");
+    return amount;
+}
+
+ALWAYS_INLINE size_t minimum_memory_for_elements(size_t num_elements, size_t element_size, size_t pad_left, size_t pad_right)
+{
+    size_t amount;
+    if (__builtin_add_overflow(byte_size(num_elements, element_size), pad_left + pad_right, &amount))
+        throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Amount of memory requested to allocate is more than allowed");
+    return amount;
+}
+
+}
+
+constexpr size_t integerRoundUp(size_t value, size_t dividend)
+{
+    return ((value + dividend - 1) / dividend) * dividend;
+}
+
+const char empty_pod_array[empty_pod_array_size]{};
+
+}

--- a/src/Columns/IBuffer.cpp
+++ b/src/Columns/IBuffer.cpp
@@ -37,6 +37,6 @@ ALWAYS_INLINE size_t minimum_memory_for_elements(size_t num_elements, size_t ele
 
 }
 
-const char empty_buffer[empty_buffer_size]{};
+const char empty_owning_buffer[empty_owning_buffer_size]{};
 
 }

--- a/src/Columns/IBuffer.cpp
+++ b/src/Columns/IBuffer.cpp
@@ -37,11 +37,6 @@ ALWAYS_INLINE size_t minimum_memory_for_elements(size_t num_elements, size_t ele
 
 }
 
-constexpr size_t integerRoundUp(size_t value, size_t dividend)
-{
-    return ((value + dividend - 1) / dividend) * dividend;
-}
-
-const char empty_pod_array[empty_pod_array_size]{};
+const char empty_buffer[empty_buffer_size]{};
 
 }

--- a/src/Columns/IBuffer.h
+++ b/src/Columns/IBuffer.h
@@ -1,0 +1,24 @@
+#include <cstddef>
+
+namespace DB 
+{
+
+template <size_t element_size, typename TAllocator, size_t pad_right, size_t pad_left>
+class IBuffer : private TAllocator
+{
+public:
+    char* data = nullptr;
+    size_t size = 0;
+
+    virtual ~IBuffer() = default;
+    IBuffer() = default;
+    IBuffer(const IBuffer &) = delete;
+
+    virtual void allocForNumElements(size_t num_elements);
+    virtual void alloc(size_t bytes);
+    virtual void realloc(size_t bytes);
+    virtual void dealloc();
+
+};
+
+}

--- a/src/Columns/IBuffer.h
+++ b/src/Columns/IBuffer.h
@@ -1,24 +1,171 @@
 #include <cstddef>
+#include <memory>
+
+#include <Common/Allocator.h>
+#include <Common/Exception.h>
+
+#ifndef NDEBUG
+#include <sys/mman.h>
+#endif
 
 namespace DB 
 {
 
-template <size_t element_size, typename TAllocator, size_t pad_right, size_t pad_left>
+static constexpr size_t empty_pod_array_size = 1024;
+extern const char empty_pod_array[empty_pod_array_size];
+constexpr size_t integerRoundUp(size_t value, size_t dividend);
+
+namespace BufferDetails
+{
+
+void protectMemoryRegion(void * addr, size_t len, int prot);
+
+/// The amount of memory occupied by the num_elements of the elements.
+size_t byte_size(size_t num_elements, size_t element_size); /// NOLINT
+
+/// Minimum amount of memory to allocate for num_elements, including padding.
+size_t minimum_memory_for_elements(size_t num_elements, size_t element_size, size_t pad_left, size_t pad_right); /// NOLINT
+
+};
+
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right_, size_t pad_left_> // NOLINT
 class IBuffer : private TAllocator
 {
+protected:
+    static constexpr size_t element_size = sizeof(T);
+    /// Round padding up to an whole number of elements to simplify arithmetic.
+    static constexpr size_t pad_right = integerRoundUp(pad_right_, element_size);
+    /// pad_left is also rounded up to 16 bytes to maintain alignment of allocated memory.
+    static constexpr size_t pad_left = integerRoundUp(integerRoundUp(pad_left_, element_size), 16);
+    /// Empty array will point to this static memory as padding and begin/end.
+    static constexpr char * null = const_cast<char *>(empty_pod_array) + pad_left;
+
+    static_assert(pad_left <= empty_pod_array_size && "Left Padding exceeds empty_pod_array_size. Is the element size too large?");
+
+    // If we are using allocator with inline memory, the minimal size of
+    // array must be in sync with the size of this memory.
+    static_assert(allocatorInitialBytes<TAllocator> == 0
+                  || allocatorInitialBytes<TAllocator> == initial_bytes);
+
+    char * c_start          = null;    /// Does not include pad_left.
+    char * c_end            = null;
+    char * c_end_of_storage = null;    /// Does not include pad_right.
+
+    T * t_start()                      { return reinterpret_cast<T *>(this->c_start); } /// NOLINT
+    T * t_end()                        { return reinterpret_cast<T *>(this->c_end); } /// NOLINT
+
+    const T * t_start() const          { return reinterpret_cast<const T *>(this->c_start); } /// NOLINT
+    const T * t_end() const            { return reinterpret_cast<const T *>(this->c_end); } /// NOLINT
+
+    virtual void allocForNumElements(size_t num_elements);
+    virtual void realloc(size_t bytes);
+    virtual void dealloc();
+    virtual void alloc(size_t bytes);
+
+    bool isInitialized() const
+    {
+        return (c_start != null) && (c_end != null) && (c_end_of_storage != null);
+    }
+
+    bool isAllocatedFromStack() const
+    {
+        static constexpr size_t stack_threshold = TAllocator::getStackThreshold();
+        return (stack_threshold > 0) && (allocated_bytes() <= stack_threshold);
+    }
+
 public:
-    char* data = nullptr;
-    size_t size = 0;
+    using value_type = T;
+    using iterator = T *;
+    using const_iterator = const T *;
+    class PODArrayOwning;
 
     virtual ~IBuffer() = default;
     IBuffer() = default;
     IBuffer(const IBuffer &) = delete;
 
-    virtual void allocForNumElements(size_t num_elements);
-    virtual void alloc(size_t bytes);
-    virtual void realloc(size_t bytes);
-    virtual void dealloc();
+    T & front()             { return t_start()[0]; }
+    T & back()              { return t_end()[-1]; }
+    const T & front() const { return t_start()[0]; }
+    const T & back() const  { return t_end()[-1]; }
 
+    iterator begin()              { return t_start(); }
+    iterator end()                { return t_end(); }
+    const_iterator begin() const  { return t_start(); }
+    const_iterator end() const    { return t_end(); }
+    const_iterator cbegin() const { return t_start(); }
+    const_iterator cend() const   { return t_end(); }
+
+    T * data() { return t_start(); }
+    const T * data() const { return t_start(); }
+
+    /// The index is signed to access -1th element without pointer overflow.
+    T & operator[] (ssize_t n)
+    {
+        /// <= size, because taking address of one element past memory range is Ok in C++ (expression like &arr[arr.size()] is perfectly valid).
+        assert((n >= (static_cast<ssize_t>(pad_left) ? -1 : 0)) && (n <= static_cast<ssize_t>(this->size())));
+        return t_start()[n];
+    }
+
+    const T & operator[] (ssize_t n) const
+    {
+        assert((n >= (static_cast<ssize_t>(pad_left) ? -1 : 0)) && (n <= static_cast<ssize_t>(this->size())));
+        return t_start()[n];
+    }
+
+    bool empty() const { return c_end == c_start; }
+    size_t size() const { return (c_end - c_start) / element_size; }
+    size_t capacity() const { return (c_end_of_storage - c_start) / element_size; }
+
+    /// This method is safe to use only for information about memory usage.
+    size_t allocated_bytes() const { return c_end_of_storage - c_start + pad_right + pad_left; } /// NOLINT
+
+    void clear() { c_end = c_start; }
+
+    ALWAYS_INLINE /// Better performance in clang build, worse performance in gcc build.
+    virtual void reserve(size_t n);
+    virtual void reserve_exact(size_t n);
+    virtual void resize(size_t n);
+    virtual void resize_exact(size_t n);
+    virtual void resize_fill(size_t n);
+    virtual void resize_fill(size_t n, const T & value);
+    virtual void shrink_to_fit();
+
+    virtual PODArrayOwning* getOwningBuffer();
+
+    void resize_assume_reserved(const size_t n)
+    {
+        c_end = c_start + BufferDetails::byte_size(n, element_size);
+    }
+
+    const char * rawData() const
+    {
+        return c_start;
+    }
+
+    bool operator== (const IBuffer & rhs) const
+    {
+        if (this->size() != rhs.size())
+            return false;
+
+        const_iterator lhs_it = begin();
+        const_iterator rhs_it = rhs.begin();
+
+        while (lhs_it != end())
+        {
+            if (*lhs_it != *rhs_it)
+                return false;
+
+            ++lhs_it;
+            ++rhs_it;
+        }
+
+        return true;
+    }
+
+    bool operator!= (const IBuffer & rhs) const
+    {
+        return !operator==(rhs);
+    }
 };
 
 }

--- a/src/Columns/IBuffer.h
+++ b/src/Columns/IBuffer.h
@@ -121,7 +121,7 @@ public:
 
     void clear() { PODBase::clear(); }
 
-    virtual std::shared_ptr<PODArrayOwning<T, initial_bytes, TAllocator, pad_right_, pad_left_>> getOwningBuffer();
+    virtual std::shared_ptr<PODArrayOwning<T, initial_bytes, TAllocator, pad_right_, pad_left_>> getOwningBuffer() = 0;
 
     void resize_assume_reserved(const size_t n) /// NOLINT
     {

--- a/src/Columns/IBuffer.h
+++ b/src/Columns/IBuffer.h
@@ -16,8 +16,6 @@
 namespace DB
 {
 
-static constexpr size_t empty_owning_buffer_size = 1024;
-extern const char empty_owning_buffer[empty_owning_buffer_size];
 // constexpr size_t integerRoundUp(size_t value, size_t dividend);
 
 namespace BufferDetails
@@ -43,10 +41,6 @@ protected:
     static constexpr size_t pad_right = integerRoundUp(pad_right_, element_size);
     /// pad_left is also rounded up to 16 bytes to maintain alignment of allocated memory.
     static constexpr size_t pad_left = integerRoundUp(integerRoundUp(pad_left_, element_size), 16);
-    /// Empty array will point to this static memory as padding and begin/end.
-    static constexpr char * null = const_cast<char *>(empty_owning_buffer) + pad_left;
-
-    // static_assert(pad_left <= empty_pod_array_size && "Left Padding exceeds empty_pod_array_size. Is the element size too large?");
 
     // If we are using allocator with inline memory, the minimal size of
     // array must be in sync with the size of this memory.
@@ -59,10 +53,10 @@ protected:
     const T * t_start() const          { return reinterpret_cast<const T *>(this->c_start); } /// NOLINT
     const T * t_end() const            { return reinterpret_cast<const T *>(this->c_end); } /// NOLINT
 
-    virtual void alloc_for_num_elements(size_t num_elements);
-    virtual void realloc(size_t bytes);
-    virtual void dealloc();
-    virtual void alloc(size_t bytes);
+    virtual void alloc_for_num_elements(size_t) {}
+    virtual void realloc(size_t) {}
+    virtual void dealloc() {}
+    virtual void alloc(size_t) {}
 
     bool isInitialized() const
     {

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <cstddef>
 #include <Columns/IColumn_fwd.h>
 #include <Core/TypeId.h>
 #include <base/StringRef.h>
+#include <Common/PODArray.h>
 #include <Common/COW.h>
 #include <Common/Exception.h>
 #include <Common/PODArray_fwd.h>
@@ -252,6 +254,16 @@ public:
     {
         for (size_t i = 0; i < length; ++i)
             insertDefault();
+    }
+
+    template <size_t ELEMENT_SIZE> // NOLINT
+    PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>* getContainer() {
+        return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>*>(doGetContainer());
+    }
+
+    template <size_t ELEMENT_SIZE> // NOLINT
+    const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>* getContainer() const {
+        return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>*>(doGetContainer());
     }
 
     /** Removes last n elements.
@@ -690,6 +702,9 @@ protected:
         Equals equals,
         Sort full_sort,
         PartialSort partial_sort) const;
+
+    virtual void* doGetContainer() { return nullptr;}
+    virtual const void* doGetContainer() const { return nullptr;}
 
 #if defined(DEBUG_OR_SANITIZER_BUILD)
     virtual void doInsertFrom(const IColumn & src, size_t n);

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -257,12 +257,12 @@ public:
     }
 
     template <size_t ELEMENT_SIZE> // NOLINT
-    PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>* getContainer() {
+    PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> * getContainer() {
         return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>*>(doGetContainer());
     }
 
     template <size_t ELEMENT_SIZE> // NOLINT
-    const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>* getContainer() const {
+    const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> * getContainer() const {
         return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>*>(doGetContainer());
     }
 
@@ -703,8 +703,8 @@ protected:
         Sort full_sort,
         PartialSort partial_sort) const;
 
-    virtual void* doGetContainer() { return nullptr;}
-    virtual const void* doGetContainer() const { return nullptr;}
+    virtual void * doGetContainer() { return nullptr;}
+    virtual const void * doGetContainer() const { return nullptr;}
 
 #if defined(DEBUG_OR_SANITIZER_BUILD)
     virtual void doInsertFrom(const IColumn & src, size_t n);

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -257,12 +257,14 @@ public:
     }
 
     template <size_t ELEMENT_SIZE> // NOLINT
-    PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> * getContainer() {
+    PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> * getContainer()
+    {
         return reinterpret_cast<PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>*>(doGetContainer());
     }
 
     template <size_t ELEMENT_SIZE> // NOLINT
-    const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> * getContainer() const {
+    const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD> * getContainer() const
+    {
         return reinterpret_cast<const PODArrayBase<ELEMENT_SIZE, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>*>(doGetContainer());
     }
 

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -283,7 +283,14 @@ public:
     /// If `is_null` is not nullptr, also take null bit into account.
     /// This is currently used to facilitate the allocation of memory for an entire continuous row
     /// in a single step. For more details, refer to the HashMethodSerialized implementation.
+<<<<<<< HEAD
     virtual void collectSerializedValueSizes(PaddedPODArray<UInt64> & /* sizes */, const UInt8 * /* is_null */) const;
+=======
+    virtual void collectSerializedValueSizes(PaddedPODArray<UInt64> & /* sizes */, const UInt8 * /* is_null */) const
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method collectSerializedValueSizes is not supported for {}", getName());
+    }
+>>>>>>> f934adb4f25 (probably working)
 
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.
     /// Returns pointer to the position after the read data.
@@ -312,7 +319,11 @@ public:
       * if 0, then don't makes reserve(),
       * otherwise (i.e. < 0), makes reserve() using size of source column.
       */
+<<<<<<< HEAD
     using Filter = IColumnFilter;
+=======
+    using Filter = PaddedPODArray<UInt8>;
+>>>>>>> f934adb4f25 (probably working)
     [[nodiscard]] virtual Ptr filter(const Filter & filt, ssize_t result_size_hint) const = 0;
 
     /** Expand column by mask inplace. After expanding column will
@@ -325,7 +336,11 @@ public:
 
     /// Permutes elements using specified permutation. Is used in sorting.
     /// limit - if it isn't 0, puts only first limit elements in the result.
+<<<<<<< HEAD
     using Permutation = IColumnPermutation;
+=======
+    using Permutation = PaddedPODArray<size_t>;
+>>>>>>> f934adb4f25 (probably working)
     [[nodiscard]] virtual Ptr permute(const Permutation & perm, size_t limit) const = 0;
 
     /// Creates new column with values column[indexes[:limit]]. If limit is 0, all indexes are used.
@@ -371,7 +386,7 @@ public:
     /// row_indexes (if not ignored) will contain row numbers for which compare result is 0
     /// see compareImpl for default implementation.
     virtual void compareColumn(const IColumn & rhs, size_t rhs_row_num,
-                               PaddedBuffer<UInt64> * row_indexes, PaddedBuffer<Int8> & compare_results,
+                               PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results,
                                int direction, int nan_direction_hint) const = 0;
 
     /// Check if all elements in the column have equal values. Return true if column is empty.
@@ -438,7 +453,7 @@ public:
       * It is necessary in ARRAY JOIN operation.
       */
     using Offset = UInt64;
-    using Offsets = std::shared_ptr<PaddedBuffer<Offset>>;
+    using Offsets = PaddedPODArray<Offset>;
     [[nodiscard]] virtual Ptr replicate(const Offsets & offsets) const = 0;
 
     /** Split column to smaller columns. Each value goes to column index, selected by corresponding element of 'selector'.
@@ -446,7 +461,7 @@ public:
       * For default implementation, see scatterImpl.
       */
     using ColumnIndex = UInt64;
-    using Selector = std::shared_ptr<PaddedBuffer<ColumnIndex>>;
+    using Selector = PaddedPODArray<ColumnIndex>;
     [[nodiscard]] virtual std::vector<MutablePtr> scatter(ColumnIndex num_columns, const Selector & selector) const = 0;
 
     /// Insert data from several other columns according to source mask (used in vertical merge).
@@ -794,8 +809,8 @@ private:
     void compareColumn(
         const IColumn & rhs_base,
         size_t rhs_row_num,
-        PaddedBuffer<UInt64> * row_indexes,
-        PaddedBuffer<Int8> & compare_results,
+        PaddedPODArray<UInt64> * row_indexes,
+        PaddedPODArray<Int8> & compare_results,
         int direction,
         int nan_direction_hint) const override;
 
@@ -812,7 +827,7 @@ private:
     void getIndicesOfNonDefaultRows(IColumn::Offsets & indices, size_t from, size_t limit) const override;
 
     /// Devirtualize byteSizeAt.
-    void collectSerializedValueSizes(PaddedBuffer<UInt64> & sizes, const UInt8 * is_null) const override;
+    void collectSerializedValueSizes(PaddedPODArray<UInt64> & sizes, const UInt8 * is_null) const override;
 
     /// Fills column values from RowRefList
     /// If row_refs_are_ranges is true, then each RowRefList has one element with >=1 consecutive rows

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -283,14 +283,7 @@ public:
     /// If `is_null` is not nullptr, also take null bit into account.
     /// This is currently used to facilitate the allocation of memory for an entire continuous row
     /// in a single step. For more details, refer to the HashMethodSerialized implementation.
-<<<<<<< HEAD
     virtual void collectSerializedValueSizes(PaddedPODArray<UInt64> & /* sizes */, const UInt8 * /* is_null */) const;
-=======
-    virtual void collectSerializedValueSizes(PaddedPODArray<UInt64> & /* sizes */, const UInt8 * /* is_null */) const
-    {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method collectSerializedValueSizes is not supported for {}", getName());
-    }
->>>>>>> f934adb4f25 (probably working)
 
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.
     /// Returns pointer to the position after the read data.
@@ -319,11 +312,7 @@ public:
       * if 0, then don't makes reserve(),
       * otherwise (i.e. < 0), makes reserve() using size of source column.
       */
-<<<<<<< HEAD
     using Filter = IColumnFilter;
-=======
-    using Filter = PaddedPODArray<UInt8>;
->>>>>>> f934adb4f25 (probably working)
     [[nodiscard]] virtual Ptr filter(const Filter & filt, ssize_t result_size_hint) const = 0;
 
     /** Expand column by mask inplace. After expanding column will
@@ -336,11 +325,7 @@ public:
 
     /// Permutes elements using specified permutation. Is used in sorting.
     /// limit - if it isn't 0, puts only first limit elements in the result.
-<<<<<<< HEAD
     using Permutation = IColumnPermutation;
-=======
-    using Permutation = PaddedPODArray<size_t>;
->>>>>>> f934adb4f25 (probably working)
     [[nodiscard]] virtual Ptr permute(const Permutation & perm, size_t limit) const = 0;
 
     /// Creates new column with values column[indexes[:limit]]. If limit is 0, all indexes are used.

--- a/src/Columns/IColumnImpl.h
+++ b/src/Columns/IColumnImpl.h
@@ -9,7 +9,9 @@
 #include <algorithm>
 #include <Columns/IColumn.h>
 #include <base/sort.h>
-#include <Common/PODArray.h>
+// #include <Common/PODArray.h>
+#include <Columns/IBuffer.h>
+#include <Columns/PODArrayOwning.h>
 #include <Common/iota.h>
 
 
@@ -100,7 +102,7 @@ using ComparatorEqualImpl = ComparatorEqualHelperImpl<ComparatorBase>;
 template <typename Compare, typename Sort, typename PartialSort>
 void IColumn::getPermutationImpl(
     size_t limit,
-    Permutation & res,
+    Permutation & result,
     Compare compare,
     Sort full_sort,
     PartialSort partial_sort) const
@@ -110,26 +112,29 @@ void IColumn::getPermutationImpl(
     if (data_size == 0)
         return;
 
-    res.resize(data_size);
+    auto res = result->getOwningBuffer();
+    res->resize(data_size);
 
     if (limit >= data_size)
         limit = 0;
 
-    iota(res.data(), data_size, Permutation::value_type(0));
+    iota(res->data(), data_size, Permutation::element_type::value_type(0));
 
     if (limit)
     {
-        partial_sort(res.begin(), res.begin() + limit, res.end(), compare);
+        partial_sort(res->begin(), res->begin() + limit, res->end(), compare);
         return;
     }
 
-    full_sort(res.begin(), res.end(), compare);
+    full_sort(res->begin(), res->end(), compare);
+
+    result = res;
 }
 
 template <typename Compare, typename Equals, typename Sort, typename PartialSort>
 void IColumn::updatePermutationImpl(
     size_t limit,
-    Permutation & res,
+    Permutation & result,
     EqualRanges & equal_ranges,
     Compare compare,
     Equals equals,
@@ -148,10 +153,11 @@ void IColumn::updatePermutationImpl(
     if (limit)
         --number_of_ranges;
 
+    auto res = result->getOwningBuffer();
     for (size_t i = 0; i < number_of_ranges; ++i)
     {
         const auto & [first, last] = equal_ranges[i];
-        full_sort(res.begin() + first, res.begin() + last, compare);
+        full_sort(res->begin() + first, res->begin() + last, compare);
 
         size_t new_first = first;
         for (size_t j = first + 1; j < last; ++j)
@@ -180,7 +186,7 @@ void IColumn::updatePermutationImpl(
         }
 
         /// Since then we are working inside the interval.
-        partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last, compare);
+        partial_sort(res->begin() + first, res->begin() + limit, res->begin() + last, compare);
 
         size_t new_first = first;
         for (size_t j = first + 1; j < limit; ++j)
@@ -208,6 +214,7 @@ void IColumn::updatePermutationImpl(
     }
 
     equal_ranges = std::move(new_ranges);
+    result = res;
 }
 
 }

--- a/src/Columns/MaskOperations.cpp
+++ b/src/Columns/MaskOperations.cpp
@@ -189,7 +189,8 @@ static MaskInfo extractMaskImpl(
 
     if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&*column))
     {
-        const PaddedPODArray<UInt8> & null_map = nullable_column->getNullMapData();
+        const auto & null_map = nullable_column->getNullMapData();
+        // const PaddedPODArray<UInt8> & null_map = nullable_column->getNullMapData();
         return extractMaskImpl<inverted>(mask, nullable_column->getNestedColumnPtr(), null_value, &null_map, nulls);
     }
 

--- a/src/Columns/PODArrayLimitView.h
+++ b/src/Columns/PODArrayLimitView.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+#include <memory>
+#include "Columns/BufferFWD.h"
+#include "IBuffer.h"
+
+#include <IO/BufferWithOwnMemory.h>
+
+namespace DB
+{
+
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right_, size_t pad_left_> // NOLINT
+class PODArrayLimitView : public IBuffer<T, initial_bytes, TAllocator, pad_right_, pad_left_>
+{
+protected:
+    using Base = IBuffer<T, initial_bytes, TAllocator, pad_right_, pad_left_>;
+    static constexpr size_t ELEMENT_SIZE = sizeof(T);
+public:
+    using value_type = T;
+    using iterator = T *;
+    using const_iterator = const T *;
+private:
+    std::shared_ptr<PaddedBuffer<T>> memory_ptr; // points to memory to prolong its lifetime
+
+public:
+    // The duty to guarantee left padding is on code writer
+    PODArrayLimitView(std::shared_ptr<PaddedBuffer<T>> memory, size_t start, size_t length) : memory_ptr(std::move(memory)) {
+        Base::c_start = reinterpret_cast<char *>(memory_ptr->begin()) + start * ELEMENT_SIZE;
+        Base::c_end = Base::c_start + length * ELEMENT_SIZE;
+        Base::c_end_of_storage = Base::c_end;
+        (void)printf("Done cut, length: %zu, current size: %zu\n", length, this->size());
+    }
+
+    ~PODArrayLimitView() override {
+        Base::c_start = Base::null;
+        Base::c_end = Base::null;
+        Base::c_end_of_storage = Base::null;
+    }
+
+    std::shared_ptr<PODArrayOwning<T, initial_bytes, TAllocator, pad_right_, pad_left_>> getOwningBuffer() final {
+        auto owning_buffer = std::make_shared<PODArrayOwning<T, initial_bytes, TAllocator, pad_right_, pad_left_>>();
+        owning_buffer->resize(this->size());
+        owning_buffer->insert_assume_reserved(this->begin(), this->end());
+        return owning_buffer;
+    }
+};
+
+}

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 #include "IBuffer.h"
 #include "IO/BufferBase.h"

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -1,33 +1,388 @@
 #include "IBuffer.h"
 
+/** Whether we can use memcpy instead of a loop with assignment to T from U.
+  * It is Ok if types are the same. And if types are integral and of the same size,
+  *  example: char, signed char, unsigned char.
+  * It's not Ok for int and float.
+  * Don't forget to apply std::decay when using this constexpr.
+  */
+template <typename T, typename U>
+constexpr bool memcpy_can_be_used_for_assignment = std::is_same_v<T, U>
+    || (std::is_integral_v<T> && std::is_integral_v<U> && sizeof(T) == sizeof(U)); /// NOLINT(misc-redundant-expression)
+
 namespace DB
 {
 
-template <typename T, typename TAllocator, size_t pad_right, size_t pad_left>
-class PODArrayOwning : public IBuffer<sizeof(T), TAllocator, pad_right, pad_left>
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right, size_t pad_left>
+class PODArrayOwning : public IBuffer<T, initial_bytes, TAllocator, pad_right, pad_left>
 {
 protected:
-    T * t_start()                      { return reinterpret_cast<T *>(this->data); } /// NOLINT
-    T * t_end()                        { return reinterpret_cast<T *>(this->data + this->size); } /// NOLINT
-
-    const T * t_start() const          { return reinterpret_cast<T *>(this->data); } /// NOLINT
-    const T * t_end() const            { return reinterpret_cast<T *>(this->data + this->size); } /// NOLINT
+    using Base = IBuffer<T, initial_bytes, TAllocator, pad_right, pad_left>;
 public:
     using value_type = T;
     using iterator = T *;
     using const_iterator = const T *;
 
-    T & front()             { return t_start()[0]; }
-    T & back()              { return t_end()[-1]; }
-    const T & front() const { return t_start()[0]; }
-    const T & back() const  { return t_end()[-1]; }
+    PODArrayOwning() = default;
 
-    iterator begin()              { return t_start(); }
-    iterator end()                { return t_end(); }
-    const_iterator begin() const  { return t_start(); }
-    const_iterator end() const    { return t_end(); }
-    const_iterator cbegin() const { return t_start(); }
-    const_iterator cend() const   { return t_end(); }
+    explicit PODArrayOwning(size_t n)
+    {
+        this->alloc_for_num_elements(n);
+        this->c_end += BufferDetails::byte_size(n, sizeof(T));
+    }
+
+    PODArrayOwning(size_t n, const T & x)
+    {
+        this->alloc_for_num_elements(n);
+        assign(n, x);
+    }
+
+    PODArrayOwning(const_iterator from_begin, const_iterator from_end)
+    {
+        this->alloc_for_num_elements(from_end - from_begin);
+        insert(from_begin, from_end);
+    }
+
+    PODArrayOwning(std::initializer_list<T> il)
+    {
+        this->reserve(std::size(il));
+
+        for (const auto & x : il)
+        {
+            this->push_back(x);
+        }
+    }
+
+    PODArrayOwning(PODArrayOwning && other) noexcept
+    {
+        this->swap(other);
+    }
+
+    PODArrayOwning & operator=(PODArrayOwning && other) noexcept
+    {
+        this->swap(other);
+        return *this;
+    }
+
+    template <typename U, typename ... TAllocatorParams>
+    void push_back(U && x, TAllocatorParams &&... allocator_params) /// NOLINT
+    {
+        if (unlikely(this->c_end + sizeof(T) > this->c_end_of_storage))
+            this->reserveForNextSize(std::forward<TAllocatorParams>(allocator_params)...);
+        
+        this->t_end();
+        new (reinterpret_cast<void*>(Base::t_end())) T(std::forward<U>(x));
+        this->c_end += sizeof(T);
+    }
+
+    template <typename ... TAllocatorParams>
+    void push_back_raw(const void * ptr, TAllocatorParams &&... allocator_params) /// NOLINT
+    {
+        size_t required_capacity = Base::size() + Base::element_size;
+        if (unlikely(required_capacity > Base::capacity()))
+            reserve(required_capacity, std::forward<TAllocatorParams>(allocator_params)...);
+
+        memcpy(Base::c_end, ptr, Base::element_size);
+        Base::c_end += Base::element_size;
+    }
+
+    template <typename... Args>
+    void emplace_back(Args &&... args) /// NOLINT
+    {
+        if (unlikely(this->c_end + sizeof(T) > this->c_end_of_storage))
+            this->reserveForNextSize();
+
+        new (Base::t_end()) T(std::forward<Args>(args)...);
+        this->c_end += sizeof(T);
+    }
+
+    void pop_back() /// NOLINT
+    {
+        this->c_end -= sizeof(T);
+    }
+
+    /// Do not insert into the array a piece of itself. Because with the resize, the iterators on themselves can be invalidated.
+    template <typename It1, typename It2, typename ... TAllocatorParams>
+    void insertPrepare(It1 from_begin, It2 from_end, TAllocatorParams &&... allocator_params)
+    {
+        this->assertNotIntersects(from_begin, from_end);
+        size_t required_capacity = this->size() + (from_end - from_begin);
+        if (required_capacity > this->capacity())
+            this->reserve(Base::roundUpToPowerOfTwoOrZero(required_capacity), std::forward<TAllocatorParams>(allocator_params)...);
+    }
+
+    /// Do not insert into the array a piece of itself. Because with the resize, the iterators on themselves can be invalidated.
+    template <typename It1, typename It2, typename ... TAllocatorParams>
+    void insert(It1 from_begin, It2 from_end, TAllocatorParams &&... allocator_params)
+    {
+        insertPrepare(from_begin, from_end, std::forward<TAllocatorParams>(allocator_params)...);
+        insert_assume_reserved(from_begin, from_end);
+    }
+
+    /// In contrast to 'insert' this method is Ok even for inserting from itself.
+    /// Because we obtain iterators after reserving memory.
+    template <typename Container, typename ... TAllocatorParams>
+    void insertByOffsets(Container && rhs, size_t from_begin, size_t from_end, TAllocatorParams &&... allocator_params)
+    {
+        static_assert(memcpy_can_be_used_for_assignment<std::decay_t<T>, std::decay_t<decltype(rhs.front())>>);
+
+        assert(from_end >= from_begin);
+        assert(from_end <= rhs.size());
+
+        size_t required_capacity = this->size() + (from_end - from_begin);
+        if (required_capacity > this->capacity())
+            this->reserve(Base::roundUpToPowerOfTwoOrZero(required_capacity), std::forward<TAllocatorParams>(allocator_params)...);
+
+        size_t bytes_to_copy = BufferDetails::byte_size(from_end - from_begin, sizeof(T));
+        if (bytes_to_copy)
+        {
+            memcpy(this->c_end, reinterpret_cast<const void *>(rhs.begin() + from_begin), bytes_to_copy);
+            this->c_end += bytes_to_copy;
+        }
+    }
+
+    /// Works under assumption, that it's possible to read up to 15 excessive bytes after `from_end` and this PODArray is padded.
+    template <typename It1, typename It2, typename ... TAllocatorParams>
+    void insertSmallAllowReadWriteOverflow15(It1 from_begin, It2 from_end, TAllocatorParams &&... allocator_params)
+    {
+        static_assert(pad_right >= PADDING_FOR_SIMD - 1);
+        static_assert(sizeof(T) == sizeof(*from_begin));
+        insertPrepare(from_begin, from_end, std::forward<TAllocatorParams>(allocator_params)...);
+        size_t bytes_to_copy = BufferDetails::byte_size(from_end - from_begin, sizeof(T));
+        memcpySmallAllowReadWriteOverflow15(this->c_end, reinterpret_cast<const void *>(&*from_begin), bytes_to_copy);
+        this->c_end += bytes_to_copy;
+    }
+
+    /// Do not insert into the array a piece of itself. Because with the resize, the iterators on themselves can be invalidated.
+    template <typename It1, typename It2>
+    void insert(iterator it, It1 from_begin, It2 from_end)
+    {
+        static_assert(memcpy_can_be_used_for_assignment<std::decay_t<T>, std::decay_t<decltype(*from_begin)>>);
+
+        size_t bytes_to_copy = BufferDetails::byte_size(from_end - from_begin, sizeof(T));
+        if (!bytes_to_copy)
+            return;
+
+        size_t bytes_to_move = BufferDetails::byte_size(Base::end() - it, sizeof(T));
+
+        insertPrepare(from_begin, from_end);
+
+        if (unlikely(bytes_to_move))
+            memmove(this->c_end + bytes_to_copy - bytes_to_move, this->c_end - bytes_to_move, bytes_to_move);
+
+        memcpy(this->c_end - bytes_to_move, reinterpret_cast<const void *>(&*from_begin), bytes_to_copy);
+
+        this->c_end += bytes_to_copy;
+    }
+
+    template <typename ... TAllocatorParams>
+    void insertFromItself(iterator from_begin, iterator from_end, TAllocatorParams && ... allocator_params)
+    {
+        static_assert(memcpy_can_be_used_for_assignment<std::decay_t<T>, std::decay_t<decltype(*from_begin)>>);
+
+        /// Convert iterators to indexes because reserve can invalidate iterators
+        size_t start_index = from_begin - Base::begin();
+        size_t end_index = from_end - Base::begin();
+        size_t copy_size = end_index - start_index;
+
+        assert(start_index <= end_index);
+
+        size_t required_capacity = this->size() + copy_size;
+        if (required_capacity > this->capacity())
+            this->reserve(Base::roundUpToPowerOfTwoOrZero(required_capacity), std::forward<TAllocatorParams>(allocator_params)...);
+
+        size_t bytes_to_copy = BufferDetails::byte_size(copy_size, sizeof(T));
+        if (bytes_to_copy)
+        {
+            auto begin = this->c_start + BufferDetails::byte_size(start_index, sizeof(T));
+            memcpy(this->c_end, reinterpret_cast<const void *>(&*begin), bytes_to_copy);
+            this->c_end += bytes_to_copy;
+        }
+    }
+
+    template <typename It1, typename It2>
+    void insert_assume_reserved(It1 from_begin, It2 from_end) /// NOLINT
+    {
+        static_assert(memcpy_can_be_used_for_assignment<std::decay_t<T>, std::decay_t<decltype(*from_begin)>>);
+        this->assertNotIntersects(from_begin, from_end);
+
+        size_t bytes_to_copy = BufferDetails::byte_size(from_end - from_begin, sizeof(T));
+        if (bytes_to_copy)
+        {
+            memcpy(this->c_end, reinterpret_cast<const void *>(&*from_begin), bytes_to_copy);
+            this->c_end += bytes_to_copy;
+        }
+    }
+
+    template <typename... TAllocatorParams>
+    void swap(PODArrayOwning& rhs, TAllocatorParams &&... allocator_params) /// NOLINT(performance-noexcept-swap)
+    {
+        /// Swap two PODArray objects, arr1 and arr2, that satisfy the following conditions:
+        /// - The elements of arr1 are stored on stack.
+        /// - The elements of arr2 are stored on heap.
+        auto swap_stack_heap = [&](PODArrayOwning & arr1, PODArrayOwning & arr2)
+        {
+            size_t stack_size = arr1.size();
+            size_t stack_allocated = arr1.allocated_bytes();
+
+            size_t heap_size = arr2.size();
+            size_t heap_allocated = arr2.allocated_bytes();
+
+            /// Keep track of the stack content we have to copy.
+            char * stack_c_start = arr1.c_start;
+
+            /// arr1 takes ownership of the heap memory of arr2.
+            arr1.c_start = arr2.c_start;
+            arr1.c_end_of_storage = arr1.c_start + heap_allocated - arr2.pad_right - arr2.pad_left;
+            arr1.c_end = arr1.c_start + BufferDetails::byte_size(heap_size, sizeof(T));
+
+            /// Allocate stack space for arr2.
+            arr2.alloc(stack_allocated, std::forward<TAllocatorParams>(allocator_params)...);
+            /// Copy the stack content.
+            memcpy(arr2.c_start, stack_c_start, BufferDetails::byte_size(stack_size, sizeof(T)));
+            arr2.c_end = arr2.c_start + BufferDetails::byte_size(stack_size, sizeof(T));
+        };
+
+        auto do_move = [&](PODArrayOwning & src, PODArrayOwning & dest)
+        {
+            if (src.isAllocatedFromStack())
+            {
+                dest.dealloc();
+                dest.alloc(src.allocated_bytes(), std::forward<TAllocatorParams>(allocator_params)...);
+                memcpy(dest.c_start, src.c_start, BufferDetails::byte_size(src.size(), sizeof(T)));
+                dest.c_end = dest.c_start + BufferDetails::byte_size(src.size(), sizeof(T));
+
+                src.c_start = Base::null;
+                src.c_end = Base::null;
+                src.c_end_of_storage = Base::null;
+            }
+            else
+            {
+                std::swap(dest.c_start, src.c_start);
+                std::swap(dest.c_end, src.c_end);
+                std::swap(dest.c_end_of_storage, src.c_end_of_storage);
+            }
+        };
+
+        if (!this->isInitialized() && !rhs.isInitialized())
+        {
+            return;
+        }
+        if (!this->isInitialized() && rhs.isInitialized())
+        {
+            do_move(rhs, *this);
+            return;
+        }
+        if (this->isInitialized() && !rhs.isInitialized())
+        {
+            do_move(*this, rhs);
+            return;
+        }
+
+        if (this->isAllocatedFromStack() && rhs.isAllocatedFromStack())
+        {
+            size_t min_size = std::min(this->size(), rhs.size());
+            size_t max_size = std::max(this->size(), rhs.size());
+
+            for (size_t i = 0; i < min_size; ++i)
+                std::swap(this->operator[](i), rhs[i]);
+
+            if (this->size() == max_size)
+            {
+                for (size_t i = min_size; i < max_size; ++i)
+                    rhs[i] = this->operator[](i);
+            }
+            else
+            {
+                for (size_t i = min_size; i < max_size; ++i)
+                    this->operator[](i) = rhs[i];
+            }
+
+            size_t lhs_size = this->size();
+            size_t lhs_allocated = this->allocated_bytes();
+
+            size_t rhs_size = rhs.size();
+            size_t rhs_allocated = rhs.allocated_bytes();
+
+            this->c_end_of_storage = this->c_start + rhs_allocated - Base::pad_right - Base::pad_left;
+            rhs.c_end_of_storage = rhs.c_start + lhs_allocated - Base::pad_right - Base::pad_left;
+
+            this->c_end = this->c_start + BufferDetails::byte_size(rhs_size, sizeof(T));
+            rhs.c_end = rhs.c_start + BufferDetails::byte_size(lhs_size, sizeof(T));
+        }
+        else if (this->isAllocatedFromStack() && !rhs.isAllocatedFromStack())
+        {
+            swap_stack_heap(*this, rhs);
+        }
+        else if (!this->isAllocatedFromStack() && rhs.isAllocatedFromStack())
+        {
+            swap_stack_heap(rhs, *this);
+        }
+        else
+        {
+            std::swap(this->c_start, rhs.c_start);
+            std::swap(this->c_end, rhs.c_end);
+            std::swap(this->c_end_of_storage, rhs.c_end_of_storage);
+        }
+    }
+
+    template <typename... TAllocatorParams>
+    void assign(size_t n, const T & x, TAllocatorParams &&... allocator_params)
+    {
+        this->resize_exact(n, std::forward<TAllocatorParams>(allocator_params)...);
+        std::fill(Base::begin(), Base::end(), x);
+    }
+
+    template <typename It1, typename It2, typename... TAllocatorParams>
+    void assign(It1 from_begin, It2 from_end, TAllocatorParams &&... allocator_params)
+    {
+        static_assert(memcpy_can_be_used_for_assignment<std::decay_t<T>, std::decay_t<decltype(*from_begin)>>);
+        this->assertNotIntersects(from_begin, from_end);
+
+        size_t required_capacity = from_end - from_begin;
+        if (required_capacity > this->capacity())
+            this->reserve_exact(required_capacity, std::forward<TAllocatorParams>(allocator_params)...);
+
+        size_t bytes_to_copy = BufferDetails::byte_size(required_capacity, sizeof(T));
+        if (bytes_to_copy)
+            memcpy(this->c_start, reinterpret_cast<const void *>(&*from_begin), bytes_to_copy);
+
+        this->c_end = this->c_start + bytes_to_copy;
+    }
+
+    // ISO C++ has strict ambiguity rules, thus we cannot apply TAllocatorParams here.
+    void assign(const PODArrayOwning & from)
+    {
+        assign(from.begin(), from.end());
+    }
+
+    void erase(const_iterator first, const_iterator last)
+    {
+        // TODO: ask milovidov why
+        iterator first_no_const = const_cast<iterator>(first);
+        iterator last_no_const = const_cast<iterator>(last);
+
+        size_t items_to_move = Base::end() - last;
+
+        while (items_to_move != 0)
+        {
+            *first_no_const = *last_no_const;
+
+            ++first_no_const;
+            ++last_no_const;
+
+            --items_to_move;
+        }
+
+        this->c_end = reinterpret_cast<char *>(first_no_const);
+    }
+
+    void erase(const_iterator pos)
+    {
+        this->erase(pos, pos + 1);
+    }
+
+    
 
 };
 

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -178,7 +178,7 @@ public:
     {
         if (unlikely(this->c_end + sizeof(T) > this->c_end_of_storage))
             this->reserveForNextSize(std::forward<TAllocatorParams>(allocator_params)...);
-        
+
         this->t_end();
         new (reinterpret_cast<void*>(Base::t_end())) T(std::forward<U>(x));
         this->c_end += sizeof(T);
@@ -490,8 +490,6 @@ public:
     {
         this->erase(pos, pos + 1);
     }
-
-    
 
 };
 

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -2,14 +2,6 @@
 
 #include <memory>
 #include "IBuffer.h"
-#include "IO/BufferBase.h"
-
-/** Whether we can use memcpy instead of a loop with assignment to T from U.
-  * It is Ok if types are the same. And if types are integral and of the same size,
-  *  example: char, signed char, unsigned char.
-  * It's not Ok for int and float.
-  * Don't forget to apply std::decay when using this constexpr.
-  */
 
 namespace DB
 {

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -8,9 +8,6 @@
   * It's not Ok for int and float.
   * Don't forget to apply std::decay when using this constexpr.
   */
-template <typename T, typename U>
-constexpr bool memcpy_can_be_used_for_assignment = std::is_same_v<T, U>
-    || (std::is_integral_v<T> && std::is_integral_v<U> && sizeof(T) == sizeof(U)); /// NOLINT(misc-redundant-expression)
 
 namespace DB
 {

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -89,7 +89,7 @@ public:
 
     void dealloc() override
     {
-        if (this->c_start == nullptr)
+        if (this->c_start == Base::null)
             return;
 
         // unprotect();
@@ -99,7 +99,7 @@ public:
 
     void realloc(size_t bytes) override
     {
-        if (this->c_start == nullptr)
+        if (this->c_start == Base::null)
         {
             alloc(bytes);
             return;

--- a/src/Columns/PODArrayOwning.h
+++ b/src/Columns/PODArrayOwning.h
@@ -1,0 +1,34 @@
+#include "IBuffer.h"
+
+namespace DB
+{
+
+template <typename T, typename TAllocator, size_t pad_right, size_t pad_left>
+class PODArrayOwning : public IBuffer<sizeof(T), TAllocator, pad_right, pad_left>
+{
+protected:
+    T * t_start()                      { return reinterpret_cast<T *>(this->data); } /// NOLINT
+    T * t_end()                        { return reinterpret_cast<T *>(this->data + this->size); } /// NOLINT
+
+    const T * t_start() const          { return reinterpret_cast<T *>(this->data); } /// NOLINT
+    const T * t_end() const            { return reinterpret_cast<T *>(this->data + this->size); } /// NOLINT
+public:
+    using value_type = T;
+    using iterator = T *;
+    using const_iterator = const T *;
+
+    T & front()             { return t_start()[0]; }
+    T & back()              { return t_end()[-1]; }
+    const T & front() const { return t_start()[0]; }
+    const T & back() const  { return t_end()[-1]; }
+
+    iterator begin()              { return t_start(); }
+    iterator end()                { return t_end(); }
+    const_iterator begin() const  { return t_start(); }
+    const_iterator end() const    { return t_end(); }
+    const_iterator cbegin() const { return t_start(); }
+    const_iterator cend() const   { return t_end(); }
+
+};
+
+}

--- a/src/Columns/PODArrayView.h
+++ b/src/Columns/PODArrayView.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/Columns/PODArrayView.h
+++ b/src/Columns/PODArrayView.h
@@ -1,1 +1,71 @@
 #pragma once
+
+#include <cstddef>
+#include <memory>
+#include "IBuffer.h"
+
+#include <IO/BufferWithOwnMemory.h>
+
+namespace DB
+{
+
+template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right_, size_t pad_left_> // NOLINT
+class PODArrayView : public IBuffer<T, initial_bytes, TAllocator, pad_right_, pad_left_>
+{
+protected:
+    using Base = IBuffer<T, initial_bytes, TAllocator, pad_right_, pad_left_>;
+    static constexpr size_t ELEMENT_SIZE = sizeof(T);
+public:
+    using value_type = T;
+    using iterator = T *;
+    using const_iterator = const T *;
+private:
+    std::shared_ptr<Memory<>> memory_ptr; // points to memory to prolong its lifetime
+
+public:
+    // The duty to guarantee left padding is on code writer
+    PODArrayView(std::shared_ptr<Memory<>> memory, char * pos, size_t n) : memory_ptr(std::move(memory)) {
+        Base::c_start = pos;
+        Base::c_end = reinterpret_cast<char *>(reinterpret_cast<T*>(pos) + n);
+        Base::c_end_of_storage = Base::c_end;
+    }
+
+    ~PODArrayView() override {
+        Base::c_start = Base::null;
+        Base::c_end = Base::null;
+        Base::c_end_of_storage = Base::null;
+    }
+
+    std::shared_ptr<PODArrayOwning<T, initial_bytes, TAllocator, pad_right_, pad_left_>> getOwningBuffer() final {
+        auto owning_buffer = std::make_shared<PODArrayOwning<T, initial_bytes, TAllocator, pad_right_, pad_left_>>();
+        auto & x = *owning_buffer;
+        const size_t initial_size = x.size();
+        x.resize(initial_size);
+        read(reinterpret_cast<char*>(x.begin()), sizeof(T) * initial_size);
+        // x.resize(initial_size + size / sizeof(typename ColumnVector<T>::ValueType));
+
+        if constexpr (std::endian::native == std::endian::big && sizeof(T) >= 2)
+            for (size_t i = initial_size; i < x.size(); ++i)
+                transformEndianness<std::endian::big, std::endian::little>(x[i]);
+        return owning_buffer;
+    }
+
+private:
+    size_t read(char * to, size_t n)
+    {
+        size_t bytes_copied = 0;
+        auto pos = Base::c_start;
+
+        while (bytes_copied < n)
+        {
+            size_t bytes_to_copy = n - bytes_copied;
+            ::memcpy(to + bytes_copied, pos, bytes_to_copy);
+            pos += bytes_to_copy;
+            bytes_copied += bytes_to_copy;
+        }
+
+        return bytes_copied;
+    }
+};
+
+}

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Columns/BufferFWD.h>
 #include "config.h"
 
 #include <base/getPageSize.h>
@@ -236,6 +237,13 @@ public:
     }
 
     template <typename ... TAllocatorParams>
+    void resize_exact(size_t n, TAllocatorParams &&... allocator_params) /// NOLINT
+    {
+        reserve_exact(n, std::forward<TAllocatorParams>(allocator_params)...);
+        resize_assume_reserved(n);
+    }
+
+    template <typename ... TAllocatorParams>
     void shrink_to_fit(TAllocatorParams &&... allocator_params)
     {
         realloc(PODArrayDetails::minimum_memory_for_elements(size(), ELEMENT_SIZE, pad_left, pad_right), std::forward<TAllocatorParams>(allocator_params)...);
@@ -349,6 +357,20 @@ public:
         {
             this->push_back(x);
         }
+    }
+
+    explicit PODArray(const PaddedBuffer<T>& buf)
+    {
+        Base::c_start = buf.c_start;
+        Base::c_end = buf.c_end;
+        Base::c_end_of_storage = buf.c_end_of_storage;
+    }
+
+    explicit PODArray(PaddedBuffer<T>& buf)
+    {
+        Base::c_start = buf.c_start;
+        Base::c_end = buf.c_end;
+        Base::c_end_of_storage = buf.c_end_of_storage;
     }
 
     PODArray(PODArray && other) noexcept

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -14,8 +14,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
 #ifndef NDEBUG
 #include <sys/mman.h>

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -87,7 +87,7 @@ size_t minimum_memory_for_elements(size_t num_elements, size_t element_size, siz
   * You can static_cast to this class if you want to insert some data regardless to the actual type T.
   */
 template <size_t ELEMENT_SIZE, size_t initial_bytes, typename TAllocator, size_t pad_right_, size_t pad_left_>
-class PODArrayBase : private boost::noncopyable, private TAllocator    /// empty base optimization
+class PODArrayBase : private boost::noncopyable, protected TAllocator    /// empty base optimization
 {
 protected:
     /// Round padding up to an whole number of elements to simplify arithmetic.
@@ -359,19 +359,19 @@ public:
         }
     }
 
-    explicit PODArray(const PaddedBuffer<T>& buf)
-    {
-        Base::c_start = buf.c_start;
-        Base::c_end = buf.c_end;
-        Base::c_end_of_storage = buf.c_end_of_storage;
-    }
+    // explicit PODArray(const PODArray<T>& buf)
+    // {
+    //     Base::c_start = buf.c_start;
+    //     Base::c_end = buf.c_end;
+    //     Base::c_end_of_storage = buf.c_end_of_storage;
+    // }
 
-    explicit PODArray(PaddedBuffer<T>& buf)
-    {
-        Base::c_start = buf.c_start;
-        Base::c_end = buf.c_end;
-        Base::c_end_of_storage = buf.c_end_of_storage;
-    }
+    // explicit PODArray(PODArray<T>& buf)
+    // {
+    //     Base::c_start = buf.c_start;
+    //     Base::c_end = buf.c_end;
+    //     Base::c_end_of_storage = buf.c_end_of_storage;
+    // }
 
     PODArray(PODArray && other) noexcept
     {

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -236,13 +236,6 @@ public:
     }
 
     template <typename ... TAllocatorParams>
-    void resize_exact(size_t n, TAllocatorParams &&... allocator_params) /// NOLINT
-    {
-        reserve_exact(n, std::forward<TAllocatorParams>(allocator_params)...);
-        resize_assume_reserved(n);
-    }
-
-    template <typename ... TAllocatorParams>
     void shrink_to_fit(TAllocatorParams &&... allocator_params)
     {
         realloc(PODArrayDetails::minimum_memory_for_elements(size(), ELEMENT_SIZE, pad_left, pad_right), std::forward<TAllocatorParams>(allocator_params)...);

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <boost/noncopyable.hpp>
 
 #include <Common/Allocator.h>
@@ -35,6 +36,7 @@ template <typename Allocator = Allocator<false>>
 struct Memory : boost::noncopyable, Allocator
 {
     static constexpr size_t pad_right = PADDING_FOR_SIMD - 1;
+    static constexpr size_t pad_left = PADDING_FOR_SIMD;
 
     size_t m_capacity = 0;  /// With padding.
     size_t m_size = 0;
@@ -84,7 +86,7 @@ struct Memory : boost::noncopyable, Allocator
             return;
         }
 
-        if (new_size <= m_capacity - pad_right)
+        if (new_size <= m_capacity - pad_right - pad_left)
         {
             m_size = new_size;
             return;
@@ -95,7 +97,8 @@ struct Memory : boost::noncopyable, Allocator
         size_t diff = new_capacity - m_capacity;
         ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
 
-        m_data = static_cast<char *>(Allocator::realloc(m_data, m_capacity, new_capacity, alignment));
+        m_data = static_cast<char *>(Allocator::realloc(m_data - pad_left, m_capacity, new_capacity, alignment));
+        m_data += pad_left;
         m_capacity = new_capacity;
         m_size = new_size;
     }
@@ -105,7 +108,7 @@ private:
     {
         size_t res = 0;
 
-        if (common::addOverflow<size_t>(value, pad_right, res))
+        if (common::addOverflow<size_t>(value, pad_right + pad_left, res))
             throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "value is too big to apply padding");
 
         return res;
@@ -125,6 +128,7 @@ private:
         ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, new_capacity);
 
         m_data = static_cast<char *>(Allocator::alloc(new_capacity, alignment));
+        m_data += pad_left;
         m_capacity = new_capacity;
         m_size = new_size;
     }
@@ -134,7 +138,7 @@ private:
         if (!m_data)
             return;
 
-        Allocator::free(m_data, m_capacity);
+        Allocator::free(m_data - pad_left, m_capacity);
         m_data = nullptr;    /// To avoid double free if next alloc will throw an exception.
     }
 };
@@ -146,12 +150,13 @@ private:
 template <typename Base>
 class BufferWithOwnMemory : public Base
 {
-protected:
-    Memory<> memory;
 public:
+    std::shared_ptr<Memory<>> memory_ptr;
+    Memory<> & memory;
+
     /// If non-nullptr 'existing_memory' is passed, then buffer will not create its own memory and will use existing_memory without ownership.
     explicit BufferWithOwnMemory(size_t size = DBMS_DEFAULT_BUFFER_SIZE, char * existing_memory = nullptr, size_t alignment = 0)
-        : Base(nullptr, 0), memory(existing_memory ? 0 : size, alignment)
+        : Base(nullptr, 0), memory_ptr(std::make_shared<Memory<>>(existing_memory ? 0 : size, alignment)), memory(*memory_ptr)
     {
         Base::set(existing_memory ? existing_memory : memory.data(), size);
         Base::padded = !existing_memory;

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -86,7 +86,7 @@ struct Memory : boost::noncopyable, Allocator
             return;
         }
 
-        if (new_size <= m_capacity - pad_right - pad_left)
+        if (new_size <= m_capacity - pad_right /*- pad_left*/)
         {
             m_size = new_size;
             return;
@@ -97,8 +97,8 @@ struct Memory : boost::noncopyable, Allocator
         size_t diff = new_capacity - m_capacity;
         ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
 
-        m_data = static_cast<char *>(Allocator::realloc(m_data - pad_left, m_capacity, new_capacity, alignment));
-        m_data += pad_left;
+        m_data = static_cast<char *>(Allocator::realloc(m_data /*- pad_left*/, m_capacity, new_capacity, alignment));
+        // m_data += pad_left;
         m_capacity = new_capacity;
         m_size = new_size;
     }
@@ -108,7 +108,7 @@ private:
     {
         size_t res = 0;
 
-        if (common::addOverflow<size_t>(value, pad_right + pad_left, res))
+        if (common::addOverflow<size_t>(value, pad_right /* + pad_left*/, res))
             throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "value is too big to apply padding");
 
         return res;
@@ -128,7 +128,7 @@ private:
         ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, new_capacity);
 
         m_data = static_cast<char *>(Allocator::alloc(new_capacity, alignment));
-        m_data += pad_left;
+        // m_data += pad_left;
         m_capacity = new_capacity;
         m_size = new_size;
     }
@@ -138,7 +138,7 @@ private:
         if (!m_data)
             return;
 
-        Allocator::free(m_data - pad_left, m_capacity);
+        Allocator::free(m_data /* - pad_left*/, m_capacity);
         m_data = nullptr;    /// To avoid double free if next alloc will throw an exception.
     }
 };


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added IBuffer and PODArrayOwning / PODArrayView for performance improvement (avoiding unnecessary copying) in ColumnVector.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
