### PR TITLE
CI: Fix for invalid CI cache reuse

### DIFF
--- a/ci/praktika/hook_cache.py
+++ b/ci/praktika/hook_cache.py
@@ -34,13 +34,11 @@ class CacheRunnerHooks:
                 artifact_digest_map[job.name] = digest
         for job in workflow.jobs:
             digests_combined_list = []
-            # Should digest depend on required job artifacts?
-            # Remove the code below and related variables: artifact_digest_map, if not?
-            # if job.requires and job.digest_config:
-            #     # include digest of required artifact to the job digest, so that they affect job state
-            #     for artifact_name in job.requires:
-            #         if artifact_name in artifact_digest_map:
-            #             digests_combined_list.append(artifact_digest_map[artifact_name])
+            if job.requires and job.digest_config:
+                # include digest of required artifact to the job digest, so that they affect job state
+                for artifact_name in job.requires:
+                    if artifact_name in artifact_digest_map:
+                        digests_combined_list.append(artifact_digest_map[artifact_name])
             digests_combined_list.append(job_digest_map[job.name])
             final_digest = "-".join(digests_combined_list)
             workflow_config.digest_jobs[job.name] = final_digest

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -4,8 +4,8 @@ from ci.defs.defs import BASE_BRANCH, SECRETS, ArtifactConfigs
 from ci.defs.job_configs import JobConfigs
 from ci.jobs.scripts.workflow_hooks.filter_job import should_skip_job
 from ci.workflows.pull_request import (
-    REQUIRED_STATELESS_TESTS_JOB_NAMES,
     REGULAR_BUILD_NAMES,
+    REQUIRED_STATELESS_TESTS_JOB_NAMES,
 )
 
 workflow = Workflow.Config(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Removes bug introduced in https://github.com/ClickHouse/ClickHouse/pull/77223
Job Digest must respect job.requires field

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
