### PR TITLE
Ignore non-existing settings in StorageObjectStorage

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
@@ -72,7 +72,17 @@ STORAGE_OBJECT_STORAGE_SETTINGS_SUPPORTED_TYPES(StorageObjectStorageSettings, IM
 
 void StorageObjectStorageSettings::loadFromQuery(ASTSetQuery & settings_ast)
 {
-    impl->applyChanges(settings_ast.changes);
+    SettingsChanges changes;
+    const auto & accessor = StorageObjectStorageSettingsTraits::Accessor::instance();
+    for (const auto & change : settings_ast.changes)
+    {
+        if (accessor.find(change.name) < accessor.size())
+        {
+            changes.push_back(change);
+        }
+    }
+
+    impl->applyChanges(changes);
 }
 
 Field StorageObjectStorageSettings::get(const std::string & name)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ignore non-existing settings in StorageObjectStorage. Required because of some incompatibilities between parsers of different ch-versions

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
