### PR TITLE
ci: increase timeout for clickhouse stop (due to slow gdb)

### DIFF
--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -414,7 +414,7 @@ clickhouse-client ${logs_saver_client_options} -q "SELECT log FROM minio_server_
 # Because it's the simplest way to read it when server has crashed.
 # Increase timeout to 10 minutes (max-tries * 2 seconds) to give gdb time to collect stack traces
 # (if safeExit breakpoint is hit after the server's internal shutdown timeout is reached).
-sudo clickhouse stop --max-tries 300 ||:
+sudo clickhouse stop --max-tries 600 ||:
 
 
 if [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then


### PR DESCRIPTION
In case of clickhouse-server is terminated forcefully (i.e. in case of some connections are still active) it will hit safeExit, and gdb will try to capture stacktrace, but 5 minutes is not enough sometimes.

So let's adjust the limit (to match it with the comment above actually).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/72819