### PR TITLE
ci: fix bufix check (due to an error for version comparison)

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -30,7 +30,8 @@ function check_clickhouse_version()
 {
     local required_version=$1 && shift
     # ClickHouse local version 25.4.1.1.
-    current_version=$(clickhouse --version | awk '{print $NF}')
+    # ClickHouse local version 25.4.1.1 (official build).
+    current_version=$(clickhouse --version | awk '{print $4}')
 
     if [ "$(printf '%s\n' "$required_version" "$current_version" | sort -V | head -n1)" = "$required_version" ]; then
         echo "ClickHouse version $current_version is OK (>= $required_version)"

--- a/tests/queries/0_stateless/00563_insert_into_remote_and_zookeeper_long.reference
+++ b/tests/queries/0_stateless/00563_insert_into_remote_and_zookeeper_long.reference
@@ -1,3 +1,8 @@
+prefer_localhost_replica=1
+1
+2
+2
+prefer_localhost_replica=0
 1
 2
 2

--- a/tests/queries/0_stateless/00563_insert_into_remote_and_zookeeper_long.sql
+++ b/tests/queries/0_stateless/00563_insert_into_remote_and_zookeeper_long.sql
@@ -1,16 +1,21 @@
--- Tags: long, zookeeper
+-- Tags: zookeeper
 
 -- Check that settings are correctly passed through Distributed table
 DROP TABLE IF EXISTS simple;
 CREATE TABLE simple (d Int8) ENGINE = ReplicatedMergeTree('/clickhouse/{database}/test_00563/tables/simple', '1') ORDER BY d;
 
--- TODO: replace '127.0.0.2' -> '127.0.0.1' after a fix
-INSERT INTO TABLE FUNCTION remote('127.0.0.2', currentDatabase(), 'simple') VALUES (1);
-INSERT INTO TABLE FUNCTION remote('127.0.0.2', currentDatabase(), 'simple') VALUES (1);
+SELECT 'prefer_localhost_replica=1';
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=1, insert_deduplicate=1 VALUES (1);
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=1, insert_deduplicate=1 VALUES (1);
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=1, insert_deduplicate=0 VALUES (2);
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=1, insert_deduplicate=0 VALUES (2);
+SELECT * FROM remote('127.0.0.1', currentDatabase(), 'simple') ORDER BY d;
 
-SET insert_deduplicate=0;
-INSERT INTO TABLE FUNCTION remote('127.0.0.2', currentDatabase(), 'simple') VALUES (2);
-INSERT INTO TABLE FUNCTION remote('127.0.0.2', currentDatabase(), 'simple') VALUES (2);
-
+SELECT 'prefer_localhost_replica=0';
+TRUNCATE TABLE simple;
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=0, insert_deduplicate=1 VALUES (1);
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=0, insert_deduplicate=1 VALUES (1);
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=0, insert_deduplicate=0 VALUES (2);
+INSERT INTO TABLE FUNCTION remote('127.0.0.1', currentDatabase(), 'simple') SETTINGS prefer_localhost_replica=0, insert_deduplicate=0 VALUES (2);
 SELECT * FROM remote('127.0.0.2', currentDatabase(), 'simple') ORDER BY d;
 DROP TABLE simple;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Just checking bug fix script. Will revert the category to not for changelog before merge.

This time I did not forgot to mark it as `pr-bugfix` to ensure that it works (sigh)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/78709