### PR TITLE
Fix 03355_join_to_in_optimization

### DIFF
--- a/tests/queries/0_stateless/03355_join_to_in_optimization.sql
+++ b/tests/queries/0_stateless/03355_join_to_in_optimization.sql
@@ -24,6 +24,7 @@ ORDER BY
     t1.key2 ASC
 SETTINGS query_plan_use_new_logical_join_step = true, query_plan_convert_join_to_in = true;
 
+SYSTEM FLUSH LOGS system.query_log;
 EXPLAIN
 SELECT hostName() AS hostName
 FROM system.query_log AS a


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix 03355_join_to_in_optimization


https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=77998&sha=e20989541393d4d4097d567e5ae3ccbbafd8859d&name_0=PR&name_1=Fast+test&name_2=Tests

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
