### PR TITLE
Disable with_remote_database_disk in some tests

### DIFF
--- a/tests/integration/test_disk_types/test.py
+++ b/tests/integration/test_disk_types/test.py
@@ -20,6 +20,9 @@ def cluster():
                 ["configs/storage_arm.xml"] if is_arm() else ["configs/storage_amd.xml"]
             ),
             with_minio=True,
+            # Disable with_remote_database_disk to reduce diversion between the public and private repo.
+            # So we do not handle the test differently in the private repo
+            with_remote_database_disk=False,
         )
         cluster.start()
 

--- a/tests/integration/test_endpoint_macro_substitution/test.py
+++ b/tests/integration/test_endpoint_macro_substitution/test.py
@@ -17,6 +17,9 @@ def cluster():
         cluster.add_instance(
             "node",
             main_configs=["configs/storage.xml", "configs/macros.xml"],
+            # Disable with_remote_database_disk to reduce diversion between the public and private repo.
+            # So we do not handle the test differently in the private repo
+            with_remote_database_disk=False,
             with_minio=True,
         )
         cluster.start()

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -22,6 +22,8 @@ main_node = cluster.add_instance(
     with_zookeeper=True,
     stay_alive=True,
     macros={"shard": 1, "replica": 1},
+    # Disable `with_remote_database_disk` as in `test_startup_without_zk`, Keeper rejects `main_node` connections before restarting
+    with_remote_database_disk=False,
 )
 dummy_node = cluster.add_instance(
     "dummy_node",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Follow up this PR [#77365](https://github.com/ClickHouse/ClickHouse/pull/77365), with_remote_database_disk is disabled in some tests to reduce diversion between the public and private repo

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
