### PR TITLE
ci: bump aspell (it does not know some words that even I know)

### DIFF
--- a/ci/docker/style-test/Dockerfile
+++ b/ci/docker/style-test/Dockerfile
@@ -7,9 +7,22 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
         python3-pip \
         locales \
         ripgrep \
+        curl \
         git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
+ARG ASPELL_VERSION=2020.12.07-0
+RUN curl -O https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-$ASPELL_VERSION.tar.bz2 && \
+    curl -O https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-$ASPELL_VERSION.tar.bz2.sig && \
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 71C636695B147849 && \
+    gpg --verify aspell6-en-$ASPELL_VERSION.tar.bz2.sig aspell6-en-$ASPELL_VERSION.tar.bz2 && \
+    tar xvf aspell6-en-$ASPELL_VERSION.tar.bz2 && \
+    cd aspell6-en-$ASPELL_VERSION && \
+    pwd && \
+    ./configure && make && make install && \
+    cd .. && \
+    rm -fr aspell6-en-$ASPELL_VERSION*
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Current version is from 2018, let's use the latest, but it is only 2020.

The word that I was looking for is "scalability"

Before:

    $ aspell --lang=en dump master | sort | grep -i scalability -c
    0

After

    $ aspell --lang=en dump master | sort | grep -i scalability -c
    1

Note: curl had been installed even before, so no extra dependencies (but just want to make it explicit)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)