### PR TITLE
Support getting Iceberg metadata file from version-hint.text file

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -231,6 +231,7 @@
     \
     M(IcebergPartitionPrunnedFiles, "Number of skipped files during Iceberg partition pruning", ValueType::Number) \
     M(IcebergTrivialCountOptimizationApplied, "Trivial count optimization applied while reading from Iceberg", ValueType::Number) \
+    M(IcebegerVersionHintUsed, "Number of times version-hint.text has been used.", ValueType::Number) \
     M(IcebergMinMaxIndexPrunnedFiles, "Number of skipped files by using MinMax index in Iceberg", ValueType::Number) \
     M(JoinBuildTableRowCount, "Total number of rows in the build table for a JOIN operation.", ValueType::Number) \
     M(JoinProbeTableRowCount, "Total number of rows in the probe table for a JOIN operation.", ValueType::Number) \

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -1,4 +1,5 @@
 #include <Databases/DataLake/DatabaseDataLake.h>
+#include "Storages/ObjectStorage/StorageObjectStorageSettings.h"
 
 #if USE_AVRO && USE_PARQUET
 
@@ -56,6 +57,7 @@ namespace Setting
 namespace StorageObjectStorageSetting
 {
     extern const StorageObjectStorageSettingsString iceberg_metadata_file_path;
+    extern const StorageObjectStorageSettingsBool iceberg_use_version_hint;
 }
 
 namespace ErrorCodes

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -39,7 +39,7 @@ namespace StorageObjectStorageSetting
     extern const StorageObjectStorageSettingsString iceberg_metadata_file_path;
     extern const StorageObjectStorageSettingsString iceberg_metadata_table_uuid;
     extern const StorageObjectStorageSettingsBool iceberg_recent_metadata_file_by_last_updated_ms_field;
-    extern const StorageObjectStorageSettingsBool iceberg_use_version_hint; 
+    extern const StorageObjectStorageSettingsBool iceberg_use_version_hint;
 }
 
 namespace ErrorCodes

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -1,3 +1,4 @@
+#include "Disks/ObjectStorages/StoredObject.h"
 #include "config.h"
 
 #if USE_AVRO
@@ -27,6 +28,7 @@
 namespace ProfileEvents
 {
     extern const Event IcebergTrivialCountOptimizationApplied;
+    extern const Event IcebegerVersionHintUsed;
 }
 
 namespace DB
@@ -37,6 +39,7 @@ namespace StorageObjectStorageSetting
     extern const StorageObjectStorageSettingsString iceberg_metadata_file_path;
     extern const StorageObjectStorageSettingsString iceberg_metadata_table_uuid;
     extern const StorageObjectStorageSettingsBool iceberg_recent_metadata_file_by_last_updated_ms_field;
+    extern const StorageObjectStorageSettingsBool iceberg_use_version_hint; 
 }
 
 namespace ErrorCodes
@@ -414,12 +417,30 @@ static std::pair<Int32, String> getLatestOrExplicitMetadataFileAndVersion(
         std::optional<String> table_uuid = configuration.getSettingsRef()[StorageObjectStorageSetting::iceberg_metadata_table_uuid].value;
         return getLatestMetadataFileAndVersion(object_storage, configuration, local_context, table_uuid);
     }
+    else if (configuration.getSettingsRef()[StorageObjectStorageSetting::iceberg_use_version_hint].value)
+    {
+        auto prefix_storage_path = configuration.getPath();
+        auto version_hint_path = std::filesystem::path(prefix_storage_path) / "metadata" / "version-hint.text";
+        std::string metadata_file;
+        StoredObject version_hint(version_hint_path);
+        auto buf = object_storage->readObject(version_hint, ReadSettings{});
+        readString(metadata_file, *buf);
+        if (!metadata_file.ends_with(".metadata.json"))
+        {
+            if (std::all_of(metadata_file.begin(), metadata_file.end(), isdigit)) 
+                metadata_file = "v" + metadata_file + ".metadata.json";
+            else 
+                metadata_file = metadata_file + ".metadata.json";
+        }
+        LOG_TEST(log, "Version hint file points to {}, will read from this metadata file", metadata_file);
+        ProfileEvents::increment(ProfileEvents::IcebegerVersionHintUsed);
+        return getMetadataFileAndVersion(std::filesystem::path(prefix_storage_path) / "metadata" / metadata_file);
+    }
     else
     {
         return getLatestMetadataFileAndVersion(object_storage, configuration, local_context, std::nullopt);
     }
 }
-
 
 bool IcebergMetadata::update(const ContextPtr & local_context)
 {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -427,9 +427,9 @@ static std::pair<Int32, String> getLatestOrExplicitMetadataFileAndVersion(
         readString(metadata_file, *buf);
         if (!metadata_file.ends_with(".metadata.json"))
         {
-            if (std::all_of(metadata_file.begin(), metadata_file.end(), isdigit)) 
+            if (std::all_of(metadata_file.begin(), metadata_file.end(), isdigit))
                 metadata_file = "v" + metadata_file + ".metadata.json";
-            else 
+            else
                 metadata_file = metadata_file + ".metadata.json";
         }
         LOG_TEST(log, "Version hint file points to {}, will read from this metadata file", metadata_file);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
@@ -31,7 +31,10 @@ Explicit table UUID to read metadata for. Ignored if iceberg_metadata_file_path 
 )", 0) \
     DECLARE(Bool, iceberg_recent_metadata_file_by_last_updated_ms_field, false, R"(
 If enabled, the engine would use the metadata file with the most recent last_updated_ms json field. Does not make sense to use with iceberg_metadata_file_path.
-)", 0)
+)", 0) \
+    DECLARE(Bool, iceberg_use_version_hint, false, R"(
+Get latest metadata path from version-hint.text file.
+)", 0) \
 
 // clang-format on
 

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -200,6 +200,7 @@ def get_creation_expression(
     format="Parquet",
     table_function=False,
     allow_dynamic_metadata_for_data_lakes=False,
+    use_version_hint=False,
     run_on_cluster=False,
     explicit_metadata_path="",
     **kwargs,
@@ -210,6 +211,9 @@ def get_creation_expression(
 
     if explicit_metadata_path:
         settings_array.append(f"iceberg_metadata_file_path = '{explicit_metadata_path}'")
+
+    if use_version_hint:
+        settings_array.append("iceberg_use_version_hint = true")
 
     if settings_array:
         settings_expression = " SETTINGS " + ",".join(settings_array)
@@ -1746,7 +1750,6 @@ def test_metadata_file_selection(started_cluster, format_version, storage_type):
 
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 500
 
-
 @pytest.mark.parametrize("format_version", ["1", "2"])
 @pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
 def test_metadata_file_format_with_uuid(started_cluster, format_version, storage_type):
@@ -1786,6 +1789,60 @@ def test_metadata_file_format_with_uuid(started_cluster, format_version, storage
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster)
 
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 500
+
+
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_metadata_file_selection_from_version_hint(started_cluster, format_version, storage_type):
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    TABLE_NAME = (
+        "test_metadata_file_selection_from_version_hint_"
+        + format_version
+        + "_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    spark.sql(
+        f"CREATE TABLE {TABLE_NAME} (id bigint, data string) USING iceberg TBLPROPERTIES ('format-version' = '2', 'write.update.mode'='merge-on-read', 'write.delete.mode'='merge-on-read', 'write.merge.mode'='merge-on-read')"
+    )
+
+    for i in range(10):
+        spark.sql(
+            f"INSERT INTO {TABLE_NAME} select id, char(id + ascii('a')) from range(10)"
+        )
+        
+    # test the case where version_hint.text file contains just the version number
+    with open(f"/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "w") as f:
+        f.write('5')
+
+    default_upload_directory(
+        started_cluster,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster, use_version_hint=True)
+
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 40
+
+    # test the case where version_hint.text file contains the whole metadata file name
+    with open(f"/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "w") as f:
+        f.write('v3.metadata.json')
+
+    default_upload_directory(
+        started_cluster,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster, use_version_hint=True)
+
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 20
 
 
 def test_restart_broken_s3(started_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

add new `iceberg_enable_version_hint` setting to leverage `version-hint.text` file.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Add support for reading `version-hint.text` file from Iceberg metadata to get the path of the `current` metadata file.
