### PR TITLE
Docs: fix typo in system table title

### DIFF
--- a/docs/en/operations/system-tables/projections.md
+++ b/docs/en/operations/system-tables/projections.md
@@ -1,7 +1,7 @@
 ---
 description: "System table containing information about existing projections in all tables."
 slug: /operations/system-tables/projections
-title: "system.processors_profile_log"
+title: "system.projections"
 keywords: ["system table", "projections"]
 ---
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
`system.projections` has title `system.processors_profile_log` by mistake. 
Closes https://github.com/ClickHouse/clickhouse-docs/issues/3447
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
