### PR TITLE
Reset cursor blinking on client termination

### DIFF
--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -485,6 +485,10 @@ ReplxxLineReader::~ReplxxLineReader()
 {
     if (history_file_fd >= 0 && close(history_file_fd))
         rx.print("Close of history file failed: %s\n", errnoToString().c_str());
+
+    /// Reset cursor blinking
+    if (overwrite_mode)
+        rx.print("%s", "\033[0 q");
 }
 
 LineReader::InputStatus ReplxxLineReader::readOneLine(const String & prompt)


### PR DESCRIPTION
Otherwise you may leave the terminal with it

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)