### PR TITLE
Make `nats_max_reconnect` obsolete

### DIFF
--- a/src/Storages/NATS/NATSSettings.cpp
+++ b/src/Storages/NATS/NATSSettings.cpp
@@ -24,7 +24,6 @@ namespace ErrorCodes
     DECLARE(UInt64, nats_num_consumers, 1, "The number of consumer channels per table.", 0) \
     DECLARE(String, nats_queue_group, "", "Name for queue group of NATS subscribers.", 0) \
     DECLARE(Bool, nats_secure, false, "Use SSL connection", 0) \
-    DECLARE(UInt64, nats_max_reconnect, 5, "Deprecated and has no effect, reconnect is performed permanently with nats_reconnect_wait timeout", 0) \
     DECLARE(UInt64, nats_reconnect_wait, 2000, "Amount of time in milliseconds to sleep between each reconnect attempt.", 0) \
     DECLARE(String, nats_server_list, "", "Server list for connection", 0) \
     DECLARE(UInt64, nats_skip_broken_messages, 0, "Skip at least this number of broken messages from NATS per block", 0) \
@@ -40,6 +39,7 @@ namespace ErrorCodes
 
 #define OBSOLETE_NATS_SETTINGS(M, ALIAS) \
     MAKE_OBSOLETE(M, Char, nats_row_delimiter, '\0') \
+    MAKE_OBSOLETE(M, UInt64, nats_max_reconnect, 5) \
 
 #define LIST_OF_NATS_SETTINGS(M, ALIAS)   \
     NATS_RELATED_SETTINGS(M, ALIAS)       \

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -50,7 +50,6 @@ namespace NATSSetting
     extern const NATSSettingsString nats_format;
     extern const NATSSettingsStreamingHandleErrorMode nats_handle_error_mode;
     extern const NATSSettingsUInt64 nats_max_block_size;
-    extern const NATSSettingsUInt64 nats_max_reconnect;
     extern const NATSSettingsUInt64 nats_max_rows_per_message;
     extern const NATSSettingsUInt64 nats_num_consumers;
     extern const NATSSettingsString nats_password;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
