### PR TITLE
Support remote disk for databases

### DIFF
--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -1,9 +1,10 @@
 #include "DisksApp.h"
 #include <Client/ClientBase.h>
 #include <Client/ReplxxLineReader.h>
-#include "Common/Exception.h"
+#include <Common/Exception.h>
 #include "Common/filesystemHelpers.h"
 #include <Common/Config/ConfigProcessor.h>
+#include <Common/Macros.h>
 #include "DisksClient.h"
 #include "ICommand.h"
 #include "ICommand_fwd.h"
@@ -525,6 +526,9 @@ int DisksApp::main(const std::vector<String> & /*args*/)
 
     global_context->makeGlobalContext();
     global_context->setApplicationType(Context::ApplicationType::DISKS);
+
+    if (config().has("macros"))
+        global_context->setMacros(std::make_unique<Macros>(config(), "macros", &logger()));
 
     String path = config().getString("path", DBMS_DEFAULT_PATH);
 

--- a/programs/disks/DisksClient.cpp
+++ b/programs/disks/DisksClient.cpp
@@ -48,6 +48,18 @@ DiskWithPath::DiskWithPath(DiskPtr disk_, std::optional<String> path_) : disk(di
     {
         path = String{"/"};
     }
+
+    String relative_path = normalizePathAndGetAsRelative(path);
+    if (disk->existsDirectory(relative_path) || relative_path.empty())
+    {
+        return;
+    }
+    throw Exception(
+        ErrorCodes::BAD_ARGUMENTS,
+        "Initializing path {} (normalized path: {}) at disk {} is not a directory",
+        path,
+        relative_path,
+        disk->getName());
 }
 
 std::vector<String> DiskWithPath::listAllFilesByPath(const String & any_path) const

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1608,6 +1608,9 @@ try
     DateLUT::serverTimezoneInstance();
     LOG_TRACE(log, "Initialized DateLUT with time zone '{}'.", getDateLUTTimeZone(DateLUT::serverTimezoneInstance()));
 
+    if (config().has("macros"))
+        global_context->setMacros(std::make_unique<Macros>(config(), "macros", log));
+
     /// Storage with temporary data for processing of heavy queries.
     if (!server_settings[ServerSetting::tmp_policy].value.empty())
     {
@@ -1701,9 +1704,6 @@ try
 
     LOG_DEBUG(log, "Initializing interserver credentials.");
     global_context->updateInterserverCredentials(config());
-
-    if (config().has("macros"))
-        global_context->setMacros(std::make_unique<Macros>(config(), "macros", log));
 
     /// Set up caches.
 

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -74,6 +74,10 @@ public:
 
     void replaceFile(const String & from_path, const String & to_path) override;
 
+    void renameExchange(const std::string & old_path, const std::string & new_path) override;
+
+    bool renameExchangeIfSupported(const std::string & old_path, const std::string & new_path) override;
+
     void removeFile(const String & path) override { removeSharedFile(path, false); }
 
     void removeFileIfExists(const String & path) override { removeSharedFileIfExists(path, false); }
@@ -123,6 +127,8 @@ public:
     void moveDirectory(const String & from_path, const String & to_path) override;
 
     void removeDirectory(const String & path) override;
+
+    void removeDirectoryIfExists(const String & path) override;
 
     DirectoryIteratorPtr iterateDirectory(const String & path) const override;
 

--- a/tests/config/config.d/remote_database_disk.xml
+++ b/tests/config/config.d/remote_database_disk.xml
@@ -1,0 +1,2 @@
+<clickhouse>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -224,6 +224,7 @@ fi
 if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
     ln -sf $SRC_PATH/users.d/database_replicated.xml $DEST_SERVER_PATH/users.d/
     ln -sf $SRC_PATH/config.d/database_replicated.xml $DEST_SERVER_PATH/config.d/
+    ln -sf $SRC_PATH/config.d/remote_database_disk.xml $DEST_SERVER_PATH/config.d/
     rm /etc/clickhouse-server/config.d/zookeeper.xml
     rm /etc/clickhouse-server/config.d/keeper_port.xml
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1574,6 +1574,7 @@ class ClickHouseCluster:
         with_nginx=False,
         with_redis=False,
         with_minio=False,
+        with_remote_database_disk=False,  # Currently, there is no remote storage can be used for the database disk. We disabled it as default.
         with_azurite=False,
         with_cassandra=False,
         with_ldap=False,
@@ -1635,6 +1636,16 @@ class ClickHouseCluster:
 
         if tag is None:
             tag = DOCKER_BASE_TAG
+        else:
+            if with_remote_database_disk:
+                raise Exception(
+                    f"Can't add instance '{name}': not support remote database disk with the old version {tag}"
+                )
+            with_remote_database_disk = False
+
+        if with_remote_database_disk is None:
+            with_remote_database_disk = False
+
         if not env_variables:
             env_variables = {}
         self.use_keeper = use_keeper
@@ -1681,6 +1692,7 @@ class ClickHouseCluster:
             with_mongo=with_mongo,
             with_redis=with_redis,
             with_minio=with_minio,
+            with_remote_database_disk=with_remote_database_disk,
             with_azurite=with_azurite,
             with_jdbc_bridge=with_jdbc_bridge,
             with_hive=with_hive,
@@ -3364,6 +3376,7 @@ class ClickHouseInstance:
         with_mongo,
         with_redis,
         with_minio,
+        with_remote_database_disk,
         with_azurite,
         with_jdbc_bridge,
         with_hive,
@@ -3460,6 +3473,7 @@ class ClickHouseInstance:
         )
         self.with_redis = with_redis
         self.with_minio = with_minio
+        self.with_remote_database_disk = with_remote_database_disk
         self.with_azurite = with_azurite
         self.with_cassandra = with_cassandra
         self.with_ldap = with_ldap

--- a/tests/integration/helpers/database_disk.py
+++ b/tests/integration/helpers/database_disk.py
@@ -1,0 +1,30 @@
+import os
+
+import tempfile
+import xml.etree.ElementTree as ET
+
+def get_database_disk_name(node):
+    if not node.with_remote_database_disk:
+        return "default"
+    tree = ET.parse(os.path.join(os.path.dirname(os.path.realpath(__file__)), "remote_database_disk.xml"))
+    root = tree.getroot()
+
+    disk_element = root.find(".//database_disk/disk")
+    return disk_element.text if disk_element is not None else "default"
+
+
+def replace_text_in_metadata(node, metadata_path: str, old_value: str, new_value: str):
+    db_disk_name = get_database_disk_name(node)
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /etc/clickhouse-server/config.xml --disk {db_disk_name} --save-logs --query "
+
+    old_metadata = node.exec_in_container(
+        ["bash", "-c", f"{disk_cmd_prefix} 'read --path-from {metadata_path}'"]
+    )
+
+    # Escape backticks to avoid command substitution
+    new_metadata = old_metadata.replace(old_value, new_value).replace("`", r"\`")
+
+    command = f"""cat <<EOF | {disk_cmd_prefix} 'w --path-to {metadata_path}'
+{new_metadata}
+EOF"""
+    node.exec_in_container(["bash", "-c", command])

--- a/tests/integration/helpers/database_disk.py
+++ b/tests/integration/helpers/database_disk.py
@@ -21,10 +21,28 @@ def replace_text_in_metadata(node, metadata_path: str, old_value: str, new_value
         ["bash", "-c", f"{disk_cmd_prefix} 'read --path-from {metadata_path}'"]
     )
 
-    # Escape backticks to avoid command substitution
-    new_metadata = old_metadata.replace(old_value, new_value).replace("`", r"\`")
+    new_metadata = old_metadata.replace(old_value, new_value)
+    write_to_file(node, db_disk_name, metadata_path, new_metadata)
 
-    command = f"""cat <<EOF | {disk_cmd_prefix} 'w --path-to {metadata_path}'
-{new_metadata}
-EOF"""
-    node.exec_in_container(["bash", "-c", command])
+
+def write_metadata(node, metadata_path: str, content: str):
+    db_disk_name = get_database_disk_name(node)
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /etc/clickhouse-server/config.xml --disk {db_disk_name} --save-logs --query "
+
+    old_metadata = node.exec_in_container(
+        ["bash", "-c", f"{disk_cmd_prefix} 'read --path-from {metadata_path}'"]
+    )
+    write_to_file(node, db_disk_name, metadata_path, content)
+
+
+def write_to_file(node, db_disk_name: str, file_path: str, content: str):
+    # Escape backticks to avoid command substitution
+    escaped_content = content.replace('"', r"\"").replace("`", r"\`")
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /etc/clickhouse-server/config.xml --save-logs --disk {db_disk_name} --query "
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"""printf "%s" "{escaped_content}" | {disk_cmd_prefix} 'w --path-to {file_path}'""",
+        ]
+    )

--- a/tests/integration/helpers/remote_database_disk.xml
+++ b/tests/integration/helpers/remote_database_disk.xml
@@ -1,0 +1,2 @@
+<clickhouse>
+</clickhouse>

--- a/tests/integration/test_alternative_keeper_config/test.py
+++ b/tests/integration/test_alternative_keeper_config/test.py
@@ -15,6 +15,7 @@ node1 = cluster.add_instance(
         "configs/enable_keeper1.xml",
     ],
     macros={"replica": "node1"},
+    with_remote_database_disk=False,
 )
 
 node2 = cluster.add_instance(
@@ -25,12 +26,14 @@ node2 = cluster.add_instance(
         "configs/enable_keeper2.xml",
     ],
     macros={"replica": "node2"},
+    with_remote_database_disk=False,
 )
 
 node3 = cluster.add_instance(
     "node3",
     main_configs=["configs/remote_servers.xml", "configs/enable_keeper3.xml"],
     macros={"replica": "node3"},
+    with_remote_database_disk=False,
 )
 
 

--- a/tests/integration/test_alternative_keeper_config/test.py
+++ b/tests/integration/test_alternative_keeper_config/test.py
@@ -7,6 +7,7 @@ from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
     "node1",
     main_configs=[

--- a/tests/integration/test_attach_table_normalizer/test.py
+++ b/tests/integration/test_attach_table_normalizer/test.py
@@ -1,10 +1,10 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.database_disk import get_database_disk_name, replace_text_in_metadata
+from helpers.database_disk import replace_text_in_metadata
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", stay_alive=True, with_remote_database_disk=False)
+node = cluster.add_instance("node", stay_alive=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_attach_table_normalizer/test.py
+++ b/tests/integration/test_attach_table_normalizer/test.py
@@ -1,9 +1,10 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.database_disk import get_database_disk_name, replace_text_in_metadata
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", stay_alive=True)
+node = cluster.add_instance("node", stay_alive=True, with_remote_database_disk=False)
 
 
 @pytest.fixture(scope="module")
@@ -13,17 +14,6 @@ def started_cluster():
         yield cluster
     finally:
         cluster.shutdown()
-
-
-def replace_substring_to_substr(node):
-    node.exec_in_container(
-        [
-            "bash",
-            "-c",
-            "sed -i 's/substring/substr/g' /var/lib/clickhouse/metadata/default/file.sql",
-        ],
-        user="root",
-    )
 
 
 def test_attach_substr(started_cluster):
@@ -36,8 +26,12 @@ def test_attach_substr(started_cluster):
     # Detach table file
     node.query("DETACH TABLE file")
 
+    metadata_path = node.query(
+        f"SELECT metadata_path FROM system.detached_tables WHERE database='default' AND table='file'"
+    ).strip()
+
     # Replace substring to substr
-    replace_substring_to_substr(node)
+    replace_text_in_metadata(node, metadata_path, "substring", "substr")
 
     # Attach table file
     node.query("ATTACH TABLE file")
@@ -45,13 +39,17 @@ def test_attach_substr(started_cluster):
 
 def test_attach_substr_restart(started_cluster):
     # Initialize
-    node.query("DROP TABLE IF EXISTS default.file")
+    node.query("DROP TABLE IF EXISTS default.file SYNC")
     node.query(
         "CREATE TABLE default.file(`s` String, `n` UInt8) ENGINE = MergeTree PARTITION BY substring(s, 1, 2) ORDER BY n "
     )
 
+    metadata_path = node.query(
+        f"SELECT metadata_path FROM system.tables WHERE database='default' AND table='file'"
+    ).strip()
+
     # Replace substring to substr
-    replace_substring_to_substr(node)
+    replace_text_in_metadata(node, metadata_path, "substring", "substr")
 
     # Restart clickhouse
     node.restart_clickhouse(kill=True)

--- a/tests/integration/test_attach_without_checksums/test.py
+++ b/tests/integration/test_attach_without_checksums/test.py
@@ -33,12 +33,16 @@ def test_attach_without_checksums(start_cluster):
     assert node1.query("SELECT COUNT() FROM test WHERE key % 10 == 0") == "0\n"
     assert node1.query("SELECT COUNT() FROM test") == "0\n"
 
+    data_path = node1.query(
+        "SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='test'"
+    ).strip()
+
     # to be sure output not empty
     node1.exec_in_container(
         [
             "bash",
             "-c",
-            'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" | grep -e ".*" ',
+            f'find {data_path}detached -name "checksums.txt" | grep -e ".*" ',
         ],
         privileged=True,
         user="root",
@@ -48,7 +52,7 @@ def test_attach_without_checksums(start_cluster):
         [
             "bash",
             "-c",
-            'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" -delete',
+            f'find {data_path}detached -name "checksums.txt" -delete',
         ],
         privileged=True,
         user="root",

--- a/tests/integration/test_attach_without_fetching/test.py
+++ b/tests/integration/test_attach_without_fetching/test.py
@@ -32,9 +32,6 @@ node_3 = cluster.add_instance("replica3", with_zookeeper=True)
 def start_cluster():
     try:
         cluster.start()
-        fill_node(node_1)
-        fill_node(node_2)
-        # the third node is filled after the DETACH query
         yield cluster
 
     except Exception as ex:
@@ -88,6 +85,13 @@ def check_data(nodes, detached_parts):
 # 2. Check that ALTER TABLE ATTACH PART|PARTITION downloads the data from other replicas if the detached/ folder
 # does not contain the part with the correct checksums.
 def test_attach_without_fetching(start_cluster):
+    for node in [node_1, node_2, node_3]:
+        node.query("DROP TABLE IF EXISTS test SYNC")
+
+    fill_node(node_1)
+    fill_node(node_2)
+    # the third node is filled after the DETACH query
+
     # Note here requests are used for both PARTITION and PART. This is done for better test diversity.
     # The partition and part are used interchangeably which is not true in most cases.
     # 0. Insert data on two replicas
@@ -116,13 +120,15 @@ def test_attach_without_fetching(start_cluster):
     # Replica 2 should also download the data from 1 as the checksums won't match.
     logging.debug("Checking attach with corrupted part data with files missing")
 
+    data_path = node_2.query(
+        "SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='test'"
+    ).strip()
+
     to_delete = node_2.exec_in_container(
         [
             "bash",
             "-c",
-            "cd {p} && ls *.bin".format(
-                p="/var/lib/clickhouse/data/default/test/detached/2_0_0_0"
-            ),
+            f"cd {data_path}detached/2_0_0_0 && ls *.bin",
         ],
         privileged=True,
     )
@@ -132,9 +138,7 @@ def test_attach_without_fetching(start_cluster):
         [
             "bash",
             "-c",
-            "cd {p} && rm -fr *.bin".format(
-                p="/var/lib/clickhouse/data/default/test/detached/2_0_0_0"
-            ),
+            f"cd {data_path}detached/2_0_0_0 && rm -fr *.bin",
         ],
         privileged=True,
     )
@@ -147,9 +151,7 @@ def test_attach_without_fetching(start_cluster):
     # Replica 2 should also download the data from 1 as the checksums won't match.
     print("Checking attach with corrupted part data with all of the files present")
 
-    corrupt_part_data_by_path(
-        node_2, "/var/lib/clickhouse/data/default/test/detached/1_0_0_0"
-    )
+    corrupt_part_data_by_path(node_2, f"{data_path}detached/1_0_0_0")
 
     node_1.query("ALTER TABLE test ATTACH PARTITION 1")
     check_data([node_1, node_2, node_3], detached_parts=[0])

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1641,6 +1641,7 @@ def test_backup_all(exclude_system_log_tables):
             "backup_log",
             "error_log",
             "latency_log",
+            "blob_storage_log",
         ]
         exclude_from_backup += ["system." + table_name for table_name in log_tables]
 

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -25,6 +25,8 @@ node = cluster.add_instance(
         "configs/zookeeper_retries.xml",
     ],
     with_minio=True,
+    # The test compares some S3 events. We disable the remote DB disk, so it doesn't affect the comparing events.
+    with_remote_database_disk=False,
     with_zookeeper=True,
     stay_alive=True,
 )

--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -8,7 +8,12 @@ from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_logs_contain_with_retry
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance("node1", with_zookeeper=True, stay_alive=True)
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True,
+    stay_alive=True,
+    with_remote_database_disk=False,
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -8,12 +8,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_logs_contain_with_retry
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance(
-    "node1",
-    with_zookeeper=True,
-    stay_alive=True,
-    with_remote_database_disk=False,
-)
+node1 = cluster.add_instance("node1", with_zookeeper=True, stay_alive=True)
 
 
 @pytest.fixture(scope="module")
@@ -40,13 +35,17 @@ def test_old_dirs_cleanup(start_cluster):
     node1.query("INSERT INTO test_table VALUES (toDate('2020-01-01'), 1, 10)")
     assert node1.query("SELECT count() FROM test_table") == "1\n"
 
+    data_path = node1.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='test_table'"
+    ).strip()
+
     node1.stop_clickhouse()
 
     node1.exec_in_container(
         [
             "bash",
             "-c",
-            "mv /var/lib/clickhouse/data/default/test_table/20200101_0_0_0 /var/lib/clickhouse/data/default/test_table/delete_tmp_20200101_0_0_0",
+            f"mv {data_path}/20200101_0_0_0 {data_path}/delete_tmp_20200101_0_0_0",
         ],
         privileged=True,
     )
@@ -54,7 +53,7 @@ def test_old_dirs_cleanup(start_cluster):
     node1.start_clickhouse()
 
     result = node1.exec_in_container(
-        ["bash", "-c", "ls /var/lib/clickhouse/data/default/test_table/"],
+        ["bash", "-c", f"ls {data_path}/"],
         privileged=True,
     )
 

--- a/tests/integration/test_compression_nested_columns/test.py
+++ b/tests/integration/test_compression_nested_columns/test.py
@@ -22,9 +22,10 @@ def start_cluster():
 
 
 def get_compression_codec_byte(node, table_name, part_name, filename):
-    cmd = "tail -c +17 /var/lib/clickhouse/data/default/{}/{}/{}.bin | od -x -N 1 | head -n 1 | awk '{{print $2}}'".format(
-        table_name, part_name, filename
-    )
+    data_path = node.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='{table_name}'"
+    ).strip()
+    cmd = f"tail -c +17 {data_path}/{part_name}/{filename}.bin | od -x -N 1 | head -n 1 | awk '{{print $2}}'"
     return node.exec_in_container(["bash", "-c", cmd]).strip()
 
 
@@ -41,6 +42,7 @@ CODECS_MAPPING = {
 
 def test_nested_compression_codec(start_cluster):
     for i, node in enumerate([node1, node2]):
+        node.query("DROP TABLE IF EXISTS compression_table SYNC")
         node.query(
             """
         CREATE TABLE compression_table (
@@ -114,3 +116,6 @@ def test_nested_compression_codec(start_cluster):
             )
             == CODECS_MAPPING["NONE"]
         )
+
+    for node in [node1, node2]:
+        node.query("DROP TABLE IF EXISTS compression_table SYNC")

--- a/tests/integration/test_disks_app_func/test.py
+++ b/tests/integration/test_disks_app_func/test.py
@@ -12,6 +12,8 @@ def started_cluster():
             "disks_app_test",
             main_configs=["config.xml"],
             with_minio=True,
+            with_zookeeper=True,
+            with_remote_database_disk=False,  # The tests work on the local disk and check local files
         )
         cluster.start()
 
@@ -117,6 +119,20 @@ def remove(source, disk, path):
     )
 
 
+def remove_recurive(source, disk, path):
+    return source.exec_in_container(
+        [
+            "/usr/bin/clickhouse",
+            "disks",
+            "--save-logs",
+            "--disk",
+            f"{disk}",
+            "--query",
+            f"remove -r {path}",
+        ]
+    )
+
+
 def init_data(source):
     source.query("DROP TABLE IF EXISTS test_table")
 
@@ -215,6 +231,8 @@ def test_disks_app_func_ld(started_cluster):
 
 def test_disks_app_func_ls(started_cluster):
     source = cluster.instances["disks_app_test"]
+
+    remove_recurive(source, "test1", ".")
 
     init_data(source)
 

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -22,12 +22,15 @@ cluster_param = pytest.mark.parametrize(
 )
 
 
-def get_dist_path(cluster, table, dist_format):
+def get_dist_path(cluster, node, table, dist_format):
+    data_path = node.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='test' AND name='{table}'"
+    ).strip()
     if dist_format == 0:
-        return f"/var/lib/clickhouse/data/test/{table}/default@not_existing:9000"
+        return f"{data_path}/default@not_existing:9000"
     if cluster == "test_cluster_internal_replication":
-        return f"/var/lib/clickhouse/data/test/{table}/shard1_all_replicas"
-    return f"/var/lib/clickhouse/data/test/{table}/shard1_replica1"
+        return f"{data_path}/shard1_all_replicas"
+    return f"{data_path}/shard1_replica1"
 
 
 @pytest.fixture(scope="module")
@@ -43,6 +46,8 @@ def started_cluster():
 
 @cluster_param
 def test_single_file(started_cluster, cluster):
+    node.query("drop table if exists test.distr_1 sync")
+
     node.query(
         "create table test.distr_1 (x UInt64, s String) engine = Distributed('{}', database, table)".format(
             cluster
@@ -53,7 +58,7 @@ def test_single_file(started_cluster, cluster):
         settings={"use_compact_format_in_distributed_parts_names": "1"},
     )
 
-    path = get_dist_path(cluster, "distr_1", 1)
+    path = get_dist_path(cluster, node, "distr_1", 1)
     query = f"select * from file('{path}/1.bin', 'Distributed')"
     out = node.exec_in_container(
         ["/usr/bin/clickhouse", "local", "--stacktrace", "-q", query]
@@ -71,11 +76,12 @@ def test_single_file(started_cluster, cluster):
 
     assert out == "1\ta\n2\tbb\n3\tccc\n"
 
-    node.query("drop table test.distr_1")
+    node.query("drop table test.distr_1 sync")
 
 
 @cluster_param
 def test_two_files(started_cluster, cluster):
+    node.query("drop table if exists test.distr_2 sync")
     node.query(
         "create table test.distr_2 (x UInt64, s String) engine = Distributed('{}', database, table)".format(
             cluster
@@ -94,7 +100,7 @@ def test_two_files(started_cluster, cluster):
         },
     )
 
-    path = get_dist_path(cluster, "distr_2", 1)
+    path = get_dist_path(cluster, node, "distr_2", 1)
     query = f"select * from file('{path}/{{1,2,3,4}}.bin', 'Distributed') order by x"
     out = node.exec_in_container(
         ["/usr/bin/clickhouse", "local", "--stacktrace", "-q", query]
@@ -112,11 +118,13 @@ def test_two_files(started_cluster, cluster):
 
     assert out == "0\t_\n1\ta\n2\tbb\n3\tccc\n"
 
-    node.query("drop table test.distr_2")
+    node.query("drop table test.distr_2 sync")
 
 
 @cluster_param
 def test_single_file_old(started_cluster, cluster):
+    node.query("drop table if exists test.distr_3 sync")
+    node.query("drop table if exists t sync")
     node.query(
         "create table test.distr_3 (x UInt64, s String) engine = Distributed('{}', database, table)".format(
             cluster
@@ -129,7 +137,7 @@ def test_single_file_old(started_cluster, cluster):
         },
     )
 
-    path = get_dist_path(cluster, "distr_3", 0)
+    path = get_dist_path(cluster, node, "distr_3", 0)
     query = f"select * from file('{path}/1.bin', 'Distributed')"
     out = node.exec_in_container(
         ["/usr/bin/clickhouse", "local", "--stacktrace", "-q", query]
@@ -151,6 +159,8 @@ def test_single_file_old(started_cluster, cluster):
 
 
 def test_remove_replica(started_cluster):
+    node.query("drop table if exists test.local_4 sync")
+    node.query("drop table if exists test.distr_4 sync")
     node.query(
         "create table test.local_4 (x UInt64, s String) engine = MergeTree order by x"
     )
@@ -182,3 +192,24 @@ def test_remove_replica(started_cluster):
     node.query("attach table test.distr_4", ignore_error=True)
     node.query("SYSTEM FLUSH DISTRIBUTED test.distr_4", ignore_error=True)
     assert node.query("select 1") == "1\n"
+
+    node.query("drop table test.local_4 sync")
+    node.query("drop table test.distr_4 sync")
+
+    # revert back the configs for the subsequent runs
+    node.exec_in_container(
+        [
+            "sed",
+            "-i",
+            "s/test_cluster_remove_replica1/test_cluster_remove_replica2/g",
+            "/etc/clickhouse-server/config.d/another_remote_servers.xml",
+        ]
+    )
+    node.exec_in_container(
+        [
+            "sed",
+            "-i",
+            "s/test_cluster_remove_replica_tmp/test_cluster_remove_replica1/g",
+            "/etc/clickhouse-server/config.d/another_remote_servers.xml",
+        ]
+    )

--- a/tests/integration/test_failed_async_inserts/test.py
+++ b/tests/integration/test_failed_async_inserts/test.py
@@ -22,6 +22,11 @@ def started_cluster():
 
 def test_failed_async_inserts(started_cluster):
     node = started_cluster.instances["node"]
+    select_query = (
+        "SELECT value FROM system.events WHERE event == 'FailedAsyncInsertQuery'"
+    )
+    failed_count = node.query(select_query).strip()
+    original_failed_count = int(failed_count) if failed_count else 0
 
     node.query(
         "CREATE TABLE async_insert_30_10_2022 (id UInt32, s String) ENGINE = Memory"
@@ -43,10 +48,8 @@ def test_failed_async_inserts(started_cluster):
         ignore_error=True,
     )
 
-    select_query = (
-        "SELECT value FROM system.events WHERE event == 'FailedAsyncInsertQuery'"
-    )
-
-    assert node.query(select_query) == "4\n"
+    failed_count = node.query(select_query).strip()
+    current_failed_count = int(failed_count) if failed_count else 0
+    assert current_failed_count - original_failed_count == 4
 
     node.query("DROP TABLE IF EXISTS async_insert_30_10_2022 SYNC")

--- a/tests/integration/test_filesystem_layout/test.py
+++ b/tests/integration/test_filesystem_layout/test.py
@@ -12,6 +12,7 @@ node = cluster.add_instance(
     ],
     with_minio=True,
     stay_alive=True,
+    with_remote_database_disk=False,  # The tests work on the local disk and check symlink
 )
 
 

--- a/tests/integration/test_insert_distributed_async_extra_dirs/test.py
+++ b/tests/integration/test_insert_distributed_async_extra_dirs/test.py
@@ -36,18 +36,22 @@ def test_insert_distributed_async_send_success():
     """
     )
 
+    data_path = node.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='dist'"
+    ).strip()
+
     node.exec_in_container(
         [
             "bash",
             "-c",
-            "mkdir /var/lib/clickhouse/data/default/dist/shard10000_replica10000",
+            f"mkdir {data_path}/shard10000_replica10000",
         ]
     )
     node.exec_in_container(
         [
             "bash",
             "-c",
-            "touch /var/lib/clickhouse/data/default/dist/shard10000_replica10000/1.bin",
+            f"touch {data_path}/shard10000_replica10000/1.bin",
         ]
     )
 
@@ -55,14 +59,14 @@ def test_insert_distributed_async_send_success():
         [
             "bash",
             "-c",
-            "mkdir /var/lib/clickhouse/data/default/dist/shard1_replica10000",
+            f"mkdir {data_path}/shard1_replica10000",
         ]
     )
     node.exec_in_container(
         [
             "bash",
             "-c",
-            "touch /var/lib/clickhouse/data/default/dist/shard1_replica10000/1.bin",
+            f"touch {data_path}/shard1_replica10000/1.bin",
         ]
     )
 
@@ -70,14 +74,14 @@ def test_insert_distributed_async_send_success():
         [
             "bash",
             "-c",
-            "mkdir /var/lib/clickhouse/data/default/dist/shard10000_replica1",
+            f"mkdir {data_path}/shard10000_replica1",
         ]
     )
     node.exec_in_container(
         [
             "bash",
             "-c",
-            "touch /var/lib/clickhouse/data/default/dist/shard10000_replica1/1.bin",
+            f"touch {data_path}/shard10000_replica1/1.bin",
         ]
     )
 

--- a/tests/integration/test_insert_distributed_async_extra_dirs/test.py
+++ b/tests/integration/test_insert_distributed_async_extra_dirs/test.py
@@ -23,6 +23,7 @@ def start_cluster():
 
 
 def test_insert_distributed_async_send_success():
+    node.query("DROP TABLE IF EXISTS data SYNC")
     node.query("CREATE TABLE data (key Int, value String) Engine=Null()")
     node.query(
         """
@@ -87,3 +88,5 @@ def test_insert_distributed_async_send_success():
 
     # will check that clickhouse-server is alive
     node.restart_clickhouse()
+
+    node.query("DROP TABLE IF EXISTS data SYNC")

--- a/tests/integration/test_insert_distributed_async_extra_dirs/test.py
+++ b/tests/integration/test_insert_distributed_async_extra_dirs/test.py
@@ -24,6 +24,8 @@ def start_cluster():
 
 def test_insert_distributed_async_send_success():
     node.query("DROP TABLE IF EXISTS data SYNC")
+    node.query("DROP TABLE IF EXISTS dist SYNC")
+
     node.query("CREATE TABLE data (key Int, value String) Engine=Null()")
     node.query(
         """

--- a/tests/integration/test_insert_distributed_async_send/test.py
+++ b/tests/integration/test_insert_distributed_async_send/test.py
@@ -42,6 +42,7 @@ n4 = cluster.add_instance(
         "configs/users.d/no_batch.xml",
         "configs/users.d/split.xml",
     ],
+    with_remote_database_disk=False,
 )
 
 batch_params = pytest.mark.parametrize(
@@ -107,7 +108,7 @@ def insert_data(node):
             "prefer_localhost_replica": 0,
         },
     )
-    path = get_path_to_dist_batch()
+    path = get_path_to_dist_batch(node, "default", "dist")
     size = int(node.exec_in_container(["bash", "-c", f"wc -c < {path}"]))
     assert size > 1 << 16
     return size
@@ -129,13 +130,16 @@ def bootstrap(batch, split=None):
     return insert_data(get_node(batch, split))
 
 
-def get_path_to_dist_batch(file="2.bin"):
+def get_path_to_dist_batch(node, database, table, file="2.bin"):
+    data_path = node.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='{database}' AND name='{table}'"
+    ).strip()
     # There are:
-    # - /var/lib/clickhouse/data/default/dist/shard1_replica1/1.bin
-    # - /var/lib/clickhouse/data/default/dist/shard1_replica2/2.bin
+    # - {data_path}/shard1_replica1/1.bin
+    # - {data_path}/shard1_replica2/2.bin
     #
     # @return the file for the n2 shard
-    return f"/var/lib/clickhouse/data/default/dist/shard1_replica2/{file}"
+    return f"{data_path}/shard1_replica2/{file}"
 
 
 def check_dist_after_corruption(truncate, batch, split=None):
@@ -162,7 +166,7 @@ def check_dist_after_corruption(truncate, batch, split=None):
     node.query("SYSTEM FLUSH DISTRIBUTED dist")
 
     # but there is broken file
-    broken = get_path_to_dist_batch("broken")
+    broken = get_path_to_dist_batch(node, "default", "dist", "broken")
     node.exec_in_container(["bash", "-c", f"ls {broken}/2.bin"])
 
     if split:
@@ -185,8 +189,8 @@ def test_insert_distributed_async_send_success(batch):
 @batch_and_split_params
 def test_insert_distributed_async_send_truncated_1(batch, split):
     size = bootstrap(batch, split)
-    path = get_path_to_dist_batch()
     node = get_node(batch, split)
+    path = get_path_to_dist_batch(node, "default", "dist")
 
     new_size = size - 10
     # we cannot use truncate, due to hardlinks
@@ -200,8 +204,8 @@ def test_insert_distributed_async_send_truncated_1(batch, split):
 @batch_params
 def test_insert_distributed_async_send_truncated_2(batch):
     bootstrap(batch)
-    path = get_path_to_dist_batch()
     node = get_node(batch)
+    path = get_path_to_dist_batch(node, "default", "dist")
 
     # we cannot use truncate, due to hardlinks
     node.exec_in_container(
@@ -216,9 +220,8 @@ def test_insert_distributed_async_send_truncated_2(batch):
 @batch_params
 def test_insert_distributed_async_send_corrupted_big(batch):
     size = bootstrap(batch)
-    path = get_path_to_dist_batch()
-
     node = get_node(batch)
+    path = get_path_to_dist_batch(node, "default", "dist")
 
     from_original_size = size - 8192
     zeros_size = 8192
@@ -236,8 +239,8 @@ def test_insert_distributed_async_send_corrupted_big(batch):
 @batch_params
 def test_insert_distributed_async_send_corrupted_small(batch):
     size = bootstrap(batch)
-    path = get_path_to_dist_batch()
     node = get_node(batch)
+    path = get_path_to_dist_batch(node, "default", "dist")
 
     from_original_size = size - 60
     zeros_size = 60

--- a/tests/integration/test_insert_distributed_async_send/test.py
+++ b/tests/integration/test_insert_distributed_async_send/test.py
@@ -42,7 +42,6 @@ n4 = cluster.add_instance(
         "configs/users.d/no_batch.xml",
         "configs/users.d/split.xml",
     ],
-    with_remote_database_disk=False,
 )
 
 batch_params = pytest.mark.parametrize(

--- a/tests/integration/test_inserts_with_keeper_retries/test.py
+++ b/tests/integration/test_inserts_with_keeper_retries/test.py
@@ -18,6 +18,7 @@ node1 = cluster.add_instance(
     main_configs=["configs/storage_conf.xml"],
     with_zookeeper=True,
     with_minio=True,
+    with_remote_database_disk=False,  # The tests stop Keeper connections, some queries will not work with the remote disk.
 )
 
 

--- a/tests/integration/test_keeper_http_control/test.py
+++ b/tests/integration/test_keeper_http_control/test.py
@@ -12,14 +12,15 @@ from helpers.network import PartitionManager
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
 
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
-    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
+    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
-    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True
+    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 node3 = cluster.add_instance(
-    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
+    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 
 

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -158,7 +158,7 @@ def check_valid_configuration(filename, password):
         setupSsl(node, filename, password)
     start_all_clickhouse()
     nodes[0].wait_for_log_line(
-        "Raft ASIO listener initiated on :::9234, SSL enabled", look_behind_lines=1000
+        "Raft ASIO listener initiated on :::9234, SSL enabled", look_behind_lines=5000
     )
     run_test()
 
@@ -170,7 +170,7 @@ def check_invalid_configuration(filename, password):
 
     nodes[0].start_clickhouse()
     nodes[0].wait_for_log_line(
-        "Raft ASIO listener initiated on :::9234, SSL enabled", look_behind_lines=1000
+        "Raft ASIO listener initiated on :::9234, SSL enabled", look_behind_lines=5000
     )
     nodes[0].wait_for_log_line("failed to connect to peer.*Connection refused")
 

--- a/tests/integration/test_keeper_map/test.py
+++ b/tests/integration/test_keeper_map/test.py
@@ -13,6 +13,7 @@ node = cluster.add_instance(
     user_configs=["configs/keeper_retries.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,  # `test_keeper_map_without_zk` stops the Keeper connection, which might not work with the remote DB disk
 )
 
 

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -15,6 +15,7 @@ node = cluster.add_instance(
     "node",
     stay_alive=True,
     with_zookeeper=True,
+    with_remote_database_disk=False,  # Disable `with_remote_database_disk` as the test does not use the default Keeper.
 )
 
 

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -3,31 +3,47 @@
 import os
 import time
 from multiprocessing.dummy import Pool
+import uuid
 
 import pytest
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
 
-# Disable `with_remote_database_disk` as the test does not use the default Keeper.
-node1 = cluster.add_instance(
-    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True, with_remote_database_disk=False,
-)
-node2 = cluster.add_instance(
-    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True, with_remote_database_disk=False,
-)
-node3 = cluster.add_instance(
-    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True, with_remote_database_disk=False,
-)
-node4 = cluster.add_instance("node4", stay_alive=True, with_remote_database_disk=False,)
 
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def started_cluster():
+    cluster = None
     try:
+        cluster = ClickHouseCluster(__file__, str(uuid.uuid4()))
+
+        # Disable `with_remote_database_disk` as the test does not use the default Keeper.
+        cluster.add_instance(
+            "node1",
+            main_configs=["configs/enable_keeper1.xml"],
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+        cluster.add_instance(
+            "node2",
+            main_configs=["configs/enable_keeper2.xml"],
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+        cluster.add_instance(
+            "node3",
+            main_configs=["configs/enable_keeper3.xml"],
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+        cluster.add_instance(
+            "node4",
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+
         cluster.start()
 
         yield cluster
@@ -36,31 +52,38 @@ def started_cluster():
         cluster.shutdown()
 
 
-def start(node):
+def start(cluster, node):
     node.start_clickhouse()
     keeper_utils.wait_until_connected(cluster, node)
 
 
-def get_fake_zk(node, timeout=30.0):
+def get_fake_zk(cluster, node, timeout=30.0):
     return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
 def test_node_move(started_cluster):
+    node1 = started_cluster.instances["node1"]
+    node2 = started_cluster.instances["node2"]
+    node3 = started_cluster.instances["node3"]
+    node4 = started_cluster.instances["node4"]
+
     zk_conn = None
     zk_conn2 = None
     zk_conn3 = None
     zk_conn4 = None
 
     try:
-        zk_conn = get_fake_zk(node1)
+        zk_conn = get_fake_zk(started_cluster, node1)
 
         for i in range(100):
+            if zk_conn.exists("/test_four_" + str(i)):
+                zk_conn.delete("/test_four_" + str(i))
             zk_conn.create("/test_four_" + str(i), b"somedata")
 
-        zk_conn2 = get_fake_zk(node2)
+        zk_conn2 = get_fake_zk(started_cluster, node2)
         zk_conn2.sync("/test_four_0")
 
-        zk_conn3 = get_fake_zk(node3)
+        zk_conn3 = get_fake_zk(started_cluster, node3)
         zk_conn3.sync("/test_four_0")
 
         for i in range(100):
@@ -73,7 +96,7 @@ def test_node_move(started_cluster):
             "/etc/clickhouse-server/config.d/enable_keeper4.xml",
         )
         p = Pool(3)
-        waiter = p.apply_async(start, (node4,))
+        waiter = p.apply_async(start, (started_cluster, node4))
         node1.copy_file_to_container(
             os.path.join(CONFIG_DIR, "enable_keeper_node4_1.xml"),
             "/etc/clickhouse-server/config.d/enable_keeper1.xml",
@@ -88,7 +111,7 @@ def test_node_move(started_cluster):
 
         waiter.wait()
 
-        zk_conn4 = get_fake_zk(node4)
+        zk_conn4 = get_fake_zk(started_cluster, node4)
         zk_conn4.sync("/test_four_0")
 
         for i in range(100):
@@ -97,7 +120,7 @@ def test_node_move(started_cluster):
         with pytest.raises(Exception):
             # Adding and removing nodes is async operation
             for i in range(10):
-                zk_conn3 = get_fake_zk(node3)
+                zk_conn3 = get_fake_zk(started_cluster, node3)
                 zk_conn3.sync("/test_four_0")
                 time.sleep(i)
     finally:

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -12,16 +12,17 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
 
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
-    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
+    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
-    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True
+    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 node3 = cluster.add_instance(
-    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
+    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True, with_remote_database_disk=False,
 )
-node4 = cluster.add_instance("node4", stay_alive=True)
+node4 = cluster.add_instance("node4", stay_alive=True, with_remote_database_disk=False,)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_keeper_nodes_remove/test.py
+++ b/tests/integration/test_keeper_nodes_remove/test.py
@@ -18,12 +18,11 @@ def started_cluster():
     try:
         run_uuid = uuid.uuid4()
         cluster = ClickHouseCluster(__file__, str(run_uuid))
-
+        # Disable `with_remote_database_disk` as the test does not use the default Keeper.
         cluster.add_instance(
             "node1",
             main_configs=["configs/enable_keeper1.xml"],
             stay_alive=True,
-            with_remote_database_disk=False,
         )
         cluster.add_instance(
             "node2",

--- a/tests/integration/test_keeper_nodes_remove/test.py
+++ b/tests/integration/test_keeper_nodes_remove/test.py
@@ -2,29 +2,42 @@
 
 import os
 import time
+import uuid
 
 import pytest
 
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
 
-node1 = cluster.add_instance(
-    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
-)
-node2 = cluster.add_instance(
-    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True
-)
-node3 = cluster.add_instance(
-    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
-)
 
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def started_cluster():
+    cluster = None
     try:
+        run_uuid = uuid.uuid4()
+        cluster = ClickHouseCluster(__file__, str(run_uuid))
+
+        cluster.add_instance(
+            "node1",
+            main_configs=["configs/enable_keeper1.xml"],
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+        cluster.add_instance(
+            "node2",
+            main_configs=["configs/enable_keeper2.xml"],
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+        cluster.add_instance(
+            "node3",
+            main_configs=["configs/enable_keeper3.xml"],
+            stay_alive=True,
+            with_remote_database_disk=False,
+        )
+
         cluster.start()
 
         yield cluster
@@ -33,7 +46,7 @@ def started_cluster():
         cluster.shutdown()
 
 
-def get_fake_zk(node, timeout=30.0):
+def get_fake_zk(cluster, node, timeout=30.0):
     return keeper_utils.get_fake_zk(cluster, node.name, timeout=timeout)
 
 
@@ -42,16 +55,22 @@ def test_nodes_remove(started_cluster):
     zk_conn2 = None
     zk_conn3 = None
 
+    node1 = started_cluster.instances["node1"]
+    node2 = started_cluster.instances["node2"]
+    node3 = started_cluster.instances["node3"]
+
     try:
-        zk_conn = get_fake_zk(node1)
+        zk_conn = get_fake_zk(started_cluster, node1)
 
         for i in range(100):
+            if zk_conn.exists("/test_two_" + str(i)):
+                zk_conn.delete("/test_two_" + str(i))
             zk_conn.create("/test_two_" + str(i), b"somedata")
 
-        zk_conn2 = get_fake_zk(node2)
+        zk_conn2 = get_fake_zk(started_cluster, node2)
         zk_conn2.sync("/test_two_0")
 
-        zk_conn3 = get_fake_zk(node3)
+        zk_conn3 = get_fake_zk(started_cluster, node3)
         zk_conn3.sync("/test_two_0")
 
         for i in range(100):
@@ -72,15 +91,17 @@ def test_nodes_remove(started_cluster):
 
         zk_conn2.stop()
         zk_conn2.close()
-        zk_conn2 = get_fake_zk(node2)
+        zk_conn2 = get_fake_zk(started_cluster, node2)
 
         for i in range(100):
             assert zk_conn2.exists("test_two_" + str(i)) is not None
+            if zk_conn2.exists("/test_two_" + str(100 + i)):
+                zk_conn2.delete("/test_two_" + str(100 + i))
             zk_conn2.create("/test_two_" + str(100 + i), b"otherdata")
 
         zk_conn.stop()
         zk_conn.close()
-        zk_conn = get_fake_zk(node1)
+        zk_conn = get_fake_zk(started_cluster, node1)
         zk_conn.sync("/test_two_0")
 
         for i in range(100):
@@ -90,7 +111,7 @@ def test_nodes_remove(started_cluster):
         try:
             zk_conn3.stop()
             zk_conn3.close()
-            zk_conn3 = get_fake_zk(node3)
+            zk_conn3 = get_fake_zk(started_cluster, node3)
             zk_conn3.sync("/test_two_0")
             time.sleep(0.1)
         except Exception:
@@ -107,7 +128,7 @@ def test_nodes_remove(started_cluster):
 
         zk_conn.stop()
         zk_conn.close()
-        zk_conn = get_fake_zk(node1)
+        zk_conn = get_fake_zk(started_cluster, node1)
         zk_conn.sync("/test_two_0")
 
         for i in range(100):
@@ -117,7 +138,7 @@ def test_nodes_remove(started_cluster):
         try:
             zk_conn2.stop()
             zk_conn2.close()
-            zk_conn2 = get_fake_zk(node2)
+            zk_conn2 = get_fake_zk(started_cluster, node2)
             zk_conn2.sync("/test_two_0")
             time.sleep(0.1)
         except Exception:

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -15,6 +15,7 @@ node = cluster.add_instance(
     "node",
     main_configs=["configs/enable_keeper.xml", "configs/use_keeper.xml"],
     stay_alive=True,
+    with_remote_database_disk=False,  # Disable `with_remote_database_disk` as the test does not use the default Keeper.
 )
 
 

--- a/tests/integration/test_keeper_persistent_log_multinode/test.py
+++ b/tests/integration/test_keeper_persistent_log_multinode/test.py
@@ -135,5 +135,8 @@ def test_restart_multinode(started_cluster):
         except Exception as ex:
             print("Got exception as ex", ex)
         finally:
+            for i in range(100):
+                if node1_zk.exists("/test_read_write_multinode_node" + str(i)):
+                    node1_zk.delete("/test_read_write_multinode_node" + str(i))
             for zk in [node1_zk, node2_zk, node3_zk]:
                 stop_zk(zk)

--- a/tests/integration/test_keeper_restore_from_snapshot/test.py
+++ b/tests/integration/test_keeper_restore_from_snapshot/test.py
@@ -5,20 +5,25 @@ import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
+
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/enable_keeper1.xml", "configs/local_storage_path.xml"],
     stay_alive=True,
+    with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
     "node2",
     main_configs=["configs/enable_keeper2.xml", "configs/local_storage_path.xml"],
     stay_alive=True,
+    with_remote_database_disk=False,
 )
 node3 = cluster.add_instance(
     "node3",
     main_configs=["configs/enable_keeper3.xml", "configs/local_storage_path.xml"],
     stay_alive=True,
+    with_remote_database_disk=False,
 )
 
 
@@ -124,5 +129,11 @@ def test_recover_from_snapshot(started_cluster):
                     node3_zk.exists("/test_snapshot_multinode_recover" + str(i)) is None
                 )
     finally:
+        for i in range(435):
+            if node1_zk.exists("/test_snapshot_multinode_recover" + str(i)):
+                node1_zk.delete("/test_snapshot_multinode_recover" + str(i))
+        if node1_zk.exists("/test_snapshot_multinode_recover"):
+            node1_zk.delete("/test_snapshot_multinode_recover")
+
         for zk in [node1_zk, node2_zk, node3_zk]:
             stop_zk(zk)

--- a/tests/integration/test_keeper_s3_snapshot/test.py
+++ b/tests/integration/test_keeper_s3_snapshot/test.py
@@ -10,23 +10,28 @@ from helpers.retry_decorator import retry
 # from kazoo.protocol.serialization import Connect, read_buffer, write_buffer
 
 cluster = ClickHouseCluster(__file__)
+
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/keeper_config1.xml"],
     stay_alive=True,
     with_minio=True,
+    with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
     "node2",
     main_configs=["configs/keeper_config2.xml"],
     stay_alive=True,
     with_minio=True,
+    with_remote_database_disk=False,
 )
 node3 = cluster.add_instance(
     "node3",
     main_configs=["configs/keeper_config3.xml"],
     stay_alive=True,
     with_minio=True,
+    with_remote_database_disk=False,
 )
 
 

--- a/tests/integration/test_keeper_snapshot_on_exit/test.py
+++ b/tests/integration/test_keeper_snapshot_on_exit/test.py
@@ -8,12 +8,13 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
 
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
-    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
+    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 
 node2 = cluster.add_instance(
-    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True
+    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 
 
@@ -51,5 +52,7 @@ def test_snapshot_on_exit(started_cluster):
         assert node2.contains_in_log("No existing snapshots")
     finally:
         if zk_conn:
+            if zk_conn.exists("/some_path"):
+                zk_conn.delete("/some_path")
             zk_conn.stop()
             zk_conn.close()

--- a/tests/integration/test_keeper_snapshots_multinode/test.py
+++ b/tests/integration/test_keeper_snapshots_multinode/test.py
@@ -5,14 +5,16 @@ import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
+
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
-    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
+    "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
-    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True
+    "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 node3 = cluster.add_instance(
-    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True
+    "node3", main_configs=["configs/enable_keeper3.xml"], stay_alive=True, with_remote_database_disk=False,
 )
 
 
@@ -128,5 +130,8 @@ def test_restart_multinode(started_cluster):
         except Exception as ex:
             print("Got exception as ex", ex)
         finally:
+            for i in range(100):
+                if node1_zk.exists("/test_read_write_multinode_node" + str(i)):
+                    node1_zk.delete("/test_read_write_multinode_node" + str(i))
             for zk in [node1_zk, node2_zk, node3_zk]:
                 stop_zk(zk)

--- a/tests/integration/test_keeper_three_nodes_start/test.py
+++ b/tests/integration/test_keeper_three_nodes_start/test.py
@@ -4,9 +4,6 @@ import uuid
 import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
-
-
-
 def get_fake_zk(cluster, nodename, timeout=30.0):
     return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
 
@@ -14,11 +11,12 @@ def get_fake_zk(cluster, nodename, timeout=30.0):
 def test_smoke():
     run_uuid = uuid.uuid4()
     cluster = ClickHouseCluster(__file__, str(run_uuid))
+    # Disable `with_remote_database_disk` as the test does not use the default Keeper.
     cluster.add_instance(
-        "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True
+        "node1", main_configs=["configs/enable_keeper1.xml"], stay_alive=True, with_remote_database_disk=False,
     )
     cluster.add_instance(
-        "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True
+        "node2", main_configs=["configs/enable_keeper2.xml"], stay_alive=True, with_remote_database_disk=False,
     )
 
     node1_zk = None

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -16,6 +16,8 @@ node = cluster.add_instance(
     user_configs=["configs/users.xml"],
     with_zookeeper=True,
     with_azurite=True,
+    # Disable `with_remote_database_disk` as `test_create_table` might access minIO and expect `DNS_ERROR`. However, minIO might be enabled when `with_remote_database_disk` is enabled;
+    with_remote_database_disk=False,
 )
 base_search_query = "SELECT COUNT() FROM system.query_log WHERE query LIKE "
 

--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -85,6 +85,10 @@ def test_system_tables(start_cluster):
             "keep_free_space": "0",
         },
     ]
+    if node1.with_remote_database_disk:
+        expected_disks_data.append(
+            {"name": "disk_db_remote", "path": "", "keep_free_space": "0"}
+        )
 
     click_disk_data = json.loads(
         node1.query("SELECT name, path, keep_free_space FROM system.disks FORMAT JSON")

--- a/tests/integration/test_mutations_hardlinks/test.py
+++ b/tests/integration/test_mutations_hardlinks/test.py
@@ -9,7 +9,11 @@ from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance("node1", main_configs=["configs/wide_parts_only.xml"])
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/wide_parts_only.xml"],
+    with_remote_database_disk=False,  # The test checks hardlinks in the local disk
+)
 
 
 @pytest.fixture(scope="module")
@@ -45,6 +49,7 @@ def check_exists(table, part_path, column_file):
 
 
 def test_update_mutation(started_cluster):
+    node1.query("DROP TABLE IF EXISTS table_for_update")
     node1.query(
         "CREATE TABLE table_for_update(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()"
     )
@@ -82,8 +87,11 @@ def test_update_mutation(started_cluster):
     check_hardlinks("table_for_update", "all_1_1_0_3", "value1.bin", 1)
     check_hardlinks("table_for_update", "all_1_1_0_3", "value2.bin", 1)
 
+    node1.query("DROP TABLE table_for_update")
+
 
 def test_modify_mutation(started_cluster):
+    node1.query("DROP TABLE IF EXISTS table_for_modify")
     node1.query(
         "CREATE TABLE table_for_modify(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()"
     )
@@ -109,8 +117,11 @@ def test_modify_mutation(started_cluster):
     check_hardlinks("table_for_modify", "all_1_1_0_2", "value1.bin", 2)
     check_hardlinks("table_for_modify", "all_1_1_0_2", "value2.bin", 1)
 
+    node1.query("DROP TABLE table_for_modify")
+
 
 def test_drop_mutation(started_cluster):
+    node1.query("DROP TABLE IF EXISTS table_for_drop")
     node1.query(
         "CREATE TABLE table_for_drop(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()"
     )
@@ -136,8 +147,11 @@ def test_drop_mutation(started_cluster):
     with pytest.raises(Exception):
         check_exists("table_for_drop", "all_1_1_0_2", "value2.mrk")
 
+    node1.query("DROP TABLE table_for_drop")
+
 
 def test_delete_and_drop_mutation(started_cluster):
+    node1.query("DROP TABLE IF EXISTS table_for_delete_and_drop")
     node1.query(
         "CREATE TABLE table_for_delete_and_drop(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()"
     )
@@ -188,3 +202,5 @@ def test_delete_and_drop_mutation(started_cluster):
         check_exists("table_for_delete_and_drop", "all_1_1_0_3", "value2.bin")
     with pytest.raises(Exception):
         check_exists("table_for_delete_and_drop", "all_1_1_0_3", "value2.mrk")
+
+    node1.query("DROP TABLE table_for_delete_and_drop")

--- a/tests/integration/test_optimize_on_insert/test.py
+++ b/tests/integration/test_optimize_on_insert/test.py
@@ -6,16 +6,8 @@ from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance(
-    "node1",
-    with_zookeeper=True,
-    with_remote_database_disk=False,
-)
-node2 = cluster.add_instance(
-    "node2",
-    with_zookeeper=True,
-    with_remote_database_disk=False,
-)
+node1 = cluster.add_instance("node1", with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -58,7 +58,9 @@ def test_partition_simple(partition_table_simple):
 
 
 def partition_complex_assert_columns_txt():
-    path_to_parts = path_to_data + "data/test/partition_complex/"
+    data_path = instance.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='test' AND name='partition_complex'"
+    ).strip()
     parts = TSV(
         q(
             "SELECT name FROM system.parts WHERE database='test' AND table='partition_complex'"
@@ -66,7 +68,7 @@ def partition_complex_assert_columns_txt():
     )
     assert len(parts) > 0
     for part_name in parts.lines:
-        path_to_columns = path_to_parts + part_name + "/columns.txt"
+        path_to_columns = data_path + part_name + "/columns.txt"
         # 2 header lines + 3 columns
         assert (
             instance.exec_in_container(["wc", "-l", path_to_columns]).split()[0] == "5"
@@ -241,7 +243,11 @@ def test_attach_check_all_parts(attach_check_all_parts_table):
     wait_for_delete_empty_parts(instance, "test.attach_partition")
     wait_for_delete_inactive_parts(instance, "test.attach_partition")
 
-    path_to_detached = path_to_data + "data/test/attach_partition/detached/"
+    data_path = instance.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='test' AND name='attach_partition'"
+    ).strip()
+
+    path_to_detached = f"{data_path}/detached/"
     instance.exec_in_container(["mkdir", "{}".format(path_to_detached + "0_5_5_0")])
     instance.exec_in_container(
         [
@@ -322,7 +328,11 @@ def test_drop_detached_parts(drop_detached_parts_table):
     q("ALTER TABLE test.drop_detached DETACH PARTITION 0")
     q("ALTER TABLE test.drop_detached DETACH PARTITION 1")
 
-    path_to_detached = path_to_data + "data/test/drop_detached/detached/"
+    data_path = instance.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='test' AND name='drop_detached'"
+    ).strip()
+
+    path_to_detached = f"{data_path}/detached/"
     instance.exec_in_container(
         ["mkdir", "{}".format(path_to_detached + "attaching_0_6_6_0")]
     )
@@ -401,38 +411,39 @@ def test_system_detached_parts(drop_detached_parts_table):
         )[:-1].split("\n"):
             q("alter table sdp_{} detach partition id '{}'".format(i, p))
 
-    path_to_detached = path_to_data + "data/default/sdp_{}/detached/{}"
     for i in range(0, 4):
+        table_name = f"sdp_{i}"
+        data_path = instance.query(
+            f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='{table_name}'"
+        ).strip()
+        path_to_detached = data_path + "detached/{}"
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "attaching_0_6_6_0")]
+            ["mkdir", path_to_detached.format("attaching_0_6_6_0")]
         )
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "deleting_0_7_7_0")]
+            ["mkdir", path_to_detached.format("deleting_0_7_7_0")]
         )
+        instance.exec_in_container(["mkdir", path_to_detached.format("any_other_name")])
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "any_other_name")]
-        )
-        instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "prefix_1_2_2_0_0")]
+            ["mkdir", path_to_detached.format("prefix_1_2_2_0_0")]
         )
 
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "ignored_202107_714380_714380_0")]
+            ["mkdir", path_to_detached.format("ignored_202107_714380_714380_0")]
         )
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "broken_202107_714380_714380_123")]
+            ["mkdir", path_to_detached.format("broken_202107_714380_714380_123")]
         )
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "clone_all_714380_714380_42")]
+            ["mkdir", path_to_detached.format("clone_all_714380_714380_42")]
         )
         instance.exec_in_container(
-            ["mkdir", path_to_detached.format(i, "clone_all_714380_714380_42_123")]
+            ["mkdir", path_to_detached.format("clone_all_714380_714380_42_123")]
         )
         instance.exec_in_container(
             [
                 "mkdir",
                 path_to_detached.format(
-                    i,
                     "broken-on-start_6711e2b2592d86d18fc0f260cf33ef2b_714380_714380_42_123",
                 ),
             ]
@@ -562,7 +573,9 @@ def test_make_clone_in_detached(started_cluster):
         "create table clone_in_detached (n int, m String) engine=ReplicatedMergeTree('/clone_in_detached', '1') order by n SETTINGS compress_marks=false, compress_primary_key=false, ratio_of_defaults_for_sparse_serialization=1"
     )
 
-    path = path_to_data + "data/default/clone_in_detached/"
+    path = instance.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database='default' AND name='clone_in_detached'"
+    ).strip()
 
     # broken part already detached
     q("insert into clone_in_detached values (42, '¯-_(ツ)_-¯')")

--- a/tests/integration/test_profile_events_s3/test.py
+++ b/tests/integration/test_profile_events_s3/test.py
@@ -21,6 +21,7 @@ def cluster():
                 "configs/ssl_conf.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,  # The test compares some S3 events. We disable the remote DB disk, so it doesn't affect the comparing events.
         )
 
         logging.info("Starting cluster...")

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1125,10 +1125,6 @@ def test_recover_staled_replica_many_mvs(started_cluster):
     dummy_node.query("DROP DATABASE IF EXISTS recover_mvs SYNC")
 
 
-@pytest.mark.skip(
-    reason="Since we create a hidden distributed table inside Replicated database it cannot start without zookeeper\
-    because it has to retrieve data from it to form a cluster."
-)
 def test_startup_without_zk(started_cluster):
     with PartitionManager() as pm:
         pm.drop_instance_zk_connections(main_node)

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -9,6 +9,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry, assert_logs_contain
+from helpers.database_disk import get_database_disk_name, replace_text_in_metadata
 
 test_recover_staled_replica_run = 1
 
@@ -1322,12 +1323,23 @@ def test_recover_digest_mismatch(started_cluster):
     main_node.query("SYSTEM SYNC DATABASE REPLICA recover_digest_mismatch")
     dummy_node.query("SYSTEM SYNC DATABASE REPLICA recover_digest_mismatch")
 
+    db_disk_name = get_database_disk_name(dummy_node)
+    db_data_path = dummy_node.query(
+        f"SELECT data_path FROM system.databases WHERE database='recover_digest_mismatch'"
+    ).strip()
+
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /etc/clickhouse-server/config.xml --disk {db_disk_name} --save-logs --query "
+    db_disk_path = dummy_node.query(
+        "SELECT path FROM system.disks WHERE name='{db_disk_name}'"
+    ).strip()
+
+    print(f"db_data_path {db_data_path}")
     ways_to_corrupt_metadata = [
-        "mv /var/lib/clickhouse/metadata/recover_digest_mismatch/t1.sql /var/lib/clickhouse/metadata/recover_digest_mismatch/m1.sql",
-        "sed --follow-symlinks -i 's/Int32/String/' /var/lib/clickhouse/metadata/recover_digest_mismatch/mv1.sql",
-        "rm -f /var/lib/clickhouse/metadata/recover_digest_mismatch/d1.sql",
-        "rm -rf /var/lib/clickhouse/metadata/recover_digest_mismatch/",  # Will trigger "Directory already exists"
-        "rm -rf /var/lib/clickhouse/store",
+        f"{disk_cmd_prefix} 'move --path-from {db_data_path}t1.sql --path-to {db_data_path}m1.sql'",
+        f"{disk_cmd_prefix} 'read --path-from {db_data_path}mv1.sql' | sed 's/Int32/String/' | {disk_cmd_prefix} 'write --path-to {db_data_path}mv1.sql'",
+        f"{disk_cmd_prefix} 'remove {db_data_path}d1.sql'",
+        f"{disk_cmd_prefix} 'remove -r {db_data_path}'",  # Will trigger "Directory already exists"
+        f"{disk_cmd_prefix} 'remove -r {db_disk_path}store/' && rm -rf /var/lib/clickhouse/store",  # Remove both metadata and data
     ]
 
     for command in ways_to_corrupt_metadata:
@@ -1394,8 +1406,24 @@ def test_replicated_table_structure_alter(started_cluster):
     )
     main_node.query("INSERT INTO table_structure.rmt VALUES (1, 2, 3)")
 
-    command = "rm -f /var/lib/clickhouse/metadata/table_structure/mem.sql"
-    competing_node.exec_in_container(["bash", "-c", command])
+    metadata_path = competing_node.query(
+        f"SELECT metadata_path FROM system.tables WHERE database='table_structure' AND name='mem'"
+    ).strip()
+    db_disk_name = get_database_disk_name(competing_node)
+    competing_node.exec_in_container(
+        [
+            "/usr/bin/clickhouse",
+            "disks",
+            "-C",
+            "/etc/clickhouse-server/config.xml",
+            "--disk",
+            f"{db_disk_name}",
+            "--save-logs",
+            "--query",
+            f"remove {metadata_path}",
+        ],
+        user="root",
+    )
     competing_node.restart_clickhouse(kill=True)
 
     dummy_node.query("ATTACH DATABASE table_structure")
@@ -1479,13 +1507,16 @@ def test_table_metadata_corruption(started_cluster):
     main_node.query("SYSTEM SYNC DATABASE REPLICA table_metadata_corruption")
     dummy_node.query("SYSTEM SYNC DATABASE REPLICA table_metadata_corruption")
 
+    metadata_path = dummy_node.query(
+        f"SELECT metadata_path FROM system.tables WHERE database='table_metadata_corruption' AND name='rmt1'"
+    ).strip()
     # Server should handle this by throwing an exception during table loading, which should lead to server shutdown
-    corrupt = "sed --follow-symlinks -i 's/ReplicatedMergeTree/CorruptedMergeTree/' /var/lib/clickhouse/metadata/table_metadata_corruption/rmt1.sql"
 
-    print(f"Corrupting metadata using `{corrupt}`")
+    print(f"Corrupting metadata {metadata_path}")
     dummy_node.stop_clickhouse(kill=True)
-    dummy_node.exec_in_container(["bash", "-c", corrupt])
-
+    replace_text_in_metadata(
+        dummy_node, metadata_path, "ReplicatedMergeTree", "CorruptedMergeTree"
+    )
     query = (
         "SELECT name, uuid, create_table_query FROM system.tables WHERE database='table_metadata_corruption' AND name NOT LIKE '.inner_id.%' "
         "ORDER BY name SETTINGS show_table_uuid_in_table_create_query_if_not_nil=1"
@@ -1494,11 +1525,13 @@ def test_table_metadata_corruption(started_cluster):
 
     # We expect clickhouse server to shutdown without LOGICAL_ERRORs or deadlocks
     dummy_node.start_clickhouse(expected_to_fail=True)
+
     assert not dummy_node.contains_in_log("LOGICAL_ERROR")
 
-    fix_corrupt = "sed --follow-symlinks -i 's/CorruptedMergeTree/ReplicatedMergeTree/' /var/lib/clickhouse/metadata/table_metadata_corruption/rmt1.sql"
-    print(f"Fix corrupted metadata using `{fix_corrupt}`")
-    dummy_node.exec_in_container(["bash", "-c", fix_corrupt])
+    print(f"Fix corrupted metadata")
+    replace_text_in_metadata(
+        dummy_node, metadata_path, "CorruptedMergeTree", "ReplicatedMergeTree"
+    )
 
     dummy_node.start_clickhouse()
     assert_eq_with_retry(dummy_node, query, expected)

--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -13,6 +13,7 @@ node = cluster.add_instance(
     main_configs=["configs/config.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,  # Disable with_remote_database_disk as test_startup_with_small_bg_pool_partitioned drops Keeper connection
 )
 
 

--- a/tests/integration/test_replicated_user_defined_functions/test.py
+++ b/tests/integration/test_replicated_user_defined_functions/test.py
@@ -16,7 +16,6 @@ from helpers.test_tools import TSV, assert_eq_with_retry
 default_zk_config = p.join(p.dirname(p.realpath(__file__)), "configs/zookeeper.xml")
 cluster = ClickHouseCluster(__file__, zookeeper_config_path="configs/zookeeper.xml")
 
-# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/config.xml"],
@@ -24,13 +23,12 @@ node1 = cluster.add_instance(
     stay_alive=True,
     with_remote_database_disk=False,
 )
-
 node2 = cluster.add_instance(
     "node2",
     main_configs=["configs/config.xml"],
     with_zookeeper=True,
     stay_alive=True,
-    with_remote_database_disk=False,
+    with_remote_database_disk=False,  # Disable `with_remote_database_disk` as test_start_without_zookeeper stops keeper before starting.
 )
 
 all_nodes = [node1, node2]

--- a/tests/integration/test_replicated_user_defined_functions/test.py
+++ b/tests/integration/test_replicated_user_defined_functions/test.py
@@ -16,11 +16,13 @@ from helpers.test_tools import TSV, assert_eq_with_retry
 default_zk_config = p.join(p.dirname(p.realpath(__file__)), "configs/zookeeper.xml")
 cluster = ClickHouseCluster(__file__, zookeeper_config_path="configs/zookeeper.xml")
 
+# Disable `with_remote_database_disk` as the test does not use the default Keeper.
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/config.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,
 )
 
 node2 = cluster.add_instance(
@@ -28,6 +30,7 @@ node2 = cluster.add_instance(
     main_configs=["configs/config.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,
 )
 
 all_nodes = [node1, node2]

--- a/tests/integration/test_restart_with_unavailable_azure/test.py
+++ b/tests/integration/test_restart_with_unavailable_azure/test.py
@@ -17,6 +17,7 @@ from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 from helpers.mock_servers import start_mock_servers
 from helpers.network import PartitionManager
 from helpers.test_tools import exec_query_with_retry
+from helpers.database_disk import replace_text_in_metadata
 
 
 RESOLVER_CONTAINER_NAME = "resolver"
@@ -81,8 +82,16 @@ def test_cluster_alive_after_restart(cluster):
         """
     )
 
+    metadata_path = node.query(
+        f"SELECT metadata_path FROM system.tables WHERE database='default' AND name='test_table'"
+    ).strip()
+
     node.stop_clickhouse()
-    node.exec_in_container(["bash", "-c", f"sed -i 's|azurite1:{azurite_port}|{RESOLVER_CONTAINER_NAME}:{RESOLVER_PORT}|g' /var/lib/clickhouse/metadata/default/test_table.sql"])
+    replace_text_in_metadata(
+        node,
+        metadata_path,
+        f"azurite1:{azurite_port}",
+        f"{RESOLVER_CONTAINER_NAME}:{RESOLVER_PORT}",
+    )
     node.start_clickhouse()
     node.query("DROP TABLE test_table")
-

--- a/tests/integration/test_s3_table_function_with_http_proxy/test.py
+++ b/tests/integration/test_s3_table_function_with_http_proxy/test.py
@@ -11,13 +11,14 @@ from helpers.cluster import ClickHouseCluster
 def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
-
+        # Disable `with_remote_database_disk` as the test uses proxy, which might not work with the default configs of the remote database disk
         cluster.add_instance(
             "remote_proxy_node",
             main_configs=[
                 "configs/config.d/proxy_remote.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -26,6 +27,7 @@ def cluster():
                 "configs/config.d/proxy_remote_no_proxy.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -34,6 +36,7 @@ def cluster():
                 "configs/config.d/proxy_list.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -42,6 +45,7 @@ def cluster():
                 "configs/config.d/proxy_list_no_proxy.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -51,6 +55,7 @@ def cluster():
                 "http_proxy": "http://proxy1",
             },
             instance_env_variables=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -61,6 +66,7 @@ def cluster():
                 "no_proxy": "not_important_host,,  minio1  ,",
             },
             instance_env_variables=True,
+            with_remote_database_disk=False,
         )
 
         logging.info("Starting cluster...")

--- a/tests/integration/test_s3_table_function_with_https_proxy/test.py
+++ b/tests/integration/test_s3_table_function_with_https_proxy/test.py
@@ -13,7 +13,7 @@ def cluster():
         cluster = ClickHouseCluster(__file__)
 
         # minio_certs_dir is set only once and used by all instances
-
+        # Disable `with_remote_database_disk` as the test uses proxy, which might not work with the default configs of the remote database disk
         cluster.add_instance(
             "remote_proxy_node",
             main_configs=[
@@ -22,6 +22,7 @@ def cluster():
             ],
             with_minio=True,
             minio_certs_dir="minio_certs",
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -31,6 +32,7 @@ def cluster():
                 "configs/config.d/ssl.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -40,6 +42,7 @@ def cluster():
                 "configs/config.d/ssl.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -49,6 +52,7 @@ def cluster():
                 "configs/config.d/ssl.xml",
             ],
             with_minio=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -61,6 +65,7 @@ def cluster():
                 "https_proxy": "https://proxy1",
             },
             instance_env_variables=True,
+            with_remote_database_disk=False,
         )
 
         cluster.add_instance(
@@ -74,6 +79,7 @@ def cluster():
                 "no_proxy": "not_important_host,,  minio1  ,",
             },
             instance_env_variables=True,
+            with_remote_database_disk=False,
         )
 
         logging.info("Starting cluster...")

--- a/tests/integration/test_s3_with_https/test.py
+++ b/tests/integration/test_s3_with_https/test.py
@@ -24,6 +24,8 @@ def cluster():
             ],
             with_minio=True,
             minio_certs_dir="minio_certs",
+            # Disable `with_remote_database_disk` as the test uses S3 with http, which might cause the S3 unreachable with default settings
+            with_remote_database_disk=False,
         )
         logging.info("Starting cluster...")
         cluster.start()

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -73,7 +73,6 @@ def randomize_table_name(table_name, random_suffix_length=10):
 def started_cluster():
     try:
         cluster = ClickHouseCluster(__file__, with_spark=True)
-        # Disable `with_remote_database_disk` as the instances does not use the default minIO
         cluster.add_instance(
             "node1",
             main_configs=[
@@ -85,7 +84,6 @@ def started_cluster():
             with_minio=True,
             stay_alive=True,
             with_zookeeper=True,
-            with_remote_database_disk=False,
         )
         cluster.add_instance(
             "node2",
@@ -97,7 +95,7 @@ def started_cluster():
             with_minio=True,
             stay_alive=True,
             with_zookeeper=True,
-            with_remote_database_disk=False,
+            with_remote_database_disk=False,  # Disable `with_remote_database_disk` as in `test_replicated_database_and_unavailable_s3``, minIO rejects node2 connections
         )
         cluster.add_instance(
             "node_with_environment_credentials",

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -110,6 +110,7 @@ def started_cluster():
                 "AWS_ACCESS_KEY_ID": minio_access_key,
                 "AWS_SECRET_ACCESS_KEY": minio_secret_key,
             },
+            with_remote_database_disk=False,
         )
 
         logging.info("Starting cluster...")

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -73,6 +73,7 @@ def randomize_table_name(table_name, random_suffix_length=10):
 def started_cluster():
     try:
         cluster = ClickHouseCluster(__file__, with_spark=True)
+        # Disable `with_remote_database_disk` as the instances does not use the default minIO
         cluster.add_instance(
             "node1",
             main_configs=[
@@ -84,6 +85,7 @@ def started_cluster():
             with_minio=True,
             stay_alive=True,
             with_zookeeper=True,
+            with_remote_database_disk=False,
         )
         cluster.add_instance(
             "node2",
@@ -95,6 +97,7 @@ def started_cluster():
             with_minio=True,
             stay_alive=True,
             with_zookeeper=True,
+            with_remote_database_disk=False,
         )
         cluster.add_instance(
             "node_with_environment_credentials",

--- a/tests/integration/test_store_cleanup/test.py
+++ b/tests/integration/test_store_cleanup/test.py
@@ -5,7 +5,10 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance(
-    "node1", stay_alive=True, main_configs=["configs/store_cleanup.xml"]
+    "node1",
+    stay_alive=True,
+    main_configs=["configs/store_cleanup.xml"],
+    with_remote_database_disk=False,  # The test checks data on the local disk
 )
 
 path_to_data = "/var/lib/clickhouse/"

--- a/tests/integration/test_throttling/test.py
+++ b/tests/integration/test_throttling/test.py
@@ -45,6 +45,8 @@ node = cluster.add_instance(
     ],
     with_minio=True,
     minio_certs_dir="minio_certs",
+    # Disable `with_remote_database_disk` as the instances does not use the default minIO
+    with_remote_database_disk=False,
 )
 
 

--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -10,20 +10,25 @@ cluster = ClickHouseCluster(
     __file__, zookeeper_config_path="configs/zookeeper_config_root_a.xml"
 )
 
+# Disable `with_remote_database_disk` as the test does not use the default Keeper
+
 node1 = cluster.add_instance(
     "node1",
     with_zookeeper=True,
     main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"],
+    with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
     "node2",
     with_zookeeper=True,
     main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"],
+    with_remote_database_disk=False,
 )
 node3 = cluster.add_instance(
     "node3",
     with_zookeeper=True,
     main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_b.xml"],
+    with_remote_database_disk=False,
 )
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support using a remote disk for databases to store metadata files.

Following up this [PR - Use IDisk to store metadata files in Databases](https://github.com/ClickHouse/ClickHouse/pull/72027), this PR implements some unimplemented methods in `DiskObjectStorage`, so that it can be used as the database disk. Additionally, for integration tests, the PR also adds a `with_remote_database_disk` option when adding an instance to enable using the remote disk for databases defined in `tests/integration/helpers/remote_database_disk.xml`. Regarding stateless tests, config `tests/config/config.d/remote_database_disk.xml` will be used when running tests with `USE_DATABASE_REPLICATED`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
