### PR TITLE
Don't block table shutdown while running CHECK TABLE

### DIFF
--- a/src/Interpreters/InterpreterCheckQuery.cpp
+++ b/src/Interpreters/InterpreterCheckQuery.cpp
@@ -138,10 +138,19 @@ public:
             std::this_thread::sleep_for(sleep_time);
         });
 
-        IStorage::DataValidationTasksPtr tmp = check_data_tasks;
-        auto result = table->checkDataNext(tmp);
-        is_finished = !result.has_value();
-        return result;
+        try
+        {
+            IStorage::DataValidationTasksPtr tmp = check_data_tasks;
+            auto result = table->checkDataNext(tmp);
+            is_finished = !result.has_value();
+            return result;
+        }
+        catch (const Exception & e)
+        {
+            is_finished = true;
+            CheckResult result{"", false, e.displayText()};
+            return result;
+        }
     }
 
     bool isFinished() const { return is_finished || !table || !check_data_tasks; }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9551,6 +9551,10 @@ IStorage::DataValidationTasksPtr StorageReplicatedMergeTree::getCheckTaskList(
 
 std::optional<CheckResult> StorageReplicatedMergeTree::checkDataNext(DataValidationTasksPtr & check_task_list)
 {
+    /// We want to throw and exit as soon as possible to allow part_check_thread to shutdown
+    if (shutdown_called || partial_shutdown_called)
+        throw Exception(ErrorCodes::ABORTED, "Table shutdown was called");
+
     if (auto part = assert_cast<DataValidationTasks *>(check_task_list.get())->next())
     {
         try

--- a/tests/integration/test_check_table/test.py
+++ b/tests/integration/test_check_table/test.py
@@ -237,6 +237,7 @@ def test_check_replicated_table_corruption(
     for node in [node1, node2]:
         node.query_with_retry("DROP TABLE IF EXISTS replicated_mt_1 SYNC")
 
+    for node in [node1, node2]:
         node.query_with_retry(
             """
         CREATE TABLE replicated_mt_1(date Date, id UInt32, value Int32)

--- a/tests/integration/test_check_table/test.py
+++ b/tests/integration/test_check_table/test.py
@@ -366,7 +366,7 @@ def test_check_all_tables(started_cluster):
             assert flag == "1"
             assert message == ""
 
-    for database in ["db1", "db2", "db3"]:
+    for database in ["db1", "db3"]:
         node1.query(f"DROP DATABASE {database} SYNC")
     node1.query("SYSTEM DISABLE FAILPOINT check_table_query_delay_for_part")
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't block table shutdown while running CHECK TABLE


Closes https://github.com/ClickHouse/ClickHouse/issues/78256
SMT changes will happen in private sync PR

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
