### PR TITLE
Fix compatibility with newer rustup (bump corrosion)

### DIFF
--- a/contrib/corrosion-cmake/config.toml.in
+++ b/contrib/corrosion-cmake/config.toml.in
@@ -7,7 +7,6 @@ CXXFLAGS = "@RUST_CXXFLAGS@"
 [build]
 rustflags = @RUSTFLAGS@
 rustdocflags = @RUSTFLAGS@
-@RUSTCWRAPPER@
 
 [unstable]
 @RUST_CARGO_BUILD_STD@


### PR DESCRIPTION
This pops up locally (after I reset the cache) and in #77306

Note, that **this PR disables the sccache for Rust** (due to sometimes it works incorrectly, i.e. does not detect changes likely), but, I AFAICS Rust does not takes significant amount of time, so this should be OK.

Refs: https://github.com/ClickHouse/corrosion/pull/1

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)