### PR TITLE
tests: disable 01304_direct_io_long under TSan

### DIFF
--- a/tests/queries/0_stateless/01304_direct_io_long.sh
+++ b/tests/queries/0_stateless/01304_direct_io_long.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: long, no-object-storage-with-slow-build, no-flaky-check
-# It can be too long with ThreadFuzzer
+# Tags: long, no-object-storage, no-flaky-check, no-tsan
+# - no-flaky-check - It can be too long with ThreadFuzzer
+# - no-tsan - It is slow under TSan and may lead to query timeouts
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=78002&sha=277e6b47cbb48700276e74c8a48c301e85880e89&name_0=PR&name_1=Stateless%20tests%20%28tsan%2C%202%2F3%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)