### PR TITLE
Avoid dynamic allocation in `UniqExactSet`

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionUniq.h
+++ b/src/AggregateFunctions/AggregateFunctionUniq.h
@@ -3,7 +3,6 @@
 #include <atomic>
 #include <memory>
 #include <type_traits>
-#include <utility>
 #include <city.h>
 
 #include <base/bit_cast.h>
@@ -145,7 +144,7 @@ struct AggregateFunctionUniqExactData
 
     /// When creating, the hash table must be small.
     using SingleLevelSet = HashSet<Key, HashCRC32<Key>, HashTableGrower<4>, HashTableAllocatorWithStackMemory<sizeof(Key) * (1 << 4)>>;
-    using TwoLevelSet = TwoLevelHashSet<Key, HashCRC32<Key>>;
+    using TwoLevelSet = TwoLevelHashSet<Key, HashCRC32<Key>, HashTableGrower<>>;
     using Set = UniqExactSet<SingleLevelSet, TwoLevelSet>;
 
     Set set;
@@ -165,7 +164,7 @@ struct AggregateFunctionUniqExactData<String, is_able_to_parallelize_merge_>
 
     /// When creating, the hash table must be small.
     using SingleLevelSet = HashSet<Key, UInt128TrivialHash, HashTableGrower<3>, HashTableAllocatorWithStackMemory<sizeof(Key) * (1 << 3)>>;
-    using TwoLevelSet = TwoLevelHashSet<Key, UInt128TrivialHash>;
+    using TwoLevelSet = TwoLevelHashSet<Key, UInt128TrivialHash, HashTableGrower<>>;
     using Set = UniqExactSet<SingleLevelSet, TwoLevelSet>;
 
     Set set;
@@ -185,7 +184,7 @@ struct AggregateFunctionUniqExactData<IPv6, is_able_to_parallelize_merge_>
 
     /// When creating, the hash table must be small.
     using SingleLevelSet = HashSet<Key, UInt128TrivialHash, HashTableGrower<3>, HashTableAllocatorWithStackMemory<sizeof(Key) * (1 << 3)>>;
-    using TwoLevelSet = TwoLevelHashSet<Key, UInt128TrivialHash>;
+    using TwoLevelSet = TwoLevelHashSet<Key, UInt128TrivialHash, HashTableGrower<>>;
     using Set = UniqExactSet<SingleLevelSet, TwoLevelSet>;
 
     Set set;

--- a/src/AggregateFunctions/UniqExactSet.h
+++ b/src/AggregateFunctions/UniqExactSet.h
@@ -154,6 +154,8 @@ public:
                 }
             }
         }
+
+        other.clear();
     }
 
     void read(ReadBuffer & in)
@@ -218,6 +220,12 @@ public:
 
     bool isSingleLevel() const { return !two_level_set; }
     bool isTwoLevel() const { return !!two_level_set; }
+
+    void clear() const
+    {
+        single_level_set.clear();
+        two_level_set.reset();
+    }
 
 private:
     SingleLevelSet & asSingleLevel() { return single_level_set; }

--- a/tests/queries/0_stateless/01083_aggregation_memory_efficient_bug.sql
+++ b/tests/queries/0_stateless/01083_aggregation_memory_efficient_bug.sql
@@ -2,7 +2,7 @@ drop table if exists da_memory_efficient_shard;
 create table da_memory_efficient_shard(A Int64, B Int64) Engine=MergeTree order by A partition by B % 2;
 insert into da_memory_efficient_shard select number, number from numbers(100000);
 
-set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1, max_memory_usage='10Gi';
+set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1;
 
 select sum(a) from (SELECT B, uniqExact(A) a FROM remote('localhost,127.0.0.1', currentDatabase(), da_memory_efficient_shard) GROUP BY B);
 

--- a/tests/queries/0_stateless/01083_aggregation_memory_efficient_bug.sql
+++ b/tests/queries/0_stateless/01083_aggregation_memory_efficient_bug.sql
@@ -2,7 +2,7 @@ drop table if exists da_memory_efficient_shard;
 create table da_memory_efficient_shard(A Int64, B Int64) Engine=MergeTree order by A partition by B % 2;
 insert into da_memory_efficient_shard select number, number from numbers(100000);
 
-set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1;
+set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1, max_memory_usage='10Gi';
 
 select sum(a) from (SELECT B, uniqExact(A) a FROM remote('localhost,127.0.0.1', currentDatabase(), da_memory_efficient_shard) GROUP BY B);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
todo

