### PR TITLE
docs - fix title for histogram_metrics

### DIFF
--- a/docs/en/operations/system-tables/histogram_metrics.md
+++ b/docs/en/operations/system-tables/histogram_metrics.md
@@ -3,7 +3,7 @@ description: 'This table contains histogram metrics that can be calculated insta
   and exported in the Prometheus format. It is always up to date.'
 keywords: ['system table', 'histogram_metrics']
 slug: /en/operations/system-tables/histogram_metrics
-title: 'histogram_metrics'
+title: 'system.histogram_metrics'
 ---
 
 import SystemTableCloud from '@site/docs/_snippets/_system_table_cloud.md';


### PR DESCRIPTION
Fix the title for `histogram_metrics` so that it's correctly populated in: https://clickhouse.com/docs/operations/system-table. Currently it's just populated as `histogram_metrics` instead of `system.histogram_metrics`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
