### PR TITLE
fix doc links for system.warnings

### DIFF
--- a/docs/en/operations/system-tables/system_warnings.md
+++ b/docs/en/operations/system-tables/system_warnings.md
@@ -18,12 +18,12 @@ If current value drops below the threshold, the entry is removed from the table.
 
 The table can be configured with these settings:
 
-- [max_table_num_to_warn](../server-configuration-parameters/settings.md#max_table_num_to_warn)
-- [max_database_num_to_warn](../server-configuration-parameters/settings.md#max_database_num_to_warn)
-- [max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn)
-- [max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn)
-- [max_part_num_to_warn](../server-configuration-parameters/settings.md#max_part_num_to_warn)
-- [max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warn)
+- [max_table_num_to_warn-](../server-configuration-parameters/settings.md#max_table_num_to_warn-max_table_num_to_warn)
+- [max_database_num_to_warn](../server-configuration-parameters/settings.md#max_database_num_to_warn-max_database_num_to_warn)
+- [max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn-max_dictionary_num_to_warn)
+- [max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn-max_view_num_to_warn)
+- [max_part_num_to_warn](../server-configuration-parameters/settings.md#max_part_num_to_warn-max_part_num_to_warn)
+- [max_pending_mutations_to_warn](../server-configuration-parameters/settings.md#max_pending_mutations_to_warn-max_pending_mutations_to_warn)
 
 Columns:
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Fix markdown links to link to the correct section. Follow up for https://github.com/ClickHouse/ClickHouse/pull/78191

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
