### PR TITLE
Docs: fix codeblock spacing

### DIFF
--- a/docs/en/engines/database-engines/backup.md
+++ b/docs/en/engines/database-engines/backup.md
@@ -16,8 +16,8 @@ Database backup works with both incremental and non-incremental backups.
 ## Creating a Database {#creating-a-database}
 
 ```sql
-    CREATE DATABASE backup_database
-    ENGINE = Backup('database_name_inside_backup', 'backup_destination')
+CREATE DATABASE backup_database
+ENGINE = Backup('database_name_inside_backup', 'backup_destination')
 ```
 
 Backup destination can be any valid backup [destination](../../operations/backup#configure-a-backup-destination) like `Disk`, `S3`, `File`.
@@ -25,8 +25,8 @@ Backup destination can be any valid backup [destination](../../operations/backup
 With `Disk` backup destination, query to create database from backup looks like this:
 
 ```sql
-    CREATE DATABASE backup_database
-    ENGINE = Backup('database_name_inside_backup', Disk('disk_name', 'backup_name')
+CREATE DATABASE backup_database
+ENGINE = Backup('database_name_inside_backup', Disk('disk_name', 'backup_name')
 ```
 
 **Engine Parameters**


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Minor fix to code block spacing
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
