### PR TITLE
Do not check receive cancel in parallel distributed insert select from *Cluster table functions

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -686,7 +686,7 @@ void TCPHandler::runImpl()
                     /// Should not check for cancel in case of input.
                     /// And for parallel distributed insert select from *Cluster table functions as well,
                     /// because it need receiving ReadTaskResponse from Client.
-                    if (!query_state->need_receive_data_for_input && interactive_delay > 1000)
+                    if (!query_state->need_receive_data_for_input && interactive_delay >= 1000)
                     {
                         auto callback = [this, &query_state]()
                         {

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1160,6 +1160,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteFromClusterStor
     QueryPipeline pipeline;
     ContextMutablePtr query_context = Context::createCopy(local_context);
     query_context->increaseDistributedDepth();
+    query_context->setSetting("interactive_delay", Field(0));
 
     const auto & current_settings = query_context->getSettingsRef();
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1160,6 +1160,10 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteFromClusterStor
     QueryPipeline pipeline;
     ContextMutablePtr query_context = Context::createCopy(local_context);
     query_context->increaseDistributedDepth();
+    /// For distributed INSERT SELECT FROM cluster* table functions, it need send and receive ReadTask
+    /// between coordinator and workers, while `receivePacketsExpectCancel` assume that the only package
+    /// received from client only can be 'Cancel', so we should disable it. Found when we use distributed
+    /// INSERT SELECT FROM hdfsCluster('lots of HDFS files'): 'Unknown packet from client 9'.
     query_context->setSetting("interactive_delay", Field(0));
 
     const auto & current_settings = query_context->getSettingsRef();


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not check cancel in parallel distributed insert select from *Cluster table functions, because it need receiving ReadTaskResponse from Client.

Exception message:
```
-- client
Code: 32. DB::Exception: Received from mmdcchsvrnewtestsz1:28328. DB::Exception: Attempt to read after eof: while receiving packet from mmdcchsvrnewtestsz6:28328: While executing Remote. (ATTEMPT_TO_READ_AFTER_EOF)

-- remote
exception: Code: 99. DB::NetException: Unknown packet from client 9. (UNKNOWN_PACKET_FROM_CLIENT)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
