### PR TITLE
Add debug logging to S3Queue metadata

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -657,20 +657,17 @@ size_t ObjectStorageQueueMetadata::unregisterActive(const StorageID & storage_id
     auto code = zk_client->tryRemove(table_path);
     const size_t remaining_nodes_num = zk_client->getChildren(registry_path).size();
 
+    const auto self = Info::create(storage_id);
     if (code == Coordination::Error::ZOK)
     {
-        LOG_TRACE(
-            log,
-            "Table '{}' has been removed from the active registry (remaining nodes: {})",
-            storage_id.getFullTableName(),
-            remaining_nodes_num);
+        LOG_TRACE(log, "Table '{}' has been removed from the active registry (remaining nodes: {})", self.table_id, remaining_nodes_num);
     }
     else
     {
         LOG_DEBUG(
             log,
             "Cannot remove table '{}' from the active registry, reason: {} (remaining nodes: {})",
-            storage_id.getFullTableName(),
+            self.table_id,
             Coordination::errorMessage(code),
             remaining_nodes_num);
     }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -654,12 +654,26 @@ size_t ObjectStorageQueueMetadata::unregisterActive(const StorageID & storage_id
     const auto registry_path = zookeeper_path / "registry";
     const auto table_path = registry_path / getProcessorID(storage_id);
 
-    zk_client->tryRemove(table_path);
+    auto code = zk_client->tryRemove(table_path);
     const size_t remaining_nodes_num = zk_client->getChildren(registry_path).size();
 
-    LOG_TRACE(
-        log, "Removed {} from active registry (remaining: {})",
-        storage_id.getFullTableName(), remaining_nodes_num);
+    if (code == Coordination::Error::ZOK)
+    {
+        LOG_TRACE(
+            log,
+            "Table '{}' has been removed from the active registry (remaining nodes: {})",
+            storage_id.getFullTableName(),
+            remaining_nodes_num);
+    }
+    else
+    {
+        LOG_DEBUG(
+            log,
+            "Cannot remove table '{}' from the active registry, reason: {} (remaining nodes: {})",
+            storage_id.getFullTableName(),
+            Coordination::errorMessage(code),
+            remaining_nodes_num);
+    }
 
     return remaining_nodes_num;
 }
@@ -707,12 +721,15 @@ size_t ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage
             }
         }
         if (!found)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot unregister: not registered");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot unregister: table '{}' is not registered", self.table_id);
 
         code = zk_client->trySet(registry_path, new_registry_str, stat.version);
 
         if (code == Coordination::Error::ZOK)
+        {
+            LOG_TRACE(log, "Table '{}' has been removed from the registry", self.table_id);
             return count;
+        }
 
         if (Coordination::isHardwareError(code)
             || code == Coordination::Error::ZBADVERSION)


### PR DESCRIPTION
Attempting to debug https://github.com/ClickHouse/clickhouse-core-incidents/issues/461.
During table removal, a table entry is missing from the ZK metadata when expected, resulting in a logical error. Perhaps there are multiple attempts to remove it.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
