### PR TITLE
Stronger workaround for unbackuping RMV in replicated DB

### DIFF
--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -1144,6 +1144,7 @@ void RestorerFromBackup::insertDataToTableImpl(const QualifiedTableName & table_
         /// the refresh query reads) is still empty, not restored from backup yet. So the
         /// refresh target table ends up empty until the next scheduled refresh.
         /// TODO: Delete this when a proper fix lands: https://github.com/ClickHouse/ClickHouse/pull/77893
+        ///       There's a similar check to remove in MergeTreeData::restorePartFromBackup
         if ((e.code() == ErrorCodes::TABLE_IS_READ_ONLY || e.code() == ErrorCodes::ABORTED) &&
             storage->getStorageID().table_name.starts_with(".tmp"))
         {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6127,35 +6127,25 @@ void MergeTreeData::restorePartFromBackup(std::shared_ptr<RestoredPartsHolder> r
     }
     catch (Exception & e)
     {
-        if (e.code() == ErrorCodes::TABLE_IS_READ_ONLY && is_dropped)
+        /// Temporary hack to work around a race condition:
+        ///  1. RESTORE creates a refreshable materialized view and its target table.
+        ///  2. The view does a refresh and exchanges+drops the target table.
+        ///  3. RESTORE tries to restore target table's data from backup and fails because the table
+        ///     is dropped.
+        ///
+        /// (This can also happen without refreshable materialized view if the user just drops a
+        ///  table during RESTORE, so it may make sense to always ignore this error. But that
+        ///  feels sketchy as it may hide a bug.)
+        ///
+        /// For refreshable MV, this doesn't fully solve the problem. The initial refresh that
+        /// replaces the table usually happens early enough that the *source* table (from which
+        /// the refresh query reads) is still empty, not restored from backup yet. So the
+        /// refresh target table ends up empty until the next scheduled refresh.
+        /// TODO: Delete this when a proper fix lands: https://github.com/ClickHouse/ClickHouse/pull/77893
+        if ((e.code() == ErrorCodes::TABLE_IS_READ_ONLY || e.code() == ErrorCodes::ABORTED) &&
+            getStorageID().table_name.starts_with(".tmp"))
         {
-            /// A hack to work around a race condition:
-            ///  1. RESTORE creates a refreshable materialized view and its target table.
-            ///  2. The view does a refresh and exchanges+drops the target table.
-            ///  3. RESTORE tries to restore target table's data from backup and fails because the table
-            ///     is dropped.
-            ///
-            /// (This can also happen without refreshable materialized view if the user just drops a
-            ///  table during RESTORE, so it may make sense to always ignore this error. But that
-            ///  feels sketchy as it may hide a bug.)
-            ///
-            /// For refreshable MV, this doesn't fully solve the problem. The initial refresh that
-            /// replaces the table usually happens early enough that the *source* table (from which
-            /// the refresh query reads) is still empty, not restored from backup yet. So the
-            /// refresh target table ends up empty until the next scheduled refresh.
-            /// TODO: Figure out a better way to deal with RMV backups. Maybe RESTORE should create
-            ///       RMVs after restoring all other tables (including RMVs' .inner_id.<uuid> tables,
-            ///       somehow).
-            StorageID storage_id = getStorageID();
-            if (storage_id.table_name.starts_with(".tmp") ||
-                getContext()->getRefreshSet().tryGetTaskForInnerTable(storage_id) != nullptr)
-            {
-                LOG_INFO(log, "Table was dropped during RESTORE, presumably by refreshable materialized view.");
-            }
-            else
-            {
-                throw;
-            }
+            LOG_INFO(log, "Table was dropped during RESTORE, presumably by refreshable materialized view.");
         }
         else
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The hack in https://github.com/ClickHouse/ClickHouse/pull/77770 didn't cover all cases, this PR makes it more aggressive: ignore any `TABLE_IS_READ_ONLY` and `ABORTED` exceptions when restoring tables from backup if the table name starts with ".tmp". This is temporary, a proper fix is in https://github.com/ClickHouse/ClickHouse/pull/77893