### PR TITLE
tests: use more reliable hits_s3 for 00156_max_execution_speed_sample_merge

### DIFF
--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -4,14 +4,14 @@ SET max_execution_speed = 4000000, timeout_before_checking_execution_speed = 0;
 CREATE TEMPORARY TABLE times (t DateTime);
 
 INSERT INTO times SELECT now();
-SELECT count() FROM test.hits SAMPLE 1 / 2;
+SELECT count() FROM test.hits_s3 SAMPLE 1 / 2;
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 1 FROM times;
 TRUNCATE TABLE times;
 
 INSERT INTO times SELECT now();
-SELECT count() FROM merge(test, '^hits$') SAMPLE 1 / 2;
+SELECT count() FROM merge(test, '^hits_s3$') SAMPLE 1 / 2;
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 1 FROM times;


### PR DESCRIPTION
- **Alternative of https://github.com/ClickHouse/ClickHouse/pull/77339**

Sometimes `00156_max_execution_speed_sample_merge` fails on CI [1]:

    2025-03-08 17:11:58 [07c07ab3da37] 2025.03.08 12:11:58.522959 [ 143686 ] {77effc3a-938b-4a96-9033-58ec2ca95beb} executeQuery: Code: 160. DB::Exception: Estimated query execution time (1272.25044 seconds) is too long. Maximum: 600. Estimated rows to process: 8232960 (21976 read in 3.39598 seconds).: While executing MergeTreeSelect(pool: PrefetchedReadPool, algorithm: Thread). (TOO_SLOW) (version 25.3.1.1473) (from [::1]:54282) (comment: 00156_max_execution_speed_sample_merge.sql) (query 4, line 7) (in query: SELECT count() FROM test.hits SAMPLE 1 / 2;), Stack trace (when copying this message, always include the lines below):

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=77175&sha=1b488899cbc9382ddea36775ff7b4d26cb0bb9c8&name_0=PR&name_1=Stateless+tests+%28tsan%2C+3%2F3%29

Some details:

    SELECT
        pe.1 AS k,
        pe.2 AS v
    FROM query_log_14189064888146039029
    ARRAY JOIN ProfileEvents AS pe
    WHERE (event_date = '2025-03-08') AND (pull_request_number = 77175) AND (check_name = 'Stateless tests (tsan, 3/3)') AND (log_comment = '00156_max_execution_speed_sample_merge.sql') AND (type != 'QueryStart') AND (type != 'QueryFinish') AND (k LIKE '%second%')
    ORDER BY v ASC

    Query id: d6d2e907-b96a-4341-9a59-be8a2a680857

        ┌─k──────────────────────────────────────────┬────────v─┐
        ....
    31. │ CachedReadBufferReadFromSourceMicroseconds │  3618753 │
    32. │ FileSegmentWaitMicroseconds                │  6596811 │
    33. │ FileSegmentWaitReadBufferMicroseconds      │  6597870 │
    34. │ ThreadpoolReaderTaskMicroseconds           │ 10231334 │
    35. │ SynchronousRemoteReadWaitMicroseconds      │ 10231517 │
    36. │ RealTimeMicroseconds                       │ 17205435 │
        └────────────────────────────────────────────┴──────────┘

The problem is that the hits located on the web disk, and sometimes due to backoff it sleeps too long:

    SELECT
        event_time_microseconds,
        logger_name,
        message
    FROM text_log_15470189561651757858
    WHERE (event_date = '2025-03-08') AND (pull_request_number = 77175) AND (check_name = 'Stateless tests (tsan, 3/3)') AND (query_id = '77effc3a-938b-4a96-9033-58ec2ca95beb')
    ORDER BY 1 ASC
    FORMAT LineAsString

    2025-03-08 10:11:54.999561      executeQuery    (from [::1]:54282) (comment: 00156_max_execution_speed_sample_merge.sql) (query 4, line 7) SELECT count() FROM test.hits SAMPLE 1 / 2; (stage: Complete)
    2025-03-08 10:11:55.004530      Planner Query to stage Complete
    2025-03-08 10:11:55.005975      Planner Query from stage FetchColumns to stage Complete
    2025-03-08 10:11:55.007251      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        Key condition: unknown
    2025-03-08 10:11:55.007429      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        MinMax index condition: unknown
    2025-03-08 10:11:55.009519      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        Filtering marks by primary and secondary keys
    2025-03-08 10:11:55.015098      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        Used generic exclusion search over index for part 201403_1_1_2 with 1608 steps
    2025-03-08 10:11:55.015363      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        Selected 1/1 parts by partition key, 1 parts by primary key, 1005/1084 marks by primary key, 1005 marks to read from 37 ranges
    2025-03-08 10:11:55.015508      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        Spreading mark ranges among streams (default reading)
    2025-03-08 10:11:55.016577      MergeTreePrefetchedReadPool(test.hits (78ebf6a1-d987-4579-b3ec-00c1a087b1f3))   Part: 201403_1_1_2, sum_marks: 1005, approx mark size: 10739, prefetch_step_bytes: 0, prefetch_step_marks: 167, (ranges: (0, 136), (139, 143), (145, 149), (152, 156), (158, 162), (164, 167), (168, 172), (173, 199), (203, 209), (212, 218), (222, 226), (229, 234), (237, 242), (245, 249), (252, 257), (258, 262), (263, 271), (272, 275), (276, 280), (281, 284), (285, 337), (342, 348), (353, 360), (365, 371), (376, 382), (386, 389), (391, 432), (433, 435), (436, 439), (440, 443), (444, 446), (447, 452), (453, 888), (889, 891), (892, 894), (895, 897), (898, 1084))
    2025-03-08 10:11:55.016641      MergeTreePrefetchedReadPool(test.hits (78ebf6a1-d987-4579-b3ec-00c1a087b1f3))   Sum marks: 1005, threads: 3, min_marks_per_thread: 335, prefetches limit: 0, total_size_approx: 10792695
    2025-03-08 10:11:55.016747      datasets.hits_v1 (78ebf6a1-d987-4579-b3ec-00c1a087b1f3) (SelectExecutor)        Reading approx. 8232960 rows with 3 streams
    2025-03-08 10:11:55.025962      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin
    2025-03-08 10:11:55.025991      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin
    2025-03-08 10:11:55.025992      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin
    2025-03-08 10:11:55.028945      ReadWriteBufferFromHTTP Failed to make request to 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin'. Error: No message received. Failed at try 2/10. Will retry with current backoff wait is 100/10000 ms.
    2025-03-08 10:11:55.130855      ReadWriteBufferFromHTTP Failed to make request to 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin'. Error: No message received. Failed at try 3/10. Will retry with current backoff wait is 200/10000 ms.
    2025-03-08 10:11:55.332753      ReadWriteBufferFromHTTP Failed to make request to 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin'. Error: No message received. Failed at try 4/10. Will retry with current backoff wait is 400/10000 ms.
    2025-03-08 10:11:55.734559      ReadWriteBufferFromHTTP Failed to make request to 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin'. Error: No message received. Failed at try 5/10. Will retry with current backoff wait is 800/10000 ms.
    2025-03-08 10:11:56.554538      ReadWriteBufferFromHTTP Failed to make request to 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams.size0.bin'. Error: No message received. Failed at try 6/10. Will retry with current backoff wait is 1600/10000 ms.
    2025-03-08 10:11:58.294619      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams%2EKey5.bin
    2025-03-08 10:11:58.332697      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/UserID.bin
    2025-03-08 10:11:58.361140      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams%2EKey5.bin
    2025-03-08 10:11:58.361626      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/ParsedParams%2EKey5.bin
    2025-03-08 10:11:58.361956      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/UserID.bin
    2025-03-08 10:11:58.362694      DiskWeb Checking existence of path: store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/201403_1_1_2/UserID.bin
    2025-03-08 10:11:58.478001      TCPHandler      Processed in 3.48146467 sec.
    2025-03-08 10:11:58.522959      executeQuery    Code: 160. DB::Exception: Estimated query execution time (1272.25044 seconds) is too long. Maximum: 600. Estimated rows to process: 8232960 (21976 read in 3.39598 seconds).: While executing MergeTreeSelect(pool: PrefetchedReadPool, algorithm: Thread). (TOO_SLOW) (version 25.3.1.1473) (from [::1]:54282) (comment: 00156_max_execution_speed_sample_merge.sql) (query 4, line 7) (in query: SELECT count() FROM test.hits SAMPLE 1 / 2;), Stack trace (when copying this message, always include the lines below):

But, tunning backoff does not help, S3 is not that reliable, so let's instead, use more reliable disk for this test with max_execution_speed constraint.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/76271