### PR TITLE
tests: fix 03357_replacing_min_age_cleanup flakiness

### DIFF
--- a/tests/queries/0_stateless/03357_replacing_min_age_cleanup.sh
+++ b/tests/queries/0_stateless/03357_replacing_min_age_cleanup.sh
@@ -10,15 +10,15 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 wait_for_number_of_parts() {
     for _ in `seq $3`
     do
-        sleep 1
         res=`$CLICKHOUSE_CLIENT -q "SELECT count(*) FROM system.parts WHERE database = currentDatabase() AND table='$1' AND active"`
         if [ "$res" -eq "$2" ]
         then
             echo "$res"
             return
         fi
+        sleep 1
     done
-    echo "$res"
+    echo "$res (FAIL)"
 }
 
 $CLICKHOUSE_CLIENT -mq "
@@ -26,7 +26,7 @@ SET alter_sync = 2;
 
 DROP TABLE IF EXISTS replacing;
 
-CREATE TABLE replacing (key int, value int, version int, deleted UInt8) ENGINE = ReplacingMergeTree(version, deleted) ORDER BY key;
+CREATE TABLE replacing (key int, value int, version int, deleted UInt8) ENGINE = ReplacingMergeTree(version, deleted) ORDER BY key SETTINGS merge_tree_clear_old_parts_interval_seconds = 1;
 
 INSERT INTO replacing VALUES (1, 1, 1, 0), (1, 1, 2, 1);
 
@@ -46,9 +46,11 @@ OPTIMIZE TABLE replacing FINAL CLEANUP; -- { serverError SUPPORT_IS_DISABLED }
 
 ALTER TABLE replacing MODIFY SETTING allow_experimental_replacing_merge_with_cleanup = true;
 
-OPTIMIZE TABLE replacing FINAL CLEANUP;"
+OPTIMIZE TABLE replacing FINAL CLEANUP;
+"
 
-wait_for_number_of_parts 'replacing' 0 10
+# OPTIMIZE FINAL CLEANUP will replace the part with empty, but only cleaner thread will clean it, so we still need to wait
+wait_for_number_of_parts 'replacing' 0 30
 
 $CLICKHOUSE_CLIENT -mq "
 DROP TABLE IF EXISTS replacing2;
@@ -56,6 +58,8 @@ DROP TABLE IF EXISTS replacing2;
 CREATE TABLE replacing2 (key int, value int, version int, deleted UInt8) ENGINE = ReplacingMergeTree(version, deleted) ORDER BY key
 SETTINGS allow_experimental_replacing_merge_with_cleanup = true,
     enable_replacing_merge_with_cleanup_for_min_age_to_force_merge = true,
+    merge_tree_clear_old_parts_interval_seconds = 1,
+    number_of_free_entries_in_pool_to_execute_optimize_entire_partition = 1,
     min_age_to_force_merge_on_partition_only = true,
     min_age_to_force_merge_seconds = 1,
     merge_selecting_sleep_ms = 1000,
@@ -65,7 +69,7 @@ SETTINGS allow_experimental_replacing_merge_with_cleanup = true,
 INSERT INTO replacing2 VALUES (1, 1, 1, 0);
 INSERT INTO replacing2 VALUES (1, 1, 2, 1);"
 
-wait_for_number_of_parts 'replacing2' 0 10
+wait_for_number_of_parts 'replacing2' 0 30
 
 $CLICKHOUSE_CLIENT -mq "
 SET alter_sync = 2;
@@ -75,7 +79,10 @@ DROP TABLE IF EXISTS t03357_replacing_replicated;
 CREATE TABLE t03357_replacing_replicated (key int, value int, version int, deleted UInt8)
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{database}/t03357_replacing_replicated', 'node', version, deleted)
 ORDER BY key
-SETTINGS cleanup_delay_period = 1, max_cleanup_delay_period = 1;
+SETTINGS
+    cleanup_delay_period = 1,
+    max_cleanup_delay_period = 1,
+    cleanup_delay_period_random_add = 0;
 
 INSERT INTO t03357_replacing_replicated VALUES (1, 1, 1, 0), (1, 1, 2, 1);
 
@@ -95,9 +102,11 @@ OPTIMIZE TABLE t03357_replacing_replicated FINAL CLEANUP; -- { serverError SUPPO
 
 ALTER TABLE t03357_replacing_replicated MODIFY SETTING allow_experimental_replacing_merge_with_cleanup = true;
 
-OPTIMIZE TABLE t03357_replacing_replicated FINAL CLEANUP;"
+OPTIMIZE TABLE t03357_replacing_replicated FINAL CLEANUP;
+"
 
-wait_for_number_of_parts 't03357_replacing_replicated' 0 10
+# OPTIMIZE FINAL CLEANUP will replace the part with empty, but only cleaner thread will clean it, so we still need to wait
+wait_for_number_of_parts 't03357_replacing_replicated' 0 30
 
 $CLICKHOUSE_CLIENT -mq "
 DROP TABLE IF EXISTS t03357_replacing_replicated2;
@@ -105,21 +114,25 @@ DROP TABLE IF EXISTS t03357_replacing_replicated2;
 CREATE TABLE t03357_replacing_replicated2 (key int, value int, version int, deleted UInt8) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{database}/t03357_replacing_replicated2', 'node', version, deleted) ORDER BY key
 SETTINGS allow_experimental_replacing_merge_with_cleanup = true,
     enable_replacing_merge_with_cleanup_for_min_age_to_force_merge = true,
+    number_of_free_entries_in_pool_to_execute_optimize_entire_partition = 1,
     min_age_to_force_merge_on_partition_only = true,
     min_age_to_force_merge_seconds = 1,
     merge_selecting_sleep_ms = 1000,
     max_merge_selecting_sleep_ms = 1000,
+    cleanup_delay_period_random_add = 0,
     cleanup_delay_period = 1,
     max_cleanup_delay_period = 1;
 
 -- Do inserts separately to create two parts to merge
 INSERT INTO t03357_replacing_replicated2 VALUES (1, 1, 1, 0);
-INSERT INTO t03357_replacing_replicated2 VALUES (1, 1, 2, 1);"
+INSERT INTO t03357_replacing_replicated2 VALUES (1, 1, 2, 1);
+"
 
-wait_for_number_of_parts 't03357_replacing_replicated2' 0 10
+wait_for_number_of_parts 't03357_replacing_replicated2' 0 30
 
 $CLICKHOUSE_CLIENT -mq "
 DROP TABLE replacing;
 DROP TABLE replacing2;
 DROP TABLE t03357_replacing_replicated;
-DROP TABLE t03357_replacing_replicated2;"
+DROP TABLE t03357_replacing_replicated2;
+"


### PR DESCRIPTION
Sometimes merges cannot be performed due to
number_of_free_entries_in_pool_to_execute_optimize_entire_partition:

    2025.03.08 15:00:12.836518 [ 713 ] {} <Trace> test_crdvdkgj.t03357_replacing_replicated2 (7598017c-f091-494a-9f77-5ce9f0291890) (MergerMutator): Nothing to merge in partition all with max_total_size_to_merge = 150.00 GiB (looked up 1 ranges)
    2025.03.08 15:00:12.836656 [ 713 ] {} <Information> test_crdvdkgj.t03357_replacing_replicated2 (7598017c-f091-494a-9f77-5ce9f0291890) (MergerMutator): Not enough idle threads to execute optimizing entire partition. See settings 'number_of_free_entries_in_pool_to_execute_optimize_entire_partition' and 'background_pool_size'

So:
- adjust number_of_free_entries_in_pool_to_execute_optimize_entire_partition to avoid this error
- adjust cleanup_delay_period_random_add since it can increase the delay (applied after max_cleanup_delay_period)
- also explicitly set merge_tree_clear_old_parts_interval_seconds just in case

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)