### PR TITLE
Optimize s3Cluster performance for queries with one bracket expansion

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -132,7 +132,7 @@ RemoteQueryExecutor::Extension StorageObjectStorageCluster::getTaskIteratorExten
 {
     auto iterator = StorageObjectStorageSource::createFileIterator(
         configuration, configuration->getQuerySettings(local_context), object_storage, /* distributed_processing */false,
-        local_context, predicate, virtual_columns, nullptr, local_context->getFileProgressCallback(), /*ignore_archive_globs=*/true);
+        local_context, predicate, virtual_columns, nullptr, local_context->getFileProgressCallback(), /*ignore_archive_globs=*/true, /*skip_object_metadata=*/true);
 
     auto callback = std::make_shared<std::function<String()>>([iterator]() mutable -> String
     {

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -416,7 +416,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
                 if (!metadata)
                     return {};
 
-                object_info->metadata = metadaat;
+                object_info->metadata = metadata;
             }
             else
                 object_info->metadata = object_storage->getObjectMetadata(path);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -130,7 +130,8 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
     const NamesAndTypesList & virtual_columns,
     ObjectInfos * read_keys,
     std::function<void(FileProgress)> file_progress_callback,
-    bool ignore_archive_globs)
+    bool ignore_archive_globs,
+    bool skip_object_metadata)
 {
     const bool is_archive = configuration->isArchive();
 
@@ -160,7 +161,7 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
             copy_configuration->setPaths(paths);
             iterator = std::make_unique<KeysIterator>(
                 object_storage, copy_configuration, virtual_columns, is_archive ? nullptr : read_keys,
-                query_settings.ignore_non_existent_file, file_progress_callback);
+                query_settings.ignore_non_existent_file, skip_object_metadata, file_progress_callback);
         }
         else
             /// Iterate through disclosed globs and make a source for each file
@@ -193,7 +194,7 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
 
         iterator = std::make_unique<KeysIterator>(
             object_storage, copy_configuration, virtual_columns, is_archive ? nullptr : read_keys,
-            query_settings.ignore_non_existent_file, file_progress_callback);
+            query_settings.ignore_non_existent_file, /*skip_object_metadata=*/false, file_progress_callback);
     }
 
     if (is_archive)
@@ -823,6 +824,7 @@ StorageObjectStorageSource::KeysIterator::KeysIterator(
     const NamesAndTypesList & virtual_columns_,
     ObjectInfos * read_keys_,
     bool ignore_non_existent_files_,
+    bool skip_object_metadata_,
     std::function<void(FileProgress)> file_progress_callback_)
     : object_storage(object_storage_)
     , configuration(configuration_)
@@ -830,6 +832,7 @@ StorageObjectStorageSource::KeysIterator::KeysIterator(
     , file_progress_callback(file_progress_callback_)
     , keys(configuration->getPaths())
     , ignore_non_existent_files(ignore_non_existent_files_)
+    , skip_object_metadata(skip_object_metadata_)
 {
     if (read_keys_)
     {
@@ -853,15 +856,17 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::KeysIterator::ne
         auto key = keys[current_index];
 
         ObjectMetadata object_metadata{};
-        if (ignore_non_existent_files)
-        {
-            auto metadata = object_storage->tryGetObjectMetadata(key);
-            if (!metadata)
-                continue;
-            object_metadata = *metadata;
+        if (!skip_object_metadata) {
+            if (ignore_non_existent_files)
+            {
+                auto metadata = object_storage->tryGetObjectMetadata(key);
+                if (!metadata)
+                    continue;
+                object_metadata = *metadata;
+            }
+            else
+                object_metadata = object_storage->getObjectMetadata(key);
         }
-        else
-            object_metadata = object_storage->getObjectMetadata(key);
 
         if (file_progress_callback)
             file_progress_callback(FileProgress(0, object_metadata.size_bytes));

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -57,7 +57,8 @@ public:
         const NamesAndTypesList & virtual_columns,
         ObjectInfos * read_keys,
         std::function<void(FileProgress)> file_progress_callback = {},
-        bool ignore_archive_globs = false);
+        bool ignore_archive_globs = false,
+        bool skip_object_metadata = false);
 
     static std::string getUniqueStoragePathIdentifier(
         const Configuration & configuration,
@@ -220,6 +221,7 @@ public:
         const NamesAndTypesList & virtual_columns_,
         ObjectInfos * read_keys_,
         bool ignore_non_existent_files_,
+        bool skip_object_metadata_,
         std::function<void(FileProgress)> file_progress_callback = {});
 
     ~KeysIterator() override = default;
@@ -236,6 +238,7 @@ private:
     const std::vector<String> keys;
     std::atomic<size_t> index = 0;
     bool ignore_non_existent_files;
+    bool skip_object_metadata;
 };
 
 /*


### PR DESCRIPTION
This `StorageObjectStorageCluster` adjustment further improves the performance of single bracket expansion queries that was introduced in https://github.com/ClickHouse/ClickHouse/pull/73518 by @thevar1able. 

We identified that a single thread dispatches new files through the `getTaskIteratorExtension` iterator. Because each callback also does a `HeadObject` request in the case of s3Cluster queries, this throttled the performance of multiple nodes attempting to fetch files in parallel. This behavior is only present in the single bracket expansion and `KeysIterator` - the `GlobIterator` fetches the metadata for objects while globbing them.

Removing the object metadata fetch in this code branch doesn't matter, since each reader also tries to fetch the metadata if not present.

Cc @thevar1able, @kssenii, @divanik.

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Optimize s3Cluster performance for queries with one bracket expansion.

