### PR TITLE
Document that the query cache is disabled in `clickhouse-local`

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -38,6 +38,11 @@ effort and avoids redundancy.
 In ClickHouse Cloud, you must use [query level settings](/operations/settings/query-level) to edit query cache settings. Editing [config level settings](/operations/configuration-files) is currently not supported.
 :::
 
+:::note
+[clickhouse-local](utilities/clickhouse-local.md) runs a single query at a time. Since query result caching does not make sense, the query
+result cache is disabled in clickhouse-local.
+:::
+
 Setting [use_query_cache](/operations/settings/settings#use_query_cache) can be used to control whether a specific query or all queries of the
 current session should utilize the query cache. For example, the first execution of query
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)