### PR TITLE
Fix async_insert with input()

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2257,7 +2257,7 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
         }
 
         /// INSERT query for which data transfer is needed (not an INSERT SELECT or input()) is processed separately.
-        if (insert && (!insert->select || input_function) && !is_async_insert_with_inlined_data)
+        if (insert && (!insert->select || input_function) && (!is_async_insert_with_inlined_data || input_function))
         {
             if (input_function && insert->format.empty())
                 throw Exception(ErrorCodes::INVALID_USAGE_OF_INPUT, "FORMAT must be specified for function input()");

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -135,6 +135,11 @@ StoragePtr InterpreterInsertQuery::getTable(ASTInsertQuery & query)
             }
             else
             {
+                ASTPtr input_function;
+                query.tryFindInputFunction(input_function);
+                if (input_function)
+                    throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Schema inference is not supported with allow_experimental_analyzer=0 for INSERT INTO FUNCTION ... SELECT FROM input()");
+
                 InterpreterSelectWithUnionQuery interpreter_select{
                     query.select, current_context, select_query_options};
                 auto tmp_pipeline = interpreter_select.buildQueryPipeline();

--- a/tests/queries/0_stateless/03380_input_async_insert.reference
+++ b/tests/queries/0_stateless/03380_input_async_insert.reference
@@ -1,0 +1,2 @@
+1	string1
+2	string2

--- a/tests/queries/0_stateless/03380_input_async_insert.sql
+++ b/tests/queries/0_stateless/03380_input_async_insert.sql
@@ -1,0 +1,6 @@
+insert into function null() select * from input('x Int, y String') settings async_insert=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+
+create table x (x Int, y String) engine=Memory;
+insert into x select * from input('x Int, y String') settings async_insert=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+
+select * from x;

--- a/tests/queries/0_stateless/03380_input_async_insert.sql
+++ b/tests/queries/0_stateless/03380_input_async_insert.sql
@@ -1,4 +1,21 @@
-insert into function null() select * from input('x Int, y String') settings async_insert=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+---
+--- Analyzer
+---
+
+insert into function null() select * from input('x Int, y String') settings async_insert=1, allow_experimental_analyzer=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+
+insert into function null('auto') select * from input('x Int, y String') settings async_insert=1, allow_experimental_analyzer=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+
+insert into function null('x Int, y String') select * from input('x Int, y String') settings async_insert=1, allow_experimental_analyzer=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+
+---
+--- Non-analyzer - does not support INSERT INTO FUNCTION null('auto') SELECT FROM input()
+---
+insert into function null() select * from input('x Int, y String') settings async_insert=1, allow_experimental_analyzer=0 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2}; -- { serverError QUERY_IS_PROHIBITED }
+
+insert into function null('x Int, y String') select * from input('x Int, y String') settings async_insert=1, allow_experimental_analyzer=0 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};
+
+drop table if exists x;
 
 create table x (x Int, y String) engine=Memory;
 insert into x select * from input('x Int, y String') settings async_insert=1 format JSONEachRow {"x" : 1, "y" : "string1"}, {"y" : "string2", "x" : 2};


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `async_insert` with `input()`

Previously it leads to the following error on client:

    Error on processing query: Code: 100. DB::Exception: Unknown packet 11 from server localhost:9000. (UNKNOWN_PACKET_FROM_SERVER) (version 25.3.1.1)

And on server the connection had been reset:

    2025.03.08 14:13:08.959747 [ 14995 ] {69139271-72b7-4490-8e69-582a576b42c1} <Error> executeQuery: Code: 210. DB::Exception: Connection reset by peer, while writing to socket (127.0.0.1:9000 -> 127.0.0.1:60668): While executing Input. (NETWORK_ERROR) (version 25.3.1.1) (from 127.0.0.1:60668) (query 1, line 1) (in query: insert into function null() select * from input('x Int, y String') settings async_insert=1 format JSONEachRow ), Stack trace (when copying this message, always include the lines below):