### PR TITLE
Fix dumping network profile events for HTTP protocol with compression enabled

### DIFF
--- a/src/Common/OpenTelemetryTraceContext.cpp
+++ b/src/Common/OpenTelemetryTraceContext.cpp
@@ -147,7 +147,7 @@ SpanHolder::SpanHolder(std::string_view _operation_name, SpanKind _kind)
     current_trace_context->span_id = this->span_id;
 }
 
-void SpanHolder::finish() noexcept
+void SpanHolder::finish(std::chrono::system_clock::time_point time) noexcept
 {
     if (!this->isTraceEnabled())
         return;
@@ -163,9 +163,7 @@ void SpanHolder::finish() noexcept
         /// The log might be disabled, check it before use
         if (log)
         {
-            this->finish_time_us
-                = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-
+            this->finish_time_us = std::chrono::duration_cast<std::chrono::microseconds>(time.time_since_epoch()).count();
             log->add(OpenTelemetrySpanLogElement(*this));
         }
     }
@@ -179,7 +177,7 @@ void SpanHolder::finish() noexcept
 
 SpanHolder::~SpanHolder()
 {
-    finish();
+    finish(std::chrono::system_clock::now());
 }
 
 bool TracingContext::parseTraceparentHeader(std::string_view traceparent, String & error)

--- a/src/Common/OpenTelemetryTraceContext.h
+++ b/src/Common/OpenTelemetryTraceContext.h
@@ -161,7 +161,7 @@ struct SpanHolder : public Span
 
     /// Finish a span explicitly if needed.
     /// It's safe to call it multiple times
-    void finish() noexcept;
+    void finish(std::chrono::system_clock::time_point time) noexcept;
 };
 
 }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -963,9 +963,7 @@ try
         LOG_DEBUG(log, "Flushed {} rows, {} bytes for query '{}'", num_rows, num_bytes, key.query_str);
         queue_shard_flush_time_history.updateWithCurrentTime();
 
-        bool pulling_pipeline = false;
-        logQueryFinish(
-            query_log_elem, insert_context, key.query, pipeline, pulling_pipeline, query_span, QueryResultCacheUsage::None, internal);
+        logQueryFinish(query_log_elem, insert_context, key.query, pipeline, /*pulling_pipeline=*/false, query_span, QueryResultCacheUsage::None, internal);
     };
 
     try

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -583,13 +583,13 @@ void logQueryFinish(
     const Settings & settings = context->getSettingsRef();
     auto log_queries = settings[Setting::log_queries] && !internal;
 
+    const auto time_now = std::chrono::system_clock::now();
     QueryStatusPtr process_list_elem = context->getProcessListElement();
     if (process_list_elem)
     {
         /// Update performance counters before logging to query_log
         CurrentThread::finalizePerformanceCounters();
 
-        auto time_now = std::chrono::system_clock::now();
         QueryStatusInfo info = process_list_elem->getInfo(true, settings[Setting::log_profile_events]);
         logQueryMetricLogFinish(context, internal, elem.client_info.current_query_id, time_now, std::make_shared<QueryStatusInfo>(info));
         elem.type = QueryLogElementType::QUERY_FINISH;
@@ -652,7 +652,7 @@ void logQueryFinish(
                 query_span->addAttribute(fmt::format("clickhouse.setting.{}", change.name), convertFieldToString(change.value));
             }
         }
-        query_span->finish();
+        query_span->finish(time_now);
     }
 }
 
@@ -721,7 +721,7 @@ void logQueryException(
         query_span->addAttribute("clickhouse.query_id", elem.client_info.current_query_id);
         query_span->addAttribute("clickhouse.exception", elem.exception);
         query_span->addAttribute("clickhouse.exception_code", elem.exception_code);
-        query_span->finish();
+        query_span->finish(time_now);
     }
 }
 
@@ -843,7 +843,7 @@ void logExceptionBeforeStart(
         query_span->addAttribute("clickhouse.exception", elem.exception);
         query_span->addAttribute("db.statement", elem.query);
         query_span->addAttribute("clickhouse.query_id", elem.client_info.current_query_id);
-        query_span->finish();
+        query_span->finish(query_end_time);
     }
 
     ProfileEvents::increment(ProfileEvents::FailedQuery);

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -32,6 +32,7 @@ struct QueryResultDetails
 
 using SetResultDetailsFunc = std::function<void(const QueryResultDetails &)>;
 using HandleExceptionInOutputFormatFunc = std::function<void(IOutputFormat & output_format, const String & format_name, const ContextPtr & context, const std::optional<FormatSettings> & format_settings)>;
+using QueryFinishCallback = std::function<void()>;
 
 
 /// Parse and execute a query.
@@ -43,7 +44,9 @@ void executeQuery(
     SetResultDetailsFunc set_result_details, /// If a non-empty callback is passed, it will be called with the query id, the content-type, the format, and the timezone, as well as additional headers.
     QueryFlags flags = {},
     const std::optional<FormatSettings> & output_format_settings = std::nullopt, /// Format settings for output format, will be calculated from the context if not set.
-    HandleExceptionInOutputFormatFunc handle_exception_in_output_format = {} /// If a non-empty callback is passed, it will be called on exception with created output format.
+    HandleExceptionInOutputFormatFunc handle_exception_in_output_format = {}, /// If a non-empty callback is passed, it will be called on exception with created output format.
+    QueryFinishCallback query_finish_callback = {} /// Use it to do everything you need to before the QueryFinish entry will be dumped to query_log
+                                                   /// NOTE: It will not be called in case of exception (i.e. ExceptionWhileProcessing)
 );
 
 

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -46,10 +46,10 @@ BlockIO::~BlockIO()
     reset();
 }
 
-void BlockIO::onFinish()
+void BlockIO::onFinish(std::chrono::system_clock::time_point finish_time)
 {
     if (finish_callback)
-        finish_callback(pipeline);
+        finish_callback(pipeline, finish_time);
 
     pipeline.reset();
 }

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -25,13 +25,13 @@ struct BlockIO
     QueryPipeline pipeline;
 
     /// Callbacks for query logging could be set here.
-    std::function<void(QueryPipeline &)> finish_callback;
+    std::function<void(QueryPipeline &, std::chrono::system_clock::time_point)> finish_callback;
     std::function<void(bool)> exception_callback;
 
     /// When it is true, don't bother sending any non-empty blocks to the out stream
     bool null_format = false;
 
-    void onFinish();
+    void onFinish(std::chrono::system_clock::time_point finish_time = std::chrono::system_clock::now());
     void onException(bool log_as_error=true);
     void onCancelOrConnectionLoss();
 

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -662,7 +662,7 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(bool append, int32_t roo
             if (execution.interrupt_execution.load())
                 throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
 
-            logQueryFinish(*query_log_elem, refresh_context, refresh_query, pipeline, /*pulling_pipeline*/ false, query_span, QueryResultCacheUsage::None, /*internal*/ false);
+            logQueryFinish(*query_log_elem, refresh_context, refresh_query, pipeline, /*pulling_pipeline=*/false, query_span, QueryResultCacheUsage::None, /*internal*/ false);
             query_log_elem = std::nullopt;
             query_span = nullptr;
             process_list_entry.reset(); // otherwise it needs to be alive for logQueryException

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -662,7 +662,7 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(bool append, int32_t roo
             if (execution.interrupt_execution.load())
                 throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
 
-            logQueryFinish(*query_log_elem, refresh_context, refresh_query, pipeline, /*pulling_pipeline=*/false, query_span, QueryResultCacheUsage::None, /*internal*/ false);
+            logQueryFinish(*query_log_elem, refresh_context, refresh_query, pipeline, /*pulling_pipeline=*/false, query_span, QueryResultCacheUsage::None, /*internal=*/false);
             query_log_elem = std::nullopt;
             query_span = nullptr;
             process_list_entry.reset(); // otherwise it needs to be alive for logQueryException

--- a/tests/queries/0_stateless/03338_http_compression_profile_events.reference
+++ b/tests/queries/0_stateless/03338_http_compression_profile_events.reference
@@ -1,0 +1,4 @@
+SELECT 1 FORMAT RowBinary	compress=0	1
+SELECT 1 FORMAT RowBinary	compress=1	1
+SELECT 1 FORMAT RowBinary	wait_end_of_query=0	1
+SELECT 1 FORMAT RowBinary	wait_end_of_query=1	1

--- a/tests/queries/0_stateless/03338_http_compression_profile_events.sh
+++ b/tests/queries/0_stateless/03338_http_compression_profile_events.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+options=(
+    compress=0
+    compress=1
+    wait_end_of_query=0
+    wait_end_of_query=1
+)
+for option in "${options[@]}"; do
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query_id=$CLICKHOUSE_TEST_UNIQUE_NAME-$option&$option" -d @- <<< "SELECT 1 FORMAT RowBinary" > /dev/null
+done
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d @- <<< "SYSTEM FLUSH LOGS system.query_log"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d @- <<< "
+    SELECT query, replace(query_id, '$CLICKHOUSE_TEST_UNIQUE_NAME-', ''), ProfileEvents['NetworkSendBytes'] > 0
+    FROM system.query_log
+    WHERE current_database = '$CLICKHOUSE_DATABASE' AND query_id LIKE '$CLICKHOUSE_TEST_UNIQUE_NAME%' AND type != 'QueryStart'
+    ORDER BY event_time_microseconds
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix dumping profile events (`NetworkSendElapsedMicroseconds`/`NetworkSendBytes`) for HTTP protocol with compression enabled (the error should not be more then the buffer size, usually around 1MiB)

The problem is that in this case the network profile events (NetworkSendElapsedMicroseconds/NetworkSendBytes) will be incremented when the entry to `query_log` had been flushed already.