### PR TITLE
Initial completion support for clickhouse-keeper-client

### DIFF
--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -267,6 +267,7 @@ void DisksApp::runInteractiveReplxx()
         .delimiters = query_delimiters,
         .word_break_characters = word_break_characters,
         .highlighter = {},
+        .on_complete_modify_callback = ReplxxLineReader::OnCompleteModifyCallback(),
     };
     ReplxxLineReader lr(std::move(reader_options));
     lr.enableBracketedPaste();

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -143,7 +143,7 @@ std::vector<String> KeeperClient::getCompletions(const String & prefix) const
     try
     {
         for (const auto & child : zookeeper->getChildren(parent_path))
-            result.push_back(parent_prefix + child);
+            result.push_back(fmt::format("\"{}{}\"", parent_prefix, child));
     }
     catch (Coordination::Exception &) {} // NOLINT(bugprone-empty-catch)
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -21,14 +21,13 @@ namespace
 
 char WORD_BREAK_CHARACTERS[] = " \t\v\f\a\b\r\n";
 
-/// Automatically wrap non first (first word is a command in keeper that should
-/// not be wrapped) word under cursor into double brackets, i.e.:
+/// Automatically prepend double quote for non first word under cursor, i.e.:
 ///
 ///     ls     => ls
-///     ls /   => ls "/"
-///     ls "/" => ls "/"
+///     ls /   => ls "/
+///     ls "/  => ls "/
 ///
-void wrapInDoubleQuotes(replxx::Replxx & rx)
+void prependDoubleQuoteForPath(replxx::Replxx & rx)
 {
     replxx::Replxx::State state(rx.get_state());
     std::string_view word_breaks(WORD_BREAK_CHARACTERS);
@@ -56,11 +55,6 @@ void wrapInDoubleQuotes(replxx::Replxx & rx)
     if (std::distance(word_begin, word_end) < 1)
         return;
 
-    if (*(word_end-1) != '"')
-    {
-        text.insert(word_end, '"');
-        ++cursor;
-    }
     if (*word_begin != '"')
     {
         text.insert(word_begin, '"');
@@ -401,7 +395,7 @@ void KeeperClient::runInteractiveReplxx()
         .delimiters = query_delimiters,
         .word_break_characters = WORD_BREAK_CHARACTERS,
         .highlighter = {},
-        .on_complete_modify_callback = wrapInDoubleQuotes,
+        .on_complete_modify_callback = prependDoubleQuoteForPath,
     };
     ReplxxLineReader lr(std::move(reader_options));
     lr.enableBracketedPaste();

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -139,7 +139,7 @@ std::vector<String> KeeperClient::getCompletions(String prefix) const
     try
     {
         for (const auto & child : zookeeper->getChildren(parent_path))
-            result.push_back(fmt::format("\"{}{}\"", parent_prefix, child));
+            result.push_back("\"" + parent_prefix + child);
     }
     catch (Coordination::Exception &) {} // NOLINT(bugprone-empty-catch)
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -19,8 +19,7 @@
 namespace
 {
 
-char WORD_BREAK_CHARACTERS[] = " \t\v\f\a\b\r\n/";
-char WORD_BREAK_CHARACTERS_NO_PATH_DELIMITER[] = " \t\v\f\a\b\r\n";
+char WORD_BREAK_CHARACTERS[] = " \t\v\f\a\b\r\n";
 
 /// Automatically wrap non first (first word is a command in keeper that should
 /// not be wrapped) word under cursor into double brackets, i.e.:
@@ -32,7 +31,7 @@ char WORD_BREAK_CHARACTERS_NO_PATH_DELIMITER[] = " \t\v\f\a\b\r\n";
 void wrapInDoubleQuotes(replxx::Replxx & rx)
 {
     replxx::Replxx::State state(rx.get_state());
-    std::string_view word_breaks(WORD_BREAK_CHARACTERS_NO_PATH_DELIMITER);
+    std::string_view word_breaks(WORD_BREAK_CHARACTERS);
 
     size_t cursor = state.cursor_position();
     std::string text(state.text());

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -129,15 +129,21 @@ std::vector<String> KeeperClient::getCompletions(const String & prefix) const
 
     fs::path path = string_path;
     String parent_path;
-    if (string_path.ends_with("/"))
+    /// parent_path has "/" at the end only if it is root
+    if (string_path.ends_with('/'))
         parent_path = getAbsolutePath(string_path);
     else
         parent_path = getAbsolutePath(path.parent_path());
 
+    /// parent_prefix always has "/" at the end
+    auto parent_prefix = parent_path;
+    if (!parent_prefix.ends_with('/'))
+        parent_prefix.append("/");
+
     try
     {
         for (const auto & child : zookeeper->getChildren(parent_path))
-            result.push_back(child);
+            result.push_back(parent_prefix + child);
     }
     catch (Coordination::Exception &) {} // NOLINT(bugprone-empty-catch)
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -97,8 +97,11 @@ String KeeperClient::executeFourLetterCommand(const String & command)
     return result;
 }
 
-std::vector<String> KeeperClient::getCompletions(const String & prefix) const
+std::vector<String> KeeperClient::getCompletions(String prefix) const
 {
+    /// Append trailing double quote to pass the parser correctly
+    if (!prefix.ends_with('"'))
+        prefix.append("\"");
     Tokens tokens(prefix.data(), prefix.data() + prefix.size(), 0, false);
     IParser::Pos pos(tokens, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
 

--- a/programs/keeper-client/KeeperClient.h
+++ b/programs/keeper-client/KeeperClient.h
@@ -56,7 +56,7 @@ protected:
 
     void loadCommands(std::vector<Command> && new_commands);
 
-    std::vector<String> getCompletions(const String & prefix) const;
+    std::vector<String> getCompletions(String prefix) const;
 
     String history_file;
     UInt32 history_max_entries; /// Maximum number of entries in the history file.

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3264,6 +3264,7 @@ void ClientBase::runInteractive()
         .in_fd = stdin_fd,
         .out_fd = stdout_fd,
         .err_fd = stderr_fd,
+        .on_complete_modify_callback = ReplxxLineReader::OnCompleteModifyCallback(),
     };
 
     lr = std::make_unique<ReplxxLineReader>(std::move(options));

--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -305,6 +305,7 @@ ReplxxLineReader::ReplxxLineReader(ReplxxLineReader::Options && options)
     , highlighter(std::move(options.highlighter))
     , word_break_characters(options.word_break_characters.data())
     , editor(getEditor())
+    , on_complete_modify_callback(options.on_complete_modify_callback)
 {
     using Replxx = replxx::Replxx;
 
@@ -348,6 +349,15 @@ ReplxxLineReader::ReplxxLineReader(ReplxxLineReader::Options && options)
     };
 
     rx.set_completion_callback(callback);
+    if (on_complete_modify_callback)
+    {
+        rx.bind_key(Replxx::KEY::TAB, [this](char32_t code)
+        {
+            on_complete_modify_callback(rx);
+            return rx.invoke(Replxx::ACTION::COMPLETE_LINE, code);
+        });
+    }
+
     rx.set_complete_on_empty(false);
     rx.set_word_break_characters(word_break_characters);
     rx.set_ignore_case(true);

--- a/src/Client/ReplxxLineReader.h
+++ b/src/Client/ReplxxLineReader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <span>
 
 #include <Client/LineReader.h>
@@ -12,6 +13,7 @@ namespace DB
 class ReplxxLineReader : public LineReader
 {
 public:
+    using OnCompleteModifyCallback = std::function<void(replxx::Replxx &)>;
 
     struct Options
     {
@@ -30,6 +32,8 @@ public:
         int in_fd = STDIN_FILENO;
         int out_fd = STDOUT_FILENO;
         int err_fd = STDERR_FILENO;
+
+        OnCompleteModifyCallback on_complete_modify_callback;
     };
 
     explicit ReplxxLineReader(Options && options);
@@ -58,6 +62,8 @@ private:
 
     std::string editor;
     bool overwrite_mode = false;
+
+    OnCompleteModifyCallback on_complete_modify_callback;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Initial completion support for clickhouse-keeper-client

It has been broken in https://github.com/ClickHouse/ClickHouse/pull/65494, this PR restores it, but only basics (due to with trickery of how symbols are handled on various levels - replxx, LineReader, custom wrappers that are added here), that includes prepend leading `"` for usability