### PR TITLE
Refactor test_reload_client_certificate to make it more stable

### DIFF
--- a/tests/integration/test_reload_client_certificate/test.py
+++ b/tests/integration/test_reload_client_certificate/test.py
@@ -1,10 +1,10 @@
 import os
 import threading
-import time
 
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -61,8 +61,11 @@ def started_cluster():
 def secure_connection_test(started_cluster):
     # No asserts, connection works
 
-    node1.query("SELECT count() FROM system.zookeeper WHERE path = '/'")
-    node2.query("SELECT count() FROM system.zookeeper WHERE path = '/'")
+    def check_node(node):
+        assert node.query('SELECT COUNT() > 0 FROM system.zookeeper_connection WHERE NOT is_expired') == '1\n'
+
+    for node in nodes:
+        check_node(node)
 
     threads_number = 4
     iterations = 4
@@ -74,7 +77,8 @@ def secure_connection_test(started_cluster):
         threads.append(
             threading.Thread(
                 target=lambda: [
-                    node1.query("SELECT count() FROM system.zookeeper WHERE path = '/'")
+                    check_node(node)
+                    for node in nodes
                     for _ in range(iterations)
                 ]
             )
@@ -118,80 +122,33 @@ EOF""".format(
             ]
         )
 
-        node.exec_in_container(
-            ["bash", "-c", "touch /etc/clickhouse-server/config.d/ssl_conf.xml"],
-        )
+        node.query("SYSTEM RELOAD CONFIG")
+        node.exec_in_container(["ss", "--kill", "-tn", "state", "established",
+                                f"( dport = :{cluster.zookeeper_port} or dport = :{cluster.zookeeper_secure_port} )"])
 
 
-def check_reload_successful(node, cert_name):
-    return node.grep_in_log(
-        f"Reloaded certificate (/etc/clickhouse-server/config.d/{cert_name}_client.crt)"
-    )
-
-
-def check_error_handshake(node):
-    return node.count_in_log("Code: 210.")
-
-
-def clean_logs():
-    for node in nodes:
-        node.exec_in_container(
-            [
-                "bash",
-                "-c",
-                "echo -n > /var/log/clickhouse-server/clickhouse-server.log",
-            ]
-        )
-
-
-def check_certificate_switch(first, second):
-    # Set first certificate
-
-    change_config_to_key(first)
-
-    # Restart zookeeper to reload the session
-
-    cluster.stop_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
-    cluster.start_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
-    cluster.wait_zookeeper_nodes_to_start(["zoo1", "zoo2", "zoo3"])
-    clean_logs()
-
-    # Change certificate
-
-    change_config_to_key(second)
-
-    # Time to log
-
-    time.sleep(10)
-
-    # Check information about client certificates reloading in log Clickhouse
-
-    reload_successful = any(check_reload_successful(node, second) for node in nodes)
-
-    # Restart zookeeper to reload the session and clean logs for new check
-
-    cluster.stop_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
-    cluster.start_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
-    clean_logs()
-    cluster.wait_zookeeper_nodes_to_start(["zoo1", "zoo2", "zoo3"])
-
-    if second == "second":
+def assert_zookeeper_connection(success):
+    if success:
+        secure_connection_test(started_cluster)
+    else:
         try:
             secure_connection_test(started_cluster)
             assert False
-        except:
-            assert True
-    else:
-        secure_connection_test(started_cluster)
-        error_handshake = any(check_error_handshake(node) == "0\n" for node in nodes)
-        assert reload_successful and error_handshake
+        except QueryRuntimeException as e:
+            assert 'ssl/tls alert certificate unknown' in e.stderr
 
 
 def test_wrong_cn_cert():
     """Checking the certificate reload with an incorrect CN, the expected behavior is Code: 210."""
-    check_certificate_switch("first", "second")
+    change_config_to_key("first")
+    assert_zookeeper_connection(True)
+    change_config_to_key("second")
+    assert_zookeeper_connection(False)
 
 
 def test_correct_cn_cert():
     """Replacement with a valid certificate, the expected behavior is to restore the connection with Zookeeper."""
-    check_certificate_switch("second", "third")
+    change_config_to_key("second")
+    assert_zookeeper_connection(False)
+    change_config_to_key("third")
+    assert_zookeeper_connection(True)


### PR DESCRIPTION
Break connection without server restart, check exact query responses instead of waiting for log messages
Closes #77987
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
