### PR TITLE
Add new s3 request setting `native_copy_allowed_patterns` with a list…

### DIFF
--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -167,7 +167,9 @@ BackupReaderS3::BackupReaderS3(
     }
 
     s3_settings.request_settings.updateFromSettings(context_->getSettingsRef(), /* if_changed */true);
-    s3_settings.request_settings[S3RequestSetting::allow_native_copy] = allow_s3_native_copy;
+
+    if (!allow_s3_native_copy)
+        s3_settings.request_settings[S3RequestSetting::allow_native_copy] = false;
 
     client = makeS3Client(s3_uri_, access_key_id_, secret_access_key_, s3_settings, context_);
 
@@ -266,7 +268,10 @@ BackupWriterS3::BackupWriterS3(
     }
 
     s3_settings.request_settings.updateFromSettings(context_->getSettingsRef(), /* if_changed */true);
-    s3_settings.request_settings[S3RequestSetting::allow_native_copy] = allow_s3_native_copy;
+
+    if (!allow_s3_native_copy)
+        s3_settings.request_settings[S3RequestSetting::allow_native_copy] = false;
+
     s3_settings.request_settings[S3RequestSetting::storage_class_name] = storage_class_name;
 
     client = makeS3Client(s3_uri_, access_key_id_, secret_access_key_, s3_settings, context_);

--- a/src/IO/S3Defines.h
+++ b/src/IO/S3Defines.h
@@ -36,6 +36,8 @@ inline static constexpr uint64_t DEFAULT_MAX_REDIRECTS = 10;
 inline static constexpr uint64_t DEFAULT_RETRY_ATTEMPTS = 100;
 
 inline static constexpr bool DEFAULT_ALLOW_NATIVE_COPY = true;
+inline static constexpr std::string_view DEFAULT_NATIVE_COPY_ALLOWED_PATTERNS = "*";
+
 inline static constexpr bool DEFAULT_CHECK_OBJECTS_AFTER_UPLOAD = false;
 
 }

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -34,6 +34,7 @@ namespace ErrorCodes
     DECLARE(UInt64, request_timeout_ms, S3::DEFAULT_REQUEST_TIMEOUT_MS, "", 0) \
     DECLARE(UInt64, list_object_keys_size, S3::DEFAULT_LIST_OBJECT_KEYS_SIZE, "", 0) \
     DECLARE(Bool, allow_native_copy, S3::DEFAULT_ALLOW_NATIVE_COPY, "", 0) \
+    DECLARE(String, native_copy_allowed_patterns, S3::DEFAULT_NATIVE_COPY_ALLOWED_PATTERNS, "", 0) \
     DECLARE(Bool, check_objects_after_upload, S3::DEFAULT_CHECK_OBJECTS_AFTER_UPLOAD, "", 0) \
     DECLARE(Bool, throw_on_zero_files_match, false, "", 0) \
     DECLARE(Bool, allow_multipart_copy, true, "", 0) \


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add new s3 request setting `native_copy_allowed_patterns` with a list of `*?` patterns for `bucket/key` supporting native copy between them.

Setting `allow_native_copy` was just a boolean so it allowed only to enable or disable native copy between S3 buckets, whereas new setting `native_copy_allowed_patterns` allows to specify more precisely which objects can be copied natively and which are not.

Example of the configuration:
```
<s3>
    <allow_native_copy>true</allow_native_copy>
    <native_copy_allowed_patterns>user1.bucket/*;backups.bucket/*
</s3>
```