### PR TITLE
s3queue: fix logical error "Cannot unregister: table uuid is not registered"

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -760,7 +760,7 @@ size_t ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage
                 if (supports_remove_recursive)
                 {
                     requests.push_back(zkutil::makeCheckRequest(registry_path, stat.version));
-                    requests.push_back(zkutil::makeRemoveRecursiveRequest(zookeeper_path, -1));
+                    requests.push_back(zkutil::makeRemoveRecursiveRequest(zookeeper_path, std::numeric_limits<uint32_t>::max()));
                 }
                 else
                 {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -125,7 +125,7 @@ public:
     void registerIfNot(const StorageID & storage_id, bool active);
     /// Unregister table.
     /// Return the number of remaining (after unregistering) registered tables.
-    size_t unregister(const StorageID & storage_id, bool active);
+    size_t unregister(const StorageID & storage_id, bool active, bool remove_metadata_if_no_registered);
     Strings getRegistered(bool active);
 
     /// According to current *active* registered tables,
@@ -155,7 +155,7 @@ private:
     void registerNonActive(const StorageID & storage_id);
     void registerActive(const StorageID & storage_id);
 
-    size_t unregisterNonActive(const StorageID & storage_id);
+    size_t unregisterNonActive(const StorageID & storage_id, bool remove_metadata_if_no_registered);
     size_t unregisterActive(const StorageID & storage_id);
 
     void updateRegistryFunc();

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -293,7 +293,7 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
     {
         try
         {
-            files_metadata->unregister(getStorageID(), /* active */true);
+            files_metadata->unregister(getStorageID(), /* active */true, /* remove_metadata_if_no_registered */false);
         }
         catch (...)
         {
@@ -544,7 +544,7 @@ void StorageObjectStorageQueue::threadFunc()
         {
             try
             {
-                files_metadata->unregister(storage_id, /* active */true);
+                files_metadata->unregister(storage_id, /* active */true, /* remove_metadata_if_no_registered */false);
             }
             catch (...)
             {

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -123,7 +123,7 @@ def test_replicated(started_cluster):
         f"CREATE DATABASE {db_name} ENGINE=Replicated('/clickhouse/databases/replicateddb', 'shard1', 'node2')"
     )
 
-    def create_table():
+    def do_create_table():
         create_table(
             started_cluster,
             node1,
@@ -137,9 +137,9 @@ def test_replicated(started_cluster):
             database_name="r",
         )
 
-    create_table()
-    node1.query(f"DROP TABLE {table_name} SYNC")
-    create_table()
+    do_create_table()
+    node1.query(f"DROP TABLE r.{table_name} SYNC")
+    do_create_table()
 
     assert '"processing_threads_num":16' in node1.query(
         f"SELECT * FROM system.zookeeper WHERE path = '{keeper_path}'"

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -170,6 +170,8 @@ def test_replicated(started_cluster):
         time.sleep(1)
     assert expected_rows == get_count()
 
+    node1.query(f"DROP TABLE {db_name}.{table_name} SYNC")
+
 
 def test_bad_settings(started_cluster):
     node = started_cluster.instances["node_cloud_mode"]

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -123,18 +123,23 @@ def test_replicated(started_cluster):
         f"CREATE DATABASE {db_name} ENGINE=Replicated('/clickhouse/databases/replicateddb', 'shard1', 'node2')"
     )
 
-    create_table(
-        started_cluster,
-        node1,
-        table_name,
-        "ordered",
-        files_path,
-        additional_settings={
-            "processing_threads_num": 16,
-            "keeper_path": keeper_path,
-        },
-        database_name="r",
-    )
+    def create_table():
+        create_table(
+            started_cluster,
+            node1,
+            table_name,
+            "ordered",
+            files_path,
+            additional_settings={
+                "processing_threads_num": 16,
+                "keeper_path": keeper_path,
+            },
+            database_name="r",
+        )
+
+    create_table()
+    node1.query(f"DROP TABLE {table_name} SYNC")
+    create_table()
 
     assert '"processing_threads_num":16' in node1.query(
         f"SELECT * FROM system.zookeeper WHERE path = '{keeper_path}'"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In storage S3Queue fix logical error "Cannot unregister: table uuid is not registered". Closes https://github.com/ClickHouse/ClickHouse/issues/78285.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
