### PR TITLE
Disable with_remote_database_disk in test_distributed_ddl and test_zookeeper_config

### DIFF
--- a/tests/integration/test_distributed_ddl/cluster.py
+++ b/tests/integration/test_distributed_ddl/cluster.py
@@ -50,6 +50,7 @@ class ClickHouseClusterWithDDLHelpers(ClickHouseCluster):
                     user_configs=user_configs,
                     macros={"layer": 0, "shard": i // 2 + 1, "replica": i % 2 + 1},
                     with_zookeeper=True,
+                    with_remote_database_disk=False,  # Disable `with_remote_database_disk` because Keeper might reject connections from the instance.
                 )
 
             self.start()

--- a/tests/integration/test_zookeeper_config/test_password.py
+++ b/tests/integration/test_zookeeper_config/test_password.py
@@ -14,10 +14,16 @@ node1 = cluster.add_instance(
         "configs/remote_servers.xml",
         "configs/zookeeper_config_with_password.xml",
     ],
+    # During the initialization, the instance cannot authenticate with Keeper, causing it to fail to start.
+    with_remote_database_disk=False,
 )
 
 node2 = cluster.add_instance(
-    "node2", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
+    "node2",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml"],
+    # During the initialization, the instance cannot authenticate with Keeper, causing it to fail to start.
+    with_remote_database_disk=False,
 )
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
