### PR TITLE
Refresh S3 credentials after error "AuthenticationRequired"

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -271,8 +271,6 @@ Aws::Auth::AWSCredentials Client::getCredentials() const
 
 bool Client::checkIfCredentialsChanged(const Aws::S3::S3Error & error) const
 {
-    if (!credentials_provider)
-        return false;
     return (error.GetExceptionName() == "AuthenticationRequired");
 }
 

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -276,6 +276,9 @@ private:
     bool checkIfWrongRegionDefined(const std::string & bucket, const Aws::S3::S3Error & error, std::string & region) const;
     void insertRegionOverride(const std::string & bucket, const std::string & region) const;
 
+    /// Returns true if a specified error means that the credentials used are expired or may have changed.
+    bool checkIfCredentialsChanged(const Aws::S3::S3Error & error) const;
+
     template <typename RequestResult>
     RequestResult processRequestResult(RequestResult && outcome) const;
 

--- a/src/IO/S3/Credentials.h
+++ b/src/IO/S3/Credentials.h
@@ -100,6 +100,7 @@ protected:
     void Reload() override;
 
 private:
+    Aws::Auth::AWSCredentials GetAWSCredentialsImpl();
     void refreshIfExpired();
 
     std::shared_ptr<AWSEC2InstanceProfileConfigLoader> ec2_metadata_config_loader;


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Refresh S3 credentials after error `AuthenticationRequired`