### PR TITLE
Fix table attach in stress test

### DIFF
--- a/tests/config/config.d/storage_conf_03008.xml
+++ b/tests/config/config.d/storage_conf_03008.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <local_plain_rewritable_03008>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <path>disks/local_plain_rewritable/</path>
+                <metadata_type>plain_rewritable</metadata_type>
+            </local_plain_rewritable_03008>
+        </disks>
+    </storage_configuration>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -105,6 +105,7 @@ ln -sf $SRC_PATH/config.d/handlers.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/threadpool_writer_pool_size.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/storage_conf_03008.xml $DEST_SERVER_PATH/config.d/
 
 # Not supported with fasttest.
 if [ "$FAST_TEST" != "1" ]; then

--- a/tests/queries/0_stateless/03008_local_plain_rewritable.sh
+++ b/tests/queries/0_stateless/03008_local_plain_rewritable.sh
@@ -11,12 +11,7 @@ ${CLICKHOUSE_CLIENT} --query "drop table if exists 03008_test_local_mt sync"
 ${CLICKHOUSE_CLIENT} -m --query "
 create table 03008_test_local_mt (a Int32, b Int64, c Int64)
 engine = MergeTree() partition by intDiv(a, 1000) order by tuple(a, b)
-settings disk = disk(
-    name = 03008_local_plain_rewritable,
-    type = object_storage,
-    object_storage_type = local,
-    metadata_type = plain_rewritable,
-    path = 'disks/local_plain_rewritable/')
+settings disk = 'local_plain_rewritable_03008'
 "
 
 ${CLICKHOUSE_CLIENT} -m --query "
@@ -32,7 +27,7 @@ select (*) from 03008_test_local_mt order by tuple(a, b) limit 10;
 ${CLICKHOUSE_CLIENT} --query "optimize table 03008_test_local_mt final;"
 
 ${CLICKHOUSE_CLIENT} -m --query "
-alter table 03008_test_local_mt modify setting disk = '03008_local_plain_rewritable', old_parts_lifetime = 3600;
+alter table 03008_test_local_mt modify setting disk = 'local_plain_rewritable_03008', old_parts_lifetime = 3600;
 select engine_full from system.tables WHERE database = currentDatabase() AND name = '03008_test_local_mt';
 " | grep -c "old_parts_lifetime = 3600"
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix failures like: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=eb4fb3f6229f3c6978452d04194aae9a035d16fe&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

```
 [ 50007 ] {} <Error> Application: Caught exception while loading metadata: Code: 722. DB::Exception: Waited job failed: Code: 695. DB::Exception: Load job \'load table test_13.03008_test_local_mt\' failed: Code: 479. DB::Exception: Unknown disk 03008_local_plain_rewritable: Cannot attach table `test_13`.`03008_test_local_mt` from metadata file store/38b/38b8ed21-d322-44a9-b886-fc1bf07832f1/03008_test_local_mt.sql from query ATTACH TABLE test_13.`03008_test_local_mt` UUID \'a01a60fc-cf6d-4d7e-a580-772f615f7ce0\' (`a` Int32, `b` Int64, `c` Int64) ENGINE = MergeTree PARTITION BY intDiv(a, 1000) ORDER BY (a, b) SETTINGS disk = \'03008_local_plain_rewritable\', index_granularity = 8192, old_parts_lifetime = 3600. (UNKNOWN_DISK), Stack trace (when copying this message, always include the lines below):
```

We replace the disk definition with a string name but because we created the disk with CREATE TABLE query, on restart in stress tests that definition is lost.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
