### PR TITLE
Improve performance of S3Queue/AzureQueue by allowing INSERTs data in parallel

### DIFF
--- a/docs/en/engines/table-engines/integrations/azure-queue.md
+++ b/docs/en/engines/table-engines/integrations/azure-queue.md
@@ -82,7 +82,7 @@ For more information about virtual columns see [here](../../../engines/table-eng
 
 ## Introspection {#introspection}
 
-Enable logging for the table via the table setting `enable_logging_to_s3queue_log=1`.
+Enable logging for the table via the table setting `enable_logging_to_queue_log=1`.
 
 Introspection capabilities are the same as the [S3Queue table engine](/engines/table-engines/integrations/s3queue#introspection) with several distinct differences:
 

--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -25,6 +25,7 @@ CREATE TABLE s3_queue_engine_table (name String, value UInt32)
     [keeper_path = '',]
     [loading_retries = 0,]
     [processing_threads_num = 16,]
+    [parallel_inserts = false,]
     [enable_logging_to_queue_log = true,]
     [last_processed_path = "",]
     [tracked_files_limit = 1000,]
@@ -127,6 +128,17 @@ Default value: `0`.
 Number of threads to perform processing. Applies only for `Unordered` mode.
 
 Default value: Number of CPUs or 16.
+
+### s3queue_parallel_inserts {#parallel_inserts}
+
+By default `processing_threads_num` will produce one `INSERT`, so it will only download files and parse in multiple threads.
+But this limits the parallelism, so for better throughput use `parallel_inserts=true`, this will allow to insert data in parallel (but keep in mind that it will result in higher number of generated data parts for MergeTree family).
+
+:::note
+`INSERT`s will be spawned with respect to `max_process*_before_commit` settings.
+:::
+
+Default value: `false`.
 
 ### s3queue_enable_logging_to_s3queue_log {#enable_logging_to_s3queue_log}
 

--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -24,15 +24,23 @@ CREATE TABLE s3_queue_engine_table (name String, value UInt32)
     [after_processing = 'keep',]
     [keeper_path = '',]
     [loading_retries = 0,]
-    [processing_threads_num = 1,]
-    [enable_logging_to_s3queue_log = 0,]
+    [processing_threads_num = 16,]
+    [enable_logging_to_queue_log = true,]
+    [last_processed_path = "",]
+    [tracked_files_limit = 1000,]
+    [tracked_file_ttl_sec = 0,]
     [polling_min_timeout_ms = 1000,]
     [polling_max_timeout_ms = 10000,]
     [polling_backoff_ms = 0,]
-    [tracked_file_ttl_sec = 0,]
-    [tracked_files_limit = 1000,]
     [cleanup_interval_min_ms = 10000,]
     [cleanup_interval_max_ms = 30000,]
+    [buckets = 0,]
+    [list_objects_batch_size = 1000,]
+    [enable_hash_ring_filtering = 0,]
+    [max_processed_files_before_commit = 100,]
+    [max_processed_rows_before_commit = 0,]
+    [max_processed_bytes_before_commit = 0,]
+    [max_processing_time_sec_before_commit = 0,]
 ```
 
 :::warning
@@ -118,7 +126,7 @@ Default value: `0`.
 
 Number of threads to perform processing. Applies only for `Unordered` mode.
 
-Default value: `1`.
+Default value: Number of CPUs or 16.
 
 ### s3queue_enable_logging_to_s3queue_log {#enable_logging_to_s3queue_log}
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -27,6 +27,7 @@ namespace ErrorCodes
     DECLARE(String, keeper_path, "", "Zookeeper node path", 0) \
     DECLARE(UInt64, loading_retries, 10, "Retry loading up to specified number of times", 0) \
     DECLARE(UInt64, processing_threads_num, 1, "Number of processing threads (default number of available CPUs or 16)", 0) \
+    DECLARE(Bool, parallel_inserts, false, "By default processing_threads_num will produce one INSERT, but this limits the parallel execution, so better scalability enable this setting (note this will create not one INSERT per file, but one per max_process*_before_commit)", 0) \
     DECLARE(UInt32, enable_logging_to_queue_log, 1, "Enable logging to system table system.(s3/azure_)queue_log", 0) \
     DECLARE(String, last_processed_path, "", "For Ordered mode. Files that have lexicographically smaller file name are considered already processed", 0) \
     DECLARE(UInt64, tracked_files_limit, 1000, "For unordered mode. Max set size for tracking processed files in ZooKeeper", 0) \
@@ -39,10 +40,10 @@ namespace ErrorCodes
     DECLARE(UInt64, buckets, 0, "Number of buckets for Ordered mode parallel processing", 0) \
     DECLARE(UInt64, list_objects_batch_size, 1000, "Size of a list batch in object storage", 0) \
     DECLARE(Bool, enable_hash_ring_filtering, 0, "Enable filtering files among replicas according to hash ring for Unordered mode", 0) \
-    DECLARE(UInt64, max_processed_files_before_commit, 100, "Number of files which can be processed before being committed to keeper", 0) \
-    DECLARE(UInt64, max_processed_rows_before_commit, 0, "Number of rows which can be processed before being committed to keeper", 0) \
-    DECLARE(UInt64, max_processed_bytes_before_commit, 0, "Number of bytes which can be processed before being committed to keeper", 0) \
-    DECLARE(UInt64, max_processing_time_sec_before_commit, 0, "Timeout in seconds after which to commit files committed to keeper", 0) \
+    DECLARE(UInt64, max_processed_files_before_commit, 100, "Number of files which can be processed before being committed to keeper (in case of parallel_inserts=true, works on a per-thread basis)", 0) \
+    DECLARE(UInt64, max_processed_rows_before_commit, 0, "Number of rows which can be processed before being committed to keeper (in case of parallel_inserts=true, works on a per-thread basis)", 0) \
+    DECLARE(UInt64, max_processed_bytes_before_commit, 0, "Number of bytes which can be processed before being committed to keeper (in case of parallel_inserts=true, works on a per-thread basis)", 0) \
+    DECLARE(UInt64, max_processing_time_sec_before_commit, 0, "Timeout in seconds after which to commit files committed to keeper (in case of parallel_inserts=true, works on a per-thread basis)", 0) \
 
 #define LIST_OF_OBJECT_STORAGE_QUEUE_SETTINGS(M, ALIAS) \
     OBJECT_STORAGE_QUEUE_RELATED_SETTINGS(M, ALIAS) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -26,7 +26,7 @@ namespace ErrorCodes
     DECLARE(ObjectStorageQueueAction, after_processing, ObjectStorageQueueAction::KEEP, "Delete or keep file in after successful processing", 0) \
     DECLARE(String, keeper_path, "", "Zookeeper node path", 0) \
     DECLARE(UInt64, loading_retries, 10, "Retry loading up to specified number of times", 0) \
-    DECLARE(UInt64, processing_threads_num, 1, "Number of processing threads", 0) \
+    DECLARE(UInt64, processing_threads_num, 1, "Number of processing threads (default number of available CPUs or 16)", 0) \
     DECLARE(UInt32, enable_logging_to_queue_log, 1, "Enable logging to system table system.(s3/azure_)queue_log", 0) \
     DECLARE(String, last_processed_path, "", "For Ordered mode. Files that have lexicographically smaller file name are considered already processed", 0) \
     DECLARE(UInt64, tracked_files_limit, 1000, "For unordered mode. Max set size for tracking processed files in ZooKeeper", 0) \
@@ -37,7 +37,7 @@ namespace ErrorCodes
     DECLARE(UInt32, cleanup_interval_min_ms, 60000, "For unordered mode. Polling backoff min for cleanup", 0) \
     DECLARE(UInt32, cleanup_interval_max_ms, 60000, "For unordered mode. Polling backoff max for cleanup", 0) \
     DECLARE(UInt64, buckets, 0, "Number of buckets for Ordered mode parallel processing", 0) \
-    DECLARE(UInt64, list_objects_batch_size, 1000, "Size of a list batcn in object storage", 0) \
+    DECLARE(UInt64, list_objects_batch_size, 1000, "Size of a list batch in object storage", 0) \
     DECLARE(Bool, enable_hash_ring_filtering, 0, "Enable filtering files among replicas according to hash ring for Unordered mode", 0) \
     DECLARE(UInt64, max_processed_files_before_commit, 100, "Number of files which can be processed before being committed to keeper", 0) \
     DECLARE(UInt64, max_processed_rows_before_commit, 0, "Number of rows which can be processed before being committed to keeper", 0) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -129,16 +129,18 @@ ObjectStorageQueueSource::FileIterator::FileIterator(
     }
 }
 
-bool ObjectStorageQueueSource::FileIterator::isFinished() const
+bool ObjectStorageQueueSource::FileIterator::isFinished()
 {
-     LOG_TEST(log, "Iterator finished: {}, objects to retry: {}", iterator_finished.load(), objects_to_retry.size());
-     return iterator_finished
-         && std::all_of(listed_keys_cache.begin(), listed_keys_cache.end(), [](const auto & v) { return v.second.keys.empty(); })
-         && objects_to_retry.empty();
+    std::lock_guard lock(mutex);
+    LOG_TEST(log, "Iterator finished: {}, objects to retry: {}", iterator_finished.load(), objects_to_retry.size());
+    return iterator_finished
+        && std::all_of(listed_keys_cache.begin(), listed_keys_cache.end(), [](const auto & v) { return v.second.keys.empty(); })
+        && objects_to_retry.empty();
 }
 
 size_t ObjectStorageQueueSource::FileIterator::estimatedKeysCount()
 {
+    std::lock_guard lock(next_mutex);
     /// Copied from StorageObjectStorageSource::estimateKeysCount().
     if (object_infos.empty() && !is_finished && object_storage_iterator->isValid())
         return std::numeric_limits<size_t>::max();
@@ -456,6 +458,7 @@ void ObjectStorageQueueSource::FileIterator::returnForRetry(ObjectInfoPtr object
 
 void ObjectStorageQueueSource::FileIterator::releaseFinishedBuckets()
 {
+    std::lock_guard lock(mutex);
     for (const auto & [processor, holders] : bucket_holders)
     {
         LOG_TEST(log, "Releasing {} bucket holders for processor {}", holders.size(), processor);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -870,7 +870,6 @@ Chunk ObjectStorageQueueSource::generateImpl()
 
             if (commit_settings.max_processed_files_before_commit)
             {
-                std::lock_guard lock(progress->processed_files_mutex);
                 if (progress->processed_files.load(std::memory_order_relaxed) >= commit_settings.max_processed_files_before_commit)
                 {
                     LOG_TRACE(log, "Number of max processed files before commit reached "

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -141,8 +141,6 @@ public:
         std::atomic<size_t> processed_rows = 0;
         std::atomic<size_t> processed_bytes = 0;
         Stopwatch elapsed_time{CLOCK_MONOTONIC_COARSE};
-
-        std::mutex processed_files_mutex;
     };
     using ProcessingProgressPtr = std::shared_ptr<ProcessingProgress>;
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -7,6 +7,7 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSource.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h>
+#include <base/defines.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 
 
@@ -52,7 +53,7 @@ public:
             bool file_deletion_on_processed_enabled_,
             std::atomic<bool> & shutdown_called_);
 
-        bool isFinished() const;
+        bool isFinished();
 
         ObjectInfoPtr next(size_t processor) override;
 
@@ -86,7 +87,7 @@ public:
         ExpressionActionsPtr filter_expr;
         bool recursive{false};
 
-        Source::ObjectInfos object_infos;
+        Source::ObjectInfos object_infos TSA_GUARDED_BY(next_mutex);
         std::vector<FileMetadataPtr> file_metadatas;
         bool is_finished = false;
         std::mutex next_mutex;
@@ -106,16 +107,16 @@ public:
             std::optional<Processor> processor;
         };
         /// A cache of keys which were iterated via glob_iterator, but not taken for processing.
-        std::unordered_map<Bucket, ListedKeys> listed_keys_cache;
+        std::unordered_map<Bucket, ListedKeys> listed_keys_cache TSA_GUARDED_BY(mutex);
 
         /// We store a vector of holders, because we cannot release them until processed files are committed.
-        std::unordered_map<size_t, std::vector<BucketHolderPtr>> bucket_holders;
+        std::unordered_map<size_t, std::vector<BucketHolderPtr>> bucket_holders TSA_GUARDED_BY(mutex);
 
         /// Is glob_iterator finished?
         std::atomic_bool iterator_finished = false;
 
         /// Only for processing without buckets.
-        std::deque<std::pair<ObjectInfoPtr, FileMetadataPtr>> objects_to_retry;
+        std::deque<std::pair<ObjectInfoPtr, FileMetadataPtr>> objects_to_retry TSA_GUARDED_BY(mutex);
 
         struct NextKeyFromBucket
         {
@@ -123,7 +124,7 @@ public:
             FileMetadataPtr file_metadata;
             ObjectStorageQueueOrderedFileMetadata::BucketInfoPtr bucket_info;
         };
-        NextKeyFromBucket getNextKeyFromAcquiredBucket(size_t processor);
+        NextKeyFromBucket getNextKeyFromAcquiredBucket(size_t processor) TSA_REQUIRES(mutex);
         bool hasKeysForProcessor(const Processor & processor) const;
     };
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.h
@@ -28,6 +28,7 @@ struct ObjectStorageQueueTableMetadata
     std::atomic<ObjectStorageQueueAction> after_processing;
     std::atomic<UInt64> loading_retries;
     std::atomic<UInt64> processing_threads_num;
+    std::atomic<bool> parallel_inserts;
     std::atomic<UInt64> tracked_files_limit;
     std::atomic<UInt64> tracked_files_ttl_sec;
     std::atomic<UInt64> buckets;
@@ -47,6 +48,7 @@ struct ObjectStorageQueueTableMetadata
         , after_processing(other.after_processing.load())
         , loading_retries(other.loading_retries.load())
         , processing_threads_num(other.processing_threads_num.load())
+        , parallel_inserts(other.parallel_inserts.load())
         , tracked_files_limit(other.tracked_files_limit.load())
         , tracked_files_ttl_sec(other.tracked_files_ttl_sec.load())
         , buckets(other.buckets.load())
@@ -89,6 +91,7 @@ struct ObjectStorageQueueTableMetadata
             "after_processing",
             "loading_retries",
             "processing_threads_num",
+            "parallel_inserts",
             "tracked_files_limit",
             "tracked_file_ttl_sec",
             "tracked_files_ttl_sec",

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -543,10 +543,16 @@ void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
 
     if (!shutdown_called)
     {
-        LOG_TRACE(log, "Reschedule processing thread in {} ms", reschedule_processing_interval_ms);
-        task->scheduleAfter(reschedule_processing_interval_ms);
+        UInt64 reschedule_interval_ms;
+        {
+            std::lock_guard lock(mutex);
+            reschedule_interval_ms = reschedule_processing_interval_ms;
+        }
 
-        if (reschedule_processing_interval_ms > 5000) /// TODO: Add a setting
+        LOG_TRACE(log, "Reschedule processing thread in {} ms", reschedule_interval_ms);
+        task->scheduleAfter(reschedule_interval_ms);
+
+        if (reschedule_interval_ms > 5000) /// TODO: Add a setting
         {
             try
             {

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -624,8 +624,9 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
         auto processing_progress = std::make_shared<ProcessingProgress>();
         for (size_t i = 0; i < threads; ++i)
         {
+            size_t processor_id = i * (streaming_tasks_index + 1);
             auto source = createSource(
-                /*processor_id=*/ i * streaming_tasks_index,
+                processor_id,
                 read_from_format_info,
                 processing_progress,
                 file_iterator,

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -579,6 +579,8 @@ bool StorageObjectStorageQueue::streamToViews()
         std::vector<std::shared_ptr<ObjectStorageQueueSource>> sources;
         sources.reserve(processing_threads_num);
 
+        auto processing_progress = std::make_shared<ProcessingProgress>();
+
         for (size_t i = 0; i < processing_threads_num; ++i)
         {
             /// FIXME:
@@ -599,7 +601,6 @@ bool StorageObjectStorageQueue::streamToViews()
                 queue_context,
                 supportsSubsetOfColumns(queue_context));
 
-            auto processing_progress = std::make_shared<ProcessingProgress>();
             auto source = createSource(
                 /*processor_id=*/ i,
                 read_from_format_info,

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -83,6 +83,7 @@ namespace ObjectStorageQueueSetting
     extern const ObjectStorageQueueSettingsUInt64 polling_max_timeout_ms;
     extern const ObjectStorageQueueSettingsUInt64 polling_backoff_ms;
     extern const ObjectStorageQueueSettingsUInt64 processing_threads_num;
+    extern const ObjectStorageQueueSettingsBool parallel_inserts;
     extern const ObjectStorageQueueSettingsUInt64 buckets;
     extern const ObjectStorageQueueSettingsUInt64 tracked_file_ttl_sec;
     extern const ObjectStorageQueueSettingsUInt64 tracked_files_limit;
@@ -256,7 +257,13 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
         (*queue_settings_)[ObjectStorageQueueSetting::cleanup_interval_max_ms],
         getContext()->getServerSettings()[ServerSetting::keeper_multiread_batch_size]);
 
-    task = getContext()->getSchedulePool().createTask("ObjectStorageQueueStreamingTask", [this] { threadFunc(); });
+    size_t task_count = (*queue_settings_)[ObjectStorageQueueSetting::parallel_inserts] ? (*queue_settings_)[ObjectStorageQueueSetting::processing_threads_num] : 1;
+    for (size_t i = 0; i < task_count; ++i)
+    {
+        auto task = getContext()->getSchedulePool().createTask("ObjectStorageQueueStreamingTask", [this, i]{ threadFunc(i); });
+        streaming_tasks.emplace_back(std::move(task));
+    }
+
 }
 
 void StorageObjectStorageQueue::startup()
@@ -267,7 +274,7 @@ void StorageObjectStorageQueue::startup()
     try
     {
         files_metadata->startup();
-        if (task)
+        for (auto & task : streaming_tasks)
             task->activateAndSchedule();
     }
     catch (...)
@@ -284,11 +291,11 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
     table_is_being_dropped = is_drop;
     shutdown_called = true;
 
-    LOG_TRACE(log, "Shutting down storage...");
-    if (task)
-    {
+    Stopwatch watch;
+    LOG_TRACE(log, "Waiting for streaming to finish...");
+    for (auto & task : streaming_tasks)
         task->deactivate();
-    }
+    LOG_TRACE(log, "Streaming finished (took: {} ms)", watch.elapsedMilliseconds());
 
     if (files_metadata)
     {
@@ -488,8 +495,11 @@ size_t StorageObjectStorageQueue::getDependencies() const
     return view_ids.size();
 }
 
-void StorageObjectStorageQueue::threadFunc()
+void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
 {
+    chassert(streaming_tasks_index < streaming_tasks.size());
+    auto & task = streaming_tasks[streaming_tasks_index];
+
     if (shutdown_called)
         return;
 
@@ -506,7 +516,7 @@ void StorageObjectStorageQueue::threadFunc()
 
             files_metadata->registerIfNot(storage_id, /* active */true);
 
-            if (streamToViews())
+            if (streamToViews(streaming_tasks_index))
             {
                 /// Reset the reschedule interval.
                 std::lock_guard lock(mutex);
@@ -550,7 +560,7 @@ void StorageObjectStorageQueue::threadFunc()
     }
 }
 
-bool StorageObjectStorageQueue::streamToViews()
+bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
 {
     // Create a stream for each consumer and join them in a union stream
     // Only insert into dependent views and expect that input blocks contain virtual columns
@@ -567,77 +577,86 @@ bool StorageObjectStorageQueue::streamToViews()
     auto queue_context = Context::createCopy(getContext());
     queue_context->makeQueryContext();
 
-    auto file_iterator = createFileIterator(queue_context, nullptr);
-    size_t total_rows = 0;
-    const size_t processing_threads_num = getTableMetadata().processing_threads_num;
-
-    LOG_TEST(log, "Using {} processing threads", processing_threads_num);
-
-    while (!shutdown_called && !file_iterator->isFinished())
+    if (!streaming_file_iterator || streaming_file_iterator->isFinished())
     {
-        QueryPipeline pipeline;
+        std::lock_guard streaming_lock(streaming_mutex);
+        streaming_file_iterator = createFileIterator(queue_context, nullptr);
+    }
+    size_t total_rows = 0;
+
+    const size_t processing_threads_num = getTableMetadata().processing_threads_num;
+    const bool parallel_inserts = getTableMetadata().parallel_inserts;
+    const size_t threads = parallel_inserts ? 1 : processing_threads_num;
+
+    LOG_TEST(log, "Using {} processing threads (processing_threads_num: {}, parallel_inserts: {})",
+        threads, processing_threads_num, parallel_inserts);
+
+    while (!shutdown_called && !streaming_file_iterator->isFinished())
+    {
+        /// FIXME:
+        /// it is possible that MV is dropped just before we start the insert,
+        /// but in this case we would not throw any exception, so
+        /// data will not be inserted anywhere.
+        InterpreterInsertQuery interpreter(
+            insert,
+            queue_context,
+            /*allow_materialized_=*/ false,
+            /*no_squash_=*/ true,
+            /*no_destination=*/ true,
+            /*async_insert_=*/ false);
+        auto block_io = interpreter.execute();
+        auto read_from_format_info = prepareReadingFromFormat(
+            block_io.pipeline.getHeader().getNames(),
+            storage_snapshot,
+            queue_context,
+            supportsSubsetOfColumns(queue_context));
+
+        Pipes pipes;
         std::vector<std::shared_ptr<ObjectStorageQueueSource>> sources;
-        sources.reserve(processing_threads_num);
+
+        pipes.reserve(threads);
+        sources.reserve(threads);
 
         auto processing_progress = std::make_shared<ProcessingProgress>();
-
-        for (size_t i = 0; i < processing_threads_num; ++i)
+        for (size_t i = 0; i < threads; ++i)
         {
-            /// FIXME:
-            /// it is possible that MV is dropped just before we start the insert,
-            /// but in this case we would not throw any exception, so
-            /// data will not be inserted anywhere.
-            InterpreterInsertQuery interpreter(
-                insert,
-                queue_context,
-                /*allow_materialized_=*/ false,
-                /*no_squash_=*/ true,
-                /*no_destination=*/ true,
-                /*async_insert_=*/ false);
-            auto block_io = interpreter.execute();
-            auto read_from_format_info = prepareReadingFromFormat(
-                block_io.pipeline.getHeader().getNames(),
-                storage_snapshot,
-                queue_context,
-                supportsSubsetOfColumns(queue_context));
-
             auto source = createSource(
-                /*processor_id=*/ i,
+                /*processor_id=*/ i * streaming_tasks_index,
                 read_from_format_info,
                 processing_progress,
-                file_iterator,
+                streaming_file_iterator,
                 DBMS_DEFAULT_BUFFER_SIZE,
                 queue_context,
                 /*commit_once_processed=*/ false);
 
+            pipes.emplace_back(source);
             sources.emplace_back(source);
-            block_io.pipeline.complete(Pipe(std::move(source)));
-
-            pipeline.addCompletedPipeline(std::move(block_io.pipeline));
         }
+        auto pipe = Pipe::unitePipes(std::move(pipes));
 
-        pipeline.setNumThreads(processing_threads_num);
-        pipeline.setConcurrencyControl(queue_context->getSettingsRef()[Setting::use_concurrency_control]);
+        block_io.pipeline.complete(std::move(pipe));
+        block_io.pipeline.setNumThreads(threads);
+        block_io.pipeline.setConcurrencyControl(queue_context->getSettingsRef()[Setting::use_concurrency_control]);
 
         std::atomic_size_t rows = 0;
-        pipeline.setProgressCallback([&](const Progress & progress) { rows += progress.read_rows.load(); });
+        block_io.pipeline.setProgressCallback([&](const Progress & progress) { rows += progress.read_rows.load(); });
 
         ProfileEvents::increment(ProfileEvents::ObjectStorageQueueInsertIterations);
 
         try
         {
-            CompletedPipelineExecutor executor(pipeline);
+            CompletedPipelineExecutor executor(block_io.pipeline);
             executor.execute();
         }
         catch (...)
         {
             commit(/*insert_succeeded=*/ false, rows, sources, getCurrentExceptionMessage(true), getCurrentExceptionCode());
-            file_iterator->releaseFinishedBuckets();
+            streaming_file_iterator->releaseFinishedBuckets();
             throw;
         }
 
         commit(/*insert_succeeded=*/ true, rows, sources);
-        file_iterator->releaseFinishedBuckets();
+        streaming_file_iterator->releaseFinishedBuckets();
         total_rows += rows;
     }
 
@@ -703,6 +722,8 @@ void StorageObjectStorageQueue::commit(
 static const std::unordered_set<std::string_view> changeable_settings_unordered_mode
 {
     "processing_threads_num",
+    /// Is not allowed to change on fly:
+    /// "parallel_inserts",
     "loading_retries",
     "after_processing",
     "tracked_files_limit",
@@ -1059,6 +1080,7 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
     settings[ObjectStorageQueueSetting::keeper_path] = zk_path;
     settings[ObjectStorageQueueSetting::loading_retries] = table_metadata.loading_retries;
     settings[ObjectStorageQueueSetting::processing_threads_num] = table_metadata.processing_threads_num;
+    settings[ObjectStorageQueueSetting::parallel_inserts] = table_metadata.parallel_inserts;
     settings[ObjectStorageQueueSetting::enable_logging_to_queue_log] = enable_logging_to_queue_log;
     settings[ObjectStorageQueueSetting::last_processed_path] = table_metadata.last_processed_path;
     settings[ObjectStorageQueueSetting::tracked_file_ttl_sec] = table_metadata.tracked_files_ttl_sec;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -10,6 +10,7 @@
 #include <Storages/System/StorageSystemObjectStorageQueueSettings.h>
 #include <Interpreters/Context.h>
 #include <Storages/StorageFactory.h>
+#include <base/defines.h>
 
 
 namespace DB
@@ -93,7 +94,7 @@ private:
 
     const std::optional<FormatSettings> format_settings;
 
-    UInt64 reschedule_processing_interval_ms;
+    UInt64 reschedule_processing_interval_ms TSA_GUARDED_BY(mutex);
 
     std::atomic<bool> mv_attached = false;
     std::atomic<bool> shutdown_called = false;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -93,14 +93,16 @@ private:
 
     const std::optional<FormatSettings> format_settings;
 
-    BackgroundSchedulePoolTaskHolder task;
-    std::atomic<bool> stream_cancelled{false};
     UInt64 reschedule_processing_interval_ms;
 
     std::atomic<bool> mv_attached = false;
     std::atomic<bool> shutdown_called = false;
     std::atomic<bool> startup_finished = false;
     std::atomic<bool> table_is_being_dropped = false;
+
+    mutable std::mutex streaming_mutex;
+    std::shared_ptr<StorageObjectStorageQueue::FileIterator> streaming_file_iterator;
+    std::vector<BackgroundSchedulePoolTaskHolder> streaming_tasks;
 
     LoggerPtr log;
 
@@ -129,9 +131,9 @@ private:
     /// A background thread function,
     /// executing the whole process of reading from object storage
     /// and pushing result to dependent tables.
-    void threadFunc();
+    void threadFunc(size_t streaming_tasks_index);
     /// A subset of logic executed by threadFunc.
-    bool streamToViews();
+    bool streamToViews(size_t streaming_tasks_index);
     /// Commit processed files to keeper as either successful or unsuccessful.
     void commit(
         bool insert_succeeded,

--- a/tests/integration/helpers/s3_queue_common.py
+++ b/tests/integration/helpers/s3_queue_common.py
@@ -157,9 +157,14 @@ def create_mv(
     mv_name=None,
     create_dst_table_first=True,
     format="column1 UInt32, column2 UInt32, column3 UInt32",
+    extra_dst_format=None,
 ):
     if mv_name is None:
         mv_name = f"{src_table_name}_mv"
+    if extra_dst_format is not None:
+        extra_dst_format = f", {extra_dst_format}"
+    else:
+        extra_dst_format = ""
 
     node.query(f"""
         DROP TABLE IF EXISTS {dst_table_name};
@@ -169,7 +174,7 @@ def create_mv(
     if create_dst_table_first:
         node.query(
             f"""
-            CREATE TABLE {dst_table_name} ({format}, _path String)
+            CREATE TABLE {dst_table_name} ({format}{extra_dst_format}, _path String)
             ENGINE = MergeTree()
             ORDER BY column1;
             CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
@@ -180,7 +185,7 @@ def create_mv(
             f"""
             SET allow_materialized_view_with_bad_select=1;
             CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
-            CREATE TABLE {dst_table_name} ({format}, _path String)
+            CREATE TABLE {dst_table_name} ({format}{extra_dst_format}, _path String)
             ENGINE = MergeTree()
             ORDER BY column1;
             """

--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -1,0 +1,246 @@
+import logging
+import time
+import math
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_queue_common import (
+    generate_random_files,
+    put_s3_file_content,
+    create_table,
+    create_mv,
+    generate_random_string,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "instance",
+            user_configs=["configs/users.xml"],
+            with_minio=True,
+            with_azurite=True,
+            with_zookeeper=True,
+            main_configs=[
+                "configs/zookeeper.xml",
+                "configs/s3queue_log.xml",
+                "configs/remote_servers.xml",
+            ],
+            stay_alive=True,
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def run_with_retry(check_result, func, retries=100):
+    for _ in range(retries):
+        last = func()
+        if check_result(last):
+            return last
+        time.sleep(1)
+    raise RuntimeError(f"{last} did not match expectations in {retries} retries")
+
+
+@pytest.mark.parametrize("parallel_inserts", [0, 1])
+def test_parallel_inserts_generated_parts(started_cluster, parallel_inserts):
+    """Ensure that per-thread INSERTs does not affect on the number of INSERTs, i.e. it still depends on the max_processed_*_before_commit instead"""
+    node = started_cluster.instances["instance"]
+
+    # A unique table name is necessary for repeatable tests
+    table_name = f"test_parallel_inserts_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+    dst_table_name = f"{table_name}_dst"
+    files_to_generate = 40
+
+    processing_threads_num = 4
+    max_processed_files_before_commit = 2
+    # Ensure that w/ and w/o parallel_inserts will generate different number of parts
+    assert processing_threads_num != max_processed_files_before_commit
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "parallel_inserts": parallel_inserts,
+            "s3queue_processing_threads_num": processing_threads_num,
+            "s3queue_loading_retries": 100,
+            "s3queue_max_processed_files_before_commit": max_processed_files_before_commit,
+        },
+    )
+    generate_random_files(
+        started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
+    )
+    create_mv(node, table_name, dst_table_name)
+
+    expected_processed = ["test_" + str(i) + ".csv" for i in range(files_to_generate)]
+
+    def get_count():
+        return int(node.query(f"select count() from {dst_table_name}"))
+
+    def get_processed_files():
+        return set(
+            node.query(
+                f"SELECT file_name FROM system.s3queue WHERE zookeeper_path ilike '%{table_name}%' and status = 'Processed' and rows_processed > 0 "
+            )
+            .strip()
+            .split("\n")
+        )
+
+    run_with_retry(lambda x: x == len(expected_processed), get_count)
+    run_with_retry(lambda x: x == set(expected_processed), get_processed_files)
+
+    def get_new_parts_in_dst():
+        return int(
+            node.query(
+                "SYSTEM FLUSH LOGS system.part_log;"
+                f"SELECT count() FROM system.part_log WHERE table = '{dst_table_name}' and event_type = 'NewPart'"
+            ).strip()
+        )
+
+    new_parts = get_new_parts_in_dst()
+    assert new_parts == math.ceil(
+        len(expected_processed) / max_processed_files_before_commit
+    )
+
+    node.query(
+        f"""
+    DROP TABLE {dst_table_name};
+    DROP TABLE {table_name};
+    """
+    )
+
+
+@pytest.mark.parametrize("parallel_inserts", [0, 1])
+def test_parallel_inserts_with_failures(started_cluster, parallel_inserts):
+    """Ensure that in case of errors, files won't be inserted multiple times w/ and w/o parallel_inserts"""
+    node = started_cluster.instances["instance"]
+
+    # A unique table name is necessary for repeatable tests
+    table_name = f"test_parallel_inserts_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+    dst_table_name = f"{table_name}_dst"
+    files_to_generate = 40
+    max_processed_files_before_commit = 10
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "parallel_inserts": parallel_inserts,
+            "s3queue_processing_threads_num": 16,
+            "s3queue_loading_retries": 2,
+            "s3queue_max_processed_files_before_commit": max_processed_files_before_commit,
+        },
+    )
+    generate_random_files(
+        started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
+    )
+
+    incorrect_values_csv = (
+        "\n".join((",".join(map(str, row)) for row in [["failed", 1, 1]])) + "\n"
+    ).encode()
+
+    correct_values_csv = (
+        "\n".join((",".join(map(str, row)) for row in [[1, 1, 1]])) + "\n"
+    ).encode()
+
+    # Ensure that in case of INSERT failures it will mark only this file as failed not the whole batch
+    # NOTE: generate_random_files() uses randint(0, 1000), so 10000 does not overlaps
+    failed_on_insert_values_csv = (
+        "\n".join((",".join(map(str, row)) for row in [[10000, 10000, 10000]])) + "\n"
+    ).encode()
+
+    put_s3_file_content(
+        started_cluster, f"{files_path}/test_99.csv", correct_values_csv
+    )
+    put_s3_file_content(
+        started_cluster, f"{files_path}/test_999.csv", failed_on_insert_values_csv
+    )
+    put_s3_file_content(
+        started_cluster, f"{files_path}/test_9999.csv", incorrect_values_csv
+    )
+    put_s3_file_content(
+        started_cluster, f"{files_path}/test_99999.csv", correct_values_csv
+    )
+    put_s3_file_content(
+        started_cluster, f"{files_path}/test_999999.csv", correct_values_csv
+    )
+
+    create_mv(
+        node,
+        table_name,
+        dst_table_name,
+        # Make failed_on_insert_values_csv fail via INSERT
+        extra_dst_format="CONSTRAINT column1_constraint CHECK column1 != 10000",
+    )
+
+    def get_count():
+        return int(node.query(f"select count() from {dst_table_name}"))
+
+    def get_processed_files():
+        return set(
+            node.query(
+                f"SELECT file_name FROM system.s3queue WHERE zookeeper_path ilike '%{table_name}%' and status = 'Processed' and rows_processed > 0 "
+            )
+            .strip()
+            .split("\n")
+        )
+
+    def get_failed_files():
+        return set(
+            node.query(
+                f"SELECT file_name FROM system.s3queue WHERE zookeeper_path ilike '%{table_name}%' and status = 'Failed'"
+            )
+            .strip()
+            .split("\n")
+        )
+
+    # wait until both files will be retries, there can be more failures due to batching
+    run_with_retry(
+        lambda x: set(["test_9999.csv", "test_999.csv"]).issubset(x), get_failed_files
+    )
+    # and then, remove the constraint to unblock the queue
+    node.query(f"ALTER TABLE {dst_table_name} DROP CONSTRAINT column1_constraint")
+
+    expected_processed = ["test_" + str(i) + ".csv" for i in range(files_to_generate)]
+    expected_processed.extend(
+        ["test_99.csv", "test_99999.csv", "test_999999.csv", "test_999.csv"]
+    )
+
+    run_with_retry(lambda x: x == len(expected_processed), get_count)
+    run_with_retry(lambda x: x == set(expected_processed), get_processed_files)
+
+    def get_new_parts_in_dst():
+        return int(
+            node.query(
+                "SYSTEM FLUSH LOGS system.part_log;"
+                f"SELECT count() FROM system.part_log WHERE table = '{dst_table_name}' and event_type = 'NewPart'"
+            ).strip()
+        )
+
+    node.query(
+        f"""
+    DROP TABLE {dst_table_name};
+    DROP TABLE {table_name};
+    """
+    )

--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -112,9 +112,17 @@ def test_parallel_inserts_generated_parts(started_cluster, parallel_inserts):
         )
 
     new_parts = get_new_parts_in_dst()
-    assert new_parts == math.ceil(
-        len(expected_processed) / max_processed_files_before_commit
-    )
+    if not parallel_inserts:
+        assert new_parts == math.ceil(
+            len(expected_processed) / max_processed_files_before_commit
+        )
+    else:
+        # Note, in case of paralell inserts due to parallelism we can have more parts
+        assert new_parts >= math.ceil(
+            len(expected_processed) / max_processed_files_before_commit
+        )
+        # But let's ensure that not too much more
+        assert new_parts < len(expected_processed)
 
     node.query(
         f"""

--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -156,7 +156,7 @@ def test_parallel_inserts_with_failures(started_cluster, parallel_inserts):
             "keeper_path": keeper_path,
             "parallel_inserts": parallel_inserts,
             "s3queue_processing_threads_num": 16,
-            "s3queue_loading_retries": 2,
+            "s3queue_loading_retries": 20,
             "s3queue_max_processed_files_before_commit": max_processed_files_before_commit,
         },
     )

--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -112,15 +112,18 @@ def test_parallel_inserts_generated_parts(started_cluster, parallel_inserts):
         )
 
     new_parts = get_new_parts_in_dst()
+    expected_parts = math.ceil(
+        len(expected_processed) / max_processed_files_before_commit
+    )
     if not parallel_inserts:
-        assert new_parts == math.ceil(
-            len(expected_processed) / max_processed_files_before_commit
-        )
+        # Note, due to parallel processing (not inserts) in this case it is
+        # possible to have less parts
+        assert new_parts <= expected_parts
+        # But not too less
+        assert new_parts >= expected_parts*0.5
     else:
-        # Note, in case of paralell inserts due to parallelism we can have more parts
-        assert new_parts >= math.ceil(
-            len(expected_processed) / max_processed_files_before_commit
-        )
+        # Note, in case of parallel inserts due to parallelism we can have more parts
+        assert new_parts >= expected_parts
         # But let's ensure that not too much more
         assert new_parts < len(expected_processed)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance of S3Queue/AzureQueue by allowing INSERTs data in parallel (can be enabled with `parallel_inserts=true` queue setting). Previously S3Queue/AzureQueue can only do first part of pipeline in parallel (downloading, parsing), INSERT was single-threaded. And `INSERT`s are almost always the bottleneck. Now it will scale almost linear with `processing_threads_num`.