### PR TITLE
Fix schedule session close

### DIFF
--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -258,6 +258,7 @@ private:
                         key.second, toString(key.first), session.use_count());
 
                     session->timeout = std::chrono::steady_clock::duration{0};
+                    session->close_time_bucket = std::chrono::steady_clock::time_point{};
                     scheduleCloseSession(*session, lock);
                     continue;
                 }


### PR DESCRIPTION
Fixes #78634

Sometimes we can delay closing the session if it's still in use. And in this case we need to reset `close_time_bucket` for the next `scheduleCloseSession` call (and avoid the assert as a result).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
