### PR TITLE
Fix bad cast in `StorageDistributed`

### DIFF
--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -448,7 +448,7 @@ void ASTSelectQuery::replaceDatabaseAndTable(const StorageID & table_id)
 }
 
 
-void ASTSelectQuery::addTableFunction(ASTPtr & table_function_ptr)
+void ASTSelectQuery::addTableFunction(const ASTPtr & table_function_ptr)
 {
     ASTTableExpression * table_expression = getFirstTableExpression(*this);
 

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -153,7 +153,7 @@ public:
     bool withFill() const;
     void replaceDatabaseAndTable(const String & database_name, const String & table_name);
     void replaceDatabaseAndTable(const StorageID & table_id);
-    void addTableFunction(ASTPtr & table_function_ptr);
+    void addTableFunction(const ASTPtr & table_function_ptr);
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
 
     void setFinal();

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -981,6 +981,9 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
         }
         else
         {
+            const auto select_with_union_query = std::make_shared<ASTSelectWithUnionQuery>();
+            select_with_union_query->list_of_selects = std::make_shared<ASTExpressionList>();
+
             const auto select = std::make_shared<ASTSelectQuery>();
 
             auto expression_list = std::make_shared<ASTExpressionList>();
@@ -988,7 +991,9 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
             select->setExpression(ASTSelectQuery::Expression::SELECT, expression_list->clone());
             select->addTableFunction(src_distributed.remote_table_function_ptr);
 
-            new_query->select = select;
+            select_with_union_query->list_of_selects->children.push_back(select->clone());
+
+            new_query->select = select_with_union_query;
         }
     }
     else

--- a/tests/queries/0_stateless/01099_parallel_distributed_insert_select.reference
+++ b/tests/queries/0_stateless/01099_parallel_distributed_insert_select.reference
@@ -28,6 +28,11 @@ test_shard_localhost
 0
 1
 2
+0
+1
+2
+3
+4
 test_cluster_two_shards_localhost
 0	2
 1	2

--- a/tests/queries/0_stateless/01099_parallel_distributed_insert_select.sql
+++ b/tests/queries/0_stateless/01099_parallel_distributed_insert_select.sql
@@ -170,12 +170,14 @@ DROP TABLE distributed_01099_a;
 DROP TABLE distributed_01099_b;
 
 --- https://github.com/ClickHouse/ClickHouse/issues/78464
-CREATE TABLE distributed_01099_c (n UInt64) ENGINE = Log;
+CREATE TABLE local_01099_c (n UInt64) ENGINE = Log;
+CREATE TABLE distributed_01099_c AS local_01099_c ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_01099_c, rand());
 
 INSERT INTO TABLE FUNCTION clusterAllReplicas('test_shard_localhost', currentDatabase(), 'distributed_01099_c') (n) SELECT number FROM remote('localhost', numbers(5)) tx;
 
 SELECT * FROM distributed_01099_c;
 
+DROP TABLE local_01099_c;
 DROP TABLE distributed_01099_c;
 
 --

--- a/tests/queries/0_stateless/01099_parallel_distributed_insert_select.sql
+++ b/tests/queries/0_stateless/01099_parallel_distributed_insert_select.sql
@@ -169,6 +169,15 @@ DROP TABLE local_01099_b;
 DROP TABLE distributed_01099_a;
 DROP TABLE distributed_01099_b;
 
+--- https://github.com/ClickHouse/ClickHouse/issues/78464
+CREATE TABLE distributed_01099_c (n UInt64) ENGINE = Log;
+
+INSERT INTO TABLE FUNCTION clusterAllReplicas('test_shard_localhost', currentDatabase(), 'distributed_01099_c') (n) SELECT number FROM remote('localhost', numbers(5)) tx;
+
+SELECT * FROM distributed_01099_c;
+
+DROP TABLE distributed_01099_c;
+
 --
 -- test_cluster_two_shards_localhost
 --


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bad cast in `StorageDistributed` when using table functions other than `view()`. Closes https://github.com/ClickHouse/ClickHouse/issues/78464

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
