### PR TITLE
tests: add listen_try to make it work without IPv6

### DIFF
--- a/tests/config/config.d/listen.xml
+++ b/tests/config/config.d/listen.xml
@@ -1,1 +1,5 @@
-<clickhouse><listen_host>::</listen_host></clickhouse>
+<clickhouse>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>true</listen_try>
+</clickhouse>

--- a/tests/queries/0_stateless/02933_change_cache_setting_without_restart.sh
+++ b/tests/queries/0_stateless/02933_change_cache_setting_without_restart.sh
@@ -21,7 +21,8 @@ cat $config_path \
 > $config_path_tmp
 mv $config_path_tmp $config_path
 
-$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG"
+# In case of listen_try we can have 'Address already in use'
+$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG" |& grep -v -e 'Address already in use'
 $CLICKHOUSE_CLIENT --query "select background_download_threads, background_download_queue_size_limit from system.filesystem_cache_settings where cache_name = '${disk_name}'"
 
 cat $config_path \
@@ -29,7 +30,7 @@ cat $config_path \
 > $config_path_tmp
 mv $config_path_tmp $config_path
 
-$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG"
+$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG" |& grep -v -e 'Address already in use'
 $CLICKHOUSE_CLIENT --query "select background_download_threads, background_download_queue_size_limit from system.filesystem_cache_settings where cache_name = '${disk_name}'"
 
 cat $config_path \
@@ -37,7 +38,7 @@ cat $config_path \
 > $config_path_tmp
 mv $config_path_tmp $config_path
 
-$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG"
+$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG" |& grep -v -e 'Address already in use'
 $CLICKHOUSE_CLIENT --query "select background_download_threads, background_download_queue_size_limit from system.filesystem_cache_settings where cache_name = '${disk_name}'"
 
 cat $config_path \
@@ -45,7 +46,7 @@ cat $config_path \
 > $config_path_tmp
 mv $config_path_tmp $config_path
 
-$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG"
+$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG" |& grep -v -e 'Address already in use'
 $CLICKHOUSE_CLIENT --query "select background_download_threads, background_download_queue_size_limit from system.filesystem_cache_settings where cache_name = '${disk_name}'"
 
 cat $config_path \
@@ -53,7 +54,7 @@ cat $config_path \
 > $config_path_tmp
 mv $config_path_tmp $config_path
 
-$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG"
+$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG" |& grep -v -e 'Address already in use'
 $CLICKHOUSE_CLIENT --query "select background_download_threads, background_download_queue_size_limit from system.filesystem_cache_settings where cache_name = '${disk_name}'"
 
 cat $config_path \
@@ -61,5 +62,5 @@ cat $config_path \
 > $config_path_tmp
 mv $config_path_tmp $config_path
 
-$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG"
+$CLICKHOUSE_CLIENT --query "SYSTEM RELOAD CONFIG" |& grep -v -e 'Address already in use'
 $CLICKHOUSE_CLIENT --query "select background_download_threads, background_download_queue_size_limit from system.filesystem_cache_settings where cache_name = '${disk_name}'"

--- a/tests/queries/0_stateless/02933_change_cache_setting_without_restart.sh
+++ b/tests/queries/0_stateless/02933_change_cache_setting_without_restart.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel, no-object-storage
+# Tags: no-fasttest, no-parallel, no-object-storage, long
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
As for IPv6 check, we have at least one test that uses IPv6 - test_user_ip_restrictions

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)