### PR TITLE
Sharded userspace page cache

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -316,6 +316,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 page_cache_max_size;
     extern const ServerSettingsDouble page_cache_free_memory_ratio;
     extern const ServerSettingsUInt64 page_cache_lookahead_blocks;
+    extern const ServerSettingsUInt64 page_cache_shards;
 }
 
 }
@@ -1171,7 +1172,8 @@ try
             server_settings[ServerSetting::page_cache_size_ratio],
             server_settings[ServerSetting::page_cache_min_size],
             server_settings[ServerSetting::page_cache_max_size],
-            server_settings[ServerSetting::page_cache_free_memory_ratio]);
+            server_settings[ServerSetting::page_cache_free_memory_ratio],
+            server_settings[ServerSetting::page_cache_shards]);
         total_memory_tracker.setPageCache(global_context->getPageCache().get());
     }
 

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -78,17 +78,35 @@ struct PageCacheWeightFunction
 extern template class CacheBase<UInt128, PageCacheCell, UInt128TrivialHash, PageCacheWeightFunction>;
 
 /// The key is hash of PageCacheKey.
-/// Private inheritance because we have to add MemoryTrackerBlockerInThread to all operations that
-/// lock the mutex and allocate memory, to avoid deadlocking if MemoryTracker calls autoResize().
-class PageCache : private CacheBase<UInt128, PageCacheCell, UInt128TrivialHash, PageCacheWeightFunction>
+///
+/// Experimentally sharded, to reduce mutex contention. Contention seems unlikely to be a problem as
+/// the blocks are pretty big (typically 1 MiB), and the main mutex is only locked during lookup,
+/// not while downloading.
+/// (If it turns out that having more than 1 shard never improves performance in practice, feel free
+///  to simplify this by removing sharding.)
+///
+/// Implementation should be careful to always use MemoryTrackerBlockerInThread for all operations
+/// that lock the mutex or allocate memory. Otherwise we'll can deadlock when MemoryTracker calls
+/// autoResize().
+class PageCache
 {
-public:
+private:
     using Base = CacheBase<UInt128, PageCacheCell, UInt128TrivialHash, PageCacheWeightFunction>;
+
+    class alignas(std::hardware_destructive_interference_size) Shard : public Base
+    {
+    public:
+        using Base::Base;
+
+        void onRemoveOverflowWeightLoss(size_t /*weight_loss*/) override;
+    };
+
+public:
     using Key = typename Base::Key;
     using Mapped = typename Base::Mapped;
     using MappedPtr = typename Base::MappedPtr;
 
-    PageCache(size_t default_block_size_, size_t default_lookahead_blocks_, std::chrono::milliseconds history_window_, const String & cache_policy, double size_ratio, size_t min_size_in_bytes_, size_t max_size_in_bytes_, double free_memory_ratio_);
+    PageCache(size_t default_block_size_, size_t default_lookahead_blocks_, std::chrono::milliseconds history_window_, const String & cache_policy, double size_ratio, size_t min_size_in_bytes_, size_t max_size_in_bytes_, double free_memory_ratio_, size_t num_shards);
 
     /// Get or insert a chunk for the given key.
     ///
@@ -121,11 +139,18 @@ private:
     /// To avoid overreacting to brief drops in memory usage, we use peak memory usage over the last
     /// `history_window` milliseconds. It's calculated using this "sliding" (leapfrogging?) window.
     /// If history_window <= 0, there's no window and we just use current memory usage.
-    std::chrono::milliseconds history_window;
-    std::array<size_t, 2> peak_memory_buckets {0, 0};
-    int64_t cur_bucket = 0;
+    std::mutex mutex;
+    std::chrono::milliseconds history_window TSA_GUARDED_BY(mutex);
+    std::array<size_t, 2> peak_memory_buckets TSA_GUARDED_BY(mutex) {0, 0};
+    int64_t cur_bucket TSA_GUARDED_BY(mutex) = 0;
 
-    void onRemoveOverflowWeightLoss(size_t /*weight_loss*/) override;
+    std::vector<std::unique_ptr<Shard>> shards;
+
+    size_t getShardIdx(UInt128 key) const
+    {
+        /// UInt128TrivialHash uses the lower 64 bits, we use the upper 64 bits.
+        return key.items[UInt128::_impl::little(1)] % shards.size();
+    }
 };
 
 using PageCachePtr = std::shared_ptr<PageCache>;

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -491,7 +491,8 @@ namespace DB
     DECLARE(UInt64, page_cache_min_size, DEFAULT_PAGE_CACHE_MIN_SIZE, "Minimum size of the userspace page cache.", 0) \
     DECLARE(UInt64, page_cache_max_size, DEFAULT_PAGE_CACHE_MAX_SIZE, "Maximum size of the userspace page cache. Set to 0 to disable the cache. If greater than page_cache_min_size, the cache size will be continuously adjusted within this range, to use most of the available memory while keeping the total memory usage below the limit (max_server_memory_usage[_to_ram_ratio]).", 0) \
     DECLARE(Double, page_cache_free_memory_ratio, 0.15, "Fraction of the memory limit to keep free from the userspace page cache. Analogous to Linux min_free_kbytes setting.", 0) \
-    DECLARE(UInt64, page_cache_lookahead_blocks, 16, "On userspace page cache miss, read up to this many consecutive blocks (page_cache_block_size) at once from the underlying storage, if they're also not in the cache.", 0) \
+    DECLARE(UInt64, page_cache_lookahead_blocks, 16, "On userspace page cache miss, read up to this many consecutive blocks at once from the underlying storage, if they're also not in the cache. Each block is page_cache_block_size bytes.", 0) \
+    DECLARE(UInt64, page_cache_shards, 4, "Stripe userspace page cache over this many shards to reduce mutex contention. Experimental, not likely to improve performance.", 0) \
     DECLARE(UInt64, mmap_cache_size, DEFAULT_MMAP_CACHE_MAX_SIZE, R"(
     Sets the cache size (in bytes) for mapped files. This setting allows avoiding frequent open/close calls (which are very expensive due to consequent page faults), and to reuse mappings from several threads and queries. The setting value is the number of mapped regions (usually equal to the number of mapped files).
 

--- a/src/IO/CachedInMemoryReadBufferFromFile.cpp
+++ b/src/IO/CachedInMemoryReadBufferFromFile.cpp
@@ -136,7 +136,11 @@ bool CachedInMemoryReadBufferFromFile::nextImpl()
                     /// Use aligned groups of blocks (rather than sliding window) to work better
                     /// with distributed cache.
                     size_t lookahead_bytes = block_size * lookahead_blocks;
-                    size_t lookahead_block_end = std::min(file_size.value(), (cache_key.offset / lookahead_bytes + 1) * lookahead_bytes);
+                    size_t lookahead_block_end = std::min(std::min(
+                        file_size.value(),
+                        (cache_key.offset / lookahead_bytes + 1) * lookahead_bytes),
+                        (read_until_position + block_size - 1) / block_size * block_size);
+
                     if (inner_read_until_position < cache_key.offset + cache_key.size ||
                         inner_read_until_position > lookahead_block_end)
                     {

--- a/src/IO/CachedInMemoryReadBufferFromFile.cpp
+++ b/src/IO/CachedInMemoryReadBufferFromFile.cpp
@@ -136,10 +136,10 @@ bool CachedInMemoryReadBufferFromFile::nextImpl()
                     /// Use aligned groups of blocks (rather than sliding window) to work better
                     /// with distributed cache.
                     size_t lookahead_bytes = block_size * lookahead_blocks;
-                    size_t lookahead_block_end = std::min(std::min(
+                    size_t lookahead_block_end = std::min({
                         file_size.value(),
-                        (cache_key.offset / lookahead_bytes + 1) * lookahead_bytes),
-                        (read_until_position + block_size - 1) / block_size * block_size);
+                        (cache_key.offset / lookahead_bytes + 1) * lookahead_bytes,
+                        (read_until_position + block_size - 1) / block_size * block_size});
 
                     if (inner_read_until_position < cache_key.offset + cache_key.size ||
                         inner_read_until_position > lookahead_block_end)

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3343,7 +3343,7 @@ void Context::clearUncompressedCache() const
 void Context::setPageCache(
     size_t default_block_size, size_t default_lookahead_blocks, std::chrono::milliseconds history_window,
     const String & cache_policy, double size_ratio, size_t min_size_in_bytes, size_t max_size_in_bytes,
-    double free_memory_ratio)
+    double free_memory_ratio, size_t num_shards)
 {
     std::lock_guard lock(shared->mutex);
 
@@ -3352,7 +3352,7 @@ void Context::setPageCache(
 
     shared->page_cache = std::make_shared<PageCache>(
         default_block_size, default_lookahead_blocks, history_window, cache_policy, size_ratio,
-        min_size_in_bytes, max_size_in_bytes, free_memory_ratio);
+        min_size_in_bytes, max_size_in_bytes, free_memory_ratio, num_shards);
 }
 
 PageCachePtr Context::getPageCache() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1133,7 +1133,8 @@ public:
     void setPageCache(
         size_t default_block_size, size_t default_lookahead_blocks,
         std::chrono::milliseconds history_window, const String & cache_policy, double size_ratio,
-        size_t min_size_in_bytes, size_t max_size_in_bytes, double free_memory_ratio);
+        size_t min_size_in_bytes, size_t max_size_in_bytes, double free_memory_ratio,
+        size_t num_shards);
     std::shared_ptr<PageCache> getPageCache() const;
     void clearPageCache() const;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Very straightforward change. Have multiple CacheBase instances and dispatch cache get/set/etc calls to one of them by hash. If mutex contention was a problem, this should solve it.

It would be surprising if cache contention is a problem since cache lookups should happen ~twice per MB (more than once because of `page_cache_lookahead_blocks`) - only tens of thousands per second. But we've seen slowness, and it seems easier to try this change than to check whether contention is actually happening (because I couldn't reproduce the slowness locally).

Also fixed a small bug in CachedInMemoryReadBufferFromFile that could make it read more than necessary sometimes; I didn't check whether it makes a difference in practice.