### PR TITLE
Safe reading of old metadata in DiskObjectStorageTransaction::writeFile()

### DIFF
--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -757,14 +757,20 @@ StoredObjects getStoredObjectsSafely(IMetadataStorage & metadata_storage, const 
     }
     catch (const Exception & e)
     {
-        if (!(e.code() == ErrorCodes::UNKNOWN_FORMAT
+        if (e.code() == ErrorCodes::UNKNOWN_FORMAT
             || e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF
             || e.code() == ErrorCodes::CANNOT_READ_ALL_DATA
             || e.code() == ErrorCodes::CANNOT_OPEN_FILE
-            || e.code() == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED))
+            || e.code() == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED)
         {
-            throw;
+            LOG_DEBUG(
+                getLogger("DiskObjectStorageTransaction"),
+                "Can't read metadata because of an exception. Skip it. Path: {}, exception: {}",
+                metadata_storage.getPath() + path,
+                e.message());
         }
+        else
+            throw;
     }
     return {};
 }

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -749,7 +749,7 @@ String revisionToString(UInt64 revision)
     return std::bitset<64>(revision).to_string();
 }
 
-StoredObjects getStorageObjectsSafely(IMetadataStorage & metadata_storage, const String & path)
+StoredObjects getStorageObjectsSafely(const IMetadataStorage & metadata_storage, const String & path)
 {
     try
     {

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -749,7 +749,7 @@ String revisionToString(UInt64 revision)
     return std::bitset<64>(revision).to_string();
 }
 
-StoredObjects getStoredObjectsSafely(IMetadataStorage & metadata_storage, const String & path)
+StoredObjects getStorageObjectsSafely(IMetadataStorage & metadata_storage, const String & path)
 {
     try
     {
@@ -816,7 +816,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
                 /// Otherwise we will produce lost blobs which nobody points to
                 /// WriteOnce storages are not affected by the issue
                 if (!tx->object_storage.isPlain() && tx->metadata_storage.existsFile(path))
-                    tx->object_storage.removeObjectsIfExist(getStoredObjectsSafely(tx->metadata_storage, path));
+                    tx->object_storage.removeObjectsIfExist(getStorageObjectsSafely(tx->metadata_storage, path));
 
                 tx->metadata_transaction->createMetadataFile(path, key_, count);
             }
@@ -849,7 +849,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
                     /// Otherwise we will produce lost blobs which nobody points to
                     /// WriteOnce storages are not affected by the issue
                     if (!object_storage_tx->object_storage.isPlain() && object_storage_tx->metadata_storage.existsFile(path))
-                        object_storage_tx->object_storage.removeObjectsIfExist(getStoredObjectsSafely(object_storage_tx->metadata_storage, path));
+                        object_storage_tx->object_storage.removeObjectsIfExist(getStorageObjectsSafely(object_storage_tx->metadata_storage, path));
 
                     tx->createMetadataFile(path, key_, count);
                 }


### PR DESCRIPTION
Add safe reading of previous blob names while overwriting for object storage disk and overwriting corrupted metadata file. 

Absence of this check can lead to inability ClickHouse to start when `IDisk::checkAccessImpl` is failed.
```
2025.03.19 15:12:39.552278 [ 108598 ] {} <Error> virtual void DB::IDisk::checkAccessImpl(const String &): Code: 32. DB::Exception: Attempt to read after eof. (ATTEMPT_TO_READ_AFTER_EOF), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000c89ffdb
1. DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x00000000076663e3
2. DB::throwReadAfterEOF() @ 0x000000000c91a118
3. void DB::readIntTextImpl<unsigned int, void, (DB::ReadIntTextCheckOverflow)0>(unsigned int&, DB::ReadBuffer&) @ 0x000000000777be4a
4. DB::DiskObjectStorageMetadata::deserialize(DB::ReadBuffer&) @ 0x000000001007e6bc
5. DB::MetadataStorageFromDisk::readMetadataUnlocked(String const&, std::shared_lock<DB::SharedMutex>&) const @ 0x000000001008d06c
6. DB::MetadataStorageFromDisk::getStorageObjects(String const&) const @ 0x000000001008dc11
7. void std::__function::__policy_invoker<void (unsigned long)>::__call_impl<std::__function::__default_alloc_func<DB::DiskObjectStorageTransaction::writeFile(String const&, unsigned long, DB::WriteMode, DB::WriteSettings const&, bool)::$_0, void (unsigned long)>>(std::__function::__policy_storage const*, unsigned long) @ 0x000000001006cdce
8. DB::WriteBuffer::finalize() @ 0x00000000076662c8
9. DB::IDisk::checkAccessImpl(String const&) @ 0x000000001001df4c
10. DB::IDisk::startup(std::shared_ptr<DB::Context const>, bool) @ 0x000000001001d6e5
11. std::shared_ptr<DB::IDisk> std::__function::__policy_invoker<std::shared_ptr<DB::IDisk> (String const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::Context const>, std::map<String, std::shared_ptr<DB::IDisk>, std::less<String>, std::allocator<std::pair<String const, std::shared_ptr<DB::IDisk>>>> const&, bool, bool)>::__call_impl<std::__function::__default_alloc_func<DB::registerDiskObjectStorage(DB::DiskFactory&, bool)::$_0, std::shared_ptr<DB::IDisk> (String const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::Context const>, std::map<String, std::shared_ptr<DB::IDisk>, std::less<String>, std::allocator<std::pair<String const, std::shared_ptr<DB::IDisk>>>> const&, bool, bool)>>(std::__function::__policy_storage const*, String const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::Context const>&&, std::map<String, std::shared_ptr<DB::IDisk>, std::less<String>, std::allocator<std::pair<String const, std::shared_ptr<DB::IDisk>>>> const&, bool, bool) @ 0x0000000010070bb6
12. DB::DiskFactory::create(String const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::Context const>, std::map<String, std::shared_ptr<DB::IDisk>, std::less<String>, std::allocator<std::pair<String const, std::shared_ptr<DB::IDisk>>>> const&, bool, bool) const @ 0x0000000010012ee0
13. DB::DiskSelector::initialize(Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::Context const>, std::function<bool (Poco::Util::AbstractConfiguration const&, String const&, String const&)>) @ 0x0000000010017123
14. DB::Context::getDiskSelector(std::lock_guard<std::mutex>&) const @ 0x000000001018c97d
15. DB::Context::getStoragePolicySelector(std::lock_guard<std::mutex>&) const @ 0x000000001016d4c2
16. DB::Context::getStoragePolicy(String const&) const @ 0x000000001018cf4b
17. DB::MergeTreeData::getStoragePolicy() const @ 0x0000000011a20f8b
18. DB::MergeTreeData::initializeDirectoriesAndFormatVersion(String const&, bool, String const&, bool) @ 0x0000000011a15e99
19. DB::StorageMergeTree::StorageMergeTree(DB::StorageID const&, String const&, DB::StorageInMemoryMetadata const&, DB::LoadingStrictnessLevel, std::shared_ptr<DB::Context>, String const&, DB::MergeTreeData::MergingParams const&, std::unique_ptr<DB::MergeTreeSettings, std::default_delete<DB::MergeTreeSettings>>) @ 0x0000000011ddeabe
20. DB::create(DB::StorageFactory::Arguments const&) @ 0x0000000011dda818
21. DB::StorageFactory::get(DB::ASTCreateQuery const&, String const&, std::shared_ptr<DB::Context>, std::shared_ptr<DB::Context>, DB::ColumnsDescription const&, DB::ConstraintsDescription const&, DB::LoadingStrictnessLevel) const @ 0x00000000113e133d
22. DB::createTableFromAST(DB::ASTCreateQuery, String const&, String const&, std::shared_ptr<DB::Context>, DB::LoadingStrictnessLevel) @ 0x000000000fe576b4
23. DB::DatabaseOrdinary::loadTableFromMetadata(std::shared_ptr<DB::Context>, String const&, DB::QualifiedTableName const&, std::shared_ptr<DB::IAST> const&, DB::LoadingStrictnessLevel) @ 0x000000000fe81c82
24. void std::__function::__policy_invoker<void (DB::AsyncLoader&, std::shared_ptr<DB::LoadJob> const&)>::__call_impl<std::__function::__default_alloc_func<DB::DatabaseOrdinary::loadTableFromMetadataAsync(DB::AsyncLoader&, std::unordered_set<std::shared_ptr<DB::LoadJob>, std::hash<std::shared_ptr<DB::LoadJob>>, std::equal_to<std::shared_ptr<DB::LoadJob>>, std::allocator<std::shared_ptr<DB::LoadJob>>>, std::shared_ptr<DB::Context>, String const&, DB::QualifiedTableName const&, std::shared_ptr<DB::IAST> const&, DB::LoadingStrictnessLevel)::$_0, void (DB::AsyncLoader&, std::shared_ptr<DB::LoadJob> const&)>>(std::__function::__policy_storage const*, DB::AsyncLoader&, std::shared_ptr<DB::LoadJob> const&) @ 0x000000000fe89f13
25. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::AsyncLoader::spawn(DB::AsyncLoader::Pool&, std::unique_lock<std::mutex>&)::$_0, void ()>>(std::__function::__policy_storage const*) @ 0x000000000ca8e316
26. ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x000000000c94c639
27. void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x000000000c94fe9a
28. void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000c94ecad
29. start_thread @ 0x0000000000008184
30. ? @ 0x00000000000fe03d
 (version 24.3.15.72 (official build))
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
