### PR TITLE
Another fix for `test_rabbitmq_restore_failed_connection_without_losses_1`

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -110,7 +110,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     """
     )
 
-    messages_num = 150000
+    messages_num = 200000
     values = []
     for i in range(messages_num):
         values.append("({i}, {i})".format(i=i))
@@ -193,7 +193,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     """
     )
 
-    messages_num = 150000
+    messages_num = 200000
 
     messages = []
     for i in range(messages_num):

--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -111,16 +111,11 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     )
 
     messages_num = 200000
-    values = []
-    for i in range(messages_num):
-        values.append("({i}, {i})".format(i=i))
-    values = ",".join(values)
-
     deadline = time.monotonic() + 180
     while time.monotonic() < deadline:
         try:
             instance.query(
-                "INSERT INTO test.producer_reconnect VALUES {}".format(values)
+                f"INSERT INTO test.producer_reconnect SELECT number, number FROM numbers({messages_num})"
             )
             break
         except QueryRuntimeException as e:
@@ -194,17 +189,11 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     )
 
     messages_num = 200000
-
-    messages = []
-    for i in range(messages_num):
-        messages.append("({i}, {i})".format(i=i))
-    messages = ",".join(messages)
-
     deadline = time.monotonic() + 180
     while time.monotonic() < deadline:
         try:
             instance.query(
-                "INSERT INTO test.consumer_reconnect VALUES {}".format(messages)
+                f"INSERT INTO test.consumer_reconnect SELECT number, number FROM numbers({messages_num})"
             )
             break
         except QueryRuntimeException as e:


### PR DESCRIPTION
Apparently, I was too conservative in https://github.com/ClickHouse/ClickHouse/pull/78887#event-17191801414 increasing the number of messages. I ended up reducing it because something else failed sometimes with such a high amount of messages, but we'll need to tackle that separately.

Increase to 200K messages to ensure not all messages are consumed
Otherwise, before suspending and resuming RabbitMQ, all messages would be consumed, making the test useless.

Happened in https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=78910&sha=480e5dce242bf417c0ab0e9fa9abda00f7bf550d&name_0=PR&name_1=Integration%20tests%20%28aarch64%2C%203%2F4%29

Related to #71049 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
