### PR TITLE
docs: add a note that keep_alive_timeout server setting is about HTTP

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1885,7 +1885,7 @@ When new credentials are applied to all replicas, old credentials may be removed
 
 ## keep_alive_timeout {#keep_alive_timeout}
 
-The number of seconds that ClickHouse waits for incoming requests before closing the connection.
+The number of seconds that ClickHouse waits for incoming requests for HTTP protocol before closing the connection.
 
 **Example**
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -824,7 +824,7 @@ namespace DB
     - `1` — Enabled.
     )", 0) \
     DECLARE(Seconds, keep_alive_timeout, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT, R"(
-    The number of seconds that ClickHouse waits for incoming requests before closing the connection.
+    The number of seconds that ClickHouse waits for incoming requests for HTTP protocol before closing the connection.
 
     **Example**
 

--- a/src/Disks/IO/ReadBufferFromWebServer.cpp
+++ b/src/Disks/IO/ReadBufferFromWebServer.cpp
@@ -7,8 +7,6 @@
 #include <IO/WriteBufferFromString.h>
 #include <Common/logger_useful.h>
 
-#include <thread>
-
 
 namespace DB
 {
@@ -16,11 +14,6 @@ namespace Setting
 {
     extern const SettingsSeconds http_connection_timeout;
     extern const SettingsSeconds http_receive_timeout;
-}
-
-namespace ServerSetting
-{
-    extern const ServerSettingsSeconds keep_alive_timeout;
 }
 
 namespace ErrorCodes


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I thought about adding few examples on how it could be tested, but decided not to.

Will just post them here

```
$ curl --rate 1/m -v "127.1:8123/?function_sleep_max_microseconds_per_block=$((1<<40))&query=select+1" "127.1:8123/?function_sleep_max_microseconds_per_block=$((1<<40))&query=select+2"
...
* Connected to 127.0.0.1 (127.0.0.1) port 8123
> GET /?function_sleep_max_microseconds_per_block=1099511627776&query=select+1 HTTP/1.1
< Keep-Alive: timeout=10, max=9999
< X-ClickHouse-Summary: {"read_rows":"1","read_bytes":"1","total_rows_to_read":"1","elapsed_ns":"881894"}
< 
1
* Connection #0 to host 127.0.0.1 left intact
Note: Transfer took 1 ms, waits 59999ms as set by --rate

* Couldn't find host 127.0.0.1 in the .netrc file; using defaults
* Connection 0 seems to be dead
* shutting down connection #0
...
* Connected to 127.0.0.1 (127.0.0.1) port 8123
> GET /?function_sleep_max_microseconds_per_block=1099511627776&query=select+2 HTTP/1.1
...
< Keep-Alive: timeout=10, max=9999
< X-ClickHouse-Summary: {"read_rows":"1","read_bytes":"1","total_rows_to_read":"1","elapsed_ns":"790342"}
```