### PR TITLE
Fix corner-case handling in `cgroupV2PathOfProcess()`

### DIFF
--- a/base/base/cgroupsv2.h
+++ b/base/base/cgroupsv2.h
@@ -14,11 +14,11 @@ static inline const std::filesystem::path default_cgroups_mount = "/sys/fs/cgrou
 /// Is cgroups v2 enabled on the system?
 bool cgroupsV2Enabled();
 
-/// Detects which cgroup v2 the process belongs to and returns the filesystem path to the cgroup.
-/// Returns an empty path the cgroup cannot be determined.
-/// Assumes that cgroupsV2Enabled() is enabled.
+/// Detects which cgroup v2 the process belongs to and returns its filesystem path.
+/// Assumes that cgroupsV2Enabled() was called prior and returned true.
+/// If the cgroup cannot be determined, an empty path is returned.
 std::filesystem::path cgroupV2PathOfProcess();
 
 /// Returns the most nested cgroup dir containing the specified file.
 /// If cgroups v2 is not enabled - returns an empty optional.
-std::optional<std::string> getCgroupsV2PathContainingFile([[maybe_unused]] std::string_view file_name);
+std::optional<std::string> getCgroupsV2PathContainingFile(std::string_view file_name);


### PR DESCRIPTION
The current logic for identifying the server's cgroup v2 relies on reading the contents of file `/proc/self/cgroup`, assuming there is a single line with prefix `0::/`. This is also what [the spec](https://www.kernel.org/doc/Documentation/cgroup-v2.txt) suggests.

Unfortunately, there are edge cases where the assumption breaks, in particular configurations

```
1:name=systemd:/
0::/
```

or

```
1:name=systemd:/
0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podd36456a4_e5e1_40d2_8c9b_ed05c6113302.slice/cri-containerd-7c5e52939a4f8f5b9de511375c7223c2efb51828d6ec2275ce5405646a036864.scope
```

which are caused by cgroups v1 and v2 enabled simultaneously on a system.

This situation is not ideal and expected to be transitory. In any case, this PR enables support for it.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ClickHouse is now able to figure out its cgroup v2 on systems with both cgroups v1 and v2 enabled.