### PR TITLE
Fix incremental builds for Rust

### DIFF
--- a/contrib/delta-kernel-rs-cmake/CMakeLists.txt
+++ b/contrib/delta-kernel-rs-cmake/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
     set(profile "release")
 endif()
 
-corrosion_import_crate(MANIFEST_PATH "${DELTA_KERNEL_RS_SOURCE_DIR}/ffi/Cargo.toml" NO_STD PROFILE ${profile} CRATE_TYPES staticlib ALL_FEATURES FLAGS --offline --crate-type=staticlib)
+corrosion_import_crate(MANIFEST_PATH "${DELTA_KERNEL_RS_SOURCE_DIR}/ffi/Cargo.toml" NO_STD PROFILE ${profile} CRATE_TYPES staticlib ALL_FEATURES FLAGS --offline)
 corrosion_set_env_vars(delta_kernel_ffi
         "CARGO_TARGET_DIR=${DELTA_KERNEL_TARGET_PATH}"
         "OPENSSL_LIBS=${SSLNAME}:${CRYPTONAME}"


### PR DESCRIPTION
`--crate-tybe=staticlib` [1] leads to:

    $ nice -n100 ninja  clickhouse -k0
    [0/2] Re-checking globbed directories...
    [27/2827] cd /src/ch/clickhouse/rust/workspace/prql && /usr/bin/cmake -E env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/src/llvm/llvm-project/...._prql --profile=release --offline --locked --config=/src/ch/clickhouse/.cmake/contrib/corrosion-cmake/config.toml -- -Cdefault-linker-libraries=no
        Finished `release` profile [optimized] target(s) in 0.20s
    [104/2827] cd /src/ch/clickhouse/contrib/delta-kernel-rs/ffi && /usr/bin/cmake -E env CARGO_TARGET_DIR=/src/ch/clickhouse/.cmake/contrib/delta-ker...e=release --offline --crate-type=staticlib --config=/src/ch/clickhouse/.cmake/contrib/corrosion-cmake/config.toml -- -Cdefault-linker-libraries=no
    warning: output filename collision.
    The lib target `delta_kernel_ffi` in package `delta_kernel_ffi v0.6.1 (/src/ch/clickhouse/contrib/delta-kernel-rs/ffi)` has the same output filename as the lib target `delta_kernel_ffi` in package `delta_kernel_ffi v0.6.1 (/src/ch/clickhouse/contrib/delta-kernel-rs/ffi)`.
    Colliding filename is: /src/ch/clickhouse/.cmake/./cargo/build/delta_kernel_ffi/x86_64-unknown-linux-gnu/release/deps/libdelta_kernel_ffi-f4a342f59d67a13a.a
    The targets should have unique names.
    Consider changing their names to be unique or compiling them separately.
    This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
    warning: output filename collision.
    The lib target `delta_kernel_ffi` in package `delta_kernel_ffi v0.6.1 (/src/ch/clickhouse/contrib/delta-kernel-rs/ffi)` has the same output filename as the lib target `delta_kernel_ffi` in package `delta_kernel_ffi v0.6.1 (/src/ch/clickhouse/contrib/delta-kernel-rs/ffi)`.
    Colliding filename is: /src/ch/clickhouse/.cmake/./cargo/build/delta_kernel_ffi/x86_64-unknown-linux-gnu/release/libdelta_kernel_ffi.a
    The targets should have unique names.
    Consider changing their names to be unique or compiling them separately.
    This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
    thread 'main' panicked at src/cargo/core/compiler/fingerprint/mod.rs:1104:13:
    assertion failed: mtimes.insert(output.clone(), mtime).is_none()
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    [127/2827] Building CXX object src/Common/mysqlxx/CMakeFiles/mysqlxx.dir/PoolWithFailover.cpp.o
    FAILED: contrib/delta-kernel-rs-cmake/CMakeFiles/_cargo-build_delta_kernel_ffi /src/ch/clickhouse/.cmake/contrib/delta-kernel-rs-cmake/CMakeFiles/_cargo-build_delta_kernel_ffi
    cd /src/ch/clickhouse/contrib/delta-kernel-rs/ffi && /usr/bin/cmake -E env CARGO_TARGET_DIR=/src/ch/clickhouse/.cmake/contrib/delta-kernel-rs/include OPENSSL_LIBS=ssl:crypto OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/src/ch/clickhouse/.cmake/contrib/openssl-cmake/ OPENSSL_INCLUDE_DIR=/src/ch/clickhouse/.cmake/contrib/delta-kernel-rs/linux_x86_64 CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/src/llvm/llvm-project/.cmake/bin/clang CC_x86_64_unknown_linux_gnu=/src/llvm/llvm-project/.cmake/bin/clang CXX_x86_64_unknown_linux_gnu=/src/llvm/llvm-project/.cmake/bin/clang++ AR_x86_64_unknown_linux_gnu=/src/llvm/llvm-project/.cmake/bin/llvm-ar CORROSION_BUILD_DIR=/src/ch/clickhouse/.cmake/contrib/delta-kernel-rs-cmake CARGO_BUILD_RUSTC=/home/azat/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/rustc /home/azat/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo rustc --lib --target=x86_64-unknown-linux-gnu --all-features --package delta_kernel_ffi --crate-type=staticlib --manifest-path /src/ch/clickhouse/contrib/delta-kernel-rs/ffi/Cargo.toml --target-dir /src/ch/clickhouse/.cmake/./cargo/build/delta_kernel_ffi --profile=release --offline --crate-type=staticlib --config=/src/ch/clickhouse/.cmake/contrib/corrosion-cmake/config.toml -- -Cdefault-linker-libraries=no
    [128/2827] cd /src/ch/clickhouse/rust/workspace/skim && /usr/bin/cmake -E env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/src/llvm/llvm-project/..._rust --profile=release --offline --locked --config=/src/ch/clickhouse/.cmake/contrib/corrosion-cmake/config.toml -- -Cdefault-linker-libraries=no
        Finished `release` profile [optimized] target(s) in 0.19s
    [193/2827] Linking CXX static library programs/extract-from-config/libclickhouse-extract-from-config-lib.a
    ninja: build stopped: cannot make progress due to previous errors.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/76921/files#r1995069020

Apparently the problem is jsut the double `--create-type=staticlib` one explicit and one via `CRATE_TYPES staticlib`. So let's remove explicit.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)