### PR TITLE
tests: retry kazoo operations and idempotence of [zoo]keeper tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -50,7 +50,7 @@ except Exception as e:
 import docker
 from dict2xml import dict2xml
 from docker.models.containers import Container
-from kazoo.client import KazooClient
+from helpers.kazoo_client import KazooClientWithImplicitRetries
 from kazoo.exceptions import KazooException
 from minio import Minio
 
@@ -3187,13 +3187,17 @@ class ClickHouseCluster:
     def open_bash_shell(self, instance_name):
         os.system(" ".join(self.base_cmd + ["exec", instance_name, "/bin/bash"]))
 
-    def get_kazoo_client(self, zoo_instance_name, timeout: float = 30.0, retries=10):
+    def get_kazoo_client(
+        self, zoo_instance_name, timeout: float = 30.0, retries=10, external_port=None
+    ):
         use_ssl = False
         if self.with_zookeeper_secure:
             port = self.zookeeper_secure_port
             use_ssl = True
         elif self.with_zookeeper:
             port = self.zookeeper_port
+        elif external_port is not None:
+            port = external_port
         else:
             raise Exception("Cluster has no ZooKeeper")
 
@@ -3204,7 +3208,7 @@ class ClickHouseCluster:
         kazoo_retry = {
             "max_tries": retries,
         }
-        zk = KazooClient(
+        zk = KazooClientWithImplicitRetries(
             hosts=f"{ip}:{port}",
             timeout=timeout,
             connection_retry=kazoo_retry,

--- a/tests/integration/helpers/kazoo_client.py
+++ b/tests/integration/helpers/kazoo_client.py
@@ -1,0 +1,21 @@
+from kazoo.client import KazooClient
+
+
+class KazooClientWithImplicitRetries(KazooClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def exists(self, *args, **kwargs):
+        return self.retry(super().exists, *args, **kwargs)
+
+    def create(self, *args, **kwargs):
+        return self.retry(super().create, *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self.retry(super().get, *args, **kwargs)
+
+    def get_children(self, *args, **kwargs):
+        return self.retry(super().get_children, *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        return self.retry(super().set, *args, **kwargs)

--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -7,6 +7,7 @@ from multiprocessing.dummy import Pool
 import pytest
 
 import helpers.keeper_utils as keeper_utils
+from helpers.test_tools import get_retry_number
 from helpers.cluster import ClickHouseCluster
 from kazoo.client import KazooState
 
@@ -68,62 +69,72 @@ def started_cluster():
         cluster.shutdown()
 
 
-def test_simple_commands(started_cluster):
+def test_simple_commands(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
         genuine_zk = get_genuine_zk()
         fake_zk = get_fake_zk()
 
         for zk in [genuine_zk, fake_zk]:
-            zk.create("/test_simple_commands", b"")
-            zk.create("/test_simple_commands/somenode1", b"hello")
-            zk.set("/test_simple_commands/somenode1", b"world")
+            zk.create(f"/test_simple_commands_{retry}", b"")
+            zk.create(f"/test_simple_commands_{retry}/somenode1", b"hello")
+            zk.set(f"/test_simple_commands_{retry}/somenode1", b"world")
 
         for zk in [genuine_zk, fake_zk]:
-            assert zk.exists("/test_simple_commands")
-            assert zk.exists("/test_simple_commands/somenode1")
-            print(zk.get("/test_simple_commands/somenode1"))
-            assert zk.get("/test_simple_commands/somenode1")[0] == b"world"
+            assert zk.exists(f"/test_simple_commands_{retry}")
+            assert zk.exists(f"/test_simple_commands_{retry}/somenode1")
+            print(zk.get(f"/test_simple_commands_{retry}/somenode1"))
+            assert zk.get(f"/test_simple_commands_{retry}/somenode1")[0] == b"world"
     finally:
         for zk in [genuine_zk, fake_zk]:
             stop_zk(zk)
 
 
-def test_sequential_nodes(started_cluster):
+def test_sequential_nodes(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
         genuine_zk = get_genuine_zk()
         fake_zk = get_fake_zk()
-        genuine_zk.create("/test_sequential_nodes")
-        fake_zk.create("/test_sequential_nodes")
+        genuine_zk.create(f"/test_sequential_nodes_{retry}")
+        fake_zk.create(f"/test_sequential_nodes_{retry}")
         for i in range(1, 11):
             genuine_zk.create(
-                "/test_sequential_nodes/" + ("a" * i) + "-", sequence=True
+                f"/test_sequential_nodes_{retry}/" + ("a" * i) + "-", sequence=True
             )
-            genuine_zk.create("/test_sequential_nodes/" + ("b" * i))
-            fake_zk.create("/test_sequential_nodes/" + ("a" * i) + "-", sequence=True)
-            fake_zk.create("/test_sequential_nodes/" + ("b" * i))
+            genuine_zk.create(f"/test_sequential_nodes_{retry}/" + ("b" * i))
+            fake_zk.create(
+                f"/test_sequential_nodes_{retry}/" + ("a" * i) + "-", sequence=True
+            )
+            fake_zk.create(f"/test_sequential_nodes_{retry}/" + ("b" * i))
 
-        genuine_childs = list(sorted(genuine_zk.get_children("/test_sequential_nodes")))
-        fake_childs = list(sorted(fake_zk.get_children("/test_sequential_nodes")))
+        genuine_childs = list(
+            sorted(genuine_zk.get_children(f"/test_sequential_nodes_{retry}"))
+        )
+        fake_childs = list(
+            sorted(fake_zk.get_children(f"/test_sequential_nodes_{retry}"))
+        )
         assert genuine_childs == fake_childs
 
-        genuine_zk.create("/test_sequential_nodes_1")
-        fake_zk.create("/test_sequential_nodes_1")
+        genuine_zk.create(f"/test_sequential_nodes_{retry}_1")
+        fake_zk.create(f"/test_sequential_nodes_{retry}_1")
 
-        genuine_zk.create("/test_sequential_nodes_1/a", sequence=True)
-        fake_zk.create("/test_sequential_nodes_1/a", sequence=True)
+        genuine_zk.create(f"/test_sequential_nodes_{retry}_1/a", sequence=True)
+        fake_zk.create(f"/test_sequential_nodes_{retry}_1/a", sequence=True)
 
-        genuine_zk.create("/test_sequential_nodes_1/a0000000002")
-        fake_zk.create("/test_sequential_nodes_1/a0000000002")
+        genuine_zk.create(f"/test_sequential_nodes_{retry}_1/a0000000002")
+        fake_zk.create(f"/test_sequential_nodes_{retry}_1/a0000000002")
 
         genuine_throw = False
         fake_throw = False
         try:
-            genuine_zk.create("/test_sequential_nodes_1/a", sequence=True)
+            genuine_zk.create(f"/test_sequential_nodes_{retry}_1/a", sequence=True)
         except Exception as ex:
             genuine_throw = True
 
         try:
-            fake_zk.create("/test_sequential_nodes_1/a", sequence=True)
+            fake_zk.create(f"/test_sequential_nodes_{retry}_1/a", sequence=True)
         except Exception as ex:
             fake_throw = True
 
@@ -131,23 +142,27 @@ def test_sequential_nodes(started_cluster):
         assert fake_throw == True
 
         genuine_childs_1 = list(
-            sorted(genuine_zk.get_children("/test_sequential_nodes_1"))
+            sorted(genuine_zk.get_children(f"/test_sequential_nodes_{retry}_1"))
         )
-        fake_childs_1 = list(sorted(fake_zk.get_children("/test_sequential_nodes_1")))
+        fake_childs_1 = list(
+            sorted(fake_zk.get_children(f"/test_sequential_nodes_{retry}_1"))
+        )
         assert genuine_childs_1 == fake_childs_1
 
-        genuine_zk.create("/test_sequential_nodes_2")
-        fake_zk.create("/test_sequential_nodes_2")
+        genuine_zk.create(f"/test_sequential_nodes_{retry}_2")
+        fake_zk.create(f"/test_sequential_nodes_{retry}_2")
 
-        genuine_zk.create("/test_sequential_nodes_2/node")
-        fake_zk.create("/test_sequential_nodes_2/node")
-        genuine_zk.create("/test_sequential_nodes_2/node", sequence=True)
-        fake_zk.create("/test_sequential_nodes_2/node", sequence=True)
+        genuine_zk.create(f"/test_sequential_nodes_{retry}_2/node")
+        fake_zk.create(f"/test_sequential_nodes_{retry}_2/node")
+        genuine_zk.create(f"/test_sequential_nodes_{retry}_2/node", sequence=True)
+        fake_zk.create(f"/test_sequential_nodes_{retry}_2/node", sequence=True)
 
         genuine_childs_2 = list(
-            sorted(genuine_zk.get_children("/test_sequential_nodes_2"))
+            sorted(genuine_zk.get_children(f"/test_sequential_nodes_{retry}_2"))
         )
-        fake_childs_2 = list(sorted(fake_zk.get_children("/test_sequential_nodes_2")))
+        fake_childs_2 = list(
+            sorted(fake_zk.get_children(f"/test_sequential_nodes_{retry}_2"))
+        )
         assert genuine_childs_2 == fake_childs_2
     finally:
         for zk in [genuine_zk, fake_zk]:
@@ -163,48 +178,63 @@ def assert_eq_stats(stat1, stat2):
     assert stat1.numChildren == stat2.numChildren
 
 
-def test_stats(started_cluster):
+def test_stats(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
         genuine_zk = get_genuine_zk()
         fake_zk = get_fake_zk()
-        genuine_zk.create("/test_stats_nodes")
-        fake_zk.create("/test_stats_nodes")
-        genuine_stats = genuine_zk.exists("/test_stats_nodes")
-        fake_stats = fake_zk.exists("/test_stats_nodes")
+        genuine_zk.create(f"/test_stats_nodes_{retry}")
+        fake_zk.create(f"/test_stats_nodes_{retry}")
+        genuine_stats = genuine_zk.exists(f"/test_stats_nodes_{retry}")
+        fake_stats = fake_zk.exists(f"/test_stats_nodes_{retry}")
         assert_eq_stats(genuine_stats, fake_stats)
         for i in range(1, 11):
-            genuine_zk.create("/test_stats_nodes/" + ("a" * i) + "-", sequence=True)
-            genuine_zk.create("/test_stats_nodes/" + ("b" * i))
-            fake_zk.create("/test_stats_nodes/" + ("a" * i) + "-", sequence=True)
-            fake_zk.create("/test_stats_nodes/" + ("b" * i))
+            genuine_zk.create(
+                f"/test_stats_nodes_{retry}/" + ("a" * i) + "-", sequence=True
+            )
+            genuine_zk.create(f"/test_stats_nodes_{retry}/" + ("b" * i))
+            fake_zk.create(
+                f"/test_stats_nodes_{retry}/" + ("a" * i) + "-", sequence=True
+            )
+            fake_zk.create(f"/test_stats_nodes_{retry}/" + ("b" * i))
 
-        genuine_stats = genuine_zk.exists("/test_stats_nodes")
-        fake_stats = fake_zk.exists("/test_stats_nodes")
+        genuine_stats = genuine_zk.exists(f"/test_stats_nodes_{retry}")
+        fake_stats = fake_zk.exists(f"/test_stats_nodes_{retry}")
         assert_eq_stats(genuine_stats, fake_stats)
         for i in range(1, 11):
             print(
-                "/test_stats_nodes/" + ("a" * i) + "-" + "{:010d}".format((i - 1) * 2)
+                f"/test_stats_nodes_{retry}/"
+                + ("a" * i)
+                + "-"
+                + "{:010d}".format((i - 1) * 2)
             )
             genuine_zk.delete(
-                "/test_stats_nodes/" + ("a" * i) + "-" + "{:010d}".format((i - 1) * 2)
+                f"/test_stats_nodes_{retry}/"
+                + ("a" * i)
+                + "-"
+                + "{:010d}".format((i - 1) * 2)
             )
-            genuine_zk.delete("/test_stats_nodes/" + ("b" * i))
+            genuine_zk.delete(f"/test_stats_nodes_{retry}/" + ("b" * i))
             fake_zk.delete(
-                "/test_stats_nodes/" + ("a" * i) + "-" + "{:010d}".format((i - 1) * 2)
+                f"/test_stats_nodes_{retry}/"
+                + ("a" * i)
+                + "-"
+                + "{:010d}".format((i - 1) * 2)
             )
-            fake_zk.delete("/test_stats_nodes/" + ("b" * i))
+            fake_zk.delete(f"/test_stats_nodes_{retry}/" + ("b" * i))
 
-        genuine_stats = genuine_zk.exists("/test_stats_nodes")
-        fake_stats = fake_zk.exists("/test_stats_nodes")
+        genuine_stats = genuine_zk.exists(f"/test_stats_nodes_{retry}")
+        fake_stats = fake_zk.exists(f"/test_stats_nodes_{retry}")
         print(genuine_stats)
         print(fake_stats)
         assert_eq_stats(genuine_stats, fake_stats)
         for i in range(100):
-            genuine_zk.set("/test_stats_nodes", ("q" * i).encode())
-            fake_zk.set("/test_stats_nodes", ("q" * i).encode())
+            genuine_zk.set(f"/test_stats_nodes_{retry}", ("q" * i).encode())
+            fake_zk.set(f"/test_stats_nodes_{retry}", ("q" * i).encode())
 
-        genuine_stats = genuine_zk.exists("/test_stats_nodes")
-        fake_stats = fake_zk.exists("/test_stats_nodes")
+        genuine_stats = genuine_zk.exists(f"/test_stats_nodes_{retry}")
+        fake_stats = fake_zk.exists(f"/test_stats_nodes_{retry}")
         print(genuine_stats)
         print(fake_stats)
         assert_eq_stats(genuine_stats, fake_stats)
@@ -213,12 +243,14 @@ def test_stats(started_cluster):
             stop_zk(zk)
 
 
-def test_watchers(started_cluster):
+def test_watchers(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
         genuine_zk = get_genuine_zk()
         fake_zk = get_fake_zk()
-        genuine_zk.create("/test_data_watches")
-        fake_zk.create("/test_data_watches")
+        genuine_zk.create(f"/test_data_watches_{retry}")
+        fake_zk.create(f"/test_data_watches_{retry}")
         genuine_data_watch_data = None
 
         def genuine_callback(event):
@@ -233,21 +265,21 @@ def test_watchers(started_cluster):
             nonlocal fake_data_watch_data
             fake_data_watch_data = event
 
-        genuine_zk.get("/test_data_watches", watch=genuine_callback)
-        fake_zk.get("/test_data_watches", watch=fake_callback)
+        genuine_zk.get(f"/test_data_watches_{retry}", watch=genuine_callback)
+        fake_zk.get(f"/test_data_watches_{retry}", watch=fake_callback)
 
         print("Calling set genuine")
-        genuine_zk.set("/test_data_watches", b"a")
+        genuine_zk.set(f"/test_data_watches_{retry}", b"a")
         print("Calling set fake")
-        fake_zk.set("/test_data_watches", b"a")
+        fake_zk.set(f"/test_data_watches_{retry}", b"a")
         time.sleep(3)
 
         print("Genuine data", genuine_data_watch_data)
         print("Fake data", fake_data_watch_data)
         assert genuine_data_watch_data == fake_data_watch_data
 
-        genuine_zk.create("/test_data_watches/child", b"a")
-        fake_zk.create("/test_data_watches/child", b"a")
+        genuine_zk.create(f"/test_data_watches_{retry}/child", b"a")
+        fake_zk.create(f"/test_data_watches_{retry}/child", b"a")
 
         genuine_children = None
 
@@ -263,16 +295,18 @@ def test_watchers(started_cluster):
             nonlocal fake_children
             fake_children = event
 
-        genuine_zk.get_children("/test_data_watches", watch=genuine_child_callback)
-        fake_zk.get_children("/test_data_watches", watch=fake_child_callback)
+        genuine_zk.get_children(
+            f"/test_data_watches_{retry}", watch=genuine_child_callback
+        )
+        fake_zk.get_children(f"/test_data_watches_{retry}", watch=fake_child_callback)
 
         print("Calling non related genuine child")
-        genuine_zk.set("/test_data_watches/child", b"q")
-        genuine_zk.set("/test_data_watches", b"q")
+        genuine_zk.set(f"/test_data_watches_{retry}/child", b"q")
+        genuine_zk.set(f"/test_data_watches_{retry}", b"q")
 
         print("Calling non related fake child")
-        fake_zk.set("/test_data_watches/child", b"q")
-        fake_zk.set("/test_data_watches", b"q")
+        fake_zk.set(f"/test_data_watches_{retry}/child", b"q")
+        fake_zk.set(f"/test_data_watches_{retry}", b"q")
 
         time.sleep(3)
 
@@ -280,9 +314,9 @@ def test_watchers(started_cluster):
         assert fake_children == None
 
         print("Calling genuine child")
-        genuine_zk.create("/test_data_watches/child_new", b"b")
+        genuine_zk.create(f"/test_data_watches_{retry}/child_new", b"b")
         print("Calling fake child")
-        fake_zk.create("/test_data_watches/child_new", b"b")
+        fake_zk.create(f"/test_data_watches_{retry}/child_new", b"b")
 
         time.sleep(3)
 
@@ -319,18 +353,22 @@ def test_watchers(started_cluster):
             fake_child_delete = event
 
         genuine_zk.get_children(
-            "/test_data_watches", watch=genuine_child_delete_callback
+            f"/test_data_watches_{retry}", watch=genuine_child_delete_callback
         )
-        fake_zk.get_children("/test_data_watches", watch=fake_child_delete_callback)
+        fake_zk.get_children(
+            f"/test_data_watches_{retry}", watch=fake_child_delete_callback
+        )
         genuine_zk.get_children(
-            "/test_data_watches/child", watch=genuine_own_delete_callback
+            f"/test_data_watches_{retry}/child", watch=genuine_own_delete_callback
         )
-        fake_zk.get_children("/test_data_watches/child", watch=fake_own_delete_callback)
+        fake_zk.get_children(
+            f"/test_data_watches_{retry}/child", watch=fake_own_delete_callback
+        )
 
         print("Calling genuine child delete")
-        genuine_zk.delete("/test_data_watches/child")
+        genuine_zk.delete(f"/test_data_watches_{retry}/child")
         print("Calling fake child delete")
-        fake_zk.delete("/test_data_watches/child")
+        fake_zk.delete(f"/test_data_watches_{retry}/child")
 
         time.sleep(3)
 
@@ -347,36 +385,40 @@ def test_watchers(started_cluster):
             stop_zk(zk)
 
 
-def test_multitransactions(started_cluster):
+def test_multitransactions(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
         genuine_zk = get_genuine_zk()
         fake_zk = get_fake_zk()
         for zk in [genuine_zk, fake_zk]:
-            zk.create("/test_multitransactions")
+            zk.create(f"/test_multitransactions_{retry}")
             t = zk.transaction()
-            t.create("/test_multitransactions/freddy")
-            t.create("/test_multitransactions/fred", ephemeral=True)
-            t.create("/test_multitransactions/smith", sequence=True)
+            t.create(f"/test_multitransactions_{retry}/freddy")
+            t.create(f"/test_multitransactions_{retry}/fred", ephemeral=True)
+            t.create(f"/test_multitransactions_{retry}/smith", sequence=True)
             results = t.commit()
             assert len(results) == 3
-            assert results[0] == "/test_multitransactions/freddy"
-            assert results[2].startswith("/test_multitransactions/smith0") is True
+            assert results[0] == f"/test_multitransactions_{retry}/freddy"
+            assert (
+                results[2].startswith(f"/test_multitransactions_{retry}/smith0") is True
+            )
 
         from kazoo.exceptions import NoNodeError, RolledBackError
 
         for i, zk in enumerate([genuine_zk, fake_zk]):
             print("Processing ZK", i)
             t = zk.transaction()
-            t.create("/test_multitransactions/q")
-            t.delete("/test_multitransactions/a")
-            t.create("/test_multitransactions/x")
+            t.create(f"/test_multitransactions_{retry}/q")
+            t.delete(f"/test_multitransactions_{retry}/a")
+            t.create(f"/test_multitransactions_{retry}/x")
             results = t.commit()
             print("Results", results)
             assert results[0].__class__ == RolledBackError
             assert results[1].__class__ == NoNodeError
-            assert zk.exists("/test_multitransactions/q") is None
-            assert zk.exists("/test_multitransactions/a") is None
-            assert zk.exists("/test_multitransactions/x") is None
+            assert zk.exists(f"/test_multitransactions_{retry}/q") is None
+            assert zk.exists(f"/test_multitransactions_{retry}/a") is None
+            assert zk.exists(f"/test_multitransactions_{retry}/x") is None
     finally:
         for zk in [genuine_zk, fake_zk]:
             stop_zk(zk)
@@ -498,14 +540,16 @@ def generate_requests(prefix="/", iters=1):
     return requests
 
 
-def test_random_requests(started_cluster):
+def test_random_requests(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
-        requests = generate_requests("/test_random_requests", 10)
+        requests = generate_requests(f"/test_random_requests_{retry}", 10)
         print("Generated", len(requests), "requests")
         genuine_zk = get_genuine_zk()
         fake_zk = get_fake_zk()
-        genuine_zk.create("/test_random_requests")
-        fake_zk.create("/test_random_requests")
+        genuine_zk.create(f"/test_random_requests_{retry}")
+        fake_zk.create(f"/test_random_requests_{retry}")
         for i, request in enumerate(requests):
             genuine_throw = False
             fake_throw = False
@@ -531,12 +575,16 @@ def test_random_requests(started_cluster):
             assert fake_result == genuine_result, "Zookeeper results differ"
         root_children_genuine = [
             elem
-            for elem in list(sorted(genuine_zk.get_children("/test_random_requests")))
+            for elem in list(
+                sorted(genuine_zk.get_children(f"/test_random_requests_{retry}"))
+            )
             if elem not in ("clickhouse", "zookeeper")
         ]
         root_children_fake = [
             elem
-            for elem in list(sorted(fake_zk.get_children("/test_random_requests")))
+            for elem in list(
+                sorted(fake_zk.get_children(f"/test_random_requests_{retry}"))
+            )
             if elem not in ("clickhouse", "zookeeper")
         ]
         assert root_children_fake == root_children_genuine
@@ -545,7 +593,9 @@ def test_random_requests(started_cluster):
             stop_zk(zk)
 
 
-def test_end_of_session(started_cluster):
+def test_end_of_session(started_cluster, request):
+    retry = get_retry_number(request)
+
     fake_zk1 = None
     fake_zk2 = None
     genuine_zk1 = None
@@ -559,8 +609,8 @@ def test_end_of_session(started_cluster):
         genuine_zk2 = cluster.get_kazoo_client("zoo1")
         genuine_zk2.start()
 
-        fake_zk1.create("/test_end_of_session")
-        genuine_zk1.create("/test_end_of_session")
+        fake_zk1.create(f"/test_end_of_session_{retry}")
+        genuine_zk1.create(f"/test_end_of_session_{retry}")
         fake_ephemeral_event = None
 
         def fake_ephemeral_callback(event):
@@ -575,21 +625,25 @@ def test_end_of_session(started_cluster):
             nonlocal genuine_ephemeral_event
             genuine_ephemeral_event = event
 
-        assert fake_zk2.exists("/test_end_of_session") is not None
-        assert genuine_zk2.exists("/test_end_of_session") is not None
+        assert fake_zk2.exists(f"/test_end_of_session_{retry}") is not None
+        assert genuine_zk2.exists(f"/test_end_of_session_{retry}") is not None
 
-        fake_zk1.create("/test_end_of_session/ephemeral_node", ephemeral=True)
-        genuine_zk1.create("/test_end_of_session/ephemeral_node", ephemeral=True)
+        fake_zk1.create(f"/test_end_of_session_{retry}/ephemeral_node", ephemeral=True)
+        genuine_zk1.create(
+            f"/test_end_of_session_{retry}/ephemeral_node", ephemeral=True
+        )
 
         assert (
             fake_zk2.exists(
-                "/test_end_of_session/ephemeral_node", watch=fake_ephemeral_callback
+                f"/test_end_of_session_{retry}/ephemeral_node",
+                watch=fake_ephemeral_callback,
             )
             is not None
         )
         assert (
             genuine_zk2.exists(
-                "/test_end_of_session/ephemeral_node", watch=genuine_ephemeral_callback
+                f"/test_end_of_session_{retry}/ephemeral_node",
+                watch=genuine_ephemeral_callback,
             )
             is not None
         )
@@ -604,8 +658,10 @@ def test_end_of_session(started_cluster):
         print("Closing fake zk")
         fake_zk1.close()
 
-        assert fake_zk2.exists("/test_end_of_session/ephemeral_node") is None
-        assert genuine_zk2.exists("/test_end_of_session/ephemeral_node") is None
+        assert fake_zk2.exists(f"/test_end_of_session_{retry}/ephemeral_node") is None
+        assert (
+            genuine_zk2.exists(f"/test_end_of_session_{retry}/ephemeral_node") is None
+        )
 
         assert fake_ephemeral_event == genuine_ephemeral_event
 
@@ -614,14 +670,16 @@ def test_end_of_session(started_cluster):
             stop_zk(zk)
 
 
-def test_end_of_watches_session(started_cluster):
+def test_end_of_watches_session(started_cluster, request):
+    retry = get_retry_number(request)
+
     fake_zk1 = None
     fake_zk2 = None
     try:
         fake_zk1 = keeper_utils.get_fake_zk(cluster, "node")
         fake_zk2 = keeper_utils.get_fake_zk(cluster, "node")
 
-        fake_zk1.create("/test_end_of_watches_session")
+        fake_zk1.create(f"/test_end_of_watches_session_{retry}")
 
         dummy_set = 0
 
@@ -631,16 +689,17 @@ def test_end_of_watches_session(started_cluster):
             print(event)
 
         for child_node in range(100):
-            fake_zk1.create("/test_end_of_watches_session/" + str(child_node))
+            fake_zk1.create(f"/test_end_of_watches_session_{retry}/" + str(child_node))
             fake_zk1.get_children(
-                "/test_end_of_watches_session/" + str(child_node), watch=dummy_callback
+                f"/test_end_of_watches_session_{retry}/" + str(child_node),
+                watch=dummy_callback,
             )
 
         fake_zk2.get_children(
-            "/test_end_of_watches_session/" + str(0), watch=dummy_callback
+            f"/test_end_of_watches_session_{retry}/" + str(0), watch=dummy_callback
         )
         fake_zk2.get_children(
-            "/test_end_of_watches_session/" + str(1), watch=dummy_callback
+            f"/test_end_of_watches_session_{retry}/" + str(1), watch=dummy_callback
         )
 
         fake_zk1.stop()
@@ -648,7 +707,7 @@ def test_end_of_watches_session(started_cluster):
 
         for child_node in range(100):
             fake_zk2.create(
-                "/test_end_of_watches_session/"
+                f"/test_end_of_watches_session_{retry}/"
                 + str(child_node)
                 + "/"
                 + str(child_node),
@@ -661,11 +720,13 @@ def test_end_of_watches_session(started_cluster):
             stop_zk(zk)
 
 
-def test_concurrent_watches(started_cluster):
+def test_concurrent_watches(started_cluster, request):
+    retry = get_retry_number(request)
+
     try:
         fake_zk = get_fake_zk()
         fake_zk.restart()
-        global_path = "/test_concurrent_watches_0"
+        global_path = f"/test_concurrent_watches_{retry}_0"
         fake_zk.create(global_path)
 
         dumb_watch_triggered_counter = 0

--- a/tests/integration/test_keeper_feature_flags_config/test.py
+++ b/tests/integration/test_keeper_feature_flags_config/test.py
@@ -68,12 +68,12 @@ def test_keeper_feature_flags(started_cluster):
         for feature, is_enabled in feature_flags:
             node.wait_for_log_line(
                 f"ZooKeeperClient: Keeper feature flag {feature.upper()}: {'enabled' if is_enabled else 'disabled'}",
-                look_behind_lines=1000,
+                look_behind_lines=10000,
             )
 
             node.wait_for_log_line(
                 f"KeeperContext: Keeper feature flag {feature.upper()}: {'enabled' if is_enabled else 'disabled'}",
-                look_behind_lines=1000,
+                look_behind_lines=10000,
             )
 
             assert f"{feature}\t{1 if is_enabled else 0}" in res

--- a/tests/integration/test_keeper_feature_flags_config/test.py
+++ b/tests/integration/test_keeper_feature_flags_config/test.py
@@ -3,7 +3,6 @@
 import os
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
@@ -31,10 +30,7 @@ def started_cluster():
 
 
 def get_connection_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
+    _fake_zk_instance = keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
     return _fake_zk_instance
 
 

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -3,10 +3,9 @@ import random
 import string
 
 import pytest
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 from kazoo.exceptions import ConnectionLoss
 
-from helpers import keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__, keeper_config_dir="configs/")
@@ -24,6 +23,7 @@ def random_string(length):
 
 
 def get_connection_zk(nodename, timeout=30.0):
+    # NOTE: here we need KazooClient without implicit retries! (KazooClientWithImplicitRetries)
     _fake_zk_instance = KazooClient(
         hosts=cluster.get_instance_ip(nodename) + ":2181", timeout=timeout
     )

--- a/tests/integration/test_keeper_mntr_data_size/test.py
+++ b/tests/integration/test_keeper_mntr_data_size/test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 import pytest
-from kazoo.client import KazooClient, KazooState
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
@@ -35,9 +34,7 @@ def started_cluster():
 
 
 def get_connection_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
+    _fake_zk_instance = keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
     _fake_zk_instance.start()
     return _fake_zk_instance
 

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -2,10 +2,9 @@
 import os
 import random
 import string
-import time
 
 import pytest
-from kazoo.client import KazooClient, KazooState
+import helpers.keeper_utils as keeper_utils
 
 from helpers.cluster import ClickHouseCluster
 
@@ -40,10 +39,7 @@ def started_cluster():
 
 
 def get_connection_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
+    _fake_zk_instance = keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
     return _fake_zk_instance
 
 

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -5,6 +5,7 @@ import string
 
 import pytest
 import helpers.keeper_utils as keeper_utils
+from helpers.test_tools import get_retry_number
 
 from helpers.cluster import ClickHouseCluster
 
@@ -47,41 +48,37 @@ def restart_clickhouse():
     node.restart_clickhouse(kill=True)
 
 
-def test_state_after_restart(started_cluster):
+def test_state_after_restart(started_cluster, request):
     try:
         node_zk = None
         node_zk2 = None
         node_zk = get_connection_zk("node")
 
-        node_zk.create("/test_state_after_restart", b"somevalue")
+        chroot = f"/test_state_after_restart_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         strs = []
         for i in range(100):
             strs.append(random_string(123).encode())
-            node_zk.create("/test_state_after_restart/node" + str(i), strs[i])
+            node_zk.create("/node" + str(i), strs[i])
 
         for i in range(100):
             if i % 7 == 0:
-                node_zk.delete("/test_state_after_restart/node" + str(i))
+                node_zk.delete("/node" + str(i))
 
         restart_clickhouse()
 
         node_zk2 = get_connection_zk("node")
+        node_zk2.chroot = chroot
 
-        assert node_zk2.get("/test_state_after_restart")[0] == b"somevalue"
+        assert node_zk2.get("/")[0] == b"somevalue"
         for i in range(100):
             if i % 7 == 0:
-                assert (
-                    node_zk2.exists("/test_state_after_restart/node" + str(i)) is None
-                )
+                assert node_zk2.exists("/node" + str(i)) is None
             else:
-                assert (
-                    len(node_zk2.get("/test_state_after_restart/node" + str(i))[0])
-                    == 123
-                )
-                assert (
-                    node_zk2.get("/test_state_after_restart/node" + str(i))[0]
-                    == strs[i]
-                )
+                assert len(node_zk2.get("/node" + str(i))[0]) == 123
+                assert node_zk2.get("/node" + str(i))[0] == strs[i]
     finally:
         try:
             if node_zk is not None:
@@ -95,51 +92,47 @@ def test_state_after_restart(started_cluster):
             pass
 
 
-def test_state_duplicate_restart(started_cluster):
+def test_state_duplicate_restart(started_cluster, request):
     try:
         node_zk = None
         node_zk2 = None
         node_zk3 = None
         node_zk = get_connection_zk("node")
 
-        node_zk.create("/test_state_duplicated_restart", b"somevalue")
+        chroot = f"/test_state_duplicated_restart_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         strs = []
         for i in range(100):
             strs.append(random_string(123).encode())
-            node_zk.create("/test_state_duplicated_restart/node" + str(i), strs[i])
+            node_zk.create("/node" + str(i), strs[i])
 
         for i in range(100):
             if i % 7 == 0:
-                node_zk.delete("/test_state_duplicated_restart/node" + str(i))
+                node_zk.delete("/node" + str(i))
 
         restart_clickhouse()
 
         node_zk2 = get_connection_zk("node")
+        node_zk2.chroot = chroot
 
-        node_zk2.create("/test_state_duplicated_restart/just_test1")
-        node_zk2.create("/test_state_duplicated_restart/just_test2")
-        node_zk2.create("/test_state_duplicated_restart/just_test3")
+        node_zk2.create("/just_test1")
+        node_zk2.create("/just_test2")
+        node_zk2.create("/just_test3")
 
         restart_clickhouse()
 
         node_zk3 = get_connection_zk("node")
+        node_zk3.chroot = chroot
 
-        assert node_zk3.get("/test_state_duplicated_restart")[0] == b"somevalue"
+        assert node_zk3.get("/")[0] == b"somevalue"
         for i in range(100):
             if i % 7 == 0:
-                assert (
-                    node_zk3.exists("/test_state_duplicated_restart/node" + str(i))
-                    is None
-                )
+                assert node_zk3.exists("/node" + str(i)) is None
             else:
-                assert (
-                    len(node_zk3.get("/test_state_duplicated_restart/node" + str(i))[0])
-                    == 123
-                )
-                assert (
-                    node_zk3.get("/test_state_duplicated_restart/node" + str(i))[0]
-                    == strs[i]
-                )
+                assert len(node_zk3.get("/node" + str(i))[0]) == 123
+                assert node_zk3.get("/node" + str(i))[0] == strs[i]
     finally:
         try:
             if node_zk is not None:
@@ -159,44 +152,37 @@ def test_state_duplicate_restart(started_cluster):
 
 
 # http://zookeeper-user.578899.n2.nabble.com/Why-are-ephemeral-nodes-written-to-disk-tp7583403p7583418.html
-def test_ephemeral_after_restart(started_cluster):
+def test_ephemeral_after_restart(started_cluster, request):
     try:
         node_zk = None
         node_zk2 = None
         node_zk = get_connection_zk("node")
 
-        node_zk.create("/test_ephemeral_after_restart", b"somevalue")
+        chroot = f"/test_ephemeral_after_restart_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         strs = []
         for i in range(100):
             strs.append(random_string(123).encode())
-            node_zk.create(
-                "/test_ephemeral_after_restart/node" + str(i), strs[i], ephemeral=True
-            )
+            node_zk.create("/node" + str(i), strs[i], ephemeral=True)
 
         for i in range(100):
             if i % 7 == 0:
-                node_zk.delete("/test_ephemeral_after_restart/node" + str(i))
+                node_zk.delete("/node" + str(i))
 
         restart_clickhouse()
 
         node_zk2 = get_connection_zk("node")
+        node_zk2.chroot = chroot
 
-        assert node_zk2.get("/test_ephemeral_after_restart")[0] == b"somevalue"
+        assert node_zk2.get("/")[0] == b"somevalue"
         for i in range(100):
             if i % 7 == 0:
-                assert (
-                    node_zk2.exists("/test_ephemeral_after_restart/node" + str(i))
-                    is None
-                )
+                assert node_zk2.exists("/node" + str(i)) is None
             else:
-                assert (
-                    len(node_zk2.get("/test_ephemeral_after_restart/node" + str(i))[0])
-                    == 123
-                )
-                assert (
-                    node_zk2.get("/test_ephemeral_after_restart/node" + str(i))[0]
-                    == strs[i]
-                )
+                assert len(node_zk2.get("/node" + str(i))[0]) == 123
+                assert node_zk2.get("/node" + str(i))[0] == strs[i]
     finally:
         try:
             if node_zk is not None:

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -6,7 +6,6 @@ import time
 from multiprocessing.dummy import Pool
 
 import pytest
-from kazoo.client import KazooClient, KazooRetry
 from kazoo.handlers.threading import KazooTimeoutError
 
 import helpers.keeper_utils as keeper_utils
@@ -143,12 +142,7 @@ def get_genuine_zk(node, timeout=30.0):
     CONNECTION_RETRIES = 100
     for i in range(CONNECTION_RETRIES):
         try:
-            _genuine_zk_instance = KazooClient(
-                hosts=cluster.get_instance_ip(node.name) + ":2181",
-                timeout=timeout,
-                connection_retry=KazooRetry(max_tries=20),
-            )
-            _genuine_zk_instance.start()
+            _genuine_zk_instance = cluster.get_kazoo_client(node.name, timeout=timeout, external_port=2181)
             return _genuine_zk_instance
         except KazooTimeoutError:
             if i == CONNECTION_RETRIES - 1:

--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -5,7 +5,6 @@ import random
 import string
 
 import pytest
-from kazoo.client import KazooClient
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
@@ -42,10 +41,7 @@ def started_cluster():
 
 
 def get_connection_zk(nodename, timeout=30.0):
-    _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
-    )
-    _fake_zk_instance.start()
+    _fake_zk_instance = keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
     return _fake_zk_instance
 
 

--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -7,6 +7,7 @@ import string
 import pytest
 
 import helpers.keeper_utils as keeper_utils
+from helpers.test_tools import get_retry_number
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -50,44 +51,46 @@ def restart_clickhouse():
     keeper_utils.wait_until_connected(cluster, node)
 
 
-def test_state_after_restart(started_cluster):
+def test_state_after_restart(started_cluster, request):
     keeper_utils.wait_until_connected(started_cluster, node)
     node_zk = None
     node_zk2 = None
     try:
         node_zk = get_connection_zk("node")
 
-        node_zk.create("/test_state_after_restart", b"somevalue")
+        chroot = f"/test_state_after_restart_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         strs = []
         for i in range(100):
             strs.append(random_string(123).encode())
-            node_zk.create("/test_state_after_restart/node" + str(i), strs[i])
+            node_zk.create("/node" + str(i), strs[i])
 
         existing_children = []
         for i in range(100):
             if i % 7 == 0:
-                node_zk.delete("/test_state_after_restart/node" + str(i))
+                node_zk.delete("/node" + str(i))
             else:
                 existing_children.append("node" + str(i))
 
         restart_clickhouse()
 
         node_zk2 = get_connection_zk("node")
+        node_zk2.chroot = chroot
 
-        assert node_zk2.get("/test_state_after_restart")[0] == b"somevalue"
+        assert node_zk2.get("/")[0] == b"somevalue"
         for i in range(100):
             if i % 7 == 0:
-                assert (
-                    node_zk2.exists("/test_state_after_restart/node" + str(i)) is None
-                )
+                assert node_zk2.exists("/node" + str(i)) is None
             else:
-                data, stat = node_zk2.get("/test_state_after_restart/node" + str(i))
+                data, stat = node_zk2.get("/node" + str(i))
                 assert len(data) == 123
                 assert data == strs[i]
                 assert stat.ephemeralOwner == 0
 
         assert list(sorted(existing_children)) == list(
-            sorted(node_zk2.get_children("/test_state_after_restart"))
+            sorted(node_zk2.get_children("/"))
         )
     finally:
         try:
@@ -102,7 +105,7 @@ def test_state_after_restart(started_cluster):
             pass
 
 
-def test_ephemeral_after_restart(started_cluster):
+def test_ephemeral_after_restart(started_cluster, request):
     keeper_utils.wait_until_connected(started_cluster, node)
     node_zk = None
     node_zk2 = None
@@ -110,39 +113,39 @@ def test_ephemeral_after_restart(started_cluster):
         node_zk = get_connection_zk("node")
 
         session_id = node_zk._session_id
-        node_zk.create("/test_ephemeral_after_restart", b"somevalue")
+
+        chroot = f"/test_ephemeral_after_restart_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         strs = []
         for i in range(100):
             strs.append(random_string(123).encode())
-            node_zk.create(
-                "/test_ephemeral_after_restart/node" + str(i), strs[i], ephemeral=True
-            )
+            node_zk.create("/node" + str(i), strs[i], ephemeral=True)
 
         existing_children = []
         for i in range(100):
             if i % 7 == 0:
-                node_zk.delete("/test_ephemeral_after_restart/node" + str(i))
+                node_zk.delete("/node" + str(i))
             else:
                 existing_children.append("node" + str(i))
 
         restart_clickhouse()
 
         node_zk2 = get_connection_zk("node")
+        node_zk2.chroot = chroot
 
-        assert node_zk2.get("/test_ephemeral_after_restart")[0] == b"somevalue"
+        assert node_zk2.get("/")[0] == b"somevalue"
         for i in range(100):
             if i % 7 == 0:
-                assert (
-                    node_zk2.exists("/test_ephemeral_after_restart/node" + str(i))
-                    is None
-                )
+                assert node_zk2.exists("/node" + str(i)) is None
             else:
-                data, stat = node_zk2.get("/test_ephemeral_after_restart/node" + str(i))
+                data, stat = node_zk2.get("/node" + str(i))
                 assert len(data) == 123
                 assert data == strs[i]
                 assert stat.ephemeralOwner == session_id
         assert list(sorted(existing_children)) == list(
-            sorted(node_zk2.get_children("/test_ephemeral_after_restart"))
+            sorted(node_zk2.get_children("/"))
         )
     finally:
         try:
@@ -157,12 +160,16 @@ def test_ephemeral_after_restart(started_cluster):
             pass
 
 
-def test_invalid_snapshot(started_cluster):
+def test_invalid_snapshot(started_cluster, request):
     keeper_utils.wait_until_connected(started_cluster, node)
     node_zk = None
     try:
         node_zk = get_connection_zk("node")
-        node_zk.create("/test_invalid_snapshot", b"somevalue")
+
+        chroot = f"/test_invalid_snapshot_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         keeper_utils.send_4lw_cmd(started_cluster, node, "csnp")
         node.stop_clickhouse()
         snapshots = (
@@ -209,17 +216,20 @@ def test_invalid_snapshot(started_cluster):
             pass
 
 
-def test_snapshot_size(started_cluster):
+def test_snapshot_size(started_cluster, request):
     keeper_utils.wait_until_connected(started_cluster, node)
     node_zk = None
     try:
         node_zk = get_connection_zk("node")
 
-        node_zk.create("/test_state_size", b"somevalue")
+        chroot = f"/test_state_size_{get_retry_number(request)}"
+        node_zk.create(chroot, b"somevalue")
+        node_zk.chroot = chroot
+
         strs = []
         for i in range(100):
             strs.append(random_string(123).encode())
-            node_zk.create("/test_state_size/node" + str(i), strs[i])
+            node_zk.create("/node" + str(i), strs[i])
 
         node_zk.stop()
         node_zk.close()

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -3,9 +3,7 @@ import os
 import time
 
 import pytest
-from kazoo.client import KazooClient
 from kazoo.handlers.threading import KazooTimeoutError
-from kazoo.retry import KazooRetry
 from kazoo.security import make_acl
 
 import helpers.keeper_utils as keeper_utils
@@ -147,12 +145,9 @@ def get_genuine_zk(timeout=60.0):
     CONNECTION_RETRIES = 100
     for i in range(CONNECTION_RETRIES):
         try:
-            _genuine_zk_instance = KazooClient(
-                hosts=cluster.get_instance_ip("node") + ":2181",
-                timeout=timeout,
-                connection_retry=KazooRetry(max_tries=20),
+            _genuine_zk_instance = cluster.get_kazoo_client(
+                "node", timeout=timeout, external_port=2181
             )
-            _genuine_zk_instance.start()
             return _genuine_zk_instance
         except KazooTimeoutError:
             if i == CONNECTION_RETRIES - 1:

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -1,7 +1,4 @@
-import time
-
 import pytest
-from kazoo.client import KazooClient
 
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
@@ -232,14 +229,6 @@ def test_attach_without_zk_incr_readonly_metric(start_cluster):
         node1.query("DROP TABLE IF EXISTS test.test_no_zk SYNC")
 
 
-def get_zk(timeout=30.0):
-    _zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip("zoo1") + ":2181", timeout=timeout
-    )
-    _zk_instance.start()
-    return _zk_instance
-
-
 def test_broken_tables_readonly_metric(start_cluster):
     try:
         tbl_uuid = node1.query("SELECT generateUUIDv4()").strip()
@@ -260,7 +249,7 @@ def test_broken_tables_readonly_metric(start_cluster):
 
         node1.stop_clickhouse()
 
-        zk_client = get_zk()
+        zk_client = cluster.get_kazoo_client("zoo1")
 
         columns_path = zk_path + "/columns"
         metadata = zk_client.get(columns_path)[0]


### PR DESCRIPTION
This will avoid flakiness in case of ConnectionLoss and similar

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
