### PR TITLE
Fix `test_rabbitmq_restore_failed_connection_without_losses_1`

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -110,7 +110,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     """
     )
 
-    messages_num = 100000
+    messages_num = 200000
     values = []
     for i in range(messages_num):
         values.append("({i}, {i})".format(i=i))
@@ -171,7 +171,6 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
 
 
 def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
-    logging.getLogger("pika").propagate = False
     instance.query(
         """
         DROP TABLE IF EXISTS test.consumer_reconnect;
@@ -193,7 +192,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     """
     )
 
-    messages_num = 150000
+    messages_num = 200000
 
     messages = []
     for i in range(messages_num):

--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -110,7 +110,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     """
     )
 
-    messages_num = 200000
+    messages_num = 150000
     values = []
     for i in range(messages_num):
         values.append("({i}, {i})".format(i=i))
@@ -152,6 +152,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
         result = instance.query("SELECT count(DISTINCT key) FROM test.view")
         if int(result) == messages_num:
             break
+        logging.debug(f"Result: {result} / {messages_num}")
         time.sleep(1)
     else:
         pytest.fail(
@@ -192,7 +193,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     """
     )
 
-    messages_num = 200000
+    messages_num = 150000
 
     messages = []
     for i in range(messages_num):


### PR DESCRIPTION
In commit 7cf0d7bd3db3f71324a8c1572f45bd7bf1638505 from https://github.com/ClickHouse/ClickHouse/pull/78773 I added a check to ensure the test tested what's supposed to test. It seems that in the case of `test_rabbitmq_restore_failed_connection_without_losses_1` all 100K messages might be consumed before suspending and resuming the RabbitMQ server. The 150K from `test_rabbitmq_restore_failed_connection_without_losses_2` seemed ok, but I've increased both to 200K to make it less likely to fail.

In my local dev using a debug build running only `test_storage_rabbitmq/test_failed_connection.py` the difference going from 100K to 200K in both tests is going from 1m00s to 1m14s in time. I think the determinism is worth the price to pay, which will be less in release.

Reference of such a test failure: https://s3.amazonaws.com/clickhouse-test-reports/PRs/78838/e50ccd49f367e26b1ba6b3bef068a2eb4410dacf//integration_tests_release_4_4/integration_run_test_storage_rabbitmq_test_failed_connection_py_0.log

Related to https://github.com/ClickHouse/ClickHouse/issues/71049

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
