### PR TITLE
Stop merges without written blocks

### DIFF
--- a/src/Storages/MergeTree/MergeProgress.h
+++ b/src/Storages/MergeTree/MergeProgress.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <base/types.h>
-#include <Common/ProfileEvents.h>
+#include <functional>
 #include <IO/Progress.h>
 #include <Storages/MergeTree/MergeList.h>
+#include <base/types.h>
+#include <Common/ProfileEvents.h>
 
 
 namespace ProfileEvents
@@ -47,23 +48,20 @@ struct MergeStageProgress
 class MergeProgressCallback
 {
 public:
+    // It should throw an exception in case the operation should be cancelled
+    using CancellationChecker = std::function<void()>;
+
     MergeProgressCallback(
-        MergeListElement * merge_list_element_ptr_, UInt64 & watch_prev_elapsed_, MergeStageProgress & stage_)
+        MergeListElement * merge_list_element_ptr_,
+        UInt64 & watch_prev_elapsed_,
+        MergeStageProgress & stage_,
+        CancellationChecker && cancellation_checker_)
         : merge_list_element_ptr(merge_list_element_ptr_)
         , watch_prev_elapsed(watch_prev_elapsed_)
         , stage(stage_)
+        , cancellation_checker(std::move(cancellation_checker_))
     {
         updateWatch();
-    }
-
-    MergeListElement * merge_list_element_ptr;
-    UInt64 & watch_prev_elapsed;
-    MergeStageProgress & stage;
-
-    void updateWatch()
-    {
-        UInt64 watch_curr_elapsed = merge_list_element_ptr->watch.elapsed();
-        watch_prev_elapsed = watch_curr_elapsed;
     }
 
     void operator()(const Progress & value)
@@ -75,6 +73,8 @@ public:
 
 
         updateWatch();
+
+        cancellation_checker();
 
         merge_list_element_ptr->bytes_read_uncompressed += value.read_bytes;
         if (stage.is_first)
@@ -91,6 +91,17 @@ public:
     }
 
 private:
+    MergeListElement * merge_list_element_ptr;
+    UInt64 & watch_prev_elapsed;
+    MergeStageProgress & stage;
+    CancellationChecker cancellation_checker;
+
+    void updateWatch()
+    {
+        UInt64 watch_curr_elapsed = merge_list_element_ptr->watch.elapsed();
+        watch_prev_elapsed = watch_curr_elapsed;
+    }
+
     void updateProfileEvents(const Progress & value, ProfileEvents::Event rows_event, ProfileEvents::Event bytes_event) const
     {
         ProfileEvents::increment(bytes_event, value.read_bytes);

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1155,7 +1155,8 @@ void MergeTask::VerticalMergeStage::prepareVerticalMergeForOneColumn() const
     ctx->column_parts_pipeline.setProgressCallback(MergeProgressCallback(
         global_ctx->merge_list_element_ptr,
         global_ctx->watch_prev_elapsed,
-        *global_ctx->column_progress));
+        *global_ctx->column_progress,
+        [&my_ctx = *global_ctx]() { my_ctx.checkOperationIsNotCanceled(); }));
 
     /// Is calculated inside MergeProgressCallback.
     ctx->column_parts_pipeline.disableProfileEventUpdate();
@@ -1916,7 +1917,11 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
     }
 
     /// Dereference unique_ptr and pass horizontal_stage_progress by reference
-    global_ctx->merged_pipeline.setProgressCallback(MergeProgressCallback(global_ctx->merge_list_element_ptr, global_ctx->watch_prev_elapsed, *global_ctx->horizontal_stage_progress));
+    global_ctx->merged_pipeline.setProgressCallback(MergeProgressCallback(
+        global_ctx->merge_list_element_ptr,
+        global_ctx->watch_prev_elapsed,
+        *global_ctx->horizontal_stage_progress,
+        [&my_ctx = *global_ctx]() { my_ctx.checkOperationIsNotCanceled(); }));
     /// Is calculated inside MergeProgressCallback.
     global_ctx->merged_pipeline.disableProfileEventUpdate();
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -2330,7 +2330,11 @@ bool MutateTask::prepare()
         ctx->materialized_projections = ctx->interpreter->grabMaterializedProjections();
         ctx->mutating_pipeline_builder = ctx->interpreter->execute();
         ctx->updated_header = ctx->interpreter->getUpdatedHeader();
-        ctx->progress_callback = MergeProgressCallback((*ctx->mutate_entry)->ptr(), ctx->watch_prev_elapsed, *ctx->stage_progress);
+        ctx->progress_callback = MergeProgressCallback(
+            (*ctx->mutate_entry)->ptr(),
+            ctx->watch_prev_elapsed,
+            *ctx->stage_progress,
+            [&my_ctx = *ctx]() { my_ctx.checkOperationIsNotCanceled(); });
 
         lightweight_delete_mode = ctx->updated_header.has(RowExistsColumn::name);
         /// If under the condition of lightweight delete mode with rebuild option, add projections again here as we can only know


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Regularly check if merges and mutations were cancelled even in case when the operation doesn't produce any blocks to write.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

cc @alesapin 
