### PR TITLE
Fix RMV pointing to a table in another database

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -514,7 +514,7 @@ bool DatabaseReplicatedDDLWorker::canRemoveQueueEntry(const String & entry_name,
 bool DatabaseReplicatedDDLWorker::checkParentTableExists(const UUID & uuid) const
 {
     auto [db, table] = DatabaseCatalog::instance().tryGetByUUID(uuid);
-    return db.get() == database && table != nullptr && !table->is_dropped.load() && !table->is_detached.load();
+    return table != nullptr && !table->is_dropped.load() && !table->is_detached.load();
 }
 
 void DatabaseReplicatedDDLWorker::initializeLogPointer(const String & processed_entry_name)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix an error when a refreshable MV wouldn't work if it points to a table in another database.