### PR TITLE
tests: fix 02982_perf_introspection_for_inserts flakiness

### DIFF
--- a/tests/queries/0_stateless/02982_perf_introspection_for_inserts.sh
+++ b/tests/queries/0_stateless/02982_perf_introspection_for_inserts.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-merge-tree-settings, no-random-settings
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Due to index_granularity(=3) randomization it takes 55x slower with release build, in sanitizers build it will be even more.

From hung check:

```
'MergeTreeDataWriterSkipIndicesCalculationMicroseconds':3'590'172'793 # 3590 seconds!
```

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=76588&sha=ab5d5995b095605686898d16454583cb53481926&name_0=PR&name_1=Stateless%20tests%20%28msan%2C%202%2F4%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)