### PR TITLE
Fix `tupleElement` formatting

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -543,7 +543,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 // is an unsigned integer lineral. We also allow nonnegative
                 // signed integer literals, because the fuzzer sometimes inserts
                 // them, and we want to have consistent formatting.
-                if (tuple_arguments_valid && lit_right)
+                if (tuple_arguments_valid && lit_left && lit_right)
                 {
                     if (isInt64OrUInt64FieldType(lit_right->value.getType())
                         && lit_right->value.safeGet<Int64>() >= 0)

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -531,7 +531,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 const auto * lit_left = arguments->children[0]->as<ASTLiteral>();
                 const auto * lit_right = arguments->children[1]->as<ASTLiteral>();
 
-                if (const auto * _ = arguments->children[0]->as<ASTAsterisk>())
+                if (arguments->children[0]->as<ASTAsterisk>())
                     tuple_arguments_valid = false;
 
                 if (lit_left)

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -9,6 +9,7 @@
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
+#include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
@@ -530,6 +531,9 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 const auto * lit_left = arguments->children[0]->as<ASTLiteral>();
                 const auto * lit_right = arguments->children[1]->as<ASTLiteral>();
 
+                if (const auto * _ = arguments->children[0]->as<ASTAsterisk>())
+                    tuple_arguments_valid = false;
+
                 if (lit_left)
                 {
                     Field::Types::Which type = lit_left->value.getType();
@@ -543,7 +547,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 // is an unsigned integer lineral. We also allow nonnegative
                 // signed integer literals, because the fuzzer sometimes inserts
                 // them, and we want to have consistent formatting.
-                if (tuple_arguments_valid && lit_left && lit_right)
+                if (tuple_arguments_valid && lit_right)
                 {
                     if (isInt64OrUInt64FieldType(lit_right->value.getType())
                         && lit_right->value.safeGet<Int64>() >= 0)

--- a/tests/queries/0_stateless/01840_tupleElement_formatting_fuzzer.reference
+++ b/tests/queries/0_stateless/01840_tupleElement_formatting_fuzzer.reference
@@ -15,29 +15,29 @@ SelectWithUnionQuery (children 1)
       Literal Tuple_(UInt64_255, UInt64_1)
       Literal UInt64_1
 255
-+SelectWithUnionQuery (children 1)
-+ ExpressionList (children 1)
-+  SelectQuery (children 2)
-+   ExpressionList (children 2)
-+    Function tupleElement (children 1)
-+     ExpressionList (children 2)
-+      Asterisk
-+      Literal UInt64_2
-+    Function tupleElement (children 1)
-+     ExpressionList (children 2)
-+      Identifier x
-+      Literal UInt64_1
-+   TablesInSelectQuery (children 1)
-+    TablesInSelectQueryElement (children 1)
-+     TableExpression (children 1)
-+      Subquery (children 1)
-+       SelectWithUnionQuery (children 1)
-+        ExpressionList (children 1)
-+         SelectQuery (children 1)
-+          ExpressionList (children 1)
-+           Function arrayJoin (alias x) (children 1)
-+            ExpressionList (children 1)
-+             Function array (children 1)
-+              ExpressionList (children 1)
-+               Literal Tuple_(UInt64_0, UInt64_1)
-+1      0
+SelectWithUnionQuery (children 1)
+ ExpressionList (children 1)
+  SelectQuery (children 2)
+   ExpressionList (children 2)
+    Function tupleElement (children 1)
+     ExpressionList (children 2)
+      Asterisk
+      Literal UInt64_2
+    Function tupleElement (children 1)
+     ExpressionList (children 2)
+      Identifier x
+      Literal UInt64_1
+   TablesInSelectQuery (children 1)
+    TablesInSelectQueryElement (children 1)
+     TableExpression (children 1)
+      Subquery (children 1)
+       SelectWithUnionQuery (children 1)
+        ExpressionList (children 1)
+         SelectQuery (children 1)
+          ExpressionList (children 1)
+           Function arrayJoin (alias x) (children 1)
+            ExpressionList (children 1)
+             Function array (children 1)
+              ExpressionList (children 1)
+               Literal Tuple_(UInt64_0, UInt64_1)
+1	0

--- a/tests/queries/0_stateless/01840_tupleElement_formatting_fuzzer.reference
+++ b/tests/queries/0_stateless/01840_tupleElement_formatting_fuzzer.reference
@@ -15,3 +15,29 @@ SelectWithUnionQuery (children 1)
       Literal Tuple_(UInt64_255, UInt64_1)
       Literal UInt64_1
 255
++SelectWithUnionQuery (children 1)
++ ExpressionList (children 1)
++  SelectQuery (children 2)
++   ExpressionList (children 2)
++    Function tupleElement (children 1)
++     ExpressionList (children 2)
++      Asterisk
++      Literal UInt64_2
++    Function tupleElement (children 1)
++     ExpressionList (children 2)
++      Identifier x
++      Literal UInt64_1
++   TablesInSelectQuery (children 1)
++    TablesInSelectQueryElement (children 1)
++     TableExpression (children 1)
++      Subquery (children 1)
++       SelectWithUnionQuery (children 1)
++        ExpressionList (children 1)
++         SelectQuery (children 1)
++          ExpressionList (children 1)
++           Function arrayJoin (alias x) (children 1)
++            ExpressionList (children 1)
++             Function array (children 1)
++              ExpressionList (children 1)
++               Literal Tuple_(UInt64_0, UInt64_1)
++1      0

--- a/tests/queries/0_stateless/01840_tupleElement_formatting_fuzzer.sql
+++ b/tests/queries/0_stateless/01840_tupleElement_formatting_fuzzer.sql
@@ -1,3 +1,6 @@
 explain ast select tupleElement(255, 100);
 explain ast select tupleElement((255, 1), 1);
 select tupleElement((255, 1), 1);
+
+EXPLAIN AST SELECT tupleElement(*, 2), tupleElement(x, 1) FROM (SELECT arrayJoin([(0,1)]) AS x);
+SELECT tupleElement(*, 2), tupleElement(x, 1) FROM (SELECT arrayJoin([(0,1)]) AS x);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix formatting for `tupleElement(*, 1)`. Closes https://github.com/ClickHouse/ClickHouse/issues/78639

