### PR TITLE
Fixed receiving messages from nats server without attached mv

### DIFF
--- a/src/Storages/NATS/NATSConsumer.cpp
+++ b/src/Storages/NATS/NATSConsumer.cpp
@@ -59,7 +59,7 @@ void NATSConsumer::subscribe()
             throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "Failed to subscribe consumer {} to subject {}", static_cast<void*>(this), subject);
         }
     }
-    LOG_DEBUG(log, "Consumer {} subscribed to {} subjects", static_cast<void*>(this), subscriptions.size());
+    LOG_DEBUG(log, "Consumer {} subscribed to {} subjects", static_cast<void*>(this), created_subscriptions.size());
 
     subscriptions = std::move(created_subscriptions);
 }

--- a/src/Storages/NATS/NATSConsumer.cpp
+++ b/src/Storages/NATS/NATSConsumer.cpp
@@ -67,7 +67,7 @@ void NATSConsumer::subscribe()
 void NATSConsumer::unsubscribe()
 {
     subscriptions.clear();
-    
+
     LOG_DEBUG(log, "Consumer {} unsubscribed", static_cast<void*>(this));
 }
 

--- a/src/Storages/NATS/NATSConsumer.cpp
+++ b/src/Storages/NATS/NATSConsumer.cpp
@@ -32,9 +32,13 @@ NATSConsumer::NATSConsumer(
 {
 }
 
+bool NATSConsumer::isSubscribed() const
+{
+    return !subscriptions.empty();
+}
 void NATSConsumer::subscribe()
 {
-    if (!subscriptions.empty())
+    if (isSubscribed())
         return;
 
     std::vector<NATSSubscriptionPtr> created_subscriptions;
@@ -52,9 +56,10 @@ void NATSConsumer::subscribe()
         }
         else
         {
-            throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "Failed to subscribe to subject {}", subject);
+            throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "Failed to subscribe consumer {} to subject {}", static_cast<void*>(this), subject);
         }
     }
+    LOG_DEBUG(log, "Consumer {} subscribed to {} subjects", static_cast<void*>(this), subscriptions.size());
 
     subscriptions = std::move(created_subscriptions);
 }
@@ -62,6 +67,8 @@ void NATSConsumer::subscribe()
 void NATSConsumer::unsubscribe()
 {
     subscriptions.clear();
+    
+    LOG_DEBUG(log, "Consumer {} unsubscribed", static_cast<void*>(this));
 }
 
 ReadBufferPtr NATSConsumer::consume()

--- a/src/Storages/NATS/NATSConsumer.h
+++ b/src/Storages/NATS/NATSConsumer.h
@@ -35,6 +35,7 @@ public:
         String subject;
     };
 
+    bool isSubscribed() const;
     void subscribe();
     void unsubscribe();
 

--- a/src/Storages/NATS/NATSSource.cpp
+++ b/src/Storages/NATS/NATSSource.cpp
@@ -61,14 +61,11 @@ NATSSource::NATSSource(
     , non_virtual_header(std::move(headers.first))
     , virtual_header(std::move(headers.second))
 {
-    storage.incrementReader();
 }
 
 
 NATSSource::~NATSSource()
 {
-    storage.decrementReader();
-
     if (!consumer)
         return;
 

--- a/src/Storages/NATS/NATSSource.h
+++ b/src/Storages/NATS/NATSSource.h
@@ -46,6 +46,7 @@ private:
     const Block virtual_header;
 
     NATSConsumerPtr consumer;
+    bool unsubscribe_on_destroy = false;
 
     Poco::Timespan max_execution_time = 0;
     Stopwatch total_stopwatch {CLOCK_MONOTONIC_COARSE};

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -131,11 +131,26 @@ StorageNATS::StorageNATS(
 
     event_loop_thread = std::make_unique<ThreadFromGlobalPool>([this] { event_handler.runLoop(); });
 
+    try
+    {
+        createConsumersConnection();        
+    }
+    catch (...)
+    {
+        if (throw_on_startup_failure)
+        {
+            stopEventLoop();
+            throw;
+        }
+
+        tryLogCurrentException(log);
+    }
+
     streaming_task = getContext()->getMessageBrokerSchedulePool().createTask("NATSStreamingTask", [this] { streamingToViewsFunc(); });
     streaming_task->deactivate();
 
-    subscribe_consumers_task = getContext()->getMessageBrokerSchedulePool().createTask("NATSSubscribeConsumersTask", [this] { subscribeConsumersFunc(); });
-    subscribe_consumers_task->deactivate();
+    initialize_consumers_task = getContext()->getMessageBrokerSchedulePool().createTask("NATSInitializeConsumersTask", [this] { initializeConsumersFunc(); });
+    initialize_consumers_task->deactivate();
 }
 StorageNATS::~StorageNATS()
 {
@@ -234,32 +249,52 @@ void StorageNATS::decrementReader()
 }
 
 
-void StorageNATS::subscribeConsumersFunc()
+void StorageNATS::initializeConsumersFunc()
 {
     if (consumers_ready)
         return;
 
-    if (!consumers_connection)
+    try
     {
-        try
-        {
-            createConsumers();
-        }
-        catch (...)
-        {
-            subscribe_consumers_task->scheduleAfter(RESCHEDULE_MS);
-            return;
-        }
+        createConsumersConnection();
+        createConsumers();
+    }
+    catch (...)
+    {
+        initialize_consumers_task->scheduleAfter(RESCHEDULE_MS);
+        return;
     }
 
+    size_t num_views = DatabaseCatalog::instance().getDependentViews(getStorageID()).size();
+    if (num_views == 0)
+    {
+        initialize_consumers_task->scheduleAfter(RESCHEDULE_MS);
+        return;
+    }
+    mv_attached.store(true);
+
     if (!subscribeConsumers())
-        subscribe_consumers_task->scheduleAfter(RESCHEDULE_MS);
+    {
+        initialize_consumers_task->scheduleAfter(RESCHEDULE_MS);
+        return;
+    }
+
+    streaming_task->activateAndSchedule();
+}
+
+void StorageNATS::createConsumersConnection()
+{
+    if (consumers_connection)
+        return;
+
+    auto connect_future = event_handler.createConnection(configuration);
+    consumers_connection = connect_future.get();
 }
 
 void StorageNATS::createConsumers()
 {
-    auto connect_future = event_handler.createConnection(configuration);
-    consumers_connection = connect_future.get();
+    if (num_created_consumers != 0)
+        return;
 
     for (size_t i = 0; i < num_consumers; ++i)
     {
@@ -274,9 +309,10 @@ void StorageNATS::createConsumers()
         }
     }
 }
+
 bool StorageNATS::subscribeConsumers()
 {
-    std::unique_lock lock(consumers_mutex);
+    std::lock_guard lock(consumers_mutex);
     size_t num_initialized = 0;
     for (auto & consumer : consumers)
     {
@@ -291,15 +327,21 @@ bool StorageNATS::subscribeConsumers()
             break;
         }
     }
-    lock.unlock();
 
     const bool are_consumers_initialized = num_initialized == num_created_consumers;
     if (are_consumers_initialized)
-    {
         consumers_ready.store(true);
-        streaming_task->activateAndSchedule();
-    }
+
     return are_consumers_initialized;
+}
+
+void StorageNATS::unsubscribeConsumers()
+{
+    std::lock_guard lock(consumers_mutex);
+    for (auto & consumer : consumers)
+        consumer->unsubscribe();
+
+    consumers_ready.store(false);
 }
 
 
@@ -331,25 +373,20 @@ void StorageNATS::read(
         size_t /* max_block_size */,
         size_t /* num_streams */)
 {
-    if (!consumers_ready)
-        throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "NATS consumers setup not finished. Connection might be lost");
-
-    if (num_created_consumers == 0)
-        return;
-
+    if (!consumers_connection || num_created_consumers == 0)
+        throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "NATS consumers setup not finished. Connection might be not established");
+    
     if (!local_context->getSettingsRef()[Setting::stream_like_engine_allow_direct_select])
         throw Exception(
             ErrorCodes::QUERY_NOT_ALLOWED, "Direct select is not allowed. To enable use setting `stream_like_engine_allow_direct_select`");
-
+    
     if (mv_attached)
         throw Exception(ErrorCodes::QUERY_NOT_ALLOWED, "Cannot read from StorageNATS with attached materialized views");
 
     auto sample_block = storage_snapshot->getSampleBlockForColumns(column_names);
     auto modified_context = addSettings(local_context);
 
-    if (!consumers_connection)
-        throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "No connection to NATS server");
-    else if (!consumers_connection->isConnected())
+    if (!consumers_connection->isConnected())
         throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "No connection to {}", consumers_connection->connectionInfoForLog());
 
     Pipes pipes;
@@ -427,23 +464,7 @@ SinkToStoragePtr StorageNATS::write(const ASTPtr &, const StorageMetadataPtr & m
 
 void StorageNATS::startup()
 {
-    try
-    {
-        createConsumers();
-    }
-    catch (...)
-    {
-        if (throw_on_startup_failure)
-        {
-            stopEventLoop();
-            throw;
-        }
-
-        tryLogCurrentException(log);
-    }
-
-    if (!consumers_connection || !subscribeConsumers())
-        subscribe_consumers_task->activateAndSchedule();
+    initialize_consumers_task->activateAndSchedule();
 }
 
 
@@ -456,17 +477,13 @@ void StorageNATS::shutdown(bool /* is_drop */)
     deactivateTask(streaming_task);
 
     /// In case it has not yet been able to setup connection;
-    deactivateTask(subscribe_consumers_task);
+    deactivateTask(initialize_consumers_task);
 
     /// Just a paranoid try catch, it is not actually needed.
     try
     {
         if (drop_table)
-        {
-            std::lock_guard lock(consumers_mutex);
-            for (auto & consumer : consumers)
-                consumer->unsubscribe();
-        }
+            unsubscribeConsumers();
 
         if (consumers_connection)
         {
@@ -600,15 +617,13 @@ bool StorageNATS::checkDependencies(const StorageID & table_id)
 
 void StorageNATS::streamingToViewsFunc()
 {
-    bool do_reschedule_with_delay = false;
+    auto table_id = getStorageID();
+
+    bool consumers_queues_are_empty = false;
+
     try
     {
-        auto table_id = getStorageID();
-
-        // Check if at least one direct dependency is attached
-        size_t num_views = DatabaseCatalog::instance().getDependentViews(table_id).size();
-
-        if (num_views && consumers_connection && consumers_connection->isConnected())
+        if (consumers_connection && consumers_connection->isConnected())
         {
             auto start_time = std::chrono::steady_clock::now();
 
@@ -620,12 +635,12 @@ void StorageNATS::streamingToViewsFunc()
                 if (!checkDependencies(table_id))
                     break;
 
-                LOG_DEBUG(log, "Started streaming to {} attached views", num_views);
+                LOG_DEBUG(log, "Started streaming to attached views");
 
                 if (streamToViews())
                 {
                     /// Reschedule with backoff.
-                    do_reschedule_with_delay = true;
+                    consumers_queues_are_empty = true;
                     break;
                 }
 
@@ -634,7 +649,7 @@ void StorageNATS::streamingToViewsFunc()
                 if (duration.count() > MAX_THREAD_WORK_DURATION_MS)
                 {
                     LOG_TRACE(log, "Reschedule streaming. Thread work duration limit exceeded");
-                    do_reschedule_with_delay = false;
+                    consumers_queues_are_empty = false;
                     break;
                 }
             }
@@ -645,15 +660,30 @@ void StorageNATS::streamingToViewsFunc()
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 
-    mv_attached.store(false);
+    if (shutdown_called)
+        return;
 
-    if (!shutdown_called)
+    size_t num_views = DatabaseCatalog::instance().getDependentViews(table_id).size();
+    if (num_views != 0)
     {
-        if (do_reschedule_with_delay)
+        if (consumers_queues_are_empty)
             streaming_task->scheduleAfter(RESCHEDULE_MS);
         else
             streaming_task->schedule();
+
+        return;
     }
+    else if (consumers_ready)
+        unsubscribeConsumers();
+
+    if (!consumers_queues_are_empty)
+    {
+        streaming_task->schedule();
+        return;
+    }
+
+    initialize_consumers_task->schedule();
+    mv_attached.store(false);
 }
 
 

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -237,18 +237,6 @@ void StorageNATS::stopEventLoop()
     LOG_TRACE(log, "Event loop thread finished in {} ms.", watch.elapsedMilliseconds());
 }
 
-void StorageNATS::incrementReader()
-{
-    ++readers_count;
-}
-
-
-void StorageNATS::decrementReader()
-{
-    --readers_count;
-}
-
-
 void StorageNATS::initializeConsumersFunc()
 {
     if (consumers_ready)

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -133,7 +133,7 @@ StorageNATS::StorageNATS(
 
     try
     {
-        createConsumersConnection();        
+        createConsumersConnection();
     }
     catch (...)
     {
@@ -363,11 +363,11 @@ void StorageNATS::read(
 {
     if (!consumers_connection || num_created_consumers == 0)
         throw Exception(ErrorCodes::CANNOT_CONNECT_NATS, "NATS consumers setup not finished. Connection might be not established");
-    
+
     if (!local_context->getSettingsRef()[Setting::stream_like_engine_allow_direct_select])
         throw Exception(
             ErrorCodes::QUERY_NOT_ALLOWED, "Direct select is not allowed. To enable use setting `stream_like_engine_allow_direct_select`");
-    
+
     if (mv_attached)
         throw Exception(ErrorCodes::QUERY_NOT_ALLOWED, "Cannot read from StorageNATS with attached materialized views");
 

--- a/src/Storages/NATS/StorageNATS.h
+++ b/src/Storages/NATS/StorageNATS.h
@@ -119,7 +119,7 @@ private:
 
     void createConsumersConnection();
     void createConsumers();
-    
+
     bool subscribeConsumers();
     void unsubscribeConsumers();
 

--- a/src/Storages/NATS/StorageNATS.h
+++ b/src/Storages/NATS/StorageNATS.h
@@ -68,9 +68,6 @@ public:
 
     const String & getFormatName() const { return format_name; }
 
-    void incrementReader();
-    void decrementReader();
-
 private:
     ContextMutablePtr nats_context;
     std::unique_ptr<NATSSettings> nats_settings;
@@ -98,7 +95,6 @@ private:
     /// to setup size of inner consumer for received messages
     uint32_t queue_size;
 
-    std::once_flag flag; /// remove exchange only once
     std::mutex task_mutex;
     BackgroundSchedulePoolTaskHolder streaming_task;
     BackgroundSchedulePoolTaskHolder initialize_consumers_task;
@@ -108,9 +104,6 @@ private:
     /// Needed for tell MV or producer background tasks
     /// that they must finish as soon as possible.
     std::atomic<bool> shutdown_called{false};
-    /// For select query we must be aware of the end of streaming
-    /// to be able to turn off the loop.
-    std::atomic<size_t> readers_count = 0;
     std::atomic<bool> mv_attached = false;
 
     mutable bool drop_table = false;

--- a/src/Storages/NATS/StorageNATS.h
+++ b/src/Storages/NATS/StorageNATS.h
@@ -89,7 +89,7 @@ private:
     NATSConnectionPtr consumers_connection; /// Connection for all consumers
     NATSConfiguration configuration;
 
-    size_t num_created_consumers = 0;
+    std::atomic<size_t> num_created_consumers = 0;
     Poco::Semaphore semaphore;
     std::mutex consumers_mutex;
     std::vector<NATSConsumerPtr> consumers; /// available NATS consumers
@@ -101,7 +101,7 @@ private:
     std::once_flag flag; /// remove exchange only once
     std::mutex task_mutex;
     BackgroundSchedulePoolTaskHolder streaming_task;
-    BackgroundSchedulePoolTaskHolder subscribe_consumers_task;
+    BackgroundSchedulePoolTaskHolder initialize_consumers_task;
 
     /// True if consumers have subscribed to all subjects
     std::atomic<bool> consumers_ready{false};
@@ -121,11 +121,14 @@ private:
     bool isSubjectInSubscriptions(const std::string & subject);
 
     /// Functions working in the background
+    void initializeConsumersFunc();
     void streamingToViewsFunc();
-    void subscribeConsumersFunc();
 
+    void createConsumersConnection();
     void createConsumers();
+    
     bool subscribeConsumers();
+    void unsubscribeConsumers();
 
     void stopEventLoop();
 

--- a/tests/integration/test_storage_nats/test.py
+++ b/tests/integration/test_storage_nats/test.py
@@ -149,7 +149,7 @@ def wait_for_table_is_ready(instance, table_name, sleep_timeout = 0.5, time_limi
     assert(check_table_is_ready(instance, table_name))
 
 # waiting for subscription to nats subjects (after subscription direct selection is not available and completed with an error)
-def wait_for_mv_is_ready(instance, table_name, sleep_timeout = 0.5, time_limit_sec = 60):
+def wait_for_mv_attached_to_table(instance, table_name, sleep_timeout = 0.5, time_limit_sec = 60):
     deadline = time.monotonic() + time_limit_sec
     while check_table_is_ready(instance, table_name) and time.monotonic() < deadline:
         time.sleep(sleep_timeout)
@@ -201,7 +201,7 @@ def test_nats_select(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     messages = []
     for i in range(50):
@@ -232,7 +232,7 @@ def test_nats_json_without_delimiter(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
     
     messages = ""
     for i in range(25):
@@ -272,7 +272,7 @@ def test_nats_csv_with_delimiter(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     messages = []
     for i in range(50):
@@ -318,7 +318,7 @@ def test_nats_tsv_with_delimiter(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     messages = []
     for i in range(50):
@@ -352,7 +352,7 @@ def test_nats_macros(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
     
     message = ""
     for i in range(50):
@@ -389,7 +389,7 @@ def test_nats_materialized_view(nats_cluster):
             SELECT * FROM test.nats group by (key, value);
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
     
     messages = []
     for i in range(50):
@@ -423,7 +423,7 @@ def test_nats_materialized_view_with_subquery(nats_cluster):
             SELECT * FROM (SELECT * FROM test.nats);
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
     
     messages = []
     for i in range(50):
@@ -460,7 +460,7 @@ def test_nats_many_materialized_views(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
     
     messages = []
     for i in range(50):
@@ -502,7 +502,7 @@ def test_nats_protobuf(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     data = b""
     for i in range(0, 20):
@@ -561,7 +561,7 @@ def test_nats_big_message(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     asyncio.run(nats_produce_messages(nats_cluster, "big", messages))
 
@@ -606,7 +606,7 @@ def test_nats_mv_combo(nats_cluster):
                 mv_id
             )
         )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     i = [0]
     messages_num = 10000
@@ -915,7 +915,7 @@ def test_nats_many_inserts(nats_cluster):
             SELECT * FROM test.nats_consume;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats_consume")
+    wait_for_mv_attached_to_table(instance, "test.nats_consume")
 
     messages_num = 10000
     values = []
@@ -995,7 +995,7 @@ def test_nats_overloaded_insert(nats_cluster):
             SELECT * FROM test.nats_consume;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats_consume")
+    wait_for_mv_attached_to_table(instance, "test.nats_consume")
 
     messages_num = 100000
 
@@ -1062,7 +1062,7 @@ def test_nats_virtual_column(nats_cluster):
         SELECT value, key, _subject FROM test.nats_virtuals;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats_virtuals")
+    wait_for_mv_attached_to_table(instance, "test.nats_virtuals")
     
     message_num = 10
     i = 0
@@ -1123,7 +1123,7 @@ def test_nats_virtual_column_with_materialized_view(nats_cluster):
         FROM test.nats_virtuals_mv;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats_virtuals_mv")
+    wait_for_mv_attached_to_table(instance, "test.nats_virtuals_mv")
     
     message_num = 10
     i = 0
@@ -1203,7 +1203,7 @@ def test_nats_many_consumers_to_each_queue(nats_cluster):
                 table_id
             )
         )
-        wait_for_mv_is_ready(instance, "test.many_consumers_{}".format(table_id))
+        wait_for_mv_attached_to_table(instance, "test.many_consumers_{0}".format(table_id))
 
     i = [0]
     messages_num = 1000
@@ -1286,7 +1286,7 @@ def test_nats_restore_failed_connection_without_losses_on_write(nats_cluster):
             SELECT * FROM test.consume;
         """
     )
-    wait_for_mv_is_ready(instance, "test.consume")
+    wait_for_mv_attached_to_table(instance, "test.consume")
 
     messages_num = 100000
     values = []
@@ -1379,7 +1379,7 @@ def test_nats_no_connection_at_startup_2(nats_cluster):
             SELECT * FROM test.cs;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.cs")
 
     messages_num = 1000
     messages = []
@@ -1421,7 +1421,7 @@ def test_nats_format_factory_settings(nats_cluster):
             SELECT * FROM test.format_settings;
         """
     )
-    wait_for_mv_is_ready(instance, "test.format_settings")
+    wait_for_mv_attached_to_table(instance, "test.format_settings")
 
 
     message = json.dumps(
@@ -1473,7 +1473,7 @@ def test_nats_drop_mv(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
     
     messages = []
     for i in range(20):
@@ -1498,7 +1498,7 @@ def test_nats_drop_mv(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     messages = []
     for i in range(20, 40):
@@ -1523,7 +1523,7 @@ def test_nats_drop_mv(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     messages = []
     for i in range(40, 50):
@@ -1559,7 +1559,7 @@ def test_nats_predefined_configuration(nats_cluster):
             SELECT * FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     asyncio.run(
         nats_produce_messages(
@@ -1643,7 +1643,7 @@ def test_max_rows_per_message(nats_cluster):
         SELECT key, value FROM test.nats;
         """
     )
-    wait_for_mv_is_ready(instance, "test.nats")
+    wait_for_mv_attached_to_table(instance, "test.nats")
 
     num_rows = 5
 
@@ -1739,7 +1739,7 @@ def test_row_based_formats(nats_cluster):
             SELECT key, value FROM test.nats;
             """
         )
-        wait_for_mv_is_ready(instance, "test.nats")
+        wait_for_mv_attached_to_table(instance, "test.nats")
 
         insert_messages = 0
 
@@ -1896,7 +1896,7 @@ def test_block_based_formats_2(nats_cluster):
             SELECT key, value FROM test.nats;
             """
         )
-        wait_for_mv_is_ready(instance, "test.nats")
+        wait_for_mv_attached_to_table(instance, "test.nats")
 
         insert_messages = 0
 

--- a/tests/integration/test_storage_nats/test.py
+++ b/tests/integration/test_storage_nats/test.py
@@ -1358,6 +1358,11 @@ def test_nats_no_connection_at_startup_1(nats_cluster):
                         nats_row_delimiter = '\\n';
         """
         )
+        instance.query_and_get_error(
+            """
+            SHOW TABLE test.cs;
+        """
+        )
 
 
 def test_nats_no_connection_at_startup_2(nats_cluster):

--- a/tests/integration/test_storage_nats/test.py
+++ b/tests/integration/test_storage_nats/test.py
@@ -47,14 +47,24 @@ def wait_nats_to_start(nats_port, ssl_ctx=None, timeout=180):
             logging.debug("Can't connect to NATS " + str(ex))
             time.sleep(0.5)
 
+def nats_check_query_result(query, time_limit_sec = 60):
+    query_result = ""
+    deadline = time.monotonic() + time_limit_sec
 
-def nats_check_result(result, check=False, ref_file="test_nats_json.reference"):
+    while time.monotonic() < deadline:
+        query_result = instance.query(query, ignore_error=True        )
+        if nats_check_result(query_result):
+            break
+
+    nats_check_result(query_result, True)
+
+def nats_check_result(query_result, check=False, ref_file="test_nats_json.reference"):
     fpath = p.join(p.dirname(__file__), ref_file)
     with open(fpath) as reference:
         if check:
-            assert TSV(result) == TSV(reference)
+            assert TSV(query_result) == TSV(reference)
         else:
-            return TSV(result) == TSV(reference)
+            return TSV(query_result) == TSV(reference)
 
 
 def kill_nats(nats_id):
@@ -98,7 +108,6 @@ def nats_setup_teardown():
 
 # Tests
 
-
 async def nats_produce_messages(cluster_inst, subject, messages=(), bytes=None):
     nc = await nats_connect_ssl(
         cluster_inst.nats_port,
@@ -118,6 +127,34 @@ async def nats_produce_messages(cluster_inst, subject, messages=(), bytes=None):
     await nc.close()
     return messages
 
+def wait_query_result(instance, query, wait_query_result, sleep_timeout = 0.5, time_limit_sec = 60):
+    deadline = time.monotonic() + time_limit_sec
+    
+    query_result = 0
+    while time.monotonic() < deadline:
+        query_result = int(instance.query(query))
+        if query_result == wait_query_result:
+            break
+        
+        time.sleep(1)
+    
+    assert query_result == wait_query_result
+
+
+def wait_for_table_is_ready(instance, table_name, sleep_timeout = 0.5, time_limit_sec = 60):
+    deadline = time.monotonic() + time_limit_sec
+    while (not check_table_is_ready(instance, table_name)) and time.monotonic() < deadline:
+        time.sleep(sleep_timeout)
+
+    assert(check_table_is_ready(instance, table_name))
+
+# waiting for subscription to nats subjects (after subscription direct selection is not available and completed with an error)
+def wait_for_mv_is_ready(instance, table_name, sleep_timeout = 0.5, time_limit_sec = 60):
+    deadline = time.monotonic() + time_limit_sec
+    while check_table_is_ready(instance, table_name) and time.monotonic() < deadline:
+        time.sleep(sleep_timeout)
+    
+    assert(not check_table_is_ready(instance, table_name))
 
 def check_table_is_ready(instance, table_name):
     try:
@@ -151,29 +188,27 @@ def test_nats_select(nats_cluster):
                      nats_subjects = 'select',
                      nats_format = 'JSONEachRow',
                      nats_row_delimiter = '\\n';
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree()
+            ORDER BY key;
         """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
 
     messages = []
     for i in range(50):
         messages.append(json.dumps({"key": i, "value": i}))
     asyncio.run(nats_produce_messages(nats_cluster, "select", messages))
 
-    # The order of messages in select * from test.nats is not guaranteed, so sleep to collect everything in one select
-    time.sleep(1)
-
-    result = ""
-    while True:
-        result += instance.query(
-            "SELECT * FROM test.nats ORDER BY key", ignore_error=True
-        )
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 
 def test_nats_json_without_delimiter(nats_cluster):
@@ -184,12 +219,21 @@ def test_nats_json_without_delimiter(nats_cluster):
             SETTINGS nats_url = 'nats1:4444',
                      nats_subjects = 'json',
                      nats_format = 'JSONEachRow';
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree()
+            ORDER BY key;
         """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
+    
     messages = ""
     for i in range(25):
         messages += json.dumps({"key": i, "value": i}) + "\n"
@@ -203,20 +247,7 @@ def test_nats_json_without_delimiter(nats_cluster):
     all_messages = [messages]
     asyncio.run(nats_produce_messages(nats_cluster, "json", all_messages))
 
-    time.sleep(1)
-
-    result = ""
-    time_limit_sec = 60
-    deadline = time.monotonic() + time_limit_sec
-
-    while time.monotonic() < deadline:
-        result += instance.query(
-            "SELECT * FROM test.nats ORDER BY key", ignore_error=True
-        )
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 
 def test_nats_csv_with_delimiter(nats_cluster):
@@ -228,11 +259,20 @@ def test_nats_csv_with_delimiter(nats_cluster):
                      nats_subjects = 'csv',
                      nats_format = 'CSV',
                      nats_row_delimiter = '\\n';
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree()
+            ORDER BY key;
         """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
 
     messages = []
     for i in range(50):
@@ -243,9 +283,12 @@ def test_nats_csv_with_delimiter(nats_cluster):
     time.sleep(1)
 
     result = ""
-    for _ in range(60):
-        result += instance.query(
-            "SELECT * FROM test.nats ORDER BY key", ignore_error=True
+    time_limit_sec = 60
+    deadline = time.monotonic() + time_limit_sec
+
+    while time.monotonic() < deadline:
+        result = instance.query(
+            "SELECT * FROM test.view ORDER BY key", ignore_error=True
         )
         if nats_check_result(result):
             break
@@ -265,13 +308,17 @@ def test_nats_tsv_with_delimiter(nats_cluster):
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM test.nats;
         """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_mv_is_ready(instance, "test.nats")
 
     messages = []
     for i in range(50):
@@ -279,14 +326,7 @@ def test_nats_tsv_with_delimiter(nats_cluster):
 
     asyncio.run(nats_produce_messages(nats_cluster, "tsv", messages))
 
-    result = ""
-    for _ in range(60):
-        result = instance.query("SELECT * FROM test.view ORDER BY key")
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
-
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 #
 
@@ -298,29 +338,28 @@ def test_nats_macros(nats_cluster):
             ENGINE = NATS
             SETTINGS nats_url = '{nats_url}',
                      nats_subjects = '{nats_subjects}',
-                     nats_format = '{nats_format}'
+                     nats_format = '{nats_format}';
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree()
+            ORDER BY key;
         """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
+    
     message = ""
     for i in range(50):
         message += json.dumps({"key": i, "value": i}) + "\n"
     asyncio.run(nats_produce_messages(nats_cluster, "macro", [message]))
 
-    time.sleep(1)
-
-    result = ""
-    for _ in range(60):
-        result += instance.query(
-            "SELECT * FROM test.nats ORDER BY key", ignore_error=True
-        )
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 
 def test_nats_materialized_view(nats_cluster):
@@ -335,44 +374,31 @@ def test_nats_materialized_view(nats_cluster):
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
-        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
-            SELECT * FROM test.nats;
-
         CREATE TABLE test.view2 (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
         CREATE MATERIALIZED VIEW test.consumer2 TO test.view2 AS
             SELECT * FROM test.nats group by (key, value);
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
-
+    wait_for_mv_is_ready(instance, "test.nats")
+    
     messages = []
     for i in range(50):
         messages.append(json.dumps({"key": i, "value": i}))
 
     asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
 
-    time_limit_sec = 60
-    deadline = time.monotonic() + time_limit_sec
-
-    while time.monotonic() < deadline:
-        result = instance.query("SELECT * FROM test.view ORDER BY key")
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
-
-    deadline = time.monotonic() + time_limit_sec
-
-    while time.monotonic() < deadline:
-        result = instance.query("SELECT * FROM test.view2 ORDER BY key")
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_result("SELECT * FROM test.view ORDER BY key")
+    nats_check_result("SELECT * FROM test.view2 ORDER BY key")
 
 
 def test_nats_materialized_view_with_subquery(nats_cluster):
@@ -387,37 +413,29 @@ def test_nats_materialized_view_with_subquery(nats_cluster):
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM (SELECT * FROM test.nats);
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
-
+    wait_for_mv_is_ready(instance, "test.nats")
+    
     messages = []
     for i in range(50):
         messages.append(json.dumps({"key": i, "value": i}))
     asyncio.run(nats_produce_messages(nats_cluster, "mvsq", messages))
 
-    time_limit_sec = 60
-    deadline = time.monotonic() + time_limit_sec
-
-    while time.monotonic() < deadline:
-        result = instance.query("SELECT * FROM test.view ORDER BY key")
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 
 def test_nats_many_materialized_views(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.view1;
-        DROP TABLE IF EXISTS test.view2;
-        DROP TABLE IF EXISTS test.consumer1;
-        DROP TABLE IF EXISTS test.consumer2;
         CREATE TABLE test.nats (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -430,16 +448,20 @@ def test_nats_many_materialized_views(nats_cluster):
         CREATE TABLE test.view2 (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer1 TO test.view1 AS
             SELECT * FROM test.nats;
         CREATE MATERIALIZED VIEW test.consumer2 TO test.view2 AS
             SELECT * FROM test.nats;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
-
+    wait_for_mv_is_ready(instance, "test.nats")
+    
     messages = []
     for i in range(50):
         messages.append(json.dumps({"key": i, "value": i}))
@@ -453,15 +475,6 @@ def test_nats_many_materialized_views(nats_cluster):
         result2 = instance.query("SELECT * FROM test.view2 ORDER BY key")
         if nats_check_result(result1) and nats_check_result(result2):
             break
-
-    instance.query(
-        """
-        DROP TABLE test.consumer1;
-        DROP TABLE test.consumer2;
-        DROP TABLE test.view1;
-        DROP TABLE test.view2;
-    """
-    )
 
     nats_check_result(result1, True)
     nats_check_result(result2, True)
@@ -479,13 +492,17 @@ def test_nats_protobuf(nats_cluster):
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM test.nats;
         """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_mv_is_ready(instance, "test.nats")
 
     data = b""
     for i in range(0, 20):
@@ -512,16 +529,7 @@ def test_nats_protobuf(nats_cluster):
         data = data + _VarintBytes(len(serialized_msg)) + serialized_msg
     asyncio.run(nats_produce_messages(nats_cluster, "pb", bytes=data))
 
-    result = ""
-    time_limit_sec = 60
-    deadline = time.monotonic() + time_limit_sec
-
-    while time.monotonic() < deadline:
-        result = instance.query("SELECT * FROM test.view ORDER BY key")
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 
 def test_nats_big_message(nats_cluster):
@@ -543,13 +551,17 @@ def test_nats_big_message(nats_cluster):
         CREATE TABLE test.view (key UInt64, value String)
             ENGINE = MergeTree
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM test.nats;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_mv_is_ready(instance, "test.nats")
 
     asyncio.run(nats_produce_messages(nats_cluster, "big", messages))
 
@@ -576,30 +588,25 @@ def test_nats_mv_combo(nats_cluster):
                      nats_num_consumers = {},
                      nats_format = 'JSONEachRow',
                      nats_row_delimiter = '\\n';
-    """.format(
+        """.format(
             NUM_CONSUMERS
         )
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
     for mv_id in range(NUM_MV):
         instance.query(
             """
-            DROP TABLE IF EXISTS test.combo_{0};
-            DROP TABLE IF EXISTS test.combo_{0}_mv;
             CREATE TABLE test.combo_{0} (key UInt64, value UInt64)
                 ENGINE = MergeTree()
                 ORDER BY key;
             CREATE MATERIALIZED VIEW test.combo_{0}_mv TO test.combo_{0} AS
                 SELECT * FROM test.nats;
-        """.format(
+            """.format(
                 mv_id
             )
         )
-
-    time.sleep(2)
+    wait_for_mv_is_ready(instance, "test.nats")
 
     i = [0]
     messages_num = 10000
@@ -659,9 +666,7 @@ def test_nats_insert(nats_cluster):
                      nats_row_delimiter = '\\n';
     """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
     values = []
     for i in range(50):
@@ -719,9 +724,7 @@ def test_fetching_messages_without_mv(nats_cluster):
                      nats_row_delimiter = '\\n';
     """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
     values = []
     for i in range(50):
@@ -782,9 +785,7 @@ def test_nats_many_subjects_insert_wrong(nats_cluster):
                      nats_row_delimiter = '\\n';
     """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
     values = []
     for i in range(50):
@@ -835,9 +836,7 @@ def test_nats_many_subjects_insert_right(nats_cluster):
                      nats_row_delimiter = '\\n';
     """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
     values = []
     for i in range(50):
@@ -890,10 +889,6 @@ def test_nats_many_subjects_insert_right(nats_cluster):
 def test_nats_many_inserts(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.nats_many;
-        DROP TABLE IF EXISTS test.nats_consume;
-        DROP TABLE IF EXISTS test.view_many;
-        DROP TABLE IF EXISTS test.consumer_many;
         CREATE TABLE test.nats_many (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -909,17 +904,18 @@ def test_nats_many_inserts(nats_cluster):
         CREATE TABLE test.view_many (key UInt64, value UInt64)
             ENGINE = MergeTree
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats_consume")
+    wait_for_table_is_ready(instance, "test.nats_many")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer_many TO test.view_many AS
             SELECT * FROM test.nats_consume;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats_consume"):
-        logging.debug("Table test.nats_consume is not yet ready")
-        time.sleep(0.5)
-
-    while not check_table_is_ready(instance, "test.nats_many"):
-        logging.debug("Table test.nats_many is not yet ready")
-        time.sleep(0.5)
+    wait_for_mv_is_ready(instance, "test.nats_consume")
 
     messages_num = 10000
     values = []
@@ -959,15 +955,6 @@ def test_nats_many_inserts(nats_cluster):
             break
         time.sleep(1)
 
-    instance.query(
-        """
-        DROP TABLE test.nats_consume;
-        DROP TABLE test.nats_many;
-        DROP TABLE test.consumer_many;
-        DROP TABLE test.view_many;
-    """
-    )
-
     assert (
         int(result) == messages_num * threads_num
     ), "ClickHouse lost some messages or got duplicated ones. Total count: {}".format(
@@ -978,9 +965,6 @@ def test_nats_many_inserts(nats_cluster):
 def test_nats_overloaded_insert(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.view_overload;
-        DROP TABLE IF EXISTS test.consumer_overload;
-        DROP TABLE IF EXISTS test.nats_consume;
         CREATE TABLE test.nats_consume (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -1000,13 +984,18 @@ def test_nats_overloaded_insert(nats_cluster):
             ORDER BY key
             SETTINGS old_parts_lifetime=5, cleanup_delay_period=2, cleanup_delay_period_random_add=3,
             cleanup_thread_preferred_points_per_iteration=0;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats_consume")
+    wait_for_table_is_ready(instance, "test.nats_overload")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer_overload TO test.view_overload AS
             SELECT * FROM test.nats_consume;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats_consume"):
-        logging.debug("Table test.nats_consume is not yet ready")
-        time.sleep(0.5)
+    wait_for_mv_is_ready(instance, "test.nats_consume")
 
     messages_num = 100000
 
@@ -1045,15 +1034,6 @@ def test_nats_overloaded_insert(nats_cluster):
         if int(result) >= messages_num * threads_num:
             break
 
-    instance.query(
-        """
-        DROP TABLE test.consumer_overload;
-        DROP TABLE test.view_overload;
-        DROP TABLE test.nats_consume;
-        DROP TABLE test.nats_overload;
-    """
-    )
-
     for thread in threads:
         thread.join()
 
@@ -1072,14 +1052,18 @@ def test_nats_virtual_column(nats_cluster):
             SETTINGS nats_url = 'nats1:4444',
                      nats_subjects = 'virtuals',
                      nats_format = 'JSONEachRow';
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats_virtuals")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.view Engine=Log AS
         SELECT value, key, _subject FROM test.nats_virtuals;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats_virtuals"):
-        logging.debug("Table test.nats_virtuals is not yet ready")
-        time.sleep(0.5)
-
+    wait_for_mv_is_ready(instance, "test.nats_virtuals")
+    
     message_num = 10
     i = 0
     messages = []
@@ -1099,7 +1083,7 @@ def test_nats_virtual_column(nats_cluster):
         """
         SELECT key, value, _subject
         FROM test.view ORDER BY key
-    """
+        """
     )
 
     expected = """\
@@ -1115,13 +1099,6 @@ def test_nats_virtual_column(nats_cluster):
 9	9	virtuals
 """
 
-    instance.query(
-        """
-        DROP TABLE test.nats_virtuals;
-        DROP TABLE test.view;
-    """
-    )
-
     assert TSV(result) == TSV(expected)
 
 
@@ -1135,15 +1112,19 @@ def test_nats_virtual_column_with_materialized_view(nats_cluster):
                      nats_format = 'JSONEachRow';
         CREATE TABLE test.view (key UInt64, value UInt64, subject String) ENGINE = MergeTree()
             ORDER BY key;
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats_virtuals_mv")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
         SELECT *, _subject as subject
         FROM test.nats_virtuals_mv;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats_virtuals_mv"):
-        logging.debug("Table test.nats_virtuals_mv is not yet ready")
-        time.sleep(0.5)
-
+    wait_for_mv_is_ready(instance, "test.nats_virtuals_mv")
+    
     message_num = 10
     i = 0
     messages = []
@@ -1187,11 +1168,10 @@ def test_nats_virtual_column_with_materialized_view(nats_cluster):
 def test_nats_many_consumers_to_each_queue(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.destination;
         CREATE TABLE test.destination(key UInt64, value UInt64)
         ENGINE = MergeTree()
         ORDER BY key;
-    """
+        """
     )
 
     num_tables = 4
@@ -1199,8 +1179,6 @@ def test_nats_many_consumers_to_each_queue(nats_cluster):
         logging.debug(("Setting up table {}".format(table_id)))
         instance.query(
             """
-            DROP TABLE IF EXISTS test.many_consumers_{0};
-            DROP TABLE IF EXISTS test.many_consumers_{0}_mv;
             CREATE TABLE test.many_consumers_{0} (key UInt64, value UInt64)
                 ENGINE = NATS
                 SETTINGS nats_url = 'nats1:4444',
@@ -1209,19 +1187,23 @@ def test_nats_many_consumers_to_each_queue(nats_cluster):
                          nats_queue_group = 'many_consumers',
                          nats_format = 'JSONEachRow',
                          nats_row_delimiter = '\\n';
+            """.format(
+                table_id
+            )
+        )
+        wait_for_table_is_ready(instance, "test.many_consumers_{}".format(table_id))
+
+    for table_id in range(num_tables):
+        logging.debug(("Setting up table mv {}".format(table_id)))
+        instance.query(
+            """
             CREATE MATERIALIZED VIEW test.many_consumers_{0}_mv TO test.destination AS
             SELECT key, value FROM test.many_consumers_{0};
         """.format(
                 table_id
             )
         )
-        while not check_table_is_ready(
-            instance, "test.many_consumers_{}".format(table_id)
-        ):
-            logging.debug(
-                "Table test.many_consumers_{} is not yet ready".format(table_id)
-            )
-            time.sleep(0.5)
+        wait_for_mv_is_ready(instance, "test.many_consumers_{}".format(table_id))
 
     i = [0]
     messages_num = 1000
@@ -1276,7 +1258,6 @@ def test_nats_many_consumers_to_each_queue(nats_cluster):
 def test_nats_restore_failed_connection_without_losses_on_write(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.consume;
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree
             ORDER BY key;
@@ -1287,9 +1268,6 @@ def test_nats_restore_failed_connection_without_losses_on_write(nats_cluster):
                      nats_format = 'JSONEachRow',
                      nats_num_consumers = 2,
                      nats_row_delimiter = '\\n';
-        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
-            SELECT * FROM test.consume;
-        DROP TABLE IF EXISTS test.producer_reconnect;
         CREATE TABLE test.producer_reconnect (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -1298,9 +1276,17 @@ def test_nats_restore_failed_connection_without_losses_on_write(nats_cluster):
                      nats_row_delimiter = '\\n';
     """
     )
-    while not check_table_is_ready(instance, "test.consume"):
-        logging.debug("Table test.consume is not yet ready")
-        time.sleep(0.5)
+    
+    wait_for_table_is_ready(instance, "test.consume")
+    wait_for_table_is_ready(instance, "test.producer_reconnect")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.consume")
 
     messages_num = 100000
     values = []
@@ -1332,13 +1318,6 @@ def test_nats_restore_failed_connection_without_losses_on_write(nats_cluster):
         time.sleep(1)
         if int(result) == messages_num:
             break
-
-    instance.query(
-        """
-        DROP TABLE test.consume;
-        DROP TABLE test.producer_reconnect;
-    """
-    )
 
     assert int(result) == messages_num, "ClickHouse lost some messages: {}".format(
         result
@@ -1380,16 +1359,27 @@ def test_nats_no_connection_at_startup_2(nats_cluster):
             ORDER BY key;
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM test.cs;
-    """
+        """
     )
 
-    instance.query("DETACH TABLE test.cs")
+    instance.query(
+        """
+        DETACH TABLE test.cs;
+        DROP VIEW test.consumer;
+        """
+    )
     with nats_cluster.pause_container("nats1"):
         instance.query("ATTACH TABLE test.cs")
 
-    while not check_table_is_ready(instance, "test.cs"):
-        logging.debug("Table test.cs is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.cs")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.cs;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
 
     messages_num = 1000
     messages = []
@@ -1402,13 +1392,6 @@ def test_nats_no_connection_at_startup_2(nats_cluster):
         time.sleep(1)
         if int(result) == messages_num:
             break
-
-    instance.query(
-        """
-        DROP TABLE test.consumer;
-        DROP TABLE test.cs;
-    """
-    )
 
     assert int(result) == messages_num, "ClickHouse lost some messages: {}".format(
         result
@@ -1425,11 +1408,21 @@ def test_nats_format_factory_settings(nats_cluster):
                      nats_subjects = 'format_settings',
                      nats_format = 'JSONEachRow',
                      date_time_input_format = 'best_effort';
+        CREATE TABLE test.view (
+            id String, date DateTime
+        ) ENGINE = MergeTree ORDER BY id;
         """
     )
-    while not check_table_is_ready(instance, "test.format_settings"):
-        logging.debug("Table test.format_settings is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.format_settings")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.format_settings;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.format_settings")
+
 
     message = json.dumps(
         {"id": "format_settings_test", "date": "2021-01-19T14:42:33.1829214Z"}
@@ -1439,34 +1432,10 @@ def test_nats_format_factory_settings(nats_cluster):
     )
 
     asyncio.run(nats_produce_messages(nats_cluster, "format_settings", [message]))
-
-    while True:
-        result = instance.query("SELECT date FROM test.format_settings")
-        if result == expected:
-            break
-
-    instance.query(
-        """
-        CREATE TABLE test.view (
-            id String, date DateTime
-        ) ENGINE = MergeTree ORDER BY id;
-        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
-            SELECT * FROM test.format_settings;
-        """
-    )
-
-    asyncio.run(nats_produce_messages(nats_cluster, "format_settings", [message]))
     while True:
         result = instance.query("SELECT date FROM test.view")
         if result == expected:
             break
-
-    instance.query(
-        """
-        DROP TABLE test.consumer;
-        DROP TABLE test.format_settings;
-    """
-    )
 
     assert result == expected
 
@@ -1479,7 +1448,7 @@ def test_nats_bad_args(nats_cluster):
             SETTINGS nats_url = 'nats1:4444',
                      nats_secure = true,
                      nats_format = 'JSONEachRow';
-    """
+        """
     )
 
 
@@ -1494,67 +1463,103 @@ def test_nats_drop_mv(nats_cluster):
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
             ORDER BY key;
-        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
-            SELECT * FROM test.nats;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
-
-    messages = []
-    for i in range(20):
-        messages.append(json.dumps({"key": i, "value": i}))
-    asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
-
-    instance.query("DROP VIEW test.consumer")
-    messages = []
-    for i in range(20, 40):
-        messages.append(json.dumps({"key": i, "value": i}))
-    asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
+    wait_for_table_is_ready(instance, "test.nats")
 
     instance.query(
         """
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM test.nats;
-    """
+        """
     )
+    wait_for_mv_is_ready(instance, "test.nats")
+    
+    messages = []
+    for i in range(20):
+        messages.append(json.dumps({"key": i, "value": i}))
+    asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
+
+    wait_query_result(instance, "SELECT count() FROM test.view", 20)
+
+    instance.query("DROP VIEW test.consumer")
+    wait_for_table_is_ready(instance, "test.nats")
+
+    messages = []
+    for i in range(100, 200):
+        messages.append(json.dumps({"key": i, "value": i}))
+    asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
+
+    time.sleep (1)
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
+
+    messages = []
+    for i in range(20, 40):
+        messages.append(json.dumps({"key": i, "value": i}))
+    asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
+
+    wait_query_result(instance, "SELECT count() FROM test.view", 40)
+
+    instance.query("DROP VIEW test.consumer")
+    wait_for_table_is_ready(instance, "test.nats")
+
+    messages = []
+    for i in range(200, 400):
+        messages.append(json.dumps({"key": i, "value": i}))
+    asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
+
+    time.sleep (1)
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
+
     messages = []
     for i in range(40, 50):
         messages.append(json.dumps({"key": i, "value": i}))
     asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
-
-    while True:
-        result = instance.query("SELECT * FROM test.view ORDER BY key")
-        if nats_check_result(result):
-            break
-
-    nats_check_result(result, True)
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
     instance.query("DROP VIEW test.consumer")
+    wait_for_table_is_ready(instance, "test.nats")
+
     messages = []
-    for i in range(50, 60):
+    for i in range(400, 500):
         messages.append(json.dumps({"key": i, "value": i}))
     asyncio.run(nats_produce_messages(nats_cluster, "mv", messages))
-
-    count = 0
-    while True:
-        count = int(instance.query("SELECT count() FROM test.nats"))
-        if count:
-            break
-
-    assert count > 0
+    nats_check_query_result("SELECT * FROM test.view ORDER BY key")
 
 
 def test_nats_predefined_configuration(nats_cluster):
     instance.query(
         """
         CREATE TABLE test.nats (key UInt64, value UInt64)
-            ENGINE = NATS(nats1) """
+            ENGINE = NATS(nats1);
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree()
+            ORDER BY key;
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.nats;
+        """
+    )
+    wait_for_mv_is_ready(instance, "test.nats")
 
     asyncio.run(
         nats_produce_messages(
@@ -1563,7 +1568,7 @@ def test_nats_predefined_configuration(nats_cluster):
     )
     while True:
         result = instance.query(
-            "SELECT * FROM test.nats ORDER BY key", ignore_error=True
+            "SELECT * FROM test.view ORDER BY key", ignore_error=True
         )
         if result == "1\t2\n":
             break
@@ -1572,8 +1577,6 @@ def test_nats_predefined_configuration(nats_cluster):
 def test_format_with_prefix_and_suffix(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.nats;
-        
         CREATE TABLE test.nats (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -1581,9 +1584,7 @@ def test_format_with_prefix_and_suffix(nats_cluster):
                      nats_format = 'CustomSeparated';
     """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_table_is_ready(instance, "test.nats")
 
     insert_messages = []
 
@@ -1624,9 +1625,6 @@ def test_format_with_prefix_and_suffix(nats_cluster):
 def test_max_rows_per_message(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.view;
-        DROP TABLE IF EXISTS test.nats;
-           
         CREATE TABLE test.nats (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -1635,14 +1633,17 @@ def test_max_rows_per_message(nats_cluster):
                      nats_max_rows_per_message = 3,
                      format_custom_result_before_delimiter = '<prefix>\n',
                      format_custom_result_after_delimiter = '<suffix>\n';
-        
+        """
+    )
+    wait_for_table_is_ready(instance, "test.nats")
+
+    instance.query(
+        """
         CREATE MATERIALIZED VIEW test.view Engine=Log AS
         SELECT key, value FROM test.nats;
-    """
+        """
     )
-    while not check_table_is_ready(instance, "test.nats"):
-        logging.debug("Table test.nats is not yet ready")
-        time.sleep(0.5)
+    wait_for_mv_is_ready(instance, "test.nats")
 
     num_rows = 5
 
@@ -1728,15 +1729,17 @@ def test_row_based_formats(nats_cluster):
                 SETTINGS nats_url = 'nats1:4444',
                          nats_subjects = '{format_name}',
                          nats_format = '{format_name}';      
-    
+            """
+        )
+        wait_for_table_is_ready(instance, "test.nats")
+
+        instance.query(
+            """
             CREATE MATERIALIZED VIEW test.view Engine=Log AS
             SELECT key, value FROM test.nats;
-        """
+            """
         )
-
-        while not check_table_is_ready(instance, "test.nats"):
-            logging.debug("Table test.nats is not yet ready")
-            time.sleep(0.5)
+        wait_for_mv_is_ready(instance, "test.nats")
 
         insert_messages = 0
 
@@ -1792,8 +1795,6 @@ def test_row_based_formats(nats_cluster):
 def test_block_based_formats_1(nats_cluster):
     instance.query(
         """
-        DROP TABLE IF EXISTS test.nats;
-        
         CREATE TABLE test.nats (key UInt64, value UInt64)
             ENGINE = NATS
             SETTINGS nats_url = 'nats1:4444',
@@ -1885,15 +1886,17 @@ def test_block_based_formats_2(nats_cluster):
                 SETTINGS nats_url = 'nats1:4444',
                          nats_subjects = '{format_name}',
                          nats_format = '{format_name}';      
-    
+            """
+        )
+        wait_for_table_is_ready(instance, "test.nats")
+
+        instance.query(
+            """
             CREATE MATERIALIZED VIEW test.view Engine=Log AS
             SELECT key, value FROM test.nats;
-        """
+            """
         )
-
-        while not check_table_is_ready(instance, "test.nats"):
-            logging.debug("Table test.nats is not yet ready")
-            time.sleep(0.5)
+        wait_for_mv_is_ready(instance, "test.nats")
 
         insert_messages = 0
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fixed receiving messages from nats server without attached mv

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Previous behavior:
Immediately after creating or attaching a table on the nats engine, we establish a connection to the nats server and subscribe to events from it. If mv was not created or was detached, messages from the nats server fill the buffer in the consumer and were read from it after the attached mv appeared or were never read and lost after shutdown.

Behavior after fix:
After creating or attaching a table on the nats engine, we establish a connection, but do not subscribe to events. Subscription is performed only after creating or attaching mv. If mv was dropped or detached, we also unsubscribe from receiving messages from nats server

Known bugs in previous behavior and behavior after fix:
We can do not consume some recieved messages from consumers buffers after shutdown of clickhouse server. NATS server already received delivery ack, but messages will be lost after shutdown