### PR TITLE
Docs: Cross-link generic prerequisites docs from build docs

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -18,9 +18,11 @@ As compiler, only Clang from homebrew is supported.
 
 ## Install Prerequisites {#install-prerequisites}
 
-First install [Homebrew](https://brew.sh/).
+First, see the generic [prerequisites documentation](developer-instruction.md).
 
-Next, run:
+Next, install [Homebrew](https://brew.sh/) and run
+
+Then run:
 
 ```bash
 brew update

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -29,6 +29,8 @@ The tutorial assumes that you have the ClickHouse repository and all submodules 
 
 ## Install Prerequisites {#install-prerequisites}
 
+First, see the generic [prerequisites documentation](developer-instruction.md).
+
 ClickHouse uses CMake and Ninja for building.
 
 You can optionally install ccache to let the build reuse already compiled object files.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)