### PR TITLE
Log invalid HTTP version string

### DIFF
--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -157,7 +157,7 @@ void HTTPServerRequest::readRequest(ReadBuffer & in)
         version += ch;
 
     if (version.size() > MAX_VERSION_LENGTH)
-        throw Poco::Net::MessageException("Invalid HTTP version string");
+        throw Poco::Net::MessageException(fmt::format("Invalid HTTP version string: {}", version));
 
     // since HTTP always use Windows-style EOL '\r\n' we always can safely skip to '\n'
 


### PR DESCRIPTION
Follow up to https://github.com/ClickHouse/ClickHouse/pull/76594.

Logs the actual invalid HTTP version string for easier debugging.

Example request:
```
$ echo "GET /?query=select 123456789 HTTP/1.1\r\n\r\n" | nc localhost 8123
HTTP/1.1 400 Bad Request
Connection: Close
```

Server log before:
```
2025.03.25 21:50:43.160482 [ 5025671 ] {} <Debug> HTTPServerConnection: HTTP request failed: Bad Request: Malformed message: Invalid HTTP version string
```

After:
```
2025.03.25 21:51:40.992283 [ 5027270 ] {} <Debug> HTTPServerConnection: HTTP request failed: Bad Request: Malformed message: Invalid HTTP version string: 123456789
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)