### PR TITLE
Fix uninitialized-value CoordinationZnode::last_success_duration in RefreshTask

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.h
+++ b/src/Storages/MaterializedView/RefreshTask.h
@@ -114,7 +114,7 @@ public:
 
         /// Time when the latest successful refresh started.
         std::chrono::sys_seconds last_success_time;
-        std::chrono::milliseconds last_success_duration;
+        std::chrono::milliseconds last_success_duration{0};
         /// Note that this may not match the DB if a refresh managed to EXCHANGE tables, then failed to write to keeper.
         /// That can only happen if last_attempt_succeeded = false.
         UUID last_success_table_uuid;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix uninitialized-value `CoordinationZnode::last_success_duration` in `RefreshTask`

The value of std::chrono::milliseconds is not initialized in the default constructor (refer: https://groups.google.com/a/isocpp.org/g/std-discussion/c/OcGX7Yj3meI).
In `DB::RefreshTask::CoordinationZnode::toString`, the value is used without being assigned.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
