### PR TITLE
Fix for failing docs check

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -251,7 +251,7 @@ DOCKERS = [
     Docker.Config(
         name="clickhouse/docs-builder",
         path="./docker/docs/builder",
-        platforms=[Docker.Platforms.AMD],
+        platforms=Docker.Platforms.arm_amd,
         depends_on=[],
     ),
     Docker.Config(

--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -35,4 +35,4 @@ COPY run.sh /run.sh
 COPY --from=htmltest-builder /usr/bin/htmltest /usr/bin/htmltest
 
 ENTRYPOINT ["/run.sh"]
-# Rebuilt Fri 14 Mar 18:01 GMT+1
+# Rebuilt Fri 4 April 12:16 GMT+1

--- a/docs/en/sql-reference/statements/attach.md
+++ b/docs/en/sql-reference/statements/attach.md
@@ -14,7 +14,7 @@ Attaches a table or a dictionary, for example, when moving a database to another
 ATTACH TABLE|DICTIONARY|DATABASE [IF NOT EXISTS] [db.]name [ON CLUSTER cluster] ...
 ```
 
-The query does not create data on the disk, but assumes that data is already in the appropriate places, and just adds information about the specified table, dictionary or database to the server. After executing the `ATTACH` query, the server will know about the existence of the table, dictionary or database.
+The query does not create data on disk, but assumes that data is already in the appropriate places, and just adds information about the specified table, dictionary or database to the server. After executing the `ATTACH` query, the server will know about the existence of the table, dictionary or database.
 
 If a table was previously detached ([DETACH](../../sql-reference/statements/detach.md) query), meaning that its structure is known, you can use shorthand without defining the structure.
 

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -69,7 +69,7 @@ def main():
     elif args.force:
         logging.info("Check the docs because of force flag")
 
-    docker_image = get_docker_image("clickhouse/docs-builder --platform linux/amd64")
+    docker_image = get_docker_image("clickhouse/docs-builder")
     if args.pull_image:
         docker_image = pull_image(docker_image)
 

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -69,7 +69,7 @@ def main():
     elif args.force:
         logging.info("Check the docs because of force flag")
 
-    docker_image = get_docker_image("clickhouse/docs-builder")
+    docker_image = get_docker_image("clickhouse/docs-builder --platform linux/amd64")
     if args.pull_image:
         docker_image = pull_image(docker_image)
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
With some recent changes docs check is now failing to pull the clickhouse/docs-builder image:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

See https://github.com/ClickHouse/clickhouse-docs/actions/runs/14260700877/job/39975444115?pr=3544#step:6:18

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
