### PR TITLE
Cast setting value from history to actual setting type

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2151,8 +2151,11 @@ void MergeTreeSettings::applyCompatibilitySetting(const String & compatibility_v
         {
             /// In case the alias is being used (e.g. use enable_analyzer) we must change the original setting
             auto final_name = MergeTreeSettingsTraits::resolveName(change.name);
-            if (get(final_name) != change.previous_value)
-                set(final_name, change.previous_value);
+            auto setting_index = MergeTreeSettingsTraits::Accessor::instance().find(final_name);
+            auto previous_value = MergeTreeSettingsTraits::Accessor::instance().castValueUtil(setting_index, change.previous_value);
+
+            if (get(final_name) != previous_value)
+                set(final_name, previous_value);
         }
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes `applyCompatibilitySetting`. Prior to this patch, all settings with a type not equal to Bool were marked as changed because the type of setting changes in the settings history was not equal to the type of settings in the settings declaration.
