### PR TITLE
Fix BuzzHouse and AST fuzzer CI runs

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -853,12 +853,12 @@ void Client::processOptions(
         config().setBool("ignore-error", true);
         ignore_error = true;
 #if USE_BUZZHOUSE
-        if (query_fuzzer_runs && !buzz_house_options_path.empty())
+        if (!buzz_house_options_path.empty())
         {
             fuzz_config = std::make_unique<BuzzHouse::FuzzConfig>(this, buzz_house_options_path);
             external_integrations = std::make_unique<BuzzHouse::ExternalIntegrations>(*fuzz_config);
 
-            if (fuzz_config->seed)
+            if (query_fuzzer_runs && fuzz_config->seed)
             {
                 fuzzer.setSeed(fuzz_config->seed);
             }

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1442,7 +1442,8 @@ ASTPtr QueryFuzzer::addJoinClause()
             std::advance(rand_col2, fuzz_rand() % to_search.size());
 
             const String id1_alias = id1->tryGetAlias();
-            const String & nidentifier = (id1_alias.empty() || (fuzz_rand() % 2 == 0)) ? id1->shortName() : id1_alias;
+            const String & nidentifier = (id1_alias.empty() || (fuzz_rand() % 2 == 0)) ?
+            (id1->shortName().empty() ? id1->name() : id1->shortName()) : id1_alias;
             ASTPtr exp1 = std::make_shared<ASTIdentifier>(Strings{next_alias, nidentifier});
             ASTPtr exp2 = rand_col2->second->clone();
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

This closes: https://github.com/ClickHouse/ClickHouse/issues/77660

### Documentation entry for user-facing changes

I broke it with the AST fuzzer update.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
