### PR TITLE
Forbid empty databases (leaked via default_database)

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -860,6 +860,8 @@ void LocalServer::processConfig()
     DatabaseCatalog::instance().initializeAndLoadTemporaryDatabase();
 
     std::string default_database = server_settings[ServerSetting::default_database];
+    if (default_database.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "default_database cannot be empty");
     {
         DatabasePtr database = createClickHouseLocalDatabaseOverlay(default_database, global_context);
         if (UUID uuid = database->getUUID(); uuid != UUIDHelpers::Nil)

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -400,6 +400,7 @@ namespace ErrorCodes
     extern const int INVALID_CONFIG_PARAMETER;
     extern const int NETWORK_ERROR;
     extern const int CORRUPTED_DATA;
+    extern const int BAD_ARGUMENTS;
 }
 
 
@@ -2341,6 +2342,8 @@ try
     /// Set current database name before loading tables and databases because
     /// system logs may copy global context.
     std::string default_database = server_settings[ServerSetting::default_database].toString();
+    if (default_database.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "default_database cannot be empty");
     global_context->setCurrentDatabaseNameInGlobalContext(default_database);
 
     LOG_INFO(log, "Loading metadata from {}", path_str);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2768,6 +2768,9 @@ String Context::getInitialQueryId() const
 
 void Context::setCurrentDatabaseNameInGlobalContext(const String & name)
 {
+    if (name.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Database name cannot be empty");
+
     if (!isGlobalContext())
         throw Exception(ErrorCodes::LOGICAL_ERROR,
                         "Cannot set current database for non global context, this method should "
@@ -2782,6 +2785,9 @@ void Context::setCurrentDatabaseNameInGlobalContext(const String & name)
 
 void Context::setCurrentDatabaseWithLock(const String & name, const std::lock_guard<ContextSharedMutex> &)
 {
+    if (name.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Database name cannot be empty");
+
     DatabaseCatalog::instance().assertDatabaseExists(name);
     current_database = name;
     need_recalculate_access = true;

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -515,10 +515,12 @@ bool DatabaseCatalog::isPredefinedTable(const StorageID & table_id) const
 
 void DatabaseCatalog::assertDatabaseExists(const String & database_name) const
 {
+    if (database_name.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Database name cannot be empty");
+
     DatabasePtr db;
     {
         std::lock_guard lock{databases_mutex};
-        assert(!database_name.empty());
         if (auto it = databases.find(database_name); it != databases.end())
             db = it->second;
     }

--- a/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
+++ b/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
@@ -1,3 +1,5 @@
+#include <Databases/DatabaseMemory.h>
+#include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/executeQuery.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/registerInterpreters.h>
@@ -41,6 +43,16 @@ extern "C" int LLVMFuzzerInitialize(int *, char ***)
     registerDictionaries(false);
     registerDisks(/* global_skip_access_check= */ true);
     registerFormats();
+
+    /// Initialize default database
+    {
+        const std::string default_database = "default";
+        DatabasePtr database = std::make_shared<DatabaseMemory>(default_database, context);
+        if (UUID uuid = database->getUUID(); uuid != UUIDHelpers::Nil)
+            DatabaseCatalog::instance().addUUIDMapping(uuid);
+        DatabaseCatalog::instance().attachDatabase(default_database, database);
+        context->setCurrentDatabase(default_database);
+    }
 
     return 0;
 }

--- a/tests/queries/0_stateless/03381_clickhouse_local_empty_default_database.reference
+++ b/tests/queries/0_stateless/03381_clickhouse_local_empty_default_database.reference
@@ -1,0 +1,2 @@
+default_database cannot be empty. (BAD_ARGUMENTS)
+default_database cannot be empty. (BAD_ARGUMENTS)

--- a/tests/queries/0_stateless/03381_clickhouse_local_empty_default_database.sh
+++ b/tests/queries/0_stateless/03381_clickhouse_local_empty_default_database.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --database '' |& grep -o "default_database cannot be empty. (BAD_ARGUMENTS)"
+$CLICKHOUSE_LOCAL -- --default_database='' |& grep -o "default_database cannot be empty. (BAD_ARGUMENTS)"


### PR DESCRIPTION
CI found [1] `LOGICAL_ERROR` for the query `DROP TABLE 13221_rm6`:

    9 0x55e550e8a55d in DB::abortOnFailedAssertion() build_docker/./src/Common/Exception.cpp:48:5
    10 0x55e550e8bc05 in DB::handle_error_code() build_docker/./src/Common/Exception.cpp:70:9
    14 0x55e519a2e1d2 in DB::Exception::Exception<>() build_docker/./src/Common/Exception.h:130:77
    15 0x55e5306e034b in DB::DatabaseCatalog::getDDLGuard() build_docker/./src/Interpreters/DatabaseCatalog.cpp:926:15
    16 0x55e531496823 in DB::InterpreterDropQuery::executeToTableImpl() build_docker/./src/Interpreters/InterpreterDropQuery.cpp:142:72
    17 0x55e531494e39 in DB::InterpreterDropQuery::executeToTable() build_docker/./src/Interpreters/InterpreterDropQuery.cpp:118:16
    18 0x55e531492e47 in DB::InterpreterDropQuery::executeSingleDropQuery() build_docker/./src/Interpreters/InterpreterDropQuery.cpp:91:16
    19 0x55e531492559 in DB::InterpreterDropQuery::execute() build_docker/./src/Interpreters/InterpreterDropQuery.cpp:72:15
    20 0x55e531c0c9fd in DB::executeQueryImpl() build_docker/./src/Interpreters/executeQuery.cpp:1459:40
    21 0x55e531c021ee in DB::executeQuery() build_docker/./src/Interpreters/executeQuery.cpp:1626:19

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/5b0fb3e3dff551c7bc3150083db1622c229825fb/libfuzzer_tests.html

The problem is that fuzzer does not install empty database, and this problem exists even for clickhouse-local

Fix this by adding some checks and initialize database for fuzzer.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
