### PR TITLE
Add parser utilities for allowing DESCRIBE TABLE as a subquery where SELECT is allowed

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -42,6 +42,7 @@
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserExplainQuery.h>
+#include <Parsers/ParserDescribeTableQuery.h>
 
 #include <Interpreters/StorageID.h>
 
@@ -102,6 +103,40 @@ static ASTPtr buildSelectFromTableFunction(const std::shared_ptr<ASTFunction> & 
 
     return result_select_query;
 }
+
+
+bool ParserDescribeSubquery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserDescribeTableQuery describe;
+    ParserExplainQuery explain;
+
+    if (pos->type != TokenType::OpeningRoundBracket)
+        return false;
+    ++pos;
+
+    ASTPtr result_node = nullptr;
+
+    if (ASTPtr describe_node; describe.parse(pos, describe_node, expected))
+    {
+        result_node = std::move(describe_node);
+    }
+    else if (ASTPtr explain_node; explain.parse(pos, explain_node, expected))
+    {
+
+    }
+    else
+    {
+        return false;
+    }
+
+    if (pos->type != TokenType::ClosingRoundBracket)
+        return false;
+    ++pos;
+
+    node = std::make_shared<ASTSubquery>(std::move(result_node));
+    return true;
+}
+
 
 bool ParserSubquery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -122,7 +122,8 @@ bool ParserDescribeSubquery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     }
     else if (ASTPtr explain_node; explain.parse(pos, explain_node, expected))
     {
-
+        /// TODO: Add support for EXPLAIN
+        return false;
     }
     else
     {

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -19,6 +19,16 @@ protected:
 };
 
 
+/** The DESCRIBE subquery, in parentheses.
+  */
+class ParserDescribeSubquery : public IParserBase
+{
+protected:
+    const char * getName() const override { return "DESCRIBE subquery"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+
 /** An identifier, for example, x_yz123 or `something special`
   * If allow_query_parameter_ = true, also parses substitutions in form {name:Identifier}
   */

--- a/src/Parsers/ParserTablesInSelectQuery.cpp
+++ b/src/Parsers/ParserTablesInSelectQuery.cpp
@@ -23,6 +23,7 @@ bool ParserTableExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     auto res = std::make_shared<ASTTableExpression>();
 
     if (!ParserWithOptionalAlias(std::make_unique<ParserSubquery>(), allow_alias_without_as_keyword).parse(pos, res->subquery, expected)
+        && !ParserWithOptionalAlias(std::make_unique<ParserDescribeSubquery>(), allow_alias_without_as_keyword).parse(pos, res->subquery, expected)
         && !ParserWithOptionalAlias(std::make_unique<ParserFunction>(false, true), allow_alias_without_as_keyword).parse(pos, res->table_function, expected)
         && !ParserWithOptionalAlias(std::make_unique<ParserCompoundIdentifier>(true, true), allow_alias_without_as_keyword)
                 .parse(pos, res->database_and_table_name, expected)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category:
- New Feature

### Changelog entry:
Addresses [#8854](https://github.com/ClickHouse/ClickHouse/issues/8854). Begin adding support for using `DESCRIBE TABLE` as a subquery.
Example usage:

Find attributes of a table `tbl` with type `UInt32`:
```
SELECT name
FROM (DESCRIBE TABLE default.tbl)
WHERE type = UInt32
```
Count the number of attributes in a table `tbl`:
```
SELECT count()
FROM (DESCRIBE TABLE default.tbl)
```

### Documentation entry for user-facing changes

- [ ] In-progress!

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
