### PR TITLE
Make the move operator for ColumnDefault truly noexcept

### DIFF
--- a/src/Storages/ColumnDefault.cpp
+++ b/src/Storages/ColumnDefault.cpp
@@ -74,7 +74,7 @@ ColumnDefault & ColumnDefault::operator=(ColumnDefault && other) noexcept
         return *this;
 
     kind = std::exchange(other.kind, ColumnDefaultKind{});
-    expression = other.expression ? other.expression->clone() : nullptr;
+    expression = std::exchange(other.expression, nullptr);
     other.expression.reset();
     ephemeral_default = std::exchange(other.ephemeral_default, false);
 

--- a/src/Storages/ColumnDefault.cpp
+++ b/src/Storages/ColumnDefault.cpp
@@ -75,7 +75,6 @@ ColumnDefault & ColumnDefault::operator=(ColumnDefault && other) noexcept
 
     kind = std::exchange(other.kind, ColumnDefaultKind{});
     expression = std::exchange(other.expression, nullptr);
-    other.expression.reset();
     ephemeral_default = std::exchange(other.ephemeral_default, false);
 
     return *this;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make the move operator for class `ColumnDefault` truly noexcept.