### PR TITLE
Improve OpenSSL error handling

### DIFF
--- a/src/Access/AuthenticationData.cpp
+++ b/src/Access/AuthenticationData.cpp
@@ -549,7 +549,7 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
 #if USE_SSL
             ///random generator FIPS complaint
             uint8_t key[32];
-            if (!RAND_bytes(key, sizeof(key)))
+            if (RAND_bytes(key, sizeof(key)) != 1)
                 throw Exception(ErrorCodes::OPENSSL_ERROR, "RAND_bytes failed: {}", getOpenSSLErrors());
 
             String salt;
@@ -573,7 +573,7 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
 #if USE_SSL
             ///random generator FIPS complaint
             uint8_t key[32];
-            if (!RAND_bytes(key, sizeof(key)))
+            if (RAND_bytes(key, sizeof(key)) != 1)
                 throw Exception(ErrorCodes::OPENSSL_ERROR, "RAND_bytes failed: {}", getOpenSSLErrors());
 
             String salt;

--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -253,13 +253,13 @@ struct HalfMD5Impl
         if (!ctx)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_new failed: {}", getOpenSSLErrors());
 
-        if (!EVP_DigestInit_ex(ctx.get(), EVP_md5(), nullptr))
+        if (EVP_DigestInit_ex(ctx.get(), EVP_md5(), nullptr) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestInit_ex failed: {}", getOpenSSLErrors());
 
-        if (!EVP_DigestUpdate(ctx.get(), begin, size))
+        if (EVP_DigestUpdate(ctx.get(), begin, size) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestUpdate failed: {}", getOpenSSLErrors());
 
-        if (!EVP_DigestFinal_ex(ctx.get(), buf.char_data, nullptr))
+        if (EVP_DigestFinal_ex(ctx.get(), buf.char_data, nullptr) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestFinal_ex failed: {}", getOpenSSLErrors());
 
         /// Compatibility with existing code. Cast is necessary for old poco AND macos where UInt64 != uint64_t

--- a/src/Functions/FunctionsStringHashFixedString.cpp
+++ b/src/Functions/FunctionsStringHashFixedString.cpp
@@ -63,7 +63,7 @@ public:
         if (!ctx_template)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_new failed: {}", getOpenSSLErrors());
 
-        if (!EVP_DigestInit_ex(ctx_template.get(), ProviderImpl::provider(), nullptr))
+        if (EVP_DigestInit_ex(ctx_template.get(), ProviderImpl::provider(), nullptr) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestInit_ex failed: {}", getOpenSSLErrors());
     }
 
@@ -74,13 +74,13 @@ public:
 
         thread_local EVP_MD_CTX_ptr ctx(EVP_MD_CTX_new(), &EVP_MD_CTX_free);
 
-        if (!EVP_MD_CTX_copy_ex(ctx.get(), ctx_template.get()))
+        if (EVP_MD_CTX_copy_ex(ctx.get(), ctx_template.get()) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_copy_ex failed: {}", getOpenSSLErrors());
 
-        if (!EVP_DigestUpdate(ctx.get(), begin, size))
+        if (EVP_DigestUpdate(ctx.get(), begin, size) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestUpdate failed: {}", getOpenSSLErrors());
 
-        if (!EVP_DigestFinal_ex(ctx.get(), out_char_data, nullptr))
+        if (EVP_DigestFinal_ex(ctx.get(), out_char_data, nullptr) != 1)
             throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestFinal_ex failed: {}", getOpenSSLErrors());
     }
 


### PR DESCRIPTION
Sorry for so many PRs related to OpenSSL error handling.

This PR is follow-up to #78727 and #78745. Turns out that OpenSSL sometimes returns `-1` to indicate errors (see [here](https://github.com/ClickHouse/ClickHouse/pull/78727/files/3834937c1765e78b1ac4314a878da5c1c102d73a#r2031773528) but there are certain `EVP_` functions for which the OpenSSL docs are s*** enough to say that "depending on the implementation" they may return `-1` in the error case), so pattern

```cpp
if (!EVP_xyz(...))
    throw BoomException();
```

doesn't work reliably. Now converted everything to `if (EVP_xyz(...) != 1)`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)