### PR TITLE
Fix crash from sanitizer report on atexit handlers

### DIFF
--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -201,6 +201,12 @@ static DISABLE_SANITIZER_INSTRUMENTATION void sanitizerDeathCallback()
 
     char buf[signal_pipe_buf_size];
     auto & signal_pipe = HandledSignals::instance().signal_pipe;
+
+    /// Signal pipe can be already closed in BaseDaemon::~BaseDaemon, but
+    /// sanitizerDeathCallback() can be called on exit handlers.
+    if (signal_pipe.fds_rw[1] == -1)
+        return;
+
     WriteBufferFromFileDescriptorDiscardOnFailure out(signal_pipe.fds_rw[1], signal_pipe_buf_size, buf);
 
     const StackTrace stack_trace;


### PR DESCRIPTION
The problem is that sanitizerDeathCallback() can be called after BaseDaemon::~BaseDaemon already closed the signal handlers pipe:

    (gdb) bt
    0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=139852995707328) at ./nptl/pthread_kill.c:44
    1  __pthread_kill_internal (signo=6, threadid=139852995707328) at ./nptl/pthread_kill.c:78
    2  __GI___pthread_kill (threadid=139852995707328, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
    3  0x00007f3210341476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
    4  0x00007f32103277f3 in __GI_abort () at ./stdlib/abort.c:79
    5  0x0000558b7830e267 in __interceptor_abort ()
    6  0x0000558b806a70f6 in DB::abortOnFailedAssertion (description=..., trace=trace@entry=0x7fff958c9320, trace_offset=trace_offset@entry=0, trace_size=<optimized out>) at ./build_docker/./src/Common/Exception.cpp:48
    7  0x0000558b806a7697 in DB::abortOnFailedAssertion (description=...) at ./build_docker/./src/Common/Exception.cpp:54
    8  0x0000558b807d6926 in DB::WriteBufferFromFileDescriptor::finalizeImpl (this=0x7fff958c98f0) at ./build_docker/./src/IO/WriteBufferFromFileDescriptor.cpp:120
    9  0x0000558b807d5e1b in DB::WriteBuffer::finalize (this=0x7fff958c98f0) at ./build_docker/./src/IO/WriteBuffer.cpp:95
    10 0x0000558b80ba028e in sanitizerDeathCallback () at ./build_docker/./src/Common/SignalHandlers.cpp:216
    11 0x0000558b782ef1c0 in __sanitizer::Die() ()
    12 0x0000558b7834fa5f in __tsan::finalize(void*) ()
    13 0x00007f3210344495 in __run_exit_handlers (status=0, listp=0x7f3210519838 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at ./stdlib/exit.c:113
    14 0x00007f3210344610 in __GI_exit (status=<optimized out>) at ./stdlib/exit.c:143
    15 0x00007f3210328d97 in __libc_start_call_main (main=main@entry=0x558b7838aee0 <main(int, char**)>, argc=argc@entry=7, argv=argv@entry=0x7fff958c9b88) at ../sysdeps/nptl/libc_start_call_main.h:74
    16 0x00007f3210328e40 in __libc_start_main_impl (main=0x558b7838aee0 <main(int, char**)>, argc=7, argv=0x7fff958c9b88, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fff958c9b78) at ../csu/libc-start.c:392
    17 0x0000558b782de02e in _start ()

And this produce useless core files of 20GB, that has zero interesting stuff in them.

Found on CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=78123&sha=99e652c97c30e00334a988387f6fa21f4711bce0&name_0=PR&name_1=Integration%20tests%20%28tsan%2C%201%2F6%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)