### PR TITLE
Update clang-tidy-cache and show its stats

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -92,7 +92,7 @@ RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/M
   && ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64 \
   && rm /MacOSX11.0.sdk.tar.xz
 
-ARG CLANG_TIDY_SHA1=c191254ea00d47ade11d7170ef82fe038c213774
+ARG CLANG_TIDY_SHA1=35edad32a0bfb3dafada7201afe28036624906ed
 RUN curl -Lo /usr/bin/clang-tidy-cache \
-        "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/clang-tidy-cache" \
+        "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
     && chmod +x /usr/bin/clang-tidy-cache

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -161,8 +161,7 @@ def main():
         res = results[-1].is_ok()
 
     if res and JobStages.BUILD in stages:
-        run_shell("Env vars", "env | sort")
-        run_shell("sccache stats", "env | sccache --show-stats")
+        run_shell("sccache stats", "sccache --show-stats")
         run_shell("clang-tidy-cache stats", "clang-tidy-cache --show-stats")
         if build_type in BUILD_TYPE_TO_DEB_PACKAGE_TYPE:
             targets = "clickhouse-bundle"
@@ -180,7 +179,7 @@ def main():
                 with_log=True,
             )
         )
-        run_shell("sccache stats", "env | sccache --show-stats")
+        run_shell("sccache stats", "sccache --show-stats")
         run_shell("clang-tidy-cache stats", "clang-tidy-cache --show-stats")
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")


### PR DESCRIPTION
Newer versions have a `--show-stats` option, so update clang-tidy-cache and show its stats

From https://github.com/ClickHouse/ClickHouse/actions/runs/14214703098/job/39828753132?pr=78466
```
>>>> clang-tidy-cache stats

Server host:            localhost
Server port:            5000
Long-term hit rate:     N/A
Hit rate:               98.7 %
Hit count:              3329
Miss count:             44
Miss rate:              1.3 %
Max hash age:           N/A
Max hash hits:          N/A
Cache size:             N/A
Cached hashes:          N/A
Cleaned hashes:         N/A
Cleaned ago:            N/A
Saved ago:              N/A
Uptime:                 N/A
Hit rate (local):       N/A
Hit count (local):      N/A
Miss count (local):     N/A
Miss rate (local):      N/A
Cached hashes (local):  N/A

<<<< clang-tidy-cache stats
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
