### PR TITLE
Move MongoDB instance initialization to a class

### DIFF
--- a/src/Dictionaries/MongoDBDictionarySource.h
+++ b/src/Dictionaries/MongoDBDictionarySource.h
@@ -53,6 +53,8 @@ public:
     std::string toString() const override;
 
 private:
+    MongoDBInstanceHolder & instance_holder = MongoDBInstanceHolder::instance();
+
     const DictionaryStructure dict_struct;
     const std::shared_ptr<MongoDBConfiguration> configuration;
     Block sample_block;

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -3,9 +3,10 @@
 #include "config.h"
 
 #if USE_MONGODB
-#include <Processors/ISource.h>
-#include <Interpreters/Context.h>
 #include <Common/JSONBuilder.h>
+#include <Interpreters/Context.h>
+#include <Processors/ISource.h>
+#include <Storages/StorageMongoDB.h>
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/collection.hpp>
@@ -32,6 +33,8 @@ public:
     String getName() const override { return "MongoDB"; }
 
 private:
+    MongoDBInstanceHolder & instance_holder = MongoDBInstanceHolder::instance();
+
     static void insertDefaultValue(IColumn & column, const IColumn & sample_column);
     void insertValue(IColumn & column, const size_t & idx, const DataTypePtr & type, const std::string & name, const bsoncxx::document::element & value);
 

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -34,7 +34,7 @@ public:
     }
 private:
     MongoDBInstanceHolder() = default;
-    static mongocxx::instance inst;
+    mongocxx::instance inst;
 };
 
 struct MongoDBConfiguration

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -16,8 +16,6 @@
 namespace DB
 {
 
-inline mongocxx::instance inst{};
-
 struct MongoDBConfiguration
 {
     std::unique_ptr<mongocxx::uri> uri;
@@ -68,6 +66,8 @@ public:
         size_t num_streams) override;
 
 private:
+    mongocxx::instance inst{};
+
     template <typename OnError>
     std::optional<bsoncxx::document::value> visitWhereFunction(
         const ContextPtr & context,

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -16,6 +16,11 @@
 namespace DB
 {
 
+/// As per MongoDB CXX driver documentation:
+/// You must create a mongocxx::instance object before you use the C++ driver,
+/// and this object must remain alive for as long as any other MongoDB objects are in scope.
+///
+/// mongocxx::instance must not be created more than once, therefore we use a singleton.
 class MongoDBInstanceHolder final : public boost::noncopyable
 {
 public:

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -16,6 +16,22 @@
 namespace DB
 {
 
+class MongoDBInstanceHolder final : public boost::noncopyable
+{
+public:
+    MongoDBInstanceHolder(MongoDBInstanceHolder const &) = delete;
+    void operator=(MongoDBInstanceHolder const &) = delete;
+
+    static MongoDBInstanceHolder & instance()
+    {
+        static MongoDBInstanceHolder instance;
+        return instance;
+    }
+private:
+    MongoDBInstanceHolder() = default;
+    static mongocxx::instance inst;
+};
+
 struct MongoDBConfiguration
 {
     std::unique_ptr<mongocxx::uri> uri;
@@ -66,7 +82,7 @@ public:
         size_t num_streams) override;
 
 private:
-    mongocxx::instance inst{};
+    MongoDBInstanceHolder & instance_holder = MongoDBInstanceHolder::instance();
 
     template <typename OnError>
     std::optional<bsoncxx::document::value> visitWhereFunction(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Split from https://github.com/ClickHouse/ClickHouse/pull/78413
Static field caused early OpenSSL initialization on server start in `mongoc-openssl.c`. Let's move it to a class member. 

