### PR TITLE
pinning workflow hash

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -149,7 +149,7 @@ jobs:
           git diff HEAD
       - name: Create ChangeLog PR
         if: ${{ inputs.type == 'patch' && ! inputs.dry-run && ! inputs.only-repo && ! inputs.only-docker }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c #v6
         with:
           author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
           token: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -149,7 +149,7 @@ jobs:
           git diff HEAD
       - name: Create ChangeLog PR
         if: ${{ inputs.type == 'patch' && ! inputs.dry-run && ! inputs.only-repo && ! inputs.only-docker }}
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c #v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
           token: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}


### PR DESCRIPTION
Hi @Felixoid , @maxknv  Just pinning dubious workflow with commit hashes instead of version tag.

The way we are doing it now is we will only pin workflow that are not in the following list of "trusted org" with more reputation:

actions,hashicorp,google-github-actions,azure,aws-actions,helm,tailscale,docker,ClickHouse

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Pinned the commit of a `create-pull-request` GitHub action.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
