### PR TITLE
Query Cache: Support deterministic UDFs

### DIFF
--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -181,7 +181,8 @@ result blocks. While this behavior is a good default, it can be suppressed using
 
 Also, results of queries with non-deterministic functions are not cached by default. Such functions include
 - functions for accessing dictionaries: [`dictGet()`](/sql-reference/functions/ext-dict-functions#dictget-dictgetordefault-dictgetornull) etc.
-- [user-defined functions](../sql-reference/statements/create/function.md),
+- [user-defined functions](../sql-reference/statements/create/function.md) without tag `<deterministic>true</deterministic>` in their XML
+  definition,
 - functions which return the current date or time: [`now()`](../sql-reference/functions/date-time-functions.md#now),
   [`today()`](../sql-reference/functions/date-time-functions.md#today),
   [`yesterday()`](../sql-reference/functions/date-time-functions.md#yesterday) etc.,

--- a/docs/en/sql-reference/functions/udf.md
+++ b/docs/en/sql-reference/functions/udf.md
@@ -39,7 +39,7 @@ A function configuration contains the following settings:
 - `send_chunk_header` - controls whether to send row count before sending a chunk of data to process. Optional. Default value is `false`.
 - `execute_direct` - If `execute_direct` = `1`, then `command` will be searched inside user_scripts folder specified by [user_scripts_path](../../operations/server-configuration-parameters/settings.md#user_scripts_path). Additional script arguments can be specified using whitespace separator. Example: `script_name arg1 arg2`. If `execute_direct` = `0`, `command` is passed as argument for `bin/sh -c`. Default value is `1`. Optional parameter.
 - `lifetime` - the reload interval of a function in seconds. If it is set to `0` then the function is not reloaded. Default value is `0`. Optional parameter.
-- `deterministic` - Specify if the function will be considered deterministic.
+- `deterministic` - if the function is deterministic (returns the same result for the same input). Default value is `false`. Optional parameter.
 
 The command must read arguments from `STDIN` and must output the result to `STDOUT`. The command must process arguments iteratively. That is after processing a chunk of arguments it must wait for the next chunk.
 
@@ -66,6 +66,7 @@ File `test_function.xml` (`/etc/clickhouse-server/test_function.xml` with defaul
         <format>TabSeparated</format>
         <command>cd /; clickhouse-local --input-format TabSeparated --output-format TabSeparated --structure 'x UInt64, y UInt64' --query "SELECT x + y FROM table"</command>
         <execute_direct>0</execute_direct>
+        <deterministic>true</deterministic>
     </function>
 </functions>
 ```

--- a/docs/en/sql-reference/functions/udf.md
+++ b/docs/en/sql-reference/functions/udf.md
@@ -39,6 +39,7 @@ A function configuration contains the following settings:
 - `send_chunk_header` - controls whether to send row count before sending a chunk of data to process. Optional. Default value is `false`.
 - `execute_direct` - If `execute_direct` = `1`, then `command` will be searched inside user_scripts folder specified by [user_scripts_path](../../operations/server-configuration-parameters/settings.md#user_scripts_path). Additional script arguments can be specified using whitespace separator. Example: `script_name arg1 arg2`. If `execute_direct` = `0`, `command` is passed as argument for `bin/sh -c`. Default value is `1`. Optional parameter.
 - `lifetime` - the reload interval of a function in seconds. If it is set to `0` then the function is not reloaded. Default value is `0`. Optional parameter.
+- `deterministic` - Specify if the function will be considered deterministic.
 
 The command must read arguments from `STDIN` and must output the result to `STDOUT`. The command must process arguments iteratively. That is after processing a chunk of arguments it must wait for the next chunk.
 

--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -173,7 +173,7 @@ ExternalLoader::LoadableMutablePtr ExternalUserDefinedExecutableFunctionsLoader:
     if (config.has(key_in_config + ".return_name"))
         result_name = config.getString(key_in_config + ".return_name");
 
-    bool deterministic = config.getBool(key_in_config + ".deterministic", false);
+    bool is_deterministic = config.getBool(key_in_config + ".deterministic", false);
 
     bool send_chunk_header = config.getBool(key_in_config + ".send_chunk_header", false);
     size_t command_termination_timeout_seconds = config.getUInt64(key_in_config + ".command_termination_timeout", 10);
@@ -241,7 +241,7 @@ ExternalLoader::LoadableMutablePtr ExternalUserDefinedExecutableFunctionsLoader:
         .parameters = std::move(parameters),
         .result_type = std::move(result_type),
         .result_name = std::move(result_name),
-        .deterministic = deterministic
+        .is_deterministic = is_deterministic
     };
 
     ShellCommandSourceCoordinator::Configuration shell_command_coordinator_configration

--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -173,6 +173,8 @@ ExternalLoader::LoadableMutablePtr ExternalUserDefinedExecutableFunctionsLoader:
     if (config.has(key_in_config + ".return_name"))
         result_name = config.getString(key_in_config + ".return_name");
 
+    bool deterministic = config.getBool(key_in_config + ".deterministic", false);
+
     bool send_chunk_header = config.getBool(key_in_config + ".send_chunk_header", false);
     size_t command_termination_timeout_seconds = config.getUInt64(key_in_config + ".command_termination_timeout", 10);
     size_t command_read_timeout_milliseconds = config.getUInt64(key_in_config + ".command_read_timeout", 10000);
@@ -239,6 +241,7 @@ ExternalLoader::LoadableMutablePtr ExternalUserDefinedExecutableFunctionsLoader:
         .parameters = std::move(parameters),
         .result_type = std::move(result_type),
         .result_name = std::move(result_name),
+        .deterministic = deterministic
     };
 
     ShellCommandSourceCoordinator::Configuration shell_command_coordinator_configration

--- a/src/Functions/UserDefined/UserDefinedExecutableFunction.h
+++ b/src/Functions/UserDefined/UserDefinedExecutableFunction.h
@@ -31,6 +31,7 @@ struct UserDefinedExecutableFunctionConfiguration
     std::vector<UserDefinedExecutableFunctionParameter> parameters;
     DataTypePtr result_type;
     String result_name;
+    bool deterministic;
 };
 
 class UserDefinedExecutableFunction final : public IExternalLoadable

--- a/src/Functions/UserDefined/UserDefinedExecutableFunction.h
+++ b/src/Functions/UserDefined/UserDefinedExecutableFunction.h
@@ -31,7 +31,7 @@ struct UserDefinedExecutableFunctionConfiguration
     std::vector<UserDefinedExecutableFunctionParameter> parameters;
     DataTypePtr result_type;
     String result_name;
-    bool deterministic;
+    bool is_deterministic;
 };
 
 class UserDefinedExecutableFunction final : public IExternalLoadable

--- a/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
+++ b/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
@@ -105,7 +105,7 @@ public:
 
     bool useDefaultImplementationForConstants() const override { return true; }
     bool useDefaultImplementationForNulls() const override { return false; }
-    bool isDeterministic() const override { return false; }
+    bool isDeterministic() const override { return executable_function->getConfiguration().deterministic; }                 //! Is the function deterministic?
     bool isDeterministicInScopeOfQuery() const override { return false; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes &) const override

--- a/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
+++ b/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
@@ -105,7 +105,7 @@ public:
 
     bool useDefaultImplementationForConstants() const override { return true; }
     bool useDefaultImplementationForNulls() const override { return false; }
-    bool isDeterministic() const override { return executable_function->getConfiguration().deterministic; }                 //! Is the function deterministic?
+    bool isDeterministic() const override { return executable_function->getConfiguration().is_deterministic; }
     bool isDeterministicInScopeOfQuery() const override { return false; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes &) const override

--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -395,7 +395,7 @@
         <!-- <check_exit_code>1</check_exit_code> -->
     </function>
 
-    <!-- Define UDFs with explicit deterministic flags -->
+    <!-- The next two UDFs have an explicit 'deterministic' tag defined -->
     <function>
         <type>executable</type>
         <name>test_function_bash_deterministic</name>
@@ -410,7 +410,7 @@
 
     <function>
         <type>executable</type>
-        <name>test_function_bash_nodeterministic</name>
+        <name>test_function_bash_nondeterministic</name>
         <return_type>String</return_type>
         <argument>
             <type>UInt64</type>

--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -394,4 +394,30 @@
         <!-- default -->
         <!-- <check_exit_code>1</check_exit_code> -->
     </function>
+
+    <!-- Define UDFs with explicit deterministic flags -->
+    <function>
+        <type>executable</type>
+        <name>test_function_bash_deterministic</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input.sh</command>
+        <deterministic>true</deterministic>
+    </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_bash_nodeterministic</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input.sh</command>
+        <deterministic>false</deterministic>
+    </function>
+
 </functions>

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -340,63 +340,49 @@ def test_executable_function_always_error_python(started_cluster):
         assert "DB::Exception: Child process was exited with return code 1" in str(ex)
 
 def test_executable_function_query_cache(started_cluster):
-    '''Test for issue #77553: Externally-defined UDFs may be non-deterministic. The query cache should treat them as such, i.e. reject them.'''
+    '''Test for issues #77553 and #59988: Users should be able to specify if externally-defined are non-deterministic, and the query cache should treat them correspondingly.'''
     '''Also see tests/0_stateless/test_query_cache_udf_sql.sql'''
     skip_test_msan(node)
 
     node.query("SYSTEM DROP QUERY CACHE");
 
+    # we are each testing an UDF without explicit <deterministic> tag (to check the default behavior) and two queries with <deterministic> true respectively false </deterministic>.
+
     # query_cache_nondeterministic_function_handling = throw
+
     assert node.query_and_get_error("SELECT test_function_bash(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'throw'")
     assert node.query("SELECT count(*) FROM system.query_cache") == "0\n"
+
+    assert node.query("SELECT test_function_bash_deterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'throw'") == "Key 1\n"
+    assert node.query("SELECT count(*) FROM system.query_cache") == "1\n"
+
+    assert node.query_and_get_error("SELECT test_function_bash_nondeterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'throw'")
+    assert node.query("SELECT count(*) FROM system.query_cache") == "1\n"
+
     node.query("SYSTEM DROP QUERY CACHE");
 
     # query_cache_nondeterministic_function_handling = save
+
     assert node.query("SELECT test_function_bash(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'save'") == "Key 1\n"
     assert node.query("SELECT count(*) FROM system.query_cache") == "1\n"
+
+    assert node.query("SELECT test_function_bash_deterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'save'") == "Key 1\n"
+    assert node.query("SELECT count(*) FROM system.query_cache") == "2\n"
+
+    assert node.query("SELECT test_function_bash_nondeterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'save'") == "Key 1\n"
+    assert node.query("SELECT count(*) FROM system.query_cache") == "3\n"
+
     node.query("SYSTEM DROP QUERY CACHE");
 
     # query_cache_nondeterministic_function_handling = ignore
+
     assert node.query("SELECT test_function_bash(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'ignore'") == "Key 1\n"
     assert node.query("SELECT count(*) FROM system.query_cache") == "0\n"
-    node.query("SYSTEM DROP QUERY CACHE");
-
-def test_executable_function_bash_deterministic(started_cluster):
-    '''Test for issue #59988: Add support for deterministic UDF. Test executable UDFs defined with deterministic=true'''
-    skip_test_msan(node)
-
-    node.query("SYSTEM DROP QUERY CACHE");
-    assert node.query("SELECT count(*) FROM system.query_cache") == "0\n"
-
-    assert node.query("SELECT test_function_bash_deterministic(1) SETTINGS use_query_cache = true;") == "Key 1\n"
-    assert node.query("SELECT test_function_bash_deterministic(2) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'throw'") == "Key 2\n"
-    assert node.query("SELECT count(*) FROM system.query_cache") == "2\n"
-    node.query("SYSTEM DROP QUERY CACHE");
-
-    assert node.query("SELECT test_function_bash_deterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'save'") == "Key 1\n"
-    assert node.query("SELECT count(*) FROM system.query_cache") == "1\n"
-    node.query("SYSTEM DROP QUERY CACHE");
 
     assert node.query("SELECT test_function_bash_deterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'ignore'") == "Key 1\n"
     assert node.query("SELECT count(*) FROM system.query_cache") == "1\n"
-    node.query("SYSTEM DROP QUERY CACHE");
 
-def test_executable_function_bash_nodeterministic(started_cluster):
-    '''Test for issue #59988: Add support for deterministic UDF. Test executable UDFs defined with deterministic=false'''
-    skip_test_msan(node)
-
-    node.query("SYSTEM DROP QUERY CACHE");
-    assert node.query("SELECT count(*) FROM system.query_cache") == "0\n"
-
-    assert node.query_and_get_error("SELECT test_function_bash_nodeterministic(1) SETTINGS use_query_cache = true;")
-    assert node.query_and_get_error("SELECT test_function_bash_nodeterministic(2) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'throw'")
-    assert node.query("SELECT count(*) FROM system.query_cache") == "0\n"
-    node.query("SYSTEM DROP QUERY CACHE");
-
-    assert node.query("SELECT test_function_bash_nodeterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'save'") == "Key 1\n"
+    assert node.query("SELECT test_function_bash_nondeterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'ignore'") == "Key 1\n"
     assert node.query("SELECT count(*) FROM system.query_cache") == "1\n"
-    node.query("SYSTEM DROP QUERY CACHE");
 
-    assert node.query("SELECT test_function_bash_nodeterministic(1) SETTINGS use_query_cache = true, query_cache_nondeterministic_function_handling = 'ignore'") == "Key 1\n"
-    assert node.query("SELECT count(*) FROM system.query_cache") == "0\n"
     node.query("SYSTEM DROP QUERY CACHE");

--- a/tests/queries/0_stateless/02494_query_cache_udf_sql.sql
+++ b/tests/queries/0_stateless/02494_query_cache_udf_sql.sql
@@ -2,7 +2,7 @@
 -- Tag no-parallel: Messes with internal cache
 
 -- Test for issue #77553: SQL-defined UDFs may be non-deterministic. The query cache should treat them as such, i.e. reject them.
--- Also see 02494_query_cache_udf_executable.sh
+-- Also see test_executable_function_query_cache in tests/integration/test_executable_user_defined_function
 
 SYSTEM DROP QUERY CACHE;
 DROP FUNCTION IF EXISTS udf;


### PR DESCRIPTION
Resolves #59988.

Example for the new syntax:

```xml
<functions>
  <function>
     <deterministic>true</deterministic> <!-- true or false. if the tag is not specified it assumes false -->
  <function>
</functions
```

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
User-defined functions (UDFs) can now be marked as deterministic via a new tag in their XML definition. Also, the query cache now checks if UDFs called within a query are deterministic. If this is the case, it caches the query result. (Issue #59988).