### PR TITLE
Fix `test_s3_plain_rewritable` flakiness

### DIFF
--- a/tests/integration/test_s3_plain_rewritable/test.py
+++ b/tests/integration/test_s3_plain_rewritable/test.py
@@ -54,6 +54,7 @@ def start_cluster():
 )
 def test(storage_policy, key_prefix):
     def create_insert(node, table_name, insert_values):
+        node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
         node.query(
             """
             CREATE TABLE {} (
@@ -130,6 +131,7 @@ def test(storage_policy, key_prefix):
     insert_values_arr = []
     for i in range(NUM_WORKERS):
         node = cluster.instances[f"node{i + 1}"]
+        node.query("OPTIMIZE TABLE test FINAL")
         insert_values_arr.append(
             node.query("SELECT * FROM test ORDER BY id FORMAT Values")
         )
@@ -169,8 +171,8 @@ def test(storage_policy, key_prefix):
 
     for i in range(NUM_WORKERS):
         node = cluster.instances[f"node{i + 1}"]
-        node.query("DROP TABLE IF EXISTS test SYNC")
-        node.query("DROP TABLE IF EXISTS test_dst SYNC")
+        node.query("DROP TABLE test SYNC")
+        node.query("DROP TABLE test_dst SYNC")
 
     it = cluster.minio_client.list_objects(
         cluster.minio_bucket, key_prefix, recursive=True


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
A part that was moved may reappear in the source table's query results if the server is restarted shortly afterward.
Flakiness reproduces with a repetitive run.
```
./runner 'test_s3_plain_rewritable/' --count 100
```
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=be433390ca14083eb3a1f5dc9a9e90e860b3882a&name_0=MasterCI&name_1=Integration%20tests%20%28aarch64%2C%203%2F4%29

Force-merge before restarting ClickHouse servers.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
