### PR TITLE
ci: cleanup system.*_log artifacts

### DIFF
--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -387,6 +387,10 @@ clickhouse-client -q "system flush logs" ||:
 # stop logs replication to make it possible to dump logs tables via clickhouse-local
 stop_logs_replication
 
+# Remove all limits to avoid TOO_MANY_ROWS_OR_BYTES while gathering system.*_log tables
+rm /etc/clickhouse-server/users.d/limits.yaml
+clickhouse-client -q "system reload config" ||:
+
 logs_saver_client_options="--max_block_size 8192 --max_memory_usage 10G --max_threads 1 --max_result_rows 0 --max_result_bytes 0 --max_bytes_to_read 0"
 
 # collect minio audit and server logs

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -451,22 +451,6 @@ do
     fi
 done
 
-# Also export trace log in flamegraph-friendly format.
-for trace_type in CPU Memory Real
-do
-    clickhouse-local "$data_path_config" --only-system-tables -q "
-            select
-                arrayStringConcat((arrayMap(x -> concat(splitByChar('/', addressToLine(x))[-1], '#', demangle(addressToSymbol(x)) ), trace)), ';') AS stack,
-                count(*) AS samples
-            from system.trace_log
-            where trace_type = '$trace_type'
-            group by trace
-            order by samples desc
-            settings allow_introspection_functions = 1
-            format TabSeparated" \
-        | zstd --threads=0 > "/test_output/trace-log-$trace_type-flamegraph.tsv.zst" ||:
-done
-
 # Grep logs for sanitizer asserts, crashes and other critical errors
 check_logs_for_critical_errors
 

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -457,15 +457,15 @@ function clickhouse_local_system()
 
 for table in query_log zookeeper_log trace_log transactions_info_log metric_log blob_storage_log error_log query_metric_log part_log latency_log
 do
-    clickhouse_local_system "$data_path_config" -q "select * from system.$table into outfile '/test_output/$table.tsv.zst'" ||:
+    clickhouse_local_system "$data_path_config" -q "select * from system.$table into outfile '/test_output/$table.tsv.zst'"
 
     if [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
-        clickhouse_local_system --path /var/lib/clickhouse1/ -q "select * from system.$table into outfile '/test_output/$table.1.tsv.zst'" ||:
-        clickhouse_local_system --path /var/lib/clickhouse2/ -q "select * from system.$table into outfile '/test_output/$table.2.tsv.zst'" ||:
+        clickhouse_local_system --path /var/lib/clickhouse1/ -q "select * from system.$table into outfile '/test_output/$table.1.tsv.zst'"
+        clickhouse_local_system --path /var/lib/clickhouse2/ -q "select * from system.$table into outfile '/test_output/$table.2.tsv.zst'"
     fi
 
     if [[ "$USE_SHARED_CATALOG" -eq 1 ]]; then
-        clickhouse_local_system --path /var/lib/clickhouse1/ -q "select * from system.$table into outfile '/test_output/$table.2.tsv.zst'" ||:
+        clickhouse_local_system --path /var/lib/clickhouse1/ -q "select * from system.$table into outfile '/test_output/$table.2.tsv.zst'"
     fi
 done
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changes
- gather `system.*_log` via `clickhouse-local` - the dependency on the server is gone - this will preserve complete `system.*_log` tables in artifacts (which is not the case now) (cc @alesapin )
- remove flamegraph-friendly artifacts (in favor of `trace_log.symbolize`) (cc @alexey-milovidov )

Reverts: https://github.com/ClickHouse/ClickHouse/pull/58955