### PR TITLE
Fix AST fuzzer

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1126,7 +1126,7 @@ static const auto identifier_lambda = [](std::pair<std::string, ASTPtr> & p)
 {
     /// No query parameters identifiers at this moment
     const auto * id = typeid_cast<ASTIdentifier *>(p.second.get());
-    return id && !id->name_parts.empty();
+    return id && !id->name_parts.empty() && !id->isParam();
 };
 
 ASTPtr QueryFuzzer::generatePredicate()

--- a/src/Parsers/ASTIdentifier.cpp
+++ b/src/Parsers/ASTIdentifier.cpp
@@ -54,6 +54,11 @@ ASTIdentifier::ASTIdentifier(std::vector<String> && name_parts_, bool special, A
     }
 }
 
+bool ASTIdentifier::isParam() const
+{
+    return !children.empty();
+}
+
 ASTPtr ASTIdentifier::getParam() const
 {
     assert(full_name.empty() && children.size() == 1);

--- a/src/Parsers/ASTIdentifier.h
+++ b/src/Parsers/ASTIdentifier.h
@@ -29,7 +29,7 @@ public:
     /** Get the text that identifies this element. */
     String getID(char delim) const override { return "Identifier" + (delim + name()); }
 
-    /** Check if identigier is a parameter */
+    /** Check if identifier is a parameter */
     bool isParam() const;
     /** Get the query param out of a non-compound identifier. */
     ASTPtr getParam() const;

--- a/src/Parsers/ASTIdentifier.h
+++ b/src/Parsers/ASTIdentifier.h
@@ -29,6 +29,8 @@ public:
     /** Get the text that identifies this element. */
     String getID(char delim) const override { return "Identifier" + (delim + name()); }
 
+    /** Check if identigier is a parameter */
+    bool isParam() const;
     /** Get the query param out of a non-compound identifier. */
     ASTPtr getParam() const;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

The query parameters still give issues. The code in ASTIdentifier is confusing. Query parameters set children expressions, and that check is missing.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
