### PR TITLE
feat: additional_table_filter support query parameters

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -436,7 +436,7 @@ ASTPtr parseAdditionalFilterConditionForTable(
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
 
-            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && context.getQueryParameters().size() > 0)
+            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && !context.getQueryParameters().empty())
             {
                 ReplaceQueryParameterVisitor visitor(context.getQueryParameters());
                 visitor.visit(query_ast);

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -435,7 +435,7 @@ ASTPtr parseAdditionalFilterConditionForTable(
                 settings[Setting::max_query_size],
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
-            
+
             if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && context.getQueryParameters().size() > 0)
             {
                 ReplaceQueryParameterVisitor visitor(context.getQueryParameters());

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -605,7 +605,7 @@ std::optional<FilterDAGInfo> buildAdditionalFiltersIfNeeded(const StoragePtr & s
                 settings[Setting::max_query_size],
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
-            
+
             if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && planner_context->getQueryContext()->getQueryParameters().size() > 0)
             {
                 ReplaceQueryParameterVisitor visitor(planner_context->getQueryContext()->getQueryParameters());

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -65,6 +65,7 @@
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/getCustomKeyFilterForParallelReplicas.h>
 #include <Interpreters/ClusterProxy/executeQuery.h>
+#include <Interpreters/ReplaceQueryParameterVisitor.h>
 
 #include <Planner/CollectColumnIdentifiers.h>
 #include <Planner/Planner.h>
@@ -79,6 +80,7 @@
 #include <Common/logger_useful.h>
 
 #include <ranges>
+#include <base/find_symbols.h>
 
 namespace DB
 {
@@ -603,6 +605,12 @@ std::optional<FilterDAGInfo> buildAdditionalFiltersIfNeeded(const StoragePtr & s
                 settings[Setting::max_query_size],
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
+            
+            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && planner_context->getQueryContext()->getQueryParameters().size() > 0)
+            {
+                ReplaceQueryParameterVisitor visitor(planner_context->getQueryContext()->getQueryParameters());
+                visitor.visit(additional_filter_ast);
+            }
             break;
         }
     }

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -606,7 +606,7 @@ std::optional<FilterDAGInfo> buildAdditionalFiltersIfNeeded(const StoragePtr & s
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
 
-            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && planner_context->getQueryContext()->getQueryParameters().size() > 0)
+            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && !planner_context->getQueryContext()->getQueryParameters().empty())
             {
                 ReplaceQueryParameterVisitor visitor(planner_context->getQueryContext()->getQueryParameters());
                 visitor.visit(additional_filter_ast);

--- a/tests/queries/0_stateless/03393_additional_table_filter_with_param.reference
+++ b/tests/queries/0_stateless/03393_additional_table_filter_with_param.reference
@@ -1,0 +1,31 @@
+-- {echoOn}
+
+DROP TABLE IF EXISTS t_param_filter;
+SET param_a = 3;
+SET param_b = 5;
+CREATE TABLE t_param_filter
+(
+    n Int32,
+) ENGINE = MergeTree()
+ORDER BY n;
+INSERT INTO t_param_filter
+SELECT number
+FROM numbers(10);
+SET allow_experimental_analyzer = 1;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+0
+1
+2
+3
+4
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+4
+SET allow_experimental_analyzer = 0;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+0
+1
+2
+3
+4
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+4

--- a/tests/queries/0_stateless/03393_additional_table_filter_with_param.sql
+++ b/tests/queries/0_stateless/03393_additional_table_filter_with_param.sql
@@ -1,0 +1,25 @@
+-- {echoOn}
+
+DROP TABLE IF EXISTS t_param_filter;
+
+SET param_a = 3;
+SET param_b = 5;
+
+CREATE TABLE t_param_filter
+(
+    n Int32,
+) ENGINE = MergeTree()
+ORDER BY n;
+
+INSERT INTO t_param_filter
+SELECT number
+FROM numbers(10);
+
+SET allow_experimental_analyzer = 1;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+
+SET allow_experimental_analyzer = 0;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support query parameters inside `additional_table_filters` setting. After the change, the following query would succeed:

```sql
SET param_x = 5;
SELECT x FROM nums SETTINGS additional_table_filters = {'nums': 'x < {a:UInt32}'};
```

Closes #74208
