### PR TITLE
CI: Refresh PR context from API

### DIFF
--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -39,6 +39,7 @@ class _Environment(MetaClasses.Serializable):
     PR_LABELS: List[str] = dataclasses.field(default_factory=list)
     REPORT_INFO: List[str] = dataclasses.field(default_factory=list)
     JOB_CONFIG: Optional[Job.Config] = None
+    TRACEBACKS: List[str] = dataclasses.field(default_factory=list)
     name = "environment"
 
     @classmethod

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -4,6 +4,7 @@ import traceback
 from typing import Any
 
 from ._environment import _Environment
+from .info import Info
 from .result import Result
 from .settings import Settings
 from .utils import Shell
@@ -102,6 +103,27 @@ class GH:
         if output:
             res = output.splitlines()
         return list(set(res))
+
+    @classmethod
+    def get_pr_title_body_labels(cls, pr=None, repo=None):
+        if not repo:
+            repo = _Environment.get().REPOSITORY
+        if not pr:
+            pr = _Environment.get().PR_NUMBER
+
+        cmd = f"gh pr view {pr} --json title,body,labels --repo {repo}"
+        output = Shell.get_output(cmd, verbose=True)
+        try:
+            pr_data = json.loads(output)
+            title = pr_data["title"]
+            body = pr_data["body"]
+            labels = [l["name"] for l in pr_data["labels"]]
+        except Exception:
+            print("ERROR: Failed to get PR data")
+            traceback.print_exc()
+            Info().store_exception_traceback()
+            return "", "", []
+        return title, body, labels
 
     @classmethod
     def get_pr_label_assigner(cls, label, pr=None, repo=None):

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -1,5 +1,6 @@
 import json
 import os
+import traceback
 import urllib
 from pathlib import Path
 from typing import Optional
@@ -190,6 +191,10 @@ class Info:
         if key:
             return custom_data.get(key, None)
         return custom_data
+
+    def store_exception_traceback(self):
+        self.env.TRACEBACKS.append(traceback.format_exc())
+        self.env.dump()
 
     def is_workflow_ok(self):
         """

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -247,6 +247,21 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         custom_data={},
     ).dump()
 
+    if env.PR_NUMBER > 0:
+        # refresh PR data
+        title, body, labels = GH.get_pr_title_body_labels()
+        if title:
+            if title != env.PR_TITLE:
+                print("PR title has been changed")
+                env.PR_TITLE = title
+            if env.PR_BODY != body:
+                print("PR body has been changed")
+                env.PR_BODY = body
+            if env.PR_LABELS != labels:
+                print("PR labels have been changed")
+                env.PR_LABELS = labels
+            env.dump()
+
     if workflow.pre_hooks:
         sw_ = Utils.Stopwatch()
         res_ = []

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -439,6 +439,8 @@ class Runner:
                 print(error)
                 info_errors.append(error)
 
+        if env.TRACEBACKS:
+            result.set_info("Stored Tracebacks:\n" + "\n".join(env.TRACEBACKS))
         result.dump()
 
         # always in the end


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
