### PR TITLE
tests: fix test_backup_restore_s3 flakiness

### DIFF
--- a/tests/integration/test_backup_restore_s3/configs/s3_settings.xml
+++ b/tests/integration/test_backup_restore_s3/configs/s3_settings.xml
@@ -1,6 +1,7 @@
 <clickhouse>
     <s3>
         <use_environment_credentials>0</use_environment_credentials>
+        <use_adaptive_timeouts>false</use_adaptive_timeouts>
         <multipart>
             <endpoint>http://minio1:9001/root/data/backups/multipart/</endpoint>
             <!-- We set max_single_part_upload_size and max_single_operation_copy_size to 1 here so


### PR DESCRIPTION
CI found [1]:

    $ grep 84a3068d83e9432ab27a7648ff7c9761 test_backup_restore_s3/_instances-0-gw0/node/logs/clickhouse-server.log | grep -e Failed -e 84a3068d83e9432ab27a7648ff7c9761.*executeQuery:
    2025.03.19 15:54:18.095032 [ 797 ] {84a3068d83e9432ab27a7648ff7c9761} <Debug> executeQuery: (from 172.16.3.1:60774) (query 1, line 1) BACKUP TABLE data TO S3('http://minio1:9001/root2/data/backups/backup13', 'miniorestricted2', '[HIDDEN]') SETTINGS allow_s3_native_copy = false (stage: Complete)
    2025.03.19 15:54:23.270635 [ 1631 ] {84a3068d83e9432ab27a7648ff7c9761} <Information> AWSClient: Failed to make request to: http://minio1:9001/root2/data/backups/backup13/data/default/data/all_1_10_2/array.bin?partNumber=11&uploadId=NDBlYmY2YWYtMTQ5NC00MWM4LWJjYjQtNjI2ZGNhMTBmOTg1LmUxZDgyYmM5LWE2NDYtNGYzNS1hMWI1LTRkNGVjYjQwMDczZXgxNzQyMzk5NjU5OTM2MTg3OTYy: Poco::Exception. Code: 1000, e.code() = 0, Timeout, Stack trace (when copying this message, always include the lines below):
    2025.03.19 15:54:25.554649 [ 797 ] {84a3068d83e9432ab27a7648ff7c9761} <Debug> executeQuery: Read 1 rows, 46.00 B in 7.45974 sec., 0.13405292945866745 rows/sec., 6.17 B/sec.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5bb0e1a5ec306a8424e646b02b7ed01c74ad3131&name_0=MasterCI&name_1=Integration%20tests%20%28asan%2C%20old%20analyzer%2C%203%2F6%29

Due to adapative timeout the requests may fail and increase S3WriteRequestsErrors, let's see how stable it will be w/o adaptive timeout (30 second connect timeout by default).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)