### PR TITLE
Kafka engine: SASL authentication via table settings

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -71,7 +71,7 @@ Optional parameters:
 
 - `kafka_security_protocol` - Protocol used to communicate with brokers. Possible values: `plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl`.
 - `kafka_sasl_mechanism` - SASL mechanism to use for authentication. Possible values: `GSSAPI`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`.
-- `kafka_sasl_username` - SASL username for use with the `PLAIN` and  `SASL-SCRAM-..` mechanisms.
+- `kafka_sasl_username` - SASL username for use with the `PLAIN` and `SASL-SCRAM-..` mechanisms.
 - `kafka_sasl_password` - SASL password for use with the `PLAIN` and `SASL-SCRAM-..` mechanisms.
 - `kafka_schema` — Parameter that must be used if the format requires a schema definition. For example, [Cap'n Proto](https://capnproto.org/) requires the path to the schema file and the name of the root `schema.capnp:Message` object.
 - `kafka_num_consumers` — The number of consumers per table. Specify more consumers if the throughput of one consumer is insufficient. The total number of consumers should not exceed the number of partitions in the topic, since only one consumer can be assigned per partition, and must not be greater than the number of physical cores on the server where ClickHouse is deployed. Default: `1`.

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -41,6 +41,10 @@ SETTINGS
     kafka_topic_list = 'topic1,topic2,...',
     kafka_group_name = 'group_name',
     kafka_format = 'data_format'[,]
+    [kafka_security_protocol = '',]
+    [kafka_sasl_mechanism = '',]
+    [kafka_sasl_username = '',]
+    [kafka_sasl_password = '',]
     [kafka_schema = '',]
     [kafka_num_consumers = N,]
     [kafka_max_block_size = 0,]
@@ -65,6 +69,10 @@ Required parameters:
 
 Optional parameters:
 
+- `kafka_security_protocol` - Protocol used to communicate with brokers. Possible values: `plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl`.
+- `kafka_sasl_mechanism` - SASL mechanism to use for authentication. Possible values: `GSSAPI`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`.
+- `kafka_sasl_username` - SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms.
+- `kafka_sasl_password` - SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism.
 - `kafka_schema` — Parameter that must be used if the format requires a schema definition. For example, [Cap'n Proto](https://capnproto.org/) requires the path to the schema file and the name of the root `schema.capnp:Message` object.
 - `kafka_num_consumers` — The number of consumers per table. Specify more consumers if the throughput of one consumer is insufficient. The total number of consumers should not exceed the number of partitions in the topic, since only one consumer can be assigned per partition, and must not be greater than the number of physical cores on the server where ClickHouse is deployed. Default: `1`.
 - `kafka_max_block_size` — The maximum batch size (in messages) for poll. Default: [max_insert_block_size](../../../operations/settings/settings.md#max_insert_block_size).

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -71,8 +71,8 @@ Optional parameters:
 
 - `kafka_security_protocol` - Protocol used to communicate with brokers. Possible values: `plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl`.
 - `kafka_sasl_mechanism` - SASL mechanism to use for authentication. Possible values: `GSSAPI`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`.
-- `kafka_sasl_username` - SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms.
-- `kafka_sasl_password` - SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism.
+- `kafka_sasl_username` - SASL username for use with the `PLAIN` and  `SASL-SCRAM-..` mechanisms.
+- `kafka_sasl_password` - SASL password for use with the `PLAIN` and `SASL-SCRAM-..` mechanisms.
 - `kafka_schema` — Parameter that must be used if the format requires a schema definition. For example, [Cap'n Proto](https://capnproto.org/) requires the path to the schema file and the name of the root `schema.capnp:Message` object.
 - `kafka_num_consumers` — The number of consumers per table. Specify more consumers if the throughput of one consumer is insufficient. The total number of consumers should not exceed the number of partitions in the topic, since only one consumer can be assigned per partition, and must not be greater than the number of physical cores on the server where ClickHouse is deployed. Default: `1`.
 - `kafka_max_block_size` — The maximum batch size (in messages) for poll. Default: [max_insert_block_size](../../../operations/settings/settings.md#max_insert_block_size).

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -87,6 +87,12 @@ void ASTSetQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, 
 
         auto format_if_secret = [&]() -> bool
         {
+            if (change.name.contains("password"))
+            {
+                ostr << " = " << "'[HIDDEN]'";
+                return true;
+            }
+
             CustomType custom;
             if (change.value.tryGet<CustomType>(custom) && custom.isSecret())
             {

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -43,6 +43,10 @@ namespace ErrorCodes
     DECLARE(UInt64, kafka_max_rows_per_message, 1, "The maximum number of rows produced in one kafka message for row-based formats.", 0) \
     DECLARE(String, kafka_keeper_path, "", "The path to the table in ClickHouse Keeper", 0) \
     DECLARE(String, kafka_replica_name, "", "The replica name in ClickHouse Keeper", 0) \
+    DECLARE(String, kafka_security_protocol, "", "Protocol used to communicate with brokers.", 0) \
+    DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
+    DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
+    DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \
     MAKE_OBSOLETE(M, Char, kafka_row_delimiter, '\0') \

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -46,7 +46,7 @@ namespace ErrorCodes
     DECLARE(String, kafka_security_protocol, "", "Protocol used to communicate with brokers.", 0) \
     DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
-    DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism", 0) \
+    DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \
     MAKE_OBSOLETE(M, Char, kafka_row_delimiter, '\0') \

--- a/src/Storages/Kafka/Kafka_fwd.h
+++ b/src/Storages/Kafka/Kafka_fwd.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Core/Types.h>
+#include <Core/Field.h>
+
+namespace Kafka
+{
+
+static constexpr auto TABLE_ENGINE_NAME = "Kafka";
+static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
+
+using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
+{
+    {"kafka_sasl_password", DEFAULT_MASKING_RULE},
+};
+
+}

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -95,6 +95,8 @@ public:
     bool supportsDynamicSubcolumns() const override { return true; }
     bool supportsSubcolumns() const override { return true; }
 
+    const KafkaSettings & getKafkaSettings() const { return *kafka_settings; }
+
 private:
     friend class ReadFromStorageKafka;
 

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -4,6 +4,7 @@
 #include <Core/StreamingHandleErrorMode.h>
 #include <Storages/IStorage.h>
 #include <Storages/Kafka/KafkaConsumer.h>
+#include <Storages/Kafka/Kafka_fwd.h>
 #include <Common/Macros.h>
 #include <Common/SettingsChanges.h>
 #include <Common/ThreadPool_fwd.h>
@@ -49,7 +50,7 @@ public:
 
     ~StorageKafka() override;
 
-    std::string getName() const override { return "Kafka"; }
+    std::string getName() const override { return Kafka::TABLE_ENGINE_NAME; }
 
     bool noPushingToViews() const override { return true; }
 

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -6,6 +6,7 @@
 #include <Core/Types.h>
 #include <Storages/IStorage.h>
 #include <Storages/Kafka/KafkaConsumer2.h>
+#include <Storages/Kafka/Kafka_fwd.h>
 #include <Common/Macros.h>
 #include <Common/SettingsChanges.h>
 #include <Common/ThreadStatus.h>
@@ -66,7 +67,7 @@ public:
 
     ~StorageKafka2() override;
 
-    std::string getName() const override { return "Kafka"; }
+    std::string getName() const override { return Kafka::TABLE_ENGINE_NAME; }
 
     bool noPushingToViews() const override { return true; }
 

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -97,6 +97,8 @@ public:
     bool supportsDynamicSubcolumns() const override { return true; }
     bool supportsSubcolumns() const override { return true; }
 
+    const KafkaSettings & getKafkaSettings() const { return *kafka_settings; }
+
 private:
     using TopicPartition = KafkaConsumer2::TopicPartition;
     using TopicPartitions = KafkaConsumer2::TopicPartitions;

--- a/tests/integration/compose/docker_compose_kafka_sasl.yml
+++ b/tests/integration/compose/docker_compose_kafka_sasl.yml
@@ -1,0 +1,29 @@
+services:
+  kafka_sasl:
+    image: confluentinc/cp-kafka:7.9.0
+    hostname: kafka_sasl
+    ports:
+      - ${KAFKA_EXTERNAL_PORT}:${KAFKA_EXTERNAL_PORT}
+    environment:
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:19093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:${KAFKA_EXTERNAL_PORT},OUTSIDE://0.0.0.0:19092,CONTROLLER://:19093
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://localhost:${KAFKA_EXTERNAL_PORT},OUTSIDE://kafka_sasl:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:SASL_PLAINTEXT,OUTSIDE:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/secrets/kafka_server_jaas.conf"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      CLUSTER_ID: "Ch3OEYBSD34fcwNTASDNDM2Qk"
+    volumes:
+      - ${KAFKA_DIR:-}/secrets:/etc/kafka/secrets
+    security_opt:
+      - label:disable
+    sysctls:
+      net.ipv4.ip_local_port_range: '55000 65535'

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -487,6 +487,7 @@ class ClickHouseCluster:
         self.base_zookeeper_cmd = None
         self.base_mysql57_cmd = []
         self.base_kafka_cmd = []
+        self.base_kafka_sasl_cmd = []
         self.base_kerberized_kafka_cmd = []
         self.base_kerberos_kdc_cmd = []
         self.base_rabbitmq_cmd = []
@@ -506,6 +507,7 @@ class ClickHouseCluster:
         self.with_postgres_cluster = False
         self.with_postgresql_java_client = False
         self.with_kafka = False
+        self.with_kafka_sasl = False
         self.with_kerberized_kafka = False
         self.with_kerberos_kdc = False
         self.with_rabbitmq = False
@@ -559,6 +561,8 @@ class ClickHouseCluster:
         self.kafka_docker_id = self.get_instance_docker_id(self.kafka_host)
 
         self.coredns_host = "coredns"
+
+        self.kafka_sasl_host = "kafka_sasl"
 
         # available when with_kerberozed_kafka == True
         # reuses kafka_dir
@@ -1225,6 +1229,22 @@ class ClickHouseCluster:
         )
         return self.base_kafka_cmd
 
+    def setup_kafka_sasl_cmd(self, instance, env_variables, docker_compose_yml_dir):
+        self.with_kafka_sasl = True
+        env_variables["KAFKA_HOST"] = self.kafka_sasl_host
+        env_variables["KAFKA_EXTERNAL_PORT"] = str(self.kafka_port)
+        env_variables["KAFKA_DIR"] = instance.path + "/"
+        self.base_cmd.extend(
+            ["--file", p.join(docker_compose_yml_dir, "docker_compose_kafka_sasl.yml")]
+        )
+        self.base_kafka_cmd = self.compose_cmd(
+            "--env-file",
+            instance.env_file,
+            "--file",
+            p.join(docker_compose_yml_dir, "docker_compose_kafka_sasl.yml"),
+        )
+        return self.base_kafka_cmd
+
     def setup_kerberized_kafka_cmd(
         self, instance, env_variables, docker_compose_yml_dir
     ):
@@ -1562,6 +1582,7 @@ class ClickHouseCluster:
         with_mysql8=False,
         with_mysql_cluster=False,
         with_kafka=False,
+        with_kafka_sasl=False,
         with_kerberized_kafka=False,
         with_kerberos_kdc=False,
         with_secrets=False,
@@ -1687,12 +1708,13 @@ class ClickHouseCluster:
             with_mysql8=with_mysql8,
             with_mysql_cluster=with_mysql_cluster,
             with_kafka=with_kafka,
+            with_kafka_sasl=with_kafka_sasl,
             with_kerberized_kafka=with_kerberized_kafka,
             with_kerberos_kdc=with_kerberos_kdc,
             with_rabbitmq=with_rabbitmq,
             with_nats=with_nats,
             with_nginx=with_nginx,
-            with_secrets=with_secrets or with_kerberos_kdc or with_kerberized_kafka,
+            with_secrets=with_secrets or with_kerberos_kdc or with_kerberized_kafka or with_kafka_sasl,
             with_mongo=with_mongo,
             with_redis=with_redis,
             with_minio=with_minio,
@@ -1832,6 +1854,11 @@ class ClickHouseCluster:
         if with_kafka and not self.with_kafka:
             cmds.append(
                 self.setup_kafka_cmd(instance, env_variables, docker_compose_yml_dir)
+            )
+
+        if with_kafka_sasl and not self.with_kafka_sasl:
+            cmds.append(
+                self.setup_kafka_sasl_cmd(instance, env_variables, docker_compose_yml_dir)
             )
 
         if with_kerberized_kafka and not self.with_kerberized_kafka:
@@ -2906,6 +2933,15 @@ class ClickHouseCluster:
                 self.wait_kafka_is_available(self.kafka_docker_id, self.kafka_port)
                 self.wait_schema_registry_to_start()
 
+            if self.with_kafka_sasl and self.base_kafka_sasl_cmd:
+                logging.debug("Setup Kafka with SASL")
+                os.mkdir(self.kafka_dir)
+                subprocess_check_call(
+                    self.base_kafka_sasl_cmd + common_opts + ["--renew-anon-volumes"]
+                )
+                self.up_called = True
+                self.wait_kafka_is_available(self.kafka_docker_id, self.kafka_port)
+
             if self.with_kerberized_kafka and self.base_kerberized_kafka_cmd:
                 logging.debug("Setup kerberized kafka")
                 os.mkdir(self.kafka_dir)
@@ -3383,6 +3419,7 @@ class ClickHouseInstance:
         with_mysql8,
         with_mysql_cluster,
         with_kafka,
+        with_kafka_sasl,
         with_kerberized_kafka,
         with_kerberos_kdc,
         with_rabbitmq,
@@ -3477,6 +3514,7 @@ class ClickHouseInstance:
         self.with_postgres_cluster = with_postgres_cluster
         self.with_postgresql_java_client = with_postgresql_java_client
         self.with_kafka = with_kafka
+        self.with_kafka_sasl = with_kafka_sasl
         self.with_kerberized_kafka = with_kerberized_kafka
         self.with_kerberos_kdc = with_kerberos_kdc
         self.with_rabbitmq = with_rabbitmq
@@ -4732,6 +4770,9 @@ class ClickHouseInstance:
         if self.with_kafka:
             depends_on.append("kafka1")
             depends_on.append("schema-registry")
+
+        if self.with_kafka_sasl:
+            depends_on.append("kafka_sasl")
 
         if self.with_kerberized_kafka:
             depends_on.append("kerberized_kafka1")

--- a/tests/integration/helpers/config_cluster.py
+++ b/tests/integration/helpers/config_cluster.py
@@ -21,3 +21,7 @@ odbc_mysql_db = "clickhouse"
 
 odbc_psql_db = "postgres"
 odbc_psql_user = "postgres"
+
+# KAFKA CREDENTIALS
+kafka_sasl_user = "admin"
+kafka_sasl_pass = "ClickHouse_Kafka_P@ssw0rd"

--- a/tests/integration/test_storage_kafka_sasl/secrets/kafka_server_jaas.conf
+++ b/tests/integration/test_storage_kafka_sasl/secrets/kafka_server_jaas.conf
@@ -1,6 +1,6 @@
 KafkaServer {
     org.apache.kafka.common.security.plain.PlainLoginModule required
     username="admin"
-    password="admin-password"
-    user_admin="admin-password";
+    password="ClickHouse_Kafka_P@ssw0rd"
+    user_admin="ClickHouse_Kafka_P@ssw0rd";
 };

--- a/tests/integration/test_storage_kafka_sasl/secrets/kafka_server_jaas.conf
+++ b/tests/integration/test_storage_kafka_sasl/secrets/kafka_server_jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin-password"
+    user_admin="admin-password";
+};

--- a/tests/integration/test_storage_kafka_sasl/test.py
+++ b/tests/integration/test_storage_kafka_sasl/test.py
@@ -3,6 +3,7 @@ import pytest
 import time
 
 from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.config_cluster import kafka_sasl_user, kafka_sasl_pass
 from helpers.test_tools import assert_eq_with_retry
 
 from kafka import KafkaProducer
@@ -24,8 +25,8 @@ def get_kafka_producer(port):
                 bootstrap_servers = "localhost:{}".format(port),
                 security_protocol = "SASL_PLAINTEXT",
                 sasl_mechanism    = "PLAIN",
-                sasl_plain_username = "admin",
-                sasl_plain_password = "admin-password",
+                sasl_plain_username = kafka_sasl_user,
+                sasl_plain_password = kafka_sasl_pass,
                 value_serializer = lambda v: v.encode('utf-8'),
             )
             logging.debug("Kafka Connection established: localhost:{}".format(port))
@@ -62,8 +63,8 @@ def test_kafka_sasl(kafka_cluster):
             SETTINGS kafka_broker_list = 'kafka_sasl:19092',
                      kafka_security_protocol = 'sasl_plaintext',
                      kafka_sasl_mechanism = 'PLAIN',
-                     kafka_sasl_username = 'admin',
-                     kafka_sasl_password = 'admin-password',
+                     kafka_sasl_username = '{kafka_sasl_user}',
+                     kafka_sasl_password = '{kafka_sasl_pass}',
                      kafka_topic_list = 'topic1',
                      kafka_group_name = 'group1',
                      kafka_format = 'JSONEachRow';

--- a/tests/integration/test_storage_kafka_sasl/test.py
+++ b/tests/integration/test_storage_kafka_sasl/test.py
@@ -41,7 +41,7 @@ def get_kafka_producer(port):
 def kafka_cluster():
     try:
         cluster.start()
-        kafka_id = instance.cluster.kafka_docker_id
+        kafka_id = instance.cluster.kafka_sasl_docker_id
         print(("kafka_id is {}".format(kafka_id)))
         yield cluster
     finally:
@@ -76,7 +76,7 @@ def test_kafka_sasl(kafka_cluster):
         """
     )
     
-    producer = get_kafka_producer(kafka_cluster.kafka_port)
+    producer = get_kafka_producer(kafka_cluster.kafka_sasl_port)
     producer.send(topic="topic1", value='{"key":1, "value":"test123"}')
     producer.flush()
 

--- a/tests/integration/test_storage_kafka_sasl/test.py
+++ b/tests/integration/test_storage_kafka_sasl/test.py
@@ -1,0 +1,82 @@
+import logging
+import pytest
+import time
+
+from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.test_tools import assert_eq_with_retry
+
+from kafka import KafkaProducer
+
+if is_arm():
+    pytestmark = pytest.mark.skip
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    with_kafka_sasl=True
+)
+
+def get_kafka_producer(port):
+    errors = []
+    for _ in range(15):
+        try:
+            producer = KafkaProducer(
+                bootstrap_servers = "localhost:{}".format(port),
+                security_protocol = "SASL_PLAINTEXT",
+                sasl_mechanism    = "PLAIN",
+                sasl_plain_username = "admin",
+                sasl_plain_password = "admin-password",
+                value_serializer = lambda v: v.encode('utf-8'),
+            )
+            logging.debug("Kafka Connection established: localhost:{}".format(port))
+            return producer
+        except Exception as e:
+            errors += [str(e)]
+            time.sleep(1)
+
+    raise Exception("Connection not established, {}".format(errors))
+
+@pytest.fixture(scope="module")
+def kafka_cluster():
+    try:
+        cluster.start()
+        kafka_id = instance.cluster.kafka_docker_id
+        print(("kafka_id is {}".format(kafka_id)))
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+@pytest.fixture(autouse=True)
+def kafka_setup_teardown():
+    instance.query("DROP DATABASE IF EXISTS test; CREATE DATABASE test;")
+    yield
+
+def test_kafka_sasl(kafka_cluster):
+    instance.query(
+        f"""
+        DROP DATABASE IF EXISTS test SYNC;
+        CREATE DATABASE test;
+
+        CREATE TABLE test.kafka_sasl (key int, value String)
+            ENGINE = Kafka
+            SETTINGS kafka_broker_list = 'kafka_sasl:19092',
+                     kafka_security_protocol = 'sasl_plaintext',
+                     kafka_sasl_mechanism = 'PLAIN',
+                     kafka_sasl_username = 'admin',
+                     kafka_sasl_password = 'admin-password',
+                     kafka_topic_list = 'topic1',
+                     kafka_group_name = 'group1',
+                     kafka_format = 'JSONEachRow';
+
+        CREATE TABLE test.messages (key int, value String) ENGINE = MergeTree ORDER BY key;
+
+        CREATE MATERIALIZED VIEW test.kafka_consumer TO test.messages (key int, value String)
+        AS SELECT key, value FROM test.kafka_sasl;
+        """
+    )
+    
+    producer = get_kafka_producer(kafka_cluster.kafka_port)
+    producer.send(topic="topic1", value='{"key":1, "value":"test123"}')
+    producer.flush()
+
+    assert_eq_with_retry(instance, "SELECT value FROM test.messages", "test123")


### PR DESCRIPTION
Adds four new table settings to the Kafka engine:
- kafka_security_protocol
- kafka_sasl_mechanism
- kafka_sasl_username
- kafka_sasl_password

The last one is displayed as `[HIDDEN]` if queried, similar to other secrets in other engines.

This allows configuring SASL-based authentication to Kafka and Kafka-compatible systems (e.g., I also tested Redpanda) directly in the CREATE TABLE statement rather than having to use configuration files or named collections - in line with what is possible today for many other table engines (MySQL, PostgreSQL, MongoDB, NATS, RabbitMQ, etc.). 

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add table settings for SASL configuration and credentials to the `Kafka` table engine. This allows configuring SASL-based authentication to Kafka and Kafka-compatible systems directly in the CREATE TABLE statement rather than having to use configuration files or named collections.