### PR TITLE
Docs: replace HTML img tag with image component

### DIFF
--- a/docs/en/getting-started/example-datasets/cell-towers.md
+++ b/docs/en/getting-started/example-datasets/cell-towers.md
@@ -24,10 +24,10 @@ import add_clickhouse_as_superset_datasource from '@site/docs/getting-started/ex
 import add_cell_towers_table_as_dataset from '@site/docs/getting-started/example-datasets/images/superset-add-dataset.png'
 import create_a_map_in_superset from '@site/docs/getting-started/example-datasets/images/superset-create-map.png'
 import specify_long_and_lat from '@site/docs/getting-started/example-datasets/images/superset-lon-lat.png'
-import superset-mcc-204 from '@site/docs/getting-started/example-datasets/images/superset-mcc-204.png'
-import superset-radio-umts from '@site/docs/getting-started/example-datasets/images/superset-radio-umts.png'
-import superset-umts-netherlands from '@site/docs/getting-started/example-datasets/images/superset-umts-netherlands.png'
-import superset-cell-tower-dashboard from '@site/docs/getting-started/example-datasets/images/superset-cell-tower-dashboard.png'
+import superset_mcc_204 from '@site/docs/getting-started/example-datasets/images/superset-mcc-204.png'
+import superset_radio_umts from '@site/docs/getting-started/example-datasets/images/superset-radio-umts.png'
+import superset_umts_netherlands from '@site/docs/getting-started/example-datasets/images/superset-umts-netherlands.png'
+import superset_cell_tower_dashboard from '@site/docs/getting-started/example-datasets/images/superset-cell-tower-dashboard.png'
 
 ## Goal {#goal}
 
@@ -342,15 +342,15 @@ The fields `lon` and `lat` contain the longitude and latitude:
 
 Add a filter with `mcc` = `204` (or substitute any other `mcc` value):
 
-<Image img={superset-mcc-204} size="md" alt="Filter on MCC 204"/>
+<Image img={superset_mcc_2024} size="md" alt="Filter on MCC 204"/>
 
 Add a filter with `radio` = `'UMTS'` (or substitute any other `radio` value, you can see the choices in the output of `DESCRIBE TABLE cell_towers`):
 
-<Image img={superset-radio-umts} size="md" alt="Filter on radio equal to UMTS"/>
+<Image img={superset_radio_umts} size="md" alt="Filter on radio equal to UMTS"/>
 
 This is the full configuration for the chart that filters on `radio = 'UMTS'` and `mcc = 204`:
 
-<Image img={superset-umts-netherlands} size="md" alt="Chart for UMTS radios in MCC 204"/>
+<Image img={superset_umts_netherlands} size="md" alt="Chart for UMTS radios in MCC 204"/>
 
 Click on **UPDATE CHART** to render the visualization.
 
@@ -358,7 +358,7 @@ Click on **UPDATE CHART** to render the visualization.
 
 This screenshot shows cell tower locations with LTE, UMTS, and GSM radios.  The charts are all created in the same way, and they are added to a dashboard.
 
-<Image img={superset-cell-tower-dashboard} size="md" alt="Dashboard of cell towers by radio type in mcc 204"/>
+<Image img={superset_cell_tower_dashboard} size="md" alt="Dashboard of cell towers by radio type in mcc 204"/>
 
 :::tip
 The data is also available for interactive queries in the [Playground](https://sql.clickhouse.com).

--- a/docs/en/getting-started/example-datasets/cell-towers.md
+++ b/docs/en/getting-started/example-datasets/cell-towers.md
@@ -17,6 +17,17 @@ import ActionsMenu from '@site/docs/_snippets/_service_actions_menu.md';
 import SQLConsoleDetail from '@site/docs/_snippets/_launch_sql_console.md';
 import SupersetDocker from '@site/docs/_snippets/_add_superset_detail.md';
 import cloud_load_data_sample from '@site/static/images/_snippets/cloud-load-data-sample.png';
+import cell_towers_1 from '@site/docs/getting-started/example-datasets/images/superset-cell-tower-dashboard.png'
+import add_a_database from '@site/docs/getting-started/example-datasets/images/superset-add.png'
+import choose_clickhouse_connect from '@site/docs/getting-started/example-datasets/images/superset-choose-a-database.png'
+import add_clickhouse_as_superset_datasource from '@site/docs/getting-started/example-datasets/images/superset-connect-a-database.png'
+import add_cell_towers_table_as_dataset from '@site/docs/getting-started/example-datasets/images/superset-add-dataset.png'
+import create_a_map_in_superset from '@site/docs/getting-started/example-datasets/images/superset-create-map.png'
+import specify_long_and_lat from '@site/docs/getting-started/example-datasets/images/superset-lon-lat.png'
+import superset-mcc-204 from '@site/docs/getting-started/example-datasets/images/superset-mcc-204.png'
+import superset-radio-umts from '@site/docs/getting-started/example-datasets/images/superset-radio-umts.png'
+import superset-umts-netherlands from '@site/docs/getting-started/example-datasets/images/superset-umts-netherlands.png'
+import superset-cell-tower-dashboard from '@site/docs/getting-started/example-datasets/images/superset-cell-tower-dashboard.png'
 
 ## Goal {#goal}
 
@@ -27,7 +38,7 @@ In this guide you will learn how to:
 
 Here is a preview of the dashboard created in this guide:
 
-![Dashboard of cell towers by radio type in mcc 204](@site/docs/getting-started/example-datasets/images/superset-cell-tower-dashboard.png)
+<Image img={cell_towers_1} size="md" alt="Dashboard of cell towers by radio type in mcc 204"/>
 
 ## Get the Dataset {#get-the-dataset}
 
@@ -291,11 +302,11 @@ To build a Superset dashboard using the OpenCelliD dataset you should:
 
   In Superset a database can be added by choosing the database type, and then providing the connection details.  Open Superset and look for the **+**, it has a menu with **Data** and then **Connect database** options.
 
-  ![Add a database](@site/docs/getting-started/example-datasets/images/superset-add.png)
-
+  <Image img={add_a_database} size="md" alt="Add a database"/>
+  
   Choose **ClickHouse Connect** from the list:
 
-  ![Choose clickhouse connect as database type](@site/docs/getting-started/example-datasets/images/superset-choose-a-database.png)
+  <Image img={choose_clickhouse_connect} size="md" alt="Choose clickhouse connect as database type"/>
 
 :::note
   If **ClickHouse Connect** is not one of your options, then you will need to install it. The command is `pip install clickhouse-connect`, and more info is [available here](https://pypi.org/project/clickhouse-connect/).
@@ -307,19 +318,19 @@ To build a Superset dashboard using the OpenCelliD dataset you should:
   Make sure that you set **SSL** on when connecting to ClickHouse Cloud or other ClickHouse systems that enforce the use of SSL.
 :::
 
-  ![Add ClickHouse as a Superset data source](@site/docs/getting-started/example-datasets/images/superset-connect-a-database.png)
+  <Image img={add_clickhouse_as_superset_datasource} size="md" alt="Add ClickHouse as a Superset data source"/>
 
 ### Add the table **cell_towers** as a Superset **dataset** {#add-the-table-cell_towers-as-a-superset-dataset}
 
   In Superset a **dataset** maps to a table within a database.  Click on add a dataset and choose your ClickHouse service, the database containing your table (`default`), and choose the `cell_towers` table:
 
-![Add cell_towers table as a dataset](@site/docs/getting-started/example-datasets/images/superset-add-dataset.png)
+<Image img={add_cell_towers_table_as_dataset} size="md" alt="Add cell_towers table as a dataset"/>
 
 ### Create some **charts** {#create-some-charts}
 
 When you choose to add a chart in Superset you have to specify the dataset (`cell_towers`) and the chart type.  Since the OpenCelliD dataset provides longitude and latitude coordinates for cell towers we will create a **Map** chart.  The **deck.gL Scatterplot** type is suited to this dataset as it works well with dense data points on a map.
 
-![Create a map in Superset](@site/docs/getting-started/example-datasets/images/superset-create-map.png)
+<Image img={create_a_map_in_superset} size="md" alt="Create a map in Superset"/>
 
 #### Specify the query used for the map {#specify-the-query-used-for-the-map}
 
@@ -327,19 +338,19 @@ A deck.gl Scatterplot requires a longitude and latitude, and one or more filters
 
 The fields `lon` and `lat` contain the longitude and latitude:
 
-![Specify longitude and latitude fields](@site/docs/getting-started/example-datasets/images/superset-lon-lat.png)
+<Image img={specify_long_and_lat} size="md" alt="Specify longitude and latitude fields"/>
 
 Add a filter with `mcc` = `204` (or substitute any other `mcc` value):
 
-![Filter on MCC 204](@site/docs/getting-started/example-datasets/images/superset-mcc-204.png)
+<Image img={superset-mcc-204} size="md" alt="Filter on MCC 204"/>
 
 Add a filter with `radio` = `'UMTS'` (or substitute any other `radio` value, you can see the choices in the output of `DESCRIBE TABLE cell_towers`):
 
-![Filter on radio = UMTS](@site/docs/getting-started/example-datasets/images/superset-radio-umts.png)
+<Image img={superset-radio-umts} size="md" alt="Filter on radio equal to UMTS"/>
 
 This is the full configuration for the chart that filters on `radio = 'UMTS'` and `mcc = 204`:
 
-![Chart for UMTS radios in MCC 204](@site/docs/getting-started/example-datasets/images/superset-umts-netherlands.png)
+<Image img={superset-umts-netherlands} size="md" alt="Chart for UMTS radios in MCC 204"/>
 
 Click on **UPDATE CHART** to render the visualization.
 
@@ -347,7 +358,7 @@ Click on **UPDATE CHART** to render the visualization.
 
 This screenshot shows cell tower locations with LTE, UMTS, and GSM radios.  The charts are all created in the same way, and they are added to a dashboard.
 
-  ![Dashboard of cell towers by radio type in mcc 204](@site/docs/getting-started/example-datasets/images/superset-cell-tower-dashboard.png)
+<Image img={superset-cell-tower-dashboard} size="md" alt="Dashboard of cell towers by radio type in mcc 204"/>
 
 :::tip
 The data is also available for interactive queries in the [Playground](https://sql.clickhouse.com).

--- a/docs/en/getting-started/example-datasets/cell-towers.md
+++ b/docs/en/getting-started/example-datasets/cell-towers.md
@@ -9,6 +9,7 @@ title: 'Geo Data using the Cell Tower Dataset'
 
 import ConnectionDetails from '@site/docs/_snippets/_gather_your_details_http.mdx';
 
+import Image from '@theme/IdealImage';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
@@ -46,7 +47,7 @@ ClickHouse Cloud provides an easy-button for uploading this dataset from S3.  Lo
 
 Choose the **Cell Towers** dataset from the **Sample data** tab, and **Load data**:
 
-<img src={cloud_load_data_sample} class="image" alt="Load cell towers dataset" />
+<Image img={cloud_load_data_sample} size='md' alt='Load cell towers dataset' />
 
 ### Examine the schema of the cell_towers table {#examine-the-schema-of-the-cell_towers-table}
 ```sql

--- a/docs/en/getting-started/example-datasets/environmental-sensors.md
+++ b/docs/en/getting-started/example-datasets/environmental-sensors.md
@@ -6,6 +6,10 @@ slug: /getting-started/example-datasets/environmental-sensors
 title: 'Environmental Sensors Data'
 ---
 
+import Image from '@theme/IdealImage';
+import no_events_per_day from './images/sensors_01.png';
+import sensors_02 from './images/sensors_02.png';
+
 [Sensor.Community](https://sensor.community/en/) is a contributors-driven global sensor network that creates Open Environmental Data. The data is collected from sensors all over the globe. Anyone can purchase a sensor and place it wherever they like. The APIs to download the data is in [GitHub](https://github.com/opendata-stuttgart/meta/wiki/APIs) and the data is freely available under the [Database Contents License (DbCL)](https://opendatacommons.org/licenses/dbcl/1-0/).
 
 :::important
@@ -154,7 +158,7 @@ ORDER BY date ASC;
 
 We can create a chart in the SQL Console to visualize the results:
 
-![Number of events per day](./images/sensors_01.png)
+<Image img={no_events_per_day} size="md" alt="Number of events per day"/>
 
 6. This query counts the number of overly hot and humid days:
 
@@ -169,5 +173,4 @@ ORDER BY day asc;
 
 Here's a visualization of the result:
 
-![Hot and humid days](./images/sensors_02.png)
-
+<Image img={sensors_02} size="md" alt="Hot and humid days"/>

--- a/docs/en/getting-started/example-datasets/github.md
+++ b/docs/en/getting-started/example-datasets/github.md
@@ -7,6 +7,11 @@ slug: /getting-started/example-datasets/github
 title: 'Writing Queries in ClickHouse using GitHub Data'
 ---
 
+import superset-github-lines-added-deleted from './images/superset-github-lines-added-deleted.png'
+import superset-commits-authors from './images/superset-commits-authors.png'
+import superset-authors-matrix from './images/superset-authors-matrix.png'
+import superset-authors-matrix_v2 from './images/superset-authors-matrix_v2.png'
+
 This dataset contains all of the commits and changes for the ClickHouse repository. It can be generated using the native `git-import` tool distributed with ClickHouse.
 
 The generated data provides a `tsv` file for each of the following tables:
@@ -532,11 +537,11 @@ This data visualizes well. Below we use Superset.
 
 **For lines added and deleted:**
 
-![](./images/superset-github-lines-added-deleted.png)
+<Image img={superset-github-lines-added-deleted} alt="For lines added and deleted" size="md"/>
 
 **For commits and authors:**
 
-![](./images/superset-commits-authors.png)
+<Image img={superset-commits-authors} alt="For commits and authors" size="md"/>
 
 ### List files with maximum number of authors {#list-files-with-maximum-number-of-authors}
 
@@ -1277,13 +1282,12 @@ LIMIT 100
 
 A Sankey chart (SuperSet) allows this to be visualized nicely. Note we increase our `LIMIT BY` to 3, to get the top 3 code removers for each author, to improve the variety in the visual.
 
-
-![](./images/superset-authors-matrix.png)
+<Image img={superset-authors-matrix} alt="Superset authors matrix" size="md"/>
 
 
 Alexey clearly likes removing other peoples code. Lets exclude him for a more balanced view of code removal.
 
-![](./images/superset-authors-matrix_v2.png)
+<Image img={superset-authors-matrix_v2} alt="Superset authors matrix v2" size="md"/>
 
 ### Who is the highest percentage contributor per day of week? {#who-is-the-highest-percentage-contributor-per-day-of-week}
 

--- a/docs/en/getting-started/example-datasets/github.md
+++ b/docs/en/getting-started/example-datasets/github.md
@@ -7,10 +7,10 @@ slug: /getting-started/example-datasets/github
 title: 'Writing Queries in ClickHouse using GitHub Data'
 ---
 
-import superset-github-lines-added-deleted from './images/superset-github-lines-added-deleted.png'
-import superset-commits-authors from './images/superset-commits-authors.png'
-import superset-authors-matrix from './images/superset-authors-matrix.png'
-import superset-authors-matrix_v2 from './images/superset-authors-matrix_v2.png'
+import superset_github_lines_added_deleted from './images/superset-github-lines-added-deleted.png'
+import superset_commits_authors from './images/superset-commits-authors.png'
+import superset_authors_matrix from './images/superset-authors-matrix.png'
+import superset_authors_matrix_v2 from './images/superset-authors-matrix_v2.png'
 
 This dataset contains all of the commits and changes for the ClickHouse repository. It can be generated using the native `git-import` tool distributed with ClickHouse.
 
@@ -537,11 +537,11 @@ This data visualizes well. Below we use Superset.
 
 **For lines added and deleted:**
 
-<Image img={superset-github-lines-added-deleted} alt="For lines added and deleted" size="md"/>
+<Image img={superset_github_lines_added_deleted} alt="For lines added and deleted" size="md"/>
 
 **For commits and authors:**
 
-<Image img={superset-commits-authors} alt="For commits and authors" size="md"/>
+<Image img={superset_commits_authors} alt="For commits and authors" size="md"/>
 
 ### List files with maximum number of authors {#list-files-with-maximum-number-of-authors}
 
@@ -1282,12 +1282,12 @@ LIMIT 100
 
 A Sankey chart (SuperSet) allows this to be visualized nicely. Note we increase our `LIMIT BY` to 3, to get the top 3 code removers for each author, to improve the variety in the visual.
 
-<Image img={superset-authors-matrix} alt="Superset authors matrix" size="md"/>
+<Image img={superset_authors_matrix} alt="Superset authors matrix" size="md"/>
 
 
 Alexey clearly likes removing other peoples code. Lets exclude him for a more balanced view of code removal.
 
-<Image img={superset-authors-matrix_v2} alt="Superset authors matrix v2" size="md"/>
+<Image img={superset_authors_matrix_v2} alt="Superset authors matrix v2" size="md"/>
 
 ### Who is the highest percentage contributor per day of week? {#who-is-the-highest-percentage-contributor-per-day-of-week}
 

--- a/docs/en/getting-started/example-datasets/stackoverflow.md
+++ b/docs/en/getting-started/example-datasets/stackoverflow.md
@@ -6,13 +6,16 @@ slug: /getting-started/example-datasets/stackoverflow
 title: 'Analyzing Stack Overflow data with ClickHouse'
 ---
 
+import Image from '@theme/IdealImage';
+import stackoverflow from './images/stackoverflow.png'
+
 This dataset contains every `Posts`, `Users`, `Votes`, `Comments`, `Badges`, `PostHistory`, and `PostLinks` that has occurred on Stack Overflow.
 
 Users can either download pre-prepared Parquet versions of the data, containing every post up to April 2024, or download the latest data in XML format and load this. Stack Overflow provide updates to this data periodically - historically every 3 months.
 
 The following diagram shows the schema for the available tables assuming Parquet format.
 
-![Stack Overflow schema](./images/stackoverflow.png)
+<Image img={stackoverflow} alt="Stack Overflow schema" size="md"/>
 
 A description of the schema of this data can be found [here](https://meta.stackexchange.com/questions/2677/database-schema-documentation-for-the-public-data-dump-and-sede).
 

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -6,6 +6,7 @@ slug: /interfaces/cli
 title: 'ClickHouse Client'
 ---
 
+import Image from '@theme/IdealImage';
 import cloud_connect_button from '@site/static/images/_snippets/cloud-connect-button.png';
 import connection_details_native from '@site/static/images/_snippets/connection-details-native.png'
 
@@ -71,19 +72,19 @@ For a complete list of command-line options, see [Command Line Options](#command
 
 The details for your ClickHouse Cloud service are available in the ClickHouse Cloud console. Select the service that you want to connect to and click **Connect**:
 
-<img src={cloud_connect_button}
-  class="image"
+<Image img={cloud_connect_button}
+  size="md"
   alt="ClickHouse Cloud service connect button"
-  style={{width: '30em'}} />
+/>
 
 <br/><br/>
 
 Choose **Native**, and the details are shown with an example `clickhouse-client` command:
 
-<img src={connection_details_native}
-  class="image"
+<Image img={connection_details_native}
+  size="md"
   alt="ClickHouse Cloud Native TCP connection details"
-  style={{width: '40em'}} />
+/>
 
 
 ### Storing connections in a configuration file {#connection-credentials}
@@ -109,7 +110,6 @@ See the [section on configuration files](#configuration_files) for more informat
 :::note
 To concentrate on the query syntax, the rest of the examples leave off the connection details (`--host`, `--port`, etc.). Remember to add them when you use the commands.
 :::
-
 
 ## Batch mode {#batch-mode}
 

--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -8,6 +8,7 @@ title: 'HTTP Interface'
 ---
 
 import PlayUI from '@site/static/images/play.png';
+import Image from '@theme/IdealImage';
 
 # HTTP Interface
 
@@ -34,7 +35,7 @@ It has a secret feature for displaying charts and graphs for query pipelines.
 
 Web UI is designed for professionals like you.
 
-<img src={PlayUI} alt="ClickHouse Web UI screenshot" />
+<Image img={PlayUI} size="md" alt="ClickHouse Web UI screenshot" />
 
 In health-check scripts use `GET /ping` request. This handler always returns "Ok." (with a line feed at the end). Available from version 18.12.13. See also `/replicas_status` to check replica's delay.
 

--- a/docs/en/interfaces/mysql.md
+++ b/docs/en/interfaces/mysql.md
@@ -7,6 +7,7 @@ slug: /interfaces/mysql
 title: 'MySQL Interface'
 ---
 
+import Image from '@theme/IdealImage';
 import mysql0 from '@site/static/images/interfaces/mysql0.png';
 import mysql1 from '@site/static/images/interfaces/mysql1.png';
 import mysql2 from '@site/static/images/interfaces/mysql2.png';
@@ -40,23 +41,23 @@ This cannot be turned off and it can lead in rare edge cases to different behavi
 
 <br/>
 
-<img src={mysql0} alt="Credentials screen - Prompt" />
+<Image img={mysql0} alt="Credentials screen - Prompt" size="md"/>
 
 2. Change the `Connect with` drop-down to `MySQL`. 
 
 <br/>
 
-<img src={mysql1} alt="Credentials screen - MySQL selected" />
+<Image img={mysql1} alt="Credentials screen - MySQL selected" size="md" />
 
 3. Toggle the switch to enable the MySQL interface for this specific service. This will expose port `3306` for this service and prompt you with your MySQL connection screen that include your unique MySQL username. The password will be the same as the service's default user password.
 
 <br/>
 
-<img src={mysql2} alt="Credentials screen - Enabled MySQL" />
+<Image img={mysql2} alt="Credentials screen - Enabled MySQL" size="md"/>
 
 Copy the MySQL connection string shown.
 
-<img src={mysql3} alt="Credentials screen - Connection String" />
+<Image img={mysql3} alt="Credentials screen - Connection String" size="md"/>
 
 ## Creating multiple MySQL users in ClickHouse Cloud {#creating-multiple-mysql-users-in-clickhouse-cloud}
 
@@ -112,7 +113,7 @@ In this case, ensure that the username follows the `mysql4<subdomain>_<username>
 
 Add the [mysql_port](../operations/server-configuration-parameters/settings.md#mysql_port) setting to your server's configuration file. For example, you could define the port in a new XML file in your `config.d/` [folder](../operations/configuration-files):
 
-``` xml
+```xml
 <clickhouse>
     <mysql_port>9004</mysql_port>
 </clickhouse>
@@ -134,13 +135,13 @@ mysql --protocol tcp -h [hostname] -u [username] -P [port_number] [database_name
 
 For example:
 
-``` bash
+```bash
 $ mysql --protocol tcp -h 127.0.0.1 -u default -P 9004 default
 ```
 
 Output if a connection succeeded:
 
-``` text
+```text
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 4
 Server version: 20.2.1.1-ClickHouse
@@ -167,6 +168,6 @@ Restrictions:
 
 To cancel a long query use `KILL QUERY connection_id` statement (it is replaced with `KILL QUERY WHERE query_id = connection_id` while proceeding). For example:
 
-``` bash
+```bash
 $ mysql --protocol tcp -h mysql_server -P 9004 default -u default --password=123 -e "KILL QUERY 123456;"
 ```

--- a/docs/en/operations/monitoring.md
+++ b/docs/en/operations/monitoring.md
@@ -9,6 +9,8 @@ slug: /operations/monitoring
 title: 'Monitoring'
 ---
 
+import Image from '@theme/IdealImage';
+
 # Monitoring
 
 :::note
@@ -22,7 +24,7 @@ You can monitor:
 
 ## Built-in advanced observability dashboard {#built-in-advanced-observability-dashboard}
 
-<img width="400" alt="Screenshot 2023-11-12 at 6 08 58 PM" src="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" />
+<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Screenshot 2023-11-12 at 6 08 58 PM" size="md" />
 
 ClickHouse comes with a built-in advanced observability dashboard feature which can be accessed by `$HOST:$PORT/dashboard` (requires user and password) that shows the following metrics:
 - Queries/second


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Replaces HTML img tags with the new image component which allows to zoom in to the image.
Requires https://github.com/ClickHouse/clickhouse-docs/pull/3505
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
