### PR TITLE
Fix analyzer: resolve positional arguments in SELECT of CREATE VIEW ... ON CLUSTER

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1107,7 +1107,9 @@ void InterpreterCreateQuery::validateMaterializedViewColumnsAndEngine(const ASTC
         {
             if (getContext()->getSettingsRef()[Setting::allow_experimental_analyzer])
             {
-                input_block = InterpreterSelectQueryAnalyzer::getSampleBlock(create.select->clone(), getContext());
+                auto context = Context::createCopy(getContext());
+                context->setQueryKindInitial();
+                input_block = InterpreterSelectQueryAnalyzer::getSampleBlock(create.select->clone(), context, SelectQueryOptions().ignoreASTOptimizations());
             }
             else
             {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1107,9 +1107,12 @@ void InterpreterCreateQuery::validateMaterializedViewColumnsAndEngine(const ASTC
         {
             if (getContext()->getSettingsRef()[Setting::allow_experimental_analyzer])
             {
+                /*
                 auto context = Context::createCopy(getContext());
                 context->setQueryKindInitial();
                 input_block = InterpreterSelectQueryAnalyzer::getSampleBlock(create.select->clone(), context, SelectQueryOptions().ignoreASTOptimizations());
+                */
+                input_block = InterpreterSelectQueryAnalyzer::getSampleBlock(create.select->clone(), getContext());
             }
             else
             {
@@ -2312,6 +2315,13 @@ void InterpreterCreateQuery::prepareOnClusterQuery(ASTCreateQuery & create, Cont
 
 BlockIO InterpreterCreateQuery::executeQueryOnCluster(ASTCreateQuery & create)
 {
+    /// Rewrite SELECT query to resolve and qualify all expressions
+    if (create.select)
+        create.set(
+            create.select,
+            InterpreterSelectQueryAnalyzer(create.select->clone(), getContext(), SelectQueryOptions{}.analyze()).getQueryTree()->toAST()
+        );
+
     prepareOnClusterQuery(create, getContext(), create.cluster);
     DDLQueryOnClusterParams params;
     params.access_to_check = getRequiredAccess();

--- a/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
@@ -158,6 +158,7 @@ static QueryTreeNodePtr buildQueryTreeAndRunPasses(const ASTPtr & query,
     /// We should not apply any query tree level optimizations on shards
     /// because it can lead to a changed header.
     if (select_query_options.ignore_ast_optimizations
+        || select_query_options.is_create_view
         || context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
         query_tree_pass_manager.runOnlyResolve(query_tree);
     else

--- a/src/Interpreters/SelectQueryOptions.h
+++ b/src/Interpreters/SelectQueryOptions.h
@@ -45,6 +45,7 @@ struct SelectQueryOptions
     bool is_create_parameterized_view = false;
     /// Bypass setting constraints for some internal queries such as projection ASTs.
     bool ignore_setting_constraints = false;
+    bool is_create_view = false; /// this select is a part of CREATE [MATERIALIZED] VIEW query
 
     /// Bypass access check for select query.
     /// This allows to skip double access check in some specific cases (e.g. insert into table with materialized view)
@@ -82,6 +83,12 @@ struct SelectQueryOptions
         ++out.subquery_depth;
         out.is_subquery = true;
         return out;
+    }
+
+    SelectQueryOptions & createView(bool value = true)
+    {
+        is_create_view = value;
+        return *this;
     }
 
     SelectQueryOptions createParameterizedView() const

--- a/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.reference
+++ b/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.reference
@@ -1,2 +1,4 @@
 d	Date					
 f	UInt64					
+a	String					
+total	UInt64					

--- a/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
+++ b/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
@@ -19,6 +19,7 @@ DROP TABLE IF EXISTS t02006 on cluster test_shard_localhost format Null;
 DROP TABLE IF EXISTS m02006 on cluster test_shard_localhost format Null;
 DROP TABLE IF EXISTS tt02006 on cluster test_shard_localhost format Null;
 
+SET enable_analyzer=1;
 
 CREATE TABLE t02006 ON CLUSTER test_shard_localhost
 (

--- a/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
+++ b/tests/queries/0_stateless/02006_test_positional_arguments_on_cluster.sql
@@ -17,3 +17,39 @@ DESC t02006;
 
 DROP TABLE IF EXISTS t02006 on cluster test_shard_localhost format Null;
 DROP TABLE IF EXISTS m02006 on cluster test_shard_localhost format Null;
+DROP TABLE IF EXISTS tt02006 on cluster test_shard_localhost format Null;
+
+
+CREATE TABLE t02006 ON CLUSTER test_shard_localhost
+(
+    `a` String,
+    `b` UInt32
+)
+ENGINE = ReplicatedMergeTree
+PRIMARY KEY a
+ORDER BY a
+format Null;
+
+CREATE TABLE tt02006 ON CLUSTER test_shard_localhost
+(
+    `a` String,
+    `total` SimpleAggregateFunction(sum, UInt64)
+)
+ENGINE = ReplicatedAggregatingMergeTree
+ORDER BY a
+format Null;
+
+CREATE MATERIALIZED VIEW m02006 ON CLUSTER test_shard_localhost TO tt02006
+AS SELECT
+    a,
+    sum(b) AS total
+FROM  t02006
+GROUP BY 1
+ORDER BY 1 ASC
+format Null;
+
+DESC m02006;
+
+DROP TABLE IF EXISTS t02006 on cluster test_shard_localhost format Null;
+DROP TABLE IF EXISTS m02006 on cluster test_shard_localhost format Null;
+DROP TABLE IF EXISTS tt02006 on cluster test_shard_localhost format Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix analyzer: CREATE VIEW ... ON CLUSTER fails if SELECT contains positional arguments

closes #67602
