### PR TITLE
Docs: rename `variance` to `stddev` for `randNormal` and `randLogNormal` functions

### DIFF
--- a/docs/en/sql-reference/functions/random-functions.md
+++ b/docs/en/sql-reference/functions/random-functions.md
@@ -196,13 +196,13 @@ Returns a random Float64 drawn from a [normal distribution](https://en.wikipedia
 **Syntax**
 
 ```sql
-randNormal(mean, variance)
+randNormal(mean, stddev)
 ```
 
 **Arguments**
 
 - `mean` - `Float64` - mean value of distribution,
-- `variance` - `Float64` - [variance](https://en.wikipedia.org/wiki/Variance) of the distribution.
+- `stddev` - `Float64` - [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of the distribution.
 
 **Returned value**
 
@@ -233,13 +233,13 @@ Returns a random Float64 drawn from a [log-normal distribution](https://en.wikip
 **Syntax**
 
 ```sql
-randLogNormal(mean, variance)
+randLogNormal(mean, stddev)
 ```
 
 **Arguments**
 
 - `mean` - `Float64` - mean value of distribution,
-- `variance` - `Float64` - [variance](https://en.wikipedia.org/wiki/Variance) of the distribution.
+- `stddev` - `Float64` - [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of the distribution.
 
 **Returned value**
 

--- a/src/Functions/randDistribution.cpp
+++ b/src/Functions/randDistribution.cpp
@@ -49,9 +49,9 @@ struct NormalDistribution
     static constexpr const char * getName() { return "randNormal"; }
     static constexpr size_t getNumberOfArguments() { return 2; }
 
-    static void generate(Float64 mean, Float64 variance, ColumnFloat64::Container & container)
+    static void generate(Float64 mean, Float64 stddev, ColumnFloat64::Container & container)
     {
-        auto distribution = std::normal_distribution<>(mean, variance);
+        auto distribution = std::normal_distribution<>(mean, stddev);
         for (auto & elem : container)
             elem = distribution(thread_local_rng);
     }
@@ -63,9 +63,9 @@ struct LogNormalDistribution
     static constexpr const char * getName() { return "randLogNormal"; }
     static constexpr size_t getNumberOfArguments() { return 2; }
 
-    static void generate(Float64 mean, Float64 variance, ColumnFloat64::Container & container)
+    static void generate(Float64 mean, Float64 stddev, ColumnFloat64::Container & container)
     {
-        auto distribution = std::lognormal_distribution<>(mean, variance);
+        auto distribution = std::lognormal_distribution<>(mean, stddev);
         for (auto & elem : container)
             elem = distribution(thread_local_rng);
     }
@@ -338,7 +338,7 @@ Typical usage:
     FunctionDocumentation{
     .description=R"(
 Returns a random number from the normal distribution.
-Accepts two parameters - mean and variance.
+Accepts two parameters - mean and standard deviation.
 
 Typical usage:
 [example:typical]
@@ -353,7 +353,7 @@ Typical usage:
     FunctionDocumentation{
     .description=R"(
 Returns a random number from the lognormal distribution (a distribution of a random variable whose logarithm is normally distributed).
-Accepts two parameters - mean and variance.
+Accepts two parameters - mean and standard deviation.
 
 Typical usage:
 [example:typical]


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Addresses https://github.com/ClickHouse/clickhouse-docs/issues/3516 which points out that the second parameter `variance` for `randNormal` should actually be called `stddev` as it is in `std::normal_distribution`. 

PR makes the changes in the code and in the docs.

Closes https://github.com/ClickHouse/clickhouse-docs/issues/3516

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
