### PR TITLE
Fix logical error in defaultRoles function

### DIFF
--- a/src/Functions/currentProfiles.cpp
+++ b/src/Functions/currentProfiles.cpp
@@ -1,4 +1,5 @@
 #include <Access/AccessControl.h>
+#include <Access/ContextAccess.h>
 #include <Access/User.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
@@ -8,7 +9,6 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Interpreters/Context.h>
-#include "Access/ContextAccess.h"
 
 
 namespace DB

--- a/src/Functions/currentRoles.cpp
+++ b/src/Functions/currentRoles.cpp
@@ -1,15 +1,17 @@
 #include <base/sort.h>
-#include <Functions/IFunction.h>
-#include <Functions/FunctionFactory.h>
-#include <Interpreters/Context.h>
+
 #include <Access/AccessControl.h>
+#include <Access/ContextAccess.h>
 #include <Access/EnabledRolesInfo.h>
 #include <Access/User.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnString.h>
-#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
 
 
 namespace DB
@@ -75,8 +77,8 @@ namespace
             {
                 static_assert(kind == Kind::DEFAULT_ROLES);
                 const auto & manager = context->getAccessControl();
-                auto user = context->getUser();
-                role_names = manager.tryReadNames(user->granted_roles.findGranted(user->default_roles));
+                if (const auto user = context->getAccess()->tryGetUser())
+                    role_names = manager.tryReadNames(user->granted_roles.findGranted(user->default_roles));
             }
 
             /// We sort the names because the result of the function should not depend on the order of UUIDs.

--- a/tests/queries/0_stateless/03362_default_profiles_context.sql
+++ b/tests/queries/0_stateless/03362_default_profiles_context.sql
@@ -1,1 +1,2 @@
 CREATE TEMPORARY TABLE t0 (c0 Int TTL defaultProfiles()) ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+CREATE TEMPORARY TABLE t0 (c0 Int TTL defaultRoles()) ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a logical error when calling `defaultRoles()` function inside a projection.
Follow-up for #76627

Closes #72958

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
