### PR TITLE
Optimize LogSeriesLimiter

### DIFF
--- a/src/Common/LoggingFormatStringHelpers.cpp
+++ b/src/Common/LoggingFormatStringHelpers.cpp
@@ -150,6 +150,14 @@ LogSeriesLimiter::LogSeriesLimiter(LoggerPtr logger_, size_t allowed_count_, tim
     ++total_count;
 }
 
+LogSeriesLimiter * LogSeriesLimiter::getChannel()
+{
+    if (!accepted)
+        return nullptr;
+
+    return this;
+}
+
 void LogSeriesLimiter::log(Poco::Message & message)
 {
     std::string_view pattern = message.getFormatString();

--- a/src/Common/LoggingFormatStringHelpers.cpp
+++ b/src/Common/LoggingFormatStringHelpers.cpp
@@ -16,13 +16,6 @@ std::mutex LogFrequencyLimiterImpl::mutex;
 void LogFrequencyLimiterImpl::log(Poco::Message & message)
 {
     std::string_view pattern = message.getFormatString();
-    if (pattern.empty())
-    {
-        /// Do not filter messages without a format string
-        if (auto * channel = logger->getChannel())
-            channel->log(message);
-        return;
-    }
 
     SipHash hash;
     hash.update(logger->name());
@@ -160,15 +153,6 @@ LogSeriesLimiter * LogSeriesLimiter::getChannel()
 
 void LogSeriesLimiter::log(Poco::Message & message)
 {
-    std::string_view pattern = message.getFormatString();
-    if (pattern.empty())
-    {
-        /// Do not filter messages without a format string
-        if (auto * channel = logger->getChannel())
-            channel->log(message);
-        return;
-    }
-
     if (!accepted)
         return;
 

--- a/src/Common/LoggingFormatStringHelpers.h
+++ b/src/Common/LoggingFormatStringHelpers.h
@@ -281,9 +281,9 @@ public:
 
     LogSeriesLimiter * operator->() { return this; }
     bool is(Poco::Message::Priority priority) { return logger->is(priority); }
-    LogSeriesLimiter * getChannel() {return this; }
     const String & name() const { return logger->name(); }
 
+    LogSeriesLimiter * getChannel();
     void log(Poco::Message & message);
 
     LoggerPtr getLogger() { return logger; }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Stop the log pipeline before creating the Message structure.