### PR TITLE
CI: Add server error log into FastTest artifacts

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -228,15 +228,18 @@ class Result(MetaClasses.Serializable):
 
         if with_local_run_command and not self.is_ok():
             command_info = f'To run locally: python -m ci.praktika run "{self.name}"'
-            first_failed_test = next((r for r in self.results if not r.is_ok()), None)
+            first_failed_test = None
+            first_failed_task_result = next(
+                (r for r in self.results if not r.is_ok()), None
+            )
             if (
-                first_failed_test
-                and first_failed_test.name in Settings.CI_DB_SUB_RESULT_NAMES_WITH_TESTS
+                first_failed_task_result.name
+                in Settings.CI_DB_SUB_RESULT_NAMES_WITH_TESTS
             ):
                 first_failed_test = next(
                     (
                         r
-                        for r in first_failed_test.results
+                        for r in first_failed_task_result.results
                         if "fail" in r.status.lower()
                     ),
                     None,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Adds server error log on job failure
Minor fix in command for local reproduction in CI report

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
