### PR TITLE
Docs: fix docs check

### DIFF
--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -575,7 +575,7 @@ BACKUP TABLE default.test to S3(named_collection_s3_backups, 'directory')
 
 For the description of parameters see [mongodb](../sql-reference/table-functions/mongodb.md).
 
-### DDL example {#ddl-example}
+### DDL example {#ddl-example-5}
 
 ```sql
 CREATE NAMED COLLECTION mymongo AS
@@ -588,7 +588,7 @@ collection = 'my_collection',
 options = 'connectTimeoutMS=10000'
 ```
 
-### XML example {#xml-example}
+### XML example {#xml-example-5}
 
 ```xml
 <clickhouse>

--- a/docs/en/operations/named-collections.md
+++ b/docs/en/operations/named-collections.md
@@ -571,11 +571,11 @@ BACKUP TABLE default.test to S3(named_collection_s3_backups, 'directory')
 </clickhouse>
 ```
 
-## Named collections for accessing MongoDB Table and Dictionary
+## Named collections for accessing MongoDB Table and Dictionary {#named-collections-for-accessing-mongodb-table-and-dictionary}
 
 For the description of parameters see [mongodb](../sql-reference/table-functions/mongodb.md).
 
-### DDL example
+### DDL example {#ddl-example}
 
 ```sql
 CREATE NAMED COLLECTION mymongo AS
@@ -588,7 +588,7 @@ collection = 'my_collection',
 options = 'connectTimeoutMS=10000'
 ```
 
-### XML example
+### XML example {#xml-example}
 
 ```xml
 <clickhouse>
@@ -606,7 +606,7 @@ options = 'connectTimeoutMS=10000'
 </clickhouse>
 ```
 
-#### MongoDB table
+#### MongoDB table {#mongodb-table}
 
 ```sql
 CREATE TABLE mytable(log_type VARCHAR, host VARCHAR, command VARCHAR) ENGINE = MongoDB(mymongo, options='connectTimeoutMS=10000&compressors=zstd')
@@ -621,7 +621,7 @@ SELECT count() FROM mytable;
 The DDL overrides the named collection setting for options.
 :::
 
-#### MongoDB Dictionary
+#### MongoDB Dictionary {#mongodb-dictionary}
 
 ```sql
 CREATE DICTIONARY dict

--- a/docs/en/sql-reference/operators/distributed-ddl.md
+++ b/docs/en/sql-reference/operators/distributed-ddl.md
@@ -1,6 +1,6 @@
 ---
 title: Distributed DDL Queries (ON CLUSTER Clause)
-slug: en/sql-reference/other/distributed-ddl
+slug: /sql-reference/other/distributed-ddl
 description: Page for Distributed DDL
 sidebar_label: Distributed DDL
 ---


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fixes for failing docs check introduced with merge of https://github.com/ClickHouse/ClickHouse/pull/75258
Not sure why docs check didn't pick it up, will need to investigate.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
