### PR TITLE
Add Stateful Test Description Link

### DIFF
--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -18,7 +18,7 @@ Each functional test sends one or multiple queries to the running ClickHouse ser
 Tests are located in `queries` directory.
 There are two subdirectories: `stateless` and `stateful`.
 - Stateless tests run queries without any preloaded test data - they often create small synthetic datasets on the fly, within the test itself.
-- Stateful tests require preloaded test data from ClickHouse and it is available to general public.
+- Stateful tests require preloaded test data from ClickHouse and it is available to general public. See [stateful test in continuous integration](continuous-integration.md#functional-stateful-tests).
 
 Each test can be one of two types: `.sql` and `.sh`.
 - An `.sql` test is the simple SQL script that is piped to `clickhouse-client`.


### PR DESCRIPTION
Easier to find setting of stateful test in the tests section.

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
