### PR TITLE
Better detection of dirty files in the source directory after build

### DIFF
--- a/docker/packager/binary-builder/build.sh
+++ b/docker/packager/binary-builder/build.sh
@@ -89,8 +89,8 @@ cmake --debug-trycompile -DCMAKE_VERBOSE_MAKEFILE=1 -LA "-DCMAKE_BUILD_TYPE=$BUI
 ninja $NINJA_FLAGS $BUILD_TARGET
 
 # We don't allow dirty files in the source directory after build
-git ls-files --others --exclude-standard | grep . && echo "^ Dirty files in the working copy after build" && exit 1
-git submodule foreach --quiet git ls-files --others --exclude-standard | grep . && echo "^ Dirty files in submodules after build" && exit 1
+git ls-files --others --exclude build_docker\* | grep . && echo "^ Dirty files in the working copy after build" && exit 1
+git submodule foreach --quiet git ls-files --others | grep . && echo "^ Dirty files in submodules after build" && exit 1
 
 ls -la ./programs
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better detection of dirty files in the source directory after build

Closes https://github.com/ClickHouse/ClickHouse/issues/77521

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
