### PR TITLE
tests: better Exception in stdout detection

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1632,7 +1632,9 @@ class TestCase:
                 description,
             )
 
-        if "Exception" in stdout and "X-ClickHouse-Exception-Code" not in stdout:
+        # "X-ClickHouse-Exception-Code" included in "Access-Control-Expose-Headers"
+        # "Exception" may be included into i.e. metric name
+        if re.search(r'(^|\W)Exception(\W|$)', stdout) and "X-ClickHouse-Exception-Code" not in stdout:
             description += "\n{}\n".format("\n".join(stdout.splitlines()[:100]))
             if debug_log:
                 description += "\n"

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1634,7 +1634,7 @@ class TestCase:
 
         # "X-ClickHouse-Exception-Code" included in "Access-Control-Expose-Headers"
         # "Exception" may be included into i.e. metric name
-        if re.search(r'(^|\W)Exception(\W|$)', stdout) and "X-ClickHouse-Exception-Code" not in stdout:
+        if re.search(r'(^|\W)(Net|Errno|)Exception(\W|$)', stdout) and "X-ClickHouse-Exception-Code" not in stdout:
             description += "\n{}\n".format("\n".join(stdout.splitlines()[:100]))
             if debug_log:
                 description += "\n"


### PR DESCRIPTION
Do not match i.e. ZooKeeperUserExceptions

Note, that it is not a big deal even if there will be error, anyway reference will not match

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)