### PR TITLE
Adjust a few old tests to flush individual logs

### DIFF
--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sh
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sh
@@ -34,7 +34,7 @@ $CLICKHOUSE_CLIENT -m -q "
 "
 
 $CLICKHOUSE_CLIENT -m -q "
-    system flush logs;
+    system flush logs part_logs;
     select 'before';
     select table, event_type, error>0, countIf(error=0) from system.part_log where database = currentDatabase() group by 1, 2, 3 order by 1, 2, 3;
 
@@ -45,7 +45,7 @@ wait_until "select count()>0 from system.part_log where table = 'rmt_slave' and 
 $CLICKHOUSE_CLIENT -m -q "
     system sync replica rmt_slave;
 
-    system flush logs;
+    system flush logs part_log;
     select 'after';
     select table, event_type, error>0, countIf(error=0) from system.part_log where database = currentDatabase() group by 1, 2, 3 order by 1, 2, 3;
 

--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sh
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sh
@@ -34,7 +34,7 @@ $CLICKHOUSE_CLIENT -m -q "
 "
 
 $CLICKHOUSE_CLIENT -m -q "
-    system flush logs part_logs;
+    system flush logs part_log;
     select 'before';
     select table, event_type, error>0, countIf(error=0) from system.part_log where database = currentDatabase() group by 1, 2, 3 order by 1, 2, 3;
 

--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sh
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_mutate_error.sh
@@ -54,7 +54,7 @@ wait_for_mutation rmt_slave 0000000000
 $CLICKHOUSE_CLIENT -m -q "
     system sync replica rmt_slave;
 
-    system flush logs;
+    system flush logs part_log;
     select 'after';
     select table, event_type, error>0, countIf(error=0) from system.part_log where database = currentDatabase() group by 1, 2, 3 order by 1, 2, 3;
 

--- a/tests/queries/0_stateless/03008_optimize_equal_ranges.sql
+++ b/tests/queries/0_stateless/03008_optimize_equal_ranges.sql
@@ -17,7 +17,7 @@ SELECT a, uniqExact(b) FROM t_optimize_equal_ranges GROUP BY a ORDER BY a SETTIN
 SELECT a, sum(c) FROM t_optimize_equal_ranges GROUP BY a ORDER BY a SETTINGS max_threads = 16;
 SELECT a, sum(c) FROM t_optimize_equal_ranges GROUP BY a ORDER BY a SETTINGS max_threads = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     used_aggregate_functions[1] AS func,

--- a/tests/queries/0_stateless/03009_consecutive_keys_nullable.sql
+++ b/tests/queries/0_stateless/03009_consecutive_keys_nullable.sql
@@ -46,7 +46,7 @@ SELECT x, count(), countIf(x IS NULL) FROM t_nullable_keys_6 GROUP BY x ORDER BY
 
 DROP TABLE t_nullable_keys_6;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     splitByChar('.', tables[1])[2] AS table,

--- a/tests/queries/0_stateless/03014_async_with_dedup_part_log_rmt.sql
+++ b/tests/queries/0_stateless/03014_async_with_dedup_part_log_rmt.sql
@@ -8,7 +8,7 @@ SET async_insert_deduplicate = 1;
 SELECT '-- Inserted part --';
 INSERT INTO 03014_async_with_dedup_part_log VALUES (2);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 SELECT error, count() FROM system.part_log
 WHERE table = '03014_async_with_dedup_part_log' AND database = currentDatabase() AND event_type = 'NewPart'
 GROUP BY error
@@ -17,7 +17,7 @@ ORDER BY error;
 SELECT '-- Deduplicated part --';
 INSERT INTO 03014_async_with_dedup_part_log VALUES (2);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 SELECT error, count() FROM system.part_log
 WHERE table = '03014_async_with_dedup_part_log' AND database = currentDatabase() AND event_type = 'NewPart'
 GROUP BY error

--- a/tests/queries/0_stateless/03020_long_values_pretty_are_not_cut_if_single.sh
+++ b/tests/queries/0_stateless/03020_long_values_pretty_are_not_cut_if_single.sh
@@ -11,7 +11,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Make sure that system.metric_log exists
 ${CLICKHOUSE_CLIENT} --query "SELECT 1 FORMAT Null"
-${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS metric_log"
 
 
 ${CLICKHOUSE_CLIENT} --output-format-pretty-multiline-fields 0 --output_format_pretty_fallback_to_vertical 0 --query "SHOW CREATE TABLE system.metric_log" --format Pretty | grep -P '^COMMENT'

--- a/tests/queries/0_stateless/03031_read_in_order_optimization_with_virtual_row.sql
+++ b/tests/queries/0_stateless/03031_read_in_order_optimization_with_virtual_row.sql
@@ -44,7 +44,7 @@ max_threads = 1,
 optimize_read_in_order = 1,
 log_comment = 'preliminary merge, no filter';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows
 FROM system.query_log
@@ -68,7 +68,7 @@ max_threads = 1,
 optimize_read_in_order = 1,
 log_comment = 'preliminary merge with filter';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows
 FROM system.query_log
@@ -91,7 +91,7 @@ max_threads = 1,
 optimize_read_in_order = 1,
 log_comment = 'no preliminary merge, no filter';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows
 FROM system.query_log
@@ -115,7 +115,7 @@ max_threads = 1,
 optimize_read_in_order = 1,
 log_comment = 'no preliminary merge, with filter';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows
 FROM system.query_log

--- a/tests/queries/0_stateless/03047_on_fly_mutations_basics.sh
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_basics.sh
@@ -47,7 +47,7 @@ SELECT id FROM t_lightweight_mut_1 ORDER BY id SETTINGS apply_mutations_on_fly =
 SYSTEM DROP MARK CACHE;
 SELECT id, v FROM t_lightweight_mut_1 ORDER BY id SETTINGS apply_mutations_on_fly = 0;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT query, ProfileEvents['FileOpen'] FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/03047_on_fly_mutations_basics_rmt.sh
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_basics_rmt.sh
@@ -55,7 +55,7 @@ SELECT id FROM t_lightweight_mut_1 ORDER BY id SETTINGS apply_mutations_on_fly =
 SYSTEM DROP MARK CACHE;
 SELECT id, v FROM t_lightweight_mut_1 ORDER BY id SETTINGS apply_mutations_on_fly = 0;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT query, ProfileEvents['S3GetObject'] FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/03047_on_fly_mutations_events.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_events.sql
@@ -40,7 +40,7 @@ ALTER TABLE t_lightweight_mut_7 UPDATE v = v WHERE 1 SETTINGS mutations_sync = 2
 
 SELECT 3, sum(v) FROM t_lightweight_mut_7;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     query,

--- a/tests/queries/0_stateless/03047_on_fly_mutations_events_2.sh
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_events_2.sh
@@ -69,7 +69,7 @@ SELECT * FROM t_mutation_events_1 ORDER BY id SETTINGS apply_mutations_on_fly = 
 SELECT * FROM t_mutation_events_2 ORDER BY id SETTINGS apply_mutations_on_fly = 0;
 SELECT * FROM t_mutation_events_2 ORDER BY id SETTINGS apply_mutations_on_fly = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     query,

--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates.sql
@@ -25,7 +25,7 @@ SELECT s2 FROM t_lightweight_mut_5 ORDER BY id;
 SYSTEM DROP MARK CACHE;
 SELECT s1, s2 FROM t_lightweight_mut_5 ORDER BY id;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT query, ProfileEvents['FileOpen'] FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_multiple_updates_rmt.sql
@@ -31,7 +31,7 @@ SELECT s2 FROM t_lightweight_mut_5 ORDER BY id;
 SYSTEM DROP MARK CACHE;
 SELECT s1, s2 FROM t_lightweight_mut_5 ORDER BY id;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT query, ProfileEvents['S3GetObject'] FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/03096_text_log_format_string_args_not_empty.sql
+++ b/tests/queries/0_stateless/03096_text_log_format_string_args_not_empty.sql
@@ -4,7 +4,7 @@ select count; -- { serverError UNKNOWN_IDENTIFIER }
 
 select conut(); -- { serverError UNKNOWN_FUNCTION }
 
-system flush logs;
+system flush logs text_log;
 
 SET max_rows_to_read = 0; -- system.text_log can be really big
 select count() > 0 from system.text_log where message_format_string = '{}{} memory usage: {}.' and not empty(value1) and value3 like '% MiB';

--- a/tests/queries/0_stateless/03097_query_log_join_processes.sql
+++ b/tests/queries/0_stateless/03097_query_log_join_processes.sql
@@ -1,6 +1,6 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/56521
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SET enable_analyzer=1;
 

--- a/tests/queries/0_stateless/03141_fetches_errors_stress.sql
+++ b/tests/queries/0_stateless/03141_fetches_errors_stress.sql
@@ -10,7 +10,7 @@ system disable failpoint replicated_sends_failpoint;
 
 system sync replica data_r2;
 
-system flush logs;
+system flush logs text_log, part_log;
 SET max_rows_to_read = 0; -- system.text_log can be really big
 select event_time_microseconds, logger_name, message from system.text_log where level = 'Error' and message like '%Malformed chunked encoding%' order by 1 format LineAsString;
 

--- a/tests/queries/0_stateless/03143_benchmark_query_id_prefix.sh
+++ b/tests/queries/0_stateless/03143_benchmark_query_id_prefix.sh
@@ -7,5 +7,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 query_id_prefix=${CLICKHOUSE_DATABASE}_test_benchmark
 $CLICKHOUSE_BENCHMARK -i 100 -c 8 <<< "SELECT 1" --query_id_prefix $query_id_prefix 2>/dev/null
 
-$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log"
 $CLICKHOUSE_CLIENT --query "SELECT countIf(query_id = '$query_id_prefix'), countIf(query_id LIKE '$query_id_prefix%') FROM system.query_log WHERE current_database = currentDatabase() AND type = 'QueryFinish'"

--- a/tests/queries/0_stateless/03143_prewhere_profile_events.sh
+++ b/tests/queries/0_stateless/03143_prewhere_profile_events.sh
@@ -60,7 +60,7 @@ settings enable_multiple_prewhere_read_steps=1;
 "
 
 ${CLICKHOUSE_CLIENT} -q "
-  SYSTEM FLUSH LOGS;
+  SYSTEM FLUSH LOGS query_log;
 
   -- 52503 which is 43 * number of granules, 10000000
   SELECT ProfileEvents['RowsReadByMainReader'], ProfileEvents['RowsReadByPrewhereReaders']

--- a/tests/queries/0_stateless/03148_async_queries_in_query_log_errors.sh
+++ b/tests/queries/0_stateless/03148_async_queries_in_query_log_errors.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 function print_flush_query_logs()
 {
-    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS"
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS asynchronous_insert_log, query_log"
     echo ""
 
     echo "system.asynchronous_insert_log"

--- a/tests/queries/0_stateless/03148_query_log_used_dictionaries.sql
+++ b/tests/queries/0_stateless/03148_query_log_used_dictionaries.sql
@@ -19,7 +19,7 @@ SETTINGS
     log_comment = 'simple_with_analyzer'
 FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT log_comment, used_dictionaries
 FROM system.query_log
@@ -38,7 +38,7 @@ SETTINGS
     log_comment = 'nested_with_analyzer'
 FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT log_comment, used_dictionaries
 FROM system.query_log
@@ -54,7 +54,7 @@ SETTINGS
     log_comment = 'simple_without_analyzer'
 FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT log_comment, used_dictionaries
 FROM system.query_log
@@ -73,7 +73,7 @@ SETTINGS
     log_comment = 'nested_without_analyzer'
 FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT log_comment, used_dictionaries
 FROM system.query_log

--- a/tests/queries/0_stateless/03150_trace_log_add_build_id.sql
+++ b/tests/queries/0_stateless/03150_trace_log_add_build_id.sql
@@ -4,7 +4,7 @@ SET log_queries = 1;
 SET log_query_threads = 1;
 SET query_profiler_real_time_period_ns = 100000000;
 SELECT sleep(1);
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS trace_log;
 
 SELECT COUNT(*) > 1 FROM system.trace_log WHERE build_id IS NOT NULL;
 

--- a/tests/queries/0_stateless/03161_lightweight_delete_projection.reference
+++ b/tests/queries/0_stateless/03161_lightweight_delete_projection.reference
@@ -9,7 +9,6 @@ testing drop mode
 ALTER TABLE users_compact MODIFY SETTING lightweight_mutation_projection_mode = 'drop';
 DELETE FROM users_compact WHERE uid = 1231;
 SELECT * FROM users_compact ORDER BY uid;
-SYSTEM FLUSH LOGS;
 -- all_1_1_0_2
 SELECT
     name
@@ -28,7 +27,6 @@ ALTER TABLE users_compact MODIFY SETTING lightweight_mutation_projection_mode = 
 DELETE FROM users_compact WHERE uid = 6666;
 SELECT * FROM users_compact ORDER BY uid;
 8888	Alice	50
-SYSTEM FLUSH LOGS;
 -- all_1_1_0_4, all_3_3_0_4
 SELECT
     name
@@ -54,7 +52,6 @@ testing drop mode
 ALTER TABLE users_wide MODIFY SETTING lightweight_mutation_projection_mode = 'drop';
 DELETE FROM users_wide WHERE uid = 1231;
 SELECT * FROM users_wide ORDER BY uid;
-SYSTEM FLUSH LOGS;
 -- all_1_1_0_2
 SELECT
     name
@@ -73,7 +70,6 @@ ALTER TABLE users_wide MODIFY SETTING lightweight_mutation_projection_mode = 're
 DELETE FROM users_wide WHERE uid = 6666;
 SELECT * FROM users_wide ORDER BY uid;
 8888	Alice	50
-SYSTEM FLUSH LOGS;
 -- all_1_1_0_4, all_3_3_0_4
 SELECT
     name

--- a/tests/queries/0_stateless/03161_lightweight_delete_projection.sql
+++ b/tests/queries/0_stateless/03161_lightweight_delete_projection.sql
@@ -34,8 +34,6 @@ DELETE FROM users_compact WHERE uid = 1231;
 
 SELECT * FROM users_compact ORDER BY uid;
 
-SYSTEM FLUSH LOGS;
-
 -- all_1_1_0_2
 SELECT
     name
@@ -56,8 +54,6 @@ ALTER TABLE users_compact MODIFY SETTING lightweight_mutation_projection_mode = 
 DELETE FROM users_compact WHERE uid = 6666;
 
 SELECT * FROM users_compact ORDER BY uid;
-
-SYSTEM FLUSH LOGS;
 
 -- all_1_1_0_4, all_3_3_0_4
 SELECT
@@ -103,8 +99,6 @@ DELETE FROM users_wide WHERE uid = 1231;
 
 SELECT * FROM users_wide ORDER BY uid;
 
-SYSTEM FLUSH LOGS;
-
 -- all_1_1_0_2
 SELECT
     name
@@ -125,8 +119,6 @@ ALTER TABLE users_wide MODIFY SETTING lightweight_mutation_projection_mode = 're
 DELETE FROM users_wide WHERE uid = 6666;
 
 SELECT * FROM users_wide ORDER BY uid;
-
-SYSTEM FLUSH LOGS;
 
 -- all_1_1_0_4, all_3_3_0_4
 SELECT

--- a/tests/queries/0_stateless/03164_materialize_skip_index.sql
+++ b/tests/queries/0_stateless/03164_materialize_skip_index.sql
@@ -41,7 +41,7 @@ EXPLAIN indexes = 1 SELECT count() FROM t_skip_index_insert WHERE a >= 110 AND a
 
 DROP TABLE IF EXISTS t_skip_index_insert;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT count(), sum(ProfileEvents['MergeTreeDataWriterSkipIndicesCalculationMicroseconds'])
 FROM system.query_log

--- a/tests/queries/0_stateless/03164_materialize_skip_index_on_merge.sql
+++ b/tests/queries/0_stateless/03164_materialize_skip_index_on_merge.sql
@@ -42,7 +42,7 @@ EXPLAIN indexes = 1 SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2
 
 SELECT database, table, name, data_compressed_bytes FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'tab';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT count(), sum(ProfileEvents['MergeTreeDataWriterSkipIndicesCalculationMicroseconds'])
 FROM system.query_log
 WHERE current_database = currentDatabase()

--- a/tests/queries/0_stateless/03164_s3_settings_for_queries_and_merges.sql
+++ b/tests/queries/0_stateless/03164_s3_settings_for_queries_and_merges.sql
@@ -19,7 +19,7 @@ OPTIMIZE TABLE t_compact_bytes_s3 FINAL;
 
 SYSTEM DROP MARK CACHE;
 SELECT count() FROM t_compact_bytes_s3 WHERE NOT ignore(c2, c4);
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 -- Errors in S3 requests will be automatically retried, however ProfileEvents can be wrong. That is why we subtract errors.
 SELECT

--- a/tests/queries/0_stateless/03164_selects_with_pk_usage_profile_event.sh
+++ b/tests/queries/0_stateless/03164_selects_with_pk_usage_profile_event.sh
@@ -34,7 +34,7 @@ query_id="$(random_str 10)"
 $CLICKHOUSE_CLIENT --query_id "$query_id" -q "
     SELECT count(*) FROM table_$table_id FORMAT Null;"
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
     SELECT
         ProfileEvents['SelectQueriesWithPrimaryKeyUsage'] AS selects_with_pk_usage
     FROM
@@ -51,7 +51,7 @@ query_id="$(random_str 10)"
 $CLICKHOUSE_CLIENT --query_id "$query_id" -q "
     SELECT count(*) FROM table_$table_id WHERE col2 >= 50000 FORMAT Null;"
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
     SELECT
         ProfileEvents['SelectQueriesWithPrimaryKeyUsage'] AS selects_with_pk_usage
     FROM
@@ -68,7 +68,7 @@ query_id="$(random_str 10)"
 $CLICKHOUSE_CLIENT --query_id "$query_id" -q "
     SELECT count(*) FROM table_$table_id WHERE pk >= 50000 FORMAT Null;"
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
     SELECT
         ProfileEvents['SelectQueriesWithPrimaryKeyUsage'] AS selects_with_pk_usage
     FROM
@@ -85,7 +85,7 @@ query_id="$(random_str 10)"
 $CLICKHOUSE_CLIENT --query_id "$query_id" -q "
     SELECT count(*) FROM table_$table_id WHERE col1 >= 50000 FORMAT Null;"
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
     SELECT
         ProfileEvents['SelectQueriesWithPrimaryKeyUsage'] AS selects_with_pk_usage
     FROM

--- a/tests/queries/0_stateless/03166_skip_indexes_vertical_merge_1.sql
+++ b/tests/queries/0_stateless/03166_skip_indexes_vertical_merge_1.sql
@@ -25,7 +25,7 @@ OPTIMIZE TABLE t_ind_merge_1 FINAL;
 SELECT count() FROM t_ind_merge_1 WHERE b < 100 SETTINGS force_data_skipping_indices = 'idx_b';
 EXPLAIN indexes = 1 SELECT count() FROM t_ind_merge_1 WHERE b < 100;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS text_log;
 SET max_rows_to_read = 0; -- system.text_log can be really big
 WITH
     (SELECT uuid FROM system.tables WHERE database = currentDatabase() AND table = 't_ind_merge_1') AS uuid,

--- a/tests/queries/0_stateless/03166_skip_indexes_vertical_merge_2.sql
+++ b/tests/queries/0_stateless/03166_skip_indexes_vertical_merge_2.sql
@@ -27,7 +27,7 @@ INSERT INTO t_ind_merge_2 SELECT number, number, rand(), rand(), rand(), rand() 
 INSERT INTO t_ind_merge_2 SELECT number, number, rand(), rand(), rand(), rand() FROM numbers(1000);
 
 OPTIMIZE TABLE t_ind_merge_2 FINAL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS text_log;
 SET max_rows_to_read = 0; -- system.text_log can be really big
 
 --- merged: a, c, d; gathered: b, e, f

--- a/tests/queries/0_stateless/03168_query_log_privileges_not_empty.sh
+++ b/tests/queries/0_stateless/03168_query_log_privileges_not_empty.sh
@@ -19,7 +19,7 @@ ${CLICKHOUSE_CLIENT} --user ${user_name} --query "${test_query}" 2>&1 >/dev/null
 ${CLICKHOUSE_CLIENT} --query "grant select(a, b) on ${table_name} to ${user_name}"
 ${CLICKHOUSE_CLIENT} --user ${user_name} --query "${test_query}"
 
-${CLICKHOUSE_CLIENT} --query "system flush logs"
+${CLICKHOUSE_CLIENT} --query "system flush logs query_log"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query = '${test_query}' and type = 'ExceptionBeforeStart' and current_database = currentDatabase() order by event_time desc limit 1"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query = '${test_query}' and type = 'QueryStart' and current_database = currentDatabase() order by event_time desc limit 1"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query = '${test_query}' and type = 'QueryFinish' and current_database = currentDatabase() order by event_time desc limit 1"

--- a/tests/queries/0_stateless/03172_error_log_table_not_empty.sh
+++ b/tests/queries/0_stateless/03172_error_log_table_not_empty.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 # system.error_log is created lazy, flush logs query makes it sure that the table is created.
-$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS;"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS error_log;"
 
 # Get the previous number of errors for 111, 222 and 333
 errors_111=$($CLICKHOUSE_CLIENT -q "SELECT sum(value) FROM system.error_log WHERE code = 111")
@@ -20,7 +20,7 @@ SELECT throwIf(true, 'error_log', toInt16(111)) SETTINGS allow_custom_error_code
 SELECT throwIf(true, 'error_log', toInt16(222)) SETTINGS allow_custom_error_code_in_throwif=1; -- { serverError 222 }
 SELECT throwIf(true, 'error_log', toInt16(333)) SETTINGS allow_custom_error_code_in_throwif=1; -- { serverError 333 }
 SELECT sleep(2) format NULL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS error_log;
 "
 
 # Check that the three random errors are propagated
@@ -36,7 +36,7 @@ SELECT throwIf(true, 'error_log', toInt16(111)) SETTINGS allow_custom_error_code
 SELECT throwIf(true, 'error_log', toInt16(222)) SETTINGS allow_custom_error_code_in_throwif=1; -- { serverError 222 }
 SELECT throwIf(true, 'error_log', toInt16(333)) SETTINGS allow_custom_error_code_in_throwif=1; -- { serverError 333 }
 SELECT sleep(2) format NULL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS error_log;
 "
 
 $CLICKHOUSE_CLIENT -m -q "

--- a/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
+++ b/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
@@ -15,7 +15,7 @@ SELECT toDate('2100-01-01') + 10 * number FROM numbers(50);
 OPTIMIZE TABLE 03173_single_function FINAL;
 
 SELECT count() FROM 03173_single_function WHERE dt IN ('2024-01-20', '2024-05-25') SETTINGS log_comment='03173_single_function';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_single_function';
 
 DROP TABLE IF EXISTS 03173_single_function;
@@ -35,7 +35,7 @@ OPTIMIZE TABLE 03173_nested_function FINAL;
 
 SELECT count() FROM 03173_nested_function WHERE id IN (10) SETTINGS log_comment='03173_nested_function';
 SELECT count() FROM 03173_nested_function WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function';
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr';
 
@@ -58,7 +58,7 @@ OPTIMIZE TABLE 03173_nested_function_lc FINAL;
 
 SELECT count() FROM 03173_nested_function_lc WHERE id IN (10) SETTINGS log_comment='03173_nested_function_lc';
 SELECT count() FROM 03173_nested_function_lc WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr_lc';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_lc';
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr_lc';
 
@@ -80,7 +80,7 @@ OPTIMIZE TABLE 03173_nested_function_null FINAL;
 
 SELECT count() FROM 03173_nested_function_null WHERE id IN (10) SETTINGS log_comment='03173_nested_function_null';
 SELECT count() FROM 03173_nested_function_null WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr_null';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_null';
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr_null';
 
@@ -104,7 +104,7 @@ OPTIMIZE TABLE 03173_nested_function_lc_null FINAL;
 
 SELECT count() FROM 03173_nested_function_lc_null WHERE id IN (10) SETTINGS log_comment='03173_nested_function_lc_null';
 SELECT count() FROM 03173_nested_function_lc_null WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr_lc_null';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_lc_null';
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr_lc_null';
 
@@ -124,7 +124,7 @@ INSERT INTO 03173_nonsafe_cast SELECT number FROM numbers(100);
 OPTIMIZE TABLE 03173_nonsafe_cast FINAL;
 
 SELECT count() FROM 03173_nonsafe_cast WHERE id IN (SELECT '50' UNION ALL SELECT '99') SETTINGS log_comment='03173_nonsafe_cast';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nonsafe_cast';
 
 DROP TABLE IF EXISTS 03173_nonsafe_cast;
@@ -145,7 +145,7 @@ OPTIMIZE TABLE 03173_multiple_partition_cols FINAL;
 
 SELECT count() FROM 03173_multiple_partition_cols WHERE key2 IN (4) SETTINGS log_comment='03173_multiple_columns';
 SELECT count() FROM 03173_multiple_partition_cols WHERE xxHash32(key2) IN (4251411170) SETTINGS log_comment='03173_multiple_columns_subexpr';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_multiple_columns';
 -- Due to xxHash32() in WHERE condition, MinMax is unable to eliminate any parts,
 -- so partition pruning leave two parts (for key1 // 50 = 0 and key1 // 50 = 1)
@@ -170,7 +170,7 @@ DROP TABLE IF EXISTS 03173_low_cardinality_set;
 CREATE TABLE 03173_low_cardinality_set (id LowCardinality(Int32)) ENGINE=Memory AS SELECT 10;
 
 SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_low_cardinality_set) SETTINGS log_comment='03173_low_cardinality_set';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_low_cardinality_set';
 
 DROP TABLE IF EXISTS 03173_low_cardinality_set;
@@ -181,7 +181,7 @@ DROP TABLE IF EXISTS 03173_nullable_set;
 CREATE TABLE 03173_nullable_set (id Nullable(Int32)) ENGINE=Memory AS SELECT 10;
 
 SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_nullable_set) SETTINGS log_comment='03173_nullable_set';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nullable_set';
 
 DROP TABLE IF EXISTS 03173_nullable_set;
@@ -192,7 +192,7 @@ DROP TABLE IF EXISTS 03173_lc_nullable_set;
 CREATE TABLE 03173_lc_nullable_set (id LowCardinality(Nullable(Int32))) ENGINE=Memory AS SELECT 10 UNION ALL SELECT NULL;
 
 SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_lc_nullable_set) SETTINGS log_comment='03173_lc_nullable_set';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_lc_nullable_set';
 
 DROP TABLE IF EXISTS 03173_lc_nullable_set;
@@ -232,7 +232,7 @@ UNION ALL
 SELECT toString(toDate('2100-01-01') + 10 * number) FROM numbers(50);
 
 SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('2000-01-21', '2023-05-02') SETTINGS log_comment='03173_nested_date_parsing';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_date_parsing';
 SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('not a date');
 
@@ -252,7 +252,7 @@ INSERT INTO 03173_empty_transform SELECT number FROM numbers(6);
 OPTIMIZE TABLE 03173_empty_transform FINAL;
 
 SELECT id FROM 03173_empty_transform WHERE xxHash32(id) % 3 IN (xxHash32(2::Int32) % 3) SETTINGS log_comment='03173_empty_transform';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_empty_transform';
 
 DROP TABLE IF EXISTS 03173_empty_transform;

--- a/tests/queries/0_stateless/03176_check_timeout_in_index_analysis.sql
+++ b/tests/queries/0_stateless/03176_check_timeout_in_index_analysis.sql
@@ -21,7 +21,7 @@ EXPLAIN indexes = 1 SELECT * FROM t_03176 ORDER BY k LIMIT 5 SETTINGS log_commen
 
 SYSTEM DISABLE FAILPOINT slowdown_index_analysis;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 -- Check that q1 was fast, q2 was slow and q3 had timeout
 SELECT log_comment, type = 'QueryFinish', intDiv(query_duration_ms, 2000), length(exception) > 0

--- a/tests/queries/0_stateless/03198_dynamic_read_subcolumns.sql
+++ b/tests/queries/0_stateless/03198_dynamic_read_subcolumns.sql
@@ -11,7 +11,7 @@ SYSTEM DROP MARK CACHE;
 SELECT d.String FROM test_dynamic SETTINGS allow_experimental_analyzer = 1;
 SYSTEM DROP MARK CACHE;
 SELECT d.String FROM test_dynamic SETTINGS allow_experimental_analyzer = 0;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT
     ProfileEvents['FileOpen']
 FROM system.query_log

--- a/tests/queries/0_stateless/03203_system_query_metric_log.sh
+++ b/tests/queries/0_stateless/03203_system_query_metric_log.sh
@@ -18,7 +18,7 @@ $CLICKHOUSE_CLIENT --query-id="${query_prefix}_fast" -q "SELECT sleep(0.1) SETTI
 
 wait
 
-$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_metric_log"
 
 function check_log()
 {

--- a/tests/queries/0_stateless/03206_projection_merge_special_mergetree.sql
+++ b/tests/queries/0_stateless/03206_projection_merge_special_mergetree.sql
@@ -57,7 +57,6 @@ INSERT INTO tp SELECT number%3, 1 FROM numbers(3);
 OPTIMIZE TABLE tp FINAL;
 
 -- expecting no projection
-SYSTEM FLUSH LOGS;
 SELECT
     name
 FROM system.projection_parts
@@ -96,7 +95,6 @@ ALTER TABLE tp ADD PROJECTION p (SELECT sum(eventcnt), type GROUP BY type);
 
 INSERT INTO tp SELECT number%3, 1 FROM numbers(3);
 
-SYSTEM FLUSH LOGS;
 -- expecting projection p
 SELECT
     name

--- a/tests/queries/0_stateless/03217_filtering_in_system_tables.sql
+++ b/tests/queries/0_stateless/03217_filtering_in_system_tables.sql
@@ -14,7 +14,7 @@ CREATE TABLE test_03217_system_tables_replica_2(x UInt32)
 SELECT 'both', database, table, left(replica_name, 2) FROM system.replicas WHERE database = currentDatabase();
 -- If filtering is not done correctly on database-table column, then this query report to read 2 rows, which are the above tables
 SELECT database, table, left(replica_name, 2) FROM system.replicas WHERE database = currentDatabase() AND table = 'test_03217_system_tables_replica_1' AND replica_name LIKE 'r1%';
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 -- argMax is necessary to make the test repeatable
 
 -- StorageSystemTables

--- a/tests/queries/0_stateless/03221_merge_profile_events.sql
+++ b/tests/queries/0_stateless/03221_merge_profile_events.sql
@@ -10,7 +10,7 @@ INSERT INTO t_merge_profile_events_1 SELECT number, number, number FROM numbers(
 INSERT INTO t_merge_profile_events_1 SELECT number, number, number FROM numbers(10000);
 
 OPTIMIZE TABLE t_merge_profile_events_1 FINAL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     merge_algorithm,
@@ -37,7 +37,7 @@ INSERT INTO t_merge_profile_events_2 SELECT number, number, number FROM numbers(
 INSERT INTO t_merge_profile_events_2 SELECT number, number, number FROM numbers(10000);
 
 OPTIMIZE TABLE t_merge_profile_events_2 FINAL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     merge_algorithm,
@@ -66,7 +66,7 @@ INSERT INTO t_merge_profile_events_3 SELECT number, number, number FROM numbers(
 INSERT INTO t_merge_profile_events_3 SELECT number, number, number FROM numbers(100000);
 
 OPTIMIZE TABLE t_merge_profile_events_3 FINAL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     merge_algorithm,

--- a/tests/queries/0_stateless/03221_mutate_profile_events.sh
+++ b/tests/queries/0_stateless/03221_mutate_profile_events.sh
@@ -24,7 +24,7 @@ ${CLICKHOUSE_CLIENT} --query "
 # Mutation query may return before the entry is added to part log.
 # So, we may have to retry the flush of logs until all entries are actually flushed.
 for _ in {1..10}; do
-    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS part_log"
     res=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.part_log WHERE database = currentDatabase() AND table = 't_mutate_profile_events' AND event_type = 'MutatePart'")
 
     if [[ $res -eq 4 ]]; then

--- a/tests/queries/0_stateless/03221_mutation_analyzer_skip_part.sh
+++ b/tests/queries/0_stateless/03221_mutation_analyzer_skip_part.sh
@@ -34,7 +34,7 @@ for _ in {1..10}; do
 done
 
 ${CLICKHOUSE_CLIENT} --query "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS part_log;
 
     -- If part is skipped in mutation and hardlinked then read_rows must be 0.
     SELECT part_name, read_rows

--- a/tests/queries/0_stateless/03229_async_insert_alter.sql
+++ b/tests/queries/0_stateless/03229_async_insert_alter.sql
@@ -17,7 +17,6 @@ INSERT INTO t_async_insert_alter VALUES (42, 24);
 ALTER TABLE t_async_insert_alter ADD COLUMN value2 Int64;
 
 SYSTEM FLUSH ASYNC INSERT QUEUE;
-SYSTEM FLUSH LOGS;
 
 SELECT * FROM t_async_insert_alter ORDER BY id;
 
@@ -28,7 +27,6 @@ INSERT INTO t_async_insert_alter VALUES (43, 34, 55);
 ALTER TABLE t_async_insert_alter MODIFY COLUMN value2 String;
 
 SYSTEM FLUSH ASYNC INSERT QUEUE;
-SYSTEM FLUSH LOGS;
 
 SELECT * FROM t_async_insert_alter ORDER BY id;
 
@@ -39,7 +37,7 @@ INSERT INTO t_async_insert_alter VALUES ('100', '200', '300');
 ALTER TABLE t_async_insert_alter DROP COLUMN value2;
 
 SYSTEM FLUSH ASYNC INSERT QUEUE;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS asynchronous_insert_log;
 
 SELECT * FROM t_async_insert_alter ORDER BY id;
 SELECT query, data_kind, status FROM system.asynchronous_insert_log WHERE database = currentDatabase() AND table = 't_async_insert_alter' ORDER BY event_time_microseconds;

--- a/tests/queries/0_stateless/03229_async_insert_alter_http.sh
+++ b/tests/queries/0_stateless/03229_async_insert_alter_http.sh
@@ -21,7 +21,6 @@ $CLICKHOUSE_CLIENT -q "
     ALTER TABLE t_async_insert_alter ADD COLUMN value2 Int64;
 
     SYSTEM FLUSH ASYNC INSERT QUEUE;
-    SYSTEM FLUSH LOGS;
 
     SELECT * FROM t_async_insert_alter ORDER BY id;
 "
@@ -34,7 +33,6 @@ $CLICKHOUSE_CLIENT -q "
     ALTER TABLE t_async_insert_alter MODIFY COLUMN value2 String;
 
     SYSTEM FLUSH ASYNC INSERT QUEUE;
-    SYSTEM FLUSH LOGS;
 
     SELECT * FROM t_async_insert_alter ORDER BY id;
 "
@@ -47,7 +45,7 @@ $CLICKHOUSE_CLIENT -q "
     ALTER TABLE t_async_insert_alter DROP COLUMN value2;
 
     SYSTEM FLUSH ASYNC INSERT QUEUE;
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS asynchronous_insert_log;
 
     SELECT * FROM t_async_insert_alter ORDER BY id;
     SELECT query, data_kind, status FROM system.asynchronous_insert_log WHERE database = currentDatabase() AND table = 't_async_insert_alter' ORDER BY event_time_microseconds;

--- a/tests/queries/0_stateless/03229_query_condition_cache.sql
+++ b/tests/queries/0_stateless/03229_query_condition_cache.sql
@@ -11,7 +11,7 @@ INSERT INTO tab SELECT number, number FROM numbers(1000000);
 
 SELECT count(*) FROM tab WHERE b = 10000 SETTINGS use_query_condition_cache = true;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT
     ProfileEvents['QueryConditionCacheHits'],
     ProfileEvents['QueryConditionCacheMisses'],
@@ -26,7 +26,7 @@ ORDER BY
 
 SELECT * FROM tab WHERE b = 10000 SETTINGS use_query_condition_cache = true;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT
     ProfileEvents['QueryConditionCacheHits'],
     ProfileEvents['QueryConditionCacheMisses'],
@@ -45,7 +45,7 @@ SYSTEM DROP QUERY CONDITION CACHE;
 
 SELECT count(*) FROM tab WHERE b = 10000 SETTINGS use_query_condition_cache = true, optimize_move_to_prewhere = false;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT
     ProfileEvents['QueryConditionCacheHits'],
     ProfileEvents['QueryConditionCacheMisses'],
@@ -60,7 +60,7 @@ ORDER BY
 
 SELECT * FROM tab WHERE b = 10000 SETTINGS use_query_condition_cache = true, optimize_move_to_prewhere = false;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT
     ProfileEvents['QueryConditionCacheHits'],
     ProfileEvents['QueryConditionCacheMisses'],

--- a/tests/queries/0_stateless/03231_hive_partitioning_filtering.sh
+++ b/tests/queries/0_stateless/03231_hive_partitioning_filtering.sh
@@ -14,7 +14,7 @@ $CLICKHOUSE_CLIENT --query_id="test_03231_1_$CLICKHOUSE_TEST_UNIQUE_NAME" --quer
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
 "
 
 for _ in {1..5}; do
@@ -34,7 +34,7 @@ $CLICKHOUSE_CLIENT --query_id="test_03231_2_$CLICKHOUSE_TEST_UNIQUE_NAME" --quer
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
 "
 
 for _ in {1..5}; do
@@ -54,7 +54,7 @@ $CLICKHOUSE_CLIENT --query_id="test_03231_3_$CLICKHOUSE_TEST_UNIQUE_NAME" --quer
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
 "
 
 for _ in {1..5}; do

--- a/tests/queries/0_stateless/03232_pr_not_ready_set.sql
+++ b/tests/queries/0_stateless/03232_pr_not_ready_set.sql
@@ -1,4 +1,4 @@
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT
     is_initial_query,
     count() AS c,

--- a/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
+++ b/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
@@ -62,7 +62,7 @@ $MY_CLICKHOUSE_CLIENT --query "
     WHERE table = 't_insert_mem' AND database = '$CLICKHOUSE_DATABASE'
     GROUP BY serialization_kind ORDER BY serialization_kind;
 
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
 
     SELECT written_bytes <= 10000000 FROM system.query_log
     WHERE query LIKE 'INSERT INTO t_insert_mem%' AND current_database = '$CLICKHOUSE_DATABASE' AND type = 'QueryFinish'

--- a/tests/queries/0_stateless/03252_merge_tree_min_bytes_to_seek.sql
+++ b/tests/queries/0_stateless/03252_merge_tree_min_bytes_to_seek.sql
@@ -16,7 +16,7 @@ SELECT count() FROM t_min_bytes_to_seek WHERE id IN (10, 1000, 5000, 9000) SETTI
 SELECT count() FROM t_min_bytes_to_seek WHERE id IN (10, 1000, 5000, 9000) SETTINGS merge_tree_min_rows_for_seek = 0;
 SELECT count() FROM t_min_bytes_to_seek WHERE id IN (10, 1000, 5000, 9000) SETTINGS merge_tree_min_rows_for_seek = 1000000000;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['SelectedRanges']
 FROM system.query_log

--- a/tests/queries/0_stateless/03254_merge_source_parts.sql
+++ b/tests/queries/0_stateless/03254_merge_source_parts.sql
@@ -3,6 +3,6 @@ CREATE TABLE test (x UInt8) ORDER BY x;
 INSERT INTO test VALUES (1);
 INSERT INTO test VALUES (2);
 OPTIMIZE TABLE test FINAL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 SELECT ProfileEvents['Merge'], ProfileEvents['MergeSourceParts'], ProfileEvents['MergedRows'], ProfileEvents['MergedColumns'] FROM system.part_log WHERE database = currentDatabase() AND table = 'test' AND event_type = 'MergeParts';
 DROP TABLE test;

--- a/tests/queries/0_stateless/03254_part_log_partition_column_is_set.sql
+++ b/tests/queries/0_stateless/03254_part_log_partition_column_is_set.sql
@@ -10,7 +10,7 @@ ALTER TABLE test UPDATE z = x || y WHERE 1;
 SELECT * FROM test ORDER BY ALL;
 TRUNCATE TABLE test;
 DROP TABLE test SYNC;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 -- SELECT * FROM system.part_log WHERE database = currentDatabase() FORMAT Vertical;
 SELECT DISTINCT throwIf(empty(partition)) FROM system.part_log WHERE database = currentDatabase();

--- a/tests/queries/0_stateless/03254_prewarm_mark_cache_columns.sql
+++ b/tests/queries/0_stateless/03254_prewarm_mark_cache_columns.sql
@@ -21,7 +21,7 @@ SYSTEM PREWARM MARK CACHE t_prewarm_columns;
 
 SELECT count() FROM t_prewarm_columns WHERE NOT ignore(*);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['LoadedMarksCount'] FROM system.query_log
 WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND query LIKE 'SELECT count() FROM t_prewarm_columns%'

--- a/tests/queries/0_stateless/03254_prewarm_mark_cache_rmt.sql
+++ b/tests/queries/0_stateless/03254_prewarm_mark_cache_rmt.sql
@@ -55,7 +55,7 @@ SYSTEM PREWARM MARK CACHE t_prewarm_cache_rmt_1;
 
 SELECT count() FROM t_prewarm_cache_rmt_1 WHERE NOT ignore(*);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['LoadedMarksCount'] > 0 FROM system.query_log
 WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND query LIKE 'SELECT count() FROM t_prewarm_cache%'

--- a/tests/queries/0_stateless/03254_system_prewarm_mark_cache.sql
+++ b/tests/queries/0_stateless/03254_system_prewarm_mark_cache.sql
@@ -18,7 +18,7 @@ SYSTEM PREWARM MARK CACHE t_prewarm_cache;
 
 SELECT count() FROM t_prewarm_cache WHERE NOT ignore(*);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['LoadedMarksCount'] > 0 FROM system.query_log
 WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND query LIKE 'SELECT count() FROM t_prewarm_cache%'

--- a/tests/queries/0_stateless/03255_merge_mutation_start_entry_in_the_part_log.sql
+++ b/tests/queries/0_stateless/03255_merge_mutation_start_entry_in_the_part_log.sql
@@ -10,7 +10,7 @@ ALTER TABLE test UPDATE z = x || y WHERE 1;
 SELECT * FROM test ORDER BY ALL;
 TRUNCATE TABLE test;
 DROP TABLE test SYNC;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT event_type, merge_reason, table, part_name, partition_id, partition, rows, merged_from
 FROM system.part_log WHERE database = currentDatabase() AND event_type IN ('MergePartsStart', 'MergeParts', 'MutatePartStart', 'MutatePart')

--- a/tests/queries/0_stateless/03257_async_insert_native_empty_block.sh
+++ b/tests/queries/0_stateless/03257_async_insert_native_empty_block.sh
@@ -20,7 +20,7 @@ echo '[]' | $MY_CLICKHOUSE_CLIENT -q "INSERT INTO json_square_brackets FORMAT JS
 echo '' | $MY_CLICKHOUSE_CLIENT -q "INSERT INTO json_square_brackets FORMAT JSONEachRow"
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS asynchronous_insert_log;
     SELECT * FROM json_square_brackets ORDER BY id;
     SELECT status, data_kind, rows FROM system.asynchronous_insert_log WHERE database = currentDatabase() AND table = 'json_square_brackets' ORDER BY event_time_microseconds;
     DROP TABLE json_square_brackets;

--- a/tests/queries/0_stateless/03258_refreshable_mv_misc.sh
+++ b/tests/queries/0_stateless/03258_refreshable_mv_misc.sh
@@ -68,7 +68,7 @@ done
 # (The following string needs to be present in this comment to silence check-style warning: **current_database = currentDatabase()**.
 #  It's ok that we don't have this condition in the query, we're checking the db name in `tables` column instead.)
 $CLICKHOUSE_CLIENT -q "
-    system flush logs;
+    system flush logs query_log;
     select replaceAll(toString(type), 'Exception', 'Ex**ption'), interface, client_name, exception != '', has(tables, '${second_db}.v') from system.query_log where event_time > now() - interval 30 minute and log_comment like 'refresh of ${second_db}.v%' group by all order by all;
 "
 

--- a/tests/queries/0_stateless/03261_delayed_streams_memory.sql
+++ b/tests/queries/0_stateless/03261_delayed_streams_memory.sql
@@ -11,7 +11,7 @@ SET max_insert_delayed_streams_for_parallel_write = 55;
 
 INSERT INTO t_100_columns (id) SELECT number FROM numbers(100);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT if (memory_usage < 300000000, 'Ok', format('Fail: memory usage {}', formatReadableSize(memory_usage)))
 FROM system.query_log

--- a/tests/queries/0_stateless/03262_system_functions_should_not_fill_query_log_functions.sql
+++ b/tests/queries/0_stateless/03262_system_functions_should_not_fill_query_log_functions.sql
@@ -1,5 +1,5 @@
 SELECT * FROM system.functions WHERE name = 'bitShiftLeft' format Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT used_aggregate_functions, used_functions, used_table_functions
 FROM system.query_log
 WHERE

--- a/tests/queries/0_stateless/03269_explain_unique_ids.sh
+++ b/tests/queries/0_stateless/03269_explain_unique_ids.sh
@@ -51,7 +51,7 @@ query_id="03269_explain_unique_ids_$RANDOM$RANDOM"
 $CLICKHOUSE_CLIENT "${opts[@]}" --log_processors_profiles=1 --query_id="$query_id" --format Null -q "$query"
 
 $CLICKHOUSE_CLIENT -q "
-  SYSTEM FLUSH LOGS;
+  SYSTEM FLUSH LOGS processors_profile_log;
 
   SELECT DISTINCT (replaceRegexpAll(processor_uniq_id, '(\w+)\(.*\)', '\\1'), step_uniq_id)
   FROM system.processors_profile_log

--- a/tests/queries/0_stateless/03270_processors_profile_log_3.sh
+++ b/tests/queries/0_stateless/03270_processors_profile_log_3.sh
@@ -42,7 +42,7 @@ $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
 "
 
 $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
-  SYSTEM FLUSH LOGS;
+  SYSTEM FLUSH LOGS processors_profile_log;
 
   SELECT sum(elapsed_us) > 0
   FROM system.processors_profile_log
@@ -87,7 +87,7 @@ $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
 "
 
 $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
-  SYSTEM FLUSH LOGS;
+  SYSTEM FLUSH LOGS processors_profile_log;
 
   SELECT sum(elapsed_us) > 0
   FROM system.processors_profile_log

--- a/tests/queries/0_stateless/03272_parallel_replicas_read_in_order.sql
+++ b/tests/queries/0_stateless/03272_parallel_replicas_read_in_order.sql
@@ -17,7 +17,7 @@ SELECT * from read_in_order_with_parallel_replicas ORDER BY id limit 1
 SETTINGS max_threads=1, log_comment='test read in order asc with parallel replicas';
 
 -- Check we don't read more mark in parallel replicas
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SET parallel_replicas_for_non_replicated_merge_tree=0;
 select count(1) from system.query_log where current_database = currentDatabase() AND log_comment = 'test read in order desc with parallel replicas' and read_rows>2;
 select count(1) from system.query_log where current_database = currentDatabase() AND log_comment = 'test read in order asc with parallel replicas' and read_rows>2;

--- a/tests/queries/0_stateless/03272_prewarm_mark_cache_add_column.sql
+++ b/tests/queries/0_stateless/03272_prewarm_mark_cache_add_column.sql
@@ -21,7 +21,7 @@ DETACH TABLE t_prewarm_add_column;
 ATTACH TABLE t_prewarm_add_column;
 
 SELECT * FROM t_prewarm_add_column ORDER BY a;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['LoadedMarksCount'] FROM system.query_log
 WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND query LIKE 'SELECT * FROM t_prewarm_add_column%'

--- a/tests/queries/0_stateless/03273_primary_index_cache.sql
+++ b/tests/queries/0_stateless/03273_primary_index_cache.sql
@@ -32,7 +32,7 @@ SYSTEM RELOAD ASYNCHRONOUS METRICS;
 SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE table = 't_primary_index_cache' AND active;
 SELECT metric, value FROM system.asynchronous_metrics WHERE metric IN ('PrimaryIndexCacheFiles', 'PrimaryIndexCacheBytes') ORDER BY metric;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     ProfileEvents['LoadedPrimaryIndexFiles'],

--- a/tests/queries/0_stateless/03273_primary_index_cache_low_cardinality.sql
+++ b/tests/queries/0_stateless/03273_primary_index_cache_low_cardinality.sql
@@ -28,7 +28,7 @@ SELECT max(length(a || b)) FROM t_primary_index_cache WHERE a > '1' AND b < '99'
 SYSTEM RELOAD ASYNCHRONOUS METRICS;
 SELECT metric, value FROM system.asynchronous_metrics WHERE metric IN ('PrimaryIndexCacheFiles', 'PrimaryIndexCacheBytes') ORDER BY metric;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     ProfileEvents['LoadedPrimaryIndexFiles'],

--- a/tests/queries/0_stateless/03274_prewarm_primary_index_cache.sql
+++ b/tests/queries/0_stateless/03274_prewarm_primary_index_cache.sql
@@ -64,7 +64,7 @@ SYSTEM PREWARM PRIMARY INDEX CACHE t_prewarm_cache_rmt_1;
 SELECT count() FROM t_prewarm_cache_rmt_1 WHERE a % 2 = 0 AND a > 100 AND a < 1000;
 SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table IN ('t_prewarm_cache_rmt_1', 't_prewarm_cache_rmt_2');
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['LoadedPrimaryIndexFiles'] FROM system.query_log
 WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND query LIKE 'SELECT count() FROM t_prewarm_cache%'

--- a/tests/queries/0_stateless/03276_null_format_matching_case_insensitive.sh
+++ b/tests/queries/0_stateless/03276_null_format_matching_case_insensitive.sh
@@ -10,7 +10,7 @@ query_id="03276_null_format_matching_case_insensitive_$RANDOM$RANDOM"
 $CLICKHOUSE_CLIENT --query_id "$query_id" -q "select * from numbers_mt(1e8) format null settings max_rows_to_read=0"
 
 $CLICKHOUSE_CLIENT -q "
-  SYSTEM FLUSH LOGS;
+  SYSTEM FLUSH LOGS query_log;
 
   -- SendBytes should be close to 0, previously for this query it was around 800MB
   select ProfileEvents['NetworkSendBytes'] < 1e6 from system.query_log where current_database = currentDatabase() and event_date >= yesterday() and query_id = '$query_id' and type = 'QueryFinish';

--- a/tests/queries/0_stateless/03277_logging_elapsed_ns.sql
+++ b/tests/queries/0_stateless/03277_logging_elapsed_ns.sql
@@ -1,6 +1,6 @@
 SELECT 42 SETTINGS log_comment='03277_logging_elapsed_ns';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     ProfileEvents['LogDebug'] + ProfileEvents['LogTrace'] > 0,

--- a/tests/queries/0_stateless/03277_prewarm_cache_2.sh
+++ b/tests/queries/0_stateless/03277_prewarm_cache_2.sh
@@ -63,7 +63,7 @@ $CLICKHOUSE_CLIENT --query "
     SYSTEM RELOAD ASYNCHRONOUS METRICS;
     SELECT metric, value FROM system.asynchronous_metrics WHERE metric IN ('PrimaryIndexCacheFiles', 'MarkCacheFiles') ORDER BY metric;
 
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
 
     SELECT
         ProfileEvents['LoadedMarksFiles'],

--- a/tests/queries/0_stateless/03279_join_choose_build_table.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table.sql
@@ -39,7 +39,7 @@ SELECT * FROM sales, products
 WHERE sales.product_id = products.id AND date = '2024-05-07'
 SETTINGS log_comment = '03279_join_choose_build_table_idx' FORMAT Null;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 -- condtitions are pushed down, but no filter by index applied
 -- build table is as it's written in query

--- a/tests/queries/0_stateless/03305_parallel_with_query_log.sh
+++ b/tests/queries/0_stateless/03305_parallel_with_query_log.sh
@@ -27,7 +27,7 @@ query_id_2=$(generate_query_id)
 $CLICKHOUSE_CLIENT -q "$query" --query_id=${query_id_2} --max_threads=2
 
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS query_log;
     SELECT '1', length(thread_ids) FROM system.query_log WHERE event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '${query_id_1}' AND type = 'QueryFinish';
     SELECT '2', length(thread_ids) > 1 FROM system.query_log WHERE event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '${query_id_2}' AND type = 'QueryFinish';
 "

--- a/tests/queries/0_stateless/03310_create_database_with_settings.sql
+++ b/tests/queries/0_stateless/03310_create_database_with_settings.sql
@@ -1,6 +1,6 @@
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
 CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} SETTINGS distributed_ddl_task_timeout=42;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT Settings['distributed_ddl_task_timeout'] FROM system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and

--- a/tests/queries/0_stateless/03310_index_hints_read_columns.sql
+++ b/tests/queries/0_stateless/03310_index_hints_read_columns.sql
@@ -18,7 +18,7 @@ SELECT sum(b) FROM t_index_hint WHERE a >= 100 AND a < 200 AND b >= 100 AND b < 
 SYSTEM DROP MARK CACHE;
 SELECT sum(b) FROM t_index_hint WHERE indexHint(a >= 100 AND a < 200) AND b >= 100 AND b < 200 SETTINGS max_threads = 1, force_primary_key = 1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     ProfileEvents['FileOpen'],
@@ -59,7 +59,7 @@ SYSTEM DROP INDEX MARK CACHE;
 SYSTEM DROP SKIPPING INDEX CACHE;
 SELECT count() FROM t_index_hint WHERE indexHint(has(s_tokens, 'my_token')) AND s LIKE '%my_token%' SETTINGS max_threads = 1, force_data_skipping_indices = 'idx_tokens';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     ProfileEvents['FileOpen'],

--- a/tests/queries/0_stateless/03312_line_numbers.sql
+++ b/tests/queries/0_stateless/03312_line_numbers.sql
@@ -7,7 +7,7 @@ SELECT 'This is the first query, and it is located on line 4',
 
 SELECT 'This is the second query, and it is located on line 8';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log, text_log;
 SELECT type, script_query_number, script_line_number, query FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() ORDER BY event_time_microseconds, type;
 
 SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND message LIKE '%(query 1, line 4)%' AND message LIKE '%This is the first query%' LIMIT 1;

--- a/tests/queries/0_stateless/03315_query_log_privileges_backup_restore.sh
+++ b/tests/queries/0_stateless/03315_query_log_privileges_backup_restore.sh
@@ -30,7 +30,7 @@ ${CLICKHOUSE_CLIENT} --query "system drop mmap cache"
 ${CLICKHOUSE_CLIENT} --query "grant backup on *.* to ${user_name}"
 ${CLICKHOUSE_CLIENT} --user ${user_name} --query "${backup_query}" 2>&1 >/dev/null | (grep -q "ACCESS_DENIED" && echo "ACCESS_DENIED error is not expected")
 
-${CLICKHOUSE_CLIENT} --query "system flush logs"
+${CLICKHOUSE_CLIENT} --query "system flush logs query_log"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query ilike '${backup_query_prefix}%' and type = 'ExceptionBeforeStart' and current_database = currentDatabase() order by event_time desc limit 1"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query ilike '${backup_query_prefix}%' and type = 'QueryStart' and current_database = currentDatabase() order by event_time desc limit 1"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query ilike '${backup_query_prefix}%' and type = 'QueryFinish' and current_database = currentDatabase() order by event_time desc limit 1"
@@ -44,7 +44,7 @@ ${CLICKHOUSE_CLIENT} --user ${user_name} --query "${restore_query}" 2>&1 >/dev/n
 ${CLICKHOUSE_CLIENT} --query "grant create, insert on *.* to ${user_name}"
 ${CLICKHOUSE_CLIENT} --user ${user_name} --query "${restore_query}" 2>&1 >/dev/null | (grep -q "ACCESS_DENIED" && echo "ACCESS_DENIED error is not expected")
 
-${CLICKHOUSE_CLIENT} --query "system flush logs"
+${CLICKHOUSE_CLIENT} --query "system flush logs query_log"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query ilike '${restore_query_prefix}%' and type = 'ExceptionBeforeStart' and current_database = currentDatabase() order by event_time desc limit 1"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query ilike '${restore_query_prefix}%' and type = 'QueryStart' and current_database = currentDatabase() order by event_time desc limit 1"
 ${CLICKHOUSE_CLIENT} --query "select used_privileges, missing_privileges from system.query_log where query ilike '${restore_query_prefix}%' and type = 'QueryFinish' and current_database = currentDatabase() order by event_time desc limit 1"

--- a/tests/queries/0_stateless/03319_concurrent_hash_join_double_preallocation_bug.sql
+++ b/tests/queries/0_stateless/03319_concurrent_hash_join_double_preallocation_bug.sql
@@ -18,7 +18,7 @@ select * from lhs as t1 join rhs as t2 on t1.a = t2.a format Null;
 -- For the next run we will preallocate the space
 select * from lhs as t1 join rhs as t2 on t1.a = t2.a format Null settings log_comment = '03319_second_query';
 
-system flush logs;
+system flush logs query_log;
 
 select ProfileEvents['HashJoinPreallocatedElementsInHashTables']
 from system.query_log

--- a/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
+++ b/tests/queries/0_stateless/03326_parallel_replicas_out_of_range.sql
@@ -3,7 +3,7 @@
 
 SET enable_analyzer=1;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     count(materialize(toLowCardinality(1))) IGNORE NULLS AS num,

--- a/tests/queries/0_stateless/03335_empty_blobs_on_azure.sh
+++ b/tests/queries/0_stateless/03335_empty_blobs_on_azure.sh
@@ -47,7 +47,7 @@ UUID=`$CLICKHOUSE_CLIENT -q "
     WHERE database = currentDatabase() AND table = 'test_empty_blobs'"`;
 
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS text_log;
 
     -- Check logs for skipping empty blob
     SELECT 'Skipped empty blobs after 1 insert:',  count() FROM system.text_log
@@ -86,7 +86,7 @@ $CLICKHOUSE_CLIENT -m -q "
     SELECT * FROM test_empty_blobs ORDER BY key;
 
     -- Check logs for skipping empty blob
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS text_log;
     SELECT 'Skipped empty blobs after 2 inserts and merge:',  count() FROM system.text_log WHERE 
         message LIKE 'Skipping writing empty blob for path %$UUID/%/arr.bin%' AND
         event_date >= yesterday() AND event_time > now() - interval 10 minute;

--- a/tests/queries/0_stateless/03335_empty_blobs_on_s3.sh
+++ b/tests/queries/0_stateless/03335_empty_blobs_on_s3.sh
@@ -32,7 +32,7 @@ UUID=`$CLICKHOUSE_CLIENT -q "
     WHERE database = currentDatabase() AND table = 'test_empty_blobs'"`;
 
 $CLICKHOUSE_CLIENT -m -q "
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS blob_storage_log, text_log;
 
     -- Check that there were no empty blobs written to S3
     SELECT 'Empty blobs: ', local_path FROM system.blob_storage_log
@@ -81,7 +81,7 @@ $CLICKHOUSE_CLIENT -m -q "
     SELECT * FROM test_empty_blobs ORDER BY key;
 
     -- Check logs for skipping empty blob
-    SYSTEM FLUSH LOGS;
+    SYSTEM FLUSH LOGS text_log;
     SELECT 'Skipped empty blobs after 2 inserts and merge:',  count() FROM system.text_log WHERE 
         message LIKE 'Skipping writing empty blob for path %$UUID/%/arr.bin%' AND
         event_date >= yesterday() AND event_time > now() - interval 10 minute;

--- a/tests/queries/0_stateless/03350_alter_table_fetch_partition_thread_pool.sql
+++ b/tests/queries/0_stateless/03350_alter_table_fetch_partition_thread_pool.sql
@@ -15,5 +15,5 @@ select 'parts in data1', count() from system.parts where database = currentDatab
 alter table data2 fetch partition () from '/tables/{database}/data1';
 select 'detached parts in data2', count() from system.detached_parts where database = currentDatabase() and table = 'data2';
 
-system flush logs;
+system flush logs query_log;
 select 'FETCH PARTITION uses multiple threads', peak_threads_usage>10 from system.query_log where event_date >= yesterday() and type != 'QueryStart' and query_kind = 'Alter' and current_database = currentDatabase();

--- a/tests/queries/0_stateless/03362_filter_transform_profile_events.sql
+++ b/tests/queries/0_stateless/03362_filter_transform_profile_events.sql
@@ -2,5 +2,5 @@ SELECT * FROM system.numbers WHERE number % 2 = 0 LIMIT 100;
 SELECT count() = 2 AS assert_exists FROM system.events WHERE name IN ('FilterTransformPassedRows', 'FilterTransformPassedBytes') HAVING assert_exists;
 
 SELECT * FROM system.numbers WHERE number % 2 = 0 LIMIT 100 FORMAT Null;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['FilterTransformPassedRows'] > 0, ProfileEvents['FilterTransformPassedBytes'] > 0 FROM system.query_log WHERE (type = 'QueryFinish') AND (current_database = currentDatabase()) AND (query = 'SELECT * FROM system.numbers WHERE number % 2 = 0 LIMIT 100 FORMAT Null;');

--- a/tests/queries/0_stateless/03364_prewhere_parallel_replicas.sh
+++ b/tests/queries/0_stateless/03364_prewhere_parallel_replicas.sh
@@ -25,7 +25,7 @@ query_id="${CLICKHOUSE_DATABASE}_prewhere_parallel_replicas_$RANDOM"
 ${CLICKHOUSE_CLIENT} "${opts[@]}" --query_id="${query_id}" --query="SELECT * FROM t WHERE b < 100000" --format Null
 
 ${CLICKHOUSE_CLIENT} -nq "
-  SYSTEM FLUSH LOGS;
+  SYSTEM FLUSH LOGS query_log;
 
   -- Check that all data was read during PREWHERE
   SELECT sum(ProfileEvents['RowsReadByPrewhereReaders']) = sum(ProfileEvents['SelectedRows'])


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adjust a few old tests to flush individual logs

References https://github.com/ClickHouse/ClickHouse/issues/57984

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
