### PR TITLE
Wrap scalar subquery type in nullable or tuple in only_analyze mode

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -606,6 +606,35 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
             replaceStorageInQueryTree(query_tree, subquery_context, storage);
         auto interpreter = std::make_unique<InterpreterSelectQueryAnalyzer>(query_tree, subquery_context, options);
 
+        auto wrap_with_nullable_or_tuple = [](Block & block)
+        {
+            block = materializeBlock(block);
+            if (block.columns() == 1)
+            {
+                auto & column = block.getByPosition(0);
+                /// Here we wrap type to nullable if we can.
+                /// It is needed cause if subquery return no rows, it's result will be Null.
+                /// In case of many columns, do not check it cause tuple can't be nullable.
+                if (!column.type->isNullable() && column.type->canBeInsideNullable())
+                {
+                    column.type = makeNullable(column.type);
+                    column.column = makeNullable(column.column);
+                }
+            } else
+            {
+                /** Make unique column names for tuple.
+                *
+                * Example: SELECT (SELECT 2 AS x, x)
+                */
+                makeUniqueColumnNamesInBlock(block);
+                block = Block({{
+                        ColumnTuple::create(block.getColumns()),
+                        std::make_shared<DataTypeTuple>(block.getDataTypes(), block.getNames()),
+                        "tuple"
+                    }});
+            }
+        };
+
         if (only_analyze)
         {
             /// If query is only analyzed, then constants are not correct.
@@ -619,6 +648,8 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                     column.column = std::move(mut_col);
                 }
             }
+
+            wrap_with_nullable_or_tuple(scalar_block);
         }
         else
         {
@@ -668,36 +699,8 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                 if (tmp_block.rows() != 0)
                     throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one row");
 
-                block = materializeBlock(block);
-                size_t columns = block.columns();
-
-                if (columns == 1)
-                {
-                    auto & column = block.getByPosition(0);
-                    /// Here we wrap type to nullable if we can.
-                    /// It is needed cause if subquery return no rows, it's result will be Null.
-                    /// In case of many columns, do not check it cause tuple can't be nullable.
-                    if (!column.type->isNullable() && column.type->canBeInsideNullable())
-                    {
-                        column.type = makeNullable(column.type);
-                        column.column = makeNullable(column.column);
-                    }
-
-                    scalar_block = block;
-                }
-                else
-                {
-                    /** Make unique column names for tuple.
-                      *
-                      * Example: SELECT (SELECT 2 AS x, x)
-                      */
-                    makeUniqueColumnNamesInBlock(block);
-
-                    scalar_block.insert({
-                        ColumnTuple::create(block.getColumns()),
-                        std::make_shared<DataTypeTuple>(block.getDataTypes(), block.getNames()),
-                        "tuple"});
-                }
+                wrap_with_nullable_or_tuple(block);
+                scalar_block = std::move(block);
             }
 
             logProcessorProfile(context, io.pipeline.getProcessors());

--- a/tests/queries/0_stateless/02250_insert_select_from_file_schema_inference.sql
+++ b/tests/queries/0_stateless/02250_insert_select_from_file_schema_inference.sql
@@ -1,8 +1,11 @@
 set use_structure_from_insertion_table_in_table_functions = 1;
+use {CLICKHOUSE_DATABASE:Identifier};
 
-insert into table function file('data_02250.jsonl') select NULL as x settings engine_file_truncate_on_insert=1;
+insert into table function file(concat(database(),'.data_02250.jsonl')) select (SELECT 1) settings engine_file_truncate_on_insert=1;
+
+insert into table function file(concat(database(),'.data_02250.jsonl')) select NULL as x settings engine_file_truncate_on_insert=1;
 drop table if exists test_02250;
 create table test_02250 (x Nullable(UInt32)) engine=Memory();
-insert into test_02250 select * from file('data_02250.jsonl');
+insert into test_02250 select * from file(concat(database(),'.data_02250.jsonl'));
 select * from test_02250;
 drop table test_02250;

--- a/tests/queries/0_stateless/02250_insert_select_from_file_schema_inference.sql
+++ b/tests/queries/0_stateless/02250_insert_select_from_file_schema_inference.sql
@@ -1,5 +1,4 @@
 set use_structure_from_insertion_table_in_table_functions = 1;
-use {CLICKHOUSE_DATABASE:Identifier};
 
 insert into table function file(concat(database(),'.data_02250.jsonl')) select (SELECT 1) settings engine_file_truncate_on_insert=1;
 


### PR DESCRIPTION
Closes: #74621
Repro:
```sql
INSERT INTO TABLE FUNCTION file('f.csv') SELECT (SELECT 1);
```
It fixes the problem that the table function schema is resolved with only_analyze==True when the select query pipeline is built as usual, so we get different headers and a logical error during port connection.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Block structure mismatch` error in case of `INSERT SELECT` into table a function with schema inference if `SELECT` has scalar subqueries.

