### PR TITLE
Make parquet version selection less confusing

### DIFF
--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -292,7 +292,7 @@ struct FormatSettings
         std::unordered_set<int> skip_row_groups = {};
         UInt64 max_block_size = DEFAULT_BLOCK_SIZE;
         size_t prefer_block_bytes = DEFAULT_BLOCK_SIZE * 256;
-        ParquetVersion output_version;
+        ParquetVersion output_version = ParquetVersion::V2_LATEST;
         ParquetCompression output_compression_method = ParquetCompression::SNAPPY;
         uint64_t output_compression_level;
         size_t data_page_size = 1024 * 1024;

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -81,6 +81,9 @@ ParquetBlockOutputFormat::ParquetBlockOutputFormat(WriteBuffer & out_, const Blo
 {
     if (format_settings.parquet.use_custom_encoder)
     {
+        if (format_settings.parquet.output_version < FormatSettings::ParquetVersion::V2_6)
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Custom parquet encoder doesn't support parquet versions < 2.6. Use output_format_parquet_use_custom_encoder = 0.");
+
         if (format_settings.parquet.parallel_encoding && format_settings.max_threads > 1)
             pool = std::make_unique<ThreadPool>(
                 CurrentMetrics::ParquetEncoderThreads,

--- a/src/Processors/Formats/Impl/ParquetMetadataInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetMetadataInputFormat.cpp
@@ -182,8 +182,9 @@ Chunk ParquetMetadataInputFormat::read()
         else if (name == names[3])
         {
             auto column = types[3]->createColumn();
-            /// Version can be only PARQUET_1_0 or PARQUET_2_LATEST (which is 2.6).
-            String version = metadata->version() == parquet::ParquetVersion::PARQUET_1_0 ? "1.0" : "2.6";
+            /// Parquet file doesn't know its exact version, only whether it's 1.x or 2.x
+            /// (FileMetaData.version = 1 or 2).
+            String version = metadata->version() == parquet::ParquetVersion::PARQUET_1_0 ? "1" : "2";
             assert_cast<ColumnString &>(*column).insertData(version.data(), version.size());
             res.addColumn(std::move(column));
         }

--- a/tests/queries/0_stateless/02718_parquet_metadata_format.reference
+++ b/tests/queries/0_stateless/02718_parquet_metadata_format.reference
@@ -2,7 +2,7 @@
     "num_columns": "3",
     "num_rows": "100000",
     "num_row_groups": "2",
-    "format_version": "2.6",
+    "format_version": "2",
     "metadata_size": "617",
     "total_uncompressed_size": "314147",
     "total_compressed_size": "27081",
@@ -172,7 +172,7 @@
 }
 {
     "num_columns": "3",
-    "format_version": "2.6"
+    "format_version": "2"
 }
 {
     "columns": [
@@ -235,7 +235,7 @@
     "num_columns": "1",
     "num_rows": "5",
     "num_row_groups": "1",
-    "format_version": "1.0",
+    "format_version": "1",
     "metadata_size": "267",
     "total_uncompressed_size": "105",
     "total_compressed_size": "128",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/78549