### PR TITLE
Account for number of replicas when determine read task size

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -190,6 +190,7 @@ namespace Setting
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool merge_tree_use_deserialization_prefixes_cache;
     extern const SettingsBool merge_tree_use_prefixes_deserialization_thread_pool;
+    extern const SettingsNonZeroUInt64 max_parallel_replicas;
 }
 
 namespace MergeTreeSetting
@@ -722,6 +723,12 @@ Pipe ReadFromMergeTree::read(
     const auto & settings = context->getSettingsRef();
     size_t sum_marks = parts_with_range.getMarksCountAllParts();
 
+    const size_t total_query_nodes = is_parallel_reading_from_replicas
+        ? std::min<size_t>(
+              context->getClusterForParallelReplicas()->getShardsInfo().at(0).getAllNodeCount(),
+              context->getSettingsRef()[Setting::max_parallel_replicas])
+        : 1;
+
     PoolSettings pool_settings{
         .threads = max_streams,
         .sum_marks = sum_marks,
@@ -729,6 +736,7 @@ Pipe ReadFromMergeTree::read(
         .preferred_block_size_bytes = settings[Setting::preferred_block_size_bytes],
         .use_uncompressed_cache = use_uncompressed_cache,
         .use_const_size_tasks_for_remote_reading = settings[Setting::merge_tree_use_const_size_tasks_for_remote_reading],
+        .total_query_nodes = total_query_nodes,
     };
 
     if (read_type == ReadType::ParallelReplicas)
@@ -1131,12 +1139,19 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder(
 
     const auto read_type = input_order_info->direction == 1 ? ReadType::InOrder : ReadType::InReverseOrder;
 
+    const size_t total_query_nodes = is_parallel_reading_from_replicas
+        ? std::min<size_t>(
+              context->getClusterForParallelReplicas()->getShardsInfo().at(0).getAllNodeCount(),
+              context->getSettingsRef()[Setting::max_parallel_replicas])
+        : 1;
+
     PoolSettings pool_settings{
         .threads = num_streams,
         .sum_marks = parts_with_ranges.getMarksCountAllParts(),
         .min_marks_for_concurrent_read = info.min_marks_for_concurrent_read,
         .preferred_block_size_bytes = settings[Setting::preferred_block_size_bytes],
         .use_uncompressed_cache = info.use_uncompressed_cache,
+        .total_query_nodes = total_query_nodes,
     };
 
     Pipes pipes;

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -101,8 +101,9 @@ calculateMinMarksPerTask(
             const auto min_bytes_per_task = settings[Setting::merge_tree_min_bytes_per_task_for_remote_reading];
             /// We're taking min here because number of tasks shouldn't be too low - it will make task stealing impossible.
             /// We also create at least two tasks per thread to have something to steal from a slow thread.
-            const auto heuristic_min_marks
-                = std::min<size_t>(pool_settings.sum_marks / pool_settings.threads / 2, min_bytes_per_task / avg_mark_bytes);
+            const auto heuristic_min_marks = std::min<size_t>(
+                pool_settings.sum_marks / (pool_settings.threads * pool_settings.total_query_nodes) / 2,
+                min_bytes_per_task / avg_mark_bytes);
             if (heuristic_min_marks > min_marks_per_task)
             {
                 LOG_TEST(

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.h
@@ -21,6 +21,9 @@ public:
         bool use_uncompressed_cache = false;
         bool do_not_steal_tasks = false;
         bool use_const_size_tasks_for_remote_reading = false;
+
+        // Not the same as the similar field in `ParallelReadingExtension`. Accounts for `max_parallel_replicas`.
+        const size_t total_query_nodes;
     };
 
     MergeTreeReadPoolBase(

--- a/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.cpp
@@ -72,8 +72,9 @@ size_t chooseSegmentSize(
 
 size_t getMinMarksPerTask(size_t min_marks_per_task, const std::vector<DB::MergeTreeReadTaskInfoPtr> & per_part_infos)
 {
-    for (const auto & info : per_part_infos)
-        min_marks_per_task = std::max(min_marks_per_task, info->min_marks_per_task);
+    const auto min_across_parts = std::ranges::min(
+        per_part_infos, [](const auto & lhs, const auto & rhs) { return lhs->min_marks_per_task < rhs->min_marks_per_task; });
+    min_marks_per_task = std::max(min_marks_per_task, min_across_parts->min_marks_per_task);
 
     if (min_marks_per_task == 0)
         throw DB::Exception(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now we use number of replicas to determine task size for reading with parallel replicas enabled. This provides better work distribution between replicas when the amount of data to read is not really big.