### PR TITLE
CI: Remove unit tests from Merge Queue

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -202,85 +202,9 @@ jobs:
             python3 -m praktika run 'Fast test' --workflow "MergeQueueCI" --ci |& tee ./ci/tmp/job.log
           fi
 
-  build_amd_binary:
-    runs-on: [self-hosted, builder]
-    needs: [config_workflow]
-    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
-    name: "Build (amd_binary)"
-    outputs:
-      data: ${{ steps.run.outputs.DATA }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
-
-      - name: Prepare env script
-        run: |
-          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
-          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
-          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
-          export PYTHONPATH=./ci:.:
-          cat > ./ci/tmp/workflow_config_mergequeueci.json << 'EOF'
-          ${{ needs.config_workflow.outputs.data }}
-          EOF
-          cat > ./ci/tmp/workflow_status.json << 'EOF'
-          ${{ toJson(needs) }}
-          EOF
-          ENV_SETUP_SCRIPT_EOF
-
-      - name: Run
-        id: run
-        run: |
-          . ./ci/tmp/praktika_setup_env.sh
-          set -o pipefail
-          if command -v ts &> /dev/null; then
-            python3 -m praktika run 'Build (amd_binary)' --workflow "MergeQueueCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
-          else
-            python3 -m praktika run 'Build (amd_binary)' --workflow "MergeQueueCI" --ci |& tee ./ci/tmp/job.log
-          fi
-
-  unit_tests_binary:
-    runs-on: [self-hosted, func-tester]
-    needs: [config_workflow, build_amd_binary]
-    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'VW5pdCB0ZXN0cyAoYmluYXJ5KQ==') }}
-    name: "Unit tests (binary)"
-    outputs:
-      data: ${{ steps.run.outputs.DATA }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
-
-      - name: Prepare env script
-        run: |
-          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
-          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
-          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
-          export PYTHONPATH=./ci:.:
-          cat > ./ci/tmp/workflow_config_mergequeueci.json << 'EOF'
-          ${{ needs.config_workflow.outputs.data }}
-          EOF
-          cat > ./ci/tmp/workflow_status.json << 'EOF'
-          ${{ toJson(needs) }}
-          EOF
-          ENV_SETUP_SCRIPT_EOF
-
-      - name: Run
-        id: run
-        run: |
-          . ./ci/tmp/praktika_setup_env.sh
-          set -o pipefail
-          if command -v ts &> /dev/null; then
-            python3 -m praktika run 'Unit tests (binary)' --workflow "MergeQueueCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
-          else
-            python3 -m praktika run 'Unit tests (binary)' --workflow "MergeQueueCI" --ci |& tee ./ci/tmp/job.log
-          fi
-
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [config_workflow, dockers_build_arm, dockers_build_amd, style_check, fast_test, build_amd_binary, unit_tests_binary]
+    needs: [config_workflow, dockers_build_arm, dockers_build_amd, style_check, fast_test]
     if: ${{ !cancelled() }}
     name: "Finish Workflow"
     outputs:

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -202,9 +202,47 @@ jobs:
             python3 -m praktika run 'Fast test' --workflow "MergeQueueCI" --ci |& tee ./ci/tmp/job.log
           fi
 
+  build_amd_binary:
+    runs-on: [self-hosted, builder]
+    needs: [config_workflow]
+    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
+    name: "Build (amd_binary)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
+          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+          cat > ./ci/tmp/workflow_config_mergequeueci.json << 'EOF'
+          ${{ needs.config_workflow.outputs.data }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          if command -v ts &> /dev/null; then
+            python3 -m praktika run 'Build (amd_binary)' --workflow "MergeQueueCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
+          else
+            python3 -m praktika run 'Build (amd_binary)' --workflow "MergeQueueCI" --ci |& tee ./ci/tmp/job.log
+          fi
+
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [config_workflow, dockers_build_arm, dockers_build_amd, style_check, fast_test]
+    needs: [config_workflow, dockers_build_arm, dockers_build_amd, style_check, fast_test, build_amd_binary]
     if: ${{ !cancelled() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/workflows/merge_queue.py
+++ b/ci/workflows/merge_queue.py
@@ -11,8 +11,24 @@ workflow = Workflow.Config(
         JobConfigs.docker_build_amd,
         JobConfigs.style_check,
         JobConfigs.fast_test,
+        *[job for job in JobConfigs.build_jobs if job.name == "Build (amd_binary)"],
+        # *[
+        #     job
+        #     for job in JobConfigs.unittest_jobs
+        #     if job.name == JobNames.UNITTEST + " (binary)"
+        # ],
     ],
     artifacts=[
+        *[
+            a
+            for a in ArtifactConfigs.unittests_binaries
+            if a.name == ArtifactNames.UNITTEST_AMD_BINARY
+        ],
+        *[
+            a
+            for a in ArtifactConfigs.clickhouse_binaries
+            if a.name == ArtifactNames.CH_AMD_BINARY
+        ],
         ArtifactConfigs.fast_test,
     ],
     # dockers=DOCKERS,

--- a/ci/workflows/merge_queue.py
+++ b/ci/workflows/merge_queue.py
@@ -11,24 +11,8 @@ workflow = Workflow.Config(
         JobConfigs.docker_build_amd,
         JobConfigs.style_check,
         JobConfigs.fast_test,
-        *[job for job in JobConfigs.build_jobs if job.name == "Build (amd_binary)"],
-        *[
-            job
-            for job in JobConfigs.unittest_jobs
-            if job.name == JobNames.UNITTEST + " (binary)"
-        ],
     ],
     artifacts=[
-        *[
-            a
-            for a in ArtifactConfigs.unittests_binaries
-            if a.name == ArtifactNames.UNITTEST_AMD_BINARY
-        ],
-        *[
-            a
-            for a in ArtifactConfigs.clickhouse_binaries
-            if a.name == ArtifactNames.CH_AMD_BINARY
-        ],
         ArtifactConfigs.fast_test,
     ],
     # dockers=DOCKERS,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Unit Tests does not help detect issues in Merge Queue CI according to [CI DB](https://play.clickhouse.com/play?user=play#U0VMRUNUICoKRlJPTSBjaGVja3MKd2hlcmUgMQogYW5kIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiBhbmQgaGVhZF9yZWYJIExJS0UgJyVnaC1yZWFkb25seS1xdWV1ZSUnCiBhbmQgY2hlY2tfbmFtZQlMSUtFICclVW5pdCUnCiBhbmQgY2hlY2tfc3RhcnRfdGltZQk+IHRvZGF5KCkgLSBJTlRFUlZBTCAzMDAgREFZUwogYW5kIHRlc3RfbmFtZSA9ICcnCiBhbmQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwoKCgoKCgo=) - remove
Binary build had 6 [failures](https://clickhouse-inc.slack.com/archives/D08BJKGLZD4/p1741202384686989) - keep running in MQ

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
