### PR TITLE
tests: remove --print-time option for clickhouse-test (always print them)

### DIFF
--- a/ci/jobs/functional_stateful_tests.py
+++ b/ci/jobs/functional_stateful_tests.py
@@ -37,7 +37,7 @@ def run_test(
     test_output_file = f"{temp_dir}/test_result.txt"
 
     test_command = f"clickhouse-test --jobs 2 --testname --shard --zookeeper --check-zookeeper-session --no-stateless \
-        --hung-check --print-time \
+        --hung-check \
         --capture-client-stacktrace --queries ./tests/queries -- '{test}' \
         | ts '%Y-%m-%d %H:%M:%S' | tee -a \"{test_output_file}\""
     if Path(test_output_file).exists():

--- a/ci/jobs/functional_stateless_tests.py
+++ b/ci/jobs/functional_stateless_tests.py
@@ -40,10 +40,10 @@ def run_stateless_test(
     nproc = int(Utils.cpu_count() / 2)
     if batch_num and batch_total:
         aux = f"--run-by-hash-total {batch_total} --run-by-hash-num {batch_num-1}"
-    statless_test_command = f"clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --hung-check --print-time \
+    statless_test_command = f"clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --hung-check \
                 --capture-client-stacktrace --queries /repo/tests/queries --test-runs 1 --hung-check \
                 {'--no-parallel' if no_parallel else ''}  {'--no-sequential' if no_sequiential else ''} \
-                --print-time --jobs {nproc} --report-coverage --report-logs-stats {aux} \
+                --jobs {nproc} --report-coverage --report-logs-stats {aux} \
                 --queries ./tests/queries -- '{test}' | ts '%Y-%m-%d %H:%M:%S' \
                 | tee -a \"{test_output_file}\""
     if Path(test_output_file).exists():

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -28,7 +28,7 @@ class ClickHouseProc:
         self.proc = None
         self.pid = 0
         nproc = int(Utils.cpu_count() / 2)
-        self.fast_test_command = f"clickhouse-test --hung-check --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --zookeeper --check-zookeeper-session --order random --print-time --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc} -- '{{TEST}}' | ts '%Y-%m-%d %H:%M:%S' \
+        self.fast_test_command = f"clickhouse-test --hung-check --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --zookeeper --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc} -- '{{TEST}}' | ts '%Y-%m-%d %H:%M:%S' \
         | tee -a \"{self.test_output_file}\""
         # TODO: store info in case of failure
         self.info = ""

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -97,7 +97,6 @@ def get_run_command(
     tests_to_run: List[str],
 ) -> str:
     additional_options = ["--hung-check"]
-    additional_options.append("--print-time")
 
     if tests_to_run:
         additional_options += tests_to_run

--- a/tests/ci/libfuzzer_test_check.py
+++ b/tests/ci/libfuzzer_test_check.py
@@ -68,7 +68,6 @@ def get_run_command(
     image: DockerImage,
 ) -> str:
     additional_options = ["--hung-check"]
-    additional_options.append("--print-time")
 
     additional_options_str = (
         '-e ADDITIONAL_OPTIONS="' + " ".join(additional_options) + '"'

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1738,9 +1738,7 @@ class TestCase:
         return TestResult(self.name, TestStatus.OK, None, total_time, description)
 
     def print_test_time(self, test_time) -> str:
-        if self.args.print_time:
-            return f" {test_time:.2f} sec."
-        return ""
+        return f" {test_time:.2f} sec."
 
     def process_result(self, result: TestResult, messages):
         args = self.args
@@ -3571,9 +3569,6 @@ def parse_args():
     )
     parser.add_argument(
         "--client-option", nargs="+", help="Specify additional client argument"
-    )
-    parser.add_argument(
-        "--print-time", action="store_true", dest="print_time", help="Print test time"
     )
     parser.add_argument(
         "--check-zookeeper-session",

--- a/tests/docker_scripts/stateful_runner.sh
+++ b/tests/docker_scripts/stateful_runner.sh
@@ -238,7 +238,6 @@ function run_tests()
         --check-zookeeper-session
         --no-stateless
         --hung-check
-        --print-time
         --capture-client-stacktrace
         --queries "/repo/tests/queries"
         "${ADDITIONAL_OPTIONS[@]}"

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -351,7 +351,6 @@ function run_tests()
         --testname
         --check-zookeeper-session
         --hung-check
-        --print-time
         --capture-client-stacktrace
         --queries "/repo/tests/queries"
         --test-runs "$NUM_TRIES"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)