### PR TITLE
Fix tests `02240_filesystem_cache_bypass_cache_threshold`, `02240_filesystem_query_cache`

### DIFF
--- a/tests/queries/0_stateless/02240_filesystem_cache_bypass_cache_threshold.reference
+++ b/tests/queries/0_stateless/02240_filesystem_cache_bypass_cache_threshold.reference
@@ -11,6 +11,7 @@ SETTINGS min_bytes_for_wide_part = 10485760,
          compress_primary_key=false,
          disk = disk(
             type = cache,
+            name = '02240_bypass_cache_threshold',
             max_size = '128Mi',
             path = 'filesystem_cache_bypass_cache_threshold/',
             enable_bypass_cache_with_threshold = 1,
@@ -18,11 +19,11 @@ SETTINGS min_bytes_for_wide_part = 10485760,
             disk = 's3_disk');
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
 SELECT  * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold' ORDER BY file_segment_range_end, size;
 0	79	80
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold';
 SELECT * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold';
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold';

--- a/tests/queries/0_stateless/02240_filesystem_cache_bypass_cache_threshold.sql
+++ b/tests/queries/0_stateless/02240_filesystem_cache_bypass_cache_threshold.sql
@@ -14,6 +14,7 @@ SETTINGS min_bytes_for_wide_part = 10485760,
          compress_primary_key=false,
          disk = disk(
             type = cache,
+            name = '02240_bypass_cache_threshold',
             max_size = '128Mi',
             path = 'filesystem_cache_bypass_cache_threshold/',
             enable_bypass_cache_with_threshold = 1,
@@ -23,10 +24,10 @@ SETTINGS min_bytes_for_wide_part = 10485760,
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
 
 SELECT  * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold' ORDER BY file_segment_range_end, size;
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold';
 SELECT * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold';
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_bypass_cache_threshold';

--- a/tests/queries/0_stateless/02240_filesystem_query_cache.reference
+++ b/tests/queries/0_stateless/02240_filesystem_query_cache.reference
@@ -13,6 +13,7 @@ SETTINGS min_bytes_for_wide_part = 10485760,
          compress_primary_key=false,
          disk = disk(
             type = cache,
+            name = '02240_filesystem_query_cache',
             max_size = '128Mi',
             path = 'filesystem_query_cache/',
             cache_on_write_operations= 1,
@@ -21,11 +22,11 @@ SETTINGS min_bytes_for_wide_part = 10485760,
 SYSTEM DROP FILESYSTEM CACHE;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
 SELECT  * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache' ORDER BY file_segment_range_end, size;
 0	79	80
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache';
 SELECT * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache';
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache';

--- a/tests/queries/0_stateless/02240_filesystem_query_cache.sql
+++ b/tests/queries/0_stateless/02240_filesystem_query_cache.sql
@@ -16,6 +16,7 @@ SETTINGS min_bytes_for_wide_part = 10485760,
          compress_primary_key=false,
          disk = disk(
             type = cache,
+            name = '02240_filesystem_query_cache',
             max_size = '128Mi',
             path = 'filesystem_query_cache/',
             cache_on_write_operations= 1,
@@ -24,10 +25,10 @@ SETTINGS min_bytes_for_wide_part = 10485760,
 SYSTEM DROP FILESYSTEM CACHE;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
 SELECT  * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache' ORDER BY file_segment_range_end, size;
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache';
 SELECT * FROM test FORMAT Null;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache';
 SYSTEM DROP FILESYSTEM CACHE;
-SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '02240_filesystem_query_cache';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
