### PR TITLE
Fixes for test_storage_rabbitmq::test_failed_connection.py

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1,8 +1,6 @@
 import json
 import logging
-import os.path as p
 import random
-import subprocess
 import threading
 import time
 import uuid
@@ -10,7 +8,6 @@ from random import randrange
 
 import pika
 import pytest
-from google.protobuf.internal.encoder import _VarintBytes
 
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -1,9 +1,6 @@
-import json
 import logging
-import subprocess
 import time
 
-import pika
 import pytest
 
 from helpers.client import QueryRuntimeException
@@ -113,13 +110,6 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     """
     )
 
-    credentials = pika.PlainCredentials("root", "clickhouse")
-    parameters = pika.ConnectionParameters(
-        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
-    )
-    connection = pika.BlockingConnection(parameters)
-    channel = connection.channel()
-
     messages_num = 100000
     values = []
     for i in range(messages_num):
@@ -145,7 +135,10 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
 
     deadline = time.monotonic() + 180
     while time.monotonic() < deadline:
-        if int(instance.query("SELECT count() FROM test.view")) != 0:
+        number = int(instance.query("SELECT count() FROM test.view"))
+        if number != 0:
+            if number == messages_num:
+                pytest.fail("The RabbitMQ messages have been consumed before suspending the RabbitMQ server")
             break
         time.sleep(0.1)
     else:
@@ -181,6 +174,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     logging.getLogger("pika").propagate = False
     instance.query(
         """
+        DROP TABLE IF EXISTS test.consumer_reconnect;
         CREATE TABLE test.consumer_reconnect (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
@@ -191,33 +185,6 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
                      rabbitmq_num_queues = 10,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
-    """
-    )
-
-    i = 0
-    messages_num = 150000
-
-    credentials = pika.PlainCredentials("root", "clickhouse")
-    parameters = pika.ConnectionParameters(
-        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
-    )
-
-    connection = pika.BlockingConnection(parameters)
-    channel = connection.channel()
-    messages = []
-    for _ in range(messages_num):
-        messages.append(json.dumps({"key": i, "value": i}))
-        i += 1
-    for msg_id in range(messages_num):
-        channel.basic_publish(
-            exchange="consumer_reconnect",
-            routing_key="",
-            body=messages[msg_id],
-            properties=pika.BasicProperties(delivery_mode=2, message_id=str(msg_id)),
-        )
-    connection.close()
-    instance.query(
-        """
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree
             ORDER BY key;
@@ -226,11 +193,37 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     """
     )
 
+    messages_num = 150000
+
+    messages = []
+    for i in range(messages_num):
+        messages.append("({i}, {i})".format(i=i))
+    messages = ",".join(messages)
+
     deadline = time.monotonic() + 180
     while time.monotonic() < deadline:
-        if int(instance.query("SELECT count() FROM test.view")) != 0:
+        try:
+            instance.query(
+                "INSERT INTO test.consumer_reconnect VALUES {}".format(messages)
+            )
             break
-        logging.debug(3)
+        except QueryRuntimeException as e:
+            if "Local: Timed out." in str(e):
+                continue
+            else:
+                raise
+    else:
+        pytest.fail(
+            f"Time limit of 180 seconds reached. The query could not be executed successfully."
+        )
+
+    deadline = time.monotonic() + 180
+    while time.monotonic() < deadline:
+        number = int(instance.query("SELECT count() FROM test.view"))
+        if number != 0:
+            if number == messages_num:
+                pytest.fail("The RabbitMQ messages have been consumed before suspending the RabbitMQ server")
+            break
         time.sleep(0.1)
     else:
         pytest.fail(f"Time limit of 180 seconds reached. The count is still 0.")


### PR DESCRIPTION
- In general, make losses_2 more similar to losses_1
- Ensure MVs are created before inserting into RabbitMQ
- Ensure not all rows are consumed before suspending RabbitMQ
- Use ClickHouse to insert into the table instead of pika

Fixes part of #71049  

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
