### PR TITLE
Reduce memory usage during prefetches of JSON column in Wide parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -72,7 +72,9 @@ void MergeTreeReaderWide::prefetchBeginOfRange(Priority priority)
 
     try
     {
-        prefetchForAllColumns(priority, columns_to_read.size(), all_mark_ranges.front().begin, all_mark_ranges.back().end, false);
+        /// Start prefetches for all columns. But don't deserialize prefixes, because it can be a heavy operation
+        /// (for example for JSON column) and starting prefetches for all subcolumns here can consume a lot of memory.
+        prefetchForAllColumns(priority, columns_to_read.size(), all_mark_ranges.front().begin, all_mark_ranges.back().end, false, /*deserialize_prefixes=*/false);
         prefetched_from_mark = all_mark_ranges.front().begin;
         /// Arguments explanation:
         /// Current prefetch is done for read tasks before they can be picked by reading threads in IMergeTreeReadPool::getTask method.
@@ -93,7 +95,12 @@ void MergeTreeReaderWide::prefetchBeginOfRange(Priority priority)
 }
 
 void MergeTreeReaderWide::prefetchForAllColumns(
-    Priority priority, size_t num_columns, size_t from_mark, size_t current_task_last_mark, bool continue_reading)
+    Priority priority,
+    size_t num_columns,
+    size_t from_mark,
+    size_t current_task_last_mark,
+    bool continue_reading,
+    bool deserialize_prefixes)
 {
     bool do_prefetch = data_part_info_for_read->getDataPartStorage()->isStoredOnRemoteDisk()
         ? settings.read_settings.remote_fs_prefetch
@@ -102,7 +109,8 @@ void MergeTreeReaderWide::prefetchForAllColumns(
     if (!do_prefetch)
         return;
 
-    deserializePrefixForAllColumnsWithPrefetch(num_columns, current_task_last_mark, priority);
+    if (deserialize_prefixes)
+        deserializePrefixForAllColumnsWithPrefetch(num_columns, current_task_last_mark, priority);
 
     /// Request reading of data in advance,
     /// so if reading can be asynchronous, it will also be performed in parallel for all columns.
@@ -142,7 +150,7 @@ size_t MergeTreeReaderWide::readRows(
         if (num_columns == 0)
             return max_rows_to_read;
 
-        prefetchForAllColumns(Priority{}, num_columns, from_mark, current_task_last_mark, continue_reading);
+        prefetchForAllColumns(Priority{}, num_columns, from_mark, current_task_last_mark, continue_reading, /*deserialize_prefixes=*/ true);
         deserializePrefixForAllColumns(num_columns, current_task_last_mark);
 
         for (size_t pos = 0; pos < num_columns; ++pos)
@@ -164,7 +172,7 @@ size_t MergeTreeReaderWide::readRows(
                 readData(
                     column_to_read, serializations[pos], column,
                     from_mark, continue_reading, current_task_last_mark,
-                    max_rows_to_read, cache, deserialize_states_cache, /* was_prefetched =*/ !prefetched_streams.empty());
+                    max_rows_to_read, cache, deserialize_states_cache);
 
                 /// For elements of Nested, column_size_before_reading may be greater than column size
                 ///  if offsets are not empty and were already read, but elements are empty.
@@ -457,9 +465,17 @@ void MergeTreeReaderWide::prefetchForColumn(
         }
     };
 
-    auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withDeserializeState(deserialize_binary_bulk_state_map[name_and_type.name]);
-    ISerialization::EnumerateStreamsSettings settings;
-    serialization->enumerateStreams(settings, callback, data);
+    /// If we already deserialized prefixes, we can use deserialization state during streams enumeration to enumerate dynamic subcolumns.
+    if (!deserialize_binary_bulk_state_map.empty())
+    {
+        auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withDeserializeState(deserialize_binary_bulk_state_map[name_and_type.name]);
+        ISerialization::EnumerateStreamsSettings settings;
+        serialization->enumerateStreams(settings, callback, data);
+    }
+    else
+    {
+        serialization->enumerateStreams(callback);
+    }
 }
 
 
@@ -472,8 +488,7 @@ void MergeTreeReaderWide::readData(
     size_t current_task_last_mark,
     size_t max_rows_to_read,
     ISerialization::SubstreamsCache & cache,
-    ISerialization::SubstreamsDeserializeStatesCache & deserialize_states_cache,
-    bool was_prefetched)
+    ISerialization::SubstreamsDeserializeStatesCache & deserialize_states_cache)
 {
     double & avg_value_size_hint = avg_value_size_hints[name_and_type.name];
     ISerialization::DeserializeBinaryBulkSettings deserialize_settings;
@@ -483,6 +498,7 @@ void MergeTreeReaderWide::readData(
 
     deserialize_settings.getter = [&](const ISerialization::SubstreamPath & substream_path)
     {
+        bool was_prefetched = prefetched_streams.contains(*IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, data_part_info_for_read->getChecksums()));
         bool seek_to_mark = !was_prefetched && !continue_reading && !read_without_marks;
 
         return getStream(

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -498,7 +498,8 @@ void MergeTreeReaderWide::readData(
 
     deserialize_settings.getter = [&](const ISerialization::SubstreamPath & substream_path)
     {
-        bool was_prefetched = prefetched_streams.contains(*IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, data_part_info_for_read->getChecksums()));
+        auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, data_part_info_for_read->getChecksums());
+        bool was_prefetched = stream_name && prefetched_streams.contains(*stream_name);
         bool seek_to_mark = !was_prefetched && !continue_reading && !read_without_marks;
 
         return getStream(

--- a/src/Storages/MergeTree/MergeTreeReaderWide.h
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.h
@@ -42,7 +42,13 @@ public:
 private:
     FileStreams streams;
 
-    void prefetchForAllColumns(Priority priority, size_t num_columns, size_t from_mark, size_t current_task_last_mark, bool continue_reading);
+    void prefetchForAllColumns(
+        Priority priority,
+        size_t num_columns,
+        size_t from_mark,
+        size_t current_task_last_mark,
+        bool continue_reading,
+        bool deserialize_prefixes);
 
     void addStreams(
         const NameAndTypePair & name_and_type,
@@ -69,8 +75,7 @@ private:
         size_t current_task_last_mark,
         size_t max_rows_to_read,
         ISerialization::SubstreamsCache & cache,
-        ISerialization::SubstreamsDeserializeStatesCache & deserialize_states_cache,
-        bool was_prefetched);
+        ISerialization::SubstreamsDeserializeStatesCache & deserialize_states_cache);
 
     /// Make next readData more simple by calling 'prefetch' of all related ReadBuffers (column streams).
     void prefetchForColumn(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce memory usage during prefetches of JSON column in Wide parts

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
