### PR TITLE
Docs: fix remaining broken anchors

### DIFF
--- a/docs/en/operations/caches.md
+++ b/docs/en/operations/caches.md
@@ -29,4 +29,4 @@ Additional cache types:
 
 To drop one of the caches, use [SYSTEM DROP ... CACHE](../sql-reference/statements/system.md#drop-mark-cache) statements.
 
-To drop the format schema cache, use the [SYSTEM DROP FORMAT SCHEMA CACHE](../sql-reference/statements/system.md#drop-format-schema-cache-system-drop-schema-format) statement.
+To drop the format schema cache, use the [SYSTEM DROP FORMAT SCHEMA CACHE](/sql-reference/statements/system#system-drop-schema-format) statement.

--- a/docs/en/operations/system-tables/merge_tree_settings.md
+++ b/docs/en/operations/system-tables/merge_tree_settings.md
@@ -12,7 +12,7 @@ Columns:
 - `name` ([String](../../sql-reference/data-types/string.md)) — Setting name.
 - `value` ([String](../../sql-reference/data-types/string.md)) — Setting value.
 - `default` ([String](../../sql-reference/data-types/string.md)) — Setting default value.
-- `changed` ([UInt8](../../sql-reference/data-types/int-uint.md#uint-ranges)) — Whether the setting was explicitly defined in the config or explicitly changed.
+- `changed` ([UInt8](/sql-reference/data-types/int-uint#integer-ranges)) — Whether the setting was explicitly defined in the config or explicitly changed.
 - `description` ([String](../../sql-reference/data-types/string.md)) — Setting description.
 - `min` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Minimum value of the setting, if any is set via [constraints](/operations/settings/constraints-on-settings). If the setting has no minimum value, contains [NULL](/operations/settings/formats#input_format_null_as_default).
 - `max` ([Nullable](../../sql-reference/data-types/nullable.md)([String](../../sql-reference/data-types/string.md))) — Maximum value of the setting, if any is set via [constraints](/operations/settings/constraints-on-settings). If the setting has no maximum value, contains [NULL](/operations/settings/formats#input_format_null_as_default).

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -2500,7 +2500,7 @@ arrayFirstOrNull(func, arr1, ...)
 
 **Parameters**
 
-- `func`: Lambda function. [Lambda function](/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func`: Lambda function. [Lambda function](/sql-reference/functions/overview#higher-order-functions).
 - `arr1`: Array to operate on. [Array](/sql-reference/data-types/array).
 
 **Returned value**
@@ -2568,7 +2568,7 @@ arrayLastOrNull(func, arr1, ...)
 
 **Parameters**
 
-- `func`: Lambda function. [Lambda function](/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func`: Lambda function. [Lambda function](/sql-reference/functions/overview#higher-order-functions).
 - `arr1`: Array to operate on. [Array](/sql-reference/data-types/array).
 
 **Returned value**

--- a/docs/en/sql-reference/functions/ext-dict-functions.md
+++ b/docs/en/sql-reference/functions/ext-dict-functions.md
@@ -27,7 +27,7 @@ dictGetOrNull('dict_name', attr_name, id_expr)
 - `dict_name` — Name of the dictionary. [String literal](/sql-reference/syntax#string).
 - `attr_names` — Name of the column of the dictionary, [String literal](/sql-reference/syntax#string), or tuple of column names, [Tuple](/sql-reference/data-types/tuple)([String literal](/sql-reference/syntax#string).
 - `id_expr` — Key value. [Expression](/sql-reference/syntax#expressions) returning dictionary key-type value or [Tuple](../data-types/tuple.md)-type value depending on the dictionary configuration.
-- `default_value_expr` — Values returned if the dictionary does not contain a row with the `id_expr` key. [Expression](/sql-reference/syntax#expressions) or [Tuple](../data-types/tuple.md)([Expression](../../sql-reference/syntax.md#syntax-expressions)), returning the value (or values) in the data types configured for the `attr_names` attribute.
+- `default_value_expr` — Values returned if the dictionary does not contain a row with the `id_expr` key. [Expression](/sql-reference/syntax#expressions) or [Tuple](../data-types/tuple.md)([Expression](/sql-reference/syntax#expressions)), returning the value (or values) in the data types configured for the `attr_names` attribute.
 
 **Returned value**
 

--- a/docs/en/sql-reference/functions/tuple-map-functions.md
+++ b/docs/en/sql-reference/functions/tuple-map-functions.md
@@ -296,7 +296,7 @@ mapSubtract(Tuple(Array, Array), Tuple(Array, Array) [, ...])
 
 **Arguments**
 
-Arguments are [maps](../data-types/map.md) or [tuples](/sql-reference/data-types/tuple) of two [arrays](/sql-reference/data-types/array), where items in the first array represent keys, and the second array contains values for the each key. All key arrays should have same type, and all value arrays should contain items which are promote to the one type ([Int64](/sql-reference/data-types/int-uint#integer-ranges), [UInt64](/sql-reference/data-types/int-uint#integer-ranges) or [Float64](../data-types/float.md#float32-float64)). The common promoted type is used as a type for the result array.
+Arguments are [maps](../data-types/map.md) or [tuples](/sql-reference/data-types/tuple) of two [arrays](/sql-reference/data-types/array), where items in the first array represent keys, and the second array contains values for the each key. All key arrays should have same type, and all value arrays should contain items which are promote to the one type ([Int64](/sql-reference/data-types/int-uint#integer-ranges), [UInt64](/sql-reference/data-types/int-uint#integer-ranges) or [Float64](/sql-reference/data-types/float)). The common promoted type is used as a type for the result array.
 
 **Returned value**
 
@@ -613,7 +613,7 @@ mapApply(func, map)
 
 **Arguments**
 
-- `func` — [Lambda function](/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func` — [Lambda function](/sql-reference/functions/overview#higher-order-functions).
 - `map` — [Map](../data-types/map.md).
 
 **Returned value**
@@ -655,7 +655,7 @@ mapFilter(func, map)
 
 **Arguments**
 
-- `func`  - [Lambda function](/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func`  - [Lambda function](/sql-reference/functions/overview#higher-order-functions).
 - `map` — [Map](../data-types/map.md).
 
 **Returned value**
@@ -858,7 +858,7 @@ mapPartialSort([func,] limit, map)
 ```
 **Arguments**
 
-- `func` – Optional function to apply to the keys and values of the map. [Lambda function](/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func` – Optional function to apply to the keys and values of the map. [Lambda function](/sql-reference/functions/overview#higher-order-functions).
 - `limit` – Elements in range [1..limit] are sorted. [(U)Int](../data-types/int-uint.md).
 - `map` – Map to sort. [Map](../data-types/map.md).
 
@@ -919,7 +919,7 @@ mapPartialReverseSort([func,] limit, map)
 ```
 **Arguments**
 
-- `func` – Optional function to apply to the keys and values of the map. [Lambda function](/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function).
+- `func` – Optional function to apply to the keys and values of the map. [Lambda function](/sql-reference/functions/overview#higher-order-functions).
 - `limit` – Elements in range [1..limit] are sorted. [(U)Int](../data-types/int-uint.md).
 - `map` – Map to sort. [Map](../data-types/map.md).
 

--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -364,6 +364,6 @@ All the rules above are also true for the [OPTIMIZE](/sql-reference/statements/o
 OPTIMIZE TABLE table_not_partitioned PARTITION tuple() FINAL;
 ```
 
-`IN PARTITION` specifies the partition to which the [UPDATE](/sql-reference/statements/alter/update.md/#alter-table-update-statements) or [DELETE](/sql-reference/statements/alter/delete) expressions are applied as a result of the `ALTER TABLE` query. New parts are created only from the specified partition. In this way, `IN PARTITION` helps to reduce the load when the table is divided into many partitions, and you only need to update the data point-by-point.
+`IN PARTITION` specifies the partition to which the [UPDATE](/sql-reference/statements/alter/update) or [DELETE](/sql-reference/statements/alter/delete) expressions are applied as a result of the `ALTER TABLE` query. New parts are created only from the specified partition. In this way, `IN PARTITION` helps to reduce the load when the table is divided into many partitions, and you only need to update the data point-by-point.
 
 The examples of `ALTER ... PARTITION` queries are demonstrated in the tests [`00502_custom_partitioning_local`](https://github.com/ClickHouse/ClickHouse/blob/master/tests/queries/0_stateless/00502_custom_partitioning_local.sql) and [`00502_custom_partitioning_replicated_zookeeper`](https://github.com/ClickHouse/ClickHouse/blob/master/tests/queries/0_stateless/00502_custom_partitioning_replicated_zookeeper.sql).

--- a/docs/en/sql-reference/table-functions/file.md
+++ b/docs/en/sql-reference/table-functions/file.md
@@ -225,7 +225,7 @@ SELECT * from file('data/path/date=*/country=*/code=*/*.parquet') where _date > 
 
 ## Settings {#settings}
 
-- [engine_file_empty_if_not_exists](operations/settings/settings.md#engine-file-empty_if-not-exists) - allows to select empty data from a file that doesn't exist. Disabled by default.
+- [engine_file_empty_if_not_exists](/operations/settings/settings#engine_file_empty_if_not_exists) - allows to select empty data from a file that doesn't exist. Disabled by default.
 - [engine_file_truncate_on_insert](/operations/settings/settings#engine_file_truncate_on_insert) - allows to truncate file before insert into it. Disabled by default.
 - [engine_file_allow_create_multiple_files](operations/settings/settings.md#engine_file_allow_create_multiple_files) - allows to create a new file on each insert if format has suffix. Disabled by default.
 - [engine_file_skip_empty_files](operations/settings/settings.md#engine_file_skip_empty_files) - allows to skip empty files while reading. Disabled by default.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fixes last remaining anchors so we can turn on the link checker:

```
 Exhaustive list of all broken anchors found:
  - Broken anchor on source page path = /docs/operations/caches:
     -> linking to /docs/sql-reference/statements/system#drop-format-schema-cache-system-drop-schema-format
  - Broken anchor on source page path = /docs/operations/system-tables/merge_tree_settings:
     -> linking to /docs/sql-reference/data-types/int-uint#uint-ranges
  - Broken anchor on source page path = /docs/sql-reference/functions/array-functions:
     -> linking to /docs/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function
  - Broken anchor on source page path = /docs/sql-reference/functions/ext-dict-functions:
     -> linking to /docs/sql-reference/syntax#syntax-expressions
  - Broken anchor on source page path = /docs/sql-reference/functions/tuple-map-functions:
     -> linking to /docs/sql-reference/data-types/float#float32-float64
     -> linking to /docs/sql-reference/functions/overview#higher-order-functions---operator-and-lambdaparams-expr-function
  - Broken anchor on source page path = /docs/sql-reference/statements/alter/partition:
     -> linking to /docs/sql-reference/statements/alter/update#alter-table-update-statements
  - Broken anchor on source page path = /docs/sql-reference/table-functions/file:
     -> linking to /docs/operations/settings/settings#engine-file-empty_if-not-exists
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
