### PR TITLE
Add create_query, source columns to system.named_collections

### DIFF
--- a/src/Common/NamedCollections/NamedCollections.cpp
+++ b/src/Common/NamedCollections/NamedCollections.cpp
@@ -175,16 +175,6 @@ public:
     }
 };
 
-String NamedCollection::sourceIdToString(NamedCollection::SourceId id)
-{
-    switch (id)
-    {
-        case NamedCollection::SourceId::NONE: return "NONE";
-        case NamedCollection::SourceId::CONFIG: return "CONFIG";
-        case NamedCollection::SourceId::SQL: return "SQL";
-    }
-}
-
 NamedCollection::NamedCollection(
     ImplPtr pimpl_,
     const std::string & collection_name_,
@@ -345,7 +335,7 @@ NamedCollectionFromConfig::NamedCollectionFromConfig(
     const std::string & collection_name_,
     const std::string & collection_path_,
     const Keys & keys_)
-    : NamedCollection(Impl::create(config_, collection_name_, collection_path_, keys_), collection_name_, false)
+    : NamedCollection(Impl::create(config_, collection_name_, collection_path_, keys_), collection_name_, /* is_mutable */ false)
 {
 }
 

--- a/src/Common/NamedCollections/NamedCollections.cpp
+++ b/src/Common/NamedCollections/NamedCollections.cpp
@@ -5,6 +5,7 @@
 #include <IO/Operators.h>
 #include <Common/NamedCollections/NamedCollectionConfiguration.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <Common/FieldVisitorToString.h>
 
 #include <fmt/ranges.h>
 
@@ -16,6 +17,7 @@ namespace ErrorCodes
 {
     extern const int NAMED_COLLECTION_IS_IMMUTABLE;
     extern const int BAD_ARGUMENTS;
+    extern const int NOT_IMPLEMENTED;
 }
 
 namespace Configuration = NamedCollectionConfiguration;
@@ -173,30 +175,27 @@ public:
     }
 };
 
+String NamedCollection::sourceIdToString(NamedCollection::SourceId id)
+{
+    switch (id)
+    {
+        case NamedCollection::SourceId::NONE: return "NONE";
+        case NamedCollection::SourceId::CONFIG: return "CONFIG";
+        case NamedCollection::SourceId::SQL: return "SQL";
+    }
+}
+
 NamedCollection::NamedCollection(
     ImplPtr pimpl_,
     const std::string & collection_name_,
-    SourceId source_id_,
-    bool is_mutable_)
+    const bool is_mutable_)
     : pimpl(std::move(pimpl_))
     , collection_name(collection_name_)
-    , source_id(source_id_)
     , is_mutable(is_mutable_)
 {
 }
 
-MutableNamedCollectionPtr NamedCollection::create(
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & collection_name,
-    const std::string & collection_path,
-    const Keys & keys,
-    SourceId source_id,
-    bool is_mutable)
-{
-    auto impl = Impl::create(config, collection_name, collection_path, keys);
-    return std::unique_ptr<NamedCollection>(
-        new NamedCollection(std::move(impl), collection_name, source_id, is_mutable));
-}
+NamedCollection::~NamedCollection() = default;
 
 bool NamedCollection::has(const Key & key) const
 {
@@ -297,8 +296,7 @@ MutableNamedCollectionPtr NamedCollection::duplicate() const
     std::lock_guard lock(mutex);
     auto impl = pimpl->createCopy(collection_name);
     return std::unique_ptr<NamedCollection>(
-        new NamedCollection(
-            std::move(impl), collection_name, SourceId::NONE, true));
+        new NamedCollection(std::move(impl), collection_name, true));
 }
 
 NamedCollection::Keys NamedCollection::getKeys(ssize_t depth, const std::string & prefix) const
@@ -332,6 +330,136 @@ std::string NamedCollection::dumpStructure() const
 std::unique_lock<std::mutex> NamedCollection::lock()
 {
     return std::unique_lock(mutex);
+}
+
+
+void NamedCollection::update(const ASTAlterNamedCollectionQuery & /*query*/)
+{
+    throw Exception(
+        ErrorCodes::NOT_IMPLEMENTED,
+        "update() not implemented for NamedCollection base class.");
+}
+
+NamedCollectionFromConfig::NamedCollectionFromConfig(
+    const Poco::Util::AbstractConfiguration & config_,
+    const std::string & collection_name_,
+    const std::string & collection_path_,
+    const Keys & keys_)
+    : NamedCollection(Impl::create(config_, collection_name_, collection_path_, keys_), collection_name_, false)
+{
+}
+
+MutableNamedCollectionPtr NamedCollectionFromConfig::create(
+    const Poco::Util::AbstractConfiguration & config_,
+    const std::string & collection_name_,
+    const std::string & collection_path_,
+    const Keys & keys_)
+{
+    return std::unique_ptr<NamedCollection>(
+        new NamedCollectionFromConfig(config_, collection_name_, collection_path_, keys_));
+}
+
+
+MutableNamedCollectionPtr NamedCollectionFromSQL::create(const ASTCreateNamedCollectionQuery & query)
+{
+    return std::unique_ptr<NamedCollection>(new NamedCollectionFromSQL(query));
+}
+
+NamedCollectionFromSQL::NamedCollectionFromSQL(const ASTCreateNamedCollectionQuery & query_)
+    : NamedCollection(nullptr, query_.collection_name, true)
+    , create_query_ptr(query_.clone()->as<ASTCreateNamedCollectionQuery &>())
+{
+    const auto config = NamedCollectionConfiguration::createConfiguration(collection_name, create_query_ptr.changes, create_query_ptr.overridability);
+
+    std::set<std::string, std::less<>> keys;
+    for (const auto & [name, _] : create_query_ptr.changes)
+        keys.insert(name);
+
+    pimpl = Impl::create(*config, collection_name, "", keys);
+}
+
+String NamedCollectionFromSQL::getCreateStatement(bool show_secrects)
+{
+    auto & changes = create_query_ptr.changes;
+    std::sort(
+        changes.begin(), changes.end(),
+        [](const SettingChange & lhs, const SettingChange & rhs) { return lhs.name < rhs.name; });
+
+    return create_query_ptr.formatWithPossiblyHidingSensitiveData(
+        /*max_length=*/0,
+        /*one_line=*/true,
+        /*show_secrets=*/show_secrects,
+        /*print_pretty_type_names=*/false,
+        /*identifier_quoting_rule=*/IdentifierQuotingRule::WhenNecessary,
+        /*identifier_quoting_style=*/IdentifierQuotingStyle::Backticks);
+}
+
+void NamedCollectionFromSQL::update(const ASTAlterNamedCollectionQuery & alter_query)
+{
+    std::lock_guard lock(mutex);
+
+    std::unordered_map<std::string, Field> result_changes_map;
+    for (const auto & [name, value] : alter_query.changes)
+    {
+        auto [it, inserted] = result_changes_map.emplace(name, value);
+        if (!inserted)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Value with key `{}` is used twice in the SET query (collection name: {})",
+                name, alter_query.collection_name);
+        }
+    }
+
+    for (const auto & [name, value] : create_query_ptr.changes)
+        result_changes_map.emplace(name, value);
+
+    std::unordered_map<std::string, bool> result_overridability_map;
+    for (const auto & [name, value] : alter_query.overridability)
+        result_overridability_map.emplace(name, value);
+    for (const auto & [name, value] : create_query_ptr.overridability)
+        result_overridability_map.emplace(name, value);
+
+    for (const auto & delete_key : alter_query.delete_keys)
+    {
+        auto it = result_changes_map.find(delete_key);
+        if (it == result_changes_map.end())
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Cannot delete key `{}` because it does not exist in collection",
+                delete_key);
+        }
+
+        result_changes_map.erase(it);
+        auto it_override = result_overridability_map.find(delete_key);
+        if (it_override != result_overridability_map.end())
+            result_overridability_map.erase(it_override);
+    }
+
+    create_query_ptr.changes.clear();
+    for (const auto & [name, value] : result_changes_map)
+        create_query_ptr.changes.emplace_back(name, value);
+    create_query_ptr.overridability = std::move(result_overridability_map);
+
+    if (create_query_ptr.changes.empty())
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Named collection cannot be empty (collection name: {})",
+            collection_name);
+
+    chassert(create_query_ptr.collection_name == alter_query.collection_name);
+    for (const auto & [name, value] : alter_query.changes)
+    {
+        auto it_override = alter_query.overridability.find(name);
+        if (it_override != alter_query.overridability.end())
+            setOrUpdate<String, true>(name, convertFieldToString(value), it_override->second);
+        else
+            setOrUpdate<String, true>(name, convertFieldToString(value), {});
+    }
+
+    for (const auto & key : alter_query.delete_keys)
+        remove<true>(key);
 }
 
 template String NamedCollection::get<String>(const NamedCollection::Key & key) const;

--- a/src/Common/NamedCollections/NamedCollections.h
+++ b/src/Common/NamedCollections/NamedCollections.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <Interpreters/Context.h>
 #include <Common/NamedCollections/NamedCollections_fwd.h>
+#include <Parsers/ASTCreateNamedCollectionQuery.h>
+#include <Parsers/ASTAlterNamedCollectionQuery.h>
+
 
 namespace Poco { namespace Util { class AbstractConfiguration; } }
 
@@ -29,13 +32,7 @@ public:
         SQL = 2,
     };
 
-    static MutableNamedCollectionPtr create(
-        const Poco::Util::AbstractConfiguration & config,
-        const std::string & collection_name,
-        const std::string & collection_path,
-        const Keys & keys,
-        SourceId source_id_,
-        bool is_mutable_);
+    static String sourceIdToString(SourceId id);
 
     bool has(const Key & key) const;
 
@@ -61,6 +58,7 @@ public:
 
     template <bool locked = false> void remove(const Key & key);
 
+    /// Creates mutable, with NONE source id full copy.
     MutableNamedCollectionPtr duplicate() const;
 
     Keys getKeys(ssize_t depth = -1, const std::string & prefix = "") const;
@@ -76,25 +74,72 @@ public:
 
     bool isMutable() const { return is_mutable; }
 
-    SourceId getSourceId() const { return source_id; }
+    virtual SourceId getSourceId() const { return SourceId::NONE; }
 
-private:
+    virtual String getCreateStatement(bool /*show_secrects*/) { return  " "; }
+
+    virtual void update(const ASTAlterNamedCollectionQuery & query);
+
+    virtual ~NamedCollection();
+
+protected:
     class Impl;
     using ImplPtr = std::unique_ptr<Impl>;
-
     NamedCollection(
         ImplPtr pimpl_,
         const std::string & collection_name,
-        SourceId source_id,
-        bool is_mutable);
+        const bool is_mutable_
+    );
 
     void assertMutable() const;
 
+
     ImplPtr pimpl;
     const std::string collection_name;
-    const SourceId source_id;
     const bool is_mutable;
     mutable std::mutex mutex;
+};
+
+class NamedCollectionFromSQL final : public NamedCollection
+{
+public:
+    static MutableNamedCollectionPtr create(const ASTCreateNamedCollectionQuery & query);
+
+    String getCreateStatement(bool show_secrects) override;
+
+    void update(const ASTAlterNamedCollectionQuery & query) override;
+
+    NamedCollection::SourceId getSourceId() const override { return SourceId::SQL; }
+
+private:
+    NamedCollectionFromSQL(const ASTCreateNamedCollectionQuery & query_);
+
+    ASTCreateNamedCollectionQuery create_query_ptr;
+};
+
+class NamedCollectionFromConfig final : public NamedCollection
+{
+public:
+
+    static MutableNamedCollectionPtr create(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & collection_name,
+        const std::string & collection_path,
+        const Keys & keys);
+
+    String getCreateStatement(bool /*show_secrects*/) override { return " "; }
+
+    void update(const ASTAlterNamedCollectionQuery & /*query*/) override { NamedCollection::assertMutable(); }
+
+    NamedCollection::SourceId getSourceId() const override { return SourceId::CONFIG; }
+
+private:
+
+    NamedCollectionFromConfig(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & collection_name,
+        const std::string & collection_path,
+        const Keys & keys);
 };
 
 }

--- a/src/Common/NamedCollections/NamedCollections.h
+++ b/src/Common/NamedCollections/NamedCollections.h
@@ -88,7 +88,7 @@ protected:
     NamedCollection(
         ImplPtr pimpl_,
         const std::string & collection_name,
-        const bool is_mutable_
+        bool is_mutable_
     );
 
     void assertMutable() const;
@@ -112,7 +112,7 @@ public:
     NamedCollection::SourceId getSourceId() const override { return SourceId::SQL; }
 
 private:
-    NamedCollectionFromSQL(const ASTCreateNamedCollectionQuery & query_);
+    explicit NamedCollectionFromSQL(const ASTCreateNamedCollectionQuery & query_);
 
     ASTCreateNamedCollectionQuery create_query_ptr;
 };

--- a/src/Common/NamedCollections/NamedCollections.h
+++ b/src/Common/NamedCollections/NamedCollections.h
@@ -27,12 +27,12 @@ public:
     using Keys = std::set<Key, std::less<>>;
     enum class SourceId : uint8_t
     {
+        /// None source_id is possible only if the object is a
+        /// duplicate of some named collection. See `duplicate` method.
         NONE = 0,
         CONFIG = 1,
         SQL = 2,
     };
-
-    static String sourceIdToString(SourceId id);
 
     bool has(const Key & key) const;
 
@@ -76,7 +76,7 @@ public:
 
     virtual SourceId getSourceId() const { return SourceId::NONE; }
 
-    virtual String getCreateStatement(bool /*show_secrects*/) { return  " "; }
+    virtual String getCreateStatement(bool /*show_secrects*/) { return  {}; }
 
     virtual void update(const ASTAlterNamedCollectionQuery & query);
 
@@ -127,7 +127,7 @@ public:
         const std::string & collection_path,
         const Keys & keys);
 
-    String getCreateStatement(bool /*show_secrects*/) override { return " "; }
+    String getCreateStatement(bool /*show_secrects*/) override { return {}; }
 
     void update(const ASTAlterNamedCollectionQuery & /*query*/) override { NamedCollection::assertMutable(); }
 

--- a/src/Common/NamedCollections/NamedCollectionsFactory.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.cpp
@@ -15,6 +15,7 @@ namespace ErrorCodes
     extern const int NAMED_COLLECTION_DOESNT_EXIST;
     extern const int NAMED_COLLECTION_ALREADY_EXISTS;
     extern const int NAMED_COLLECTION_IS_IMMUTABLE;
+    extern const int LOGICAL_ERROR;
 }
 
 NamedCollectionFactory & NamedCollectionFactory::instance()
@@ -335,7 +336,13 @@ void NamedCollectionFactory::updateFromSQL(const ASTAlterNamedCollectionQuery & 
     auto updated_collection_ptr = metadata_storage->update(query);
 
     auto it = loaded_named_collections.find(collection_name);
-    chassert(it != loaded_named_collections.end());
+    if (it == loaded_named_collections.end())
+    {
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "The named collection {} unexpectedly does not exist.",
+            collection_name);
+    }
 
     if (!it->second->isMutable())
     {

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
@@ -524,7 +524,7 @@ ASTCreateNamedCollectionQuery NamedCollectionsMetadataStorage::readCreateQuery(c
     return create_query;
 }
 
-void NamedCollectionsMetadataStorage::writeCreateQuery(const String& collection_name, const String& create_statement, bool replace)
+void NamedCollectionsMetadataStorage::writeCreateQuery(const String & collection_name, const String & create_statement, bool replace)
 {
     storage->write(getFileName(collection_name), create_statement, replace);
 }

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
@@ -45,19 +45,6 @@ static const std::string named_collections_storage_config_path = "named_collecti
 
 namespace
 {
-    MutableNamedCollectionPtr createNamedCollectionFromAST(const ASTCreateNamedCollectionQuery & query)
-    {
-        const auto & collection_name = query.collection_name;
-        const auto config = NamedCollectionConfiguration::createConfiguration(collection_name, query.changes, query.overridability);
-
-        std::set<std::string, std::less<>> keys;
-        for (const auto & [name, _] : query.changes)
-            keys.insert(name);
-
-        return NamedCollection::create(
-            *config, collection_name, "", keys, NamedCollection::SourceId::SQL, /* is_mutable */true);
-    }
-
     std::string getFileName(const std::string & collection_name)
     {
         return escapeForFileName(collection_name) + ".sql";
@@ -468,7 +455,7 @@ NamedCollectionsMetadataStorage::NamedCollectionsMetadataStorage(
 MutableNamedCollectionPtr NamedCollectionsMetadataStorage::get(const std::string & collection_name) const
 {
     const auto query = readCreateQuery(collection_name);
-    return createNamedCollectionFromAST(query);
+    return NamedCollectionFromSQL::create(query);
 }
 
 NamedCollectionsMap NamedCollectionsMetadataStorage::getAll() const
@@ -488,10 +475,11 @@ NamedCollectionsMap NamedCollectionsMetadataStorage::getAll() const
     return result;
 }
 
-MutableNamedCollectionPtr NamedCollectionsMetadataStorage::create(const ASTCreateNamedCollectionQuery & query)
+MutableNamedCollectionPtr NamedCollectionsMetadataStorage::create(const ASTCreateNamedCollectionQuery & create_query)
 {
-    writeCreateQuery(query);
-    return createNamedCollectionFromAST(query);
+    auto collection_ptr = NamedCollectionFromSQL::create(create_query);
+    writeCreateQuery(create_query.collection_name, collection_ptr->getCreateStatement(true));
+    return collection_ptr;
 }
 
 void NamedCollectionsMetadataStorage::remove(const std::string & collection_name)
@@ -504,62 +492,14 @@ bool NamedCollectionsMetadataStorage::removeIfExists(const std::string & collect
     return storage->removeIfExists(getFileName(collection_name));
 }
 
-void NamedCollectionsMetadataStorage::update(const ASTAlterNamedCollectionQuery & query)
+MutableNamedCollectionPtr NamedCollectionsMetadataStorage::update(const ASTAlterNamedCollectionQuery & query)
 {
     auto create_query = readCreateQuery(query.collection_name);
+    auto collection_ptr = NamedCollectionFromSQL::create(create_query);
+    collection_ptr->update(query);
+    writeCreateQuery(query.collection_name, collection_ptr->getCreateStatement(true), true);
 
-    std::unordered_map<std::string, Field> result_changes_map;
-    for (const auto & [name, value] : query.changes)
-    {
-        auto [it, inserted] = result_changes_map.emplace(name, value);
-        if (!inserted)
-        {
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Value with key `{}` is used twice in the SET query (collection name: {})",
-                name, query.collection_name);
-        }
-    }
-
-    for (const auto & [name, value] : create_query.changes)
-        result_changes_map.emplace(name, value);
-
-    std::unordered_map<std::string, bool> result_overridability_map;
-    for (const auto & [name, value] : query.overridability)
-        result_overridability_map.emplace(name, value);
-    for (const auto & [name, value] : create_query.overridability)
-        result_overridability_map.emplace(name, value);
-
-    for (const auto & delete_key : query.delete_keys)
-    {
-        auto it = result_changes_map.find(delete_key);
-        if (it == result_changes_map.end())
-        {
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Cannot delete key `{}` because it does not exist in collection",
-                delete_key);
-        }
-
-        result_changes_map.erase(it);
-        auto it_override = result_overridability_map.find(delete_key);
-        if (it_override != result_overridability_map.end())
-            result_overridability_map.erase(it_override);
-    }
-
-    create_query.changes.clear();
-    for (const auto & [name, value] : result_changes_map)
-        create_query.changes.emplace_back(name, value);
-    create_query.overridability = std::move(result_overridability_map);
-
-    if (create_query.changes.empty())
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Named collection cannot be empty (collection name: {})",
-            query.collection_name);
-
-    chassert(create_query.collection_name == query.collection_name);
-    writeCreateQuery(create_query, true);
+    return collection_ptr;
 }
 
 std::vector<std::string> NamedCollectionsMetadataStorage::listCollections() const
@@ -584,15 +524,9 @@ ASTCreateNamedCollectionQuery NamedCollectionsMetadataStorage::readCreateQuery(c
     return create_query;
 }
 
-void NamedCollectionsMetadataStorage::writeCreateQuery(const ASTCreateNamedCollectionQuery & query, bool replace)
+void NamedCollectionsMetadataStorage::writeCreateQuery(const String& collection_name, const String& create_statement, bool replace)
 {
-    auto normalized_query = query.clone();
-    auto & changes = typeid_cast<ASTCreateNamedCollectionQuery *>(normalized_query.get())->changes;
-    ::sort(
-        changes.begin(), changes.end(),
-        [](const SettingChange & lhs, const SettingChange & rhs) { return lhs.name < rhs.name; });
-
-    storage->write(getFileName(query.collection_name), normalized_query->formatWithSecretsOneLine(), replace);
+    storage->write(getFileName(collection_name), create_statement, replace);
 }
 
 bool NamedCollectionsMetadataStorage::isReplicated() const

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
@@ -22,7 +22,7 @@ public:
 
     bool removeIfExists(const std::string & collection_name);
 
-    void update(const ASTAlterNamedCollectionQuery & query);
+    MutableNamedCollectionPtr update(const ASTAlterNamedCollectionQuery & query);
 
     void shutdown();
 
@@ -46,7 +46,7 @@ private:
 
     ASTCreateNamedCollectionQuery readCreateQuery(const std::string & collection_name) const;
 
-    void writeCreateQuery(const ASTCreateNamedCollectionQuery & query, bool replace = false);
+    void writeCreateQuery(const String& collection_name, const String& create_statement, bool replace = false);
 };
 
 

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
@@ -46,7 +46,7 @@ private:
 
     ASTCreateNamedCollectionQuery readCreateQuery(const std::string & collection_name) const;
 
-    void writeCreateQuery(const String& collection_name, const String& create_statement, bool replace = false);
+    void writeCreateQuery(const String & collection_name, const String & create_statement, bool replace = false);
 };
 
 

--- a/src/Parsers/ASTCreateNamedCollectionQuery.h
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.h
@@ -30,4 +30,6 @@ protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
+using ASTCreateNamedCollectionQueryPtr = std::shared_ptr<ASTCreateNamedCollectionQuery>;
+
 }

--- a/src/Storages/System/StorageSystemNamedCollections.cpp
+++ b/src/Storages/System/StorageSystemNamedCollections.cpp
@@ -1,5 +1,6 @@
 #include "StorageSystemNamedCollections.h"
 
+#include <base/EnumReflection.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnTuple.h>
 #include <DataTypes/DataTypeString.h>
@@ -67,7 +68,7 @@ void StorageSystemNamedCollections::fillData(MutableColumns & res_columns, Conte
 
         offsets.push_back(offsets.back() + size);
 
-        res_columns[2]->insert(NamedCollection::sourceIdToString(collection->getSourceId()));
+        res_columns[2]->insert(magic_enum::enum_name(collection->getSourceId()));
         res_columns[3]->insert(collection->getCreateStatement(access_secrets));
     }
 }

--- a/src/Storages/System/StorageSystemNamedCollections.cpp
+++ b/src/Storages/System/StorageSystemNamedCollections.cpp
@@ -22,6 +22,8 @@ ColumnsDescription StorageSystemNamedCollections::getColumnsDescription()
     {
         {"name", std::make_shared<DataTypeString>(), "Name of the collection."},
         {"collection", std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>()), "Collection internals."},
+        {"source", std::make_shared<DataTypeString>(), "Named collection source."},
+        {"create_query", std::make_shared<DataTypeString>(), "Named collection create query."},
     };
 }
 
@@ -50,12 +52,13 @@ void StorageSystemNamedCollections::fillData(MutableColumns & res_columns, Conte
         auto & tuple_column = column_map->getNestedData();
         auto & key_column = tuple_column.getColumn(0);
         auto & value_column = tuple_column.getColumn(1);
+        bool access_secrets = access->isGranted(AccessType::SHOW_NAMED_COLLECTIONS_SECRETS);
 
         size_t size = 0;
         for (const auto & key : collection->getKeys())
         {
             key_column.insertData(key.data(), key.size());
-            if (access->isGranted(AccessType::SHOW_NAMED_COLLECTIONS_SECRETS))
+            if (access_secrets)
                 value_column.insert(collection->get<String>(key));
             else
                 value_column.insert("[HIDDEN]");
@@ -63,6 +66,9 @@ void StorageSystemNamedCollections::fillData(MutableColumns & res_columns, Conte
         }
 
         offsets.push_back(offsets.back() + size);
+
+        res_columns[2]->insert(NamedCollection::sourceIdToString(collection->getSourceId()));
+        res_columns[3]->insert(collection->getCreateStatement(access_secrets));
     }
 }
 

--- a/tests/integration/test_named_collections/test.py
+++ b/tests/integration/test_named_collections/test.py
@@ -808,3 +808,55 @@ def test_name_escaping(cluster, instance_name):
     node.restart_clickhouse()
 
     node.query("DROP NAMED COLLECTION `test_!strange/symbols!`")
+
+
+@pytest.mark.parametrize(
+    "instance_name, show_secrets",
+    [("node", True), ("node_only_named_collection_control", False)],
+)
+def test_system_named_collection(cluster, instance_name, show_secrets):
+    node = cluster.instances[instance_name]
+
+    def validate_named_collection(collection_name, source, key_value):
+        assert (
+            node.query(
+                f"SELECT name FROM system.named_collections WHERE name='{collection_name}'"
+            )
+            == f"{collection_name}\n"
+        )
+        assert (
+            node.query(
+                f"SELECT collection['key1'] FROM system.named_collections WHERE name='{collection_name}'"
+            )
+            == f"{f'{key_value}' if show_secrets else '[HIDDEN]'}\n"
+        )
+        assert (
+            node.query(
+                f"SELECT source FROM system.named_collections WHERE name='{collection_name}'"
+            )
+            == f"{source}\n"
+        )
+        if source == "CONFIG":
+            assert (
+                node.query(
+                    f"SELECT create_query FROM system.named_collections WHERE name='{collection_name}'"
+                )
+                == " \n"
+            )
+        else:
+            hidden_str = "\\'[HIDDEN]\\'"
+            assert (
+                node.query(
+                    f"SELECT create_query FROM system.named_collections WHERE name='{collection_name}'"
+                )
+                == f"CREATE NAMED COLLECTION collection2 AS key1 = {f'{key_value}' if show_secrets else hidden_str} OVERRIDABLE\n"
+            )
+
+    validate_named_collection("collection1", "CONFIG", "value1")
+
+    node.query("CREATE NAMED COLLECTION collection2 AS key1=1 OVERRIDABLE")
+    validate_named_collection("collection2", "SQL", "1")
+    node.query("ALTER NAMED COLLECTION collection2 SET key1 = 30")
+    validate_named_collection("collection2", "SQL", "30")
+
+    node.query("DROP NAMED COLLECTION collection2")

--- a/tests/integration/test_named_collections/test.py
+++ b/tests/integration/test_named_collections/test.py
@@ -794,6 +794,7 @@ def test_keeper_storage_remove_on_cluster(cluster, ignore, expected_raise):
         node.query(
             f"DROP NAMED COLLECTION test_nc ON CLUSTER `replicated_nc_nodes_cluster`"
         )
+    node.query("DROP NAMED COLLECTION IF EXISTS test_nc")
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_named_collections/test.py
+++ b/tests/integration/test_named_collections/test.py
@@ -842,7 +842,7 @@ def test_system_named_collection(cluster, instance_name, show_secrets):
                 node.query(
                     f"SELECT create_query FROM system.named_collections WHERE name='{collection_name}'"
                 )
-                == " \n"
+                == "\n"
             )
         else:
             hidden_str = "\\'[HIDDEN]\\'"

--- a/tests/integration/test_named_collections_if_exists_on_cluster/test.py
+++ b/tests/integration/test_named_collections_if_exists_on_cluster/test.py
@@ -95,7 +95,7 @@ def test_create_alter_drop_on_cluster(cluster):
         NODE03: [foobar_final_state],
     }
 
-    q_get_collections = f"select * from {SYSTEM_TABLE} order by name desc format JSON"
+    q_get_collections = f"select name, collection from {SYSTEM_TABLE} order by name desc format JSON"
 
     def check_state():
         for name, node in list(cluster.instances.items()):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add new columns(`create_query` and `source`) for `system.named_collections`. Closes https://github.com/ClickHouse/ClickHouse/issues/78179.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

### Example
```
:) CREATE NAMED COLLECTION test2 AS ke111='1', key2='22'

CREATE NAMED COLLECTION test2 AS ke111 = '1', key2 = '22'

Query id: 9df182f7-1e2e-4a47-83da-fb20c4109713

Ok.

0 rows in set. Elapsed: 0.020 sec. 

:) SELECT * FROM system.named_collections

SELECT *
FROM system.named_collections

Query id: 486f3352-3ec2-477a-b0e8-4d13bd22654c

   ┌─name──┬─collection─────────────────────────────┬─source─┬─create_query───────────────────────────────────────────────────────────┐
1. │ test2 │ {'ke111':'[HIDDEN]','key2':'[HIDDEN]'} │ SQL    │ CREATE NAMED COLLECTION test2 AS ke111 = '[HIDDEN]', key2 = '[HIDDEN]' │
   └───────┴────────────────────────────────────────┴────────┴────────────────────────────────────────────────────────────────────────┘

```
