### PR TITLE
Fix "alterable" column in system.s3_queue_settings

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -99,18 +99,23 @@ void ObjectStorageQueueSettings::dumpToSystemEngineSettingsColumns(
             settings_changes.begin(), settings_changes.end(),
             [&](const SettingChange & change){ return change.name == setting_name; });
     };
+    auto is_changeable = [&](const std::string & setting_name) -> bool
+    {
+        return StorageObjectStorageQueue::isSettingChangeable(setting_name, (*this)[ObjectStorageQueueSetting::mode]);
+    };
 
     for (const auto & change : impl->all())
     {
         size_t i = 0;
+        const auto & name = change.getName();
         res_columns[i++]->insert(database_name);
         res_columns[i++]->insert(table_name);
-        res_columns[i++]->insert(change.getName());
+        res_columns[i++]->insert(name);
         res_columns[i++]->insert(convertFieldToString(change.getValue()));
         res_columns[i++]->insert(change.getTypeName());
-        res_columns[i++]->insert(is_changed(change.getName()));
+        res_columns[i++]->insert(is_changed(name));
         res_columns[i++]->insert(change.getDescription());
-        res_columns[i++]->insert(false);
+        res_columns[i++]->insert(is_changeable(name));
     }
 }
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -750,7 +750,7 @@ void checkNormalizedSetting(const std::string & name)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Setting is not normalized: {}", name);
 }
 
-static bool isSettingChangeable(const std::string & name, ObjectStorageQueueMode mode)
+bool StorageObjectStorageQueue::isSettingChangeable(const std::string & name, ObjectStorageQueueMode mode)
 {
     checkNormalizedSetting(name);
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -63,6 +63,9 @@ public:
 
     ObjectStorageQueueSettings getSettings() const;
 
+    /// Can setting be changed via ALTER TABLE MODIFY SETTING query.
+    static bool isSettingChangeable(const std::string & name, ObjectStorageQueueMode mode);
+
 private:
     friend class ReadFromObjectStorageQueue;
     using FileIterator = ObjectStorageQueueSource::FileIterator;

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -358,6 +358,23 @@ def test_alter_settings(started_cluster):
     }
     string_settings = {"after_processing": "delete"}
 
+    def check_alterable(setting):
+        if setting.startswith("s3queue_"):
+            name = setting[len("s3queue_"):]
+        else:
+            name = setting
+        if name == "tracked_files_ttl_sec":
+            name = "tracked_file_ttl_sec" # sadly
+        assert 1 == int(node1.query(f"select alterable from system.s3_queue_settings where name = '{name}'"))
+
+    for setting, _ in int_settings.items():
+        check_alterable(setting)
+
+    for setting, _ in string_settings.items():
+        check_alterable(setting)
+
+    assert 0 == int(node1.query(f"select alterable from system.s3_queue_settings where name = 'mode'"))
+
     def with_keeper(setting):
         return setting in {
             "after_processing",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "alterable" column in system.s3_queue_settings returning always `false`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
