### PR TITLE
Process table-level settings in ObjectStorage cluster table functions correctly

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -2,7 +2,7 @@
 
 #include <Common/Exception.h>
 #include <Common/StringUtils.h>
-#include "Parsers/ASTSetQuery.h"
+#include <Parsers/ASTSetQuery.h>
 
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -2,6 +2,7 @@
 
 #include <Common/Exception.h>
 #include <Common/StringUtils.h>
+#include "Parsers/ASTSetQuery.h"
 
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>
@@ -115,6 +116,18 @@ void StorageObjectStorageCluster::updateQueryToSendIfNeeded(
             configuration->getEngineName());
     }
 
+    ASTPtr settings_temporary_storage = nullptr;
+    for (auto * it = args.begin(); it != args.end(); ++it)
+    {
+        ASTSetQuery * settings_ast = (*it)->as<ASTSetQuery>();
+        if (settings_ast)
+        {
+            settings_temporary_storage = std::move(*it);
+            args.erase(it);
+            break;
+        }
+    }
+
     if (!endsWith(table_function->name, "Cluster"))
         configuration->addStructureAndFormatToArgsIfNeeded(args, structure, configuration->format, context, /*with_structure=*/true);
     else
@@ -123,6 +136,10 @@ void StorageObjectStorageCluster::updateQueryToSendIfNeeded(
         args.erase(args.begin());
         configuration->addStructureAndFormatToArgsIfNeeded(args, structure, configuration->format, context, /*with_structure=*/true);
         args.insert(args.begin(), cluster_name_arg);
+    }
+    if (settings_temporary_storage)
+    {
+        args.insert(args.end(), std::move(settings_temporary_storage));
     }
 }
 

--- a/tests/queries/0_stateless/03402_cluster_table_functions_settings_parsing.reference
+++ b/tests/queries/0_stateless/03402_cluster_table_functions_settings_parsing.reference
@@ -1,0 +1,2 @@
+1	Mars
+1	Mars

--- a/tests/queries/0_stateless/03402_cluster_table_functions_settings_parsing.sql
+++ b/tests/queries/0_stateless/03402_cluster_table_functions_settings_parsing.sql
@@ -1,0 +1,5 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: Depends on AWS
+
+SELECT * FROM icebergS3Cluster('default', 'http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = 'metadata/v2.metadata.json');
+SELECT * FROM icebergS3Cluster('default', s3_conn, filename='est', SETTINGS iceberg_metadata_file_path = 'metadata/v2.metadata.json');

--- a/tests/queries/0_stateless/03402_cluster_table_functions_settings_parsing.sql
+++ b/tests/queries/0_stateless/03402_cluster_table_functions_settings_parsing.sql
@@ -1,5 +1,5 @@
 -- Tags: no-fasttest
 -- Tag no-fasttest: Depends on AWS
 
-SELECT * FROM icebergS3Cluster('default', 'http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = 'metadata/v2.metadata.json');
-SELECT * FROM icebergS3Cluster('default', s3_conn, filename='est', SETTINGS iceberg_metadata_file_path = 'metadata/v2.metadata.json');
+SELECT * FROM icebergS3Cluster('test_cluster_two_shards_localhost', 'http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = 'metadata/v2.metadata.json');
+SELECT * FROM icebergS3Cluster('test_cluster_two_shards_localhost', s3_conn, filename='est', SETTINGS iceberg_metadata_file_path = 'metadata/v2.metadata.json');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ObjectStorage cluster table functions failed when used with table level-settings 