### PR TITLE
s3queue: respect loading_retries for errors during push to mv

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -493,7 +493,7 @@ void ObjectStorageQueueIFileMetadata::prepareFailedRequestsImpl(
 
     LOG_TRACE(
         log,
-        "File `{}` failed at try {}/{}, "
+        "File {} failed at try {}/{}, "
         "retries node exists: {} (failed node path: {})",
         path, node_metadata.retries, max_loading_retries, has_failed_before, failed_node_path);
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -178,7 +178,8 @@ public:
         Coordination::Requests & requests,
         bool insert_succeeded,
         StoredObjects & successful_files,
-        const std::string & exception_message = {});
+        const std::string & exception_message = {},
+        int error_code = 0);
 
     /// Do some work after Processed/Failed files were successfully committed to keeper.
     void finalizeCommit(bool insert_succeeded, const std::string & exception_message = {});

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -636,7 +636,7 @@ bool StorageObjectStorageQueue::streamToViews()
         }
         catch (...)
         {
-            commit(/* insert_succeeded */false, rows, sources, getCurrentExceptionMessage(true));
+            commit(/* insert_succeeded */false, rows, sources, getCurrentExceptionMessage(true), getCurrentExceptionCode());
             file_iterator->releaseFinishedBuckets();
             throw;
         }
@@ -654,14 +654,15 @@ void StorageObjectStorageQueue::commit(
     bool insert_succeeded,
     size_t inserted_rows,
     std::vector<std::shared_ptr<ObjectStorageQueueSource>> & sources,
-    const std::string & exception_message) const
+    const std::string & exception_message,
+    int error_code) const
 {
     ProfileEvents::increment(ProfileEvents::ObjectStorageQueueProcessedRows, inserted_rows);
 
     Coordination::Requests requests;
     StoredObjects successful_objects;
     for (auto & source : sources)
-        source->prepareCommitRequests(requests, insert_succeeded, successful_objects, exception_message);
+        source->prepareCommitRequests(requests, insert_succeeded, successful_objects, exception_message, error_code);
 
     if (requests.empty())
     {

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -138,7 +138,8 @@ private:
         bool insert_succeeded,
         size_t inserted_rows,
         std::vector<std::shared_ptr<ObjectStorageQueueSource>> & sources,
-        const std::string & exception_message = {}) const;
+        const std::string & exception_message = {},
+        int error_code = 0) const;
 };
 
 }

--- a/tests/integration/helpers/s3_queue_common.py
+++ b/tests/integration/helpers/s3_queue_common.py
@@ -164,11 +164,11 @@ def create_mv(
         DROP TABLE IF EXISTS {dst_table_name};
         DROP TABLE IF EXISTS {mv_name};
 
+        CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
+
         CREATE TABLE {dst_table_name} ({format}, _path String)
         ENGINE = MergeTree()
         ORDER BY column1;
-
-        CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
         """
     )
 

--- a/tests/integration/helpers/s3_queue_common.py
+++ b/tests/integration/helpers/s3_queue_common.py
@@ -155,21 +155,34 @@ def create_mv(
     src_table_name,
     dst_table_name,
     mv_name=None,
+    create_dst_table_first=True,
     format="column1 UInt32, column2 UInt32, column3 UInt32",
 ):
     if mv_name is None:
         mv_name = f"{src_table_name}_mv"
-    node.query(
-        f"""
+
+    node.query(f"""
         DROP TABLE IF EXISTS {dst_table_name};
         DROP TABLE IF EXISTS {mv_name};
+    """)
 
-        CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
-
-        CREATE TABLE {dst_table_name} ({format}, _path String)
-        ENGINE = MergeTree()
-        ORDER BY column1;
-        """
+    if create_dst_table_first:
+        node.query(
+            f"""
+            CREATE TABLE {dst_table_name} ({format}, _path String)
+            ENGINE = MergeTree()
+            ORDER BY column1;
+            CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
+            """
+        )
+    else:
+        node.query(
+            f"""
+            CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
+            CREATE TABLE {dst_table_name} ({format}, _path String)
+            ENGINE = MergeTree()
+            ORDER BY column1;
+            """
     )
 
 

--- a/tests/integration/helpers/s3_queue_common.py
+++ b/tests/integration/helpers/s3_queue_common.py
@@ -178,6 +178,7 @@ def create_mv(
     else:
         node.query(
             f"""
+            SET allow_materialized_view_with_bad_select=1;
             CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT *, _path FROM {src_table_name};
             CREATE TABLE {dst_table_name} ({format}, _path String)
             ENGINE = MergeTree()

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -410,10 +410,10 @@ def test_streaming_to_view(started_cluster, mode):
 def test_streaming_to_many_views(started_cluster, mode):
     node = started_cluster.instances["instance"]
     table_name = f"streaming_to_many_views_{mode}"
-    # A unique path is necessary for repeatable tests
     keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
     files_path = f"{table_name}_data"
 
+    loading_retries = 2
     create_table(
         started_cluster,
         node,
@@ -424,42 +424,106 @@ def test_streaming_to_many_views(started_cluster, mode):
             "keeper_path": keeper_path,
             "polling_min_timeout_ms": 100,
             "polling_max_timeout_ms": 100,
+            "s3queue_loading_retries": loading_retries,
             "polling_backoff_ms": 0,
         },
     )
 
-    for i in range(10):
-        base_name = f"{table_name}_{i + 1}"
-        mv_table_name = f"{base_name}_mv"
-        dst_table_name = f"{base_name}_dst"
-        create_mv(node, table_name, dst_table_name, mv_name = mv_table_name)
+    tables_num = 10
+    mv_tables = [f"{table_name}_{i + 1}_mv" for i in range(tables_num)]
+    dst_tables = [f"{table_name}_{i + 1}_dst" for i in range(tables_num)]
 
-    files_num = 20
-    row_num = 100
-    files = [(f"{files_path}/test_{i}.csv", i) for i in range(0, files_num)]
-    total_values = generate_random_files(
-        started_cluster, files_path, files_num, files=files, row_num=row_num
+    for i in range(tables_num):
+        create_mv(node, table_name, dst_tables[i], mv_name=mv_tables[i])
+
+    start_idx = [0]
+    expect_files_num = [0]
+    expect_rows_num = [0]
+    files = []
+
+    def generate_files(files_num=20, row_num=100):
+        files.extend(
+            [
+                (f"{files_path}/test_{i}.csv", i)
+                for i in range(start_idx[0], start_idx[0] + files_num)
+            ]
+        )
+        generate_random_files(
+            started_cluster, files_path, files_num, files=files, row_num=row_num
+        )
+        start_idx[0] += files_num
+        expect_files_num[0] += files_num
+        expect_rows_num[0] += files_num * row_num
+
+    def check(dst_tables, expect_rows_num, expect_files_num):
+        for dst_table_name in dst_tables:
+
+            def get_uniq_paths_count():
+                return int(node.query(f"SELECT uniqExact(_path) FROM {dst_table_name}"))
+
+            for _ in range(20):
+                if get_uniq_paths_count() == expect_files_num:
+                    break
+                time.sleep(1)
+
+            processed_files = node.query(
+                f"SELECT distinct(_path) FROM {dst_table_name}"
+            )
+            missing_files = [
+                x[0] for x in files if x[0] not in processed_files.strip().split("\n")
+            ]
+            assert (
+                get_uniq_paths_count() == expect_files_num
+            ), f"Missing files for {dst_table_name}: {missing_files}"
+
+            def get_rows_count():
+                return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+            for _ in range(20):
+                if get_rows_count() == expect_rows_num:
+                    break
+                time.sleep(1)
+
+            rows_count = get_rows_count()
+            assert (
+                expect_rows_num == rows_count
+            ), f"Missing or extra data for {dst_table_name}: {rows_count} (expected: {expect_rows_num})"
+
+    generate_files()
+    check(dst_tables, expect_rows_num[0], expect_files_num[0])
+
+    # Create incorrect destination table
+    broken_dst_table = f"{table_name}_{expect_files_num[0] + 1}_dst"
+    create_mv(
+        node,
+        table_name,
+        broken_dst_table,
+        mv_name=f"{table_name}_{expect_files_num[0] + 1}_mv",
+        format="column1 String, column2 JSON",
     )
-    expected_values = sorted(set([tuple(i) for i in total_values]))
 
-    for i in range(10):
-        base_name = f"{table_name}_{i + 1}"
-        dst_table_name = f"{base_name}_dst"
-        def check():
-            return int(node.query(f"SELECT uniqExact(_path) FROM {dst_table_name}"))
+    generate_files()
+    rows_from_last_insert = 100 * 20
+    # we expect duplicates, but exactly certain amount,
+    # which must stop once loading retries limit is reached.
+    check(
+        dst_tables,
+        expect_rows_num[0] + rows_from_last_insert * loading_retries,
+        expect_files_num[0],
+    )
+    check([broken_dst_table], 0, 0)
 
-        for _ in range(20):
-            if check() == files_num:
-                break
-            time.sleep(1)
-        processed_files = node.query(f"SELECT distinct(_path) FROM {dst_table_name}")
-        missing_files = [
-            x[0] for x in files if x[0] not in processed_files.strip().split("\n")
-        ]
-        assert check() == files_num, f"Missing files for {dst_table_name}: {missing_files}"
-        count = int(node.query(f"SELECT count() FROM {dst_table_name}"))
-        expected = row_num * files_num
-        assert expected == count, f"Missing or extra data for {dst_table_name}: {count} (expected: {expected})"
+    for i in range(20, 40):
+        log_message = f"File {files_path}/test_{i}.csv failed at try 2/2, retries node exists: true"
+        assert node.contains_in_log(
+            log_message
+        ), f"Cannot find log message 1 for path {files_path}/test_{i}.csv: {log_message}"
+        log_message = (
+            f"File {files_path}/test_{i}.csv failed to process and will not be retried"
+        )
+        assert node.contains_in_log(
+            log_message
+        ), f"Cannot find log message 2 for path {files_path}/test_{i}.csv: {log_message}"
 
 
 def test_multiple_tables_meta_mismatch(started_cluster):

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -441,10 +441,10 @@ def test_streaming_to_many_views(started_cluster, mode):
     expect_rows_num = [0]
     files = []
 
-    def generate_files(files_num=20, row_num=100):
+    def generate_files(files_num=20, row_num=100, file_prefix = "a"):
         files.extend(
             [
-                (f"{files_path}/test_{i}.csv", i)
+                (f"{files_path}/{file_prefix}_{i}.csv", i)
                 for i in range(start_idx[0], start_idx[0] + files_num)
             ]
         )
@@ -502,7 +502,7 @@ def test_streaming_to_many_views(started_cluster, mode):
         format="column1 String, column2 JSON",
     )
 
-    generate_files()
+    generate_files(file_prefix = "b")
     rows_from_last_insert = 100 * 20
     # we expect duplicates, but exactly certain amount,
     # which must stop once loading retries limit is reached.
@@ -514,16 +514,16 @@ def test_streaming_to_many_views(started_cluster, mode):
     check([broken_dst_table], 0, 0)
 
     for i in range(20, 40):
-        log_message = f"File {files_path}/test_{i}.csv failed at try 2/2, retries node exists: true"
+        log_message = f"File {files_path}/b_{i}.csv failed at try 2/2, retries node exists: true"
         assert node.contains_in_log(
             log_message
-        ), f"Cannot find log message 1 for path {files_path}/test_{i}.csv: {log_message}"
+        ), f"Cannot find log message 1 for path {files_path}/b_{i}.csv: {log_message}"
         log_message = (
-            f"File {files_path}/test_{i}.csv failed to process and will not be retried"
+            f"File {files_path}/b_{i}.csv failed to process and will not be retried"
         )
         assert node.contains_in_log(
             log_message
-        ), f"Cannot find log message 2 for path {files_path}/test_{i}.csv: {log_message}"
+        ), f"Cannot find log message 2 for path {files_path}/b_{i}.csv: {log_message}"
 
 
 def test_multiple_tables_meta_mismatch(started_cluster):

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -500,6 +500,7 @@ def test_streaming_to_many_views(started_cluster, mode):
         broken_dst_table,
         mv_name=f"{table_name}_{expect_files_num[0] + 1}_mv",
         format="column1 String, column2 JSON",
+        create_dst_table_first=False
     )
 
     generate_files(file_prefix = "b")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect `loading_retries` limit for errors during push to materialized view for StorageS3(Azure)Queue. Before that such errors were retried indefinitely.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
