### PR TITLE
Fix possible recursive static var initialization (in debug build) due to big allocations check

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -6,6 +6,7 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/LockMemoryExceptionInThread.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/OvercommitTracker.h>
 #include <Common/PageCache.h>
 #include <Common/ProfileEvents.h>
@@ -200,28 +201,31 @@ void MemoryTracker::injectFault() const
         description ? " memory tracker" : "Memory tracker");
 }
 
+/// Big allocations through allocNoThrow (without checking memory limits) may easily lead to OOM (and it's hard to debug).
+/// Let's find them.
 void MemoryTracker::debugLogBigAllocationWithoutCheck(Int64 size [[maybe_unused]])
 {
-    /// Big allocations through allocNoThrow (without checking memory limits) may easily lead to OOM (and it's hard to debug).
-    /// Let's find them.
-#ifdef DEBUG_OR_SANITIZER_BUILD
-    if (size < 0)
-        return;
+    if constexpr (MemoryTrackerDebugBlockerInThread::isEnabled())
+    {
+        if (MemoryTrackerDebugBlockerInThread::isBlocked())
+            return;
 
-    constexpr Int64 threshold = 16 * 1024 * 1024;   /// The choice is arbitrary (maybe we should decrease it)
-    if (size < threshold)
-        return;
+        if (size < 0)
+            return;
 
-    MemoryTrackerBlockerInThread blocker(VariableContext::Global);
-    LOG_TEST(
-        getLogger("MemoryTracker"),
-        "Too big allocation ({} bytes) without checking memory limits, "
-        "it may lead to OOM. Stack trace: {}",
-        size,
-        StackTrace().toString());
-#else
-    /// Avoid trash logging in release builds
-#endif
+        /// The choice is arbitrary (maybe we should decrease it)
+        constexpr Int64 threshold = 16 * 1024 * 1024;
+        if (size < threshold)
+            return;
+
+        MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+        LOG_TEST(
+            getLogger("MemoryTracker"),
+            "Too big allocation ({} bytes) without checking memory limits, "
+            "it may lead to OOM. Stack trace: {}",
+            size,
+            StackTrace().toString());
+    }
 }
 
 AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryTracker * query_tracker, double _sample_probability)

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -207,15 +207,15 @@ void MemoryTracker::debugLogBigAllocationWithoutCheck(Int64 size [[maybe_unused]
 {
     if constexpr (MemoryTrackerDebugBlockerInThread::isEnabled())
     {
-        if (MemoryTrackerDebugBlockerInThread::isBlocked())
-            return;
-
         if (size < 0)
             return;
 
         /// The choice is arbitrary (maybe we should decrease it)
         constexpr Int64 threshold = 16 * 1024 * 1024;
         if (size < threshold)
+            return;
+
+        if (MemoryTrackerDebugBlockerInThread::isBlocked())
             return;
 
         MemoryTrackerBlockerInThread blocker(VariableContext::Global);

--- a/src/Common/MemoryTrackerDebugBlockerInThread.cpp
+++ b/src/Common/MemoryTrackerDebugBlockerInThread.cpp
@@ -1,0 +1,16 @@
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
+
+thread_local uint64_t MemoryTrackerDebugBlockerInThread::counter = 0;
+
+MemoryTrackerDebugBlockerInThread::MemoryTrackerDebugBlockerInThread()
+{
+    ++counter;
+}
+
+MemoryTrackerDebugBlockerInThread::~MemoryTrackerDebugBlockerInThread()
+{
+    --counter;
+}
+#endif

--- a/src/Common/MemoryTrackerDebugBlockerInThread.cpp
+++ b/src/Common/MemoryTrackerDebugBlockerInThread.cpp
@@ -2,15 +2,22 @@
 
 #ifdef DEBUG_OR_SANITIZER_BUILD
 
-thread_local uint64_t MemoryTrackerDebugBlockerInThread::counter = 0;
+#include <cstdint>
+
+static thread_local uint64_t MemoryTrackerDebugBlockerInThreadCounter;
 
 MemoryTrackerDebugBlockerInThread::MemoryTrackerDebugBlockerInThread()
 {
-    ++counter;
+    ++MemoryTrackerDebugBlockerInThreadCounter;
 }
 
 MemoryTrackerDebugBlockerInThread::~MemoryTrackerDebugBlockerInThread()
 {
-    --counter;
+    --MemoryTrackerDebugBlockerInThreadCounter;
+}
+
+bool MemoryTrackerDebugBlockerInThread::isBlocked()
+{
+    return MemoryTrackerDebugBlockerInThreadCounter > 0;
 }
 #endif

--- a/src/Common/MemoryTrackerDebugBlockerInThread.h
+++ b/src/Common/MemoryTrackerDebugBlockerInThread.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <base/defines.h> /// DEBUG_OR_SANITIZER_BUILD
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
+#include <cstdint>
+
+struct MemoryTrackerDebugBlockerInThread
+{
+public:
+    MemoryTrackerDebugBlockerInThread();
+    ~MemoryTrackerDebugBlockerInThread();
+
+    static bool isBlocked() { return counter > 0; }
+    static constexpr bool isEnabled() { return true; }
+
+private:
+    static thread_local uint64_t counter;
+};
+#else
+struct MemoryTrackerDebugBlockerInThread
+{
+public:
+    static constexpr bool isEnabled() { return false; }
+    static constexpr bool isBlocked() { return true; }
+};
+#endif

--- a/src/Common/MemoryTrackerDebugBlockerInThread.h
+++ b/src/Common/MemoryTrackerDebugBlockerInThread.h
@@ -3,19 +3,14 @@
 #include <base/defines.h> /// DEBUG_OR_SANITIZER_BUILD
 
 #ifdef DEBUG_OR_SANITIZER_BUILD
-#include <cstdint>
-
 struct MemoryTrackerDebugBlockerInThread
 {
 public:
     MemoryTrackerDebugBlockerInThread();
     ~MemoryTrackerDebugBlockerInThread();
 
-    static bool isBlocked() { return counter > 0; }
     static constexpr bool isEnabled() { return true; }
-
-private:
-    static thread_local uint64_t counter;
+    static bool isBlocked();
 };
 #else
 struct MemoryTrackerDebugBlockerInThread

--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -4,7 +4,6 @@
 
 #include <vector>
 #include <string>
-#include <unordered_map>
 #include <Common/Elf.h>
 #include <boost/noncopyable.hpp>
 

--- a/tests/queries/0_stateless/03337_local_static_var_recursive_initialization.sh
+++ b/tests/queries/0_stateless/03337_local_static_var_recursive_initialization.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# We only care about does it crashes or not with:
+#
+#   __cxa_guard_acquire detected recursive initialization: do you have a function-local static variable whose initialization depends on that function
+#
+# Due to recursive initialization of SymbolIndex, one on fly due to Exception,
+# another one due to allocation for SymbolIndex itself, that exceed default
+# limit of 16MiB for non-tracked allocations
+#
+# NOTE: --log-level=test is important (since only in case of test level it will
+# try to capture stacktrace in case of big untracked allocation)
+$CLICKHOUSE_LOCAL --log-level=test 'select throwIf(1) -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }' >& /dev/null


### PR DESCRIPTION
CI found some errors like:

    __cxa_guard_acquire detected recursive initialization: do you have a function-local static variable whose initialization depends on that function

The problem was with SymbolIndex.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/78061

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible recursive static var initialization (in debug build) due to big allocations check