### PR TITLE
Fix column rollback on JSON parsing error

### DIFF
--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -59,7 +59,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int INCORRECT_DATA;
 }
 
 template <typename JSONParser>

--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -1467,11 +1467,11 @@ public:
         auto element_type = removeNullable(elementToDataType(element, format_settings));
         if (!checkIfTypeIsComplete(element_type))
         {
-            throw Exception(
-                ErrorCodes::INCORRECT_DATA,
+            error = fmt::format(
                 "Cannot infer the type of JSON element {}, because it contains only nulls. To use String type for elements with incomplete "
                 "type, enable setting input_format_json_infer_incomplete_types_as_strings",
                 jsonElementToString<JSONParser>(element, format_settings));
+            return false;
         }
 
         auto element_type_name = element_type->getName();

--- a/tests/queries/0_stateless/03405_json_parsing_error_bug.sql
+++ b/tests/queries/0_stateless/03405_json_parsing_error_bug.sql
@@ -1,0 +1,2 @@
+select ['{}', '{"c" : [1, {"b" : []}]}']::Array(JSON) settings input_format_json_infer_incomplete_types_as_strings=0; -- {serverError INCORRECT_DATA}
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix column rollback on JSON parsing error.

Closes https://github.com/ClickHouse/ClickHouse/issues/75498?reload=1?reload=1

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
