### PR TITLE
add metrics on failed data part merges

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -384,6 +384,9 @@
     M(StartupScriptsExecutionState, "State of startup scripts execution: 0 = not finished, 1 = success, 2 = failure.") \
     \
     M(IsServerShuttingDown, "Indicates if the server is shutting down: 0 = no, 1 = yes") \
+    \
+    M(TotalMergeFailures, "Number of all failed merges since startup, including the ones that were aborted") \
+    M(NonAbortedMergeFailures, "Number of failed merges since startup, excluding the merges that were aborted") \
 
 #ifdef APPLY_FOR_EXTERNAL_METRICS
     #define APPLY_FOR_METRICS(M) APPLY_FOR_BUILTIN_METRICS(M) APPLY_FOR_EXTERNAL_METRICS(M)

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -3,6 +3,7 @@
 #include <DataTypes/ObjectUtils.h>
 #include <Disks/SingleDiskVolume.h>
 #include <IO/HashingWriteBuffer.h>
+#include <Common/CurrentMetrics.h>
 #include <Common/logger_useful.h>
 #include <Common/escapeForFileName.h>
 #include <Core/Settings.h>
@@ -54,6 +55,8 @@ namespace ProfileEvents
 namespace CurrentMetrics
 {
     extern const Metric PartMutation;
+    extern const Metric TotalMergeFailures;
+    extern const Metric NonAbortedMergeFailures;
 }
 
 namespace DB
@@ -2096,37 +2099,50 @@ bool MutateTask::execute()
     Stopwatch watch;
     SCOPE_EXIT({ ctx->execute_elapsed_ns += watch.elapsedNanoseconds(); });
 
-    switch (state)
+    try
     {
-        case State::NEED_PREPARE:
+        switch (state)
         {
-            if (!prepare())
-                return false;
+            case State::NEED_PREPARE:
+            {
+                if (!prepare())
+                    return false;
 
-            state = State::NEED_EXECUTE;
-            return true;
-        }
-        case State::NEED_EXECUTE:
-        {
-            ctx->checkOperationIsNotCanceled();
-
-            if (task->executeStep())
+                state = State::NEED_EXECUTE;
                 return true;
+            }
+            case State::NEED_EXECUTE:
+            {
+                ctx->checkOperationIsNotCanceled();
 
-            // The `new_data_part` is a shared pointer and must be moved to allow
-            // part deletion in case it is needed in `MutateFromLogEntryTask::finalize`.
-            //
-            // `tryRemovePartImmediately` requires `std::shared_ptr::unique() == true`
-            // to delete the part timely. When there are multiple shared pointers,
-            // only the part state is changed to `Deleting`.
-            //
-            // Fetching a byte-identical part (in case of checksum mismatches) will fail with
-            // `Part ... should be deleted after previous attempt before fetch`.
-            promise.set_value(std::move(ctx->new_data_part));
-            return false;
+                if (task->executeStep())
+                    return true;
+
+                // The `new_data_part` is a shared pointer and must be moved to allow
+                // part deletion in case it is needed in `MutateFromLogEntryTask::finalize`.
+                //
+                // `tryRemovePartImmediately` requires `std::shared_ptr::unique() == true`
+                // to delete the part timely. When there are multiple shared pointers,
+                // only the part state is changed to `Deleting`.
+                //
+                // Fetching a byte-identical part (in case of checksum mismatches) will fail with
+                // `Part ... should be deleted after previous attempt before fetch`.
+                promise.set_value(std::move(ctx->new_data_part));
+                return false;
+            }
         }
+        return false;
     }
-    return false;
+    catch (...)
+    {
+        const auto error_code = getCurrentExceptionCode();
+        if (error_code != ErrorCodes::ABORTED)
+        {
+            CurrentMetrics::add(CurrentMetrics::NonAbortedMergeFailures);
+        }
+        CurrentMetrics::add(CurrentMetrics::TotalMergeFailures);
+        throw;
+    }
 }
 
 void MutateTask::cancel() noexcept


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce two new metrics: `TotalMergeFailures` and `NonAbortedMergeFailures`. These metrics are needed to detect the cases where too many merges fail within a short period.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
