### PR TITLE
Fix Keeper test_snapshot_on_exit

### DIFF
--- a/tests/integration/test_keeper_snapshot_on_exit/test.py
+++ b/tests/integration/test_keeper_snapshot_on_exit/test.py
@@ -39,6 +39,10 @@ def test_snapshot_on_exit(started_cluster):
         zk_conn = get_fake_zk(node1)
         zk_conn.create("/some_path", b"some_data")
 
+        zk_conn.stop()
+        zk_conn.close()
+        zk_conn = None
+
         node1.stop_clickhouse()
         assert node1.contains_in_log("Created persistent snapshot")
 
@@ -52,7 +56,9 @@ def test_snapshot_on_exit(started_cluster):
         assert node2.contains_in_log("No existing snapshots")
     finally:
         if zk_conn:
-            if zk_conn.exists("/some_path"):
-                zk_conn.delete("/some_path")
             zk_conn.stop()
             zk_conn.close()
+
+        zk_conn = get_fake_zk(node1)
+        if zk_conn.exists("/some_path"):
+            zk_conn.delete("/some_path")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d081549e29213ff1aaf23447d2addec3aed3bc6e&name_0=MasterCI&name_1=Integration%20tests%20%28aarch64%2C%202%2F4%29

It fails when retries are not enough for server to start

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
