### PR TITLE
Fix 77452

### DIFF
--- a/tests/queries/0_stateless/02597_projection_materialize_and_replication.sql
+++ b/tests/queries/0_stateless/02597_projection_materialize_and_replication.sql
@@ -6,27 +6,20 @@ CREATE TABLE test (
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test/test_table', '1')
 ORDER BY (c_id, p_id);
 
-INSERT INTO test SELECT '1', '11', '111' FROM numbers(3);
+INSERT INTO test SELECT '1', '11', '111' FROM numbers(30);
 
-INSERT INTO test SELECT '2', '22', '22' FROM numbers(3);
+INSERT INTO test SELECT '2', '22', '22' FROM numbers(30);
 
 set mutations_sync=0;
 
-ALTER TABLE test UPDATE d = d || toString(sleepEachRow(0.3)) where 1;
+ALTER TABLE test UPDATE d = d || toString(sleepEachRow(0.1)) where 1;
 
-select * from test format Null;
+ALTER TABLE test ADD PROJECTION d_order ( SELECT min(c_id) GROUP BY `d`);
+ALTER TABLE test MATERIALIZE PROJECTION d_order;
+ALTER TABLE test DROP PROJECTION d_order SETTINGS mutations_sync = 2; --{serverError 36}
 
-ALTER TABLE test ADD PROJECTION d_order ( SELECT min(c_id) GROUP BY `d`) SETTINGS mutations_sync = 2;
-
-select * from test format Null;
-
+-- just to wait prev mutation
 ALTER TABLE test DELETE where d = 'Hello' SETTINGS mutations_sync = 2;
-
-select * from test format Null;
-
-ALTER TABLE test MATERIALIZE PROJECTION d_order SETTINGS mutations_sync = 2;
-
-select * from test format Null;
 
 ALTER TABLE test DROP PROJECTION d_order SETTINGS mutations_sync = 2;
 

--- a/tests/queries/0_stateless/02597_projection_materialize_and_replication.sql
+++ b/tests/queries/0_stateless/02597_projection_materialize_and_replication.sql
@@ -14,12 +14,19 @@ set mutations_sync=0;
 
 ALTER TABLE test UPDATE d = d || toString(sleepEachRow(0.3)) where 1;
 
-ALTER TABLE test ADD PROJECTION d_order ( SELECT min(c_id) GROUP BY `d`);
-ALTER TABLE test MATERIALIZE PROJECTION d_order;
-ALTER TABLE test DROP PROJECTION d_order SETTINGS mutations_sync = 2; --{serverError BAD_ARGUMENTS}
+select * from test format Null;
 
--- just to wait prev mutation
+ALTER TABLE test ADD PROJECTION d_order ( SELECT min(c_id) GROUP BY `d`) SETTINGS mutations_sync = 2;
+
+select * from test format Null;
+
 ALTER TABLE test DELETE where d = 'Hello' SETTINGS mutations_sync = 2;
+
+select * from test format Null;
+
+ALTER TABLE test MATERIALIZE PROJECTION d_order SETTINGS mutations_sync = 2;
+
+select * from test format Null;
 
 ALTER TABLE test DROP PROJECTION d_order SETTINGS mutations_sync = 2;
 

--- a/tests/queries/0_stateless/02597_projection_materialize_and_replication.sql
+++ b/tests/queries/0_stateless/02597_projection_materialize_and_replication.sql
@@ -16,7 +16,7 @@ ALTER TABLE test UPDATE d = d || toString(sleepEachRow(0.1)) where 1;
 
 ALTER TABLE test ADD PROJECTION d_order ( SELECT min(c_id) GROUP BY `d`);
 ALTER TABLE test MATERIALIZE PROJECTION d_order;
-ALTER TABLE test DROP PROJECTION d_order SETTINGS mutations_sync = 2; --{serverError 36}
+ALTER TABLE test DROP PROJECTION d_order SETTINGS mutations_sync = 2; --{serverError BAD_ARGUMENTS}
 
 -- just to wait prev mutation
 ALTER TABLE test DELETE where d = 'Hello' SETTINGS mutations_sync = 2;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
Fix test flakiness. The client didn't wait for `ALTER ADD PROJECTION` before attempting to drop it.

Closes https://github.com/ClickHouse/ClickHouse/issues/77452

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
