### PR TITLE
Optimize memory usage for NativeReader

### DIFF
--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -196,7 +196,10 @@ Block NativeReader::read()
             {
                 serialization = column_lazy->getDefaultSerialization();
                 const auto & tmp_columns = column_lazy->getColumns();
-                read_column = ColumnTuple::create(tmp_columns)->cloneEmpty();
+
+                auto new_column = ColumnTuple::create(tmp_columns)->cloneEmpty();
+                new_column->reserve(rows);
+                read_column = std::move(new_column);
             }
             else
             {
@@ -214,12 +217,16 @@ Block NativeReader::read()
                 info->deserializeFromKindsBinary(istr);
 
             serialization = column.type->getSerialization(*info);
-            read_column = column.type->createColumn(*serialization);
+            auto new_column = column.type->createColumn(*serialization);
+            new_column->reserve(rows);
+            read_column = std::move(new_column);
         }
         else
         {
             serialization = column.type->getDefaultSerialization();
-            read_column = column.type->createColumn(*serialization);
+            auto new_column = column.type->createColumn(*serialization);
+            new_column->reserve(rows);
+            read_column = std::move(new_column);
         }
 
         if (use_index)
@@ -231,9 +238,12 @@ Block NativeReader::read()
                 throw Exception(ErrorCodes::INCORRECT_INDEX, "Index points to column with wrong type: corrupted index or data");
         }
 
-        double avg_value_size_hint = avg_value_size_hints.empty() ? 0 : avg_value_size_hints[i];
-        if (!skip_reading && rows)    /// If no rows, nothing to read.
+        /// If no rows, nothing to read.
+        if (!skip_reading && rows)
+        {
+            double avg_value_size_hint = avg_value_size_hints.empty() ? 0 : avg_value_size_hints[i];
             readData(*serialization, read_column, istr, format_settings, rows, avg_value_size_hint);
+        }
 
         column.column = std::move(read_column);
 

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
@@ -35,7 +35,7 @@ Check total_bytes/total_rows for StripeLog
 113	1
 Check total_bytes/total_rows for Memory
 0	0
-256	1
+130	1
 Check total_bytes/total_rows for Buffer
 0	0
 256	50

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
@@ -93,6 +93,7 @@ DROP TABLE check_system_tables;
 SELECT 'Check total_bytes/total_rows for Memory';
 CREATE TABLE check_system_tables (key UInt16) ENGINE = Memory();
 SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+-- it will take 130 bytes, 2 + padding left+right (64x2)
 INSERT INTO check_system_tables VALUES (1);
 SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 DROP TABLE check_system_tables;

--- a/tests/queries/0_stateless/03339_native_reader_exact_rows.sql
+++ b/tests/queries/0_stateless/03339_native_reader_exact_rows.sql
@@ -1,0 +1,16 @@
+-- Tags: long
+
+-- We use temporary files that uses NativeReader, with a block slightly bigger
+-- then power of two, to increase memory overhead.
+
+-- This will create a temporary buffer of two columns for the total of 5m rows
+SELECT number FROM numbers(5e6) ORDER BY number * 1234567890123456789 LIMIT 4999980, 20
+SETTINGS
+    max_threads=1,
+    max_memory_usage='135Mi',
+    /* 65536 rows takes buffer of 512KB, so use slightly bigger value to increase overhead */
+    max_block_size=65540,
+    max_bytes_before_external_sort='10Mi',
+    max_bytes_ratio_before_external_sort=0,
+    min_external_sort_block_bytes='1Mi'
+FORMAT Null


### PR DESCRIPTION
NativeReader does not use information about number of rows that it has, to avoid excessive allocations (allocator uses power of 2).

Before this patch the query from the test needs 150Mi, after ~110MiB.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize memory usage for NativeReader