### PR TITLE
`system.query_condition_cache`: Add field for plaintext condition

### DIFF
--- a/docs/en/operations/query-condition-cache.md
+++ b/docs/en/operations/query-condition-cache.md
@@ -58,6 +58,8 @@ To clear the query condition cache, run [`SYSTEM DROP QUERY CONDITION CACHE`](..
 
 The content of the cache is displayed in system table [system.query_condition_cache](system-tables/query_condition_cache.md).
 To calculate the current size of the query condition cache in MB, run `SELECT formatReadableSize(sum(entry_size)) FROM system.query_condition_cache`.
+If you like to investigate individual filter conditions, you can check field `condition` in `system.query_condition_cache`.
+Note that the field is only populated if the query runs with enabled setting [query_condition_cache_store_conditions_as_plaintext](settings/settings#query_condition_cache_store_conditions_as_plaintext).
 
 The number of query condition cache hits and misses since database start are shown as events "QueryConditionCacheHits" and "QueryConditionCacheMisses" in system table [system.events](system-tables/events.md).
 Both counters are only updated for `SELECT` queries which run with setting `use_query_condition_cache = true`, other queries do not affect "QueryCacheMisses".

--- a/docs/en/operations/system-tables/query_condition_cache.md
+++ b/docs/en/operations/system-tables/query_condition_cache.md
@@ -17,7 +17,8 @@ Columns:
 
 - `table_uuid` ([String](../../sql-reference/data-types/string.md)) — The table UUID.
 - `part_name` ([String](../../sql-reference/data-types/string.md)) — The part name.
-- `key_hash` ([String](/sql-reference/data-types/string.md)) — The hash of the filter condition.
+- `condition` ([String](/sql-reference/data-types/string.md)) — The hashed filter condition. Only set if setting query_condition_cache_store_conditions_as_plaintext = true.
+- `condition_hash` ([String](/sql-reference/data-types/string.md)) — The hash of the filter condition.
 - `entry_size` ([UInt64](../../sql-reference/data-types/int-uint.md)) — The size of the entry in bytes.
 - `matching_marks` ([String](../../sql-reference/data-types/string.md)) — Matching marks.
 
@@ -32,7 +33,8 @@ Row 1:
 ──────
 table_uuid:     28270a24-ea27-49f6-99cd-97b9bee976ac
 part_name:      all_1_1_0
-key_hash:       5456494897146899690 -- 5.46 quintillion
+condition:      or(equals(b, 10000_UInt16), equals(c, 10000_UInt16))
+condition_hash: 5456494897146899690 -- 5.46 quintillion
 entry_size:     40
 matching_marks: 111111110000000000000000000000000000000000000000000000000111111110000000000000000
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4830,6 +4830,16 @@ Possible values:
 - 0 - Disabled
 - 1 - Enabled
 )", 0) \
+    DECLARE(Bool, query_condition_cache_store_conditions_as_plaintext, false, R"(
+Stores the filter condition for the [query condition cache](/operations/query-condition-cache) in plaintext.
+If enabled, system.query_condition_cache shows the verbatim filter condition which makes it easier to debug issues with the cache.
+Disabled by default because plaintext filter conditions may expose sensitive information.
+
+Possible values:
+
+- 0 - Disabled
+- 1 - Enabled
+)", 0) \
     DECLARE(Bool, optimize_rewrite_sum_if_to_count_if, true, R"(
 Rewrite sumIf() and sum(if()) function countIf() function when logically equivalent
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -76,6 +76,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"low_priority_query_wait_time_ms", 1000, 1000, "New setting."},
             {"allow_experimental_shared_set_join", 0, 1, "A setting for ClickHouse Cloud to enable SharedSet and SharedJoin"},
             {"distributed_cache_read_request_max_tries", 20, 20, "New setting"},
+            {"query_condition_cache_store_conditions_as_plaintext", false, false, "New setting"},
             {"min_os_cpu_wait_time_ratio_to_throw", 0, 2, "New setting"},
             {"max_os_cpu_wait_time_ratio_to_throw", 0, 6, "New setting"},
         });

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -35,6 +35,10 @@ private:
         const String part_name;
         const size_t condition_hash;
 
+        /// -- Additional members, conceptually not part of the key. Only included for pretty-printing
+        ///    in system.query_condition_cache:
+        const String condition;
+
         bool operator==(const Key & other) const;
     };
 
@@ -74,7 +78,7 @@ public:
 
     /// Add an entry to the cache. The passed marks represent ranges of the column with matches of the predicate.
     void write(
-        const UUID & table_id, const String & part_name, size_t condition_hash,
+        const UUID & table_id, const String & part_name, size_t condition_hash, const String & condition,
         const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
 
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -173,7 +173,7 @@ void FilterStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQ
     pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
     {
         bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
-        return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals, nullptr, condition_hash);
+        return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals, nullptr, condition);
     });
 
     if (!blocksHaveEqualStructure(pipeline.getHeader(), *output_header))
@@ -248,9 +248,9 @@ void FilterStep::updateOutputHeader()
         return;
 }
 
-void FilterStep::setQueryConditionHash(size_t condition_hash_)
+void FilterStep::setConditionForQueryConditionCache(size_t condition_hash_, const String & condition_)
 {
-    condition_hash = condition_hash_;
+    condition = {condition_hash_, condition_};
 }
 
 bool FilterStep::canUseType(const DataTypePtr & filter_type)

--- a/src/Processors/QueryPlan/FilterStep.h
+++ b/src/Processors/QueryPlan/FilterStep.h
@@ -26,7 +26,7 @@ public:
     const String & getFilterColumnName() const { return filter_column_name; }
     bool removesFilterColumn() const { return remove_filter_column; }
 
-    void setQueryConditionHash(size_t condition_hash_);
+    void setConditionForQueryConditionCache(size_t condition_hash_, const String & condition_);
 
     static bool canUseType(const DataTypePtr & type);
 
@@ -42,7 +42,7 @@ private:
     String filter_column_name;
     bool remove_filter_column;
 
-    std::optional<size_t> condition_hash;
+    std::optional<std::pair<size_t, String>> condition; /// for query condition cache
 };
 
 }

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -35,6 +35,7 @@ namespace Setting
     extern const SettingsBool query_plan_try_use_vector_search;
     extern const SettingsBool query_plan_convert_join_to_in;
     extern const SettingsBool use_query_condition_cache;
+    extern const SettingsBool query_condition_cache_store_conditions_as_plaintext;
     extern const SettingsBoolAuto query_plan_join_swap_table;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsSeconds lock_acquire_timeout;
@@ -92,6 +93,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     aggregation_in_order = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_aggregation_in_order] && from[Setting::query_plan_aggregation_in_order];
     optimize_projection = from[Setting::optimize_use_projections];
     use_query_condition_cache = from[Setting::use_query_condition_cache] && from[Setting::allow_experimental_analyzer];
+    query_condition_cache_store_conditions_as_plaintext = from[Setting::query_condition_cache_store_conditions_as_plaintext];
 
     optimize_use_implicit_projections = optimize_projection && from[Setting::optimize_use_implicit_projections];
     force_use_projection = optimize_projection && from[Setting::force_optimize_projection];

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -67,7 +67,8 @@ struct QueryPlanOptimizationSettings
     bool optimize_sorting_by_input_stream_properties;
     bool aggregation_in_order;
     bool optimize_projection;
-    bool use_query_condition_cache = false;
+    bool use_query_condition_cache;
+    bool query_condition_cache_store_conditions_as_plaintext;
 
     /// --- Third-pass optimizations (Processors/QueryPlan/QueryPlan.cpp)
     bool build_sets = true; /// this one doesn't have a corresponding setting

--- a/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
+++ b/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
@@ -38,6 +38,12 @@ void updateQueryConditionCache(const Stack & stack, const QueryPlanOptimizationS
         return;
 
     const auto & outputs = filter_actions_dag->getOutputs();
+
+    /// Restrict to the case that ActionsDAG has a single output. This isn't technically necessary but de-risks the
+    /// implementatino a lot while not losing much usefulness.
+    if (outputs.size() != 1)
+        return;
+
     for (const auto * output : outputs)
         if (!VirtualColumnUtils::isDeterministic(output))
             return;
@@ -46,8 +52,16 @@ void updateQueryConditionCache(const Stack & stack, const QueryPlanOptimizationS
     {
         if (auto * filter_step = typeid_cast<FilterStep *>(iter->node->step.get()))
         {
-            size_t condition_hash = filter_actions_dag->getOutputs().front()->getHash();
-            filter_step->setQueryConditionHash(condition_hash);
+            size_t condition_hash = filter_actions_dag->getOutputs()[0]->getHash();
+
+            String condition;
+            if (optimization_settings.query_condition_cache_store_conditions_as_plaintext)
+            {
+                Names outputs_names = filter_actions_dag->getNames();
+                condition = outputs_names[0];
+            }
+
+            filter_step->setConditionForQueryConditionCache(condition_hash, condition);
             return;
         }
     }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -187,6 +187,7 @@ namespace Setting
     extern const SettingsUInt64 merge_tree_min_read_task_size;
     extern const SettingsBool read_in_order_use_virtual_row;
     extern const SettingsBool use_query_condition_cache;
+    extern const SettingsBool query_condition_cache_store_conditions_as_plaintext;
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool merge_tree_use_deserialization_prefixes_cache;
     extern const SettingsBool merge_tree_use_prefixes_deserialization_thread_pool;
@@ -221,6 +222,7 @@ static MergeTreeReaderSettings getMergeTreeReaderSettings(
         .enable_multiple_prewhere_read_steps = settings[Setting::enable_multiple_prewhere_read_steps],
         .force_short_circuit_execution = settings[Setting::query_plan_merge_filters],
         .use_query_condition_cache = settings[Setting::use_query_condition_cache] && settings[Setting::allow_experimental_analyzer],
+        .query_condition_cache_store_conditions_as_plaintext = settings[Setting::query_condition_cache_store_conditions_as_plaintext],
         .use_deserialization_prefixes_cache = settings[Setting::merge_tree_use_deserialization_prefixes_cache],
         .use_prefixes_deserialization_thread_pool = settings[Setting::merge_tree_use_prefixes_deserialization_thread_pool],
     };

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -67,7 +67,7 @@ FilterTransform::FilterTransform(
     bool remove_filter_column_,
     bool on_totals_,
     std::shared_ptr<std::atomic<size_t>> rows_filtered_,
-    std::optional<size_t> condition_hash_)
+    std::optional<std::pair<size_t, String>> condition_)
     : ISimpleTransform(
             header_,
             transformHeader(header_, expression_ ? &expression_->getActionsDAG() : nullptr, filter_column_name_, remove_filter_column_),
@@ -77,7 +77,7 @@ FilterTransform::FilterTransform(
     , remove_filter_column(remove_filter_column_)
     , on_totals(on_totals_)
     , rows_filtered(rows_filtered_)
-    , condition_hash(condition_hash_)
+    , condition(condition_)
 {
     transformed_header = getInputPort().getHeader();
     if (expression)
@@ -88,7 +88,7 @@ FilterTransform::FilterTransform(
     if (column)
         constant_filter_description = ConstantFilterDescription(*column);
 
-    if (condition_hash.has_value())
+    if (condition.has_value())
         query_condition_cache = Context::getGlobalContextInstance()->getQueryConditionCache();
 }
 
@@ -270,7 +270,8 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
         query_condition_cache->write(
             buffered_mark_ranges_info->table_uuid,
             buffered_mark_ranges_info->part_name,
-            *condition_hash,
+            condition->first,
+            condition->second,
             buffered_mark_ranges_info->mark_ranges,
             buffered_mark_ranges_info->marks_count,
             buffered_mark_ranges_info->has_final_mark);
@@ -294,7 +295,8 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
             query_condition_cache->write(
                 buffered_mark_ranges_info->table_uuid,
                 buffered_mark_ranges_info->part_name,
-                *condition_hash,
+                condition->first,
+                condition->second,
                 buffered_mark_ranges_info->mark_ranges,
                 buffered_mark_ranges_info->marks_count,
                 buffered_mark_ranges_info->has_final_mark);

--- a/src/Processors/Transforms/FilterTransform.h
+++ b/src/Processors/Transforms/FilterTransform.h
@@ -23,7 +23,7 @@ public:
     FilterTransform(
         const Block & header_, ExpressionActionsPtr expression_, String filter_column_name_,
         bool remove_filter_column_, bool on_totals_ = false, std::shared_ptr<std::atomic<size_t>> rows_filtered_ = nullptr,
-        std::optional<size_t> condition_hash_ = std::nullopt);
+        std::optional<std::pair<size_t, String>> condition_ = std::nullopt);
 
     static Block
     transformHeader(const Block & header, const ActionsDAG * expression, const String & filter_column_name, bool remove_filter_column);
@@ -47,8 +47,11 @@ private:
 
     std::shared_ptr<std::atomic<size_t>> rows_filtered;
 
-    std::optional<size_t> condition_hash; /// If set, we need to update the query condition cache at runtime for every processed chunk
+    /// If set, we need to update the query condition cache at runtime for every processed chunk
+    std::optional<std::pair<size_t, String>> condition;
+
     std::shared_ptr<QueryConditionCache> query_condition_cache;
+
     MarkRangesInfoPtr buffered_mark_ranges_info; /// Buffers mark info for chunks from the same table and part.
                                                  /// The goal is to write less often into the query condition cache (reduce lock contention).
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -54,6 +54,7 @@ struct MergeTreeReaderSettings
     bool can_read_part_without_marks = false;
     /// If we should write/read to/from the query condition cache.
     bool use_query_condition_cache = false;
+    bool query_condition_cache_store_conditions_as_plaintext = false;
     bool use_deserialization_prefixes_cache = false;
     bool use_prefixes_deserialization_thread_pool = false;
 };

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -17,6 +17,7 @@
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
+#include <Storages/VirtualColumnUtils.h>
 #include <city.h>
 #include <Storages/LazilyReadInfo.h>
 
@@ -176,17 +177,23 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                 /// Update the query condition cache for filters in PREWHERE stage
                 if (reader_settings.use_query_condition_cache && task && prewhere_info)
                 {
-                    for (const auto * outputs : prewhere_info->prewhere_actions.getOutputs())
+                    for (const auto * output : prewhere_info->prewhere_actions.getOutputs())
                     {
-                        if (outputs->result_name == prewhere_info->prewhere_column_name)
+                        if (output->result_name == prewhere_info->prewhere_column_name)
                         {
+                            if (!VirtualColumnUtils::isDeterministic(output))
+                                continue;
+
                             auto query_condition_cache = Context::getGlobalContextInstance()->getQueryConditionCache();
                             auto data_part = task->getInfo().data_part;
 
                             query_condition_cache->write(
                                 data_part->storage.getStorageID().uuid,
                                 data_part->name,
-                                outputs->getHash(),
+                                output->getHash(),
+                                reader_settings.query_condition_cache_store_conditions_as_plaintext
+                                    ? prewhere_info->prewhere_actions.getNames()[0]
+                                    : "",
                                 task->getPrewhereUnmatchedMarks(),
                                 data_part->index_granularity->getMarksCount(),
                                 data_part->index_granularity->hasFinalMark());

--- a/src/Storages/System/StorageSystemQueryConditionCache.cpp
+++ b/src/Storages/System/StorageSystemQueryConditionCache.cpp
@@ -16,7 +16,8 @@ ColumnsDescription StorageSystemQueryConditionCache::getColumnsDescription()
     {
         {"table_uuid", std::make_shared<DataTypeUUID>(), "The table UUID."},
         {"part_name", std::make_shared<DataTypeString>(), "The part name."},
-        {"key_hash", std::make_shared<DataTypeUInt64>(), "The hash of the filter condition."},
+        {"condition", std::make_shared<DataTypeString>(), "The hashed filter condition. Only set if setting query_condition_cache_store_conditions_as_plaintext = true."},
+        {"condition_hash", std::make_shared<DataTypeUInt64>(), "The hash of the filter condition."},
         {"entry_size", std::make_shared<DataTypeUInt64>(), "The size of the entry in bytes."},
         {"matching_marks", std::make_shared<DataTypeString>(), "Matching marks."}
     };
@@ -48,11 +49,12 @@ void StorageSystemQueryConditionCache::fillData(MutableColumns & res_columns, Co
     {
         res_columns[0]->insert(key.table_id);
         res_columns[1]->insert(key.part_name);
-        res_columns[2]->insert(key.condition_hash);
-        res_columns[3]->insert(QueryConditionCache::QueryConditionCacheEntryWeight()(*entry));
+        res_columns[2]->insert(key.condition);
+        res_columns[3]->insert(key.condition_hash);
+        res_columns[4]->insert(QueryConditionCache::QueryConditionCacheEntryWeight()(*entry));
 
         std::shared_lock lock(entry->mutex);
-        res_columns[4]->insert(to_string(entry->matching_marks));
+        res_columns[5]->insert(to_string(entry->matching_marks));
     }
 }
 

--- a/tests/queries/0_stateless/03229_query_condition_cache_plaintext_condition.reference
+++ b/tests/queries/0_stateless/03229_query_condition_cache_plaintext_condition.reference
@@ -1,0 +1,8 @@
+--- with move to PREWHERE
+Run two queries, with and without query_condition_cache_store_conditions_as_plaintext enabled
+all_1_1_0	
+all_1_1_0	equals(b, 9000_UInt16)
+--- without move to PREWHERE
+Run two queries, with and without query_condition_cache_store_conditions_as_plaintext enabled
+all_1_1_0	
+all_1_1_0	equals(b, 9000_UInt16)

--- a/tests/queries/0_stateless/03229_query_condition_cache_plaintext_condition.reference
+++ b/tests/queries/0_stateless/03229_query_condition_cache_plaintext_condition.reference
@@ -1,8 +1,8 @@
 --- with move to PREWHERE
 Run two queries, with and without query_condition_cache_store_conditions_as_plaintext enabled
 all_1_1_0	
-all_1_1_0	equals(b, 9000_UInt16)
+all_1_1_0	equals(b, 90000_UInt32)
 --- without move to PREWHERE
 Run two queries, with and without query_condition_cache_store_conditions_as_plaintext enabled
 all_1_1_0	
-all_1_1_0	equals(b, 9000_UInt16)
+all_1_1_0	equals(b, 90000_UInt32)

--- a/tests/queries/0_stateless/03229_query_condition_cache_plaintext_condition.sql
+++ b/tests/queries/0_stateless/03229_query_condition_cache_plaintext_condition.sql
@@ -1,0 +1,35 @@
+-- Tags: no-parallel
+-- Tag no-parallel: Messes with internal cache
+
+SET allow_experimental_analyzer = 1;
+
+-- Tests the effect of setting 'query_condition_cache_store_conditions_as_plaintext'
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO tab SELECT number, number FROM numbers(1_000_000); -- 1 mio rows sounds like a lot but the QCC doesn't cache anything if there is less data
+
+SELECT '--- with move to PREWHERE';
+SET optimize_move_to_prewhere = true;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT 'Run two queries, with and without query_condition_cache_store_conditions_as_plaintext enabled';
+SELECT count(*) FROM tab WHERE b = 10_000 SETTINGS use_query_condition_cache = true, query_condition_cache_store_conditions_as_plaintext = false FORMAT Null;
+SELECT count(*) FROM tab WHERE b = 90_000 SETTINGS use_query_condition_cache = true, query_condition_cache_store_conditions_as_plaintext = true FORMAT Null;
+SELECT part_name, condition FROM system.query_condition_cache ORDER BY condition;
+
+SELECT '--- without move to PREWHERE';
+SET optimize_move_to_prewhere = false;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT 'Run two queries, with and without query_condition_cache_store_conditions_as_plaintext enabled';
+SELECT count(*) FROM tab WHERE b = 10_000 SETTINGS use_query_condition_cache = true, query_condition_cache_store_conditions_as_plaintext = false FORMAT Null;
+SELECT count(*) FROM tab WHERE b = 90_000 SETTINGS use_query_condition_cache = true, query_condition_cache_store_conditions_as_plaintext = true FORMAT Null;
+SELECT part_name, condition FROM system.query_condition_cache ORDER BY condition;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/03229_query_condition_cache_profile_events.sql
+++ b/tests/queries/0_stateless/03229_query_condition_cache_profile_events.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-parallel-replicas
 -- Tag no-parallel: Messes with internal cache
 
 SET allow_experimental_analyzer = 1;


### PR DESCRIPTION
It was hard to understand for some queries which filter conditions a hash in the query condition cache represented. Now storing the original filter condition explicitly. 

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added field `condition` to system table `system.query_condition_cache`. It stores the plaintext condition whose hash is used as a key in the query condition cache.