### PR TITLE
fix flaky test `test_storage_s3_queue/test_4.py`

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -624,6 +624,10 @@ def test_registry(started_cluster):
         database_name=db_name,
     )
 
+    # ensure that the table is created on node2 before we query the registry as there might be a race between the time
+    # we actually create the table on node2 and when we query the registry.
+    node2.query(f"SYSTEM SYNC DATABASE REPLICA {db_name}")
+
     registry, stat = zk.get(f"{keeper_path}/registry/")
 
     uuid2 = node1.query(

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -1,16 +1,10 @@
-import io
-import json
 import logging
-import random
-import string
 import time
 import uuid
 from multiprocessing.dummy import Pool
 
 import pytest
-from kazoo.exceptions import NoNodeError
 
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 from helpers.s3_queue_common import (
     run_query,
@@ -140,7 +134,7 @@ def test_replicated(started_cluster):
         f"SELECT * FROM system.zookeeper WHERE path = '{keeper_path}'"
     )
 
-    total_values = generate_random_files(
+    generate_random_files(
         started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
     )
 
@@ -170,10 +164,8 @@ def test_bad_settings(started_cluster):
     node = started_cluster.instances["node_cloud_mode"]
 
     table_name = f"test_bad_settings_{uuid.uuid4().hex[:8]}"
-    dst_table_name = f"{table_name}_dst"
     keeper_path = f"/clickhouse/test_{table_name}"
     files_path = f"{table_name}_data"
-    files_to_generate = 10
 
     try:
         create_table(
@@ -225,7 +217,7 @@ def test_processing_threads(started_cluster):
         )
     )
 
-    total_values = generate_random_files(
+    generate_random_files(
         started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
     )
 
@@ -296,7 +288,7 @@ def test_alter_settings(started_cluster):
         f"SELECT * FROM system.zookeeper WHERE path = '{keeper_path}'"
     )
 
-    total_values = generate_random_files(
+    generate_random_files(
         started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
     )
 
@@ -588,7 +580,7 @@ def test_registry(started_cluster):
     for elem in expected:
         assert elem in str(registry)
 
-    total_values = generate_random_files(
+    generate_random_files(
         started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
     )
 


### PR DESCRIPTION
Try to fix flaky test `test_registry` in `test_storage_s3_queue/test_4.py`. It looks like the second table is not created on node2 when we query the registry from Zookeeper and thus fails assertion. Try syncing the database replica on node2 to ensure that it's in sync with node1 before asserting.

Closes: #78503
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
