### PR TITLE
Fix skip indices are not used with OR predicates

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1647,12 +1647,7 @@ static void buildIndexes(
             condition = index_helper->createIndexCondition(filter_actions_dag, context);
         }
 
-        if (const auto * bloom_filter_index_condition = typeid_cast<const MergeTreeIndexConditionBloomFilter *>(condition.get()))
-        {
-            if (bloom_filter_index_condition->isIndexUseful())
-                skip_indexes.useful_indices.emplace_back(index_helper, condition);
-        }
-        else if (!condition->alwaysUnknownOrTrue())
+        if (!condition->alwaysUnknownOrTrue())
         {
             skip_indexes.useful_indices.emplace_back(index_helper, condition);
         }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1647,7 +1647,7 @@ static void buildIndexes(
             condition = index_helper->createIndexCondition(filter_actions_dag, context);
         }
 
-        if (const auto * bloom_filter_index_condition = dynamic_cast<const MergeTreeIndexConditionBloomFilter *>(condition.get()))
+        if (const auto * bloom_filter_index_condition = typeid_cast<const MergeTreeIndexConditionBloomFilter *>(condition.get()))
         {
             if (bloom_filter_index_condition->isIndexUseful())
                 skip_indexes.useful_indices.emplace_back(index_helper, condition);

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -78,8 +78,6 @@ public:
 
     bool alwaysUnknownOrTrue() const override;
 
-    bool isIndexUseful() const;
-
     bool mayBeTrueOnGranule(MergeTreeIndexGranulePtr granule) const override
     {
         if (const auto & bf_granule = typeid_cast<const MergeTreeIndexGranuleBloomFilter *>(granule.get()))

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -78,6 +78,8 @@ public:
 
     bool alwaysUnknownOrTrue() const override;
 
+    bool isIndexUseful() const;
+
     bool mayBeTrueOnGranule(MergeTreeIndexGranulePtr granule) const override
     {
         if (const auto & bf_granule = typeid_cast<const MergeTreeIndexGranuleBloomFilter *>(granule.get()))

--- a/tests/queries/0_stateless/03377_bloom_filter_skip_index.reference
+++ b/tests/queries/0_stateless/03377_bloom_filter_skip_index.reference
@@ -1,0 +1,104 @@
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Expression
+        ReadFromMergeTree (default.example)
+        Indexes:
+          PrimaryKey
+            Keys: 
+              id
+            Condition: (id in 5-element set)
+            Parts: 1/1
+            Granules: 5/5
+          Skip
+            Name: colA_idx
+            Description: bloom_filter GRANULARITY 1
+            Parts: 1/1
+            Granules: 1/5
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Expression
+        ReadFromMergeTree (default.example)
+        Indexes:
+          PrimaryKey
+            Keys: 
+              id
+            Condition: (id in 5-element set)
+            Parts: 1/1
+            Granules: 5/5
+          Skip
+            Name: colB_idx
+            Description: bloom_filter GRANULARITY 1
+            Parts: 1/1
+            Granules: 1/5
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Expression
+        ReadFromMergeTree (default.example)
+        Indexes:
+          PrimaryKey
+            Keys: 
+              id
+            Condition: (id in 5-element set)
+            Parts: 1/1
+            Granules: 5/5
+          Skip
+            Name: colA_idx
+            Description: bloom_filter GRANULARITY 1
+            Parts: 1/1
+            Granules: 5/5
+          Skip
+            Name: colB_idx
+            Description: bloom_filter GRANULARITY 1
+            Parts: 1/1
+            Granules: 5/5
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Expression
+        ReadFromMergeTree (default.example)
+        Indexes:
+          PrimaryKey
+            Keys: 
+              id
+            Condition: (id in 5-element set)
+            Parts: 1/1
+            Granules: 5/5
+          Skip
+            Name: colA_idx
+            Description: bloom_filter GRANULARITY 1
+            Parts: 1/1
+            Granules: 5/5
+          Skip
+            Name: colB_idx
+            Description: bloom_filter GRANULARITY 1
+            Parts: 1/1
+            Granules: 5/5
+Expression ((Project names + Projection))
+  MergingAggregated
+    Expression (Change column names)
+      ReadFromPreparedSource (Optimized trivial count)
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.example)
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.example)
+        Indexes:
+          PrimaryKey
+            Keys: 
+              id
+            Condition: (id in 5-element set)
+            Parts: 1/1
+            Granules: 5/5
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.example)

--- a/tests/queries/0_stateless/03377_bloom_filter_skip_index.sql
+++ b/tests/queries/0_stateless/03377_bloom_filter_skip_index.sql
@@ -1,4 +1,4 @@
---- Checks if the skip indices are correctly used depending on the filter predicates.
+--- Checks if the skip indices are correctly used depending on the filter predicates -- issue #75228.
 
 DROP TABLE IF EXISTS `example`;
 CREATE TABLE `example`
@@ -54,3 +54,5 @@ EXPLAIN indexes = 1
 SELECT count()
 FROM `example`
 WHERE id IN (0,1,2,3,4) AND (colB = 'bb' AND 1 = 2); -- short circuit, neither primary index nor skip indices needed
+
+DROP TABLE `example`;

--- a/tests/queries/0_stateless/03377_bloom_filter_skip_index.sql
+++ b/tests/queries/0_stateless/03377_bloom_filter_skip_index.sql
@@ -1,0 +1,56 @@
+--- Checks if the skip indices are correctly used depending on the filter predicates.
+
+DROP TABLE IF EXISTS `example`;
+CREATE TABLE `example`
+(
+    `id` UInt32,
+    `colA` String,
+    `colB` String,
+    INDEX `colA_idx` colA TYPE bloom_filter GRANULARITY 1,
+    INDEX `colB_idx` colB TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY `id`
+SETTINGS index_granularity = 1;
+
+INSERT INTO `example` VALUES(0, 'aa', 'ba'),(1, 'ab', 'bb'),(2, 'ac', 'bc'),(3, 'ad', 'bd'),(4, 'ae', 'be');
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE id IN (0,1,2,3,4) AND colA = 'aa';
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE id IN (0,1,2,3,4) AND colB = 'bb';
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE id IN (0,1,2,3,4) AND (colA = 'aa' OR colB = 'bb'); 
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE id IN (0,1,2,3,4) AND NOT(colA != 'aa' AND colB != 'bb'); 
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE 1 = 1 OR colA = 'aa'; -- short circuit, don't need the skip index.
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE 1 = 2 AND colA = 'aa'; -- short circuit, don't need the skip index.
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE id IN (0,1,2,3,4) AND (colB = 'bb' OR 1 = 1); -- short circuit, don't need the skip index
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM `example`
+WHERE id IN (0,1,2,3,4) AND (colB = 'bb' AND 1 = 2); -- short circuit, neither primary index nor skip indices needed


### PR DESCRIPTION
Resolves #75228

The underlying issue is that every index is checked separately [here](https://github.com/ClickHouse/ClickHouse/blob/d2b015ee5f5d9890c6c1e3a231bc07d69d664b97/src/Processors/QueryPlan/ReadFromMergeTree.cpp#L1746) if it might be useful in the query. The issue arises when there is an `OR` predicate in the filter query because a simple state about RPN evaluates to true or unknown is not enough. This is a corner case only for the `OR` predicate.
If we replace the `OR` predicate the query from https://github.com/ClickHouse/ClickHouse/issues/75228 with `NOT(colA != 'aa' AND colB != 'bb')` (which is logically the same as `OR`) as `EXPLAIN indexes=1 SELECT * FROM or_test WHERE id IN (0,1,2,3,4) and NOT(colA!='aa' AND colB!='bb')`, the skip indices would be used as expected:
```
EXPLAIN indexes = 1
SELECT *
FROM or_test
WHERE (id IN (0, 1, 2, 3, 4)) AND (NOT ((colA != 'aa') AND (colB != 'bb')))

Query id: 0a5ff444-0274-47d1-b790-fb763dc6ad73

    ┌─explain─────────────────────────────────────────┐
 1. │ Expression ((Project names + Projection))       │
 2. │   Expression                                    │
 3. │     ReadFromMergeTree (or_test)                 │
 4. │     Indexes:                                    │
 5. │       PrimaryKey                                │
 6. │         Keys:                                   │
 7. │           id                                    │
 8. │         Condition: (id in 5-element set)        │
 9. │         Parts: 1/1                              │
10. │         Granules: 5/5                           │
11. │       Skip                                      │
12. │         Name: colA_idx                          │
13. │         Description: bloom_filter GRANULARITY 1 │
14. │         Parts: 1/1                              │
15. │         Granules: 5/5                           │
16. │       Skip                                      │
17. │         Name: colB_idx                          │
18. │         Description: bloom_filter GRANULARITY 1 │
19. │         Parts: 1/1                              │
20. │         Granules: 5/5                           │
    └─────────────────────────────────────────────────┘
```

To fix it, a new method `isIndexUseful` has been added to `MergeTreeIndexConditionBloomFilter` which decides the usefulness of the index based on multiple states.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a bug that disjunctions (ORs) of filter conditions were not evaluated by bloom filter indexes (issue #75228).