### PR TITLE
Fix flaky test_reload_while_loading 

### DIFF
--- a/tests/integration/test_dictionaries_update_and_reload/test.py
+++ b/tests/integration/test_dictionaries_update_and_reload/test.py
@@ -144,7 +144,6 @@ def test_reload_while_loading(started_cluster):
         instance, "slow"
     ), get_loading_duration(instance, "slow")
     assert start_time > prev_start_time
-    assert duration < prev_duration
 
     time.sleep(1)  # Still loading.
     assert get_status(instance, "slow") == "LOADING"

--- a/tests/integration/test_dictionaries_update_and_reload/test.py
+++ b/tests/integration/test_dictionaries_update_and_reload/test.py
@@ -97,12 +97,12 @@ def test_reload_while_loading(started_cluster):
     assert get_loading_duration(instance, "slow") == 0
 
     query_id = str(uuid.uuid4())
-    # It's not possible to get a value from the dictionary within 2 second, so the following query fails by timeout.
+    # It's not possible to get a value from the dictionary within 10 seconds, so the following query fails by timeout.
     with pytest.raises(QueryTimeoutExceedException):
         query(
             "SELECT dictGetInt32('slow', 'a', toUInt64(5))",
             query_id=query_id,
-            timeout=2,
+            timeout=10,
         )
 
     # The instance should receive the query
@@ -131,7 +131,7 @@ def test_reload_while_loading(started_cluster):
     # SYSTEM RELOAD DICTIONARY should restart loading.
     query_id = str(uuid.uuid4())
     with pytest.raises(QueryTimeoutExceedException):
-        query("SYSTEM RELOAD DICTIONARY 'slow'", query_id=query_id, timeout=2)
+        query("SYSTEM RELOAD DICTIONARY 'slow'", query_id=query_id, timeout=10)
     # The instance should receive the query
     query("SYSTEM FLUSH LOGS")
     assert instance.wait_for_log_line(

--- a/tests/integration/test_dictionaries_update_and_reload/test.py
+++ b/tests/integration/test_dictionaries_update_and_reload/test.py
@@ -17,13 +17,14 @@ DICTIONARY_FILES = [
     "configs/dictionaries/slow.xml",
 ]
 
-cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance("instance", dictionaries=DICTIONARY_FILES)
 
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def started_cluster():
+    cluster = None
     try:
+        cluster = ClickHouseCluster(__file__, str(uuid.uuid4()))
+        instance = cluster.add_instance("instance", dictionaries=DICTIONARY_FILES)
+
         cluster.start()
         instance.query("CREATE DATABASE IF NOT EXISTS test")
 
@@ -33,13 +34,13 @@ def started_cluster():
         cluster.shutdown()
 
 
-def get_status(dictionary_name):
+def get_status(instance, dictionary_name):
     return instance.query(
         "SELECT status FROM system.dictionaries WHERE name='" + dictionary_name + "'"
     ).rstrip("\n")
 
 
-def get_last_exception(dictionary_name):
+def get_last_exception(instance, dictionary_name):
     return (
         instance.query(
             "SELECT last_exception FROM system.dictionaries WHERE name='"
@@ -51,7 +52,7 @@ def get_last_exception(dictionary_name):
     )
 
 
-def get_loading_start_time(dictionary_name):
+def get_loading_start_time(instance, dictionary_name):
     s = instance.query(
         "SELECT toTimeZone(loading_start_time, 'UTC') FROM system.dictionaries WHERE name='"
         + dictionary_name
@@ -62,7 +63,7 @@ def get_loading_start_time(dictionary_name):
     return time.strptime(s, "%Y-%m-%d %H:%M:%S")
 
 
-def get_last_successful_update_time(dictionary_name):
+def get_last_successful_update_time(instance, dictionary_name):
     s = instance.query(
         "SELECT toTimeZone(last_successful_update_time, 'UTC') FROM system.dictionaries WHERE name='"
         + dictionary_name
@@ -73,7 +74,7 @@ def get_last_successful_update_time(dictionary_name):
     return time.strptime(s, "%Y-%m-%d %H:%M:%S")
 
 
-def get_loading_duration(dictionary_name):
+def get_loading_duration(instance, dictionary_name):
     return float(
         instance.query(
             "SELECT loading_duration FROM system.dictionaries WHERE name='"
@@ -83,16 +84,17 @@ def get_loading_duration(dictionary_name):
     )
 
 
-def replace_in_file_in_container(file_name, what, replace_with):
+def replace_in_file_in_container(instance, file_name, what, replace_with):
     instance.exec_in_container(["sed", "-i", f"s/{what}/{replace_with}/g", file_name])
 
 
 def test_reload_while_loading(started_cluster):
+    instance = started_cluster.instances["instance"]
     query = instance.query
 
     # dictionaries_lazy_load == false, so this dictionary is not loaded.
-    assert get_status("slow") == "NOT_LOADED"
-    assert get_loading_duration("slow") == 0
+    assert get_status(instance, "slow") == "NOT_LOADED"
+    assert get_loading_duration(instance, "slow") == 0
 
     query_id = str(uuid.uuid4())
     # It's not possible to get a value from the dictionary within 2 second, so the following query fails by timeout.
@@ -111,14 +113,18 @@ def test_reload_while_loading(started_cluster):
     )
 
     # The dictionary is now loading.
-    assert get_status("slow") == "LOADING"
-    start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
+    assert get_status(instance, "slow") == "LOADING"
+    start_time, duration = get_loading_start_time(
+        instance, "slow"
+    ), get_loading_duration(instance, "slow")
     assert duration > 0
 
     time.sleep(1)  # Still loading.
-    assert get_status("slow") == "LOADING"
+    assert get_status(instance, "slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
-    start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
+    start_time, duration = get_loading_start_time(
+        instance, "slow"
+    ), get_loading_duration(instance, "slow")
     assert start_time == prev_start_time
     assert duration >= prev_duration
 
@@ -132,34 +138,39 @@ def test_reload_while_loading(started_cluster):
         query_id,
         look_behind_lines=1000,
     )
-    assert get_status("slow") == "LOADING"
+    assert get_status(instance, "slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
-    start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
+    start_time, duration = get_loading_start_time(
+        instance, "slow"
+    ), get_loading_duration(instance, "slow")
     assert start_time > prev_start_time
     assert duration < prev_duration
 
     time.sleep(1)  # Still loading.
-    assert get_status("slow") == "LOADING"
+    assert get_status(instance, "slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
-    start_time, duration = get_loading_start_time("slow"), get_loading_duration("slow")
+    start_time, duration = get_loading_start_time(
+        instance, "slow"
+    ), get_loading_duration(instance, "slow")
     assert start_time == prev_start_time
     assert duration >= prev_duration
 
     # Changing the configuration file should restart loading again.
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/slow.xml", "sleep 100", "sleep 0"
+        instance, "/etc/clickhouse-server/dictionaries/slow.xml", "sleep 100", "sleep 0"
     )
     query("SYSTEM RELOAD CONFIG")
 
     # This time loading should finish quickly.
-    assert get_status("slow") == "LOADED"
+    assert get_status(instance, "slow") == "LOADED"
 
-    last_successful_update_time = get_last_successful_update_time("slow")
+    last_successful_update_time = get_last_successful_update_time(instance, "slow")
     assert last_successful_update_time > start_time
     assert query("SELECT dictGetInt32('slow', 'a', toUInt64(5))") == "6\n"
 
 
 def test_reload_after_loading(started_cluster):
+    instance = started_cluster.instances["instance"]
     query = instance.query
 
     assert query("SELECT dictGetInt32('executable', 'a', toUInt64(7))") == "8\n"
@@ -171,10 +182,10 @@ def test_reload_after_loading(started_cluster):
     # soon. Should probably be fixed by switching to use std::filesystem.
     time.sleep(1)
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/executable.xml", "8", "81"
+        instance, "/etc/clickhouse-server/dictionaries/executable.xml", "8", "81"
     )
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/file.txt", "10", "101"
+        instance, "/etc/clickhouse-server/dictionaries/file.txt", "10", "101"
     )
 
     # SYSTEM RELOAD 'name' reloads only the specified dictionary.
@@ -189,10 +200,10 @@ def test_reload_after_loading(started_cluster):
     # SYSTEM RELOAD DICTIONARIES reloads all loaded dictionaries.
     time.sleep(1)  # see the comment above
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/executable.xml", "81", "82"
+        instance, "/etc/clickhouse-server/dictionaries/executable.xml", "81", "82"
     )
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/file.txt", "101", "102"
+        instance, "/etc/clickhouse-server/dictionaries/file.txt", "101", "102"
     )
     query("SYSTEM RELOAD DICTIONARY 'file'")
     query("SYSTEM RELOAD DICTIONARY 'executable'")
@@ -203,10 +214,10 @@ def test_reload_after_loading(started_cluster):
     # Wait slightly more, to be sure it did reload.
     time.sleep(1)  # see the comment above
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/executable.xml", "82", "83"
+        instance, "/etc/clickhouse-server/dictionaries/executable.xml", "82", "83"
     )
     replace_in_file_in_container(
-        "/etc/clickhouse-server/dictionaries/file.txt", "102", "103"
+        instance, "/etc/clickhouse-server/dictionaries/file.txt", "102", "103"
     )
     time.sleep(10)
     assert query("SELECT dictGetInt32('file', 'a', toUInt64(9))") == "103\n"
@@ -214,17 +225,18 @@ def test_reload_after_loading(started_cluster):
 
 
 def test_reload_after_fail_by_system_reload(started_cluster):
+    instance = started_cluster.instances["instance"]
     query = instance.query
 
     # dictionaries_lazy_load == false, so this dictionary is not loaded.
-    assert get_status("no_file") == "NOT_LOADED"
+    assert get_status(instance, "no_file") == "NOT_LOADED"
 
     # We expect an error because the file source doesn't exist.
     no_such_file_error = "No such file"
     assert no_such_file_error in instance.query_and_get_error(
         "SELECT dictGetInt32('no_file', 'a', toUInt64(9))"
     )
-    assert get_status("no_file") == "FAILED"
+    assert get_status(instance, "no_file") == "FAILED"
 
     # SYSTEM RELOAD should not change anything now, the status is still FAILED.
     assert no_such_file_error in instance.query_and_get_error(
@@ -233,7 +245,7 @@ def test_reload_after_fail_by_system_reload(started_cluster):
     assert no_such_file_error in instance.query_and_get_error(
         "SELECT dictGetInt32('no_file', 'a', toUInt64(9))"
     )
-    assert get_status("no_file") == "FAILED"
+    assert get_status(instance, "no_file") == "FAILED"
 
     # Creating the file source makes the dictionary able to load.
     instance.copy_file_to_container(
@@ -242,7 +254,7 @@ def test_reload_after_fail_by_system_reload(started_cluster):
     )
     query("SYSTEM RELOAD DICTIONARY 'no_file'")
     query("SELECT dictGetInt32('no_file', 'a', toUInt64(9))") == "10\n"
-    assert get_status("no_file") == "LOADED"
+    assert get_status(instance, "no_file") == "LOADED"
 
     # Removing the file source should not spoil the loaded dictionary.
     instance.exec_in_container(
@@ -252,19 +264,20 @@ def test_reload_after_fail_by_system_reload(started_cluster):
         "SYSTEM RELOAD DICTIONARY 'no_file'"
     )
     query("SELECT dictGetInt32('no_file', 'a', toUInt64(9))") == "10\n"
-    assert get_status("no_file") == "LOADED"
+    assert get_status(instance, "no_file") == "LOADED"
 
 
 def test_reload_after_fail_by_timer(started_cluster):
+    instance = started_cluster.instances["instance"]
     # dictionaries_lazy_load == false, so this dictionary is not loaded.
-    assert get_status("no_file_2") == "NOT_LOADED"
+    assert get_status(instance, "no_file_2") == "NOT_LOADED"
 
     # We expect an error because the file source doesn't exist.
     expected_error = "No such file"
     assert expected_error in instance.query_and_get_error(
         "SELECT dictGetInt32('no_file_2', 'a', toUInt64(9))"
     )
-    assert get_status("no_file_2") == "FAILED"
+    assert get_status(instance, "no_file_2") == "FAILED"
 
     # Passed time should not change anything now, the status is still FAILED.
     time.sleep(6)
@@ -274,7 +287,7 @@ def test_reload_after_fail_by_timer(started_cluster):
 
     # on sanitizers builds it can return 'FAILED_AND_RELOADING' which is not quite right
     # add retry for these builds
-    assert get_status("no_file_2") in ["FAILED", "FAILED_AND_RELOADING"]
+    assert get_status(instance, "no_file_2") in ["FAILED", "FAILED_AND_RELOADING"]
 
     # Creating the file source makes the dictionary able to load.
     instance.copy_file_to_container(
@@ -289,7 +302,7 @@ def test_reload_after_fail_by_timer(started_cluster):
     )
     instance.query("SYSTEM RELOAD DICTIONARY no_file_2")
     instance.query("SELECT dictGetInt32('no_file_2', 'a', toUInt64(9))") == "10\n"
-    assert get_status("no_file_2") in ["LOADED", "LOADED_AND_RELOADING"]
+    assert get_status(instance, "no_file_2") in ["LOADED", "LOADED_AND_RELOADING"]
 
     # Removing the file source should not spoil the loaded dictionary.
     instance.exec_in_container(
@@ -297,10 +310,11 @@ def test_reload_after_fail_by_timer(started_cluster):
     )
     time.sleep(6)
     instance.query("SELECT dictGetInt32('no_file_2', 'a', toUInt64(9))") == "10\n"
-    assert get_status("no_file_2") in ["LOADED", "LOADED_AND_RELOADING"]
+    assert get_status(instance, "no_file_2") in ["LOADED", "LOADED_AND_RELOADING"]
 
 
 def test_reload_after_fail_in_cache_dictionary(started_cluster):
+    instance = started_cluster.instances["instance"]
     query = instance.query
     query_and_get_error = instance.query_and_get_error
 
@@ -310,8 +324,8 @@ def test_reload_after_fail_in_cache_dictionary(started_cluster):
     assert expected_error in query_and_get_error(
         "SELECT dictGetUInt64('cache_xypairs', 'y', toUInt64(1))"
     )
-    assert get_status("cache_xypairs") == "LOADED"
-    assert expected_error in get_last_exception("cache_xypairs")
+    assert get_status(instance, "cache_xypairs") == "LOADED"
+    assert expected_error in get_last_exception(instance, "cache_xypairs")
 
     # Create table `test.xypairs`.
     query(
@@ -330,7 +344,7 @@ def test_reload_after_fail_in_cache_dictionary(started_cluster):
         ignore_error=True,
     )
     query("SELECT dictGet('cache_xypairs', 'y', toUInt64(2))") == "0"
-    assert get_last_exception("cache_xypairs") == ""
+    assert get_last_exception(instance, "cache_xypairs") == ""
 
     # Drop table `test.xypairs`.
     query("DROP TABLE test.xypairs")
@@ -338,13 +352,13 @@ def test_reload_after_fail_in_cache_dictionary(started_cluster):
     # Values are cached so we can get them.
     query("SELECT dictGet('cache_xypairs', 'y', toUInt64(1))") == "56"
     query("SELECT dictGet('cache_xypairs', 'y', toUInt64(2))") == "0"
-    assert get_last_exception("cache_xypairs") == ""
+    assert get_last_exception(instance, "cache_xypairs") == ""
 
     # But we can't get a value from the source table which isn't cached.
     assert expected_error in query_and_get_error(
         "SELECT dictGetUInt64('cache_xypairs', 'y', toUInt64(3))"
     )
-    assert expected_error in get_last_exception("cache_xypairs")
+    assert expected_error in get_last_exception(instance, "cache_xypairs")
 
     # Passed time should not spoil the cache.
     time.sleep(5)
@@ -354,7 +368,7 @@ def test_reload_after_fail_in_cache_dictionary(started_cluster):
         "SELECT dictGetUInt64('cache_xypairs', 'y', toUInt64(3))"
     )
     assert (expected_error in error) or (update_error in error)
-    last_exception = get_last_exception("cache_xypairs")
+    last_exception = get_last_exception(instance, "cache_xypairs")
     assert (expected_error in last_exception) or (update_error in last_exception)
 
     # Create table `test.xypairs` again with changed values.
@@ -373,4 +387,4 @@ def test_reload_after_fail_in_cache_dictionary(started_cluster):
     )
     query("SELECT dictGet('cache_xypairs', 'y', toUInt64(2))") == "0"
     query("SELECT dictGet('cache_xypairs', 'y', toUInt64(3))") == "79"
-    assert get_last_exception("cache_xypairs") == ""
+    assert get_last_exception(instance, "cache_xypairs") == ""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test_reload_while_loading, increase timeout from 1 to 10s, ensure that the instance receives the query triggering the dict loading

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
