### PR TITLE
cctools: update gdb to 16.2 (6x faster backtraces on CI) and fix Apple TAPI/cctools port

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -101,15 +101,12 @@ DOCKERS = [
     #     platforms=Docker.Platforms.arm_amd,
     #     depends_on=[],
     # ),
-    # TODO: fix build failure:
-    # 7 58.76 In file included from ./../code-sign-blobs/superblob.h:7:
-    # 7 58.76 ./../code-sign-blobs/blob.h:185:60: error: no member named 'clone' in 'Security::BlobCore'
-    # Docker.Config(
-    #     name="clickhouse/cctools",
-    #     path="./docker/packager/cctools",
-    #     platforms=Docker.Platforms.arm_amd,
-    #     depends_on=["clickhouse/fasttest"],
-    # ),
+    Docker.Config(
+        name="clickhouse/cctools",
+        path="./docker/packager/cctools",
+        platforms=Docker.Platforms.arm_amd,
+        depends_on=["clickhouse/fasttest"],
+    ),
     Docker.Config(
         name="clickhouse/test-util",
         path="./docker/test/util",

--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -5,7 +5,7 @@ ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
 
 # If the cctools is updated, then first build it in the CI, then update here in a different commit
-COPY --from=clickhouse/cctools:d9e3596e706b /cctools /cctools
+COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /cctools /cctools
 
 # A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
 RUN apt-get update \

--- a/ci/docker/fasttest/Dockerfile
+++ b/ci/docker/fasttest/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-COPY --from=clickhouse/cctools:0d6b90a7a490 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
 # Give suid to gdb to grant it attach permissions
 RUN chmod u+s /opt/gdb/bin/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -12,7 +12,7 @@ ENV CXX=clang++-${LLVM_VERSION}
 RUN git clone https://github.com/tpoechtrager/apple-libtapi.git \
     && cd apple-libtapi \
     && git checkout 15dfc2a8c9a2a89d06ff227560a69f5265b692f9 \
-    && INSTALLPREFIX=/cctools ./build.sh \
+    && INSTALLPREFIX=/cctools NINJA=1 ./build.sh \
     && ./install.sh \
     && cd .. \
     && rm -rf apple-libtapi

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -19,10 +19,9 @@ RUN git clone https://github.com/tpoechtrager/apple-libtapi.git \
 
 # Build and install tools for cross-linking to Darwin (x86-64)
 # Build and install tools for cross-linking to Darwin (aarch64)
-RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 1010.6-ld64-951.9 \
+RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 986-ld64-711 \
     && apt-get update \
     && apt-get install --yes \
-        libdispatch-dev \
         make \
     && cd cctools-port/cctools \
     && ./configure --prefix=/cctools --with-libtapi=/cctools \
@@ -34,7 +33,7 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 1010.6-l
     && make install -j$(nproc) \
     && cd ../.. \
     && rm -rf cctools-port \
-    && apt-get purge make libdispatch-dev \
+    && apt-get purge make \
     && apt-get clean
 
 #

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -4,7 +4,7 @@
 # It's based on the assumption that we don't care of the cctools version so much
 # It event does not depend on the clickhouse/fasttest in the `docker/images.json`
 ARG FROM_TAG=latest
-FROM clickhouse/fasttest:$FROM_TAG as builder
+FROM clickhouse/fasttest:$FROM_TAG AS builder
 
 ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 986-ld64
     && make install -j$(nproc) \
     && cd ../.. \
     && rm -rf cctools-port \
-    && apt-get purge make \
+    && apt-get purge make --yes \
     && apt-get clean
 
 #

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git \
 #     DWARF error: invalid or unhandled FORM value: 0x23
 #
 ENV LD=ld.lld-${LLVM_VERSION}
-ARG GDB_VERSION=15.1
+ARG GDB_VERSION=16.2
 RUN apt-get update \
     && apt-get install --yes \
         libgmp-dev \
@@ -58,3 +58,5 @@ RUN wget https://sourceware.org/pub/gdb/releases/gdb-$GDB_VERSION.tar.gz \
 FROM scratch
 COPY --from=builder /cctools /cctools
 COPY --from=builder /opt/gdb /opt/gdb
+
+# NOTE: this file should be kept in sync with other docker images, since they use COPY from this image

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -23,6 +23,7 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 986-ld64
     && apt-get update \
     && apt-get install --yes \
         make \
+    && apt-get clean \
     && cd cctools-port/cctools \
     && ./configure --prefix=/cctools --with-libtapi=/cctools \
         --target=x86_64-apple-darwin \
@@ -32,9 +33,7 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 986-ld64
         --target=aarch64-apple-darwin \
     && make install -j$(nproc) \
     && cd ../.. \
-    && rm -rf cctools-port \
-    && apt-get purge make --yes \
-    && apt-get clean
+    && rm -rf cctools-port
 
 #
 # GDB

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -20,6 +20,7 @@ RUN git clone https://github.com/tpoechtrager/apple-libtapi.git \
 # Build and install tools for cross-linking to Darwin (x86-64)
 # Build and install tools for cross-linking to Darwin (aarch64)
 RUN git clone https://github.com/tpoechtrager/cctools-port.git \
+    && apt-get update && apt-get install --yes make \
     && cd cctools-port/cctools \
     && git checkout 2a3e1c2a6ff54a30f898b70cfb9ba1692a55fad7 \
     && ./configure --prefix=/cctools --with-libtapi=/cctools \
@@ -30,7 +31,9 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git \
         --target=aarch64-apple-darwin \
     && make install -j$(nproc) \
     && cd ../.. \
-    && rm -rf cctools-port
+    && rm -rf cctools-port \
+    && apt-get purge make \
+    && apt-get clean
 
 #
 # GDB

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -20,7 +20,10 @@ RUN git clone https://github.com/tpoechtrager/apple-libtapi.git \
 # Build and install tools for cross-linking to Darwin (x86-64)
 # Build and install tools for cross-linking to Darwin (aarch64)
 RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 1010.6-ld64-951.9 \
-    && apt-get update && apt-get install --yes make \
+    && apt-get update \
+    && apt-get install --yes \
+        libdispatch-dev \
+        make \
     && cd cctools-port/cctools \
     && ./configure --prefix=/cctools --with-libtapi=/cctools \
         --target=x86_64-apple-darwin \
@@ -31,7 +34,7 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 1010.6-l
     && make install -j$(nproc) \
     && cd ../.. \
     && rm -rf cctools-port \
-    && apt-get purge make \
+    && apt-get purge make libdispatch-dev \
     && apt-get clean
 
 #

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -19,10 +19,9 @@ RUN git clone https://github.com/tpoechtrager/apple-libtapi.git \
 
 # Build and install tools for cross-linking to Darwin (x86-64)
 # Build and install tools for cross-linking to Darwin (aarch64)
-RUN git clone https://github.com/tpoechtrager/cctools-port.git \
+RUN git clone https://github.com/tpoechtrager/cctools-port.git --branch 1010.6-ld64-951.9 \
     && apt-get update && apt-get install --yes make \
     && cd cctools-port/cctools \
-    && git checkout 2a3e1c2a6ff54a30f898b70cfb9ba1692a55fad7 \
     && ./configure --prefix=/cctools --with-libtapi=/cctools \
         --target=x86_64-apple-darwin \
     && make install -j$(nproc) \

--- a/docker/test/integration/base/Dockerfile
+++ b/docker/test/integration/base/Dockerfile
@@ -73,5 +73,5 @@ maxClientCnxns=80' > /opt/zookeeper/conf/zoo.cfg && \
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-COPY --from=clickhouse/cctools:0d6b90a7a490 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -85,7 +85,7 @@ COPY modprobe.sh /usr/local/bin/modprobe
 COPY dockerd-entrypoint.sh /usr/local/bin/
 COPY misc/ /misc/
 
-COPY --from=clickhouse/cctools:0d6b90a7a490 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"
 
 # Same options as in test/base/Dockerfile

--- a/docker/test/performance-comparison/Dockerfile
+++ b/docker/test/performance-comparison/Dockerfile
@@ -41,7 +41,7 @@ RUN pip3 --no-cache-dir install -r requirements.txt
 
 COPY run.sh /
 
-COPY --from=clickhouse/cctools:0d6b90a7a490 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"
 
 CMD ["bash", "/run.sh"]

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -56,5 +56,5 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-COPY --from=clickhouse/cctools:0d6b90a7a490 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"


### PR DESCRIPTION
#### apple

- enable cctools image on CI and:
- fix apple TAPI compilation
- fix cctools port compilation

#### gdb

##### gdb 15.1

    $ docker run --privileged -v /src/ch/tmp/ci/clickhouse-release-no-preserve_most:/bin/clickhouse --rm -it --entrypoint bash clickhouse/integration-tests-runner:9379b995482fcddb1050
    time gdb clickhouse -batch -ex 'b __cxa_throw' -ex 'run -q "select throwIf(1)"' -ex 'bt full' -ex detach
    [Inferior 1 (process 43) detached]
    Code: 395. DB::Exception: Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(1_UInt8 :: 1) -> throwIf(1_UInt8) UInt8 : 2'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO)

    real    1m39.168s
    user    1m47.433s
    sys     0m2.997s

##### gdb 16.2

    $ time gdb /src/ch/tmp/ci/clickhouse-release-no-preserve_most -batch -ex 'b __cxa_throw' -ex 'run -q "select throwIf(1)"' -ex 'bt full' -ex detach
    [Inferior 1 (process 5746) detached]
    Code: 395. DB::Exception: Value passed to 'throwIf' function is non-zero: while executing 'FUNCTION throwIf(1_UInt8 :: 1) -> throwIf(1_UInt8) UInt8 : 2'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO)

    real    0m15.760s
    user    0m28.587s
    sys     0m1.191s

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Previous update: https://github.com/ClickHouse/ClickHouse/pull/66494