### PR TITLE
*wip*: Enable query condition cache

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4377,7 +4377,7 @@ Possible values:
     DECLARE(Bool, enable_sharing_sets_for_mutations, true, R"(
 Allow sharing set objects build for IN subqueries between different tasks of the same mutation. This reduces memory usage and CPU consumption
 )", 0) \
-    DECLARE(Bool, use_query_condition_cache, false, R"(
+    DECLARE(Bool, use_query_condition_cache, true, R"(
 Enable the query condition cache.
 
 Possible values:


### PR DESCRIPTION
Testing what happens if the query condition cache (#69236) is enabled by default.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)