### PR TITLE
ci: disable async_insert for sending system.*_log to ci-logs cluster and increase stop timeout

### DIFF
--- a/tests/config/users.d/ci_logs_sender.yaml
+++ b/tests/config/users.d/ci_logs_sender.yaml
@@ -5,6 +5,8 @@ profiles:
         # the INSERTs will be retried anyway
         send_timeout: 15
         receive_timeout: 15
+        # Disable async INSERT, since the batches should be big enough
+        async_insert: 0
 users:
     ci_logs_sender:
         profile: ci_logs_sender

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -179,7 +179,7 @@ EOL
 
 function stop_server()
 {
-    local max_tries=90
+    local max_tries=300
     local check_hang=true
     local pid
     # Preserve the pid, since the server can hung after the PID will be deleted.


### PR DESCRIPTION
I found this on CI [1]:

    2025.03.25 21:30:01.453922 [ 129437 ] {} <Error> system.error_log_sender.DistributedInsertQueue.default: Code: 159. DB::Exception: Received from kng4alm55c.us-east-2.aws.clickhouse-staging.com:9440. DB::Exception: Wait for async insert timeout (120000 ms) exceeded). Stack trace:

  [1]: https://github.com/ClickHouse/ClickHouse/pull/78266#issuecomment-2770842740

And `async_insert` is useless there, since the batches should be big enough.

But after that there can be some issues like this:

        2025.03.25 18:39:13.283903 [ 43045 ] {} <Error> system.text_log_sender.DistributedInsertQueue.default: Code: 159. DB::Exception: Received from kng4alm55c.us-east-2.aws.clickhouse-staging.com:9440. DB::Exception: Timeout exceeded: elapsed 60035.290694 ms, maximum: 60000 ms. Stack trace:

So let's also tune timeout just in case

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/78266
Refs: https://github.com/ClickHouse/ClickHouse/issues/76133

_Note, that I thought about implementing some hints for background Distributed INSERTs, relying on `async_insert_max_data_size`, but the problem is that it will rely on client setting value, not the server._