### PR TITLE
Vector search fixes

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -111,9 +111,21 @@ size_t tryUseVectorSearch(QueryPlan::Node * parent_node, QueryPlan::Nodes & /*no
     /// Extract reference_vec. It is expected to be a COLUMN-type node and of type Const(Array(Float*)).
     const ActionsDAG::NodeRawConstPtrs & sort_column_node_children = sort_column_node->children;
     std::vector<Float64> reference_vector;
+    String search_column_name;
+    /// ORDER BY cosineDistance(vec1, [1.0, 2.0 ...]) -> search_column_name is `vec1` and reference_vector is [1.0, 2.0 ...]
     for (const auto * child : sort_column_node_children)
     {
-        if (child->type == ActionsDAG::ActionType::COLUMN)
+        if (child->type == ActionsDAG::ActionType::ALIAS)
+        {
+            auto column_name_node = child->children.at(0);
+            if (column_name_node->type == ActionsDAG::ActionType::INPUT)
+                search_column_name = column_name_node->result_name;
+        }
+        else if (child->type == ActionsDAG::ActionType::INPUT) /// old analyzer
+        {
+            search_column_name = child->result_name;
+        }
+        else if (child->type == ActionsDAG::ActionType::COLUMN)
         {
             /// Is it an Array(Float32) or Array(Float64) column?
             const DataTypePtr & data_type = child->result_type;
@@ -148,10 +160,10 @@ size_t tryUseVectorSearch(QueryPlan::Node * parent_node, QueryPlan::Nodes & /*no
         }
     }
 
-    if (reference_vector.empty())
+    if (search_column_name.empty() || reference_vector.empty())
         return updated_layers;
 
-    auto vector_search_parameters = std::make_optional<VectorSearchParameters>(distance_function, n, reference_vector);
+    auto vector_search_parameters = std::make_optional<VectorSearchParameters>(search_column_name, distance_function, n, reference_vector);
     read_from_mergetree_step->setVectorSearchParameters(std::move(vector_search_parameters));
 
     return updated_layers;

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.h
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.h
@@ -142,6 +142,7 @@ class MergeTreeIndexConditionVectorSimilarity final : public IMergeTreeIndexCond
 public:
     explicit MergeTreeIndexConditionVectorSimilarity(
         const std::optional<VectorSearchParameters> & parameters_,
+        const String & index_column_name_,
         unum::usearch::metric_kind_t metric_kind_,
         ContextPtr context);
 
@@ -153,6 +154,7 @@ public:
 
 private:
     std::optional<VectorSearchParameters> parameters;
+    const String index_column_name;
     const unum::usearch::metric_kind_t metric_kind;
     const size_t expansion_search;
 };
@@ -176,6 +178,7 @@ public:
     bool isVectorSimilarityIndex() const override { return true; }
 
 private:
+    const String index_column_name;
     const unum::usearch::metric_kind_t metric_kind;
     const unum::usearch::scalar_kind_t scalar_kind;
     const UsearchHnswParams usearch_hnsw_params;

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -43,6 +43,7 @@ struct MergeTreeIndexFormat
 /// A vehicle which transports elements of the SELECT query to the vector similarity index.
 struct VectorSearchParameters
 {
+    String search_column_name;
     String distance_function;
     size_t limit;
     std::vector<Float64> reference_vector;

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -49,13 +49,6 @@
     Sizes of columns doesn't match
 02861_filter_pushdown_const_bug
 
-    https://github.com/ClickHouse/ClickHouse/issues/74547
-    vector search segfault
-02354_vector_search_multiple_marks
-02354_vector_search_expansion_search
-02354_vector_search_detach_attach
-02354_vector_search_different_array_sizes
-
     https://github.com/ClickHouse/ClickHouse/issues/74711
 03080_incorrect_join_with_merge
 

--- a/tests/queries/0_stateless/02354_vector_search_correct_index.reference
+++ b/tests/queries/0_stateless/02354_vector_search_correct_index.reference
@@ -1,0 +1,25 @@
+Expression (Project names)
+  Limit (preliminary LIMIT (without OFFSET))
+    Sorting (Sorting for ORDER BY)
+      Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+        ReadFromMergeTree (default.tab)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 1/1
+            Granules: 1/1
+          Skip
+            Name: idx
+            Description: vector_similarity GRANULARITY 100000000
+            Parts: 1/1
+            Granules: 1/1
+Expression (Project names)
+  Limit (preliminary LIMIT (without OFFSET))
+    Sorting (Sorting for ORDER BY)
+      Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+        ReadFromMergeTree (default.tab)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 1/1
+            Granules: 1/1

--- a/tests/queries/0_stateless/02354_vector_search_correct_index.sql
+++ b/tests/queries/0_stateless/02354_vector_search_correct_index.sql
@@ -1,0 +1,15 @@
+-- Tags: no-fasttest, no-ordinary-database
+
+set allow_experimental_vector_similarity_index=1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab(id Int32, vec1 Array(Float32), vec2 Array(Float32), INDEX idx vec1 TYPE vector_similarity('hnsw', 'L2Distance')) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (0, [1.0, 0.0], [1.0, 0.0]), (1, [1.1, 0.0], [1.1, 0.0]), (2, [1.2, 0.0], [1.2, 0.0]), (3, [1.3, 0.0], [1.3, 0.0]), (4, [1.4, 0.0], [1.4, 0,0]), (5, [1.5, 0.0], [1.5, 0.0]), (6, [0.0, 2.0], [0.0, 2.0]), (7, [0.0, 2.1], [0.0, 2.1]), (8, [0.0, 2.2], [0.0, 2.2]), (9, [0.0, 2.3], [0.0, 2.3]), (10, [0.0, 2.4], [0.0, 2.4]), (11, [0.0, 2.5], [0.0, 2.5]);
+
+-- should use vector index
+explain indexes=1 WITH [0.0, 2.0] AS reference_vec SELECT id FROM tab ORDER BY L2Distance(vec1, reference_vec) LIMIT 3;
+
+-- should not use vector index as column is vec2
+explain indexes=1 WITH [0.0, 2.0] AS reference_vec SELECT id FROM tab ORDER BY L2Distance(vec2, reference_vec) LIMIT 3;


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/77894 - Crash when multiple connections/threads accessed a vector index
Resolves https://github.com/ClickHouse/ClickHouse/issues/77978 - Vector index was incorrectly used for a KNN query
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Clickhouse server process crashes when multiple connections/threads concurrently accessed a vector index is now resolved
- A vector search query on a non-indexed vector column was returning incorrect results if there was another vector column in the table with a defined similarity index. The query now correctly performs a brute-force search (KNN) and returns correct results.
