### PR TITLE
It only to be fixed if metadata_version in memory metadata less than replica_metadata_version

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -214,7 +214,9 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
         const bool replica_metadata_version_exists = replica_metadata_version != -1;
         if (replica_metadata_version_exists)
         {
-            storage.setInMemoryMetadata(storage.getInMemoryMetadataPtr()->withMetadataVersion(replica_metadata_version));
+            const Int32 current_replica_metadata_version = storage.getInMemoryMetadataPtr()->getMetadataVersion();
+            if (current_replica_metadata_version < replica_metadata_version)
+                storage.setInMemoryMetadata(storage.getInMemoryMetadataPtr()->withMetadataVersion(replica_metadata_version));
         }
         else
         {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

It only to be fixed if `metadata_version` in memory metadata less than `replica_metadata_version`, in `tests/queries/0_stateless/02432_s3_parallel_parts_cleanup.sql`, sometimes may cause error : 
```
Code: 517. DB::Exception: Received from localhost:9000. DB::Exception: Metadata on replica is not up to date with common metadata in Zookeeper. It means that this replica still not applied some of previous alters. Probably too many alters executing concurrently (highly not recommended). You can retry this error. (CANNOT_ASSIGN_ALTER)
(query: alter table rmt2 modify column k Nullable(String); 
```
because `metadata_version` in memory is 2, but `fixReplicaMetadataVersionIfNeeded()` returned 0 (rmt2 create by `cloneMetadataIfNeeded()`, it is metadata_alters_in_queue != 0), caused `metadata_version` in memory set to 0.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
