### PR TITLE
CI: Label ci-performance to run only performance tests in PR ci

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/can_be_merged.py
+++ b/ci/jobs/scripts/workflow_hooks/can_be_merged.py
@@ -1,0 +1,18 @@
+import sys
+
+from praktika.info import Info
+
+from ci.jobs.scripts.workflow_hooks.pr_description import Labels
+
+
+def check():
+    info = Info()
+    if Labels.CI_PERFORMANCE in info.pr_labels:
+        print(f"WARNING: {Labels.CI_PERFORMANCE} label is set, merge not allowed")
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    if not check():
+        sys.exit(1)

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -1,6 +1,7 @@
 from praktika.info import Info
 
 from ci.defs.defs import JobNames
+from ci.jobs.scripts.workflow_hooks.pr_description import Labels
 
 
 def only_docs(changed_files):
@@ -39,12 +40,27 @@ def should_skip_job(job_name):
     if only_docs(changed_files) and job_name not in ONLY_DOCS_JOBS:
         return True, "Docs only update"
 
-    if "do not test" in _info_cache.pr_labels and job_name not in ONLY_DOCS_JOBS:
+    if Labels.DO_NOT_TEST in _info_cache.pr_labels and job_name not in ONLY_DOCS_JOBS:
         return True, "Skipped, labeled with 'do not test'"
+
+    if Labels.CI_PERFORMANCE in _info_cache.pr_labels and (
+        "performance" not in job_name.lower()
+        and job_name
+        not in (
+            "Build (amd_release)",
+            "Build (arm_release)",
+            JobNames.DOCKER_BUILDS_ARM,
+            JobNames.DOCKER_BUILDS_AMD,
+        )
+    ):
+        return (
+            True,
+            "Skipped, labeled with 'ci-performance' - run performance jobs only",
+        )
 
     # skip ARM perf tests for non-performance update
     if (
-        "pr-performance" not in _info_cache.pr_labels
+        Labels.PR_PERFORMANCE not in _info_cache.pr_labels
         and JobNames.PERFORMANCE in job_name
         and "aarch64" in job_name
     ):

--- a/ci/jobs/scripts/workflow_hooks/pr_description.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_description.py
@@ -66,6 +66,8 @@ class Labels:
     RELEASE_LTS = "release-lts"
     SUBMODULE_CHANGED = "submodule changed"
 
+    CI_PERFORMANCE = "ci-performance"
+
     # automatic backport for critical bug fixes
     AUTO_BACKPORT = {"pr-critical-bugfix"}
 

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -251,7 +251,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
             )
 
         results.append(
-            Result.create_from(name="Pre Checks", results=res_, stopwatch=sw_)
+            Result.create_from(name="Pre Hooks", results=res_, stopwatch=sw_)
         )
 
     # checks:
@@ -420,12 +420,16 @@ def _finish_workflow(workflow, job_name):
             )
 
         results.append(
-            Result.create_from(name="Post Checks", results=results_, stopwatch=sw_)
+            Result.create_from(name="Post Hooks", results=results_, stopwatch=sw_)
         )
 
     ready_for_merge_status = Result.Status.SUCCESS
     ready_for_merge_description = ""
     failed_results = []
+
+    if results and any(not result.is_ok() for result in results):
+        failed_results.append(["Workflow Post Hook"])
+
     for result in workflow_result.results:
         if result.name == job_name or result.status in (
             Result.Status.SUCCESS,

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -428,7 +428,7 @@ def _finish_workflow(workflow, job_name):
     failed_results = []
 
     if results and any(not result.is_ok() for result in results):
-        failed_results.append(["Workflow Post Hook"])
+        failed_results.append("Workflow Post Hook")
 
     for result in workflow_result.results:
         if result.name == job_name or result.status in (
@@ -451,10 +451,10 @@ def _finish_workflow(workflow, job_name):
             print(
                 f"NOTE: Result for [{result.name}] has not ok status [{result.status}]"
             )
-            ready_for_merge_status = Result.Status.FAILED
             failed_results.append(result.name)
 
     if failed_results:
+        ready_for_merge_status = Result.Status.FAILED
         failed_jobs_csv = ",".join(failed_results)
         if len(failed_jobs_csv) < 80:
             ready_for_merge_description = f"Failed: {failed_jobs_csv}"

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -2,7 +2,7 @@ from praktika import Workflow
 
 from ci.defs.defs import BASE_BRANCH, SECRETS, ArtifactConfigs
 from ci.defs.job_configs import JobConfigs
-from ci.jobs.scripts.workflow_hooks.should_skip_job import should_skip_job
+from ci.jobs.scripts.workflow_hooks.filter_job import should_skip_job
 
 workflow = Workflow.Config(
     name="MasterCI",

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -2,7 +2,7 @@ from praktika import Workflow
 
 from ci.defs.defs import BASE_BRANCH, SECRETS, ArtifactConfigs, JobNames
 from ci.defs.job_configs import JobConfigs
-from ci.jobs.scripts.workflow_hooks.should_skip_job import should_skip_job
+from ci.jobs.scripts.workflow_hooks.filter_job import should_skip_job
 from ci.jobs.scripts.workflow_hooks.trusted import can_be_trusted
 
 workflow = Workflow.Config(
@@ -71,6 +71,7 @@ workflow = Workflow.Config(
     workflow_filter_hooks=[should_skip_job],
     post_hooks=[
         "python3 ./ci/jobs/scripts/workflow_hooks/feature_docs.py",
+        "python3 ./ci/jobs/scripts/workflow_hooks/can_be_merged.py",
     ],
 )
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- "ci-performance" label to run only performance related jobs in PR CI
- set red Mergeable check to prohibit merge with "ci-performance" label

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
