### PR TITLE
More consistent error handling of OpenSSL calls

### DIFF
--- a/src/Access/AuthenticationData.cpp
+++ b/src/Access/AuthenticationData.cpp
@@ -549,12 +549,8 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
 #if USE_SSL
             ///random generator FIPS complaint
             uint8_t key[32];
-            if (RAND_bytes(key, sizeof(key)) != 1)
-            {
-                char buf[512] = {0};
-                ERR_error_string_n(ERR_get_error(), buf, sizeof(buf));
-                throw Exception(ErrorCodes::OPENSSL_ERROR, "Cannot generate salt for password. OpenSSL {}", buf);
-            }
+            if (!RAND_bytes(key, sizeof(key)))
+                throw Exception(ErrorCodes::OPENSSL_ERROR, "RAND_bytes failed: {}", getOpenSSLErrors());
 
             String salt;
             salt.resize(sizeof(key) * 2);
@@ -577,12 +573,8 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
 #if USE_SSL
             ///random generator FIPS complaint
             uint8_t key[32];
-            if (RAND_bytes(key, sizeof(key)) != 1)
-            {
-                char buf[512] = {0};
-                ERR_error_string_n(ERR_get_error(), buf, sizeof(buf));
-                throw Exception(ErrorCodes::OPENSSL_ERROR, "Cannot generate salt for password. OpenSSL {}", buf);
-            }
+            if (!RAND_bytes(key, sizeof(key)))
+                throw Exception(ErrorCodes::OPENSSL_ERROR, "RAND_bytes failed: {}", getOpenSSLErrors());
 
             String salt;
             salt.resize(sizeof(key) * 2);

--- a/src/Functions/FunctionsAES.cpp
+++ b/src/Functions/FunctionsAES.cpp
@@ -1,5 +1,6 @@
 #include <Functions/FunctionsAES.h>
 #include <Interpreters/Context.h>
+#include <Common/OpenSSLHelpers.h>
 
 #if USE_SSL
 
@@ -16,12 +17,11 @@ namespace ErrorCodes
     extern const int OPENSSL_ERROR;
 }
 
-
 namespace OpenSSLDetails
 {
 void onError(std::string error_message)
 {
-    throw Exception(ErrorCodes::OPENSSL_ERROR, "{}. OpenSSL error code: {}", error_message, ERR_get_error());
+    throw Exception(ErrorCodes::OPENSSL_ERROR, "{} failed: {}", error_message, getOpenSSLErrors());
 }
 
 StringRef foldEncryptionKeyInMySQLCompatitableMode(size_t cipher_key_size, StringRef key, std::array<char, EVP_MAX_KEY_LENGTH> & folded_key)

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -6,6 +6,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <Common/OpenSSLHelpers.h>
 #include <Common/safe_cast.h>
 
 #if USE_SSL
@@ -333,25 +334,25 @@ private:
                 if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM)
                 {
                     // 1.a.1: Init CTX with custom IV length and optionally with AAD
-                    if (EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr) != 1)
-                        onError("Failed to initialize encryption context with cipher");
+                    if (!EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr))
+                        onError("EVP_EncryptInit_ex");
 
-                    if (EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_SET_IVLEN, safe_cast<int>(iv_value.size), nullptr) != 1)
-                        onError("Failed to set custom IV length to " + std::to_string(iv_value.size));
+                    if (!EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_SET_IVLEN, safe_cast<int>(iv_value.size), nullptr))
+                        onError("EVP_CIPHER_CTX_ctrl");
 
-                    if (EVP_EncryptInit_ex(evp_ctx, nullptr, nullptr,
+                    if (!EVP_EncryptInit_ex(evp_ctx, nullptr, nullptr,
                             reinterpret_cast<const unsigned char*>(key_value.data),
-                            reinterpret_cast<const unsigned char*>(iv_value.data)) != 1)
-                        onError("Failed to set key and IV");
+                            reinterpret_cast<const unsigned char*>(iv_value.data)))
+                        onError("EVP_EncryptInit_ex");
 
                     // 1.a.2 Set AAD
                     if (aad_column)
                     {
                         const auto aad_data = aad_column->getDataAt(row_idx);
                         int tmp_len = 0;
-                        if (aad_data.size != 0 && EVP_EncryptUpdate(evp_ctx, nullptr, &tmp_len,
-                                reinterpret_cast<const unsigned char *>(aad_data.data), safe_cast<int>(aad_data.size)) != 1)
-                            onError("Failed to set AAD data");
+                        if (aad_data.size != 0 && !EVP_EncryptUpdate(evp_ctx, nullptr, &tmp_len,
+                                reinterpret_cast<const unsigned char *>(aad_data.data), safe_cast<int>(aad_data.size)))
+                            onError("EVP_EncryptUpdate");
                     }
                 }
                 else
@@ -359,25 +360,25 @@ private:
                     // 1.b: Init CTX
                     validateIV<mode>(iv_value, iv_size);
 
-                    if (EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr,
+                    if (!EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr,
                             reinterpret_cast<const unsigned char*>(key_value.data),
-                            reinterpret_cast<const unsigned char*>(iv_value.data)) != 1)
-                        onError("Failed to initialize cipher context");
+                            reinterpret_cast<const unsigned char*>(iv_value.data)))
+                        onError("EVP_EncryptInit_ex");
                 }
 
                 int output_len = 0;
                 // 2: Feed the data to the cipher
-                if (EVP_EncryptUpdate(evp_ctx,
+                if (!EVP_EncryptUpdate(evp_ctx,
                         reinterpret_cast<unsigned char*>(encrypted), &output_len,
-                        reinterpret_cast<const unsigned char*>(input_value.data), static_cast<int>(input_value.size)) != 1)
-                    onError("Failed to encrypt");
+                        reinterpret_cast<const unsigned char*>(input_value.data), static_cast<int>(input_value.size)))
+                    onError("EVP_EncryptUpdate");
                 __msan_unpoison(encrypted, output_len); /// OpenSSL uses assembly which evades msan's analysis
                 encrypted += output_len;
 
                 // 3: retrieve encrypted data (ciphertext)
-                if (EVP_EncryptFinal_ex(evp_ctx,
-                        reinterpret_cast<unsigned char*>(encrypted), &output_len) != 1)
-                    onError("Failed to fetch ciphertext");
+                if (!EVP_EncryptFinal_ex(evp_ctx,
+                        reinterpret_cast<unsigned char*>(encrypted), &output_len))
+                    onError("EVP_EncryptFinal_ex");
                 __msan_unpoison(encrypted, output_len); /// OpenSSL uses assembly which evades msan's analysis
                 encrypted += output_len;
 
@@ -385,8 +386,8 @@ private:
                 // https://tools.ietf.org/html/rfc5116#section-5.1
                 if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM)
                 {
-                    if (EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_GET_TAG, tag_size, encrypted) != 1)
-                        onError("Failed to retrieve GCM tag");
+                    if (!EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_GET_TAG, tag_size, encrypted))
+                        onError("EVP_CIPHER_CTX_ctrl");
                     encrypted += tag_size;
                 }
             }
@@ -635,27 +636,27 @@ private:
                 // 1: Init CTX
                 if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM)
                 {
-                    if (EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr) != 1)
-                        onError("Failed to initialize cipher context 1");
+                    if (!EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr))
+                        onError("EVP_DecryptInit_ex");
 
                     // 1.a.1 : Set custom IV length
-                    if (EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_SET_IVLEN, safe_cast<int>(iv_value.size), nullptr) != 1)
-                        onError("Failed to set custom IV length to " + std::to_string(iv_value.size));
+                    if (!EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_SET_IVLEN, safe_cast<int>(iv_value.size), nullptr))
+                        onError("EVP_CIPHER_CTX_ctrl");
 
                     // 1.a.1 : Init CTX with key and IV
-                    if (EVP_DecryptInit_ex(evp_ctx, nullptr, nullptr,
+                    if (!EVP_DecryptInit_ex(evp_ctx, nullptr, nullptr,
                             reinterpret_cast<const unsigned char*>(key_value.data),
-                            reinterpret_cast<const unsigned char*>(iv_value.data)) != 1)
-                        onError("Failed to set key and IV");
+                            reinterpret_cast<const unsigned char*>(iv_value.data)))
+                        onError("EVP_DecryptInit_ex");
 
                     // 1.a.2: Set AAD if present
                     if (aad_column)
                     {
                         StringRef aad_data = aad_column->getDataAt(row_idx);
                         int tmp_len = 0;
-                        if (aad_data.size != 0 && EVP_DecryptUpdate(evp_ctx, nullptr, &tmp_len,
-                                reinterpret_cast<const unsigned char *>(aad_data.data), safe_cast<int>(aad_data.size)) != 1)
-                            onError("Failed to sed AAD data");
+                        if (aad_data.size != 0 && !EVP_DecryptUpdate(evp_ctx, nullptr, &tmp_len,
+                                reinterpret_cast<const unsigned char *>(aad_data.data), safe_cast<int>(aad_data.size)))
+                        onError("EVP_DecryptUpdate");
                     }
                 }
                 else
@@ -663,20 +664,20 @@ private:
                     // 1.b: Init CTX
                     validateIV<mode>(iv_value, iv_size);
 
-                    if (EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr,
+                    if (!EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr,
                             reinterpret_cast<const unsigned char*>(key_value.data),
-                            reinterpret_cast<const unsigned char*>(iv_value.data)) != 1)
-                        onError("Failed to initialize cipher context");
+                            reinterpret_cast<const unsigned char*>(iv_value.data)))
+                        onError("EVP_DecryptInit_ex");
                 }
 
                 // 2: Feed the data to the cipher
                 int output_len = 0;
-                if (EVP_DecryptUpdate(evp_ctx,
+                if (!EVP_DecryptUpdate(evp_ctx,
                         reinterpret_cast<unsigned char*>(decrypted), &output_len,
-                        reinterpret_cast<const unsigned char*>(input_value.data), static_cast<int>(input_value.size)) != 1)
+                        reinterpret_cast<const unsigned char*>(input_value.data), static_cast<int>(input_value.size)))
                 {
                     if constexpr (!use_null_when_decrypt_fail)
-                        onError("Failed to decrypt");
+                        onError("EVP_DecryptUpdate");
                     decrypt_fail = true;
                 }
                 else
@@ -687,16 +688,16 @@ private:
                     if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM)
                     {
                         void * tag = const_cast<void *>(reinterpret_cast<const void *>(input_value.data + input_value.size));
-                        if (EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_SET_TAG, tag_size, tag) != 1)
-                            onError("Failed to set tag");
+                        if (!EVP_CIPHER_CTX_ctrl(evp_ctx, EVP_CTRL_AEAD_SET_TAG, tag_size, tag))
+                            onError("EVP_CIPHER_CTX_ctrl");
                     }
 
                     // 4: retrieve encrypted data (ciphertext)
-                    if (!decrypt_fail && EVP_DecryptFinal_ex(evp_ctx,
-                            reinterpret_cast<unsigned char*>(decrypted), &output_len) != 1)
+                    if (!decrypt_fail && !EVP_DecryptFinal_ex(evp_ctx,
+                            reinterpret_cast<unsigned char*>(decrypted), &output_len))
                     {
                         if constexpr (!use_null_when_decrypt_fail)
-                            onError("Failed to decrypt");
+                            onError("EVP_DecryptFinal_ex");
                         decrypt_fail = true;
                     }
                     else

--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -13,6 +13,7 @@
 #pragma clang diagnostic ignored "-Wused-but-marked-unused"
 #include <xxhash.h>
 
+#include <Common/OpenSSLHelpers.h>
 #include <Common/SipHash.h>
 #include <Common/typeid_cast.h>
 #include <Common/safe_cast.h>
@@ -250,16 +251,16 @@ struct HalfMD5Impl
         const auto ctx = EVP_MD_CTX_ptr(EVP_MD_CTX_new(), EVP_MD_CTX_free);
 
         if (!ctx)
-            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_new failed");
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_new failed: {}", getOpenSSLErrors());
 
         if (!EVP_DigestInit_ex(ctx.get(), EVP_md5(), nullptr))
-            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestInit_ex failed");
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestInit_ex failed: {}", getOpenSSLErrors());
 
         if (!EVP_DigestUpdate(ctx.get(), begin, size))
-            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestUpdate failed");
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestUpdate failed: {}", getOpenSSLErrors());
 
         if (!EVP_DigestFinal_ex(ctx.get(), buf.char_data, nullptr))
-            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestFinal_ex failed");
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestFinal_ex failed: {}", getOpenSSLErrors());
 
         /// Compatibility with existing code. Cast is necessary for old poco AND macos where UInt64 != uint64_t
         transformEndianness<std::endian::big>(buf.uint64_data);

--- a/src/Functions/FunctionsStringHashFixedString.cpp
+++ b/src/Functions/FunctionsStringHashFixedString.cpp
@@ -48,6 +48,8 @@ namespace ErrorCodes
 #if USE_SSL
 using EVP_MD_CTX_ptr = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
 
+/// Initializes a context with the right provider in the constructor.
+/// Apply() then only copies it (once per new thread), this is faster than re-creating the context every time.
 template <typename ProviderImpl>
 class OpenSSLProvider
 {
@@ -55,12 +57,13 @@ public:
     static constexpr auto name = ProviderImpl::name;
     static constexpr auto length = ProviderImpl::length;
 
-    OpenSSLProvider() : ctx_template(EVP_MD_CTX_new(), &EVP_MD_CTX_free)
+    OpenSSLProvider()
+        : ctx_template(EVP_MD_CTX_new(), &EVP_MD_CTX_free)
     {
         if (!ctx_template)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_new failed: {}", getOpenSSLErrors());
 
-        if (EVP_DigestInit_ex(ctx_template.get(), ProviderImpl::provider(), nullptr) != 1)
+        if (!EVP_DigestInit_ex(ctx_template.get(), ProviderImpl::provider(), nullptr))
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestInit_ex failed: {}", getOpenSSLErrors());
     }
 
@@ -70,13 +73,14 @@ public:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No context provided");
 
         thread_local EVP_MD_CTX_ptr ctx(EVP_MD_CTX_new(), &EVP_MD_CTX_free);
-        if (EVP_MD_CTX_copy_ex(ctx.get(), ctx_template.get()) != 1)
+
+        if (!EVP_MD_CTX_copy_ex(ctx.get(), ctx_template.get()))
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_copy_ex failed: {}", getOpenSSLErrors());
 
-        if (EVP_DigestUpdate(ctx.get(), begin, size) != 1)
+        if (!EVP_DigestUpdate(ctx.get(), begin, size))
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestUpdate failed: {}", getOpenSSLErrors());
 
-        if (EVP_DigestFinal_ex(ctx.get(), out_char_data, nullptr) != 1)
+        if (!EVP_DigestFinal_ex(ctx.get(), out_char_data, nullptr))
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestFinal_ex failed: {}", getOpenSSLErrors());
     }
 

--- a/src/IO/FileEncryptionCommon.cpp
+++ b/src/IO/FileEncryptionCommon.cpp
@@ -7,6 +7,7 @@
 #    include <IO/WriteBuffer.h>
 #    include <IO/WriteHelpers.h>
 #    include <Common/SipHash.h>
+#    include <Common/OpenSSLHelpers.h>
 #    include <Common/safe_cast.h>
 
 #    include <cassert>
@@ -98,7 +99,7 @@ namespace
             uint8_t * ciphertext = reinterpret_cast<uint8_t *>(out.position());
             int ciphertext_size = 0;
             if (!EVP_EncryptUpdate(evp_ctx, ciphertext, &ciphertext_size, &in[in_size], static_cast<int>(part_size)))
-                throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to encrypt: {}", ERR_get_error());
+                throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_EncryptUpdate failed: {}", getOpenSSLErrors());
 
             __msan_unpoison(ciphertext, ciphertext_size); /// OpenSSL uses assembly which evades msans analysis
 
@@ -123,7 +124,7 @@ namespace
         uint8_t ciphertext[kBlockSize];
         int ciphertext_size = 0;
         if (!EVP_EncryptUpdate(evp_ctx, ciphertext, &ciphertext_size, padded_data, safe_cast<int>(padded_data_size)))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to encrypt: {}", ERR_get_error());
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_EncryptUpdate failed: {}", getOpenSSLErrors());
 
         if (!ciphertext_size)
             return 0;
@@ -144,7 +145,7 @@ namespace
         int ciphertext_size = 0;
         if (!EVP_EncryptFinal_ex(evp_ctx,
                                  ciphertext, &ciphertext_size))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to finalize encrypting: {}", ERR_get_error());
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_EncryptFinal_ex: {}", getOpenSSLErrors());
         __msan_unpoison(ciphertext, ciphertext_size); /// OpenSSL uses assembly which evades msans analysis
         if (ciphertext_size)
             out.write(reinterpret_cast<const char *>(ciphertext), ciphertext_size);
@@ -157,7 +158,7 @@ namespace
         uint8_t * plaintext = reinterpret_cast<uint8_t *>(out);
         int plaintext_size = 0;
         if (!EVP_DecryptUpdate(evp_ctx, plaintext, &plaintext_size, in, safe_cast<int>(size)))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to decrypt: {}", ERR_get_error());
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DecryptUpdate: {}", getOpenSSLErrors());
         __msan_unpoison(plaintext, plaintext_size); /// OpenSSL uses assembly which evades msans analysis
         return plaintext_size;
     }
@@ -171,7 +172,7 @@ namespace
         uint8_t plaintext[kBlockSize];
         int plaintext_size = 0;
         if (!EVP_DecryptUpdate(evp_ctx, plaintext, &plaintext_size, padded_data, safe_cast<int>(padded_data_size)))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to decrypt: {}", ERR_get_error());
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DecryptUpdate: {}", getOpenSSLErrors());
 
         if (!plaintext_size)
             return 0;
@@ -191,7 +192,7 @@ namespace
         uint8_t plaintext[kBlockSize];
         int plaintext_size = 0;
         if (!EVP_DecryptFinal_ex(evp_ctx, plaintext, &plaintext_size))
-            throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to finalize decrypting: {}", ERR_get_error());
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DecryptFinal_ex: {}", getOpenSSLErrors());
         __msan_unpoison(plaintext, plaintext_size); /// OpenSSL uses assembly which evades msans analysis
         if (plaintext_size)
             memcpy(out, plaintext, plaintext_size);
@@ -271,9 +272,8 @@ InitVector InitVector::random()
 {
     UInt128 counter;
     auto * buf = reinterpret_cast<unsigned char *>(counter.items);
-    auto ret = RAND_bytes(buf, sizeof(counter.items));
-    if (ret != 1)
-        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "OpenSSL error code: {}", ERR_get_error());
+    if (!RAND_bytes(buf, sizeof(counter.items)))
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "RAND_bytes failed: {}", getOpenSSLErrors());
     return InitVector{counter};
 }
 
@@ -298,11 +298,11 @@ void Encryptor::encrypt(const char * data, size_t size, WriteBuffer & out)
     auto * evp_ctx = evp_ctx_ptr.get();
 
     if (!EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to initialize encryption context with cipher: {}", ERR_get_error());
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "EVP_EncryptInit_ex failed: {}", getOpenSSLErrors());
 
     if (!EVP_EncryptInit_ex(evp_ctx, nullptr, nullptr,
                             reinterpret_cast<const uint8_t*>(key.c_str()), reinterpret_cast<const uint8_t*>(current_iv.c_str())))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to set key and IV for encryption: {}", ERR_get_error());
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "!EVP_EncryptInit_ex failed: {}", getOpenSSLErrors());
 
     size_t in_size = 0;
     size_t out_size = 0;
@@ -342,11 +342,11 @@ void Encryptor::decrypt(const char * data, size_t size, char * out)
     auto * evp_ctx = evp_ctx_ptr.get();
 
     if (!EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to initialize decryption context with cipher: {}", ERR_get_error());
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "EVP_DecryptInit_ex failed: {}", getOpenSSLErrors());
 
     if (!EVP_DecryptInit_ex(evp_ctx, nullptr, nullptr,
                             reinterpret_cast<const uint8_t*>(key.c_str()), reinterpret_cast<const uint8_t*>(current_iv.c_str())))
-        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Failed to set key and IV for decryption: {}", ERR_get_error());
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "EVP_DecryptInit_ex failed: {}", getOpenSSLErrors());
 
     size_t in_size = 0;
     size_t out_size = 0;

--- a/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
+++ b/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
@@ -1,8 +1,8 @@
 -- Tags: no-parallel, no-fasttest, no-ubsan, no-batch, no-flaky-check
 -- no-parallel because we want to run this test when most of the other tests already passed
 -- This is not a regular test. It is intended to run once after other tests to validate certain statistics about the whole test runs.
--- TODO: I advise to put in inside clickhouse-test instead.
 
+-- TODO: I advise to put in inside clickhouse-test instead.
 -- If this test fails, see the "Top patterns of log messages" diagnostics in the end of run.log
 
 system flush logs text_log;
@@ -76,6 +76,7 @@ create temporary table known_short_messages (s String) as select * from (select 
     '',
     '({}) Keys: {}',
     '({}) {}',
+    '{} failed: {}',
     'Aggregating',
     'Attempt to read after EOF.',
     'Attempt to read after eof',


### PR DESCRIPTION
Makes the error handling for calls to OpenSSL a bit more consistent across the codebase

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)