### PR TITLE
Fix race when shutting down queue metadata

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -39,7 +39,7 @@ ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFa
     return it->second.metadata;
 }
 
-void ObjectStorageQueueMetadataFactory::remove(const std::string & zookeeper_path, const StorageID & storage_id)
+void ObjectStorageQueueMetadataFactory::remove(const std::string & zookeeper_path, const StorageID & storage_id, bool remove_metadata_if_no_registered)
 {
     std::lock_guard lock(mutex);
     auto it = metadata_by_path.find(zookeeper_path);
@@ -53,8 +53,8 @@ void ObjectStorageQueueMetadataFactory::remove(const std::string & zookeeper_pat
     {
         const auto registry_size = it->second.metadata->unregister(
             storage_id,
-            /* active */false,
-            /* remove_all_metadata_if_no_registered */true);
+            /* active */ false,
+            remove_metadata_if_no_registered);
 
         LOG_TRACE(log, "Remaining registry size: {}", registry_size);
     }
@@ -63,7 +63,7 @@ void ObjectStorageQueueMetadataFactory::remove(const std::string & zookeeper_pat
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 
-    if (!it->second.ref_count)
+    if (*it->second.ref_count == 0)
         metadata_by_path.erase(it);
 }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -17,7 +17,7 @@ public:
         ObjectStorageQueueMetadataPtr metadata,
         const StorageID & storage_id);
 
-    void remove(const std::string & zookeeper_path, const StorageID & storage_id);
+    void remove(const std::string & zookeeper_path, const StorageID & storage_id, bool remove_metadata_if_no_registered);
 
     std::unordered_map<std::string, FilesMetadataPtr> getAll();
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -307,15 +307,6 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
     LOG_TRACE(log, "Shut down storage");
 }
 
-void StorageObjectStorageQueue::drop()
-{
-    if (files_metadata)
-    {
-        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
-        files_metadata.reset();
-    }
-}
-
 bool StorageObjectStorageQueue::supportsSubsetOfColumns(const ContextPtr & context_) const
 {
     return FormatFactory::instance().checkIfFormatSupportsSubsetOfColumns(configuration->format, context_, format_settings);

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -272,7 +272,7 @@ void StorageObjectStorageQueue::startup()
     }
     catch (...)
     {
-        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
+        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID(), /*remove_metadata_if_no_registered=*/true);
         files_metadata.reset();
         throw;
     }
@@ -301,7 +301,7 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
             tryLogCurrentException(log);
         }
 
-        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
+        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID(), is_drop);
         files_metadata.reset();
     }
     LOG_TRACE(log, "Shut down storage");

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -272,7 +272,8 @@ void StorageObjectStorageQueue::startup()
     }
     catch (...)
     {
-        files_metadata->shutdown();
+        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
+        files_metadata.reset();
         throw;
     }
     startup_finished = true;
@@ -300,7 +301,7 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
             tryLogCurrentException(log);
         }
 
-        files_metadata->shutdown();
+        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
         files_metadata.reset();
     }
     LOG_TRACE(log, "Shut down storage");
@@ -308,7 +309,11 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
 
 void StorageObjectStorageQueue::drop()
 {
-    ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
+    if (files_metadata)
+    {
+        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID());
+        files_metadata.reset();
+    }
 }
 
 bool StorageObjectStorageQueue::supportsSubsetOfColumns(const ContextPtr & context_) const

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -106,7 +106,6 @@ private:
 
     void startup() override;
     void shutdown(bool is_drop) override;
-    void drop() override;
 
     bool supportsSubsetOfColumns(const ContextPtr & context_) const;
     bool supportsSubcolumns() const override { return true; }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/eb4fb3f6229f3c6978452d04194aae9a035d16fe//stress_test_azure_tsan/stderr.log

The issue is with tables that have manually set `keeper_path` like in `03396_s3_do_not_retry_dns_errors`.
Same, shared metadata object is used for all tables with same path but when you call shutdown it will unconditionally shutdown the metadata even if some other tables are still using it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
