### PR TITLE
Optimize incremental compilation in case of MarkRange.h changes

### DIFF
--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -178,11 +178,6 @@ void Chunk::append(const Chunk & chunk, size_t from, size_t length)
     setColumns(std::move(mutable_columns), rows);
 }
 
-void MarkRangesInfo::appendMarkRanges(const MarkRanges & mark_ranges_)
-{
-    mark_ranges.insert(mark_ranges.end(), mark_ranges_.begin(), mark_ranges_.end());
-}
-
 void convertToFullIfConst(Chunk & chunk)
 {
     size_t num_rows = chunk.getNumRows();

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -3,7 +3,6 @@
 #include <Columns/IColumn_fwd.h>
 #include <Common/CollectionOfDerived.h>
 #include <Core/Types_fwd.h>
-#include <Storages/MergeTree/MarkRange.h>
 
 #include <memory>
 
@@ -157,30 +156,6 @@ public:
 };
 
 using AsyncInsertInfoPtr = std::shared_ptr<AsyncInsertInfo>;
-
-/// Lineage information: from which table, part and mark range does the chunk come from?
-/// This information is needed by the query condition cache.
-class MarkRangesInfo : public ChunkInfoCloneable<MarkRangesInfo>
-{
-public:
-    MarkRangesInfo(UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, MarkRanges mark_ranges_)
-        : table_uuid(table_uuid_)
-        , part_name(part_name_)
-        , marks_count(marks_count_)
-        , has_final_mark(has_final_mark_)
-        , mark_ranges(std::move(mark_ranges_))
-    {}
-
-    void appendMarkRanges(const MarkRanges & mark_ranges_);
-
-    UUID table_uuid;
-    String part_name;
-    size_t marks_count;
-    bool has_final_mark;
-    MarkRanges mark_ranges;
-};
-
-using MarkRangesInfoPtr = std::shared_ptr<MarkRangesInfo>;
 
 /// Converts all columns to full serialization in chunk.
 /// It's needed, when you have to access to the internals of the column,

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Processors/Chunk.h>
+#include <Storages/MergeTree/MarkRange.h>
 #include <Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h>
 
 namespace ProfileEvents

--- a/src/Storages/MergeTree/MarkRange.cpp
+++ b/src/Storages/MergeTree/MarkRange.cpp
@@ -3,6 +3,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 
+#include <base/defines.h>
 #include <fmt/ranges.h>
 
 namespace DB
@@ -11,6 +12,11 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+}
+
+MarkRange::MarkRange(size_t begin_, size_t end_) : begin(begin_), end(end_)
+{
+    chassert(begin <= end);
 }
 
 size_t MarkRange::getNumberOfMarks() const
@@ -115,6 +121,18 @@ void MarkRanges::deserialize(ReadBuffer & in)
         readBinaryLittleEndian((*this)[i].begin, in);
         readBinaryLittleEndian((*this)[i].end, in);
     }
+}
+
+MarkRangesInfo::MarkRangesInfo(UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, MarkRanges mark_ranges_)
+    : table_uuid(table_uuid_)
+    , part_name(part_name_)
+    , marks_count(marks_count_)
+    , has_final_mark(has_final_mark_)
+    , mark_ranges(mark_ranges_)
+{}
+void MarkRangesInfo::appendMarkRanges(const MarkRanges & mark_ranges_)
+{
+    mark_ranges.insert(mark_ranges.end(), mark_ranges_.begin(), mark_ranges_.end());
 }
 
 }

--- a/src/Storages/MergeTree/MarkRange.h
+++ b/src/Storages/MergeTree/MarkRange.h
@@ -2,14 +2,15 @@
 
 #include <cstddef>
 #include <deque>
-
+#include <Processors/Chunk.h>
 #include <fmt/format.h>
-
-#include <IO/WriteBuffer.h>
-#include <IO/ReadBuffer.h>
+#include <base/types.h>
 
 namespace DB
 {
+
+class ReadBuffer;
+class WriteBuffer;
 
 
 /** A pair of marks that defines the range of rows in a part. Specifically,
@@ -21,7 +22,7 @@ struct MarkRange
     size_t end;
 
     MarkRange() = default;
-    MarkRange(size_t begin_, size_t end_) : begin(begin_), end(end_) { chassert(begin <= end); }
+    MarkRange(size_t begin_, size_t end_);
 
     size_t getNumberOfMarks() const;
 
@@ -48,6 +49,22 @@ size_t getLastMark(const MarkRanges & ranges);
 std::string toString(const MarkRanges & ranges);
 
 void assertSortedAndNonIntersecting(const MarkRanges & ranges);
+
+/// Lineage information: from which table, part and mark range does the chunk come from?
+/// This information is needed by the query condition cache.
+class MarkRangesInfo : public ChunkInfoCloneable<MarkRangesInfo>
+{
+public:
+    MarkRangesInfo(UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, MarkRanges mark_ranges_);
+    void appendMarkRanges(const MarkRanges & mark_ranges_);
+
+    UUID table_uuid;
+    String part_name;
+    size_t marks_count;
+    bool has_final_mark;
+    MarkRanges mark_ranges;
+};
+using MarkRangesInfoPtr = std::shared_ptr<MarkRangesInfo>;
 
 }
 


### PR DESCRIPTION
The problem is that Chunk.h is very common header, and it includes MarkRange, so let's simply move ChunkInfoCloneable<MarkRangesInfo> into MarkRange.h

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)