### PR TITLE
Fix block device time metrics calculation

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -1395,7 +1395,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
             static constexpr size_t sector_size = 512;
 
             /// Always in milliseconds according to the docs.
-            static constexpr double time_multiplier = 1e-6;
+            static constexpr double time_multiplier = 1e-3;
 
 #define BLOCK_DEVICE_EXPLANATION \
     " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." \


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect values of `BlockActiveTime`, `BlockDiscardTime`, `BlockWriteTime`, `BlockQueueTime`, and `BlockReadTime` asynchronous metrics (before the change 1 second was incorrectly reported as 0.001).

### Documentation entry for user-facing changes:

The comment in the code correctly states that the metric in `/sys/block/<dev>/stat` is provided in milliseconds. See [kernel documentation](https://www.kernel.org/doc/Documentation/block/stat.txt).

ClickHouse states that it exports metrics related to block device in seconds. 

However, the conversion to seconds was incorrect. One second equals 1000 milliseconds, thus the multiplier should be `1e-3`, not `1e-6` (which corresponds to microseconds).

Note: This change could be considered a breaking change. Alternatively, the documentation could be adjusted, or new metrics introduced. But given the lack of earlier user reports, the practical impact appears minimal.