### PR TITLE
tests: fix 03293_tty_binary_confirmation flakiness

### DIFF
--- a/tests/queries/0_stateless/03293_tty_binary_confirmation.expect
+++ b/tests/queries/0_stateless/03293_tty_binary_confirmation.expect
@@ -25,7 +25,7 @@ expect_after {
 # useful debugging configuration
 # exp_internal 1
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion --enable-progress-table-toggle=0 --highlight 0 --history_file=$history_file"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion --enable-progress-table-toggle=0 --highlight 0 --progress no --history_file=$history_file"
 expect ":) "
 
 # Make a query


### PR DESCRIPTION
The problem is that it is likely interfer with progress and never receive the match that expect(1) expectds

I.e. here [1] it does not match first "PAR", while there is binary in the output, so it is definitelly should be there, and it is release build, timeout is not possible there.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b928c8e96e24f0bd0a69743d03b972c900813b30&name_0=MasterCI&name_1=Stateless%20tests%20%28release%29

Closes https://github.com/ClickHouse/ClickHouse/issues/78053

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
