### PR TITLE
RFC: Do not retry S3 requests in case of host not found

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -1,5 +1,6 @@
 #include <Poco/Timespan.h>
 #include <Common/LatencyBuckets.h>
+#include <Common/NetException.h>
 #include <Common/config_version.h>
 #include "config.h"
 
@@ -104,6 +105,7 @@ namespace DB::ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
     extern const int TOO_MANY_REDIRECTS;
+    extern const int DNS_ERROR;
 }
 
 namespace DB::S3
@@ -667,6 +669,22 @@ void PocoHTTPClient::makeRequestInternalImpl(
             return;
         }
         throw Exception(ErrorCodes::TOO_MANY_REDIRECTS, "Too many redirects while trying to access {}", request.GetUri().GetURIString());
+    }
+    catch (const NetException & e)
+    {
+        if (!latency_recorded)
+        {
+            addLatency(request, S3LatencyType::Connect, connect_time);
+            addLatency(request, first_byte_latency_type, first_byte_time);
+        }
+        auto error_message = getCurrentExceptionMessageAndPattern(/* with_stacktrace */ true);
+        error_message.text = fmt::format("Failed to make request to: {}: {}", uri, error_message.text);
+        LOG_INFO(log, error_message);
+
+        response->SetClientErrorType(e.code() == ErrorCodes::DNS_ERROR ? Aws::Client::CoreErrors::ENDPOINT_RESOLUTION_FAILURE : Aws::Client::CoreErrors::NETWORK_CONNECTION);
+        response->SetClientErrorMessage(getCurrentExceptionMessage(false));
+
+        addMetric(request, S3MetricType::Errors);
     }
     catch (...)
     {

--- a/tests/queries/0_stateless/03396_s3_do_not_retry_dns_errors.sh
+++ b/tests/queries/0_stateless/03396_s3_do_not_retry_dns_errors.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Test from https://github.com/ClickHouse/ClickHouse/issues/68663
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+    CREATE TABLE IF NOT EXISTS test_s3_issue_queue
+    (
+        test_field String
+    )
+    ENGINE = S3Queue('http://minio.such-tld-will-never-be-registered-for-clickhose-tests:9000/not-exist-s3-bucket/**.json', JSONEachRow)
+    SETTINGS keeper_path = '/clickhouse/db_name/s3queue/test_s3_issue', mode = 'unordered', after_processing = 'keep', s3queue_loading_retries = 3, s3queue_processing_threads_num = 30, s3queue_enable_logging_to_s3queue_log = 1, s3queue_polling_min_timeout_ms = 1000, s3queue_polling_max_timeout_ms = 5000, s3queue_polling_backoff_ms = 1500, s3queue_tracked_file_ttl_sec = 345600, s3queue_tracked_files_limit = 1000000;
+
+    CREATE TABLE IF NOT EXISTS test_s3_issue (test_field String) ENGINE = Null;
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_s3_issue_mv TO test_s3_issue AS SELECT * FROM test_s3_issue_queue;
+" |& grep -v "AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider: Token file must be specified to use STS AssumeRole web identity creds provider."
+
+# just to ensure that some streaming will be started, the test cannot be flaky
+# because of this, it can simply does not check what it should properly, but
+# overcomplicating the test does not worth it
+sleep 5
+
+# 20 seconds should be enough to ensure that DNS_ERROR will not be retried 100
+# times, but simply only few
+timeout 20s $CLICKHOUSE_CLIENT -nm -q "
+    DROP TABLE IF EXISTS test_s3_issue_mv SYNC;
+"


### PR DESCRIPTION
The problem is that in case you simply created endpoint with incorrect hostname then you will have to wait until 100 retries (done) will be done, and this too slow.

But note that DNS may sometimes incorrectly return NOTEXIST, and even though ClickHouse has builtin DNS cache (that may help in terms of less load to DNS only) it still may be affected.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not retry S3 requests in case of host not found

Fixes: https://github.com/ClickHouse/ClickHouse/issues/68663