### PR TITLE
ci: fix bug-fix check (due to new settings added to tests configurations in 25.4)

### DIFF
--- a/tests/config/config.d/backoff_policy.xml
+++ b/tests/config/config.d/backoff_policy.xml
@@ -1,8 +1,5 @@
 <clickhouse>
     <merge_tree>
         <max_postpone_time_for_failed_mutations_ms>200</max_postpone_time_for_failed_mutations_ms>
-        <max_postpone_time_for_failed_replicated_fetches_ms>0</max_postpone_time_for_failed_replicated_fetches_ms>
-        <max_postpone_time_for_failed_replicated_merges_ms>0</max_postpone_time_for_failed_replicated_merges_ms>
-        <max_postpone_time_for_failed_replicated_tasks_ms>0</max_postpone_time_for_failed_replicated_tasks_ms>
     </merge_tree>
 </clickhouse>

--- a/tests/config/config.d/backoff_policy_25_4.xml
+++ b/tests/config/config.d/backoff_policy_25_4.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <merge_tree>
+        <max_postpone_time_for_failed_replicated_fetches_ms>0</max_postpone_time_for_failed_replicated_fetches_ms>
+        <max_postpone_time_for_failed_replicated_merges_ms>0</max_postpone_time_for_failed_replicated_merges_ms>
+        <max_postpone_time_for_failed_replicated_tasks_ms>0</max_postpone_time_for_failed_replicated_tasks_ms>
+    </merge_tree>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -26,6 +26,20 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+function check_clickhouse_version()
+{
+    local required_version=$1 && shift
+    # ClickHouse local version 25.4.1.1.
+    current_version=$(clickhouse --version | awk '{print $NF}')
+
+    if [ "$(printf '%s\n' "$required_version" "$current_version" | sort -V | head -n1)" = "$required_version" ]; then
+        echo "ClickHouse version $current_version is OK (>= $required_version)"
+    else
+        echo "ClickHouse version $current_version is too old. Required >= $required_version"
+        return 1
+    fi
+}
+
 echo "Going to install test configs from $SRC_PATH into $DEST_SERVER_PATH"
 
 mkdir -p $DEST_SERVER_PATH/config.d/
@@ -51,6 +65,9 @@ ln -sf $SRC_PATH/config.d/database_atomic.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/max_concurrent_queries.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/merge_tree_settings.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/backoff_policy.xml $DEST_SERVER_PATH/config.d/
+if check_clickhouse_version 25.4; then
+    ln -sf $SRC_PATH/config.d/backoff_policy_25_4.xml $DEST_SERVER_PATH/config.d/
+fi
 ln -sf $SRC_PATH/config.d/merge_tree_old_dirs_cleanup.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/test_cluster_with_incorrect_pw.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/keeper_port.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
And instead of relying on $BUGFIX_VALIDATE_CHECK, it looks cleaner to use explicit version checks.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/74576