### PR TITLE
Better guard pages with MADV_GUARD_INSTALL/MADV_GUARD_REMOVE (linux 6.13+)

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -1,6 +1,7 @@
 #include "Keeper.h"
 
 #include <Common/ClickHouseRevision.h>
+#include <Common/formatReadable.h>
 #include <Common/getMultipleKeysFromConfig.h>
 #include <Common/DNSResolver.h>
 #include <Interpreters/DNSCacheUpdater.h>

--- a/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
+++ b/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
@@ -3,6 +3,7 @@
 #include <ranges>
 #include <IO/copyData.h>
 #include <Common/Exception.h>
+#include <Common/formatReadable.h>
 
 namespace DB
 {

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -11,6 +11,7 @@
 #include <Common/DateLUT.h>
 #include <Common/DateLUTImpl.h>
 #include <Common/MemoryTracker.h>
+#include <Common/formatReadable.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/Exception.h>
 #include <Common/ErrorCodes.h>

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -23,6 +23,7 @@
 #include <Common/DNSResolver.h>
 #include <Common/StringUtils.h>
 #include <Common/OpenSSLHelpers.h>
+#include <Common/formatReadable.h>
 #include <Common/randomSeed.h>
 #include <Core/Block.h>
 #include <Core/ProtocolDefines.h>

--- a/src/Common/AsyncTaskExecutor.cpp
+++ b/src/Common/AsyncTaskExecutor.cpp
@@ -1,5 +1,6 @@
 #include <Common/AsyncTaskExecutor.h>
 #include <base/scope_guard.h>
+#include <fmt/format.h>
 
 
 namespace DB

--- a/src/Common/AsyncTaskExecutor.h
+++ b/src/Common/AsyncTaskExecutor.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <mutex>
+#include <base/types.h>
 #include <Common/Epoll.h>
 #include <Common/Fiber.h>
 #include <Common/FiberStack.h>

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -1,0 +1,79 @@
+#include <base/defines.h>
+#include <Common/formatReadable.h>
+#include <Common/CurrentMemoryTracker.h>
+#include <Common/Exception.h>
+#include <Common/memory.h>
+#include <base/getPageSize.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/mman.h>
+#include <Common/FiberStack.h>
+
+#if defined(BOOST_USE_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
+/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
+
+
+FiberStack::FiberStack(size_t stack_size_)
+    : stack_size(stack_size_)
+    , page_size(getPageSize())
+{
+}
+
+boost::context::stack_context FiberStack::allocate() const
+{
+    size_t num_pages = 1 + (stack_size - 1) / page_size;
+    size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
+
+    void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (MAP_FAILED == vp)
+        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
+
+    /// TODO: make reports on illegal guard page access more clear.
+    /// Currently we will see segfault and almost random stacktrace.
+    try
+    {
+        memoryGuardInstall(vp, page_size);
+    }
+    catch (...)
+    {
+        ::munmap(vp, num_bytes);
+        throw;
+    }
+
+    /// Do not count guard page in memory usage.
+    auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
+    trace.onAlloc(vp, num_pages * page_size);
+
+    boost::context::stack_context sctx;
+    sctx.size = num_bytes;
+    sctx.sp = static_cast< char * >(vp) + sctx.size;
+#if defined(BOOST_USE_VALGRIND)
+    sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
+#endif
+    return sctx;
+}
+
+void FiberStack::deallocate(boost::context::stack_context & sctx) const
+{
+#if defined(BOOST_USE_VALGRIND)
+    VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
+#endif
+    void * vp = static_cast< char * >(sctx.sp) - sctx.size;
+    ::munmap(vp, sctx.size);
+
+    /// Do not count guard page in memory usage.
+    auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
+    trace.onFree(vp, sctx.size - page_size);
+}

--- a/src/Common/FiberStack.h
+++ b/src/Common/FiberStack.h
@@ -1,37 +1,11 @@
 #pragma once
-#include <base/defines.h>
 #include <boost/context/stack_context.hpp>
-#include <Common/formatReadable.h>
-#include <Common/CurrentMemoryTracker.h>
-#include <Common/Exception.h>
-#include <Common/memory.h>
-#include <base/getPageSize.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/mman.h>
-
-#if defined(BOOST_USE_VALGRIND)
-#include <valgrind/valgrind.h>
-#endif
-
-/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
-#ifndef MAP_ANONYMOUS
-#define MAP_ANONYMOUS MAP_ANON
-#endif
-
-namespace DB::ErrorCodes
-{
-    extern const int CANNOT_ALLOCATE_MEMORY;
-}
 
 /// This is an implementation of allocator for fiber stack.
 /// The reference implementation is protected_fixedsize_stack from boost::context.
 /// This implementation additionally track memory usage. It is the main reason why it is needed.
 class FiberStack
 {
-private:
-    size_t stack_size;
-    size_t page_size = 0;
 public:
     /// NOTE: If you see random segfaults in CI and stack starts from boost::context::...fiber...
     /// probably it worth to try to increase stack size for coroutines.
@@ -40,55 +14,12 @@ public:
     /// way. We will have 80 pages with 4KB page size.
     static constexpr size_t default_stack_size = 320 * 1024; /// 64KB was not enough for tests
 
-    explicit FiberStack(size_t stack_size_ = default_stack_size) : stack_size(stack_size_)
-    {
-        page_size = getPageSize();
-    }
+    explicit FiberStack(size_t stack_size_ = default_stack_size);
 
-    boost::context::stack_context allocate() const
-    {
-        size_t num_pages = 1 + (stack_size - 1) / page_size;
-        size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
+    boost::context::stack_context allocate() const;
+    void deallocate(boost::context::stack_context & sctx) const;
 
-        void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (MAP_FAILED == vp)
-            throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
-
-        /// TODO: make reports on illegal guard page access more clear.
-        /// Currently we will see segfault and almost random stacktrace.
-        try
-        {
-            memoryGuardInstall(vp, page_size);
-        }
-        catch (...)
-        {
-            ::munmap(vp, num_bytes);
-            throw;
-        }
-
-        /// Do not count guard page in memory usage.
-        auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
-        trace.onAlloc(vp, num_pages * page_size);
-
-        boost::context::stack_context sctx;
-        sctx.size = num_bytes;
-        sctx.sp = static_cast< char * >(vp) + sctx.size;
-#if defined(BOOST_USE_VALGRIND)
-        sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
-#endif
-        return sctx;
-    }
-
-    void deallocate(boost::context::stack_context & sctx) const
-    {
-#if defined(BOOST_USE_VALGRIND)
-        VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
-#endif
-        void * vp = static_cast< char * >(sctx.sp) - sctx.size;
-        ::munmap(vp, sctx.size);
-
-        /// Do not count guard page in memory usage.
-        auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
-        trace.onFree(vp, sctx.size - page_size);
-    }
+private:
+    const size_t stack_size;
+    const size_t page_size;
 };

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -4,6 +4,7 @@
 #include <Common/ThreadStatus.h>
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
+#include <Common/memory.h>
 #include <base/getPageSize.h>
 #include <base/errnoToString.h>
 #include <Interpreters/Context.h>
@@ -42,13 +43,12 @@ struct ThreadStack
     ThreadStack()
         : data(aligned_alloc(getPageSize(), getSize()))
     {
-        /// Add a guard page
-        /// (and since the stack grows downward, we need to protect the first page).
-        mprotect(data, getPageSize(), PROT_NONE);
+        /// Since the stack grows downward, we need to protect the first page
+        memoryGuardInstall(data, getPageSize());
     }
     ~ThreadStack()
     {
-        mprotect(data, getPageSize(), PROT_WRITE|PROT_READ);
+        memoryGuardRemove(data, getPageSize());
         free(data);
     }
 

--- a/src/Common/memory.cpp
+++ b/src/Common/memory.cpp
@@ -1,0 +1,62 @@
+#include <sys/mman.h>
+#include <Poco/Environment.h>
+#include <Common/Exception.h>
+#include <Common/VersionNumber.h>
+#include <Common/memory.h>
+
+#ifdef __linux__
+#if !defined(MADV_GUARD_INSTALL)
+#define MADV_GUARD_INSTALL 102
+#endif
+
+#if !defined(MADV_GUARD_REMOVE)
+#define MADV_GUARD_REMOVE 103
+#endif
+
+static bool supportsGuardPages()
+{
+    DB::VersionNumber madv_guard_minimal_version(6, 13, 0);
+    DB::VersionNumber linux_version(Poco::Environment::osVersion());
+    return (linux_version >= madv_guard_minimal_version);
+}
+static bool supports_guard_pages = supportsGuardPages();
+#endif // __linux__
+
+namespace DB::ErrorCodes
+{
+    extern const int SYSTEM_ERROR;
+}
+
+/// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
+void memoryGuardInstall(void *addr, size_t len)
+{
+#ifdef __linux__
+    if (supports_guard_pages)
+    {
+        if (madvise(addr, len, MADV_GUARD_INSTALL))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot madvise(MADV_GUARD_INSTALL)");
+    }
+    else
+#endif
+    {
+        if (mprotect(addr, len, PROT_NONE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot mprotect(PROT_NONE)");
+    }
+}
+
+/// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
+void memoryGuardRemove(void *addr, size_t len)
+{
+#ifdef __linux__
+    if (supports_guard_pages)
+    {
+        if (madvise(addr, len, MADV_GUARD_REMOVE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot madvise(MADV_GUARD_INSTALL)");
+    }
+    else
+#endif
+    {
+        if (mprotect(addr, len, PROT_READ|PROT_WRITE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot mprotect(PROT_NONE)");
+    }
+}

--- a/src/Common/memory.cpp
+++ b/src/Common/memory.cpp
@@ -4,7 +4,7 @@
 #include <Common/VersionNumber.h>
 #include <Common/memory.h>
 
-#ifdef __linux__
+#ifdef OS_LINUX
 #if !defined(MADV_GUARD_INSTALL)
 #define MADV_GUARD_INSTALL 102
 #endif
@@ -20,7 +20,7 @@ static bool supportsGuardPages()
     return (linux_version >= madv_guard_minimal_version);
 }
 static bool supports_guard_pages = supportsGuardPages();
-#endif // __linux__
+#endif // OS_LINUX
 
 namespace DB::ErrorCodes
 {
@@ -30,7 +30,7 @@ namespace DB::ErrorCodes
 /// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
 void memoryGuardInstall(void *addr, size_t len)
 {
-#ifdef __linux__
+#ifdef OS_LINUX
     if (supports_guard_pages)
     {
         if (madvise(addr, len, MADV_GUARD_INSTALL))
@@ -47,7 +47,7 @@ void memoryGuardInstall(void *addr, size_t len)
 /// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
 void memoryGuardRemove(void *addr, size_t len)
 {
-#ifdef __linux__
+#ifdef OS_LINUX
     if (supports_guard_pages)
     {
         if (madvise(addr, len, MADV_GUARD_REMOVE))

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -17,6 +17,12 @@
 #    include <cstdlib>
 #endif
 
+#if defined(OS_LINUX)
+#    include <malloc.h>
+#elif defined(OS_DARWIN)
+#    include <malloc/malloc.h>
+#endif
+
 namespace ProfileEvents
 {
     extern const Event GWPAsanAllocateSuccess;
@@ -172,12 +178,6 @@ inline ALWAYS_INLINE void deleteSized(void * ptr, std::size_t size [[maybe_unuse
     free(ptr);
 }
 
-#endif
-
-#if defined(OS_LINUX)
-#    include <malloc.h>
-#elif defined(OS_DARWIN)
-#    include <malloc/malloc.h>
 #endif
 
 template <std::same_as<std::align_val_t>... TAlign>

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -32,7 +32,8 @@ namespace ProfileEvents
 
 /// Guard pages interface.
 ///
-/// Uses MADV_GUARD_INSTALL/MADV_GUARD_REMOVE which does not splits VMA, unlike mprotect()
+/// Uses MADV_GUARD_INSTALL/MADV_GUARD_REMOVE (since Linux 6.13+) which does
+/// not splits VMA (unlike mprotect()), or fallback to mprotect()
 ///
 /// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
 void memoryGuardInstall(void *addr, size_t len);

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -24,6 +24,15 @@ namespace ProfileEvents
     extern const Event GWPAsanFree;
 }
 
+/// Guard pages interface.
+///
+/// Uses MADV_GUARD_INSTALL/MADV_GUARD_REMOVE which does not splits VMA, unlike mprotect()
+///
+/// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
+void memoryGuardInstall(void *addr, size_t len);
+/// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
+void memoryGuardRemove(void *addr, size_t len);
+
 namespace Memory
 {
 

--- a/src/Coordination/FourLetterCommand.h
+++ b/src/Coordination/FourLetterCommand.h
@@ -5,16 +5,14 @@
 #include <atomic>
 #include <memory>
 #include <unordered_map>
-#include <string>
 #include <vector>
+#include <base/types.h>
 #include <boost/noncopyable.hpp>
 
 namespace DB
 {
 
 class KeeperDispatcher;
-
-using String = std::string;
 
 struct IFourLetterCommand;
 using FourLetterCommandPtr = std::shared_ptr<DB::IFourLetterCommand>;

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -7,6 +7,7 @@
 #include <QueryPipeline/RemoteInserter.h>
 #include <Common/Exception.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/formatReadable.h>
 #include <Common/quoteString.h>
 #include <base/defines.h>
 #include <IO/Operators.h>


### PR DESCRIPTION
In 6.13 MADV_GUARD_INSTALL/REMOVE had been added to Linux kernel, that allows to do more efficient guard pages, quote from [1]:

    The new guard-page feature addresses this problem by working at the page-table level rather than creating a new VMA. A process can create guard pages with a call to madvise(), requesting the MADV_GUARD_INSTALL operation. The indicated range of memory will be rendered inaccessible; any data that might have been stored there prior to the operation will be deleted. There is an operation (MADV_GUARD_REMOVE) to remove guard pages as well.

  [1]: https://lwn.net/Articles/1011366/

And since we have guard pages for fiber stacks and each thread stack, this should be a huge win for number of VMAs (which is limited to 65K by default)

### Tested manually on 6.14rc1

Without this patch:

```
[pid  6775] mprotect(0x7ffe68e57000, 4096, PROT_NONE) = 0
$ pgrep clickhouse-serv | xargs pmap | grep 7ffe68e57000
00007ffe68e57000      4K -----   [ anon ]
```

After:

```
[pid 32305] madvise(0x7ffe67cd9000, 4096, MADV_GUARD_INSTALL) = 0
$ pgrep clickhouse-serv | xargs pmap | grep 7ffe67cd9000 -c
0
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)