### PR TITLE
s3queue fix crash because of expired context

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -156,7 +156,8 @@ ObjectStorageQueueMetadata::~ObjectStorageQueueMetadata()
 
 void ObjectStorageQueueMetadata::startup()
 {
-    if (mode == ObjectStorageQueueMode::UNORDERED
+    if (!task
+        && mode == ObjectStorageQueueMode::UNORDERED
         && (table_metadata.tracked_files_limit || table_metadata.tracked_files_ttl_sec))
     {
         task = Context::getGlobalContextInstance()->getSchedulePool().createTask(
@@ -168,7 +169,8 @@ void ObjectStorageQueueMetadata::startup()
             generateRescheduleInterval(
                 cleanup_interval_min_ms, cleanup_interval_max_ms));
     }
-    update_registry_thread = std::make_unique<ThreadFromGlobalPool>([this](){ updateRegistryFunc(); });
+    if (!update_registry_thread)
+        update_registry_thread = std::make_unique<ThreadFromGlobalPool>([this](){ updateRegistryFunc(); });
 }
 
 void ObjectStorageQueueMetadata::shutdown()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -143,6 +143,19 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     , log(getLogger("StorageObjectStorageQueue(" + zookeeper_path_.string() + ")"))
     , local_file_statuses(std::make_shared<LocalFileStatuses>())
 {
+    LOG_TRACE(
+        log, "Mode: {}, buckets: {}, processing threads: {}, result buckets num: {}",
+        table_metadata.mode, table_metadata.buckets.load(),
+        table_metadata.processing_threads_num.load(), buckets_num);
+}
+
+ObjectStorageQueueMetadata::~ObjectStorageQueueMetadata()
+{
+    shutdown();
+}
+
+void ObjectStorageQueueMetadata::startup()
+{
     if (mode == ObjectStorageQueueMode::UNORDERED
         && (table_metadata.tracked_files_limit || table_metadata.tracked_files_ttl_sec))
     {
@@ -155,15 +168,7 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
             generateRescheduleInterval(
                 cleanup_interval_min_ms, cleanup_interval_max_ms));
     }
-    LOG_TRACE(log, "Mode: {}, buckets: {}, processing threads: {}, result buckets num: {}",
-              table_metadata.mode, table_metadata.buckets.load(), table_metadata.processing_threads_num.load(), buckets_num);
-
     update_registry_thread = std::make_unique<ThreadFromGlobalPool>([this](){ updateRegistryFunc(); });
-}
-
-ObjectStorageQueueMetadata::~ObjectStorageQueueMetadata()
-{
-    shutdown();
 }
 
 void ObjectStorageQueueMetadata::shutdown()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -64,6 +64,8 @@ public:
 
     ~ObjectStorageQueueMetadata();
 
+    /// Startup background threads.
+    void startup();
     /// Shutdown background threads.
     void shutdown();
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -73,14 +73,12 @@ void ObjectStorageQueueMetadataFactory::remove(const std::string & zookeeper_pat
 
     if (registry_size == 0)
     {
-        try
+        auto zk_client = Context::getGlobalContextInstance()->getZooKeeper();
+        auto code = zk_client->tryRemoveRecursive(it->first);
+        if (code != Coordination::Error::ZOK
+            && !Coordination::isHardwareError(code))
         {
-            auto zk_client = Context::getGlobalContextInstance()->getZooKeeper();
-            zk_client->removeRecursive(it->first);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(log);
+            LOG_ERROR(log, "Unexpected error while removing metadata: {}, path: {}", code, it->first);
         }
     }
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -264,9 +264,17 @@ void StorageObjectStorageQueue::startup()
     /// Register the metadata in startup(), unregister in shutdown.
     /// (If startup is never called, shutdown also won't be called.)
     files_metadata = ObjectStorageQueueMetadataFactory::instance().getOrCreate(zk_path, std::move(temp_metadata), getStorageID());
-
-    if (task)
-        task->activateAndSchedule();
+    try
+    {
+        files_metadata->startup();
+        if (task)
+            task->activateAndSchedule();
+    }
+    catch (...)
+    {
+        files_metadata->shutdown();
+        throw;
+    }
 }
 
 void StorageObjectStorageQueue::shutdown(bool is_drop)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash because of expired context in StorageS3(Azure)Queue.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
