### PR TITLE
docs: use precision to calculate decimal value ranges

### DIFF
--- a/docs/en/sql-reference/data-types/decimal.md
+++ b/docs/en/sql-reference/data-types/decimal.md
@@ -27,6 +27,8 @@ Depending on P parameter value Decimal(P, S) is a synonym for:
 
 ## Decimal Value Ranges {#decimal-value-ranges}
 
+Decimal(P, S) - ( -1 \* 10^(P - S), 1 \* 10^(P - S) )
+
 - Decimal32(S) - ( -1 \* 10^(9 - S), 1 \* 10^(9 - S) )
 - Decimal64(S) - ( -1 \* 10^(18 - S), 1 \* 10^(18 - S) )
 - Decimal128(S) - ( -1 \* 10^(38 - S), 1 \* 10^(38 - S) )

--- a/docs/en/sql-reference/data-types/decimal.md
+++ b/docs/en/sql-reference/data-types/decimal.md
@@ -28,7 +28,6 @@ Depending on P parameter value Decimal(P, S) is a synonym for:
 ## Decimal Value Ranges {#decimal-value-ranges}
 
 Decimal(P, S) - ( -1 \* 10^(P - S), 1 \* 10^(P - S) )
-
 - Decimal32(S) - ( -1 \* 10^(9 - S), 1 \* 10^(9 - S) )
 - Decimal64(S) - ( -1 \* 10^(18 - S), 1 \* 10^(18 - S) )
 - Decimal128(S) - ( -1 \* 10^(38 - S), 1 \* 10^(38 - S) )


### PR DESCRIPTION
There's a bit of a conceptual mismatch between the explicit precision we define using Decimal(P, S) and the underlying storage type Decimal32(S) etc. that ClickHouse uses.

> Depending on P parameter value Decimal(P, S) is a synonym for:
> 
> P from [ 1 : 9 ] - for Decimal32(S)
> P from [ 10 : 18 ] - for Decimal64(S)
> P from [ 19 : 38 ] - for Decimal128(S)
> P from [ 39 : 76 ] - for Decimal256(S)

The documentation provides the decimal value range formula based on the underlying storage type e.g., 
`Decimal32(S) → -10^(9-S) to 10^(9-S)`, assuming P is always 9 for `Decimal32`.

However, if we explicitly specify `Decimal(8, S)`, the range is actually based on `P = 8`, not 9. Even though it's stored as `Decimal32(S)`, the provided precision is enforced.

So in order to calculate the correct range for any given combination of precision P and scale S, the following general formula should be used:
`Decimal(P, S) → -10^(P-S) to 10^(P-S)`


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)