### PR TITLE
Fix InterpreterDropQuery::executeToDatabaseImpl calling waitDetachedTableNotInUse for non-DETACH queries

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -464,7 +464,7 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
     }
 
     // only if operation is DETACH
-    if ((!drop || !truncate) && query.sync)
+    if (!drop && !truncate && query.sync)
     {
         /// Avoid "some tables are still in use" when sync mode is enabled
         for (const auto & table_uuid : uuids_to_wait)
@@ -474,7 +474,7 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
     /// Protects from concurrent CREATE TABLE queries
     auto db_guard = DatabaseCatalog::instance().getExclusiveDDLGuardForDatabase(database_name);
     // only if operation is DETACH
-    if (!drop || !truncate)
+    if (!drop && !truncate)
         database->assertCanBeDetached(true);
 
     /// DETACH or DROP database itself. If TRUNCATE skip dropping/erasing the database.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I don't know anything about this code, but `!drop || !truncate` doesn't make sense (it's always `true`), the author obviously meant `!drop && !truncate`. Here's a fix. It was broken by https://github.com/ClickHouse/ClickHouse/pull/53261 1.5 years ago, so it's possible that this bug became load-bearing, and something will break. If so, we'll replace `!drop || !truncate` with `true` instead.