### PR TITLE
tests: better mocks for S3 (add some logging) and decrease tune failure rate

### DIFF
--- a/tests/integration/helpers/s3_mocks/broken_s3.py
+++ b/tests/integration/helpers/s3_mocks/broken_s3.py
@@ -1,5 +1,4 @@
 import http.server
-import logging
 import random
 import socket
 import socketserver

--- a/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
@@ -1,12 +1,10 @@
 import http.client
 import http.server
-import random
 import socketserver
 import sys
 import urllib.parse
 
 UPSTREAM_HOST = "minio1:9001"
-random.seed("No delete objects/1.0")
 
 
 def request(command, url, headers={}, data=None):

--- a/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
@@ -68,6 +68,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_header(k, v)
         self.end_headers()
         if random.random() < 0.25 and len(r.content) > 1024 * 1024:
+            self.log_message("Breaking request %s", self.path)
             r.content = r.content[: len(r.content) // 2]
         self.wfile.write(r.content)
 

--- a/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
@@ -67,7 +67,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         for k, v in r.headers.items():
             self.send_header(k, v)
         self.end_headers()
-        if random.random() < 0.25 and len(r.content) > 1024 * 1024:
+        if random.random() < 0.20 and len(r.content) > 1024 * 1024:
             self.log_message("Breaking request %s", self.path)
             r.content = r.content[: len(r.content) // 2]
         self.wfile.write(r.content)

--- a/tests/integration/test_s3_access_headers/s3_mocks/mocker_s3.py
+++ b/tests/integration/test_s3_access_headers/s3_mocks/mocker_s3.py
@@ -1,12 +1,10 @@
 import http.client
 import http.server
-import random
 import socketserver
 import sys
 import urllib.parse
 
 UPSTREAM_HOST = "minio1:9001"
-random.seed("No list objects/1.0")
 
 
 def request(command, url, headers={}, data=None):

--- a/tests/integration/test_storage_s3/s3_mocks/no_list_objects.py
+++ b/tests/integration/test_storage_s3/s3_mocks/no_list_objects.py
@@ -1,12 +1,10 @@
 import http.client
 import http.server
-import random
 import socketserver
 import sys
 import urllib.parse
 
 UPSTREAM_HOST = "minio1:9001"
-random.seed("No list objects/1.0")
 
 list_request_counter = 0
 list_request_max_number = 10

--- a/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
+++ b/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
@@ -1,8 +1,6 @@
 import http.server
 import random
 import re
-import socket
-import struct
 import sys
 import time
 
@@ -99,7 +97,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
                     # self.wfile._sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 0, 0))
                     # self.wfile._sock.shutdown(socket.SHUT_RDWR)
                     # self.wfile._sock.close()
-                    print("Dropping connection")
+                    self.log_message("Dropping connection %s", self.path)
                     break
 
         if self.path == "/root/slow_send_test.csv":


### PR DESCRIPTION
I.e. sometimes test_merge_tree_s3/test.py::test_s3_disk_reads_on_unstable_connection[node] fails [1], and likely the problem is that all connections had been unstable:

    E           helpers.client.QueryRuntimeException: Client failed! Return code: 232, stderr: Received exception from server (version 25.3.1):
    E           Code: 1000. DB::Exception: Received from 172.16.1.6:9000. DB::Exception: Malformed message: Unexpected EOF. Stack trace:

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=77322&sha=latest&name_0=PR&name_1=Integration+tests+%28asan%2C+old+analyzer%2C+2%2F6%29&name_2=test_merge_tree_s3%2Ftest.py%3A%3Atest_s3_disk_reads_on_unstable_connection%5Bnode%5D<!---

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)