### PR TITLE
[Do not enable CI, only for discussion] Shared thread pool for partitioned sinks

### DIFF
--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -179,7 +179,8 @@ public:
         WriteBuffer & buf,
         const Block & sample,
         const ContextPtr & context,
-        const std::optional<FormatSettings> & format_settings = std::nullopt) const;
+        const std::optional<FormatSettings> & format_settings = std::nullopt,
+        std::shared_ptr<ThreadPool> pool = nullptr) const;
 
     OutputFormatPtr getOutputFormat(
         const String & name,

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -16,12 +16,6 @@ namespace DB
         collector_finished.wait();
 
         {
-            std::lock_guard lock(collector_thread_mutex);
-            if (collector_thread.joinable())
-                collector_thread.join();
-        }
-
-        {
             std::lock_guard lock(mutex);
 
             if (background_exception)
@@ -109,12 +103,6 @@ namespace DB
             std::unique_lock<std::mutex> lock(mutex);
             collector_condvar.notify_all();
             writer_condvar.notify_all();
-        }
-
-        {
-            std::lock_guard lock(collector_thread_mutex);
-            if (collector_thread.joinable())
-                collector_thread.join();
         }
 
         try

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.h
@@ -16,7 +16,8 @@ public:
         const std::optional<FormatSettings> & format_settings_,
         const Block & sample_block_,
         ContextPtr context,
-        const std::string & blob_path = "");
+        const std::string & blob_path = "",
+        std::shared_ptr<ThreadPool> pool = nullptr);
 
     ~StorageObjectStorageSink() override;
 
@@ -49,7 +50,7 @@ public:
         ContextPtr context_,
         const ASTPtr & partition_by);
 
-    SinkPtr createSinkForPartition(const String & partition_id) override;
+    SinkPtr createSinkForPartition(const String & partition_id, std::shared_ptr<ThreadPool> pool) override;
 
 private:
     void validateKey(const String & str);

--- a/src/Storages/PartitionedSink.h
+++ b/src/Storages/PartitionedSink.h
@@ -28,7 +28,7 @@ public:
 
     void onFinish() override;
 
-    virtual SinkPtr createSinkForPartition(const String & partition_id) = 0;
+    virtual SinkPtr createSinkForPartition(const String & partition_id, std::shared_ptr<ThreadPool> pool) = 0;
 
     static void validatePartitionKey(const String & str, bool allow_slash);
 
@@ -37,6 +37,7 @@ public:
 private:
     ContextPtr context;
     Block sample_block;
+    std::shared_ptr<ThreadPool> pool;
 
     ExpressionActionsPtr partition_by_expr;
     String partition_by_column_name;

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -718,7 +718,7 @@ public:
     {
     }
 
-    SinkPtr createSinkForPartition(const String & partition_id) override
+    SinkPtr createSinkForPartition(const String & partition_id, std::shared_ptr<ThreadPool> /*unused because it is not parallel*/) override
     {
         auto partition_path = PartitionedSink::replaceWildcards(uri, partition_id);
         context->getRemoteHostFilter().checkURL(Poco::URI(partition_path));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Related to https://github.com/ClickHouse/ClickHouse/issues/51533

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
