### PR TITLE
Mark query condition cache as refreshable

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -4,6 +4,7 @@
 #include <Core/BaseSettingsFwdMacrosImpl.h>
 #include <Core/ServerSettings.h>
 #include <IO/MMappedFileCache.h>
+#include <Interpreters/Cache/QueryConditionCache.h>
 #include <IO/UncompressedCache.h>
 #include <IO/SharedThreadPools.h>
 #include <Interpreters/Context.h>
@@ -1140,9 +1141,9 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
             {"mark_cache_size", {std::to_string(context->getMarkCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"uncompressed_cache_size", {std::to_string(context->getUncompressedCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"index_mark_cache_size", {std::to_string(context->getIndexMarkCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
-            {"index_uncompressed_cache_size",
-                {std::to_string(context->getIndexUncompressedCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
+            {"index_uncompressed_cache_size", {std::to_string(context->getIndexUncompressedCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"mmap_cache_size", {std::to_string(context->getMMappedFileCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
+            {"query_condition_cache_size", {std::to_string(context->getQueryConditionCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
 
             {"merge_workload", {context->getMergeWorkload(), ChangeableWithoutRestart::Yes}},
             {"mutation_workload", {context->getMutationWorkload(), ChangeableWithoutRestart::Yes}},

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -103,6 +103,11 @@ void QueryConditionCache::setMaxSizeInBytes(size_t max_size_in_bytes)
     cache.setMaxSizeInBytes(max_size_in_bytes);
 }
 
+size_t QueryConditionCache::maxSizeInBytes()
+{
+    return cache.maxSizeInBytes();
+}
+
 bool QueryConditionCache::Key::operator==(const Key & other) const
 {
     return table_id == other.table_id

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -73,6 +73,7 @@ public:
     void clear();
 
     void setMaxSizeInBytes(size_t max_size_in_bytes);
+    size_t maxSizeInBytes();
 
 private:
     Cache cache;


### PR DESCRIPTION
This is a manual backport of https://github.com/ClickHouse/ClickHouse/pull/77809 to branch `25.3`.

(I added label `must-be-backported` and CI added `pr-backports-created` and `pr-backports-created-cloud` in the upstream PR but I don't see any backport PRs.)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)