### PR TITLE
Optimize order by single nullable or low-cardinality columns

### DIFF
--- a/tests/performance/order_by_single_nullable.xml
+++ b/tests/performance/order_by_single_nullable.xml
@@ -1,0 +1,14 @@
+<test>
+    <create_query>CREATE TABLE IF NOT EXISTS t_opt_orderby (a UInt64, b Nullable(UInt64)) ENGINE = Memory()</create_query>
+    <fill_query>insert into t_opt_orderby select * from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000</fill_query>
+
+    <settings>
+        <max_threads>1</max_threads>
+        <compile_sort_description>0</compile_sort_description>
+    </settings>
+
+    <query>select a from t_opt_orderby order by a</query>
+    <query>select b from t_opt_orderby order by b</query>
+
+    <drop_query>DROP TABLE IF EXISTS t_opt_orderby</drop_query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize order by single nullable or low-cardinality columns


Opt1: devirtualize ColumnNullable::compareAt to improve order by single nullable column
``` sql
alter table hits_v1 add column nWatchId Nullable(UInt64) materialized toNullable(WatchID)
alter table hits_v1 materialize column nWatchId;
select nWatchId from datasets.hits_v1 order by nWatchId format Null settings compile_sort_description = 0; 

Before:
0 rows in set. Elapsed: 1.638 sec. Processed 8.87 million rows, 79.87 MB (5.42 million rows/s., 48.75 MB/s.)
0 rows in set. Elapsed: 1.602 sec. Processed 8.87 million rows, 79.87 MB (5.54 million rows/s., 49.85 MB/s.)
0 rows in set. Elapsed: 1.537 sec. Processed 8.87 million rows, 79.87 MB (5.77 million rows/s., 51.96 MB/s.) 

After
0 rows in set. Elapsed: 1.404 sec. Processed 8.87 million rows, 79.87 MB (6.32 million rows/s., 56.90 MB/s.)
0 rows in set. Elapsed: 1.396 sec. Processed 8.87 million rows, 79.87 MB (6.36 million rows/s., 57.21 MB/s.)
0 rows in set. Elapsed: 1.360 sec. Processed 8.87 million rows, 79.87 MB (6.53 million rows/s., 58.73 MB/s.)
```

Opt2: inroduce binary search in `SortingQueueImpl::updateBatchSize` in case batch_size large. It happens when sort columns have low cardinality. 
``` sql 
CREATE TABLE IF NOT EXISTS t (a UInt64, b Nullable(UInt64)) ENGINE = Memory() ;

-- cardinality: 100
truncate table t; 
insert into t select a%100, b%100 from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000;  
before:
0 rows in set. Elapsed: 0.155 sec. Processed 10.00 million rows, 90.00 MB (64.55 million rows/s., 580.93 MB/s.)
0 rows in set. Elapsed: 0.151 sec. Processed 10.00 million rows, 90.00 MB (66.31 million rows/s., 596.78 MB/s.)
after:
0 rows in set. Elapsed: 0.111 sec. Processed 10.00 million rows, 90.00 MB (90.43 million rows/s., 813.86 MB/s.)
0 rows in set. Elapsed: 0.113 sec. Processed 10.00 million rows, 90.00 MB (88.47 million rows/s., 796.22 MB/s.)

-- cardinality: 1000
truncate table t; 
insert into t select a%1000, b%1000 from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000;  
before
0 rows in set. Elapsed: 0.166 sec. Processed 10.00 million rows, 90.00 MB (60.36 million rows/s., 543.24 MB/s.)
0 rows in set. Elapsed: 0.165 sec. Processed 10.00 million rows, 90.00 MB (60.47 million rows/s., 544.21 MB/s.)
after
0 rows in set. Elapsed: 0.136 sec. Processed 10.00 million rows, 90.00 MB (73.74 million rows/s., 663.65 MB/s.)
0 rows in set. Elapsed: 0.131 sec. Processed 10.00 million rows, 90.00 MB (76.48 million rows/s., 688.32 MB/s.)

-- cardinality: 10000
truncate table t; 
insert into t select a%10000, b%10000 from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000;  
before
0 rows in set. Elapsed: 0.203 sec. Processed 10.00 million rows, 90.00 MB (49.30 million rows/s., 443.71 MB/s.)
0 rows in set. Elapsed: 0.197 sec. Processed 10.00 million rows, 90.00 MB (50.77 million rows/s., 456.89 MB/s.)
after
0 rows in set. Elapsed: 0.250 sec. Processed 10.00 million rows, 90.00 MB (40.06 million rows/s., 360.54 MB/s.)
0 rows in set. Elapsed: 0.257 sec. Processed 10.00 million rows, 90.00 MB (38.95 million rows/s., 350.55 MB/s.)

-- cardinality: 100000
truncate table t; 
insert into t select a%100000, b%100000 from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000;  
before
0 rows in set. Elapsed: 0.529 sec. Processed 10.00 million rows, 90.00 MB (18.89 million rows/s., 169.97 MB/s.)
0 rows in set. Elapsed: 0.496 sec. Processed 10.00 million rows, 90.00 MB (20.14 million rows/s., 181.29 MB/s.)
after
0 rows in set. Elapsed: 0.571 sec. Processed 10.00 million rows, 90.00 MB (17.51 million rows/s., 157.61 MB/s.)
0 rows in set. Elapsed: 0.541 sec. Processed 10.00 million rows, 90.00 MB (18.49 million rows/s., 166.37 MB/s.)

-- cardinality: 1000000
truncate table t; 
insert into t select a%1000000, b%1000000 from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000;  
before
0 rows in set. Elapsed: 1.501 sec. Processed 10.00 million rows, 90.00 MB (6.66 million rows/s., 59.98 MB/s.)
0 rows in set. Elapsed: 1.517 sec. Processed 10.00 million rows, 90.00 MB (6.59 million rows/s., 59.31 MB/s.)
after
0 rows in set. Elapsed: 1.466 sec. Processed 10.00 million rows, 90.00 MB (6.82 million rows/s., 61.41 MB/s.)
0 rows in set. Elapsed: 1.380 sec. Processed 10.00 million rows, 90.00 MB (7.25 million rows/s., 65.23 MB/s.)

-- random distribution
truncate table t; 
insert into t select a, b from  generateRandom('a UInt64, b Nullable(UInt64)') limit 10000000;  
before:
0 rows in set. Elapsed: 1.500 sec. Processed 10.00 million rows, 90.00 MB (6.67 million rows/s., 60.01 MB/s.)
0 rows in set. Elapsed: 1.505 sec. Processed 10.00 million rows, 90.00 MB (6.64 million rows/s., 59.80 MB/s.)
after:
0 rows in set. Elapsed: 1.507 sec. Processed 10.00 million rows, 90.00 MB (6.64 million rows/s., 59.73 MB/s.)
0 rows in set. Elapsed: 1.463 sec. Processed 10.00 million rows, 90.00 MB (6.84 million rows/s., 61.53 MB/s.)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
