### PR TITLE
Make data types in used_data_type_families info canonical

### DIFF
--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
@@ -24,3 +24,4 @@ used_database_engines
 
 arraySort(used_data_type_families)	used_storages
 ['DateTime','Int64']	['Memory']
+

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
@@ -17,10 +17,10 @@ used_functions
 ['repeat']
 
 arraySort(used_data_type_families)
-['Int32','Nullable','String']
+['Int32','Nullable(String)','String']
 
 used_database_engines
 ['Atomic']
 
 arraySort(used_data_type_families)	used_storages
-['Int64','DateTime']	['Memory']
+['DateTime','Int64']	['Memory']

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
@@ -23,5 +23,4 @@ used_database_engines
 ['Atomic']
 
 arraySort(used_data_type_families)	used_storages
-['Int64','datetime']	['Memory']
-
+['Int64','DateTime']	['Memory']

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
@@ -68,7 +68,7 @@ WHERE current_database = currentDatabase() AND type == 'QueryFinish' AND (query 
 ORDER BY query_start_time DESC LIMIT 1 FORMAT TabSeparatedWithNames;
 SELECT '';
 
-CREATE OR REPLACE TABLE test_query_log_factories_info1.memory_table (id BIGINT, date DATETIME) ENGINE=Memory();
+CREATE OR REPLACE TABLE test_query_log_factories_info1.memory_table (id BIGINT, date DATETIME, date2 DateTime) ENGINE=Memory();
 
 SYSTEM FLUSH LOGS query_log;
 SELECT arraySort(used_data_type_families), used_storages


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make data types in `used_data_type_families` in `system.query_log` canonical.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
