### PR TITLE
tests: disable 02125_many_mutations* for Replicated database (too slow)

### DIFF
--- a/tests/queries/0_stateless/02125_many_mutations.sh
+++ b/tests/queries/0_stateless/02125_many_mutations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-shared-merge-tree
+# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-shared-merge-tree, no-parallel, no-replicated-database
 # no-shared-merge-tree -- this test is too slow
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/02125_many_mutations_2.sh
+++ b/tests/queries/0_stateless/02125_many_mutations_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-parallel, no-shared-merge-tree
+# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-parallel, no-shared-merge-tree, no-replicated-database
 # no-shared-merge-tree -- this test is too slow
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
There are lot of failures for this two tests (`02125_many_mutations` and `02125_many_mutations_2`), and the problem is that they are just too slow to run on **Replicated database** (especially w/o no-parallel) [1] - **15x slower**.

Anyway this test is not for Replicated database.

  [1]: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3Rfc3RhdHVzLCB0ZXN0X2R1cmF0aW9uX21zLCB0ZXN0X25hbWUKRlJPTSBjaGVja3MKV0hFUkUgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDIgZGF5CiAgICBBTkQgKGNoZWNrX25hbWUgPSAnU3RhdGVsZXNzIHRlc3RzIChyZWxlYXNlKScgT1IgY2hlY2tfbmFtZSBMSUtFICclRGF0YWJhc2VSZXBsaWNhdGVkJScpCiAgICBBTkQgKGhlYWRfcmVmID0gJ21hc3RlcicgQU5EIHN0YXJ0c1dpdGgoaGVhZF9yZXBvLCAnQ2xpY2tIb3VzZS8nKSkKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIEFORCBwb3NpdGlvbih0ZXN0X25hbWUsICcwMjEyNV9tYW55X211dGF0aW9ucycpID4gMApPUkRFUiBCWSBjaGVja19zdGFydF90aW1lCkxJTUlUIDUwIEJZIGNoZWNrX25hbWUKTElNSVQgMTAw

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/65589