### PR TITLE
Use proper error code over LOGICAL_ERROR for unsupported GLOBAL JOIN kind (fixes AST fuzzer)

### DIFF
--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -41,6 +41,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int INCOMPATIBLE_TYPE_OF_JOIN;
     extern const int DISTRIBUTED_IN_JOIN_SUBQUERY_DENIED;
 }
 
@@ -381,7 +382,7 @@ QueryTreeNodePtr buildQueryTreeForShard(const PlannerContextPtr & planner_contex
             else
             {
                 throw Exception(
-                    ErrorCodes::LOGICAL_ERROR, "Unexpected join kind: {}", join_kind);
+                    ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN, "Unexpected join kind: {}", join_kind);
             }
 
             auto subquery_node

--- a/tests/queries/0_stateless/03395_global_join_unsupported_kind.sql
+++ b/tests/queries/0_stateless/03395_global_join_unsupported_kind.sql
@@ -1,0 +1,1 @@
+SELECT t1.* FROM remote('127.1') AS t1 global FULL OUTER JOIN remote('127.1') AS t2 ON t1.dummy = t2.dummy SETTINGS allow_experimental_analyzer=1; -- { serverError INCOMPATIBLE_TYPE_OF_JOIN }


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=78016&sha=latest&name_0=PR&name_1=AST+fuzzer+%28ubsan%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)