### PR TITLE
tests: fix 01175_distributed_ddl_output_mode_long flakiness

### DIFF
--- a/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh
+++ b/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh
@@ -61,7 +61,10 @@ $CLIENT --distributed_ddl_output_mode=throw -q "select value from system.setting
 $CLIENT --distributed_ddl_output_mode=throw -q "create table throw on cluster test_shard_localhost (n int) engine=Memory;"
 $CLIENT --distributed_ddl_output_mode=throw -q "create table throw on cluster test_shard_localhost (n int) engine=Memory format Null;" 2>&1 | sed "s/DB::Exception/Error/g" | sed "s/ (version.*)//"
 
-run_until_out_contains 'not finished on 1 ' $CLICKHOUSE_CLIENT_WITH_SETTINGS --distributed_ddl_output_mode=throw -q "drop table if exists throw on cluster test_unavailable_shard;" 2>&1 | sed "s/DB::Exception/Error/g" | sed "s/ (version.*)//" | sed "s/Distributed DDL task .* is not finished/Distributed DDL task <task> is not finished/" | sed "s/for .* seconds/for <sec> seconds/"
+# ┌─host──────┬─port─┬─status─┬─error─┬─num_hosts_remaining─┬─num_hosts_active─┐
+# │ localhost │ 9000 │      0 │       │                   1 │                0 │
+# └───────────┴──────┴────────┴───────┴─────────────────────┴──────────────────┘
+run_until_out_contains '9000	0		1	0' $CLICKHOUSE_CLIENT_WITH_SETTINGS --distributed_ddl_output_mode=throw -q "drop table if exists throw on cluster test_unavailable_shard;" 2>&1 | sed "s/DB::Exception/Error/g" | sed "s/ (version.*)//" | sed "s/Distributed DDL task .* is not finished/Distributed DDL task <task> is not finished/" | sed "s/for .* seconds/for <sec> seconds/"
 
 
 $CLIENT --distributed_ddl_output_mode=null_status_on_timeout -q "select value from system.settings where name='distributed_ddl_output_mode';"


### PR DESCRIPTION
The problem was "drop table if exists throw on cluster test_unavailable_shard" query, which may not print anything if DROP TABLE on correct replica will take slightly around distributed_ddl_task_timeout (in the test
distributed_ddl_task_timeout=1, but the DROP takes slightly less then 1 second, and the status block had not been printed)

So adjust the pattern for this query (run_until_out_contains), to wait until this block is there, the exception should match if the num_hosts_remaining==1.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7d1386d83c79ab225f7d4a321f311205e90bfb4e&name_0=MasterCI&name_1=Stateless%20tests%20%28debug%2C%20s3%20storage%29
Cc: @tavplubix 