### PR TITLE
Fix IN clause coercion for BFloat16

### DIFF
--- a/base/base/BFloat16.h
+++ b/base/base/BFloat16.h
@@ -48,6 +48,13 @@ public:
     {
     }
 
+    static constexpr BFloat16 fromBits(UInt16 bits) noexcept
+    {
+        BFloat16 res;
+        res.x = bits;
+        return res;
+    }
+
     template <typename T>
     constexpr BFloat16 & operator=(const T & other)
     {

--- a/base/base/BFloat16.h
+++ b/base/base/BFloat16.h
@@ -3,7 +3,6 @@
 #include <bit>
 #include <base/types.h>
 #include <base/defines.h>
-#include <fmt/format.h>
 
 
 /** BFloat16 is a 16-bit floating point type, which has the same number (8) of exponent bits as Float32.
@@ -331,30 +330,5 @@ public:
     static constexpr BFloat16 min() noexcept { return BFloat16::fromBits(0b0000000100000000); }
     static constexpr BFloat16 max() noexcept { return BFloat16::fromBits(0b0111111101111111); }
     static constexpr BFloat16 infinity() noexcept { return BFloat16::fromBits(0b0111111110000000); }
-};
-}
-
-namespace fmt
-{
-template <>
-struct fmt::formatter<BFloat16>
-{
-    constexpr auto parse(format_parse_context & ctx)
-    {
-        const auto * it = ctx.begin();
-        const auto * end = ctx.end();
-
-        /// Only support {}.
-        if (it != end && *it != '}')
-            throw format_error("Invalid format for BFloat16");
-
-        return it;
-    }
-
-    template <typename FormatContext>
-    auto format(const BFloat16 & value, FormatContext & ctx) const
-    {
-        return format_to(ctx.out(), "{}", Float32(value));
-    }
 };
 }

--- a/base/base/BFloat16.h
+++ b/base/base/BFloat16.h
@@ -321,6 +321,19 @@ constexpr inline auto operator/(BFloat16 a, T b)
     return Float32(a) / b;
 }
 
+namespace std
+{
+template <>
+class numeric_limits<BFloat16>
+{
+public:
+    static constexpr BFloat16 lowest() noexcept { return BFloat16::fromBits(0b1111111101111111); }
+    static constexpr BFloat16 min() noexcept { return BFloat16::fromBits(0b0000000100000000); }
+    static constexpr BFloat16 max() noexcept { return BFloat16::fromBits(0b0111111101111111); }
+    static constexpr BFloat16 infinity() noexcept { return BFloat16::fromBits(0b0111111110000000); }
+};
+}
+
 namespace fmt
 {
 template <>

--- a/base/base/BFloat16.h
+++ b/base/base/BFloat16.h
@@ -3,6 +3,7 @@
 #include <bit>
 #include <base/types.h>
 #include <base/defines.h>
+#include <fmt/format.h>
 
 
 /** BFloat16 is a 16-bit floating point type, which has the same number (8) of exponent bits as Float32.
@@ -318,4 +319,29 @@ requires(!std::is_same_v<T, BFloat16>)
 constexpr inline auto operator/(BFloat16 a, T b)
 {
     return Float32(a) / b;
+}
+
+namespace fmt
+{
+template <>
+struct fmt::formatter<BFloat16>
+{
+    constexpr auto parse(format_parse_context & ctx)
+    {
+        const auto * it = ctx.begin();
+        const auto * end = ctx.end();
+
+        /// Only support {}.
+        if (it != end && *it != '}')
+            throw format_error("Invalid format for BFloat16");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const BFloat16 & value, FormatContext & ctx) const
+    {
+        return format_to(ctx.out(), "{}", Float32(value));
+    }
+};
 }

--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -244,6 +244,8 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
             return convertNumericType<Int128>(src, type);
         if (which_type.isInt256())
             return convertNumericType<Int256>(src, type);
+        if (which_type.isBFloat16())
+            return convertNumericType<BFloat16>(src, type);
         if (which_type.isFloat32())
             return convertNumericType<Float32>(src, type);
         if (which_type.isFloat64())

--- a/tests/queries/0_stateless/03404_bfloat16_insert_values.reference
+++ b/tests/queries/0_stateless/03404_bfloat16_insert_values.reference
@@ -1,0 +1,18 @@
+Basic tests
+0
+1
+1
+1
+1
+Edge cases
+1
+1
+1
+1
+0
+Compare to Float32
+1
+1
+1
+1
+0

--- a/tests/queries/0_stateless/03404_bfloat16_insert_values.sql
+++ b/tests/queries/0_stateless/03404_bfloat16_insert_values.sql
@@ -1,0 +1,20 @@
+SELECT 'Basic tests';
+SELECT toBFloat16(-1) IN [0, 1, 2] AS result;
+SELECT toBFloat16(-1) IN [-2, -1, 0, 1, 2] AS result;
+SELECT toBFloat16(-1) IN [toFloat32(-2), toFloat32(-1), toFloat32(0), toFloat32(1), toFloat32(2)] AS result;
+SELECT toBFloat16(-1) IN [toFloat64(-2), toFloat64(-1), toFloat64(0), toFloat64(1), toFloat64(2)] AS result;
+SELECT toFloat64(-1) IN [toBFloat16(-2), toBFloat16(-1), toBFloat16(0), toBFloat16(1), toBFloat16(2)] AS result;
+
+SELECT 'Edge cases';
+SELECT toBFloat16(0) IN [-0] AS result;
+SELECT toBFloat16(0/0) IN [0/0] AS result;
+SELECT toBFloat16(0/0) IN [-0/0] AS result;
+SELECT toBFloat16(1/0) IN [1/0] AS result;
+SELECT toBFloat16(1/0) IN [-1/0] AS result;
+
+SELECT 'Compare to Float32';
+SELECT toFloat32(0) IN [-0] AS result;
+SELECT toFloat32(0/0) IN [0/0] AS result;
+SELECT toFloat32(0/0) IN [-0/0] AS result;
+SELECT toFloat32(1/0) IN [1/0] AS result;
+SELECT toFloat32(1/0) IN [-1/0] AS result;


### PR DESCRIPTION
Using `BFloat16` in an `IN` clause (e.g., `SELECT toBFloat16(1) IN [1, 2, 3];`) now returns the expected result instead of a type mismatch error, aligning its behaviour with that of `Float32` and `Float64`. Extends tests to catch any regressions.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `IN` clause type coercion for `BFloat16` (i.e. `SELECT toBFloat16(1) IN [1, 2, 3];` now returns `1`). Closes #78754.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)