### PR TITLE
Fix applying async_insert from server (via apply_settings_from_server)

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -72,7 +72,7 @@ Client::Client()
 
 Client::~Client() = default;
 
-void Client::processError(const String & query) const
+void Client::processError(const std::string_view & query) const
 {
     if (server_exception)
     {

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -72,7 +72,7 @@ Client::Client()
 
 Client::~Client() = default;
 
-void Client::processError(const std::string_view & query) const
+void Client::processError(std::string_view query) const
 {
     if (server_exception)
     {

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -27,13 +27,13 @@ public:
 protected:
     Poco::Util::LayeredConfiguration & getClientConfiguration() override;
 
-    bool processWithFuzzing(const String & full_query) override;
+    bool processWithFuzzing(const std::string_view & full_query) override;
     bool buzzHouse() override;
     std::optional<bool> processFuzzingStep(const String & query_to_execute, const ASTPtr & parsed_query, bool permissive);
 
     void connect() override;
 
-    void processError(const String & query) const override;
+    void processError(const std::string_view & query) const override;
 
     String getName() const override { return "client"; }
 

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -27,13 +27,13 @@ public:
 protected:
     Poco::Util::LayeredConfiguration & getClientConfiguration() override;
 
-    bool processWithFuzzing(const std::string_view & full_query) override;
+    bool processWithFuzzing(std::string_view full_query) override;
     bool buzzHouse() override;
     std::optional<bool> processFuzzingStep(const String & query_to_execute, const ASTPtr & parsed_query, bool permissive);
 
     void connect() override;
 
-    void processError(const std::string_view & query) const override;
+    void processError(std::string_view query) const override;
 
     String getName() const override { return "client"; }
 

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -47,7 +47,8 @@ extern const int BUZZHOUSE;
 
 std::optional<bool> Client::processFuzzingStep(const String & query_to_execute, const ASTPtr & parsed_query, const bool permissive)
 {
-    processParsedSingleQuery(query_to_execute, query_to_execute, parsed_query);
+    bool async_insert = false;
+    processParsedSingleQuery(query_to_execute, parsed_query, async_insert);
 
     const auto * exception = server_exception ? server_exception.get() : client_exception.get();
     // Sometimes you may get TOO_DEEP_RECURSION from the server,

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -48,7 +48,7 @@ extern const int BUZZHOUSE;
 std::optional<bool> Client::processFuzzingStep(const String & query_to_execute, const ASTPtr & parsed_query, const bool permissive)
 {
     bool async_insert = false;
-    processParsedSingleQuery(query_to_execute, parsed_query, async_insert);
+    processParsedSingleQuery(query_to_execute, query_to_execute, parsed_query, async_insert);
 
     const auto * exception = server_exception ? server_exception.get() : client_exception.get();
     // Sometimes you may get TOO_DEEP_RECURSION from the server,
@@ -106,7 +106,7 @@ std::optional<bool> Client::processFuzzingStep(const String & query_to_execute, 
 }
 
 /// Returns false when server is not available.
-bool Client::processWithFuzzing(const std::string_view & full_query)
+bool Client::processWithFuzzing(std::string_view full_query)
 {
     ASTPtr orig_ast;
 

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -48,7 +48,7 @@ extern const int BUZZHOUSE;
 std::optional<bool> Client::processFuzzingStep(const String & query_to_execute, const ASTPtr & parsed_query, const bool permissive)
 {
     bool async_insert = false;
-    processParsedSingleQuery(query_to_execute, query_to_execute, parsed_query, async_insert);
+    processParsedSingleQuery(query_to_execute, parsed_query, async_insert);
 
     const auto * exception = server_exception ? server_exception.get() : client_exception.get();
     // Sometimes you may get TOO_DEEP_RECURSION from the server,

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -106,7 +106,7 @@ std::optional<bool> Client::processFuzzingStep(const String & query_to_execute, 
 }
 
 /// Returns false when server is not available.
-bool Client::processWithFuzzing(const String & full_query)
+bool Client::processWithFuzzing(const std::string_view & full_query)
 {
     ASTPtr orig_ast;
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -151,7 +151,7 @@ Poco::Util::LayeredConfiguration & LocalServer::getClientConfiguration()
     return config();
 }
 
-void LocalServer::processError(const std::string_view &) const
+void LocalServer::processError(std::string_view) const
 {
     if (ignore_error)
         return;

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -151,7 +151,7 @@ Poco::Util::LayeredConfiguration & LocalServer::getClientConfiguration()
     return config();
 }
 
-void LocalServer::processError(const String &) const
+void LocalServer::processError(const std::string_view &) const
 {
     if (ignore_error)
         return;

--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -34,7 +34,7 @@ protected:
 
     void connect() override;
 
-    void processError(const String & query) const override;
+    void processError(const std::string_view & query) const override;
 
     String getName() const override { return "local"; }
 

--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -34,7 +34,7 @@ protected:
 
     void connect() override;
 
-    void processError(const std::string_view & query) const override;
+    void processError(std::string_view query) const override;
 
     String getName() const override { return "local"; }
 

--- a/programs/server/users.xml
+++ b/programs/server/users.xml
@@ -5,6 +5,7 @@
     <profiles>
         <!-- Default settings. -->
         <default>
+            <!-- <async_insert>1</async_insert> -->
         </default>
 
         <!-- Profile that allows only read queries. -->

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2255,7 +2255,7 @@ void ClientBase::processParsedSingleQuery(
         /// Send part of the query without data, because data will be sent separately.
         /// But for asynchronous inserts we don't extract data, because it's needed
         /// to be done on server side in that case (for coalescing the data from multiple inserts on server side).
-        if (insert && !is_async_insert_with_inlined_data)
+        if (insert && insert->data && !is_async_insert_with_inlined_data)
         {
             chassert(full_query.data() <= insert->data && insert->end <= full_query.data() + full_query.size() && "INSERT query points to full_query");
             query_to_execute = full_query.substr(0, insert->data - full_query.data());

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2762,7 +2762,7 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
                 // , where the inline data is delimited by semicolon and not by a
                 // newline.
                 auto * insert_ast = parsed_query->as<ASTInsertQuery>();
-                if (insert_ast && !is_async_insert_with_inlined_data)
+                if (insert_ast && insert_ast->data && !is_async_insert_with_inlined_data)
                 {
                     this_query_end = insert_ast->end;
                     adjustQueryEnd(

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2891,6 +2891,9 @@ bool ClientBase::addMergeTreeSettings(ASTCreateQuery & ast_create)
 void ClientBase::applySettingsFromServerIfNeeded()
 {
     const Settings & settings = client_context->getSettingsRef();
+    if (!settings[Setting::apply_settings_from_server])
+        return;
+
     SettingsChanges changes_to_apply;
     for (const SettingChange & change : settings_from_server)
     {
@@ -2900,8 +2903,7 @@ void ClientBase::applySettingsFromServerIfNeeded()
             changes_to_apply.push_back(change);
     }
 
-    if (settings[Setting::apply_settings_from_server])
-        global_context->applySettingsChanges(changes_to_apply);
+    global_context->applySettingsChanges(changes_to_apply);
 }
 
 void ClientBase::startKeystrokeInterceptorIfExists()

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -115,7 +115,7 @@ protected:
     /// This is the analogue of Poco::Application::config()
     virtual Poco::Util::LayeredConfiguration & getClientConfiguration() = 0;
 
-    virtual bool processWithFuzzing(const String &)
+    virtual bool processWithFuzzing(const std::string_view &)
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Query processing with fuzzing is not implemented");
     }
@@ -126,14 +126,15 @@ protected:
     }
 
     virtual void connect() = 0;
-    virtual void processError(const String & query) const = 0;
+    virtual void processError(const std::string_view & query) const = 0;
     virtual String getName() const = 0;
 
     void processOrdinaryQuery(const String & query_to_execute, ASTPtr parsed_query);
     void processInsertQuery(const String & query_to_execute, ASTPtr parsed_query);
 
+    /// Note, data that @parsed_query may refer to (in case of INSERT) should point to the same memory as full_query
     void processParsedSingleQuery(
-        const String & full_query,
+        const std::string_view & full_query,
         ASTPtr parsed_query,
         bool & is_async_insert_with_inlined_data,
         std::optional<bool> echo_query_ = {},

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -115,7 +115,7 @@ protected:
     /// This is the analogue of Poco::Application::config()
     virtual Poco::Util::LayeredConfiguration & getClientConfiguration() = 0;
 
-    virtual bool processWithFuzzing(const std::string_view &)
+    virtual bool processWithFuzzing(std::string_view)
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Query processing with fuzzing is not implemented");
     }
@@ -126,15 +126,18 @@ protected:
     }
 
     virtual void connect() = 0;
-    virtual void processError(const std::string_view & query) const = 0;
+    virtual void processError(std::string_view query) const = 0;
     virtual String getName() const = 0;
 
-    void processOrdinaryQuery(const String & query_to_execute, ASTPtr parsed_query);
-    void processInsertQuery(const String & query_to_execute, ASTPtr parsed_query);
+    void processOrdinaryQuery(String query, ASTPtr parsed_query);
+    void processInsertQuery(String query, ASTPtr parsed_query);
 
-    /// Note, data that @parsed_query may refer to (in case of INSERT) should point to the same memory as full_query
+    /// @full_query - query including trailing comments, INSERT inline data, used for echo and for handling INSERTs w/o async_insert
+    /// @query_to_execute - query for execution (without trailing comments and inline data), but in case of INSERT w/o async_insert calculated based on the full_query
+    /// @parsed_query should point to the same memory as full_query (in case of INSERT)
     void processParsedSingleQuery(
-        const std::string_view & full_query,
+        std::string_view full_query,
+        std::string_view query_to_execute,
         ASTPtr parsed_query,
         bool & is_async_insert_with_inlined_data,
         std::optional<bool> echo_query_ = {},

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -132,16 +132,12 @@ protected:
     void processOrdinaryQuery(String query, ASTPtr parsed_query);
     void processInsertQuery(String query, ASTPtr parsed_query);
 
-    /// @full_query - query including trailing comments, INSERT inline data, used for echo and for handling INSERTs w/o async_insert
-    /// @query_to_execute - query for execution (without trailing comments and inline data), but in case of INSERT w/o async_insert calculated based on the full_query
-    /// @parsed_query should point to the same memory as full_query (in case of INSERT)
     void processParsedSingleQuery(
-        std::string_view full_query,
-        std::string_view query_to_execute,
+        std::string_view query_,
         ASTPtr parsed_query,
         bool & is_async_insert_with_inlined_data,
-        std::optional<bool> echo_query_ = {},
-        bool report_error = false);
+        // to handle INSERT w/o async_insert
+        size_t insert_query_without_data_length = 0);
 
     static void adjustQueryEnd(const char *& this_query_end, const char * all_queries_end, uint32_t max_parser_depth, uint32_t max_parser_backtracks);
     virtual void setupSignalHandler() = 0;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -132,8 +132,12 @@ protected:
     void processOrdinaryQuery(const String & query_to_execute, ASTPtr parsed_query);
     void processInsertQuery(const String & query_to_execute, ASTPtr parsed_query);
 
-    void processParsedSingleQuery(const String & full_query, const String & query_to_execute,
-        ASTPtr parsed_query, std::optional<bool> echo_query_ = {}, bool report_error = false);
+    void processParsedSingleQuery(
+        const String & full_query,
+        ASTPtr parsed_query,
+        bool & is_async_insert_with_inlined_data,
+        std::optional<bool> echo_query_ = {},
+        bool report_error = false);
 
     static void adjustQueryEnd(const char *& this_query_end, const char * all_queries_end, uint32_t max_parser_depth, uint32_t max_parser_backtracks);
     virtual void setupSignalHandler() = 0;
@@ -143,7 +147,7 @@ protected:
     bool executeMultiQuery(const String & all_queries_text);
     MultiQueryProcessingStage analyzeMultiQueryText(
         const char *& this_query_begin, const char *& this_query_end, const char * all_queries_end,
-        String & query_to_execute, ASTPtr & parsed_query, const String & all_queries_text,
+        ASTPtr & parsed_query,
         std::unique_ptr<Exception> & current_exception);
 
     void clearTerminal();

--- a/src/Client/TestHint.cpp
+++ b/src/Client/TestHint.cpp
@@ -18,8 +18,7 @@ namespace DB::ErrorCodes
 namespace DB
 {
 
-TestHint::TestHint(const String & query_)
-    : query(query_)
+TestHint::TestHint(const std::string_view & query)
 {
     // Don't parse error hints in leading comments, because it feels weird.
     // Leading 'echo' hint is OK.

--- a/src/Client/TestHint.h
+++ b/src/Client/TestHint.h
@@ -54,7 +54,7 @@ class TestHint
 {
 public:
     using ErrorVector = std::vector<int>;
-    explicit TestHint(const String & query_);
+    explicit TestHint(const std::string_view & query);
 
     const auto & serverErrors() const { return server_errors; }
     const auto & clientErrors() const { return client_errors; }
@@ -69,7 +69,6 @@ public:
     bool needRetry(const std::unique_ptr<Exception> & server_exception, size_t * retries_counter);
 
 private:
-    const String & query;
     ErrorVector server_errors{};
     ErrorVector client_errors{};
     std::optional<bool> echo;

--- a/src/Common/QueryFuzzer.h
+++ b/src/Common/QueryFuzzer.h
@@ -70,7 +70,7 @@ public:
 
 private:
     template <typename Parser>
-    ASTPtr tryParseQueryForFuzzedTables(const String & full_query)
+    ASTPtr tryParseQueryForFuzzedTables(const std::string_view & full_query)
     {
         String message;
         const char * pos = full_query.data();
@@ -112,7 +112,7 @@ private:
 
 public:
     template <typename ParsedAST, typename Parser>
-    ASTs getQueriesForFuzzedTables(const String & full_query)
+    ASTs getQueriesForFuzzedTables(const std::string_view & full_query)
     {
         auto parsed_query = tryParseQueryForFuzzedTables<Parser>(full_query);
         if (!parsed_query)

--- a/src/Parsers/ParserInsertQuery.cpp
+++ b/src/Parsers/ParserInsertQuery.cpp
@@ -306,7 +306,7 @@ bool ParserInsertQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     query->select = select;
     query->settings_ast = settings_ast;
     query->data = data != end ? data : nullptr;
-    query->end = end;
+    query->end = data ? end : nullptr;
 
     if (columns)
         query->children.push_back(columns);

--- a/src/Server/ClientEmbedded/ClientEmbedded.cpp
+++ b/src/Server/ClientEmbedded/ClientEmbedded.cpp
@@ -43,7 +43,7 @@ void ClientEmbedded::printHelpMessage(const OptionsDescription & options_descrip
 }
 
 
-void ClientEmbedded::processError(const std::string_view &) const
+void ClientEmbedded::processError(std::string_view) const
 {
     if (ignore_error)
         return;

--- a/src/Server/ClientEmbedded/ClientEmbedded.cpp
+++ b/src/Server/ClientEmbedded/ClientEmbedded.cpp
@@ -43,7 +43,7 @@ void ClientEmbedded::printHelpMessage(const OptionsDescription & options_descrip
 }
 
 
-void ClientEmbedded::processError(const String &) const
+void ClientEmbedded::processError(const std::string_view &) const
 {
     if (ignore_error)
         return;

--- a/src/Server/ClientEmbedded/ClientEmbedded.h
+++ b/src/Server/ClientEmbedded/ClientEmbedded.h
@@ -54,7 +54,7 @@ protected:
 
     Poco::Util::LayeredConfiguration & getClientConfiguration() override;
 
-    void processError(const String & query) const override;
+    void processError(const std::string_view & query) const override;
 
     String getName() const override { return "embedded"; }
 

--- a/src/Server/ClientEmbedded/ClientEmbedded.h
+++ b/src/Server/ClientEmbedded/ClientEmbedded.h
@@ -54,7 +54,7 @@ protected:
 
     Poco::Util::LayeredConfiguration & getClientConfiguration() override;
 
-    void processError(const std::string_view & query) const override;
+    void processError(std::string_view query) const override;
 
     String getName() const override { return "embedded"; }
 

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -448,9 +448,9 @@ DistributedSink::runWritingJob(JobReplica & job, const Block & current_block, si
                     copy_query_ast,
                     job.local_context,
                     allow_materialized,
-                    /* no_squash */ false,
-                    /* no_destination */ false,
-                    /* async_isnert */ false);
+                    /* no_squash= */ false,
+                    /* no_destination= */ false,
+                    /* async_insert_= */ false);
                 auto block_io = interp.execute();
 
                 job.pipeline = std::move(block_io.pipeline);
@@ -755,9 +755,9 @@ void DistributedSink::writeToLocal(const Cluster::ShardInfo & shard_info, const 
             query_ast,
             context,
             allow_materialized,
-            /* no_squash */ false,
-            /* no_destination */ false,
-            /* async_isnert */ false);
+            /* no_squash= */ false,
+            /* no_destination= */ false,
+            /* async_insert_= */ false);
 
         auto block_io = interp.execute();
         PushingPipelineExecutor executor(block_io.pipeline);

--- a/tests/integration/test_settings_from_server/configs/users.d/users.xml
+++ b/tests/integration/test_settings_from_server/configs/users.d/users.xml
@@ -15,6 +15,9 @@
             <output_format_json_quote_64bit_integers>0</output_format_json_quote_64bit_integers>
             <compatibility>24.11</compatibility>
         </compat_profile>
+        <async_insert_profile>
+            <async_insert>1</async_insert>
+        </async_insert_profile>
     </profiles>
     <users>
         <default>
@@ -33,5 +36,9 @@
             <password></password>
             <profile>compat_profile</profile>
         </compat_user>
+        <async_insert_user>
+            <password></password>
+            <profile>async_insert_profile</profile>
+        </async_insert_user>
     </users>
 </clickhouse>

--- a/tests/integration/test_settings_from_server/test.py
+++ b/tests/integration/test_settings_from_server/test.py
@@ -87,3 +87,18 @@ def test_settings_from_server(started_cluster):
     assert quoted_pos != -1, "first query should return quoted number"
     assert unquoted_pos != -1, "second query should return unquoted number"
     assert quoted_pos < unquoted_pos, "should be quoted for first query, unquoted for second"
+
+
+@pytest.mark.parametrize("async_insert", [1, 0])
+@pytest.mark.parametrize("user", ["default", "async_insert_user"])
+def test_async_insert_from_server(started_cluster, async_insert, user):
+    node.query("drop table if exists data")
+    node.query("create table data (key Int) engine=Null")
+
+    node.query(
+        "insert into data values (1)",
+        settings={"async_insert": async_insert},
+        user=user,
+    )
+
+    node.query("drop table data")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix applying `async_insert` from server (via `apply_settings_from_server`) (previously leads to `Unknown packet 11 from server` errors on the client)

The problem is that async_insert is checked during parsing, to know what
to send to the server, even before server settings available. And this
leads to "Unknown packet 11 from server" errors.

So, first approach will be to simply ignore async_insert for
apply_settings_from_server, but this setting is interesting to apply
from the server (since this may have performance impact).

Another is to detect what part of the query we should apply after server
settings had been received, this patch follows this approach.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/78130
Supersedes: https://github.com/ClickHouse/ClickHouse/pull/78493