### PR TITLE
ci: fix hangs during sending system.*_log to ci-logs

### DIFF
--- a/docker/test/base/setup_export_logs.sh
+++ b/docker/test/base/setup_export_logs.sh
@@ -201,9 +201,11 @@ function setup_logs_replication
         echo "Creating materialized view system.${table}_watcher" >&2
 
         clickhouse-client --query "
-            CREATE MATERIALIZED VIEW system.${table}_watcher TO system.${table}_sender AS
-            SELECT ${EXTRA_COLUMNS_EXPRESSION_FOR_TABLE}, *
-            FROM system.${table}
+            CREATE MATERIALIZED VIEW system.${table}_watcher
+            TO system.${table}_sender
+            DEFINER = ci_logs_sender
+            AS
+            SELECT ${EXTRA_COLUMNS_EXPRESSION_FOR_TABLE}, * FROM system.${table}
         " || continue
     done
 )

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -95,6 +95,7 @@ fi
 
 ln -sf $SRC_PATH/users.d/log_queries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/readonly.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/ci_logs_sender.yaml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/access_management.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/database_atomic_drop_detach_sync.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/opentelemetry.xml $DEST_SERVER_PATH/users.d/

--- a/tests/config/users.d/ci_logs_sender.yaml
+++ b/tests/config/users.d/ci_logs_sender.yaml
@@ -1,0 +1,15 @@
+profiles:
+    ci_logs_sender:
+        # The async sends will block the table shutdown for the timeout,
+        # and default timeout of 300 seconds is too big and may lead to hangs,
+        # the INSERTs will be retried anyway
+        send_timeout: 15
+        receive_timeout: 15
+users:
+    ci_logs_sender:
+        profile: ci_logs_sender
+        no_password: true
+        networks:
+            ip:
+            - ::1
+            - 127.0.0.1


### PR DESCRIPTION
The problem is that it uses default send_timeout/receive_timeout, and for this period of time the distributed table cannot be shutted down.

Let's tune timeouts for sending data ci-logs.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/76133