### PR TITLE
tests: explicit number of threads for S3Queue tests

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -130,6 +130,7 @@ def test_replicated(started_cluster):
         "ordered",
         files_path,
         additional_settings={
+            "processing_threads_num": 16,
             "keeper_path": keeper_path,
         },
         database_name="r",
@@ -209,6 +210,7 @@ def test_processing_threads(started_cluster):
         "ordered",
         files_path,
         additional_settings={
+            "processing_threads_num": 16,
             "keeper_path": keeper_path,
         },
     )


### PR DESCRIPTION
Otherwise it may fail (i.e. locally) if the machine has more then 16 CPUs (since 16 is a minimum).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)