### PR TITLE
Docs: Update docs of system.warnings

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -821,6 +821,20 @@ Type: `UInt64`
 
 Default: `100000`
 
+## max_pending_mutations_to_warn {#max_pending_mutations_to_warn}
+
+If the number of pending mutations exceeds the specified value, clickhouse server will add warning messages to `system.warnings` table.
+
+**Example**
+
+```xml
+<max_pending_mutations_to_warn>400</max_pending_mutations_to_warn>
+```
+
+Type: `UInt64`
+
+Default: `500`
+
 ## max_table_num_to_throw {#max_table_num_to_throw}
 
 If number of tables is greater than this value, server will throw an exception.

--- a/docs/en/operations/system-tables/system_warnings.md
+++ b/docs/en/operations/system-tables/system_warnings.md
@@ -18,12 +18,12 @@ If current value drops below the threshold, the entry is removed from the table.
 
 The table can be configured with these settings:
 
-[max_table_num_to_warn](../server-configuration-parameters/settings.md#max_table_num_to_warn)
-[max_database_num_to_warn](../server-configuration-parameters/settings.md#max_database_num_to_warn)
-[max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn)
-[max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn)
-[max_part_num_to_warn](../server-configuration-parameters/settings.md#max_part_num_to_warn)
-[max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warn)
+- [max_table_num_to_warn](../server-configuration-parameters/settings.md#max_table_num_to_warn)
+- [max_database_num_to_warn](../server-configuration-parameters/settings.md#max_database_num_to_warn)
+- [max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn)
+- [max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn)
+- [max_part_num_to_warn](../server-configuration-parameters/settings.md#max_part_num_to_warn)
+- [max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warn)
 
 Columns:
 

--- a/docs/en/operations/system-tables/system_warnings.md
+++ b/docs/en/operations/system-tables/system_warnings.md
@@ -23,7 +23,7 @@ The table can be configured with these settings:
 [max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn)
 [max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn)
 [max_part_num_to_warn](../server-configuration-parameters/settings.md#max_part_num_to_warn)
-[max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warm)
+[max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warn)
 
 Columns:
 

--- a/docs/en/operations/system-tables/system_warnings.md
+++ b/docs/en/operations/system-tables/system_warnings.md
@@ -11,76 +11,24 @@ import SystemTableCloud from '@site/docs/_snippets/_system_table_cloud.md';
 
 <SystemTableCloud/>
 
-This table contains warning messages about clickhouse server. The threshold for some of the warnings can be configured
-accordingly. When the warning threshold is crossed, clickhouse server will add a warning message to `system.warnings`
-table. It will also update a warning message according to the current value and remove it when it drops below the
-configured threshold. Currently, the following warnings are configurable.
+This table shows warnings about the ClickHouse server.
+Warnings of the same type are combined into a single warning.
+For example, if the number N of attached databases exceeds a configurable threshold T, a single entry containing the current value N is shown instead of N separate entries.
+If current value drops below the threshold, the entry is removed from the table.
 
-### Maximum number of tables {#max_num_of_tables}
+The table can be configured with these settings:
 
-For warning when the maximum number of attached tables exceeds the specified value.
-
-**Configuration:**
-
-```xml
-<max_table_num_to_warn>500</max_table_num_to_warn>
-```
-
-### Maximum number of databases {#max_num_of_databases}
-
-For warning when the number of attached databases exceeds the specified value.
-
-**Configuration:**
-
-```xml
-<max_database_num_to_warn>500</max_database_num_to_warn>
-```
-
-### Maximum number of dictionaries {#max_num_of_dictionaries}
-
-For warning when the number of attached dictionaries exceeds the specified value.
-
-**Configuration:**
-
-```xml
-<max_dictionary_num_to_warn>500</max_dictionary_num_to_warn>
-```
-
-### Maximum number of views {#max_num_of_views}
-
-For warning when the number of attached views exceeds the specified value.
-
-**Configuration:**
-
-```xml
-<max_view_num_to_warn>500</max_view_num_to_warn>
-```
-
-### Maximum number of parts {#max_num_of_parts}
-
-For warning when the number of active parts exceeds the specified value.
-
-**Configuration:**
-
-```xml
-<max_part_num_to_warn>500</max_part_num_to_warn>
-```
-
-### Maximum number of pending mutations {#max_num_of_pending_mutations}
-
-For warning when the number of pending mutations exceeds the specified value.
-
-**Configuration:**
-
-```xml
-<max_pending_mutations_to_warn>500</max_pending_mutations_to_warn>
-```
+[max_table_num_to_warn](../server-configuration-parameters/settings.md#max_table_num_to_warn)
+[max_database_num_to_warn](../server-configuration-parameters/settings.md#max_database_num_to_warn)
+[max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn)
+[max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn)
+[max_part_num_to_warn](../server-configuration-parameters/settings.md#max_part_num_to_warn)
+[max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warm)
 
 Columns:
 
 - `message` ([String](../../sql-reference/data-types/string.md)) — Warning message.
-- `message_format_string` ([LowCardinality(String)](../../sql-reference/data-types/string.md)) — The format string that
-  was used to format the message.
+- `message_format_string` ([LowCardinality(String)](../../sql-reference/data-types/string.md)) — The format string used to format the message.
 
 **Example**
 


### PR DESCRIPTION
A little follow-up to #77842 to reduce the amount of duplication in the documentation.

### Changelog category (leave one):
- Documentation (changelog entry is not required)