### PR TITLE
Docs: Do not recommend CLion

### DIFF
--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -102,28 +102,16 @@ Below you can find some quick links which may be useful when writing code for Cl
 
 ### IDE {#ide}
 
-**CLion (recommended)**
+[Visual Studio Code](https://code.visualstudio.com/) and [Neovim](https://neovim.io/) are two options that have worked well in the past for developing ClickHouse. If you are using VS Code, we recommend using the [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) to replace IntelliSense as it is much more performant.
 
-If you do not know which IDE to use, we recommend that you use [CLion](https://www.jetbrains.com/clion/).
-CLion is commercial software, but it offers a 30 day free trial.
-It is also free of charge for students.
-CLion can be used on both Linux and macOS.
+[KDevelop](https://kdevelop.org/) and [Qt Creator](https://www.qt.io/product/development-tools) are other great alternatives. While KDevelop is a great IDE, it is sometimes unstable. If KDevelop crashes when opening a project, you should click the "Stop All" button as soon as it has opened the list of project files. After doing so, KDevelop should be fine to work with.
 
-A few things to know when using CLion to develop ClickHouse:
+Other IDEs you can use are [Sublime Text](https://www.sublimetext.com/), [Kate](https://kate-editor.org/), or [CLion](https://www.jetbrains.com/clion/). CLion tends to be slow on larger projects like ClickHouse.
+A few things to keep in mind when using CLion:
 
 - CLion creates a `build` path on its own and automatically selects `debug` for the build type
 - It uses a version of CMake that is defined in CLion and not the one installed by you
 - CLion will use `make` to run build tasks instead of `ninja` (this is normal behavior)
-
-**Alternatives**
-
-[KDevelop](https://kdevelop.org/) and [QTCreator](https://www.qt.io/product/development-tools) are other great alternative IDEs for developing ClickHouse.
-While KDevelop is a great IDE, it is sometimes unstable.
-If KDevelop crashes when opening a project, you should click the "Stop All" button as soon as it has opened the list of project's files.
-After doing so, KDevelop should be fine to work with.
-
-Other IDEs you can use are [Sublime Text](https://www.sublimetext.com/), [Visual Studio Code](https://code.visualstudio.com/), or [Kate](https://kate-editor.org/) (all of which are available on Linux).
-If you are using VS Code, we recommend using the [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) to replace IntelliSense as it is much more performant.
 
 ## Create A Pull Request {#create-a-pull-request}
 

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -684,6 +684,7 @@ Nambiar
 Namenode
 NamesAndTypesList
 Nano
+Neovim
 Nesterov
 NetworkReceive
 NetworkReceiveBytes


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not recommend CLion as default IDE for ClickHouse development

### Documentation entry for user-facing changes
Currently, CLion is the recommended IDE for ClickHouse development. However, it is extremely slow with larger projects like this one. This PR reviews such recommendation and warns the developer of potential speed issues