### PR TITLE
Minor refactoring near `MergeTree` reader

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -267,7 +267,8 @@ void optimizeLazyMaterialization(Stack & stack, QueryPlan::Nodes & nodes, size_t
     if (lazily_read_info->lazily_read_columns.empty())
         return;
 
-    lazily_read_info->data_parts_info = std::make_shared<DataPartsInfo>();
+    lazily_read_info->data_part_infos = std::make_shared<DataPartInfoByIndex>();
+
     auto lazy_column_reader = std::make_unique<MergeTreeLazilyReader>(
         sorting_step->getOutputHeader(),
         reading_step->getMergeTreeData(),

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -42,6 +42,7 @@
 #include <Storages/MergeTree/MergeTreeReadPoolInOrder.h>
 #include <Storages/MergeTree/MergeTreeReadPoolParallelReplicas.h>
 #include <Storages/MergeTree/MergeTreeReadPoolParallelReplicasInOrder.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergeTreeSource.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
@@ -2276,17 +2277,16 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
 
     if (lazily_read_info)
     {
-        chassert(lazily_read_info->data_parts_info);
-        for (auto & ranges_in_data_part : result.parts_with_ranges)
+        for (const auto & ranges_in_data_part : result.parts_with_ranges)
         {
-            lazily_read_info->data_parts_info->emplace(
-                ranges_in_data_part.part_index_in_query,
-                DataPartInfo
-                {
-                    .data_part = ranges_in_data_part.data_part,
-                    .alter_conversions = MergeTreeData::getAlterConversionsForPart(
-                        ranges_in_data_part.data_part, mutations_snapshot, storage_snapshot->metadata, getContext())
-                });
+            auto alter_conversions = MergeTreeData::getAlterConversionsForPart(
+                ranges_in_data_part.data_part,
+                mutations_snapshot,
+                storage_snapshot->metadata,
+                getContext());
+
+            auto part_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(ranges_in_data_part.data_part, std::move(alter_conversions));
+            lazily_read_info->data_part_infos->emplace(ranges_in_data_part.part_index_in_query, std::move(part_info));
         }
     }
 

--- a/src/Storages/LazilyReadInfo.h
+++ b/src/Storages/LazilyReadInfo.h
@@ -9,11 +9,16 @@ namespace DB
 struct LazilyReadInfo;
 using LazilyReadInfoPtr = std::shared_ptr<LazilyReadInfo>;
 
+class IMergeTreeDataPartInfoForReader;
+using MergeTreeDataPartInfoForReaderPtr = std::shared_ptr<IMergeTreeDataPartInfoForReader>;
+using DataPartInfoByIndex = std::unordered_map<size_t, MergeTreeDataPartInfoForReaderPtr>;
+using DataPartInfoByIndexPtr = std::shared_ptr<DataPartInfoByIndex>;
+
 struct LazilyReadInfo
 {
     ColumnsWithTypeAndName lazily_read_columns;
     bool remove_part_offset_column;
-    DataPartsInfoPtr data_parts_info;
+    DataPartInfoByIndexPtr data_part_infos;
 
     LazilyReadInfo() = default;
 };

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -29,6 +29,7 @@
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/MergeTree/MergeTreeIndexGranularityAdaptive.h>
 #include <Storages/MergeTree/PrimaryIndexCache.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <base/JSON.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
@@ -1515,7 +1516,11 @@ UInt64 IMergeTreeDataPart::readExistingRowsCount()
     StorageMetadataPtr metadata_ptr = storage.getInMemoryMetadataPtr();
     StorageSnapshotPtr storage_snapshot_ptr = std::make_shared<StorageSnapshot>(storage, metadata_ptr);
 
-    MergeTreeReaderPtr reader = getReader(
+    auto alter_conversions = std::make_shared<AlterConversions>();
+    auto part_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this(), alter_conversions);
+
+    MergeTreeReaderPtr reader = createMergeTreeReader(
+        part_info,
         cols,
         storage_snapshot_ptr,
         MarkRanges{MarkRange(0, total_mark)},
@@ -1523,16 +1528,9 @@ UInt64 IMergeTreeDataPart::readExistingRowsCount()
         /*uncompressed_cache=*/{},
         storage.getContext()->getMarkCache().get(),
         nullptr,
-        std::make_shared<AlterConversions>(),
         MergeTreeReaderSettings{},
         ValueSizeMap{},
         ReadBufferFromFileBase::ProfileCallback{});
-
-    if (!reader)
-    {
-        LOG_WARNING(storage.log, "Create reader failed while reading existing rows count");
-        return rows_count;
-    }
 
     size_t current_mark = 0;
     bool continue_reading = false;
@@ -2538,7 +2536,11 @@ ColumnPtr IMergeTreeDataPart::getColumnSample(const NameAndTypePair & column) co
     MergeTreeReaderSettings settings;
     settings.can_read_part_without_marks = true;
 
-    MergeTreeReaderPtr reader = getReader(
+    auto alter_conversions = std::make_shared<AlterConversions>();
+    auto part_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this(), alter_conversions);
+
+    MergeTreeReaderPtr reader = createMergeTreeReader(
+        part_info,
         cols,
         storage_snapshot_ptr,
         MarkRanges{MarkRange(0, total_mark)},
@@ -2546,7 +2548,6 @@ ColumnPtr IMergeTreeDataPart::getColumnSample(const NameAndTypePair & column) co
         /*uncompressed_cache=*/{},
         storage.getContext()->getMarkCache().get(),
         nullptr,
-        std::make_shared<AlterConversions>(),
         settings,
         ValueSizeMap{},
         ReadBufferFromFileBase::ProfileCallback{});

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -74,10 +74,6 @@ public:
 
     using Checksums = MergeTreeDataPartChecksums;
     using Checksum = MergeTreeDataPartChecksums::Checksum;
-    using ValueSizeMap = std::map<std::string, double>;
-    using VirtualFields = std::unordered_map<String, Field>;
-
-    using MergeTreeReaderPtr = std::unique_ptr<IMergeTreeReader>;
 
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;
     using NameToNumber = std::unordered_map<std::string, size_t>;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -96,19 +96,6 @@ public:
         Type part_type_,
         const IMergeTreeDataPart * parent_part_);
 
-    virtual MergeTreeReaderPtr getReader(
-        const NamesAndTypesList & columns_,
-        const StorageSnapshotPtr & storage_snapshot,
-        const MarkRanges & mark_ranges,
-        const VirtualFields & virtual_fields,
-        UncompressedCache * uncompressed_cache,
-        MarkCache * mark_cache,
-        DeserializationPrefixesCache * deserialization_prefixes_cache,
-        const AlterConversionsPtr & alter_conversions,
-        const MergeTreeReaderSettings & reader_settings_,
-        const ValueSizeMap & avg_value_size_hints_,
-        const ReadBufferFromFileBase::ProfileCallback & profile_callback_) const = 0;
-
     virtual bool isStoredOnReadonlyDisk() const = 0;
     virtual bool isStoredOnRemoteDisk() const = 0;
     virtual bool isStoredOnRemoteDiskWithZeroCopySupport() const = 0;

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -405,4 +405,74 @@ String IMergeTreeReader::getMessageForDiagnosticOfBrokenPart(size_t from_mark, s
         offset);
 }
 
+MergeTreeReaderPtr createMergeTreeReaderCompact(
+    const MergeTreeDataPartInfoForReaderPtr & read_info,
+    const NamesAndTypesList & columns_to_read,
+    const StorageSnapshotPtr & storage_snapshot,
+    const MarkRanges & mark_ranges,
+    const VirtualFields & virtual_fields,
+    UncompressedCache * uncompressed_cache,
+    MarkCache * mark_cache,
+    DeserializationPrefixesCache * deserialization_prefixes_cache,
+    const MergeTreeReaderSettings & reader_settings,
+    const ValueSizeMap & avg_value_size_hints,
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback);
+
+MergeTreeReaderPtr createMergeTreeReaderWide(
+    const MergeTreeDataPartInfoForReaderPtr & read_info,
+    const NamesAndTypesList & columns_to_read,
+    const StorageSnapshotPtr & storage_snapshot,
+    const MarkRanges & mark_ranges,
+    const VirtualFields & virtual_fields,
+    UncompressedCache * uncompressed_cache,
+    MarkCache * mark_cache,
+    DeserializationPrefixesCache * deserialization_prefixes_cache,
+    const MergeTreeReaderSettings & reader_settings,
+    const ValueSizeMap & avg_value_size_hints,
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback);
+
+MergeTreeReaderPtr createMergeTreeReader(
+    const MergeTreeDataPartInfoForReaderPtr & read_info,
+    const NamesAndTypesList & columns_to_read,
+    const StorageSnapshotPtr & storage_snapshot,
+    const MarkRanges & mark_ranges,
+    const VirtualFields & virtual_fields,
+    UncompressedCache * uncompressed_cache,
+    MarkCache * mark_cache,
+    DeserializationPrefixesCache * deserialization_prefixes_cache,
+    const MergeTreeReaderSettings & reader_settings,
+    const ValueSizeMap & avg_value_size_hints,
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback)
+{
+    if (read_info->isCompactPart())
+        return createMergeTreeReaderCompact(
+            read_info,
+            columns_to_read,
+            storage_snapshot,
+            mark_ranges,
+            virtual_fields,
+            uncompressed_cache,
+            mark_cache,
+            deserialization_prefixes_cache,
+            reader_settings,
+            avg_value_size_hints,
+            profile_callback);
+
+    if (read_info->isWidePart())
+        return createMergeTreeReaderWide(
+            read_info,
+            columns_to_read,
+            storage_snapshot,
+            mark_ranges,
+            virtual_fields,
+            uncompressed_cache,
+            mark_cache,
+            deserialization_prefixes_cache,
+            reader_settings,
+            avg_value_size_hints,
+            profile_callback);
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown part type");
+}
+
 }

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -73,7 +73,7 @@ IMergeTreeReader::IMergeTreeReader(
     }
 }
 
-const IMergeTreeReader::ValueSizeMap & IMergeTreeReader::getAvgValueSizeHints() const
+const ValueSizeMap & IMergeTreeReader::getAvgValueSizeHints() const
 {
     return avg_value_size_hints;
 }

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -9,14 +9,15 @@
 namespace DB
 {
 
+using VirtualFields = std::unordered_map<String, Field>;
+using ValueSizeMap = std::map<std::string, double>;
+
 /// Reads the data between pairs of marks in the same part. When reading consecutive ranges, avoids unnecessary seeks.
 /// When ranges are almost consecutive, seeks are fast because they are performed inside the buffer.
 /// Avoids loading the marks file if it is not needed (e.g. when reading the whole part).
 class IMergeTreeReader : private boost::noncopyable
 {
 public:
-    using ValueSizeMap = std::map<std::string, double>;
-    using VirtualFields = std::unordered_map<String, Field>;
     using DeserializeBinaryBulkStateMap = std::unordered_map<std::string, ISerialization::DeserializeBinaryBulkStatePtr>;
     using FileStreams = std::map<std::string, std::unique_ptr<MergeTreeReaderStream>>;
 
@@ -139,8 +140,6 @@ private:
 };
 
 using MergeTreeReaderPtr = std::unique_ptr<IMergeTreeReader>;
-using VirtualFields = std::unordered_map<String, Field>;
-using ValueSizeMap = std::map<std::string, double>;
 
 MergeTreeReaderPtr createMergeTreeReader(
     const MergeTreeDataPartInfoForReaderPtr & read_info,

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -138,4 +138,21 @@ private:
     VirtualFields virtual_fields;
 };
 
+using MergeTreeReaderPtr = std::unique_ptr<IMergeTreeReader>;
+using VirtualFields = std::unordered_map<String, Field>;
+using ValueSizeMap = std::map<std::string, double>;
+
+MergeTreeReaderPtr createMergeTreeReader(
+    const MergeTreeDataPartInfoForReaderPtr & read_info,
+    const NamesAndTypesList & columns,
+    const StorageSnapshotPtr & storage_snapshot,
+    const MarkRanges & mark_ranges,
+    const VirtualFields & virtual_fields,
+    UncompressedCache * uncompressed_cache,
+    MarkCache * mark_cache,
+    DeserializationPrefixesCache * deserialization_prefixes_cache,
+    const MergeTreeReaderSettings & reader_settings,
+    const ValueSizeMap & avg_value_size_hints,
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback);
+
 }

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
@@ -31,7 +31,8 @@ MergeTreeDataPartCompact::MergeTreeDataPartCompact(
 {
 }
 
-IMergeTreeDataPart::MergeTreeReaderPtr MergeTreeDataPartCompact::getReader(
+MergeTreeReaderPtr createMergeTreeReaderCompact(
+    const MergeTreeDataPartInfoForReaderPtr & read_info,
     const NamesAndTypesList & columns_to_read,
     const StorageSnapshotPtr & storage_snapshot,
     const MarkRanges & mark_ranges,
@@ -39,13 +40,10 @@ IMergeTreeDataPart::MergeTreeReaderPtr MergeTreeDataPartCompact::getReader(
     UncompressedCache * uncompressed_cache,
     MarkCache * mark_cache,
     DeserializationPrefixesCache * deserialization_prefixes_cache,
-    const AlterConversionsPtr & alter_conversions,
     const MergeTreeReaderSettings & reader_settings,
     const ValueSizeMap & avg_value_size_hints,
-    const ReadBufferFromFileBase::ProfileCallback & profile_callback) const
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback)
 {
-    auto read_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this(), alter_conversions);
-
     return std::make_unique<MergeTreeReaderCompactSingleBuffer>(
         read_info, columns_to_read, virtual_fields,
         storage_snapshot, uncompressed_cache,

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.h
@@ -28,19 +28,6 @@ public:
         const MutableDataPartStoragePtr & data_part_storage_,
         const IMergeTreeDataPart * parent_part_ = nullptr);
 
-    MergeTreeReaderPtr getReader(
-        const NamesAndTypesList & columns,
-        const StorageSnapshotPtr & storage_snapshot,
-        const MarkRanges & mark_ranges,
-        const VirtualFields & virtual_fields,
-        UncompressedCache * uncompressed_cache,
-        MarkCache * mark_cache,
-        DeserializationPrefixesCache * deserialization_prefixes_cache,
-        const AlterConversionsPtr & alter_conversions,
-        const MergeTreeReaderSettings & reader_settings_,
-        const ValueSizeMap & avg_value_size_hints,
-        const ReadBufferFromFileBase::ProfileCallback & profile_callback) const override;
-
     bool isStoredOnReadonlyDisk() const override;
 
     bool isStoredOnRemoteDisk() const override;

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
@@ -35,7 +35,8 @@ MergeTreeDataPartWide::MergeTreeDataPartWide(
 {
 }
 
-IMergeTreeDataPart::MergeTreeReaderPtr MergeTreeDataPartWide::getReader(
+MergeTreeReaderPtr createMergeTreeReaderWide(
+    const MergeTreeDataPartInfoForReaderPtr & read_info,
     const NamesAndTypesList & columns_to_read,
     const StorageSnapshotPtr & storage_snapshot,
     const MarkRanges & mark_ranges,
@@ -43,12 +44,10 @@ IMergeTreeDataPart::MergeTreeReaderPtr MergeTreeDataPartWide::getReader(
     UncompressedCache * uncompressed_cache,
     MarkCache * mark_cache,
     DeserializationPrefixesCache * deserialization_prefixes_cache,
-    const AlterConversionsPtr & alter_conversions,
     const MergeTreeReaderSettings & reader_settings,
     const ValueSizeMap & avg_value_size_hints,
-    const ReadBufferFromFileBase::ProfileCallback & profile_callback) const
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback)
 {
-    auto read_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this(), alter_conversions);
     return std::make_unique<MergeTreeReaderWide>(
         read_info,
         columns_to_read,

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.h
@@ -23,19 +23,6 @@ public:
         const MutableDataPartStoragePtr & data_part_storage_,
         const IMergeTreeDataPart * parent_part_ = nullptr);
 
-    MergeTreeReaderPtr getReader(
-        const NamesAndTypesList & columns,
-        const StorageSnapshotPtr & storage_snapshot,
-        const MarkRanges & mark_ranges,
-        const VirtualFields & virtual_fields,
-        UncompressedCache * uncompressed_cache,
-        MarkCache * mark_cache,
-        DeserializationPrefixesCache * deserialization_prefixes_cache,
-        const AlterConversionsPtr & alter_conversions,
-        const MergeTreeReaderSettings & reader_settings_,
-        const ValueSizeMap & avg_value_size_hints,
-        const ReadBufferFromFileBase::ProfileCallback & profile_callback) const override;
-
     bool isStoredOnReadonlyDisk() const override;
 
     bool isStoredOnRemoteDisk() const override;

--- a/src/Storages/MergeTree/MergeTreeLazilyReader.h
+++ b/src/Storages/MergeTree/MergeTreeLazilyReader.h
@@ -43,7 +43,7 @@ private:
         MutableColumns & lazily_read_columns);
 
     const MergeTreeData & storage;
-    DataPartsInfoPtr data_parts_info;
+    DataPartInfoByIndexPtr data_part_infos;
     StorageSnapshotPtr storage_snapshot;
     bool use_uncompressed_cache;
     Names requested_column_names;

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/MergeTreeReadTask.h>
 #include <Storages/MergeTree/MergeTreeBlockReadUtils.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Common/Exception.h>
 #include <IO/Operators.h>
 
@@ -57,7 +58,10 @@ MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
 
     auto create_reader = [&](const NamesAndTypesList & columns_to_read, bool is_prewhere)
     {
-        return read_info->data_part->getReader(
+        auto part_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(read_info->data_part, read_info->alter_conversions);
+
+        return createMergeTreeReader(
+            part_info,
             columns_to_read,
             extras.storage_snapshot,
             ranges,
@@ -65,7 +69,6 @@ MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
             extras.uncompressed_cache,
             extras.mark_cache,
             is_prewhere ? nullptr : read_info->deserialization_prefixes_cache.get(),
-            read_info->alter_conversions,
             extras.reader_settings,
             extras.value_size_map,
             extras.profile_callback);

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -21,7 +21,6 @@ using MergeTreeBlockSizePredictorPtr = std::shared_ptr<MergeTreeBlockSizePredict
 class IMergeTreeDataPart;
 using DataPartPtr = std::shared_ptr<const IMergeTreeDataPart>;
 using MergeTreeReaderPtr = std::unique_ptr<IMergeTreeReader>;
-using VirtualFields = std::unordered_map<String, Field>;
 
 class DeserializationPrefixesCache;
 using DeserializationPrefixesCachePtr = std::shared_ptr<DeserializationPrefixesCache>;
@@ -96,7 +95,7 @@ public:
         MarkCache * mark_cache = nullptr;
         MergeTreeReaderSettings reader_settings{};
         StorageSnapshotPtr storage_snapshot{};
-        IMergeTreeReader::ValueSizeMap value_size_map{};
+        ValueSizeMap value_size_map{};
         ReadBufferFromFileBase::ProfileCallback profile_callback{};
     };
 

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -33,7 +33,7 @@ MergeTreeReaderWide::MergeTreeReaderWide(
     DeserializationPrefixesCache * deserialization_prefixes_cache_,
     MarkRanges mark_ranges_,
     MergeTreeReaderSettings settings_,
-    IMergeTreeDataPart::ValueSizeMap avg_value_size_hints_,
+    ValueSizeMap avg_value_size_hints_,
     const ReadBufferFromFileBase::ProfileCallback & profile_callback_,
     clockid_t clock_type_)
     : IMergeTreeReader(

--- a/src/Storages/MergeTree/RangesInDataPart.h
+++ b/src/Storages/MergeTree/RangesInDataPart.h
@@ -65,7 +65,7 @@ struct RangesInDataPart
     size_t getRowsCount() const;
 };
 
-struct RangesInDataParts: public std::vector<RangesInDataPart>
+struct RangesInDataParts : public std::vector<RangesInDataPart>
 {
     using std::vector<RangesInDataPart>::vector; /// NOLINT(modernize-type-traits)
 
@@ -74,13 +74,5 @@ struct RangesInDataParts: public std::vector<RangesInDataPart>
     size_t getMarksCountAllParts() const;
     size_t getRowsCountAllParts() const;
 };
-
-struct DataPartInfo
-{
-    DataPartPtr data_part;
-    AlterConversionsPtr alter_conversions;
-};
-using DataPartsInfo = std::unordered_map<size_t, DataPartInfo>;
-using DataPartsInfoPtr = std::shared_ptr<DataPartsInfo>;
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Required for lightweight updates.
