### PR TITLE
Fix max_size argument value check in groupArray* functions

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -785,7 +785,7 @@ AggregateFunctionPtr createAggregateFunctionGroupArray(
         if (type != Field::Types::Int64 && type != Field::Types::UInt64)
                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 
-        if ((type == Field::Types::Int64 && parameters[0].safeGet<Int64>() < 0) ||
+        if ((type == Field::Types::Int64 && parameters[0].safeGet<Int64>() <= 0) ||
             (type == Field::Types::UInt64 && parameters[0].safeGet<UInt64>() == 0))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 
@@ -821,7 +821,7 @@ AggregateFunctionPtr createAggregateFunctionGroupArraySample(
         if (type != Field::Types::Int64 && type != Field::Types::UInt64)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 
-        if ((type == Field::Types::Int64 && parameters[i].safeGet<Int64>() < 0) ||
+        if ((type == Field::Types::Int64 && parameters[i].safeGet<Int64>() <= 0) ||
                 (type == Field::Types::UInt64 && parameters[i].safeGet<UInt64>() == 0))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 

--- a/src/AggregateFunctions/AggregateFunctionGroupArraySorted.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArraySorted.cpp
@@ -404,7 +404,7 @@ AggregateFunctionPtr createAggregateFunctionGroupArray(
         if (type != Field::Types::Int64 && type != Field::Types::UInt64)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 
-        if ((type == Field::Types::Int64 && parameters[0].safeGet<Int64>() < 0)
+        if ((type == Field::Types::Int64 && parameters[0].safeGet<Int64>() <= 0)
             || (type == Field::Types::UInt64 && parameters[0].safeGet<UInt64>() == 0))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 

--- a/src/AggregateFunctions/AggregateFunctionGroupUniqArray.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupUniqArray.cpp
@@ -320,7 +320,7 @@ AggregateFunctionPtr createAggregateFunctionGroupUniqArray(
         if (type != Field::Types::Int64 && type != Field::Types::UInt64)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 
-        if ((type == Field::Types::Int64 && parameters[0].safeGet<Int64>() < 0) ||
+        if ((type == Field::Types::Int64 && parameters[0].safeGet<Int64>() <= 0) ||
             (type == Field::Types::UInt64 && parameters[0].safeGet<UInt64>() == 0))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter for aggregate function {} should be positive number", name);
 

--- a/tests/queries/0_stateless/03398_group_array_zero_max_elements.sql
+++ b/tests/queries/0_stateless/03398_group_array_zero_max_elements.sql
@@ -1,0 +1,53 @@
+-- Related to https://github.com/ClickHouse/ClickHouse/issues/78088
+
+-- Asserting that groupArray* function calls with zero `max_size` argument of
+-- different types (Int/UInt) will produce BAD_ARGUMENTS error
+
+SELECT groupArray(0::UInt64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArray(0::Int64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArray(0::UInt64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArray(0::Int64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArray(0::UInt64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupArray(0::Int64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+
+SELECT groupArraySorted(0::UInt64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySorted(0::Int64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySorted(0::UInt64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySorted(0::Int64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySorted(0::UInt64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySorted(0::Int64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+
+SELECT groupArraySample(0::UInt64, 123)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySample(0::Int64, 123)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySample(0::UInt64, 123)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySample(0::Int64, 123)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySample(0::UInt64, 123)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupArraySample(0::Int64, 123)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+
+SELECT groupArrayLast(0::UInt64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayLast(0::Int64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayLast(0::UInt64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayLast(0::Int64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayLast(0::UInt64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayLast(0::Int64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+
+SELECT groupArrayMovingSum(0::UInt64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingSum(0::Int64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingSum(0::UInt64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingSum(0::Int64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingSum(0::UInt64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingSum(0::Int64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+
+SELECT groupArrayMovingAvg(0::UInt64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingAvg(0::Int64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingAvg(0::UInt64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingAvg(0::Int64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingAvg(0::UInt64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupArrayMovingAvg(0::Int64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+
+SELECT groupUniqArray(0::UInt64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupUniqArray(0::Int64)(1); -- { serverError BAD_ARGUMENTS }
+SELECT groupUniqArray(0::UInt64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupUniqArray(0::Int64)('x'); -- { serverError BAD_ARGUMENTS }
+SELECT groupUniqArray(0::UInt64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }
+SELECT groupUniqArray(0::Int64)(number) FROM numbers(5); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
Resolves #78088

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`groupArray*` functions now produce BAD_ARGUMENTS error for Int-typed 0 value of max_size argument, like it's already done for UInt one, instead of trying to execute with it.
