### PR TITLE
Fix reference in lambda callback

### DIFF
--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -480,7 +480,7 @@ void ClusterDiscovery::initialUpdate()
         zk->createAncestors(path->zk_path);
         zk->createIfNotExists(path->zk_path, "");
 
-        auto watch_callback = [&path](auto) { path->need_update = true; };
+        auto watch_callback = [path](auto) { path->need_update = true; };
         zk->getChildrenWatch(path->zk_path, nullptr, watch_callback);
     }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix using reference on local variable

### Documentation entry for user-facing changes
Fix of https://github.com/ClickHouse/ClickHouse/pull/76001#issuecomment-2745892240
