### PR TITLE
Set remote_filesystem_read_method to threadpool

### DIFF
--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -146,7 +146,7 @@ std::unique_ptr<WriteBufferFromFileBase> MetadataStorageFromPlainObjectStorageMo
         std::string data;
         auto read_settings = getReadSettings();
         read_settings.remote_fs_method = RemoteFSReadMethod::threadpool;
-        read_settings.remote_fs_prefetch = 0;
+        read_settings.remote_fs_prefetch = false;
         read_settings.remote_fs_buffer_size = 1024;
 
         auto read_buf = object_storage->readObject(metadata_object, read_settings);

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -145,7 +145,8 @@ std::unique_ptr<WriteBufferFromFileBase> MetadataStorageFromPlainObjectStorageMo
 
         std::string data;
         auto read_settings = getReadSettings();
-        read_settings.remote_fs_method = RemoteFSReadMethod::read;
+        read_settings.remote_fs_method = RemoteFSReadMethod::prefetch;
+        read_settings.remote_fs_prefetch = 0;
         read_settings.remote_fs_buffer_size = 1024;
 
         auto read_buf = object_storage->readObject(metadata_object, read_settings);

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<WriteBufferFromFileBase> MetadataStorageFromPlainObjectStorageMo
 
         std::string data;
         auto read_settings = getReadSettings();
-        read_settings.remote_fs_method = RemoteFSReadMethod::prefetch;
+        read_settings.remote_fs_method = RemoteFSReadMethod::threadpool;
         read_settings.remote_fs_prefetch = 0;
         read_settings.remote_fs_buffer_size = 1024;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -55,7 +55,7 @@ void MetadataStorageFromPlainRewritableObjectStorage::load()
 
     auto settings = getReadSettings();
     settings.enable_filesystem_cache = false;
-    settings.remote_fs_method = RemoteFSReadMethod::prefetch;
+    settings.remote_fs_method = RemoteFSReadMethod::threadpool;
     settings.remote_fs_prefetch = 0;
     settings.remote_fs_buffer_size = 1024;  /// These files are small.
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -55,7 +55,8 @@ void MetadataStorageFromPlainRewritableObjectStorage::load()
 
     auto settings = getReadSettings();
     settings.enable_filesystem_cache = false;
-    settings.remote_fs_method = RemoteFSReadMethod::read;
+    settings.remote_fs_method = RemoteFSReadMethod::prefetch;
+    settings.remote_fs_prefetch = 0;
     settings.remote_fs_buffer_size = 1024;  /// These files are small.
 
     LOG_DEBUG(log, "Loading metadata");

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -56,7 +56,7 @@ void MetadataStorageFromPlainRewritableObjectStorage::load()
     auto settings = getReadSettings();
     settings.enable_filesystem_cache = false;
     settings.remote_fs_method = RemoteFSReadMethod::threadpool;
-    settings.remote_fs_prefetch = 0;
+    settings.remote_fs_prefetch = false;
     settings.remote_fs_buffer_size = 1024;  /// These files are small.
 
     LOG_DEBUG(log, "Loading metadata");

--- a/src/IO/ReadSettings.cpp
+++ b/src/IO/ReadSettings.cpp
@@ -27,7 +27,7 @@ ReadSettings getReadSettingsForMetadata()
 {
     ReadSettings read_settings = getReadSettings();
     read_settings.local_fs_method = LocalFSReadMethod::read;
-    read_settings.remote_fs_method = RemoteFSReadMethod::prefetch;
+    read_settings.remote_fs_method = RemoteFSReadMethod::threadpool;
     read_settings.remote_fs_prefetch = 0;
     read_settings.enable_filesystem_cache = false;
     read_settings.read_through_distributed_cache = false;

--- a/src/IO/ReadSettings.cpp
+++ b/src/IO/ReadSettings.cpp
@@ -27,7 +27,8 @@ ReadSettings getReadSettingsForMetadata()
 {
     ReadSettings read_settings = getReadSettings();
     read_settings.local_fs_method = LocalFSReadMethod::read;
-    read_settings.remote_fs_method = RemoteFSReadMethod::read;
+    read_settings.remote_fs_method = RemoteFSReadMethod::prefetch;
+    read_settings.remote_fs_prefetch = 0;
     read_settings.enable_filesystem_cache = false;
     read_settings.read_through_distributed_cache = false;
     read_settings.local_fs_buffer_size = METADATA_FILE_BUFFER_SIZE;

--- a/src/IO/ReadSettings.cpp
+++ b/src/IO/ReadSettings.cpp
@@ -28,7 +28,7 @@ ReadSettings getReadSettingsForMetadata()
     ReadSettings read_settings = getReadSettings();
     read_settings.local_fs_method = LocalFSReadMethod::read;
     read_settings.remote_fs_method = RemoteFSReadMethod::threadpool;
-    read_settings.remote_fs_prefetch = 0;
+    read_settings.remote_fs_prefetch = false;
     read_settings.enable_filesystem_cache = false;
     read_settings.read_through_distributed_cache = false;
     read_settings.local_fs_buffer_size = METADATA_FILE_BUFFER_SIZE;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

cc @kssenii 
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
