### PR TITLE
Fix flaky test_old_dirs_cleanup

### DIFF
--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -16,18 +16,6 @@ def start_cluster():
     try:
         cluster.start()
 
-        for i, node in enumerate((node1,)):
-            node_name = "node" + str(i + 1)
-            node.query(
-                """
-                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
-                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table', '{}')
-                PARTITION BY date ORDER BY id
-                """.format(
-                    node_name
-                )
-            )
-
         yield cluster
 
     finally:
@@ -35,6 +23,15 @@ def start_cluster():
 
 
 def test_old_dirs_cleanup(start_cluster):
+    node1.query("DROP TABLE IF EXISTS test_table SYNC")
+    node1.query(
+        """
+        CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table', 'node1')
+        PARTITION BY date ORDER BY id
+        """
+    )
+
     node1.query("INSERT INTO test_table VALUES (toDate('2020-01-01'), 1, 10)")
     assert node1.query("SELECT count() FROM test_table") == "1\n"
 
@@ -62,3 +59,5 @@ def test_old_dirs_cleanup(start_cluster):
 
     assert_logs_contain_with_retry(node1, "Removing temporary directory")
     assert_logs_contain_with_retry(node1, "delete_tmp_20200101_0_0_0")
+
+    node1.query("DROP TABLE test_table SYNC")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flaky test_old_dirs_cleanup

When running test_old_dirs_cleanup multiple times, the test table is thoroughly cleaned up. When inserting in the subsequent run, the block ID is ignored with log
```
<Information> default.test_table (fb87266d-a93b-4db7-b772-dbb47ea2e676) (Replicated OutputStream): Block with ID 20200101_7213548727725015914_1272175113083552101 already exists locally as part 20200101_0_0_0; ignoring it.
```
It caused the asserts to failed: `assert node1.query("SELECT count() FROM test_table") == "1\n"` because of no inserted data.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
