### PR TITLE
Update documentation for shutdown_wait_unfinished_queries to reflect usage

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -984,9 +984,9 @@ Default: `1`
 
 ## shutdown_wait_unfinished_queries {#shutdown_wait_unfinished_queries}
 
-If set true ClickHouse will wait for running queries finish before shutdown.
+The number of seconds ClickHouse will wait for running queries finish before shutdown.
 
-Type: `Bool`
+Type: `UInt64`
 
 Default: `0`
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Documentation (changelog entry is not required)


The documentation for this feature implies that this is a boolean value but the actual code usage reflects that this is a wait time. This change updates the docs to reflect that. 

The setting is used [in Server.cpp](https://github.com/ClickHouse/ClickHouse/blob/66f23c86477a73d630645dba36281c45e8449f65/programs/server/Server.cpp#L1242) and [waitServersToFinish](https://github.com/ClickHouse/ClickHouse/blob/66f23c86477a73d630645dba36281c45e8449f65/src/Server/waitServersToFinish.cpp#L8)'s function signature uses this as a time to wait and not as a boolean.

```
current_connections = waitServersToFinish(servers_to_start_before_tables, servers_lock, server_settings[ServerSetting::shutdown_wait_unfinished]);

...

size_t waitServersToFinish(std::vector<DB::ProtocolServerAdapter> & servers, std::mutex & mutex, size_t seconds_to_wait)
```
