### PR TITLE
Use fmt::format instead of std::format

### DIFF
--- a/src/Client/ProgressTable.cpp
+++ b/src/Client/ProgressTable.cpp
@@ -1,5 +1,4 @@
 #include "ProgressTable.h"
-#include "Common/AllocatorWithMemoryTracking.h"
 #include "Common/ProfileEvents.h"
 #include "base/defines.h"
 
@@ -13,10 +12,11 @@
 #include <Common/TerminalSize.h>
 #include <Common/formatReadable.h>
 
-#include <format>
 #include <mutex>
 #include <numeric>
 #include <unordered_map>
+
+#include <fmt/format.h>
 
 
 namespace DB
@@ -40,7 +40,7 @@ constexpr std::string_view SHOW_CURSOR = "\033[?25h";
 
 std::string moveUpNLines(size_t N)
 {
-    return std::format("\033[{}A", N);
+    return fmt::format("\033[{}A", N);
 }
 
 std::string formatReadableValue(ProfileEvents::ValueType value_type, double value)

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -30,7 +30,6 @@
 #include <fstream>
 
 #if USE_SSL
-#include <format>
 #include <IO/BufferWithOwnMemory.h>
 #include <Compression/ICompressionCodec.h>
 #include <Compression/CompressionCodecEncrypted.h>

--- a/src/Common/FileRenamer.cpp
+++ b/src/Common/FileRenamer.cpp
@@ -6,7 +6,6 @@
 
 #include <chrono>
 #include <filesystem>
-#include <format>
 #include <map>
 
 #include <boost/algorithm/string.hpp>

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -2,7 +2,7 @@
 #include "config.h"
 
 #include <filesystem>
-#include <format>
+
 #include <IO/Archives/ArchiveUtils.h>
 #include <IO/Archives/IArchiveReader.h>
 #include <IO/Archives/IArchiveWriter.h>
@@ -357,8 +357,8 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesInMemory)
         {
             for (int i = 0; i < files; i++)
             {
-                auto filename = std::format("{}.txt", i);
-                auto contents = std::format("The contents of {}.txt", i);
+                auto filename = fmt::format("{}.txt", i);
+                auto contents = fmt::format("The contents of {}.txt", i);
                 auto out = writer->writeFile(filename, times * contents.size());
                 for (int j = 0; j < times; j++)
                     writeString(contents, *out);
@@ -378,8 +378,8 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesInMemory)
 
     for (int i = 0; i < files; i++)
     {
-        auto filename = std::format("{}.txt", i);
-        auto contents = std::format("The contents of {}.txt", i);
+        auto filename = fmt::format("{}.txt", i);
+        auto contents = fmt::format("The contents of {}.txt", i);
         ASSERT_TRUE(reader->fileExists(filename));
         EXPECT_EQ(reader->getFileInfo(filename).uncompressed_size, times * contents.size());
 
@@ -460,8 +460,8 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesOnDisk)
         {
             for (int i = 0; i < files; i++)
             {
-                auto filename = std::format("{}.txt", i);
-                auto contents = std::format("The contents of {}.txt", i);
+                auto filename = fmt::format("{}.txt", i);
+                auto contents = fmt::format("The contents of {}.txt", i);
                 auto out = writer->writeFile(filename, times * contents.size());
                 for (int j = 0; j < times; j++)
                     writeString(contents, *out);
@@ -479,8 +479,8 @@ TEST_P(ArchiveReaderAndWriterTest, ManyFilesOnDisk)
 
     for (int i = 0; i < files; i++)
     {
-        auto filename = std::format("{}.txt", i);
-        auto contents = std::format("The contents of {}.txt", i);
+        auto filename = fmt::format("{}.txt", i);
+        auto contents = fmt::format("The contents of {}.txt", i);
         ASSERT_TRUE(reader->fileExists(filename));
         EXPECT_EQ(reader->getFileInfo(filename).uncompressed_size, times * contents.size());
 

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -9,9 +9,9 @@
 
 #include <Common/config_version.h>
 
-#include <format>
-#include <unistd.h>
 #include <boost/algorithm/string/trim.hpp>
+#include <fmt/format.h>
+#include <unistd.h>
 
 
 namespace DB
@@ -282,7 +282,7 @@ bool ClientInfo::clientVersionEquals(const ClientInfo & other, bool compare_patc
 
 String ClientInfo::getVersionStr() const
 {
-    return std::format("{}.{}.{} ({})", client_version_major, client_version_minor, client_version_patch, client_tcp_protocol_version);
+    return fmt::format("{}.{}.{} ({})", client_version_major, client_version_minor, client_version_patch, client_tcp_protocol_version);
 }
 
 void ClientInfo::fillOSUserHostNameAndVersionInfo()
@@ -323,7 +323,7 @@ String toString(ClientInfo::Interface interface)
             return "PROMETHEUS";
     }
 
-    return std::format("Unknown server interface ({}).", static_cast<int>(interface));
+    return fmt::format("Unknown server interface ({}).", static_cast<int>(interface));
 }
 
 void ClientInfo::setFromHTTPRequest(const Poco::Net::HTTPRequest & request)

--- a/src/Parsers/Kusto/Formatters.cpp
+++ b/src/Parsers/Kusto/Formatters.cpp
@@ -1,6 +1,8 @@
 #include "Formatters.h"
 
-#include <format>
+#include <fmt/format.h>
+
+#include <cmath>
 
 namespace DB
 {
@@ -14,13 +16,13 @@ std::string formatKQLTimespan(const Int64 ticks)
     const auto abs_ticks = std::abs(ticks);
     std::string result = ticks < 0 ? "-" : "";
     if (abs_ticks >= TICKS_PER_DAY)
-        result.append(std::format("{}.", abs_ticks / TICKS_PER_DAY));
+        result.append(fmt::format("{}.", abs_ticks / TICKS_PER_DAY));
 
-    result.append(std::format(
+    result.append(fmt::format(
         "{:02}:{:02}:{:02}", (abs_ticks / TICKS_PER_HOUR) % 24, (abs_ticks / TICKS_PER_MINUTE) % 60, (abs_ticks / TICKS_PER_SECOND) % 60));
 
     if (const auto fractional_second = abs_ticks % TICKS_PER_SECOND)
-        result.append(std::format(".{:07}", fractional_second));
+        result.append(fmt::format(".{:07}", fractional_second));
 
     return result;
 }

--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -6,7 +6,7 @@
 #include <base/EnumReflection.h>
 #include <pcg_random.hpp>
 #include <Poco/String.h>
-#include <format>
+
 #include <numeric>
 #include <stack>
 
@@ -197,7 +197,7 @@ String IParserKQLFunction::getConvertedArgument(const String & fn_name, IParser:
                         array_index += getExpression(pos);
                         ++pos;
                     }
-                    token = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+                    token = fmt::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
                 }
                 else
                     token = String(pos->begin, pos->end);
@@ -301,7 +301,7 @@ String IParserKQLFunction::kqlCallToExpression(
             return acc;
         });
 
-    const auto kql_call = std::format("{}({})", function_name, params_str);
+    const auto kql_call = fmt::format("{}({})", function_name, params_str);
     Tokens call_tokens(kql_call.data(), kql_call.data() + kql_call.length(), 0, true);
     IParser::Pos tokens_pos(call_tokens, max_depth, max_backtracks);
     return DB::IParserKQLFunction::getExpression(tokens_pos);
@@ -363,7 +363,7 @@ String IParserKQLFunction::getExpression(IParser::Pos & pos)
             array_index += getExpression(pos);
             ++pos;
         }
-        arg = std::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+        arg = fmt::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
     }
 
     return arg;

--- a/src/Parsers/Kusto/KustoFunctions/KQLBinaryFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLBinaryFunctions.cpp
@@ -15,8 +15,6 @@
 #include <Parsers/Kusto/ParserKQLStatement.h>
 #include <Parsers/ParserSetQuery.h>
 
-#include <format>
-
 namespace DB
 {
 
@@ -28,7 +26,7 @@ bool BinaryAnd::convertImpl(String & out, IParser::Pos & pos)
 
     const auto lhs = getArgument(function_name, pos);
     const auto rhs = getArgument(function_name, pos);
-    out = std::format("bitAnd(cast({0}, 'Int64'), cast({1}, 'Int64'))", lhs, rhs);
+    out = fmt::format("bitAnd(cast({0}, 'Int64'), cast({1}, 'Int64'))", lhs, rhs);
     return true;
 }
 
@@ -39,7 +37,7 @@ bool BinaryNot::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto value = getArgument(function_name, pos);
-    out = std::format("bitNot(cast({0}, 'Int64'))", value);
+    out = fmt::format("bitNot(cast({0}, 'Int64'))", value);
     return true;
 }
 
@@ -51,7 +49,7 @@ bool BinaryOr::convertImpl(String & out, IParser::Pos & pos)
 
     const auto lhs = getArgument(function_name, pos);
     const auto rhs = getArgument(function_name, pos);
-    out = std::format("bitOr(cast({0}, 'Int64'), cast({1}, 'Int64'))", lhs, rhs);
+    out = fmt::format("bitOr(cast({0}, 'Int64'), cast({1}, 'Int64'))", lhs, rhs);
     return true;
 }
 
@@ -63,7 +61,7 @@ bool BinaryShiftLeft::convertImpl(String & out, IParser::Pos & pos)
 
     const auto value = getArgument(function_name, pos);
     const auto count = getArgument(function_name, pos);
-    out = std::format("if({1} < 0, null, bitShiftLeft(cast({0}, 'Int64'), {1}))", value, count);
+    out = fmt::format("if({1} < 0, null, bitShiftLeft(cast({0}, 'Int64'), {1}))", value, count);
     return true;
 }
 
@@ -75,7 +73,7 @@ bool BinaryShiftRight::convertImpl(String & out, IParser::Pos & pos)
 
     const auto value = getArgument(function_name, pos);
     const auto count = getArgument(function_name, pos);
-    out = std::format("if({1} < 0, null, bitShiftRight(cast({0}, 'Int64'), {1}))", value, count);
+    out = fmt::format("if({1} < 0, null, bitShiftRight(cast({0}, 'Int64'), {1}))", value, count);
     return true;
 }
 
@@ -87,7 +85,7 @@ bool BinaryXor::convertImpl(String & out, IParser::Pos & pos)
 
     const auto lhs = getArgument(function_name, pos);
     const auto rhs = getArgument(function_name, pos);
-    out = std::format("bitXor(cast({0}, 'Int64'), cast({1}, 'Int64'))", lhs, rhs);
+    out = fmt::format("bitXor(cast({0}, 'Int64'), cast({1}, 'Int64'))", lhs, rhs);
     return true;
 }
 

--- a/src/Parsers/Kusto/KustoFunctions/KQLCastingFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLCastingFunctions.cpp
@@ -3,7 +3,6 @@
 #include <Parsers/Kusto/KustoFunctions/KQLCastingFunctions.h>
 #include <Parsers/Kusto/KustoFunctions/KQLFunctionFactory.h>
 
-#include <format>
 #include <Poco/String.h>
 #include <Common/re2.h>
 
@@ -17,7 +16,7 @@ bool ToBool::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto param = getArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "multiIf(toString({0}) = 'true', true, "
         "toString({0}) = 'false', false, toInt64OrNull(toString({0})) != 0)",
         param,
@@ -33,7 +32,7 @@ bool ToDateTime::convertImpl(String & out, IParser::Pos & pos)
 
     const auto param = getArgument(function_name, pos);
 
-    out = std::format("parseDateTime64BestEffortOrNull(toString({0}),9,'UTC')", param);
+    out = fmt::format("parseDateTime64BestEffortOrNull(toString({0}),9,'UTC')", param);
     return true;
 }
 
@@ -44,7 +43,7 @@ bool ToDouble::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto param = getArgument(function_name, pos);
-    out = std::format("toFloat64OrNull(toString({0}))", param);
+    out = fmt::format("toFloat64OrNull(toString({0}))", param);
     return true;
 }
 
@@ -55,7 +54,7 @@ bool ToInt::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto param = getArgument(function_name, pos);
-    out = std::format("toInt32OrNull(toString({0}))", param);
+    out = fmt::format("toInt32OrNull(toString({0}))", param);
     return true;
 }
 
@@ -66,7 +65,7 @@ bool ToLong::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto param = getArgument(function_name, pos);
-    out = std::format("toInt64OrNull(toString({0}))", param);
+    out = fmt::format("toInt64OrNull(toString({0}))", param);
     return true;
 }
 
@@ -77,7 +76,7 @@ bool ToString::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto param = getArgument(function_name, pos);
-    out = std::format("ifNull(toString({0}), '')", param);
+    out = fmt::format("ifNull(toString({0}), '')", param);
     return true;
 }
 bool ToTimeSpan::convertImpl(String & out, IParser::Pos & pos)
@@ -100,7 +99,7 @@ bool ToTimeSpan::convertImpl(String & out, IParser::Pos & pos)
         try
         {
             auto result = kqlCallToExpression("time", {arg}, pos.max_depth, pos.max_backtracks);
-            out = std::format("{}", result);
+            out = fmt::format("{}", result);
         }
         catch (...)
         {
@@ -108,7 +107,7 @@ bool ToTimeSpan::convertImpl(String & out, IParser::Pos & pos)
         }
     }
     else
-        out = std::format("{}", arg);
+        out = fmt::format("{}", arg);
 
     return true;
 }
@@ -148,7 +147,7 @@ bool ToDecimal::convertImpl(String & out, IParser::Pos & pos)
         else
             scale = std::stoi(res.substr(exponential_pos + 1, res.length()));
 
-        out = std::format("toDecimal128({}::String,{})", res, scale);
+        out = fmt::format("toDecimal128({}::String,{})", res, scale);
     }
     else
     {
@@ -161,7 +160,7 @@ bool ToDecimal::convertImpl(String & out, IParser::Pos & pos)
         if (scale < 0)
             out = "NULL";
         else
-            out = std::format("toDecimal128({}::String,{})", res, scale);
+            out = fmt::format("toDecimal128({}::String,{})", res, scale);
     }
 
     return true;

--- a/src/Parsers/Kusto/KustoFunctions/KQLDataTypeFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDataTypeFunctions.cpp
@@ -10,7 +10,8 @@
 #include <Parsers/Kusto/Utilities.h>
 #include <Parsers/ParserSetQuery.h>
 #include "Poco/String.h"
-#include <format>
+
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -34,7 +35,7 @@ bool DatatypeDatetime::convertImpl(String & out, IParser::Pos & pos)
 
     ++pos;
     if (pos->type == TokenType::QuotedIdentifier)
-        datetime_str = std::format("'{}'", String(pos->begin + 1, pos->end - 1));
+        datetime_str = fmt::format("'{}'", String(pos->begin + 1, pos->end - 1));
     else if (pos->type == TokenType::StringLiteral)
         datetime_str = String(pos->begin, pos->end);
     else if (pos->type == TokenType::BareWord)
@@ -43,7 +44,7 @@ bool DatatypeDatetime::convertImpl(String & out, IParser::Pos & pos)
         if (Poco::toUpper(datetime_str) == "NULL")
             out = "NULL";
         else
-            out = std::format(
+            out = fmt::format(
                 "if(toTypeName({0}) = 'Int64' OR toTypeName({0}) = 'Int32'OR toTypeName({0}) = 'Float64' OR  toTypeName({0}) = 'UInt32' OR "
                 " toTypeName({0}) = 'UInt64', toDateTime64({0},9,'UTC'), parseDateTime64BestEffortOrNull({0}::String,9,'UTC'))",
                 datetime_str);
@@ -59,9 +60,9 @@ bool DatatypeDatetime::convertImpl(String & out, IParser::Pos & pos)
                 break;
         }
         --pos;
-        datetime_str = std::format("'{}'", String(start->begin, pos->end));
+        datetime_str = fmt::format("'{}'", String(start->begin, pos->end));
     }
-    out = std::format("parseDateTime64BestEffortOrNull({},9,'UTC')", datetime_str);
+    out = fmt::format("parseDateTime64BestEffortOrNull({},9,'UTC')", datetime_str);
     ++pos;
     return true;
 }
@@ -127,7 +128,7 @@ bool DatatypeGuid::convertImpl(String & out, IParser::Pos & pos)
         --pos;
         guid_str = String(start->begin, pos->end);
     }
-    out = std::format("toUUIDOrNull('{}')", guid_str);
+    out = fmt::format("toUUIDOrNull('{}')", guid_str);
     ++pos;
     return true;
 }
@@ -143,7 +144,7 @@ bool DatatypeInt::convertImpl(String & out, IParser::Pos & pos)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "String is not parsed as int literal.");
 
     auto arg = getConvertedArgument(fn_name, pos);
-    out = std::format("toInt32({})", arg);
+    out = fmt::format("toInt32({})", arg);
     return true;
 }
 
@@ -163,7 +164,7 @@ bool DatatypeReal::convertImpl(String & out, IParser::Pos & pos)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "String is not parsed as double literal.");
 
     auto arg = getConvertedArgument(fn_name, pos);
-    out = std::format("toFloat64({})", arg);
+    out = fmt::format("toFloat64({})", arg);
     return true;
 }
 
@@ -193,9 +194,9 @@ bool DatatypeTimespan::convertImpl(String & out, IParser::Pos & pos)
     if (time_span.parse(pos, node, expected))
     {
         if (sign)
-            out = std::format("-{}::Float64", time_span.toSeconds());
+            out = fmt::format("-{}::Float64", time_span.toSeconds());
         else
-            out = std::format("{}::Float64", time_span.toSeconds());
+            out = fmt::format("{}::Float64", time_span.toSeconds());
         ++pos;
     }
     else
@@ -235,7 +236,7 @@ bool DatatypeDecimal::convertImpl(String & out, IParser::Pos & pos)
         else
             scale = std::stoi(arg.substr(exponential_pos + 1, arg.length()));
 
-        out = std::format("toDecimal128({}::String,{})", arg, scale);
+        out = fmt::format("toDecimal128({}::String,{})", arg, scale);
         return true;
     }
 
@@ -250,7 +251,7 @@ bool DatatypeDecimal::convertImpl(String & out, IParser::Pos & pos)
     if (scale < 0 || Poco::toUpper(arg) == "NULL")
         out = "NULL";
     else
-        out = std::format("toDecimal128({}::String,{})", arg, scale);
+        out = fmt::format("toDecimal128({}::String,{})", arg, scale);
 
     return true;
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLDateTimeFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDateTimeFunctions.cpp
@@ -1,4 +1,3 @@
-#include <format>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/IParserBase.h>
@@ -17,6 +16,9 @@
 #include <Parsers/Kusto/Utilities.h>
 #include <Parsers/ParserSetQuery.h>
 #include "Poco/String.h"
+
+#include <fmt/format.h>
+
 namespace DB::ErrorCodes
 {
 extern const int BAD_ARGUMENTS;
@@ -42,7 +44,7 @@ bool Ago::convertImpl(String & out, IParser::Pos & pos)
     if (pos->type != TokenType::ClosingRoundBracket)
     {
         const auto offset = getConvertedArgument(fn_name, pos);
-        out = std::format("now64(9,'UTC') - {}", offset);
+        out = fmt::format("now64(9,'UTC') - {}", offset);
     }
     else
         out = "now64(9,'UTC')";
@@ -70,7 +72,7 @@ bool DatetimeAdd::convertImpl(String & out, IParser::Pos & pos)
     ++pos;
     const String datetime = getConvertedArgument(fn_name, pos);
 
-    out = std::format("date_add({}, {}, {})", period, offset, datetime);
+    out = fmt::format("date_add({}, {}, {})", period, offset, datetime);
 
     return true;
 };
@@ -119,7 +121,7 @@ bool DatetimePart::convertImpl(String & out, IParser::Pos & pos)
     else
         throw Exception(ErrorCodes::SYNTAX_ERROR, "Unexpected argument {} for {}", part, fn_name);
 
-    out = std::format("formatDateTime({}, '{}')", date, format);
+    out = fmt::format("formatDateTime({}, '{}')", date, format);
     return true;
 }
 
@@ -137,7 +139,7 @@ bool DatetimeDiff::convertImpl(String & out, IParser::Pos & pos)
     ++pos;
     arguments = arguments + getConvertedArgument(fn_name, pos);
 
-    out = std::format("DateDiff({}) * -1", arguments);
+    out = fmt::format("DateDiff({}) * -1", arguments);
     return true;
 }
 
@@ -154,7 +156,7 @@ bool DayOfWeek::convertImpl(String & out, IParser::Pos & pos)
     ++pos;
     const String datetime_str = getConvertedArgument(fn_name, pos);
 
-    out = std::format("concat((toDayOfWeek({})%7)::String, '.00:00:00')", datetime_str);
+    out = fmt::format("concat((toDayOfWeek({})%7)::String, '.00:00:00')", datetime_str);
     return true;
 }
 
@@ -180,7 +182,7 @@ bool EndOfMonth::convertImpl(String & out, IParser::Pos & pos)
         if (offset.empty())
             throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
     }
-    out = std::format(
+    out = fmt::format(
         "toDateTime(toLastDayOfMonth(toDateTime({}, 9, 'UTC') + toIntervalMonth({})), 9, 'UTC') + toIntervalHour(23) + "
         "toIntervalMinute(59) + toIntervalSecond(60) - toIntervalMicrosecond(1)",
         datetime_str,
@@ -204,7 +206,7 @@ bool EndOfDay::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         offset = getConvertedArgument(fn_name, pos);
     }
-    out = std::format(
+    out = fmt::format(
         "toDateTime(toStartOfDay({}),9,'UTC') + (INTERVAL {} +1 DAY) - (INTERVAL 1 microsecond)", datetime_str, toString(offset));
 
     return true;
@@ -225,7 +227,7 @@ bool EndOfWeek::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         offset = getConvertedArgument(fn_name, pos);
     }
-    out = std::format(
+    out = fmt::format(
         "toDateTime(toStartOfDay({}),9,'UTC') + (INTERVAL {} +1 WEEK) - (INTERVAL 1 microsecond)", datetime_str, toString(offset));
 
     return true;
@@ -253,7 +255,7 @@ bool EndOfYear::convertImpl(String & out, IParser::Pos & pos)
         offset.erase(remove(offset.begin(), offset.end(), ' '), offset.end());
     }
 
-    out = std::format(
+    out = fmt::format(
         "(((((toDateTime(toString(toLastDayOfMonth(toDateTime({0}, 9, 'UTC') + toIntervalYear({1}) + toIntervalMonth(12 - "
         "toInt8(substring(toString(toDateTime({0}, 9, 'UTC')), 6, 2))))), 9, 'UTC') + toIntervalHour(23)) + toIntervalMinute(59)) + "
         "toIntervalSecond(60)) - toIntervalMicrosecond(1)))",
@@ -333,7 +335,7 @@ bool FormatDateTime::convertImpl(String & out, IParser::Pos & pos)
     }
     if (decimal > 0 && formatspecifier.contains('.'))
     {
-        out = std::format(
+        out = fmt::format(
             "concat("
             "substring(toString(formatDateTime({0} , '{1}')),1, position(toString(formatDateTime({0},'{1}')),'.')) ,"
             "substring(substring(toString({0}), position(toString({0}),'.')+1),1,{2}),"
@@ -344,7 +346,7 @@ bool FormatDateTime::convertImpl(String & out, IParser::Pos & pos)
             decimal);
     }
     else
-        out = std::format("formatDateTime({0},'{1}')", datetime, formatspecifier);
+        out = fmt::format("formatDateTime({0},'{1}')", datetime, formatspecifier);
 
     return true;
 }
@@ -426,7 +428,7 @@ bool FormatTimeSpan::convertImpl(String & out, IParser::Pos & pos)
         if (decimal > 0)
         {
             if (format.substr(format.length() - decimal - 1, 1) == last_delim)
-                out = std::format(
+                out = fmt::format(
                     "concat(substring(toString(formatDateTime(toDateTime64({0},9,'UTC') ,'{1}')),1, length(toString(formatDateTime("
                     "toDateTime64({0},9,'UTC'),'{1}'))) - position("
                     "reverse(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}'))),'{3}')+1),substring(SUBSTRING(toString("
@@ -436,7 +438,7 @@ bool FormatTimeSpan::convertImpl(String & out, IParser::Pos & pos)
                     decimal,
                     last_delim);
             else
-                out = std::format(
+                out = fmt::format(
                     "concat(substring(toString(formatDateTime(toDateTime64({0},9,'UTC') ,'{1}')),1, length(toString(formatDateTime("
                     "toDateTime64({0},9,'UTC'),'{1}'))) - position("
                     "reverse(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}'))),'{3}')),substring(SUBSTRING(toString(toDateTime64({"
@@ -447,14 +449,14 @@ bool FormatTimeSpan::convertImpl(String & out, IParser::Pos & pos)
                     last_delim);
         }
         else
-            out = std::format("formatDateTime(toDateTime64({0},9,'UTC'),'{1}')", datetime, formatspecifier);
+            out = fmt::format("formatDateTime(toDateTime64({0},9,'UTC'),'{1}')", datetime, formatspecifier);
     }
     else
     {
         if (decimal > 0)
         {
             if (format.substr(format.length() - decimal - 1, 1) == last_delim)
-                out = std::format(
+                out = fmt::format(
                     "concat(leftPad('{5}', {3},'0'),substring(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}')),1,"
                     "length(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}'))) - position("
                     "reverse(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}'))),'{4}') "
@@ -467,7 +469,7 @@ bool FormatTimeSpan::convertImpl(String & out, IParser::Pos & pos)
                     last_delim,
                     day_val);
             else
-                out = std::format(
+                out = fmt::format(
                     "concat(leftPad('{5}', {3}, '0'),substring(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}')),1,"
                     "length(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}'))) - position("
                     "reverse(toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}'))),'{4}')),substring(SUBSTRING(toString(toDateTime64({"
@@ -482,7 +484,7 @@ bool FormatTimeSpan::convertImpl(String & out, IParser::Pos & pos)
                     day_val);
         }
         else if (decimal == 0)
-            out = std::format(
+            out = fmt::format(
                 "concat(leftPad('{3}',{2},'0'),toString(formatDateTime(toDateTime64({0},9,'UTC'),'{1}')))",
                 datetime,
                 formatspecifier,
@@ -573,7 +575,7 @@ bool MakeTimeSpan::convertImpl(String & out, IParser::Pos & pos)
     //Add dummy yyyy-mm-dd to parse datetime in CH
     datetime_str = "0000-00-00 " + datetime_str;
 
-    out = std::format(
+    out = fmt::format(
         "CONCAT('{}',toString(SUBSTRING(toString(toTime(parseDateTime64BestEffortOrNull('{}', 9,'UTC'))),12)))", day, datetime_str);
     return true;
 }
@@ -608,7 +610,7 @@ bool MakeDateTime::convertImpl(String & out, IParser::Pos & pos)
     }
 
     arguments = arguments + "7,'UTC'";
-    out = std::format("makeDateTime64({})", arguments);
+    out = fmt::format("makeDateTime64({})", arguments);
 
     return true;
 }
@@ -623,7 +625,7 @@ bool Now::convertImpl(String & out, IParser::Pos & pos)
     if (pos->type != TokenType::ClosingRoundBracket)
     {
         const auto offset = getConvertedArgument(fn_name, pos);
-        out = std::format("now64(9,'UTC') + {}", offset);
+        out = fmt::format("now64(9,'UTC') + {}", offset);
     }
     else
         out = "now64(9,'UTC')";
@@ -646,7 +648,7 @@ bool StartOfDay::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         offset = getConvertedArgument(fn_name, pos);
     }
-    out = std::format("date_add(DAY,{}, parseDateTime64BestEffortOrNull(toString((toStartOfDay({}))), 9, 'UTC')) ", offset, datetime_str);
+    out = fmt::format("date_add(DAY,{}, parseDateTime64BestEffortOrNull(toString((toStartOfDay({}))), 9, 'UTC')) ", offset, datetime_str);
     return true;
 }
 
@@ -665,7 +667,7 @@ bool StartOfMonth::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         offset = getConvertedArgument(fn_name, pos);
     }
-    out = std::format(
+    out = fmt::format(
         "date_add(MONTH,{}, parseDateTime64BestEffortOrNull(toString((toStartOfMonth({}))), 9, 'UTC')) ", offset, datetime_str);
     return true;
 }
@@ -685,7 +687,7 @@ bool StartOfWeek::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         offset = getConvertedArgument(fn_name, pos);
     }
-    out = std::format(
+    out = fmt::format(
         "date_add(Week,{}, parseDateTime64BestEffortOrNull(toString((toStartOfWeek({}))), 9, 'UTC')) ", offset, datetime_str);
     return true;
 }
@@ -705,7 +707,7 @@ bool StartOfYear::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         offset = getConvertedArgument(fn_name, pos);
     }
-    out = std::format(
+    out = fmt::format(
         "date_add(YEAR,{}, parseDateTime64BestEffortOrNull(toString((toStartOfYear({}, 'UTC'))), 9, 'UTC'))", offset, datetime_str);
     return true;
 }
@@ -719,7 +721,7 @@ bool UnixTimeMicrosecondsToDateTime::convertImpl(String & out, IParser::Pos & po
     ++pos;
     const String value = getConvertedArgument(fn_name, pos);
 
-    out = std::format("fromUnixTimestamp64Micro({},'UTC')", value);
+    out = fmt::format("fromUnixTimestamp64Micro({},'UTC')", value);
     return true;
 }
 
@@ -732,7 +734,7 @@ bool UnixTimeMillisecondsToDateTime::convertImpl(String & out, IParser::Pos & po
     ++pos;
     const String value = getConvertedArgument(fn_name, pos);
 
-    out = std::format("fromUnixTimestamp64Milli({},'UTC')", value);
+    out = fmt::format("fromUnixTimestamp64Milli({},'UTC')", value);
     return true;
 }
 
@@ -745,7 +747,7 @@ bool UnixTimeNanosecondsToDateTime::convertImpl(String & out, IParser::Pos & pos
     ++pos;
     const String value = getConvertedArgument(fn_name, pos);
 
-    out = std::format("fromUnixTimestamp64Nano({},'UTC')", value);
+    out = fmt::format("fromUnixTimestamp64Nano({},'UTC')", value);
     return true;
 }
 
@@ -760,7 +762,7 @@ bool UnixTimeSecondsToDateTime::convertImpl(String & out, IParser::Pos & pos)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} accepts only long, int and double type of arguments", fn_name);
 
     String expression = getConvertedArgument(fn_name, pos);
-    out = std::format(
+    out = fmt::format(
         " if(toTypeName({0}) = 'Int64' OR toTypeName({0}) = 'Int32'OR toTypeName({0}) = 'Float64' OR  toTypeName({0}) = 'UInt32' OR  "
         "toTypeName({0}) = 'UInt64', toDateTime64({0}, 9, 'UTC'), toDateTime64(throwIf(true, '{1} only accepts Int, Long and double type "
         "of arguments'), 9, 'UTC'))",
@@ -777,7 +779,7 @@ bool WeekOfYear::convertImpl(String & out, IParser::Pos & pos)
         return false;
     ++pos;
     const String time_str = getConvertedArgument(fn_name, pos);
-    out = std::format("toWeek({},3,'UTC')", time_str);
+    out = fmt::format("toWeek({},3,'UTC')", time_str);
     return true;
 }
 

--- a/src/Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.cpp
@@ -9,7 +9,7 @@
 #include <Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.h>
 #include <Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.h>
 
-#include <format>
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -34,7 +34,7 @@ bool ArrayIif::convertImpl(String & out, IParser::Pos & pos)
     const auto if_true = getArgument(function_name, pos);
     const auto if_false = getArgument(function_name, pos);
 
-    out = std::format(
+    out = fmt::format(
         "arrayMap(x -> multiIf(toTypeName(x.1) = 'String', null, toInt64(x.1) != 0, x.2, x.3), "
         "arrayZip({0}, arrayResize({1}, length({0}), null), arrayResize({2}, length({0}), null)))",
         conditions,
@@ -69,7 +69,7 @@ bool ArrayReverse::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto array = getArgument(function_name, pos);
-    out = std::format("if(throwIf(not startsWith(toTypeName({0}), 'Array'), 'Only arrays are supported'), [], reverse({0}))", array);
+    out = fmt::format("if(throwIf(not startsWith(toTypeName({0}), 'Array'), 'Only arrays are supported'), [], reverse({0}))", array);
 
     return true;
 }
@@ -82,7 +82,7 @@ bool ArrayRotateLeft::convertImpl(String & out, IParser::Pos & pos)
 
     const auto array = getArgument(function_name, pos);
     const auto count = getArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "arrayMap(x -> {0}[moduloOrZero(x + length({0}) + moduloOrZero({1}, toInt64(length({0}))), length({0})) + 1], "
         "range(0, length({0})))",
         array,
@@ -113,7 +113,7 @@ bool ArrayShiftLeft::convertImpl(String & out, IParser::Pos & pos)
     const auto array = getArgument(function_name, pos);
     const auto count = getArgument(function_name, pos);
     const auto fill = getOptionalArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "arrayResize(if({1} > 0, arraySlice({0}, {1} + 1), arrayConcat(arrayWithConstant(abs({1}), fill_value_{3}), {0})), "
         "length({0}), if(isNull({2}) and (extract(toTypeName({0}), 'Array\\((.*)\\)') as element_type_{3}) = 'String', "
         "defaultValueOfTypeName(if(element_type_{3} = 'Nothing', 'Nullable(Nothing)', element_type_{3})), {2}) as fill_value_{3})",
@@ -155,7 +155,7 @@ bool ArraySlice::convertImpl(String & out, IParser::Pos & pos)
     const auto start = getArgument(function_name, pos);
     const auto end = getArgument(function_name, pos);
 
-    out = std::format(
+    out = fmt::format(
         "arraySlice({0}, plus(1, if({1} >= 0, {1}, arrayMax([-length({0}), {1}]) + length({0}))) as offset_{3}, "
         "                plus(1, if({2} >= 0, {2}, arrayMax([-length({0}), {2}]) + length({0}))) - offset_{3} + 1)",
         array,
@@ -185,7 +185,7 @@ bool ArraySplit::convertImpl(String & out, IParser::Pos & pos)
     const auto array = getArgument(function_name, pos);
     const auto indices = getArgument(function_name, pos);
 
-    out = std::format(
+    out = fmt::format(
         "if(empty(arrayMap(x -> if(x >= 0, x, arrayMax([0, x + length({0})::Int64])), flatten([{1}])) as indices_{2}), [{0}], "
         "arrayConcat([arraySlice({0}, 1, indices_{2}[1])], arrayMap(i -> arraySlice({0}, indices_{2}[i] + 1, "
         "if(i = length(indices_{2}), length({0})::Int64, indices_{2}[i + 1]::Int64) - indices_{2}[i]), "
@@ -231,7 +231,7 @@ bool JaccardIndex::convertImpl(String & out, IParser::Pos & pos)
 
     const auto lhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
-    out = std::format(
+    out = fmt::format(
         "divide(length({0}), length({1}))",
         kqlCallToExpression("set_intersect", {lhs, rhs}, pos.max_depth, pos.max_backtracks),
         kqlCallToExpression("set_union", {lhs, rhs}, pos.max_depth, pos.max_backtracks));
@@ -272,7 +272,7 @@ bool Repeat::convertImpl(String & out, IParser::Pos & pos)
 
     if (count.empty())
         throw Exception(ErrorCodes::SYNTAX_ERROR, "number of arguments do not match in function: {}", function_name);
-    out = "if(" + count + " < 0, [NULL], " + std::format("arrayWithConstant(abs({1}), {0}))", value, count);
+    out = "if(" + count + " < 0, [NULL], " + fmt::format("arrayWithConstant(abs({1}), {0}))", value, count);
 
     return true;
 }
@@ -294,7 +294,7 @@ bool SetDifference::convertImpl(String & out, IParser::Pos & pos)
             return kqlCallToExpression("set_union", std::vector<std::string_view>(arrays.cbegin(), arrays.cend()), pos.max_depth, pos.max_backtracks);
         });
 
-    out = std::format("arrayFilter(x -> not has({1}, x), arrayDistinct({0}))", lhs, rhs);
+    out = fmt::format("arrayFilter(x -> not has({1}, x), arrayDistinct({0}))", lhs, rhs);
 
     return true;
 }
@@ -314,7 +314,7 @@ bool SetUnion::convertImpl(String & out, IParser::Pos & pos)
     if (!directMapping(out, pos, "arrayConcat"))
         return false;
 
-    out = std::format("arrayDistinct({0})", out);
+    out = fmt::format("arrayDistinct({0})", out);
 
     return true;
 }
@@ -354,7 +354,7 @@ bool Zip::convertImpl(String & out, IParser::Pos & pos)
             for (int i = 0; i < std::ssize(arguments); ++i)
             {
                 lengths.append(i > 0 ? ", " : "");
-                lengths.append(std::format(
+                lengths.append(fmt::format(
                     "length(if(match(toTypeName({0}), 'Array\\(Nullable\\(.*\\)\\)'), {0}, "
                     "cast({0}, concat('Array(Nullable(', extract(toTypeName({0}), 'Array\\((.*)\\)'), '))'))) as arg{1}_{2})",
                     arguments[i],
@@ -362,14 +362,14 @@ bool Zip::convertImpl(String & out, IParser::Pos & pos)
                     unique_identifier));
             }
 
-            auto result = std::format("arrayResize(arg0_{1}, arrayMax([{0}]) as max_length_{1}, null)", lengths, unique_identifier);
+            auto result = fmt::format("arrayResize(arg0_{1}, arrayMax([{0}]) as max_length_{1}, null)", lengths, unique_identifier);
             for (int i = 1; i < std::ssize(arguments); ++i)
-                result.append(std::format(", arrayResize(arg{0}_{1}, max_length_{1}, null)", i, unique_identifier));
+                result.append(fmt::format(", arrayResize(arg{0}_{1}, max_length_{1}, null)", i, unique_identifier));
 
             return result;
         });
 
-    out = std::format("arrayMap(t -> [untuple(t)], arrayZip({0}))", resized_arguments);
+    out = fmt::format("arrayMap(t -> [untuple(t)], arrayZip({0}))", resized_arguments);
 
     return true;
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -16,7 +16,8 @@
 #include <Parsers/Kusto/ParserKQLStatement.h>
 #include <Parsers/ParserSetQuery.h>
 #include <boost/lexical_cast.hpp>
-#include <format>
+
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -38,24 +39,24 @@ bool Bin::convertImpl(String & out, IParser::Pos & pos)
     //remove sapce between minus and number
     round_to.erase(std::remove_if(round_to.begin(), round_to.end(), isspace), round_to.end());
 
-    auto t = std::format("toFloat64({})", value);
+    auto t = fmt::format("toFloat64({})", value);
 
     bin_size = std::stod(round_to);
 
     if (origal_expr == "datetime" || origal_expr == "date")
     {
-        out = std::format("toDateTime64(toInt64({0}/{1}) * {1}, 9, 'UTC')", t, bin_size);
+        out = fmt::format("toDateTime64(toInt64({0}/{1}) * {1}, 9, 'UTC')", t, bin_size);
     }
     else if (origal_expr == "timespan" || origal_expr == "time" || ParserKQLDateTypeTimespan().parseConstKQLTimespan(origal_expr))
     {
-        String bin_value = std::format("toInt64({0}/{1}) * {1}", t, bin_size);
-        out = std::format(
+        String bin_value = fmt::format("toInt64({0}/{1}) * {1}", t, bin_size);
+        out = fmt::format(
             "concat(toString(toInt32((({}) as x) / 3600)),':', toString(toInt32(x % 3600 / 60)),':',toString(toInt32(x % 3600 % 60)))",
             bin_value);
     }
     else
     {
-        out = std::format("toInt64({0} / {1}) * {1}", t, bin_size);
+        out = fmt::format("toInt64({0} / {1}) * {1}", t, bin_size);
     }
     return true;
 }
@@ -77,25 +78,25 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
     ++pos;
     String fixed_point_str = getConvertedArgument(fn_name, pos);
 
-    auto t1 = std::format("toFloat64({})", fixed_point_str);
-    auto t2 = std::format("toFloat64({})", expression_str);
+    auto t1 = fmt::format("toFloat64({})", fixed_point_str);
+    auto t2 = fmt::format("toFloat64({})", expression_str);
     int dir = t2 >= t1 ? 0 : -1;
     bin_size = std::stod(bin_size_str);
 
     if (origal_expr == "datetime" || origal_expr == "date")
     {
-        out = std::format("toDateTime64({} + toInt64(({} - {}) / {} + {}) * {}, 9, 'UTC')", t1, t2, t1, bin_size, dir, bin_size);
+        out = fmt::format("toDateTime64({} + toInt64(({} - {}) / {} + {}) * {}, 9, 'UTC')", t1, t2, t1, bin_size, dir, bin_size);
     }
     else if (origal_expr == "timespan" || origal_expr == "time" || ParserKQLDateTypeTimespan().parseConstKQLTimespan(origal_expr))
     {
-        String bin_value = std::format("{} + toInt64(({} - {}) / {} + {}) * {}", t1, t2, t1, bin_size, dir, bin_size);
-        out = std::format(
+        String bin_value = fmt::format("{} + toInt64(({} - {}) / {} + {}) * {}", t1, t2, t1, bin_size, dir, bin_size);
+        out = fmt::format(
             "concat(toString(toInt32((({}) as x) / 3600)),':', toString(toInt32(x % 3600 / 60)), ':', toString(toInt32(x % 3600 % 60)))",
             bin_value);
     }
     else
     {
-        out = std::format("{} + toInt64(({} - {}) / {} + {}) * {}", t1, t2, t1, bin_size, dir, bin_size);
+        out = fmt::format("{} + toInt64(({} - {}) / {} + {}) * {}", t1, t2, t1, bin_size, dir, bin_size);
     }
     return true;
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLIPFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLIPFunctions.cpp
@@ -15,7 +15,7 @@
 #include <Parsers/Kusto/ParserKQLStatement.h>
 #include <Parsers/ParserSetQuery.h>
 
-#include <format>
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -28,7 +28,7 @@ bool Ipv4Compare::convertImpl(String & out, IParser::Pos & pos)
     const auto lhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Parsed);
-    out = std::format(
+    out = fmt::format(
         "if(isNull({0} as lhs_ip_{5}) or isNull({1} as lhs_mask_{5}) "
         "or isNull({2} as rhs_ip_{5}) or isNull({3} as rhs_mask_{5}), null, "
         "sign(IPv4StringToNumOrNull(toString((tupleElement(IPv4CIDRToRange(assumeNotNull(lhs_ip_{5}), "
@@ -51,7 +51,7 @@ bool Ipv4IsInRange::convertImpl(String & out, IParser::Pos & pos)
 
     const auto ip_address = getArgument(function_name, pos, ArgumentState::Parsed);
     const auto ip_range = getArgument(function_name, pos, ArgumentState::Raw);
-    out = std::format(
+    out = fmt::format(
         "if(isNull(IPv4StringToNumOrNull({0}) as ip_{3}) "
         "or isNull({1} as range_start_ip_{3}) or isNull({2} as range_mask_{3}), null, "
         "bitXor(range_start_ip_{3}, bitAnd(ip_{3}, bitNot(toUInt32(intExp2(toInt32(32 - range_mask_{3})) - 1)))) = 0) ",
@@ -71,7 +71,7 @@ bool Ipv4IsMatch::convertImpl(String & out, IParser::Pos & pos)
     const auto lhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Raw);
-    out = std::format("equals({}, 0)", kqlCallToExpression("ipv4_compare", {lhs, rhs, mask ? *mask : "32"}, pos.max_depth, pos.max_backtracks));
+    out = fmt::format("equals({}, 0)", kqlCallToExpression("ipv4_compare", {lhs, rhs, mask ? *mask : "32"}, pos.max_depth, pos.max_backtracks));
     return true;
 }
 
@@ -86,7 +86,7 @@ bool Ipv4IsPrivate::convertImpl(String & out, IParser::Pos & pos)
     const auto ip_address = getArgument(function_name, pos);
     const auto unique_identifier = generateUniqueIdentifier();
 
-    out += std::format(
+    out += fmt::format(
         "multiIf(length(splitByChar('/', {0}) as tokens_{1}) > 2 or isNull(toIPv4OrNull(tokens_{1}[1]) as nullable_ip_{1}) "
         "or length(tokens_{1}) = 2 and isNull(toUInt8OrNull(tokens_{1}[-1]) as mask_{1}), null, "
         "ignore(assumeNotNull(nullable_ip_{1}) as ip_{1}, "
@@ -100,7 +100,7 @@ bool Ipv4IsPrivate::convertImpl(String & out, IParser::Pos & pos)
             out += " or ";
 
         const auto & subnet = s_private_subnets[i];
-        out += std::format(
+        out += fmt::format(
             "length(tokens_{1}) = 1 and isIPAddressInRange(IPv4NumToString(ip_{1}), '{0}') or "
             "length(tokens_{1}) = 2 and isIPAddressInRange(begin_{1}, '{0}') and isIPAddressInRange(end_{1}, '{0}')",
             subnet,
@@ -118,7 +118,7 @@ bool Ipv4NetmaskSuffix::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto ip_range = getArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "multiIf(length(splitByChar('/', {0}) as tokens_{1}) > 2 or not isIPv4String(tokens_{1}[1]), null, "
         "length(tokens_{1}) = 1, 32, isNull(toUInt8OrNull(tokens_{1}[-1]) as mask_{1}), null, toUInt8(min2(mask_{1}, 32)))",
         ip_range,
@@ -133,7 +133,7 @@ bool ParseIpv4::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto ip_address = getArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "multiIf(length(splitByChar('/', {0}) as tokens_{1}) = 1, IPv4StringToNumOrNull(tokens_{1}[1]) as ip_{1}, "
         "length(tokens_{1}) = 2 and isNotNull(ip_{1}) and isNotNull(toUInt8OrNull(tokens_{1}[-1]) as mask_{1}), "
         "IPv4StringToNumOrNull(toString(tupleElement(IPv4CIDRToRange(toIPv4(assumeNotNull(ip_{1})), assumeNotNull(mask_{1})), 1))), null)",
@@ -150,7 +150,7 @@ bool ParseIpv4Mask::convertImpl(String & out, IParser::Pos & pos)
 
     const auto ip_address = getArgument(function_name, pos);
     const auto mask = getArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "if(isNull(toIPv4OrNull({0}) as ip_{2}) or isNull(toUInt8OrNull(toString({1})) as mask_{2}), null, "
         "toUInt32(tupleElement(IPv4CIDRToRange(assumeNotNull(ip_{2}), arrayMax([0, arrayMin([32, assumeNotNull(mask_{2})])])), 1)))",
         ip_address,
@@ -169,7 +169,7 @@ bool Ipv6Compare::convertImpl(String & out, IParser::Pos & pos)
     const auto rhs = getArgument(function_name, pos);
     const auto mask = getOptionalArgument(function_name, pos);
     const auto calculated_mask = mask ? *mask : "128";
-    out = std::format(
+    out = fmt::format(
         "if(length(splitByChar('/', {1}) as lhs_tokens_{0}) > 2 or length(splitByChar('/', {2}) as rhs_tokens_{0}) > 2 "
         "or isNull(IPv6StringToNumOrNull(lhs_tokens_{0}[1]) as lhs_ipv6_{0}) or length(lhs_tokens_{0}) = 2 "
         "and isNull((if(isIPv4String(lhs_tokens_{0}[1]), 96, 0) + toUInt8OrNull(lhs_tokens_{0}[-1])) as lhs_suffix_{0}) "
@@ -196,7 +196,7 @@ bool Ipv6IsMatch::convertImpl(String & out, IParser::Pos & pos)
     const auto lhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Raw);
-    out = std::format("equals({}, 0)", kqlCallToExpression("ipv6_compare", {lhs, rhs, mask ? *mask : "128"}, pos.max_depth, pos.max_backtracks));
+    out = fmt::format("equals({}, 0)", kqlCallToExpression("ipv6_compare", {lhs, rhs, mask ? *mask : "128"}, pos.max_depth, pos.max_backtracks));
     return true;
 }
 
@@ -207,7 +207,7 @@ bool ParseIpv6::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto ip_address = getArgument(function_name, pos);
-    out = std::format(
+    out = fmt::format(
         "if(length(splitByChar('/', assumeNotNull({0})) as tokens_{1}) > 2 or isNull(IPv6StringToNumOrNull(tokens_{1}[1]) as ip_{1}) "
         "or length(tokens_{1}) = 2 and isNull(toUInt8OrNull(tokens_{1}[-1]) as mask_{1}), null, "
         "arrayStringConcat(flatten(extractAllGroups(lower(hex(tupleElement(IPv6CIDRToRange(assumeNotNull(ip_{1}), toUInt8(ifNull(mask_{1} "
@@ -226,7 +226,7 @@ bool ParseIpv6Mask::convertImpl(String & out, IParser::Pos & pos)
     const auto ip_address = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getArgument(function_name, pos, ArgumentState::Raw);
     const auto unique_identifier = generateUniqueIdentifier();
-    out = std::format(
+    out = fmt::format(
         "if(empty({0} as ipv4_{3}), {1}, {2})",
         kqlCallToExpression("format_ipv4", {"trim_start('::', " + ip_address + ")", mask + " - 96"}, pos.max_depth, pos.max_backtracks),
         kqlCallToExpression("parse_ipv6", {"strcat(tostring(parse_ipv6(" + ip_address + ")), '/', tostring(" + mask + "))"}, pos.max_depth, pos.max_backtracks),
@@ -243,7 +243,7 @@ bool FormatIpv4::convertImpl(String & out, IParser::Pos & pos)
 
     const auto ip_address = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Parsed);
-    out = std::format(
+    out = fmt::format(
         "ifNull(if(isNotNull(toUInt32OrNull(toString({0})) as param_as_uint32_{3}) and toTypeName({0}) = 'String' or ({1}) < 0 "
         "or isNull(ifNull(param_as_uint32_{3}, {2}) as ip_as_number_{3}), null, "
         "IPv4NumToString(bitAnd(ip_as_number_{3}, bitNot(toUInt32(intExp2(toInt32(32 - ({1}))) - 1))))), '')",
@@ -263,7 +263,7 @@ bool FormatIpv4Mask::convertImpl(String & out, IParser::Pos & pos)
     const auto ip_address = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Raw);
     const auto calculated_mask = mask ? *mask : "32";
-    out = std::format(
+    out = fmt::format(
         "if(empty({1} as formatted_ip_{2}) or position(toTypeName({0}), 'Int') = 0 or not {0} between 0 and 32, '', "
         "concat(formatted_ip_{2}, '/', toString(toInt64(min2({0}, ifNull({3} as suffix_{2}, 32))))))",
         ParserKQLBase::getExprFromToken(calculated_mask, pos.max_depth, pos.max_backtracks),

--- a/src/Parsers/Kusto/KustoFunctions/KQLMathematicalFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLMathematicalFunctions.cpp
@@ -1,6 +1,6 @@
 #include "KQLMathematicalFunctions.h"
 
-#include <format>
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -11,7 +11,7 @@ bool IsNan::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     const auto argument = getArgument(function_name, pos);
-    out = std::format("if(toTypeName({0}) = 'Float64', isNaN({0}), throwIf(true, 'Expected argument of data type real'))", argument);
+    out = fmt::format("if(toTypeName({0}) = 'Float64', isNaN({0}), throwIf(true, 'Expected argument of data type real'))", argument);
 
     return true;
 }

--- a/src/Parsers/Kusto/ParserKQLDateTypeTimespan.cpp
+++ b/src/Parsers/Kusto/ParserKQLDateTypeTimespan.cpp
@@ -1,12 +1,14 @@
 #include <cmath>
 #include <cstdlib>
-#include <format>
+
 #include <unordered_map>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/IParserBase.h>
 #include <Parsers/Kusto/ParserKQLDateTypeTimespan.h>
 #include <Parsers/Kusto/ParserKQLQuery.h>
 #include <Common/StringUtils.h>
+
+#include <fmt/format.h>
 
 namespace DB
 {

--- a/src/Parsers/Kusto/ParserKQLExtend.cpp
+++ b/src/Parsers/Kusto/ParserKQLExtend.cpp
@@ -1,4 +1,3 @@
-#include <format>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/IParserBase.h>
@@ -10,6 +9,8 @@
 #include <Parsers/Kusto/Utilities.h>
 #include <Parsers/ParserSelectQuery.h>
 #include <Parsers/ParserTablesInSelectQuery.h>
+
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -31,7 +32,7 @@ bool ParserKQLExtend ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     {
         if (alias.empty())
         {
-            alias = std::format("Column{}", new_column_index);
+            alias = fmt::format("Column{}", new_column_index);
             ++new_column_index;
             new_extend_str += " AS";
         }
@@ -75,7 +76,7 @@ bool ParserKQLExtend ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     }
     apply_alias();
 
-    String expr = std::format("SELECT * {}, {} from prev", except_str, new_extend_str);
+    String expr = fmt::format("SELECT * {}, {} from prev", except_str, new_extend_str);
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
     IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
 

--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -24,7 +24,8 @@
 #include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/ParserTablesInSelectQuery.h>
 
-#include <format>
+#include <fmt/format.h>
+
 namespace DB
 {
 
@@ -238,9 +239,9 @@ String ParserKQLBase::getExprFromToken(Pos & pos)
                         ErrorCodes::SYNTAX_ERROR, "{} is not a valid alias", std::string_view(start_pos->begin, start_pos->end));
 
                 if (function_name == "array_sort_asc" || function_name == "array_sort_desc")
-                    new_column_str = std::format("{0}[1] AS {1}", column_str, String(start_pos->begin, start_pos->end));
+                    new_column_str = fmt::format("{0}[1] AS {1}", column_str, String(start_pos->begin, start_pos->end));
                 else
-                    new_column_str = std::format("{0} AS {1}", column_str, String(start_pos->begin, start_pos->end));
+                    new_column_str = fmt::format("{0} AS {1}", column_str, String(start_pos->begin, start_pos->end));
 
                 columns.push_back(new_column_str);
             }
@@ -273,7 +274,7 @@ String ParserKQLBase::getExprFromToken(Pos & pos)
                             throw Exception(ErrorCodes::SYNTAX_ERROR, "{} has invalid alias for {}", whole_alias, function_name);
 
                         alias_inside = String(start_pos->begin, start_pos->end);
-                        auto new_column_str = std::format("{0}[{1}] AS {2}", column_str, index, alias_inside);
+                        auto new_column_str = fmt::format("{0}[{1}] AS {2}", column_str, index, alias_inside);
                         columns.push_back(new_column_str);
                         comma_meet = false;
                         ++index;
@@ -488,7 +489,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (op == "project")
                 project_clause = op_str;
             else if (op == "where" || op == "filter")
-                where_clause = where_clause.empty() ? std::format("({})", op_str) : where_clause + std::format("AND ({})", op_str);
+                where_clause = where_clause.empty() ? fmt::format("({})", op_str) : where_clause + fmt::format("AND ({})", op_str);
             else if (op == "limit" || op == "take")
                 limit_clause = op_str;
             else if (op == "order by" || op == "sort by")
@@ -523,7 +524,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             for (auto i = 0; i < kql_parser[last_op].backspace_steps; ++i)
                 --last_pos;
 
-            String sub_query = std::format("({})", String(operation_pos.front().second->begin, last_pos->end));
+            String sub_query = fmt::format("({})", String(operation_pos.front().second->begin, last_pos->end));
             Tokens token_subquery(sub_query.data(), sub_query.data() + sub_query.size(), 0, true);
             IParser::Pos pos_subquery(token_subquery, pos.max_depth, pos.max_backtracks);
 

--- a/src/Parsers/Kusto/ParserKQLSummarize.cpp
+++ b/src/Parsers/Kusto/ParserKQLSummarize.cpp
@@ -21,7 +21,8 @@
 #include <Parsers/ParserSetQuery.h>
 #include <Parsers/ParserTablesInSelectQuery.h>
 #include <Parsers/ParserWithElement.h>
-#include <format>
+
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -95,12 +96,12 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 String aggregate_fun = String(begin_pos->begin, begin_pos->end);
                 if (aggregate_functions.find(aggregate_fun) == aggregate_functions.end())
                 {
-                    alias = std::format("Columns{}", new_column_index);
+                    alias = fmt::format("Columns{}", new_column_index);
                     ++new_column_index;
                 }
                 else
                 {
-                    alias = std::format("{}_", aggregate_fun);
+                    alias = fmt::format("{}_", aggregate_fun);
                     auto agg_colum_pos = begin_pos;
                     ++agg_colum_pos;
                     ++agg_colum_pos;
@@ -112,7 +113,7 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                             alias = alias + String(agg_colum_pos->begin, agg_colum_pos->end);
                     }
                 }
-                expr = std::format("{} = {}", alias, expr);
+                expr = fmt::format("{} = {}", alias, expr);
             }
             expr_aggregations.push_back(expr);
         }
@@ -141,11 +142,11 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                     }
                     if (alias.empty())
                     {
-                        alias = std::format("Columns{}", new_column_index);
+                        alias = fmt::format("Columns{}", new_column_index);
                         ++new_column_index;
                     }
 
-                    expr = std::format("{} = {}", alias, expr);
+                    expr = fmt::format("{} = {}", alias, expr);
                 }
             }
             expr_groupbys.push_back(expr);

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -492,3 +492,9 @@ find $ROOT_PATH/{src,base,programs,utils} -name '*.cpp' -or -name '*.h' | xargs 
 do
     echo "Found the inclusion of magic_enum.hpp in '${line}'. Please use <base/EnumReflection.h> instead"
 done
+
+# Currently fmt::format is faster both at compile and runtime
+find $ROOT_PATH/{src,base,programs,utils} -name '*.h' -or -name '*.cpp' | grep -vP $EXCLUDE | xargs grep -l "std::format" | while read -r file;
+do
+    echo "Found the usage of std::format in '${file}'. Please use fmt::format instead"
+done


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use fmt::format instead of std::format

Currently fmt::format is faster both at compile and runtime, so no point on using `<format>` (yet) for these cases.

From build trace:

```
SELECT
    detail,
    count(),
    sum(dur)
FROM build_time_trace
WHERE (date = today()) AND (NOT is_total) AND (time >= (now() - toIntervalHour(6)))
GROUP BY detail
ORDER BY sum(dur) DESC
LIMIT 200
```

```
     ┌─detail─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─count()─┬───sum(dur)─┐


32. │ std::__format::__vformat_to<std::basic_format_parse_context<char>, std::__format::__compile_time_basic_format_context<char>>                                                                                                                               │      23 │    1163885 │

35. │ std::__format::__handle_replacement_field<std::__wrap_iter<const char *>, std::basic_format_parse_context<char>, std::__format::__compile_time_basic_format_context<char>>                                                                                 │      23 │    1115391 │

47. │ std::__format::__compile_time_visit_format_arg<char>                                                                                                                                                                                                       │      23 │     979370 │


 98. │ std::__format::__retarget_buffer<wchar_t>::__grow_buffer                                                                                                                                                                                                   │      68 │     551359 │

104. │ std::__format::__compile_time_validate_argument<char, bool, false>                                                                                                                                                                                         │      23 │     510898 │
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
