### PR TITLE
Less frequent logs from CgroupsReader

### DIFF
--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -82,7 +82,7 @@ uint64_t readMetricsFromStatFile(ReadBufferFromFile & buf, std::initializer_list
             continue;
         }
         if (found_mask & (1l << (it - keys.begin())))
-            LOG_ERROR(getLogger("CgroupsReader"), "Duplicate key '{}' in '{}'", current_key, buf.getFileName());
+            LOG_WARNING(LogFrequencyLimiter(getLogger("CgroupsReader"), 300), "Duplicate key '{}' in '{}'", current_key, buf.getFileName());
         found_mask |= 1ll << (it - keys.begin());
 
         assertChar(' ', buf);
@@ -95,7 +95,7 @@ uint64_t readMetricsFromStatFile(ReadBufferFromFile & buf, std::initializer_list
         for (const auto * it = keys.begin(); it != keys.end(); ++it)
         {
             if (!(found_mask & (1l << (it - keys.begin()))))
-                LOG_ERROR(getLogger("CgroupsReader"), "Cannot find '{}' in '{}'", *it, buf.getFileName());
+                LOG_WARNING(LogFrequencyLimiter(getLogger("CgroupsReader"), 300), "Cannot find '{}' in '{}'", *it, buf.getFileName());
         }
     }
     return sum;


### PR DESCRIPTION
This should fix the following messages in the logs for old kernels (`kernel` added in 5.18):

```
2025.03.18 14:06:25.283809 [ 1074750 ] {} <Error> CgroupsReader: Cannot find 'kernel' in '/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-b2883e313f8c4b65a72030853c03f4a1.scope/memory.stat'
2025.03.18 14:06:25.334968 [ 1074750 ] {} <Error> CgroupsReader: Cannot find 'kernel' in '/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-b2883e313f8c4b65a72030853c03f4a1.scope/memory.stat'
2025.03.18 14:06:25.385706 [ 1074750 ] {} <Error> CgroupsReader: Cannot find 'kernel' in '/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-b2883e313f8c4b65a72030853c03f4a1.scope/memory.stat'
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)