### PR TITLE
Fix possible crash due to concurrent S3Queue metadata initialization

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -156,6 +156,10 @@ ObjectStorageQueueMetadata::~ObjectStorageQueueMetadata()
 
 void ObjectStorageQueueMetadata::startup()
 {
+    if (startup_called)
+        return;
+    startup_called = true;
+
     if (!task
         && mode == ObjectStorageQueueMode::UNORDERED
         && (table_metadata.tracked_files_limit || table_metadata.tracked_files_ttl_sec))

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -176,6 +176,7 @@ private:
     LoggerPtr log;
 
     std::atomic_bool shutdown_called = false;
+    std::atomic_bool startup_called = false;
     BackgroundSchedulePoolTaskHolder task;
 
     class LocalFileStatuses;


### PR DESCRIPTION
CI found [1] data-race:

    WARNING: ThreadSanitizer: data race (pid=2462)
      Write of size 8 at 0x7250003046d8 by thread T638:
        #0 std::__1::unique_ptr<ThreadFromGlobalPoolImpl<true, true>, std::__1::default_delete<ThreadFromGlobalPoolImpl<true, true>>>::reset[abi:ne190107](ThreadFromGlobalPoolImpl<true, true>*) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:290:20 (clickhouse+0x1b7cb690) (BuildId: 4a160c0aae7301fdf3b5d5fc2cec3707e5318bfa)
        #1 std::__1::unique_ptr<ThreadFromGlobalPoolImpl<true, true>, std::__1::default_delete<ThreadFromGlobalPoolImpl<true, true>>>::operator=[abi:ne190107](std::__1::unique_ptr<ThreadFromGlobalPoolImpl<true, true>, std::__1::default_delete<ThreadFromGlobalPoolImpl<true, true>>>&&) build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:232:5 (clickhouse+0x1b7cb690)
        #2 DB::ObjectStorageQueueMetadata::startup() build_docker/./src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp:173:32 (clickhouse+0x1b7cb690)
        #3 DB::StorageObjectStorageQueue::startup() build_docker/./src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp:269:25 (clickhouse+0x1b89f8d6) (BuildId: 4a160c0aae7301fdf3b5d5fc2cec3707e5318bfa)

      Previous read of size 8 at 0x7250003046d8 by thread T659:
        #0 std::__1::unique_ptr<ThreadFromGlobalPoolImpl<true, true>, std::__1::default_delete<ThreadFromGlobalPoolImpl<true, true>>>::operator bool[abi:ne190107]() const build_docker/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:279:19 (clickhouse+0x1b7cb4b8) (BuildId: 4a160c0aae7301fdf3b5d5fc2cec3707e5318bfa)
        #1 DB::ObjectStorageQueueMetadata::startup() build_docker/./src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp:172:10 (clickhouse+0x1b7cb4b8)
        #2 DB::StorageObjectStorageQueue::startup() build_docker/./src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp:269:25 (clickhouse+0x1b89f8d6) (BuildId: 4a160c0aae7301fdf3b5d5fc2cec3707e5318bfa)

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=77841&sha=42886968f1af877d77394c74cf07e0bf9dcbda45&name_0=PR&name_1=Integration+tests+%28tsan%2C+6%2F6%29

The reason is pretty obvious, the tables in test_registry shares the same metadata object and on server restart may try to initialize it twice, that leads to a data-race above.

**This should fix failures of the `test_storage_s3_queue/test_4.py::test_registry` - one of the hot reason of CI failures**

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash due to concurrent S3Queue metadata initialization

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/77720
Fixes: https://github.com/ClickHouse/ClickHouse/issues/78040