### PR TITLE
Fix system.detached_tables after RENAME DATABASE or DROP TABLE

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -362,6 +362,8 @@ void DatabaseOnDisk::dropTable(ContextPtr local_context, const String & table_na
             table->drop();
             table->is_dropped = true;
         }
+        std::lock_guard lock(mutex);
+        snapshot_detached_tables.erase(table_name);
     }
     catch (...)
     {

--- a/tests/queries/0_stateless/03397_system_detached_tables_rename_drop.reference
+++ b/tests/queries/0_stateless/03397_system_detached_tables_rename_drop.reference
@@ -1,0 +1,3 @@
+--- after rename
+default_2	test_table	0
+--- after drop

--- a/tests/queries/0_stateless/03397_system_detached_tables_rename_drop.sh
+++ b/tests/queries/0_stateless/03397_system_detached_tables_rename_drop.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+TEST_DB="${CLICKHOUSE_DATABASE}"
+TEST_DB_2="${CLICKHOUSE_DATABASE}_2"
+
+$CLICKHOUSE_CLIENT "
+
+DROP DATABASE IF EXISTS ${TEST_DB};
+CREATE DATABASE IF NOT EXISTS ${TEST_DB} ENGINE=Atomic;
+CREATE TABLE ${TEST_DB}.test_table (n Int64) ENGINE=MergeTree ORDER BY n;
+DETACH TABLE ${TEST_DB}.test_table;
+RENAME DATABASE ${TEST_DB} TO ${TEST_DB_2};
+
+SELECT '--- after rename';
+SELECT database, table, is_permanently FROM system.detached_tables WHERE database='${TEST_DB_2}';
+
+ATTACH TABLE ${TEST_DB_2}.test_table;
+DROP TABLE ${TEST_DB_2}.test_table SYNC;
+
+SELECT '--- after drop';
+SELECT database, table, is_permanently FROM system.detached_tables WHERE database='${TEST_DB_2}';
+
+DROP DATABASE ${TEST_DB_2} SYNC;
+
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system.detached_tables displaying incorrect information after RENAME DATABASE or DROP TABLE queries.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
