### PR TITLE
Revert "Revert "Select and load the correct vector index based on search column""

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -143,6 +143,7 @@ void USearchIndexWithSerialization::deserialize(ReadBuffer & istr)
         /// See the comment in MergeTreeIndexGranuleVectorSimilarity::deserializeBinary why we throw here
         throw Exception(ErrorCodes::INCORRECT_DATA, "Could not load vector similarity index. Please drop the index and create it again. Error: {}", String(result.error.release()));
 
+    /// Indicate the number of concurrent threads that will potentially search this specific usearch index
     try_reserve(limits());
 }
 
@@ -396,9 +397,11 @@ void MergeTreeIndexAggregatorVectorSimilarity::update(const Block & block, size_
 
 MergeTreeIndexConditionVectorSimilarity::MergeTreeIndexConditionVectorSimilarity(
     const std::optional<VectorSearchParameters> & parameters_,
+    const String & index_column_,
     unum::usearch::metric_kind_t metric_kind_,
     ContextPtr context)
     : parameters(parameters_)
+    , index_column(index_column_)
     , metric_kind(metric_kind_)
     , expansion_search(context->getSettingsRef()[Setting::hnsw_candidate_list_size_for_search])
 {
@@ -413,13 +416,21 @@ bool MergeTreeIndexConditionVectorSimilarity::mayBeTrueOnGranule(MergeTreeIndexG
 
 bool MergeTreeIndexConditionVectorSimilarity::alwaysUnknownOrTrue() const
 {
-    /// The vector similarity index was build for a specific distance function ("metric_kind").
-    /// We can use it for vector search only if the distance function used in the SELECT query is the same.
-    bool distance_function_in_query_and_distance_function_in_index_match = parameters &&
-        ((parameters->distance_function == "L2Distance" && metric_kind == unum::usearch::metric_kind_t::l2sq_k)
-        || (parameters->distance_function == "cosineDistance" && metric_kind == unum::usearch::metric_kind_t::cos_k));
+    if (!parameters)
+        return true;
 
-    return !distance_function_in_query_and_distance_function_in_index_match;
+    /// The vector similarity index was build on a specific column.
+    /// It can only be used if the ORDER BY clause in the SELECT query is against the same column.
+    if (parameters->column != index_column)
+        return true;
+
+    /// The vector similarity index was build for a specific distance function.
+    /// It can only be used if the ORDER BY clause in the SELECT query uses the same distance function.
+    if ((parameters->distance_function == "L2Distance" && metric_kind != unum::usearch::metric_kind_t::l2sq_k)
+        || (parameters->distance_function == "cosineDistance" && metric_kind != unum::usearch::metric_kind_t::cos_k))
+            return true;
+
+    return false;
 }
 
 std::vector<UInt64> MergeTreeIndexConditionVectorSimilarity::calculateApproximateNearestNeighbors(MergeTreeIndexGranulePtr granule_) const
@@ -496,7 +507,8 @@ MergeTreeIndexConditionPtr MergeTreeIndexVectorSimilarity::createIndexCondition(
 
 MergeTreeIndexConditionPtr MergeTreeIndexVectorSimilarity::createIndexCondition(const ActionsDAG * /*filter_actions_dag*/, ContextPtr context, const std::optional<VectorSearchParameters> & parameters) const
 {
-    return std::make_shared<MergeTreeIndexConditionVectorSimilarity>(parameters, metric_kind, context);
+    const String & index_column = index.column_names[0];
+    return std::make_shared<MergeTreeIndexConditionVectorSimilarity>(parameters, index_column, metric_kind, context);
 }
 
 MergeTreeIndexPtr vectorSimilarityIndexCreator(const IndexDescription & index)

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.h
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.h
@@ -142,6 +142,7 @@ class MergeTreeIndexConditionVectorSimilarity final : public IMergeTreeIndexCond
 public:
     explicit MergeTreeIndexConditionVectorSimilarity(
         const std::optional<VectorSearchParameters> & parameters_,
+        const String & index_column_,
         unum::usearch::metric_kind_t metric_kind_,
         ContextPtr context);
 
@@ -153,6 +154,7 @@ public:
 
 private:
     std::optional<VectorSearchParameters> parameters;
+    const String index_column;
     const unum::usearch::metric_kind_t metric_kind;
     const size_t expansion_search;
 };

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -43,6 +43,7 @@ struct MergeTreeIndexFormat
 /// A vehicle which transports elements of the SELECT query to the vector similarity index.
 struct VectorSearchParameters
 {
+    String column;
     String distance_function;
     size_t limit;
     std::vector<Float64> reference_vector;

--- a/tests/queries/0_stateless/02354_vector_search_choose_correct_index.reference
+++ b/tests/queries/0_stateless/02354_vector_search_choose_correct_index.reference
@@ -1,0 +1,27 @@
+Searches on vec1 should use the vector index
+Expression (Project names)
+  Limit (preliminary LIMIT (without OFFSET))
+    Sorting (Sorting for ORDER BY)
+      Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+        ReadFromMergeTree (default.tab)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 1/1
+            Granules: 1/1
+          Skip
+            Name: idx
+            Description: vector_similarity GRANULARITY 100000000
+            Parts: 1/1
+            Granules: 1/1
+Searches on vec2 should be brute force
+Expression (Project names)
+  Limit (preliminary LIMIT (without OFFSET))
+    Sorting (Sorting for ORDER BY)
+      Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+        ReadFromMergeTree (default.tab)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 1/1
+            Granules: 1/1

--- a/tests/queries/0_stateless/02354_vector_search_choose_correct_index.sql
+++ b/tests/queries/0_stateless/02354_vector_search_choose_correct_index.sql
@@ -1,4 +1,5 @@
--- Tags: no-fasttest, no-ordinary-database
+-- Tags: no-fasttest, no-ordinary-database, no-parallel-replicas
+-- no-parallel-replicas: EXPLAIN returns a different plan, this is expected behavior
 
 SET allow_experimental_vector_similarity_index=1;
 SET enable_analyzer = 1; -- analyzer vs. non-analyzer produce slightly different EXPLAIN

--- a/tests/queries/0_stateless/02354_vector_search_choose_correct_index.sql
+++ b/tests/queries/0_stateless/02354_vector_search_choose_correct_index.sql
@@ -1,0 +1,18 @@
+-- Tags: no-fasttest, no-ordinary-database
+
+SET allow_experimental_vector_similarity_index=1;
+SET enable_analyzer = 1; -- analyzer vs. non-analyzer produce slightly different EXPLAIN
+
+-- Test for issue #77978
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab(id Int32, vec1 Array(Float32), vec2 Array(Float32), INDEX idx vec1 TYPE vector_similarity('hnsw', 'L2Distance')) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (0, [1.0, 0.0], [1.0, 0.0]), (1, [1.1, 0.0], [1.1, 0.0]), (2, [1.2, 0.0], [1.2, 0.0]), (3, [1.3, 0.0], [1.3, 0.0]), (4, [1.4, 0.0], [1.4, 0,0]), (5, [1.5, 0.0], [1.5, 0.0]), (6, [0.0, 2.0], [0.0, 2.0]), (7, [0.0, 2.1], [0.0, 2.1]), (8, [0.0, 2.2], [0.0, 2.2]), (9, [0.0, 2.3], [0.0, 2.3]), (10, [0.0, 2.4], [0.0, 2.4]), (11, [0.0, 2.5], [0.0, 2.5]);
+
+SELECT 'Searches on vec1 should use the vector index';
+EXPLAIN indexes=1 WITH [0.0, 2.0] AS reference_vec SELECT id FROM tab ORDER BY L2Distance(vec1, reference_vec) LIMIT 3;
+
+SELECT 'Searches on vec2 should be brute force';
+EXPLAIN indexes=1 WITH [0.0, 2.0] AS reference_vec SELECT id FROM tab ORDER BY L2Distance(vec2, reference_vec) LIMIT 3;


### PR DESCRIPTION
#78101 reverted #78069 because of failures in `02354_vector_search_choose_correct_index` with parallel replicas. This PR reverts the revert, the test now no longer runs on parallel replicas (--> https://github.com/ClickHouse/ClickHouse/commit/d09ac6845b6284a67a190550af4be2faec8eb399)

@shankar-iyer 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)