### PR TITLE
Fix "The requested output format {} is binary... Do you want to output it anyway? [y/N]" prompt

### DIFF
--- a/src/IO/Ask.cpp
+++ b/src/IO/Ask.cpp
@@ -15,6 +15,7 @@ bool ask(std::string question, ReadBuffer & in, WriteBuffer & out)
         writeText(question, out);
         out.next();
         readStringUntilNewlineInto(answer, in);
+        skipToNextLineOrEOF(in);
 
         if (answer.empty() || answer == "n" || answer == "N")
             return false;

--- a/tests/queries/0_stateless/03293_tty_binary_confirmation.expect
+++ b/tests/queries/0_stateless/03293_tty_binary_confirmation.expect
@@ -44,7 +44,7 @@ send -- "n\r"
 
 expect {
     "PAR" { exit 1 }
-    ":) " { send -- "\r" }
+    ":) " {}
 }
 
 send -- "SELECT 1 FORMAT Parquet\r"
@@ -54,7 +54,7 @@ send -- "\r"
 
 expect {
     "PAR" { exit 1 }
-    ":) " { send -- "\r" }
+    ":) " {}
 }
 
 send -- "exit\r"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "The requested output format {} is binary... Do you want to output it anyway? [y/N]" prompt

Previously due to we do not consume the last LF, after first question we will always get that LF as an answer for the second, and this will be treated as default "N".

And this was part of the problem why `03293_tty_binary_confirmation` was flaky (previously I was able to reproduce the test failures with 100/1000 runs, after even after 10000 runs no failures. Though the failure reasons was different, but let's see)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/78053
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/74989