### PR TITLE
Early connection drop on overloaded CPU

### DIFF
--- a/ci/jobs/scripts/check_style/check_cpp.sh
+++ b/ci/jobs/scripts/check_style/check_cpp.sh
@@ -82,6 +82,7 @@ EXTERN_TYPES_EXCLUDES=(
     ProfileEvents::keeper_profile_events
     ProfileEvents::CountersIncrement
     ProfileEvents::size
+    ProfileEvents::checkCPUOverload
 
     CurrentMetrics::add
     CurrentMetrics::sub

--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -528,7 +528,8 @@ try
                         createKeeperPrometheusHandlerFactory(*this, config_getter(), async_metrics, "PrometheusHandler-factory"),
                         server_pool,
                         socket,
-                        http_params));
+                        http_params,
+                        nullptr));
             });
 
         /// HTTP control endpoints
@@ -550,7 +551,7 @@ try
                 port_name,
                 "HTTP Control: http://" + address.toString(),
                 std::make_unique<HTTPServer>(
-                    std::move(my_http_context), createKeeperHTTPControlMainHandlerFactory(config_getter(), global_context->getKeeperDispatcher(), "KeeperHTTPControlHandler-factory"), server_pool, socket, http_params)
+                    std::move(my_http_context), createKeeperHTTPControlMainHandlerFactory(config_getter(), global_context->getKeeperDispatcher(), "KeeperHTTPControlHandler-factory"), server_pool, socket, http_params, nullptr)
                     );
         });
     }

--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -528,8 +528,7 @@ try
                         createKeeperPrometheusHandlerFactory(*this, config_getter(), async_metrics, "PrometheusHandler-factory"),
                         server_pool,
                         socket,
-                        http_params,
-                        nullptr));
+                        http_params));
             });
 
         /// HTTP control endpoints
@@ -551,7 +550,7 @@ try
                 port_name,
                 "HTTP Control: http://" + address.toString(),
                 std::make_unique<HTTPServer>(
-                    std::move(my_http_context), createKeeperHTTPControlMainHandlerFactory(config_getter(), global_context->getKeeperDispatcher(), "KeeperHTTPControlHandler-factory"), server_pool, socket, http_params, nullptr)
+                    std::move(my_http_context), createKeeperHTTPControlMainHandlerFactory(config_getter(), global_context->getKeeperDispatcher(), "KeeperHTTPControlHandler-factory"), server_pool, socket, http_params)
                     );
         });
     }

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1,8 +1,15 @@
+#include <Common/LoggingFormatStringHelpers.h>
+#include <Common/thread_local_rng.h>
 #include <Common/ProfileEvents.h>
 #include <Common/CurrentThread.h>
 #include <Common/TraceSender.h>
 #include <Interpreters/Context.h>
+#include <Common/ErrorCodes.h>
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
 
+#include <cfloat>
+#include <random>
 
 // clang-format off
 /// Available events. Add something here as you wish.
@@ -993,6 +1000,11 @@ The server successfully detected this situation and will download merged part fr
     #define APPLY_FOR_EVENTS(M) APPLY_FOR_BUILTIN_EVENTS(M)
 #endif
 
+namespace DB::ErrorCodes
+{
+    extern const int SERVER_OVERLOADED;
+}
+
 namespace ProfileEvents
 {
 
@@ -1112,6 +1124,42 @@ ValueType getValueType(Event event)
 }
 
 Event end() { return END; }
+
+bool checkCPUOverload(Int64 os_cpu_busy_time_threshold, double min_ratio, double max_ratio, bool should_throw)
+{
+    double cpu_load = global_counters.getCPUOverload(os_cpu_busy_time_threshold);
+
+    if (cpu_load > DBL_EPSILON)
+    {
+        double current_ratio = std::min(std::max(min_ratio, cpu_load), max_ratio);
+        double probability_to_throw = (max_ratio <= min_ratio) ? 0.0 : (current_ratio - min_ratio) / (max_ratio - min_ratio);
+
+        const PreformattedMessage error_message = PreformattedMessage::create("CPU is overloaded, CPU is waiting for execution way more than executing, "
+                "ratio of wait time (OSCPUWaitMicroseconds metric) to busy time (OSCPUVirtualTimeMicroseconds metric) is {}. "
+                "Min ratio for error {}{}, max ratio for error {}{}, probability used to decide whether to {} {}.{}",
+                current_ratio,
+                should_throw ? "(min_os_cpu_wait_time_ratio_to_throw setting) " : "",
+                min_ratio,
+                should_throw ? "(max_os_cpu_wait_time_ratio_to_throw setting) " : "",
+                max_ratio,
+                should_throw ? "discard the query" : "drop the connection",
+                probability_to_throw,
+                should_throw ? " Consider reducing the number of queries or increase backoff between retries." : "");
+
+        if (std::bernoulli_distribution server_overloaded(probability_to_throw); server_overloaded(thread_local_rng))
+        {
+            if (should_throw)
+                throw DB::Exception(error_message, DB::ErrorCodes::SERVER_OVERLOADED);
+            else
+            {
+                LOG_ERROR(getLogger("ProfileEvents"), error_message);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
 
 void increment(Event event, Count amount)
 {

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -193,6 +193,10 @@ namespace ProfileEvents
     /// Get index just after last event identifier.
     Event end();
 
+    /// Check CPU overload. If should_throw parameter is set, the method will throw when the server is overloaded.
+    /// Otherwise, this method will return true if the server is overloaded.
+    bool checkCPUOverload(Int64 os_cpu_busy_time_threshold, double min_ratio, double max_ratio, bool should_throw);
+
     struct CountersIncrement
     {
         CountersIncrement() noexcept = default;

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1037,8 +1037,8 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     )", 0) \
     DECLARE(Bool, storage_shared_set_join_use_inner_uuid, true, "If enabled, an inner UUID is generated during the creation of SharedSet and SharedJoin. ClickHouse Cloud only", 0) \
     DECLARE(UInt64, os_cpu_busy_time_threshold, 1'000'000, "Threshold of OS CPU busy time in microseconds (OSCPUVirtualTimeMicroseconds metric) to consider CPU doing some useful work, no CPU overload would be considered if busy time was below this value.", 0) \
-    DECLARE(Float, min_os_cpu_wait_time_ratio_to_drop_connection, 10.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
-    DECLARE(Float, max_os_cpu_wait_time_ratio_to_drop_connection, 20.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \
+    DECLARE(Float, min_os_cpu_wait_time_ratio_to_drop_connection, 10.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider dropping connections. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
+    DECLARE(Float, max_os_cpu_wait_time_ratio_to_drop_connection, 20.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider dropping connections. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \
 
 
 // clang-format on

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1037,6 +1037,8 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     )", 0) \
     DECLARE(Bool, storage_shared_set_join_use_inner_uuid, true, "If enabled, an inner UUID is generated during the creation of SharedSet and SharedJoin. ClickHouse Cloud only", 0) \
     DECLARE(UInt64, os_cpu_busy_time_threshold, 1'000'000, "Threshold of OS CPU busy time in microseconds (OSCPUVirtualTimeMicroseconds metric) to consider CPU doing some useful work, no CPU overload would be considered if busy time was below this value.", 0) \
+    DECLARE(Float, min_os_cpu_wait_time_ratio_to_drop_connection, 10.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
+    DECLARE(Float, max_os_cpu_wait_time_ratio_to_drop_connection, 20.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \
 
 
 // clang-format on

--- a/src/Server/HTTP/HTTPServer.cpp
+++ b/src/Server/HTTP/HTTPServer.cpp
@@ -11,9 +11,10 @@ HTTPServer::HTTPServer(
     Poco::ThreadPool & thread_pool,
     Poco::Net::ServerSocket & socket_,
     Poco::Net::HTTPServerParams::Ptr params,
+    const TCPServerConnectionFilter::Ptr & filter,
     const ProfileEvents::Event & read_event,
     const ProfileEvents::Event & write_event)
-    : TCPServer(new HTTPServerConnectionFactory(context, params, factory_, read_event, write_event), thread_pool, socket_, params), factory(factory_)
+    : TCPServer(new HTTPServerConnectionFactory(context, params, factory_, read_event, write_event), thread_pool, socket_, params, filter), factory(factory_)
 {
 }
 

--- a/src/Server/HTTP/HTTPServer.h
+++ b/src/Server/HTTP/HTTPServer.h
@@ -21,6 +21,7 @@ public:
         Poco::ThreadPool & thread_pool,
         Poco::Net::ServerSocket & socket,
         Poco::Net::HTTPServerParams::Ptr params,
+        const TCPServerConnectionFilter::Ptr & filter = nullptr,
         const ProfileEvents::Event & read_event_ = ProfileEvents::end(),
         const ProfileEvents::Event & write_event_ = ProfileEvents::end());
 

--- a/src/Server/TCPServer.cpp
+++ b/src/Server/TCPServer.cpp
@@ -1,3 +1,4 @@
+#include <Poco/Net/TCPServer.h>
 #include <Poco/Net/TCPServerConnectionFactory.h>
 #include <Server/TCPServer.h>
 
@@ -25,12 +26,15 @@ TCPServer::TCPServer(
     TCPServerConnectionFactory::Ptr factory_,
     Poco::ThreadPool & thread_pool,
     Poco::Net::ServerSocket & socket_,
-    Poco::Net::TCPServerParams::Ptr params)
+    Poco::Net::TCPServerParams::Ptr params,
+    const TCPServerConnectionFilter::Ptr & filter)
     : Poco::Net::TCPServer(new TCPServerConnectionFactoryImpl(*this, factory_), thread_pool, socket_, params)
     , factory(factory_)
     , socket(socket_)
     , is_open(true)
     , port_number(socket.address().port())
-{}
+{
+    setConnectionFilter(filter);
+}
 
 }

--- a/src/Server/TCPServer.h
+++ b/src/Server/TCPServer.h
@@ -1,14 +1,32 @@
 #pragma once
 
 #include <Poco/Net/TCPServer.h>
+#include <Poco/Net/TCPServerParams.h>
 
 #include <base/types.h>
 #include <Server/TCPServerConnectionFactory.h>
+#include <Core/ServerSettings.h>
+
+#include <functional>
 
 
 namespace DB
 {
 class Context;
+
+class TCPServerConnectionFilter : public Poco::Net::TCPServerConnectionFilter
+{
+public:
+    explicit TCPServerConnectionFilter(std::function<bool()> filter_func_) : filter_func(std::move(filter_func_)) {}
+
+    bool accept(const Poco::Net::StreamSocket &) override { return filter_func(); }
+
+protected:
+    ~TCPServerConnectionFilter() override = default;
+
+private:
+    std::function<bool()> filter_func;
+};
 
 class TCPServer : public Poco::Net::TCPServer
 {
@@ -17,7 +35,8 @@ public:
         TCPServerConnectionFactory::Ptr factory,
         Poco::ThreadPool & thread_pool,
         Poco::Net::ServerSocket & socket,
-        Poco::Net::TCPServerParams::Ptr params = new Poco::Net::TCPServerParams);
+        Poco::Net::TCPServerParams::Ptr params = new Poco::Net::TCPServerParams,
+        const TCPServerConnectionFilter::Ptr & filter = nullptr);
 
     /// Close the socket and ask existing connections to stop serving queries
     void stop()

--- a/tests/integration/test_server_overload/configs/early_drop.xml
+++ b/tests/integration/test_server_overload/configs/early_drop.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <os_cpu_busy_time_threshold>300000</os_cpu_busy_time_threshold>
+    <min_os_cpu_wait_time_ratio_to_drop_connection>2.0</min_os_cpu_wait_time_ratio_to_drop_connection>
+    <max_os_cpu_wait_time_ratio_to_drop_connection>6.0</max_os_cpu_wait_time_ratio_to_drop_connection>
+</clickhouse>

--- a/tests/integration/test_server_overload/test.py
+++ b/tests/integration/test_server_overload/test.py
@@ -9,10 +9,15 @@ from helpers.client import CommandRequest, QueryRuntimeException
 
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance(
-    "node",
+node1 = cluster.add_instance(
+    "node1",
     main_configs=["configs/min_cpu_busy_time.xml"],
     clickhouse_start_cmd=f"taskset -c 0 {CLICKHOUSE_START_COMMAND}",
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/early_drop.xml"],
+    clickhouse_start_cmd=f"taskset -c 1 {CLICKHOUSE_START_COMMAND}",
 )
 
 
@@ -27,14 +32,31 @@ def started_cluster():
 
 def test_overload(started_cluster):
     for i in range(4):
-        node.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30)
+        node1.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30)
 
     for i in range(30):
         try:
-            node.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=2, max_os_cpu_wait_time_ratio_to_throw=6")
+            node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=2, max_os_cpu_wait_time_ratio_to_throw=6")
         except QueryRuntimeException as ex:
             assert "(SERVER_OVERLOADED)" in str(ex), "Only server overloaded error is expected"
             return
         time.sleep(0.5)
 
     assert False, "Expected to get the server overloaded error at least once"
+
+
+def test_drop_connections(started_cluster):
+    for i in range(4):
+        node2.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30)
+
+    for i in range(30):
+        try:
+            node2.query("select 1")
+        except QueryRuntimeException as ex:
+            assert "Connection reset by peer" in str(ex), "Only connection drop is expected"
+            assert node2.contains_in_log("CPU is overloaded, CPU is waiting for execution way more than executing"), "Expected server overloaded error in the log"
+            assert node2.contains_in_log("probability used to decide whether to drop the connection"), "Expected message that the connection was dropped due to server overload in the log"
+            return
+        time.sleep(0.5)
+
+    assert False, "Expected to drop the connection due to the server being overloaded at least once"

--- a/tests/integration/test_server_overload/test.py
+++ b/tests/integration/test_server_overload/test.py
@@ -31,23 +31,35 @@ def started_cluster():
 
 
 def test_overload(started_cluster):
+    queries = []
     for i in range(4):
-        node1.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30)
+        queries.append(node1.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=15))
+
+    def wait_for_queries():
+        for query in queries:
+            query.get_answer()
 
     for i in range(30):
         try:
             node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=2, max_os_cpu_wait_time_ratio_to_throw=6")
         except QueryRuntimeException as ex:
             assert "(SERVER_OVERLOADED)" in str(ex), "Only server overloaded error is expected"
+            wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
-        time.sleep(0.5)
+        time.sleep(0.3)
 
     assert False, "Expected to get the server overloaded error at least once"
+    wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
 
 
 def test_drop_connections(started_cluster):
+    queries = []
     for i in range(4):
-        node2.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30)
+        queries.append(node2.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=15))
+
+    def wait_for_queries():
+        for query in queries:
+            query.get_answer()
 
     for i in range(30):
         try:
@@ -56,7 +68,9 @@ def test_drop_connections(started_cluster):
             assert "Connection reset by peer" in str(ex), "Only connection drop is expected"
             assert node2.contains_in_log("CPU is overloaded, CPU is waiting for execution way more than executing"), "Expected server overloaded error in the log"
             assert node2.contains_in_log("probability used to decide whether to drop the connection"), "Expected message that the connection was dropped due to server overload in the log"
+            wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
-        time.sleep(0.5)
+        time.sleep(0.3)
 
     assert False, "Expected to drop the connection due to the server being overloaded at least once"
+    wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ClickHouse/ClickHouse/pull/63206

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Drop connections if the CPU is massively overloaded. The decision is made based on the ratio of wait time (`OSCPUWaitMicroseconds`) to busy time (`OSCPUVirtualTimeMicroseconds`). The query is dropped with some probability, when this ratio is between `min_os_cpu_wait_time_ratio_to_drop_connection` and `max_os_cpu_wait_time_ratio_to_drop_connection`. 