### PR TITLE
Docs: fix remaining links

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/quantileexact.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/quantileexact.md
@@ -91,7 +91,7 @@ SELECT quantileExactLow(0.1)(number) FROM numbers(10)
 └───────────────────────────────┘
 ```
 
-When using multiple `quantile*` functions with different levels in a query, the internal states are not combined (that is, the query works less efficiently than it could). In this case, use the [quantiles](/ru/sql-reference/aggregate-functions/reference/quantiles) function.
+When using multiple `quantile*` functions with different levels in a query, the internal states are not combined (that is, the query works less efficiently than it could). In this case, use the [quantiles](/sql-reference/aggregate-functions/reference/quantiles) function.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -2550,7 +2550,7 @@ finalizeAggregation(state)
 
 **Arguments**
 
-- `state` — State of aggregation. [AggregateFunction](/sql-reference/data-types/aggregatefunctione).
+- `state` — State of aggregation. [AggregateFunction](/sql-reference/data-types/aggregatefunction).
 
 **Returned value(s)**
 

--- a/docs/en/sql-reference/statements/create/role.md
+++ b/docs/en/sql-reference/statements/create/role.md
@@ -19,7 +19,7 @@ CREATE ROLE [IF NOT EXISTS | OR REPLACE] name1 [, name2 [,...]] [ON CLUSTER clus
 
 A user can be assigned multiple roles. Users can apply their assigned roles in arbitrary combinations by the [SET ROLE](../../../sql-reference/statements/set-role.md) statement. The final scope of privileges is a combined set of all the privileges of all the applied roles. If a user has privileges granted directly to it's user account, they are also combined with the privileges granted by roles.
 
-User can have default roles which apply at user login. To set default roles, use the [SET DEFAULT ROLE]((/sql-reference/statements/set-role#set-default-role)) statement or the [ALTER USER](/sql-reference/statements/alter/user) statement.
+User can have default roles which apply at user login. To set default roles, use the [SET DEFAULT ROLE](/sql-reference/statements/set-role#set-default-role) statement or the [ALTER USER](/sql-reference/statements/alter/user) statement.
 
 To revoke a role, use the [REVOKE](../../../sql-reference/statements/revoke.md) statement.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fixes remaining broken links so we can turn on link checker:

```
Exhaustive list of all broken links found:
- Broken link on source page path = /docs/sql-reference/aggregate-functions/reference/quantileexact:
   -> linking to /docs/ru/sql-reference/aggregate-functions/reference/quantiles
- Broken link on source page path = /docs/sql-reference/functions/other-functions:
   -> linking to /docs/sql-reference/data-types/aggregatefunctione
- Broken link on source page path = /docs/sql-reference/statements/create/role:
   -> linking to (/sql-reference/statements/set-role#set-default-role) (resolved as: /docs/sql-reference/statements/create/(/sql-reference/statements/set-role#set-default-role))
```
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
