### PR TITLE
ci: add symbolizer to clickhouse/integration-tests-runner

### DIFF
--- a/docker/test/base/Dockerfile
+++ b/docker/test/base/Dockerfile
@@ -26,30 +26,6 @@ RUN BRIDGE_VERSION='25.1.5.31' \
     && dpkg -i clickhouse-odbc-bridge_${BRIDGE_VERSION}_${ARCH}.deb clickhouse-library-bridge_${BRIDGE_VERSION}_${ARCH}.deb \
     && rm clickhouse-odbc-bridge_${BRIDGE_VERSION}_${ARCH}.deb clickhouse-library-bridge_${BRIDGE_VERSION}_${ARCH}.deb
 
-# Sanitizer options for services (clickhouse-server)
-# Set resident memory limit for TSAN to 45GiB (46080MiB) to avoid OOMs in Stress tests
-# and MEMORY_LIMIT_EXCEEDED exceptions in Functional tests (total memory limit in Functional tests is ~55.24 GiB).
-# TSAN will flush shadow memory when reaching this limit.
-# It may cause false-negatives, but it's better than OOM.
-#  max_allocation_size_mb is set to 32GB, so we have much bigger chance to run into memory limit than the limitation of the sanitizers
-RUN echo "TSAN_OPTIONS='verbosity=1000 halt_on_error=1 abort_on_error=1 history_size=7 memory_limit_mb=46080 second_deadlock_stack=1 max_allocation_size_mb=32768'" >> /etc/environment
-RUN echo "UBSAN_OPTIONS='print_stacktrace=1 max_allocation_size_mb=32768'" >> /etc/environment
-RUN echo "MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768'" >> /etc/environment
-RUN echo "LSAN_OPTIONS='suppressions=/usr/share/clickhouse-test/config/lsan_suppressions.txt max_allocation_size_mb=32768'" >> /etc/environment
-RUN echo "ASAN_OPTIONS='halt_on_error=1 abort_on_error=1'" >> /etc/environment
-# Sanitizer options for current shell (not current, but the one that will be spawned on "docker run")
-# (but w/o verbosity for TSAN, otherwise test.reference will not match)
-ENV TSAN_OPTIONS='halt_on_error=1 abort_on_error=1 history_size=7 memory_limit_mb=46080 second_deadlock_stack=1 max_allocation_size_mb=32768'
-ENV UBSAN_OPTIONS='print_stacktrace=1 max_allocation_size_mb=32768'
-ENV MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768'
-ENV LSAN_OPTIONS='max_allocation_size_mb=32768'
-ENV ASAN_OPTIONS='halt_on_error=1 abort_on_error=1'
-
-# for external_symbolizer_path, and also ensure that llvm-symbolizer really
-# exists (since you don't want to fallback to addr2line, it is very slow)
-RUN test -f /usr/bin/llvm-symbolizer-${LLVM_VERSION}
-RUN ln -s /usr/bin/llvm-symbolizer-${LLVM_VERSION} /usr/bin/llvm-symbolizer
-
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -1,6 +1,6 @@
 # docker build -t clickhouse/integration-tests-runner .
 ARG FROM_TAG=latest
-FROM clickhouse/test-base:$FROM_TAG
+FROM clickhouse/test-util:$FROM_TAG
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t clickhouse/integration-tests-runner .
-FROM ubuntu:22.04
+ARG FROM_TAG=latest
+FROM clickhouse/test-base:$FROM_TAG
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
     libicu-dev \
     bsdutils \
     curl \
+    openssh-client \
     liblua5.1-dev \
     luajit \
     libssl-dev \

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -33,6 +33,30 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
+# Sanitizer options for services (clickhouse-server)
+# Set resident memory limit for TSAN to 45GiB (46080MiB) to avoid OOMs in Stress tests
+# and MEMORY_LIMIT_EXCEEDED exceptions in Functional tests (total memory limit in Functional tests is ~55.24 GiB).
+# TSAN will flush shadow memory when reaching this limit.
+# It may cause false-negatives, but it's better than OOM.
+#  max_allocation_size_mb is set to 32GB, so we have much bigger chance to run into memory limit than the limitation of the sanitizers
+RUN echo "TSAN_OPTIONS='verbosity=1000 halt_on_error=1 abort_on_error=1 history_size=7 memory_limit_mb=46080 second_deadlock_stack=1 max_allocation_size_mb=32768'" >> /etc/environment
+RUN echo "UBSAN_OPTIONS='print_stacktrace=1 max_allocation_size_mb=32768'" >> /etc/environment
+RUN echo "MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768'" >> /etc/environment
+RUN echo "LSAN_OPTIONS='suppressions=/usr/share/clickhouse-test/config/lsan_suppressions.txt max_allocation_size_mb=32768'" >> /etc/environment
+RUN echo "ASAN_OPTIONS='halt_on_error=1 abort_on_error=1'" >> /etc/environment
+# Sanitizer options for current shell (not current, but the one that will be spawned on "docker run")
+# (but w/o verbosity for TSAN, otherwise test.reference will not match)
+ENV TSAN_OPTIONS='halt_on_error=1 abort_on_error=1 history_size=7 memory_limit_mb=46080 second_deadlock_stack=1 max_allocation_size_mb=32768'
+ENV UBSAN_OPTIONS='print_stacktrace=1 max_allocation_size_mb=32768'
+ENV MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768'
+ENV LSAN_OPTIONS='max_allocation_size_mb=32768'
+ENV ASAN_OPTIONS='halt_on_error=1 abort_on_error=1'
+
+# for external_symbolizer_path, and also ensure that llvm-symbolizer really
+# exists (since you don't want to fallback to addr2line, it is very slow)
+RUN test -f /usr/bin/llvm-symbolizer-${LLVM_VERSION}
+RUN ln -s /usr/bin/llvm-symbolizer-${LLVM_VERSION} /usr/bin/llvm-symbolizer
+
 # Install cmake 3.20+ for Rust support
 # Used https://askubuntu.com/a/1157132 as reference
 RUN curl -s https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /etc/apt/trusted.gpg.d/kitware.gpg && \


### PR DESCRIPTION
Yes, server does not need it since it uses `clickhouse/integration-test`, but the client uses `clickhouse/integration-tests-runner`, and the client also may have races.

I've switched the image to be based on `clickhouse/test-util`, and now **`clickhouse/integration-tests-runner` is 225 MiB (6%) more**.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)