### PR TITLE
Fix assert `Unexpected state. Back: [5242880, 10485759], result range: [0, 12582911], limit: 0. (s3 storage)`

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -638,7 +638,7 @@ FileCache::getOrSet(
 
     assertInitialized();
 
-    FileSegment::Range initial_range(offset, offset + size - 1);
+    FileSegment::Range initial_range(offset, std::min(offset + size, file_size) - 1);
     /// result_range is initial range, which will be adjusted according to
     /// 1. aligned_offset, aligned_end_offset
     /// 2. max_file_segments_limit
@@ -764,14 +764,16 @@ FileCache::getOrSet(
         }
     }
 
+    /// Compare with initial_range and not result_range,
+    /// See comment in splitRange for explanation.
     chassert(file_segments_limit
-             ? file_segments.back()->range().left <= result_range.right
-             : file_segments.back()->range().contains(result_range.right),
+             ? file_segments.back()->range().left <= initial_range.right
+             : file_segments.back()->range().contains(initial_range.right),
              fmt::format(
                  "Unexpected state. Back: {}, result range: {}, "
-                 "limit: {}, initial offset: {}, initial size: {}",
+                 "limit: {}, initial offset: {}, initial size: {}, file size: {}",
                  file_segments.back()->range().toString(), result_range.toString(),
-                 file_segments_limit, offset, size));
+                 file_segments_limit, offset, size, file_size));
 
     chassert(!file_segments_limit || file_segments.size() <= file_segments_limit);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not for changelog and not to backport because it is not a real issue, but incorrect assertion. Closes https://github.com/ClickHouse/ClickHouse/issues/74943.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
