### PR TITLE
Split Resize/StrictResize to avoid lock contention

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6570,7 +6570,7 @@ When the query prioritization mechanism is employed (see setting `priority`), lo
 )", BETA) \
     DECLARE(Float, min_os_cpu_wait_time_ratio_to_throw, 0.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
     DECLARE(Float, max_os_cpu_wait_time_ratio_to_throw, 0.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \
-    DECLARE(NonZeroUInt64, min_outstreams_per_resize_after_split, 24, R"(
+    DECLARE(UInt64, min_outstreams_per_resize_after_split, 24, R"(
 Specifies the minimum number of output streams of a `Resize` or `StrictResize` processor after the split is performed during pipeline generation. If the resulting number of streams is less than this value, the split operation will not occur.
 
 ### What is a Resize Node
@@ -6594,6 +6594,9 @@ In some cases, where the inputs/outputs are indivisible by the number of split `
 
 ### Purpose of the Setting
 The `min_outstreams_per_resize_after_split` setting ensures that the splitting of `Resize` nodes is meaningful and avoids creating too few streams, which could lead to inefficient parallel processing. By enforcing a minimum number of output streams, this setting helps maintain a balance between parallelism and overhead, optimizing query execution in scenarios involving stream splitting and merging.
+
+### Disabling the Setting
+To disable the split of `Resize` nodes, set this setting to 0. This will prevent the splitting of `Resize` nodes during pipeline generation, allowing them to retain their original structure without division into smaller nodes.
 )", 0) \
     \
     /* ####################################################### */ \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6570,6 +6570,31 @@ When the query prioritization mechanism is employed (see setting `priority`), lo
 )", BETA) \
     DECLARE(Float, min_os_cpu_wait_time_ratio_to_throw, 0.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
     DECLARE(Float, max_os_cpu_wait_time_ratio_to_throw, 0.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \
+    DECLARE(NonZeroUInt64, min_outstreams_per_resize_after_split, 24, R"(
+Specifies the minimum number of output streams of a `Resize` or `StrictResize` processor after the split is performed during pipeline generation. If the resulting number of streams is less than this value, the split operation will not occur.
+
+### What is a Resize Node
+A `Resize` node is a processor in the query pipeline that adjusts the number of data streams flowing through the pipeline. It can either increase or decrease the number of streams to balance the workload across multiple threads or processors. For example, if a query requires more parallelism, the `Resize` node can split a single stream into multiple streams. Conversely, it can merge multiple streams into fewer streams to consolidate data processing.
+
+The `Resize` node ensures that data is evenly distributed across streams, maintaining the structure of the data blocks. This helps optimize resource utilization and improve query performance.
+
+### Why the Resize Node Needs to Be Split
+During pipeline execution, ExecutingGraph::Node::status_mutex of the centrally-hubbed `Resize` node is heavily contended especially in high-core-count environments, and this contention leads to:
+1. Increased latency for ExecutingGraph::updateNode, directly impacting query performance.
+2. Excessive CPU cycles are wasted in spin-lock contention (native_queued_spin_lock_slowpath), degrading efficiency.
+3. Reduced CPU utilization, limiting parallelism and throughput.
+
+### How the Resize Node Gets Split
+1. The number of output streams is checked to ensure the split could be performed: the output streams of each split processor meet or exceed the `min_outstreams_per_resize_after_split` threshold.
+2. The `Resize` node is divided into smaller `Resize` nodes with equal count of ports, each handling a subset of input and output streams.
+3. Each group is processed independently, reducing the lock contention.
+
+### Splitting Resize Node with Arbitrary Inputs/Outputs
+In some cases, where the inputs/outputs are indivisible by the number of split `Resize` nodes, some inputs are connected to `NullSource`s and some outputs are connected to `NullSink`s. This allows the split to occur without affecting the overall data flow.
+
+### Purpose of the Setting
+The `min_outstreams_per_resize_after_split` setting ensures that the splitting of `Resize` nodes is meaningful and avoids creating too few streams, which could lead to inefficient parallel processing. By enforcing a minimum number of output streams, this setting helps maintain a balance between parallelism and overhead, optimizing query execution in scenarios involving stream splitting and merging.
+)", 0) \
     \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -75,6 +75,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_job_stack_trace", false, false, "The setting was disabled by default to avoid performance overhead."},
             {"input_format_parquet_enable_json_parsing", true, true, "When reading Parquet files, parse JSON columns as ClickHouse JSON Column."},
 
+            {"min_outstreams_per_resize_after_split", UInt64(-1), 24, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.5",
         {
@@ -118,7 +119,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_url_encoding", true, false, "Changed existing setting's default value"},
             {"s3_slow_all_threads_after_network_error", false, true, "New setting"},
             /// Release closed. Please use 25.6
-            {"min_outstreams_per_resize_after_split", UInt64(-1), 24, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.4",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -147,6 +147,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"parallel_replicas_insert_select_local_pipeline", false, false, "Use local pipeline during distributed INSERT SELECT with parallel replicas. Currently disabled due to performance issues"},
             {"parallel_hash_join_threshold", 0, 0, "New setting"},
             /// Release closed. Please use 25.5
+            {"min_outstreams_per_resize_after_split", 24, 24, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.3",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -74,8 +74,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_iceberg_partition_pruning", false, true, "Enable Iceberg partition pruning by default."},
             {"enable_job_stack_trace", false, false, "The setting was disabled by default to avoid performance overhead."},
             {"input_format_parquet_enable_json_parsing", true, true, "When reading Parquet files, parse JSON columns as ClickHouse JSON Column."},
-
-            {"min_outstreams_per_resize_after_split", UInt64(-1), 24, "New setting."},
+            {"min_outstreams_per_resize_after_split", 0, 24, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.5",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -118,6 +118,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_url_encoding", true, false, "Changed existing setting's default value"},
             {"s3_slow_all_threads_after_network_error", false, true, "New setting"},
             /// Release closed. Please use 25.6
+            {"min_outstreams_per_resize_after_split", UInt64(-1), 24, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.4",
         {
@@ -147,7 +148,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"parallel_replicas_insert_select_local_pipeline", false, false, "Use local pipeline during distributed INSERT SELECT with parallel replicas. Currently disabled due to performance issues"},
             {"parallel_hash_join_threshold", 0, 0, "New setting"},
             /// Release closed. Please use 25.5
-            {"min_outstreams_per_resize_after_split", 24, 24, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.3",
         {

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -495,7 +495,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
         /// Add resize transform to uniformly distribute data between aggregating streams.
         /// But not if we execute aggregation over partitioned data in which case data streams shouldn't be mixed.
         if (!storage_has_evenly_distributed_read && !skip_merging)
-            pipeline.resize(pipeline.getNumStreams(), true);
+            pipeline.resize(pipeline.getNumStreams(), true, settings.min_outstreams_per_resize_after_split);
 
         auto many_data = std::make_shared<ManyAggregatedData>(pipeline.getNumStreams());
 
@@ -514,7 +514,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     skip_merging);
             });
 
-        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads);
+        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads, false, settings.min_outstreams_per_resize_after_split);
 
         aggregating = collector.detachProcessors(0);
     }

--- a/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
+++ b/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
@@ -10,6 +10,7 @@ namespace Setting
     extern const SettingsBool query_plan_merge_filters;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
+    extern const SettingsUInt64 min_outstreams_per_resize_after_split;
 }
 
 BuildQueryPipelineSettings::BuildQueryPipelineSettings(ContextPtr from)
@@ -22,6 +23,7 @@ BuildQueryPipelineSettings::BuildQueryPipelineSettings(ContextPtr from)
 
     max_threads = from->getSettingsRef()[Setting::max_threads];
     aggregation_memory_efficient_merge_threads = from->getSettingsRef()[Setting::aggregation_memory_efficient_merge_threads];
+    min_outstreams_per_resize_after_split = from->getSettingsRef()[Setting::min_outstreams_per_resize_after_split];
 
     /// Setting query_plan_merge_filters is enabled by default.
     /// But it can brake short-circuit without splitting filter step into smaller steps.

--- a/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
+++ b/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
@@ -10,7 +10,7 @@ namespace Setting
     extern const SettingsBool query_plan_merge_filters;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
-    extern const SettingsUInt64 min_outstreams_per_resize_after_split;
+    extern const SettingsNonZeroUInt64 min_outstreams_per_resize_after_split;
 }
 
 BuildQueryPipelineSettings::BuildQueryPipelineSettings(ContextPtr from)

--- a/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
+++ b/src/Processors/QueryPlan/BuildQueryPipelineSettings.cpp
@@ -10,7 +10,7 @@ namespace Setting
     extern const SettingsBool query_plan_merge_filters;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
-    extern const SettingsNonZeroUInt64 min_outstreams_per_resize_after_split;
+    extern const SettingsUInt64 min_outstreams_per_resize_after_split;
 }
 
 BuildQueryPipelineSettings::BuildQueryPipelineSettings(ContextPtr from)

--- a/src/Processors/QueryPlan/BuildQueryPipelineSettings.h
+++ b/src/Processors/QueryPlan/BuildQueryPipelineSettings.h
@@ -28,6 +28,7 @@ struct BuildQueryPipelineSettings
 
     size_t max_threads;
     size_t aggregation_memory_efficient_merge_threads;
+    size_t min_outstreams_per_resize_after_split;
 
     const ExpressionActionsSettings & getActionsSettings() const { return actions_settings; }
 };

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -686,6 +686,9 @@ void Pipe::addChains(std::vector<Chain> chains)
 void Pipe::addSplitResizeTransform(size_t num_streams, size_t groups, bool strict)
 {
     /// The caller guarantees that the numbers of input/output ports are divisible by the number of groups.
+    assert(numOutputPorts() % groups == 0);
+    assert(num_streams % groups == 0);
+
     const size_t num_inputs = numOutputPorts() / groups;
     const size_t num_outputs = num_streams / groups;
     OutputPortRawPtrs resize_output_ports(num_streams);

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -730,7 +730,7 @@ void Pipe::addSplitResizeTransform(size_t num_streams, size_t groups, bool stric
     max_parallel_streams = std::max<size_t>(max_parallel_streams, output_ports.size());
 }
 
-void Pipe::resize(size_t num_streams, bool strict)
+void Pipe::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_resize_after_split)
 {
     if (output_ports.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot resize an empty Pipe");
@@ -756,10 +756,9 @@ void Pipe::resize(size_t num_streams, bool strict)
     /// 1. Mitigates lock contention.
     /// 2. Maintains ResizeProcessor's benefit of balancing data flow among multiple streams.
     {
-        constexpr size_t RESIZE_SPLIT_THRESHOLD = 24;
         size_t groups = 2;
 
-        while (!(num_streams % groups) && !(numOutputPorts() % groups) && num_streams / groups >= RESIZE_SPLIT_THRESHOLD)
+        while (!(num_streams % groups) && !(numOutputPorts() % groups) && num_streams / groups >= min_outstreams_per_resize_after_split)
             groups <<= 1;
         groups >>= 1;
 

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -20,7 +20,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int BAD_ARGUMENTS;
 }
 
 static void checkSource(const IProcessor & source)
@@ -770,11 +769,7 @@ void Pipe::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_res
     /// Benefits:
     /// 1. Mitigates lock contention.
     /// 2. Maintains ResizeProcessor's benefit of balancing data flow among multiple streams.
-    if (min_outstreams_per_resize_after_split == 0)
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "min_outstreams_per_resize_after_split should be greater than zero");
-
+    assert(min_outstreams_per_resize_after_split != 0);
     if (output_ports.size() > 1 && num_streams / min_outstreams_per_resize_after_split > 1)
     {
         addSplitResizeTransform(num_streams, min_outstreams_per_resize_after_split, strict);

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -769,8 +769,9 @@ void Pipe::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_res
     /// Benefits:
     /// 1. Mitigates lock contention.
     /// 2. Maintains ResizeProcessor's benefit of balancing data flow among multiple streams.
-    chassert(min_outstreams_per_resize_after_split != 0);
-    if (output_ports.size() > 1 && num_streams / min_outstreams_per_resize_after_split > 1)
+    ///
+    /// Disable this optimization when min_outstreams_per_resize_after_split is 0
+    if (output_ports.size() > 1 && min_outstreams_per_resize_after_split != 0 && num_streams / min_outstreams_per_resize_after_split > 1)
     {
         addSplitResizeTransform(num_streams, min_outstreams_per_resize_after_split, strict);
         return;

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -684,7 +684,7 @@ void Pipe::addChains(std::vector<Chain> chains)
     max_parallel_streams = std::max(max_parallel_streams, max_parallel_streams_for_chains);
 }
 
-void Pipe::addSplitResizeTransform(size_t num_streams, UInt64 min_outstreams_per_resize_after_split, bool strict)
+void Pipe::addSplitResizeTransform(size_t num_streams, size_t min_outstreams_per_resize_after_split, bool strict)
 {
     OutputPortRawPtrs resize_output_ports(num_streams);
 

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -693,7 +693,7 @@ void Pipe::addSplitResizeTransform(size_t num_streams, size_t min_outstreams_per
     size_t outstreams_per_group = (num_streams + groups - 1) / groups;
     size_t groups_with_extra_outstream = num_streams % groups;
 
-    assert(groups > 1);
+    chassert(groups > 1);
 
     for (size_t i = 0, next_input = 0, next_output = 0; i < groups; ++i)
     {
@@ -769,7 +769,7 @@ void Pipe::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_res
     /// Benefits:
     /// 1. Mitigates lock contention.
     /// 2. Maintains ResizeProcessor's benefit of balancing data flow among multiple streams.
-    assert(min_outstreams_per_resize_after_split != 0);
+    chassert(min_outstreams_per_resize_after_split != 0);
     if (output_ports.size() > 1 && num_streams / min_outstreams_per_resize_after_split > 1)
     {
         addSplitResizeTransform(num_streams, min_outstreams_per_resize_after_split, strict);

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -775,7 +775,7 @@ void Pipe::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_res
         addSplitResizeTransform(num_streams, min_outstreams_per_resize_after_split, strict);
         return;
     }
-    else if (strict && num_streams == numOutputPorts())
+    if (strict && num_streams == numOutputPorts())
         return;
 
     ProcessorPtr resize;

--- a/src/QueryPipeline/Pipe.cpp
+++ b/src/QueryPipeline/Pipe.cpp
@@ -20,6 +20,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 static void checkSource(const IProcessor & source)
@@ -769,7 +770,12 @@ void Pipe::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_res
     /// Benefits:
     /// 1. Mitigates lock contention.
     /// 2. Maintains ResizeProcessor's benefit of balancing data flow among multiple streams.
-    if (output_ports.size() > 1 && num_streams >= 2 * min_outstreams_per_resize_after_split)
+    if (min_outstreams_per_resize_after_split == 0)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "min_outstreams_per_resize_after_split should be greater than zero");
+
+    if (output_ports.size() > 1 && num_streams / min_outstreams_per_resize_after_split > 1)
     {
         addSplitResizeTransform(num_streams, min_outstreams_per_resize_after_split, strict);
         return;

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -90,7 +90,7 @@ public:
     void addChains(std::vector<Chain> chains);
 
     /// Changes the number of output ports if needed. Adds (Strict)ResizeProcessor.
-    void resize(size_t num_streams, bool strict = false, UInt64 min_outstreams_per_resize_after_split = std::numeric_limits<UInt64>::max());
+    void resize(size_t num_streams, bool strict = false, UInt64 min_outstreams_per_resize_after_split = 0);
 
     using Transformer = std::function<Processors(OutputPortRawPtrs ports)>;
 

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -90,7 +90,7 @@ public:
     void addChains(std::vector<Chain> chains);
 
     /// Changes the number of output ports if needed. Adds (Strict)ResizeProcessor.
-    void resize(size_t num_streams, bool strict = false);
+    void resize(size_t num_streams, bool strict = false, UInt64 min_outstreams_per_resize_after_split = std::numeric_limits<UInt64>::max());
 
     using Transformer = std::function<Processors(OutputPortRawPtrs ports)>;
 

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -130,7 +130,7 @@ private:
     bool isCompleted() const { return !empty() && output_ports.empty(); }
     static Pipe unitePipes(Pipes pipes, Processors * collected_processors, bool allow_empty_header);
     void setSinks(const Pipe::ProcessorGetterWithStreamKind & getter);
-    void addSplitResizeTransform(size_t num_streams, size_t groups, bool strict);
+    void addSplitResizeTransform(size_t num_streams, size_t min_outstreams_per_resize_after_split, bool strict);
 
     friend class QueryPipelineBuilder;
     friend class QueryPipeline;

--- a/src/QueryPipeline/Pipe.h
+++ b/src/QueryPipeline/Pipe.h
@@ -130,6 +130,7 @@ private:
     bool isCompleted() const { return !empty() && output_ports.empty(); }
     static Pipe unitePipes(Pipes pipes, Processors * collected_processors, bool allow_empty_header);
     void setSinks(const Pipe::ProcessorGetterWithStreamKind & getter);
+    void addSplitResizeTransform(size_t num_streams, size_t groups, bool strict);
 
     friend class QueryPipelineBuilder;
     friend class QueryPipeline;

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -193,10 +193,10 @@ void QueryPipelineBuilder::addMergingAggregatedMemoryEfficientTransform(Aggregat
     DB::addMergingAggregatedMemoryEfficientTransform(pipe, std::move(params), num_merging_processors);
 }
 
-void QueryPipelineBuilder::resize(size_t num_streams, bool strict)
+void QueryPipelineBuilder::resize(size_t num_streams, bool strict, UInt64 min_outstreams_per_resize_after_split)
 {
     checkInitializedAndNotCompleted();
-    pipe.resize(num_streams, strict);
+    pipe.resize(num_streams, strict, min_outstreams_per_resize_after_split);
 }
 
 void QueryPipelineBuilder::narrow(size_t size)

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -97,7 +97,7 @@ public:
     void addMergingAggregatedMemoryEfficientTransform(AggregatingTransformParamsPtr params, size_t num_merging_processors);
 
     /// Changes the number of output ports if needed. Adds ResizeTransform.
-    void resize(size_t num_streams, bool strict = false, UInt64 min_outstreams_per_resize_after_split = std::numeric_limits<UInt64>::max());
+    void resize(size_t num_streams, bool strict = false, UInt64 min_outstreams_per_resize_after_split = 0);
 
     /// Concat some ports to have no more then size outputs.
     /// This method is needed for Merge table engine in case of reading from many tables.

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -97,7 +97,7 @@ public:
     void addMergingAggregatedMemoryEfficientTransform(AggregatingTransformParamsPtr params, size_t num_merging_processors);
 
     /// Changes the number of output ports if needed. Adds ResizeTransform.
-    void resize(size_t num_streams, bool strict = false);
+    void resize(size_t num_streams, bool strict = false, UInt64 min_outstreams_per_resize_after_split = std::numeric_limits<UInt64>::max());
 
     /// Concat some ports to have no more then size outputs.
     /// This method is needed for Merge table engine in case of reading from many tables.

--- a/src/QueryPipeline/tests/gtest_resize_transform.cpp
+++ b/src/QueryPipeline/tests/gtest_resize_transform.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+#include <Core/Block.h>
+#include <Columns/ColumnVector.h>
+#include <Processors/Sources/BlocksListSource.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Columns/ColumnsNumber.h>
+#include <QueryPipeline/Pipe.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <QueryPipeline/QueryPipeline.h>
+
+using namespace DB;
+
+static Block getBlockWithSize(const std::vector<std::string> & columns, size_t rows)
+{
+    ColumnsWithTypeAndName cols;
+    for (const auto & column : columns)
+    {
+        auto column_ptr = ColumnUInt64::create(rows, 0);
+        for (size_t j = 0; j < rows; ++j)
+            column_ptr->getElement(j) = j;
+        cols.emplace_back(std::move(column_ptr), std::make_shared<DataTypeUInt64>(), column);
+    }
+    return Block(cols);
+}
+
+static Pipe getInputStreams(const std::vector<std::string> & column_names, size_t num_streams, size_t rows_per_stream)
+{
+    Pipes pipes;
+    for (size_t i = 0; i < num_streams; ++i)
+    {
+        BlocksList blocks;
+        blocks.push_back(getBlockWithSize(column_names, rows_per_stream));
+        pipes.emplace_back(std::make_shared<BlocksListSource>(std::move(blocks)));
+    }
+    return Pipe::unitePipes(std::move(pipes));
+}
+
+static void testSplitResizeTransform(size_t instreams, size_t outstreams, size_t min_outstreams_per_resize_after_split, bool strict)
+{
+    constexpr size_t rows_per_stream = 10;
+
+    const std::vector<std::string> key_columns{"K1", "K2", "K3"};
+
+    size_t expected_groups = std::min<size_t>(instreams, outstreams / min_outstreams_per_resize_after_split);
+    size_t groups_with_extra_instream = instreams % expected_groups;
+    size_t groups_with_extra_outstream = outstreams % expected_groups;
+
+    auto pipe = getInputStreams(key_columns, instreams, rows_per_stream);
+
+    EXPECT_EQ(pipe.numOutputPorts(), instreams);
+    pipe.resize(outstreams, strict, min_outstreams_per_resize_after_split);
+    EXPECT_EQ(pipe.numOutputPorts(), outstreams);
+
+    const Processors & procs = pipe.getProcessors();
+    Processors resize_procs;
+    for (const auto & proc : procs)
+    {
+        if (!strict && proc->getName() == "Resize")
+            resize_procs.push_back(proc);
+        else if (strict && proc->getName() == "StrictResize")
+            resize_procs.push_back(proc);
+    }
+
+    ASSERT_GE(resize_procs.size(), 1);
+    EXPECT_EQ(resize_procs.size(), expected_groups);
+
+    size_t instreams_per_group = (instreams + expected_groups - 1) / expected_groups;
+    size_t outstreams_per_group = (outstreams + expected_groups - 1) / expected_groups;
+
+    size_t null_source_count = 0;
+    size_t null_sink_count = 0;
+    for (auto i = 0; i < resize_procs.size(); ++i)
+    {
+        auto resize = resize_procs[i];
+        EXPECT_EQ(resize->getInputs().size(), instreams_per_group);
+        EXPECT_EQ(resize->getOutputs().size(), outstreams_per_group);
+        if (groups_with_extra_instream != 0 && i >= groups_with_extra_instream)
+        {
+            const auto & null_source = resize->getInputs().back().getOutputPort().getProcessor();
+            EXPECT_EQ(null_source.getName(), "NullSource");
+            ++null_source_count;
+        }
+        if (groups_with_extra_outstream != 0 && i >= groups_with_extra_outstream)
+        {
+            const auto & null_sink = resize->getOutputs().back().getInputPort().getProcessor();
+            EXPECT_EQ(null_sink.getName(), "NullSink");
+            ++null_sink_count;
+        }
+    }
+
+    EXPECT_EQ(null_source_count, expected_groups * instreams_per_group - instreams);
+    EXPECT_EQ(null_sink_count, expected_groups * outstreams_per_group - outstreams);
+
+    QueryPipeline pipeline(std::move(pipe));
+    PullingPipelineExecutor executor(pipeline);
+
+    size_t total_rows = 0;
+    Block block;
+    while (executor.pull(block))
+    {
+        total_rows += block.rows();
+    }
+    EXPECT_EQ(total_rows, rows_per_stream * instreams);
+}
+
+
+TEST(ResizeTransformTest, SplitResizeTest)
+{
+    for (size_t instreams = 2; instreams < 100; ++instreams)
+    {
+        for (size_t outstreams = 1; outstreams < 100; ++outstreams)
+        {
+            for (size_t min_outstreams_per_resize_after_split : {16, 24, 32})
+            {
+                if (outstreams >= 2 * min_outstreams_per_resize_after_split)
+                {
+                    testSplitResizeTransform(instreams, outstreams, min_outstreams_per_resize_after_split, false /* strict */);
+                    testSplitResizeTransform(instreams, outstreams, min_outstreams_per_resize_after_split, true /* strict */);
+                }
+            }
+        }
+    }
+}

--- a/src/QueryPipeline/tests/gtest_resize_transform.cpp
+++ b/src/QueryPipeline/tests/gtest_resize_transform.cpp
@@ -112,7 +112,7 @@ TEST(ResizeTransformTest, SplitResizeTest)
         {
             for (size_t min_outstreams_per_resize_after_split : {16, 24, 32})
             {
-                if (outstreams >= 2 * min_outstreams_per_resize_after_split)
+                if (outstreams / min_outstreams_per_resize_after_split > 1)
                 {
                     testSplitResizeTransform(instreams, outstreams, min_outstreams_per_resize_after_split, false /* strict */);
                     testSplitResizeTransform(instreams, outstreams, min_outstreams_per_resize_after_split, true /* strict */);

--- a/src/QueryPipeline/tests/gtest_resize_transform.cpp
+++ b/src/QueryPipeline/tests/gtest_resize_transform.cpp
@@ -71,7 +71,7 @@ static void testSplitResizeTransform(size_t instreams, size_t outstreams, size_t
     size_t null_sink_count = 0;
     for (auto i = 0; i < resize_procs.size(); ++i)
     {
-        auto resize = resize_procs[i];
+        const auto & resize = resize_procs[i];
         EXPECT_EQ(resize->getInputs().size(), instreams_per_group);
         EXPECT_EQ(resize->getOutputs().size(), outstreams_per_group);
         if (groups_with_extra_instream != 0 && i >= groups_with_extra_instream)

--- a/tests/queries/0_stateless/02343_aggregation_pipeline.reference
+++ b/tests/queries/0_stateless/02343_aggregation_pipeline.reference
@@ -47,6 +47,153 @@ ExpressionTransform
                 ExpressionTransform × 16
                   (ReadFromSystemNumbers)
                   NumbersRange × 16 0 → 1
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 36;
+(Expression)
+ExpressionTransform × 36
+  (Aggregating)
+  Resize 36 → 36
+    AggregatingTransform × 36
+      StrictResize 36 → 36
+        (Expression)
+        ExpressionTransform × 36
+          (Aggregating)
+          Resize 1 → 36
+            AggregatingTransform
+              (Expression)
+              ExpressionTransform
+                (ReadFromSystemNumbers)
+                NumbersRange 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 36;
+(Expression)
+ExpressionTransform × 36
+  (Aggregating)
+  Resize 36 → 36
+    AggregatingTransform × 36
+      StrictResize 36 → 36
+        (Expression)
+        ExpressionTransform × 36
+          (Aggregating)
+          Resize 36 → 36
+            AggregatingTransform × 36
+              (Expression)
+              ExpressionTransform × 36
+                (ReadFromSystemNumbers)
+                NumbersRange × 36 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 36;
+(Expression)
+ExpressionTransform
+  (Sorting)
+  MergingSortedTransform 36 → 1
+    MergeSortingTransform × 36
+      LimitsCheckingTransform × 36
+        PartialSortingTransform × 36
+          (Expression)
+          ExpressionTransform × 36
+            (Aggregating)
+            Resize 36 → 36
+              AggregatingTransform × 36
+                (Expression)
+                ExpressionTransform × 36
+                  (ReadFromSystemNumbers)
+                  NumbersRange × 36 0 → 1
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 48;
+(Expression)
+ExpressionTransform × 48
+  (Aggregating)
+  Resize × 2 24 → 24
+    AggregatingTransform × 48
+      StrictResize × 2 24 → 24
+        (Expression)
+        ExpressionTransform × 48
+          (Aggregating)
+          Resize 1 → 48
+            AggregatingTransform
+              (Expression)
+              ExpressionTransform
+                (ReadFromSystemNumbers)
+                NumbersRange 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 48;
+(Expression)
+ExpressionTransform × 48
+  (Aggregating)
+  Resize × 2 24 → 24
+    AggregatingTransform × 48
+      StrictResize × 2 24 → 24
+        (Expression)
+        ExpressionTransform × 48
+          (Aggregating)
+          Resize × 2 24 → 24
+            AggregatingTransform × 48
+              (Expression)
+              ExpressionTransform × 48
+                (ReadFromSystemNumbers)
+                NumbersRange × 48 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 48;
+(Expression)
+ExpressionTransform
+  (Sorting)
+  MergingSortedTransform 48 → 1
+    MergeSortingTransform × 48
+      LimitsCheckingTransform × 48
+        PartialSortingTransform × 48
+          (Expression)
+          ExpressionTransform × 48
+            (Aggregating)
+            Resize × 2 24 → 24
+              AggregatingTransform × 48
+                (Expression)
+                ExpressionTransform × 48
+                  (ReadFromSystemNumbers)
+                  NumbersRange × 48 0 → 1
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
+(Expression)
+ExpressionTransform × 96
+  (Aggregating)
+  Resize × 4 24 → 24
+    AggregatingTransform × 96
+      StrictResize × 4 24 → 24
+        (Expression)
+        ExpressionTransform × 96
+          (Aggregating)
+          Resize 1 → 96
+            AggregatingTransform
+              (Expression)
+              ExpressionTransform
+                (ReadFromSystemNumbers)
+                NumbersRange 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
+(Expression)
+ExpressionTransform × 96
+  (Aggregating)
+  Resize × 4 24 → 24
+    AggregatingTransform × 96
+      StrictResize × 4 24 → 24
+        (Expression)
+        ExpressionTransform × 96
+          (Aggregating)
+          Resize × 4 24 → 24
+            AggregatingTransform × 96
+              (Expression)
+              ExpressionTransform × 96
+                (ReadFromSystemNumbers)
+                NumbersRange × 96 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 96;
+(Expression)
+ExpressionTransform
+  (Sorting)
+  MergingSortedTransform 96 → 1
+    MergeSortingTransform × 96
+      LimitsCheckingTransform × 96
+        PartialSortingTransform × 96
+          (Expression)
+          ExpressionTransform × 96
+            (Aggregating)
+            Resize × 4 24 → 24
+              AggregatingTransform × 96
+                (Expression)
+                ExpressionTransform × 96
+                  (ReadFromSystemNumbers)
+                  NumbersRange × 96 0 → 1
 explain pipeline select number from remote('127.0.0.{1,2,3}', system, numbers_mt) group by number settings distributed_aggregation_memory_efficient = 1;
 (Expression)
 ExpressionTransform × 16

--- a/tests/queries/0_stateless/02343_aggregation_pipeline.reference
+++ b/tests/queries/0_stateless/02343_aggregation_pipeline.reference
@@ -53,32 +53,30 @@ ExpressionTransform × 36
   (Aggregating)
   Resize 36 → 36
     AggregatingTransform × 36
-      StrictResize 36 → 36
-        (Expression)
-        ExpressionTransform × 36
-          (Aggregating)
-          Resize 1 → 36
-            AggregatingTransform
-              (Expression)
-              ExpressionTransform
-                (ReadFromSystemNumbers)
-                NumbersRange 0 → 1
+      (Expression)
+      ExpressionTransform × 36
+        (Aggregating)
+        Resize 1 → 36
+          AggregatingTransform
+            (Expression)
+            ExpressionTransform
+              (ReadFromSystemNumbers)
+              NumbersRange 0 → 1
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 36;
 (Expression)
 ExpressionTransform × 36
   (Aggregating)
   Resize 36 → 36
     AggregatingTransform × 36
-      StrictResize 36 → 36
-        (Expression)
-        ExpressionTransform × 36
-          (Aggregating)
-          Resize 36 → 36
-            AggregatingTransform × 36
-              (Expression)
-              ExpressionTransform × 36
-                (ReadFromSystemNumbers)
-                NumbersRange × 36 0 → 1
+      (Expression)
+      ExpressionTransform × 36
+        (Aggregating)
+        Resize 36 → 36
+          AggregatingTransform × 36
+            (Expression)
+            ExpressionTransform × 36
+              (ReadFromSystemNumbers)
+              NumbersRange × 36 0 → 1
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 36;
 (Expression)
 ExpressionTransform
@@ -145,55 +143,55 @@ ExpressionTransform
                 ExpressionTransform × 48
                   (ReadFromSystemNumbers)
                   NumbersRange × 48 0 → 1
-explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 49;
 (Expression)
-ExpressionTransform × 96
+ExpressionTransform × 49
   (Aggregating)
-  Resize × 4 24 → 24
-    AggregatingTransform × 96
-      StrictResize × 4 24 → 24
+  Resize × 2 25 → 25
+    AggregatingTransform × 49
+      StrictResize × 2 25 → 25
         (Expression)
-        ExpressionTransform × 96
+        ExpressionTransform × 49
           (Aggregating)
-          Resize 1 → 96
+          Resize 1 → 49
             AggregatingTransform
               (Expression)
               ExpressionTransform
                 (ReadFromSystemNumbers)
                 NumbersRange 0 → 1
-explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 49;
 (Expression)
-ExpressionTransform × 96
+ExpressionTransform × 49
   (Aggregating)
-  Resize × 4 24 → 24
-    AggregatingTransform × 96
-      StrictResize × 4 24 → 24
+  Resize × 2 25 → 25
+    AggregatingTransform × 49
+      StrictResize × 2 25 → 25
         (Expression)
-        ExpressionTransform × 96
+        ExpressionTransform × 49
           (Aggregating)
-          Resize × 4 24 → 24
-            AggregatingTransform × 96
+          Resize × 2 25 → 25
+            AggregatingTransform × 49
               (Expression)
-              ExpressionTransform × 96
+              ExpressionTransform × 49
                 (ReadFromSystemNumbers)
-                NumbersRange × 96 0 → 1
-explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 96;
+                NumbersRange × 49 0 → 1
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 49;
 (Expression)
 ExpressionTransform
   (Sorting)
-  MergingSortedTransform 96 → 1
-    MergeSortingTransform × 96
-      LimitsCheckingTransform × 96
-        PartialSortingTransform × 96
+  MergingSortedTransform 49 → 1
+    MergeSortingTransform × 49
+      LimitsCheckingTransform × 49
+        PartialSortingTransform × 49
           (Expression)
-          ExpressionTransform × 96
+          ExpressionTransform × 49
             (Aggregating)
-            Resize × 4 24 → 24
-              AggregatingTransform × 96
+            Resize × 2 25 → 25
+              AggregatingTransform × 49
                 (Expression)
-                ExpressionTransform × 96
+                ExpressionTransform × 49
                   (ReadFromSystemNumbers)
-                  NumbersRange × 96 0 → 1
+                  NumbersRange × 49 0 → 1
 explain pipeline select number from remote('127.0.0.{1,2,3}', system, numbers_mt) group by number settings distributed_aggregation_memory_efficient = 1;
 (Expression)
 ExpressionTransform × 16

--- a/tests/queries/0_stateless/02343_aggregation_pipeline.sql
+++ b/tests/queries/0_stateless/02343_aggregation_pipeline.sql
@@ -25,9 +25,9 @@ explain pipeline select * from (select * from numbers(1e8) group by number) grou
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 48;
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 48;
 
-explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
-explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
-explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 96;
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 49;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 49;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 49;
 
 explain pipeline select number from remote('127.0.0.{1,2,3}', system, numbers_mt) group by number settings distributed_aggregation_memory_efficient = 1;
 

--- a/tests/queries/0_stateless/02343_aggregation_pipeline.sql
+++ b/tests/queries/0_stateless/02343_aggregation_pipeline.sql
@@ -17,6 +17,18 @@ explain pipeline select * from (select * from numbers(1e8) group by number) grou
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0;
 explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0;
 
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 36;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 36;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 36;
+
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 48;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 48;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 48;
+
+explain pipeline select * from (select * from numbers(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) group by number settings max_rows_to_read = 0, max_threads = 96;
+explain pipeline select * from (select * from numbers_mt(1e8) group by number) order by number settings max_rows_to_read = 0, max_threads = 96;
+
 explain pipeline select number from remote('127.0.0.{1,2,3}', system, numbers_mt) group by number settings distributed_aggregation_memory_efficient = 1;
 
 explain pipeline select number from remote('127.0.0.{1,2,3}', system, numbers_mt) group by number settings distributed_aggregation_memory_efficient = 0;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The existing implementation of `Pipe::resize` creates a single `Resize` or `StrictResize` node by inserting it into the pipeline topology, which then acts as a central hub connecting all input streams (upstream nodes) to a unified set of output streams (downstream nodes). This design leads to contention for the` ExecutingGraph::Node::status_mutex` during pipeline graph execution, especially in high-core-count environments. When pipelines scale to tens or hundreds of streams, this contention results in:

- Increased latency for `ExecutingGraph::updateNode`, directly impacting query performance.
- Excessive CPU cycles wasted in spin-lock contention (`native_queued_spin_lock_slowpath`), degrading efficiency.
- Reduced CPU utilization , limiting parallelism and throughput.

Given that, we propose to split `Resize`/`StrictResize` nodes when the number of streams exceeds a predefined threshold. This reduces contention by distributing the workload across multiple nodes, minimizing concurrent access to `status_mutex`, and at the same time, maintains `Resize` processor's benefit of balancing data flow among multiple streams.

We tested on ClickBench using an Intel server (384 vCPU), this change delivers significant improvements:

Top Query Improvements :
Q30: **+73.9%**
Q27: **+55.7%**
Q31: **+51.3%**
Q6: **+41.0%**
Q2: **+34.3%**
Q42: **+33.5%**
**13** other queries improved by **>10%** .
**Geomean improvement** across all 43 queries: **+11.7%** .


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
