### PR TITLE
Fix 00157_cache_dictionary Timeout

### DIFF
--- a/tests/queries/0_stateless/00157_cache_dictionary.sql
+++ b/tests/queries/0_stateless/00157_cache_dictionary.sql
@@ -9,7 +9,7 @@ ORDER BY (CounterID, EventDate, intHash32(UserID))
 SAMPLE BY intHash32(UserID)
 SETTINGS storage_policy = 'default';
 
-INSERT INTO test.hits_1m SELECT * FROM test.hits LIMIT 1000000
+INSERT INTO test.hits_1m SELECT * FROM test.hits LIMIT 500000
 SETTINGS min_insert_block_size_rows = 0, min_insert_block_size_bytes = 0, max_block_size = 8192, max_insert_threads = 1, max_threads = 1, max_parallel_replicas=1;
 
 CREATE DATABASE IF NOT EXISTS db_dict;

--- a/tests/queries/0_stateless/00157_cache_dictionary.sql
+++ b/tests/queries/0_stateless/00157_cache_dictionary.sql
@@ -7,9 +7,12 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(EventDate)
 ORDER BY (CounterID, EventDate, intHash32(UserID))
 SAMPLE BY intHash32(UserID)
-SETTINGS storage_policy = 'default';
+SETTINGS storage_policy = 'default',
+-- set index_granularity correctly to avoid time out
+index_granularity = 8192,
+index_granularity_bytes = 10485760;
 
-INSERT INTO test.hits_1m SELECT * FROM test.hits LIMIT 500000
+INSERT INTO test.hits_1m SELECT * FROM test.hits LIMIT 1000000
 SETTINGS min_insert_block_size_rows = 0, min_insert_block_size_bytes = 0, max_block_size = 8192, max_insert_threads = 1, max_threads = 1, max_parallel_replicas=1;
 
 CREATE DATABASE IF NOT EXISTS db_dict;


### PR DESCRIPTION
resolve [this](https://github.com/ClickHouse/ClickHouse/issues/67893), fix it by setting default index granularity.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
