### PR TITLE
Fix filesystem_cache_log working only under setting

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -78,7 +78,7 @@ CachedOnDiskReadBufferFromFile::CachedOnDiskReadBufferFromFile(
     , allow_seeks_after_first_read(allow_seeks_after_first_read_)
     , use_external_buffer(use_external_buffer_)
     , query_context_holder(cache_->getQueryContextHolder(query_id, settings_))
-    , cache_log(cache_log_)
+    , cache_log(settings.enable_filesystem_cache_log ? cache_log_ : nullptr)
 {
 }
 

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.h
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.h
@@ -27,11 +27,8 @@ public:
         ReadBufferCreator && read_buffer_creator_,
         const StoredObjects & blobs_to_read_,
         const ReadSettings & settings_,
-        std::shared_ptr<FilesystemCacheLog> cache_log_,
         bool use_external_buffer_,
         size_t buffer_size);
-
-    ~ReadBufferFromRemoteFSGather() override;
 
     String getFileName() const override { return current_object.remote_path; }
 
@@ -64,14 +61,11 @@ private:
 
     bool moveToNextBuffer();
 
-    void appendUncachedReadInfo();
-
     void reset();
 
     const ReadSettings settings;
     const StoredObjects blobs_to_read;
     const ReadBufferCreator read_buffer_creator;
-    const std::shared_ptr<FilesystemCacheLog> cache_log;
     const String query_id;
     const bool use_external_buffer;
     const bool with_file_cache;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -741,7 +741,6 @@ std::unique_ptr<ReadBufferFromFileBase> DiskObjectStorage::readFile(
         std::move(read_buffer_creator),
         storage_objects,
         read_settings,
-        global_context->getFilesystemCacheLog(),
         use_external_buffer_for_gather,
         /* buffer_size */use_external_buffer_for_gather ? 0 : buffer_size);
 

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -768,3 +768,44 @@ SELECT * FROM test;
     assert 100 == int(node.query(
         f"SELECT max_elements FROM system.filesystem_cache_settings WHERE cache_name = '{cache_name}'"
     ))
+
+
+def test_filesystem_cache_log(cluster):
+    node = cluster.instances["node"]
+    node.query(
+        """
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test (a Int32, b String)
+ENGINE = MergeTree() ORDER BY tuple()
+SETTINGS disk = disk(type = cache,
+            max_size = '10Gi',
+            path = "test_filesystem_cache_log",
+            disk = hdd_blob),
+        min_bytes_for_wide_part = 10485760;
+    """
+    )
+
+    node.query(
+        """
+INSERT INTO test SELECT 1, 'test';
+    """
+    )
+
+    query_id = "system_filesystem_cache_log"
+    node.query(
+        "SELECT * FROM test FORMAT Null SETTINGS enable_filesystem_cache_log = 0",
+        query_id=query_id,
+    )
+
+    node.query("SYSTEM FLUSH LOGS")
+    assert 0 == int(node.query(f"SELECT count() FROM system.filesystem_cache_log WHERE query_id = '{query_id}'"))
+
+    query_id = "system_filesystem_cache_log_2"
+    node.query(
+        "SELECT * FROM test FORMAT Null SETTINGS enable_filesystem_cache_log = 1",
+        query_id=query_id,
+    )
+
+    node.query("SYSTEM FLUSH LOGS")
+    assert 0 < int(node.query(f"SELECT count() FROM system.filesystem_cache_log WHERE query_id = '{query_id}'"))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system.filesystem_cache_log working only under setting `enable_filesystem_cache_log`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
