### PR TITLE
Add the ability for non-scaling sleep for zero copy replication merges and mutations

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -672,6 +672,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         addSettingsChanges(merge_tree_settings_changes_history, "25.3",
         {
             {"shared_merge_tree_enable_keeper_parts_extra_data", false, false, "New setting"},
+            {"zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock", 0, 0, "New setting"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "25.2",
         {

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -8,13 +8,8 @@
 #include <Common/quoteString.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ProfileEventsScope.h>
-#include <Common/randomSeed.h>
 
 #include <Core/BackgroundSchedulePool.h>
-
-#include <pcg_random.hpp>
-
-#include <cmath>
 
 namespace ProfileEvents
 {
@@ -34,7 +29,6 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsUInt64 prefer_fetch_merged_part_size_threshold;
     extern const MergeTreeSettingsSeconds prefer_fetch_merged_part_time_threshold;
     extern const MergeTreeSettingsSeconds try_fetch_recompressed_part_timeout;
-    extern const MergeTreeSettingsUInt64 zero_copy_merge_mutation_min_parts_size_sleep_before_lock;
 }
 
 namespace ErrorCodes
@@ -53,7 +47,6 @@ MergeFromLogEntryTask::MergeFromLogEntryTask(
         storage_,
         selected_entry_,
         task_result_callback_)
-    , rng(randomSeed())
 {
 }
 
@@ -260,27 +253,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MergeFromLogEntryTask::prepare()
                 };
             }
 
-            if ((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock] != 0 &&
-                estimated_space_for_merge >= (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock])
-            {
-                /// In zero copy replication only one replica execute merge/mutation, others just download merged parts metadata.
-                /// Here we are trying to mitigate the skew of merges execution because of faster/slower replicas.
-                /// Replicas can be slow because of different reasons like bigger latency for ZooKeeper or just slight step behind because of bigger queue.
-                /// In this case faster replica can pick up all merges execution, especially large merges while other replicas can just idle. And even in this case
-                /// the fast replica is not overloaded because amount of executing merges doesn't affect the ability to acquire locks for new merges.
-                ///
-                /// So here we trying to solve it with the simplest solution -- sleep random time up to 500ms for 1GB part and up to 7 seconds for 300GB part.
-                /// It can sound too much, but we are trying to acquire these locks in background tasks which can be scheduled each 5 seconds or so.
-                double start_to_sleep_seconds = std::logf((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value);
-                uint64_t right_border_to_sleep_ms = static_cast<uint64_t>((std::log(estimated_space_for_merge) - start_to_sleep_seconds + 0.5) * 1000);
-                uint64_t time_to_sleep_milliseconds = std::min<uint64_t>(10000UL, std::uniform_int_distribution<uint64_t>(1, 1 + right_border_to_sleep_ms)(rng));
-
-                LOG_INFO(log, "Merge size is {} bytes (it's more than sleep threshold {}) so will intentionally sleep for {} ms to allow other replicas to took this big merge",
-                    estimated_space_for_merge, (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value, time_to_sleep_milliseconds);
-
-                std::this_thread::sleep_for(std::chrono::milliseconds(time_to_sleep_milliseconds));
-            }
-
+            maybeSleepBeforeZeroCopyLock(estimated_space_for_merge);
             zero_copy_lock = storage.tryCreateZeroCopyExclusiveLock(entry.new_part_name, disk);
 
             if (!zero_copy_lock || !zero_copy_lock->isLocked())

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.h
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.h
@@ -3,8 +3,6 @@
 #include <memory>
 #include <utility>
 
-#include <pcg_random.hpp>
-
 #include <Storages/MergeTree/IExecutableTask.h>
 #include <Storages/MergeTree/MergeTask.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeQueue.h>
@@ -55,7 +53,6 @@ private:
     Priority priority;
 
     MergeTaskPtr merge_task;
-    pcg64 rng;
 };
 
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -253,6 +253,7 @@ namespace ErrorCodes
     DECLARE(Bool, check_sample_column_is_correct, true, "Check columns or columns by hash for sampling are unsigned integer.", 0) \
     DECLARE(Bool, allow_vertical_merges_from_compact_to_wide_parts, true, "Allows vertical merges from compact to wide parts. This settings must have the same value on all replicas", 0) \
     DECLARE(Bool, enable_the_endpoint_id_with_zookeeper_name_prefix, false, "Enable the endpoint id with zookeeper name prefix for the replicated merge tree table", 0) \
+    DECLARE(UInt64, zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock, 0, "If zero copy replication is enabled sleep random amount of time up to 500ms before trying to lock for merge or mutation", 0) \
     DECLARE(UInt64, zero_copy_merge_mutation_min_parts_size_sleep_before_lock, 1ULL * 1024 * 1024 * 1024, "If zero copy replication is enabled sleep random amount of time before trying to lock depending on parts size for merge or mutation", 0) \
     DECLARE(Bool, allow_floating_point_partition_key, false, "Allow floating point as partition key", 0) \
     DECLARE(UInt64, sleep_before_loading_outdated_parts_ms, 0, "For testing. Do not change it.", 0) \
@@ -575,6 +576,17 @@ void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool allow
             ErrorCodes::BAD_ARGUMENTS,
             "The value of merge_selecting_sleep_slowdown_factor setting ({}) cannot be less than 1.0",
             merge_selecting_sleep_slowdown_factor.value);
+    }
+
+    if (zero_copy_merge_mutation_min_parts_size_sleep_before_lock != 0
+        && zero_copy_merge_mutation_min_parts_size_sleep_before_lock < zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock)
+    {
+        throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "The value of zero_copy_merge_mutation_min_parts_size_sleep_before_lock setting ({}) cannot be less than"
+                " the value of zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock ({})",
+                zero_copy_merge_mutation_min_parts_size_sleep_before_lock.value,
+                zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock.value);
     }
 }
 

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -6,7 +6,6 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/MergeTree/Compaction/CompactionStatistics.h>
-#include <cmath>
 
 namespace ProfileEvents
 {
@@ -24,7 +23,6 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsSeconds lock_acquire_timeout_for_background_operations;
     extern const MergeTreeSettingsUInt64 prefer_fetch_merged_part_size_threshold;
     extern const MergeTreeSettingsSeconds prefer_fetch_merged_part_time_threshold;
-    extern const MergeTreeSettingsUInt64 zero_copy_merge_mutation_min_parts_size_sleep_before_lock;
 }
 
 ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
@@ -152,27 +150,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
                 };
             }
 
-            if ((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock] != 0 &&
-                estimated_space_for_result >= (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock])
-            {
-                /// In zero copy replication only one replica execute merge/mutation, others just download merged parts metadata.
-                /// Here we are trying to metigate the skew of merges execution because of faster/slower replicas.
-                /// Replicas can be slow because of different reasons like bigger latency for ZooKeeper or just slight step behind because of bigger queue.
-                /// In this case faster replica can pick up all merges execution, especially large merges while other replicas can just idle. And even in this case
-                /// the fast replica is not overloaded because amount of executing merges don't affect the ability to aquite locks for new merges.
-                ///
-                /// So here we trying to solve it with the simplest solution -- sleep random time up to 500ms for 1GB part and up to 7 seconds for 300GB part.
-                /// It can sound too much, but we are trying to acquire these locks in background tasks which can be scheduled each 5 seconds or so.
-                double start_to_sleep_seconds = std::logf((*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value);
-                uint64_t right_border_to_sleep_ms = static_cast<uint64_t>((std::log(estimated_space_for_result) - start_to_sleep_seconds + 0.5) * 1000);
-                uint64_t time_to_sleep_milliseconds = std::min<uint64_t>(10000UL, std::uniform_int_distribution<uint64_t>(1, 1 + right_border_to_sleep_ms)(rng));
-
-                LOG_INFO(log, "Mutation size is {} bytes (it's more than sleep threshold {}) so will intentionally sleep for {} ms to allow other replicas to took this big mutation",
-                    estimated_space_for_result, (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value, time_to_sleep_milliseconds);
-
-                std::this_thread::sleep_for(std::chrono::milliseconds(time_to_sleep_milliseconds));
-            }
-
+            maybeSleepBeforeZeroCopyLock(estimated_space_for_result);
             zero_copy_lock = storage.tryCreateZeroCopyExclusiveLock(entry.new_part_name, disk);
 
             if (!zero_copy_lock || !zero_copy_lock->isLocked())

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.h
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <pcg_random.hpp>
-
 #include <Storages/MergeTree/IExecutableTask.h>
 #include <Storages/MergeTree/MutateTask.h>
 #include <Storages/MergeTree/ReplicatedMergeMutateTaskBase.h>
@@ -9,7 +7,6 @@
 #include <Storages/MergeTree/ReplicatedMergeTreeLogEntry.h>
 #include <Storages/MergeTree/ZeroCopyLock.h>
 #include <Storages/StorageReplicatedMergeTree.h>
-#include <Common/randomSeed.h>
 
 namespace DB
 {
@@ -27,7 +24,6 @@ public:
             storage_,
             selected_entry_,
             task_result_callback_)
-        , rng(randomSeed())
         {}
 
 
@@ -66,7 +62,6 @@ private:
     FutureMergedMutatedPartPtr future_mutated_part{nullptr};
 
     MutateTaskPtr mutate_task;
-    pcg64 rng;
 };
 
 

--- a/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
@@ -2,6 +2,7 @@
 
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/MergeTree/ReplicatedMergeTreeLogEntry.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeQueue.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Common/ErrorCodes.h>
@@ -13,6 +14,8 @@ namespace DB
 namespace MergeTreeSetting
 {
     extern const MergeTreeSettingsUInt64 max_postpone_time_for_failed_mutations_ms;
+    extern const MergeTreeSettingsUInt64 zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock;
+    extern const MergeTreeSettingsUInt64 zero_copy_merge_mutation_min_parts_size_sleep_before_lock;
 }
 
 namespace ErrorCodes
@@ -262,6 +265,55 @@ ReplicatedMergeMutateTaskBase::CheckExistingPartResult ReplicatedMergeMutateTask
 
 
     return CheckExistingPartResult::OK;
+}
+
+
+void ReplicatedMergeMutateTaskBase::maybeSleepBeforeZeroCopyLock(uint64_t estimated_space_for_result)
+{
+    const auto storage_settings_ptr = storage.getSettings();
+    uint64_t min_parts_size_sleep_no_scale = (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_no_scale_before_lock].value;
+    uint64_t min_parts_size_sleep_log_scale = (*storage_settings_ptr)[MergeTreeSetting::zero_copy_merge_mutation_min_parts_size_sleep_before_lock].value;
+    uint64_t min_parts_size_sleep = 0;
+    bool log_scale = false;
+    String task_for_log = (entry.type == ReplicatedMergeTreeLogEntryData::MERGE_PARTS) ? "merge" : "mutation";
+
+    if (min_parts_size_sleep_no_scale != 0 && estimated_space_for_result >= min_parts_size_sleep_no_scale)
+        min_parts_size_sleep = min_parts_size_sleep_no_scale;
+
+    if (min_parts_size_sleep_log_scale != 0 && estimated_space_for_result >= min_parts_size_sleep_log_scale)
+    {
+        min_parts_size_sleep = min_parts_size_sleep_log_scale;
+        log_scale = true;
+    }
+
+    if (min_parts_size_sleep != 0)
+    {
+        /// In zero copy replication only one replica execute merge/mutation, others just download merged parts metadata.
+        /// Here we are trying to mitigate the skew of merges execution because of faster/slower replicas.
+        /// Replicas can be slow because of different reasons like bigger latency for ZooKeeper or just slight step behind because of bigger queue.
+        /// In this case faster replica can pick up all merges execution, especially large merges while other replicas can just idle. And even in this case
+        /// the fast replica is not overloaded because amount of executing merges doesn't affect the ability to acquire locks for new merges.
+        ///
+        /// So here we trying to solve it with the simplest solution -- sleep random time up to 500ms if there's no scale.
+        /// If log scale is used, then we will sleep depending on the part size. E.g. up to 500ms for 1GB part and up to 7 seconds for 300GB part.
+        /// It can sound too much, but we are trying to acquire these locks in background tasks which can be scheduled each 5 seconds or so.
+        /// Using no scale helps in a situation when we have a lot of merges small in size (e.g. 256KB), and we still want to balance the merges load by adding some sleep.
+        /// But at the same time we don't want to ruin really big parts merges by introducing long sleeps.
+        uint64_t right_border_to_sleep_ms = 500;
+
+        if (log_scale)
+        {
+            double start_to_sleep_seconds = std::logf(min_parts_size_sleep);
+            right_border_to_sleep_ms = static_cast<uint64_t>((std::log(estimated_space_for_result) - start_to_sleep_seconds + 0.5) * 1000);
+        }
+
+        uint64_t time_to_sleep_milliseconds = std::min<uint64_t>(10000UL, std::uniform_int_distribution<uint64_t>(1, 1 + right_border_to_sleep_ms)(rng));
+
+        LOG_INFO(log, "Size of {} is {} bytes (it's more than sleep threshold {} for {} scale) so will intentionally sleep for {} ms to allow other replicas to take this big {}",
+            task_for_log, estimated_space_for_result, min_parts_size_sleep, (log_scale ? "log" : "no"), time_to_sleep_milliseconds, task_for_log);
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(time_to_sleep_milliseconds));
+    }
 }
 
 

--- a/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.h
+++ b/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.h
@@ -1,8 +1,11 @@
 #pragma once
 
 
+#include <pcg_random.hpp>
+
 #include <Storages/MergeTree/IExecutableTask.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeQueue.h>
+#include <Common/randomSeed.h>
 
 
 namespace DB
@@ -28,6 +31,7 @@ public:
         /// This is needed to ask an asssignee to assign a new merge/mutate operation
         /// It takes bool argument and true means that current task is successfully executed.
         , task_result_callback(task_result_callback_)
+        , rng(randomSeed())
     {
     }
 
@@ -51,6 +55,8 @@ protected:
 
     virtual PrepareResult prepare() = 0;
     virtual bool finalize(ReplicatedMergeMutateTaskBase::PartLogWriter write_part_log) = 0;
+
+    void maybeSleepBeforeZeroCopyLock(uint64_t estimated_space_for_result);
 
     /// Will execute a part of inner MergeTask or MutateTask
     virtual bool executeInnerTask() = 0;
@@ -94,6 +100,7 @@ private:
     State state{State::NEED_PREPARE};
     IExecutableTask::TaskResultCallback task_result_callback;
     bool print_exception = true;
+    pcg64 rng;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add the ability to randomly sleep up to 500ms independent of part sizes before merges/mutations execution in case of zero-copy replication. 
