### PR TITLE
Use insertion columns for INFILE schema inference

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1906,15 +1906,15 @@ void ClientBase::sendData(Block & sample, const ColumnsDescription & columns_des
 
         if (parsed_insert_query->columns)
         {
-            auto columns = processColumnTransformers(columns_for_storage_file, parsed_insert_query->columns, client_context->getCurrentDatabase(), client_context->getInsertionTable());
+            auto columns = processColumnTransformers(client_context->getCurrentDatabase(), client_context->getInsertionTable(), columns_for_storage_file, parsed_insert_query->columns);
             ColumnsDescription reordered_description{};
             for (const auto & col_name : columns->children)
             {
                 auto col = columns_for_storage_file.get(col_name->getColumnName());
-                reordered_description.add(col);
+                reordered_description.add(std::move(col));
             }
 
-            columns_for_storage_file = reordered_description;
+            columns_for_storage_file = std::move(reordered_description);
         }
 
         StorageFile::CommonArguments args{

--- a/src/Interpreters/processColumnTransformers.cpp
+++ b/src/Interpreters/processColumnTransformers.cpp
@@ -59,10 +59,10 @@ ASTPtr processColumnTransformers(
 }
 
 ASTPtr processColumnTransformers(
-        const ColumnsDescription & columns,
-        ASTPtr query_columns,
         const String & current_database,
-        const StorageID & table_id)
+        const StorageID & table_id,
+        const ColumnsDescription & columns,
+        ASTPtr query_columns)
 {
     return processColumnTransformersImpl(columns, {}, query_columns, current_database, table_id);
 }

--- a/src/Interpreters/processColumnTransformers.cpp
+++ b/src/Interpreters/processColumnTransformers.cpp
@@ -12,27 +12,29 @@
 namespace DB
 {
 
-ASTPtr processColumnTransformers(
-        const String & current_database,
-        const StoragePtr & table,
-        const StorageMetadataPtr & metadata_snapshot,
-        ASTPtr query_columns)
+namespace
 {
-    const auto & columns = metadata_snapshot->getColumns();
+ASTPtr processColumnTransformersImpl(
+    const ColumnsDescription & columns,
+    const NamesAndTypesList & virtual_columns,
+    ASTPtr query_columns,
+    const String & current_database,
+    const StorageID & storage_id)
+{
     auto names_and_types = columns.getOrdinary();
     removeDuplicateColumns(names_and_types);
 
     TablesWithColumns tables_with_columns;
     {
         auto table_expr = std::make_shared<ASTTableExpression>();
-        table_expr->database_and_table_name = std::make_shared<ASTTableIdentifier>(table->getStorageID());
+        table_expr->database_and_table_name = std::make_shared<ASTTableIdentifier>(storage_id);
         table_expr->children.push_back(table_expr->database_and_table_name);
         tables_with_columns.emplace_back(DatabaseAndTableWithAlias(*table_expr, current_database), names_and_types);
     }
 
     tables_with_columns[0].addHiddenColumns(columns.getMaterialized());
     tables_with_columns[0].addHiddenColumns(columns.getAliases());
-    tables_with_columns[0].addHiddenColumns(table->getVirtualsList());
+    tables_with_columns[0].addHiddenColumns(virtual_columns);
 
     NameSet source_columns_set;
     for (const auto & identifier : query_columns->children)
@@ -44,6 +46,25 @@ ASTPtr processColumnTransformers(
     visitor.visit(columns_ast);
 
     return columns_ast;
+}
+}
+
+ASTPtr processColumnTransformers(
+        const String & current_database,
+        const StoragePtr & table,
+        const StorageMetadataPtr & metadata_snapshot,
+        ASTPtr query_columns)
+{
+    return processColumnTransformersImpl(metadata_snapshot->columns, table->getVirtualsList(), query_columns, current_database, table->getStorageID());
+}
+
+ASTPtr processColumnTransformers(
+        const ColumnsDescription & columns,
+        ASTPtr query_columns,
+        const String & current_database,
+        const StorageID & table_id)
+{
+    return processColumnTransformersImpl(columns, {}, query_columns, current_database, table_id);
 }
 
 }

--- a/src/Interpreters/processColumnTransformers.h
+++ b/src/Interpreters/processColumnTransformers.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Parsers/IAST_fwd.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/IStorage_fwd.h>
+#include <Interpreters/StorageID.h>
 
 namespace DB
 {
@@ -15,5 +17,11 @@ ASTPtr processColumnTransformers(
         const StoragePtr & table,
         const StorageMetadataPtr & metadata_snapshot,
         ASTPtr query_columns);
+
+ASTPtr processColumnTransformers(
+        const ColumnsDescription & columns,
+        ASTPtr query_columns,
+        const String & current_database,
+        const StorageID & table_id);
 
 }

--- a/src/Interpreters/processColumnTransformers.h
+++ b/src/Interpreters/processColumnTransformers.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include <Parsers/IAST_fwd.h>
-#include <Storages/ColumnsDescription.h>
 #include <Storages/IStorage_fwd.h>
-#include <Interpreters/StorageID.h>
 
 namespace DB
 {
 
 struct StorageInMemoryMetadata;
 using StorageMetadataPtr = std::shared_ptr<const StorageInMemoryMetadata>;
+class ColumnsDescription;
+struct StorageID;
 
 /// Process column transformers (e.g. * EXCEPT(a)), asterisks and qualified columns.
 ASTPtr processColumnTransformers(
@@ -19,9 +19,9 @@ ASTPtr processColumnTransformers(
         ASTPtr query_columns);
 
 ASTPtr processColumnTransformers(
-        const ColumnsDescription & columns,
-        ASTPtr query_columns,
         const String & current_database,
-        const StorageID & table_id);
+        const StorageID & table_id,
+        const ColumnsDescription & columns,
+        ASTPtr query_columns);
 
 }

--- a/tests/queries/0_stateless/02878_use_structure_from_insertion_table_with_explicit_insert_columns.reference
+++ b/tests/queries/0_stateless/02878_use_structure_from_insertion_table_with_explicit_insert_columns.reference
@@ -2,3 +2,6 @@
 0	0
 42	0
 42	0
+42	world
+42	world
+42	world

--- a/tests/queries/0_stateless/02878_use_structure_from_insertion_table_with_explicit_insert_columns.sh
+++ b/tests/queries/0_stateless/02878_use_structure_from_insertion_table_with_explicit_insert_columns.sh
@@ -15,3 +15,16 @@ select * from test order by x;
 "
 
 rm $CLICKHOUSE_TEST_UNIQUE_NAME.native
+
+$CLICKHOUSE_LOCAL -q "select 'world' as y, 42 as x format Values" > $CLICKHOUSE_TEST_UNIQUE_NAME.values
+$CLICKHOUSE_LOCAL -q "
+create table test_infile (val UInt64, key String) engine=Memory;
+insert into test_infile select * from file('$CLICKHOUSE_TEST_UNIQUE_NAME.values'); -- { serverError CANNOT_PARSE_TEXT }
+insert into test_infile from infile '$CLICKHOUSE_TEST_UNIQUE_NAME.values' FORMAT Values; -- { clientError CANNOT_PARSE_TEXT }
+insert into test_infile (key, val) from infile '$CLICKHOUSE_TEST_UNIQUE_NAME.values' FORMAT Values;
+insert into test_infile (* EXCEPT 'val', * EXCEPT 'key') from infile '$CLICKHOUSE_TEST_UNIQUE_NAME.values' FORMAT Values;
+insert into test_infile (* EXCEPT 'val', test_infile.val) from infile '$CLICKHOUSE_TEST_UNIQUE_NAME.values' FORMAT Values;
+select * from test_infile order by key, val;
+"
+
+rm $CLICKHOUSE_TEST_UNIQUE_NAME.values


### PR DESCRIPTION
Take columns order during client data streaming from insertion columns.
Closes #71050

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use insertion columns for INFILE schema inference

