### PR TITLE
Optimize system.tables for *_mutations access

### DIFF
--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -718,7 +718,9 @@ protected:
 
                 if (table_merge_tree)
                 {
-                    auto mutation_counters = table_merge_tree->getMutationCounters();
+                    MutationCounters mutation_counters;
+                    if (columns_mask[src_index] || columns_mask[src_index + 1] || columns_mask[src_index + 2])
+                        mutation_counters = table_merge_tree->getMutationCounters();
 
                     if (columns_mask[src_index++])
                         res_columns[res_index++]->insert(mutation_counters.num_data);


### PR DESCRIPTION
Request it only if those columns has been requested.

Note, that the main motivation was to fix private CI, since for SMT `02990_rmt_replica_path_uuid` after the referenced PR started to fail.

Fixes: ClickHouse/ClickHouse#78515 (cc @CurtizJ )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)