### PR TITLE
Fix cloning of ASTTableIdentifier (fixes AST fuzzer on CI)

### DIFF
--- a/src/Parsers/ASTIdentifier.cpp
+++ b/src/Parsers/ASTIdentifier.cpp
@@ -206,6 +206,7 @@ ASTPtr ASTTableIdentifier::clone() const
 {
     auto ret = std::make_shared<ASTTableIdentifier>(*this);
     ret->semantic = std::make_shared<IdentifierSemanticImpl>(*ret->semantic);
+    ret->cloneChildren();
     return ret;
 }
 

--- a/src/Parsers/ASTQueryParameter.cpp
+++ b/src/Parsers/ASTQueryParameter.cpp
@@ -18,6 +18,13 @@ void ASTQueryParameter::formatImplWithoutAlias(WriteBuffer & ostr, const FormatS
         << (settings.hilite ? hilite_none : "");
 }
 
+ASTPtr ASTQueryParameter::clone() const
+{
+    auto ret = std::make_shared<ASTQueryParameter>(*this);
+    ret->cloneChildren();
+    return ret;
+}
+
 void ASTQueryParameter::appendColumnNameImpl(WriteBuffer & ostr) const
 {
     writeString(name, ostr);

--- a/src/Parsers/ASTQueryParameter.h
+++ b/src/Parsers/ASTQueryParameter.h
@@ -19,7 +19,7 @@ public:
     /** Get the text that identifies this element. */
     String getID(char delim) const override { return String("QueryParameter") + delim + name + ':' + type; }
 
-    ASTPtr clone() const override { return std::make_shared<ASTQueryParameter>(*this); }
+    ASTPtr clone() const override;
 
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 

--- a/tests/queries/0_stateless/03393_ASTTableIdentifier_fuzzer.sql
+++ b/tests/queries/0_stateless/03393_ASTTableIdentifier_fuzzer.sql
@@ -1,0 +1,2 @@
+create table null (key Int) engine=Null;
+SELECT * FROM {CLICKHOUSE_DATABASE:Identifier}.null;


### PR DESCRIPTION
Note, that the real fix for is in ASTTableIdentifier::clone(), the second one (in ASTQueryParameter::clone()) is just to make it less error-prone for futher development.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix cloning of ASTQueryParameter

Fixes: https://github.com/ClickHouse/ClickHouse/issues/78015