### PR TITLE
Fix wrong arguments order for TableFunctionFactory::execute() for loop

### DIFF
--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -127,7 +127,8 @@ namespace DB
                     context,
                     table_name,
                     std::move(cached_columns),
-                    is_insert_query);
+                    /*use_global_context=*/false,
+                    /*is_insert_query=*/is_insert_query);
         }
         auto res = std::make_shared<StorageLoop>(
                 StorageID(getDatabaseName(), table_name),


### PR DESCRIPTION
Note, that it should not change anything since loop does not support write anyway, so is_insert_query should always be false.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)