### PR TITLE
tests: avoid joining thread from itself in coordinator unit tests

### DIFF
--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -186,6 +186,11 @@ struct SimpliestRaftServer
         }
     }
 
+    ~SimpliestRaftServer()
+    {
+        state_manager->flushAndShutDownLogStore();
+    }
+
     // Server ID.
     int server_id;
 


### PR DESCRIPTION
While investigating completelly unrelated MQ problems, @maxknv showed me this report [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/20939563b3af67d8f908da654924539ab4e42082/unit_tests__release_.html

Right now the test had been refactored, but this should fix the problem.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)