### PR TITLE
Fix excessive memory usage due to prefetch over cached disks

### DIFF
--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -732,7 +732,11 @@ std::unique_ptr<ReadBufferFromFileBase> DiskObjectStorage::readFile(
         ? std::max<size_t>(settings.remote_fs_buffer_size, DBMS_DEFAULT_BUFFER_SIZE)
         : settings.remote_fs_buffer_size;
 
-    size_t total_objects_size = file_size ? *file_size : getTotalSize(storage_objects);
+    /// For object storage file_size and read_hint is interchangeable, and
+    /// read_hint should be respected, since it is passed by various MergeTree
+    /// readers, and we should not read more then this size, since this may
+    /// lead to excessive memory usage.
+    size_t total_objects_size = file_size ? *file_size : (read_hint ? *read_hint : getTotalSize(storage_objects));
     if (total_objects_size)
         buffer_size = std::min(buffer_size, total_objects_size);
 

--- a/tests/queries/0_stateless/03394_cached_disks_wide_tables_memory_usage.sql
+++ b/tests/queries/0_stateless/03394_cached_disks_wide_tables_memory_usage.sql
@@ -1,3 +1,6 @@
+-- Tags: no-fasttest
+-- - no-fasttest -- requires S3
+
 DROP TABLE IF EXISTS metric_log;
 
 SYSTEM FLUSH LOGS metric_log;

--- a/tests/queries/0_stateless/03394_cached_disks_wide_tables_memory_usage.sql
+++ b/tests/queries/0_stateless/03394_cached_disks_wide_tables_memory_usage.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS metric_log;
+
+SYSTEM FLUSH LOGS metric_log;
+CREATE TABLE metric_log AS system.metric_log
+ENGINE = MergeTree
+PARTITION BY tuple()
+ORDER BY (event_date, event_time)
+SETTINGS disk = 's3_cache', merge_selector_base = 1000, min_bytes_for_wide_part = '1Gi';
+
+insert into metric_log select * from generateRandom() limit 4e3;
+insert into metric_log select * from generateRandom() limit 4e3;
+insert into metric_log select * from generateRandom() limit 4e3;
+insert into metric_log select * from generateRandom() limit 4e3;
+insert into metric_log select * from generateRandom() limit 400;
+insert into metric_log select * from generateRandom() limit 400;
+
+OPTIMIZE TABLE metric_log FINAL;
+SYSTEM FLUSH LOGS part_log;
+select * from system.part_log where database = currentDatabase() and table = 'metric_log' and peak_memory_usage > 1_000_000_000 format Vertical;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix excessive memory usage due to prefetch over cached disks (in cloud)

The problem is that MergeTree storage has various advanced storage types, that store all columns in one file, and it passes read_hint, not file_size to the readFile()

Later, in case of cached disks, it may increase the buffer size up to 1MiB, which will lead to huge excessive memory usage (it depends on the initial size, but for system.metric_log I saw **32x difference**.

Note however that this is the case only for advanced features in Cloud.

Note, that https://github.com/ClickHouse/ClickHouse/pull/77898 already fixes this for merges, but not for INSERTs