### PR TITLE
tests: fix 03237_create_or_replace_view flakiness

### DIFF
--- a/tests/queries/0_stateless/03237_create_or_replace_view_atomically_with_atomic_engine.sh
+++ b/tests/queries/0_stateless/03237_create_or_replace_view_atomically_with_atomic_engine.sh
@@ -16,10 +16,13 @@ function create_or_replace_view_thread
 }
 export -f create_or_replace_view_thread;
 
+# Old analyzer doesn't retry in case of resolving table identifier errors
+# (like UUID mismatch or non-existing tables), so this test is forced to
+# run with enabled analyzer
 function select_view_thread
 {
     for _ in {1..20}; do
-        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${CLICKHOUSE_DATABASE}_db.test_view FORMAT NULL"  | grep -v -P 'Code: (60|741)'
+        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${CLICKHOUSE_DATABASE}_db.test_view FORMAT NULL SETTINGS allow_experimental_analyzer = 1"
     done
 }
 export -f select_view_thread;


### PR DESCRIPTION
This test fails on disabled analyzer jobs ([report](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3Rfc3RhdHVzLCBjb3VudCgpCkZST00gY2hlY2tzCldIRVJFIDEKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IHRvRGF0ZSgnMjAyNS0wMy0yNycpIC0gSU5URVJWQUwgMTQgREFZCiAgICBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpCiAgICBBTkQgdGVzdF9zdGF0dXMgbm90IGluICgnU0tJUFBFRCcpCiAgICBBTkQgdGVzdF9uYW1lID0gJzAzMjM3X2NyZWF0ZV9vcl9yZXBsYWNlX3ZpZXdfYXRvbWljYWxseV93aXRoX2F0b21pY19lbmdpbmUnCkdST1VQIEJZIDEsIDIKT1JERVIgQlkgMg==)), due to a known issue, which has been fixed for analyzer in #69812 in 3fc2f551d147ee2cc7572303c5b6538395d79b1a

AFAIK patches for the old analyzer are not accepted anymore due to its future deprecation, so maybe it makes sense to force running this test with enabled analyzer even for "old analyzer" CI jobs.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/70319