### PR TITLE
Fix 'Unknown packet 11 from server' with async_insert + apply_settings_from_server

### DIFF
--- a/tests/integration/test_settings_from_server/configs/users.d/users.xml
+++ b/tests/integration/test_settings_from_server/configs/users.d/users.xml
@@ -15,6 +15,9 @@
             <output_format_json_quote_64bit_integers>0</output_format_json_quote_64bit_integers>
             <compatibility>24.11</compatibility>
         </compat_profile>
+        <async_insert_profile>
+            <async_insert>true</async_insert>
+        </async_insert_profile>
     </profiles>
     <users>
         <default>
@@ -33,5 +36,9 @@
             <password></password>
             <profile>compat_profile</profile>
         </compat_user>
+        <async_insert_user>
+            <password></password>
+            <profile>async_insert_profile</profile>
+        </async_insert_user>
     </users>
 </clickhouse>

--- a/tests/integration/test_settings_from_server/test.py
+++ b/tests/integration/test_settings_from_server/test.py
@@ -87,3 +87,7 @@ def test_settings_from_server(started_cluster):
     assert quoted_pos != -1, "first query should return quoted number"
     assert unquoted_pos != -1, "second query should return unquoted number"
     assert quoted_pos < unquoted_pos, "should be quoted for first query, unquoted for second"
+
+def test_async_insert(started_cluster):
+    node.query("create table a (k Int64) engine MergeTree order by k")
+    node.query("insert into a values (1)", user="async_insert_user")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed "Unknown packet 11 from server" when async_insert is enabled in user profile. Possible workarounds on older versions: (1) disable apply_settings_from_server (in user profile or in INSERT query's SETTINGS), or (2) add `SETTINGS async_insert=1` to the INSERT query (before VALUES).


Closes https://github.com/ClickHouse/ClickHouse/issues/78130