### PR TITLE
Disable filesystem_cache_prefer_bigger_buffer_size for merges

### DIFF
--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -723,7 +723,8 @@ std::unique_ptr<ReadBufferFromFileBase> DiskObjectStorage::readFile(
         return object_storage->readObject(object_, read_settings, read_hint, file_size);
     };
 
-    /// Avoid cache fragmentation by choosing bigger buffer size.
+    /// Avoid cache fragmentation by choosing a bigger buffer size.
+    /// But don't use it if the cache is used passively (only for reading if data is already cached, such as during merges).
     bool prefer_bigger_buffer_size = read_settings.filesystem_cache_prefer_bigger_buffer_size
         && !read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
         && object_storage->supportsCache()

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -725,6 +725,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskObjectStorage::readFile(
 
     /// Avoid cache fragmentation by choosing bigger buffer size.
     bool prefer_bigger_buffer_size = read_settings.filesystem_cache_prefer_bigger_buffer_size
+        && !read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
         && object_storage->supportsCache()
         && read_settings.enable_filesystem_cache;
 

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -756,17 +756,22 @@ FileCache::getOrSet(
 
         if (!file_segments.front()->range().contains(result_range.left))
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected {} to include {} "
-                            "(end offset: {}, aligned offset: {}, aligned end offset: {})",
-                            file_segments.front()->range().toString(), offset, result_range.right, aligned_offset, aligned_end_offset);
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR, "Expected {} to include {} "
+                "(end offset: {}, aligned offset: {}, aligned end offset: {})",
+                file_segments.front()->range().toString(), offset,
+                result_range.right, aligned_offset, aligned_end_offset);
         }
     }
 
     chassert(file_segments_limit
              ? file_segments.back()->range().left <= result_range.right
              : file_segments.back()->range().contains(result_range.right),
-             fmt::format("Unexpected state. Back: {}, result range: {}, limit: {}",
-                         file_segments.back()->range().toString(), result_range.toString(), file_segments_limit));
+             fmt::format(
+                 "Unexpected state. Back: {}, result range: {}, "
+                 "limit: {}, initial offset: {}, initial size: {}",
+                 file_segments.back()->range().toString(), result_range.toString(),
+                 file_segments_limit, offset, size));
 
     chassert(!file_segments_limit || file_segments.size() <= file_segments_limit);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable `filesystem_cache_prefer_bigger_buffer_size` when the cache is used passively, such as for merges.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
