### PR TITLE
Several more fixes to transposed metric log

### DIFF
--- a/src/Interpreters/TransposedMetricLog.cpp
+++ b/src/Interpreters/TransposedMetricLog.cpp
@@ -463,16 +463,18 @@ void TransposedMetricLog::prepareTable()
                 std::vector<std::string> name_parts;
                 splitInto<'_'>(name_parts, name);
                 // ['transposed', 'metric', 'log', 'X']
-                if (name_parts.size() > 3)
+                if (name_parts.size() == 4)
                 {
                     int suffix;
+                    /// Ignore weird tables like transposed_metric_log_aaa
                     if (tryParse<Int32>(suffix, name_parts.back()))
                         prepareViewForTable(database, iterator->table()->getStorageID(), view_name + "_" + toString(suffix), suffix);
                 }
-                else
+                else if (name_parts.size() == 3) // ['transposed', 'metric', 'log']
                 {
                     prepareViewForTable(database, storage_id, view_name, 0);
                 }
+                /// All other non-standard names are itentionaly ignored
 
                 iterator->next();
             }

--- a/src/Interpreters/TransposedMetricLog.cpp
+++ b/src/Interpreters/TransposedMetricLog.cpp
@@ -474,7 +474,7 @@ void TransposedMetricLog::prepareTable()
                 {
                     prepareViewForTable(database, storage_id, view_name, 0);
                 }
-                /// All other non-standard names are itentionaly ignored
+                /// All other non-standard names are intentionally ignored
 
                 iterator->next();
             }

--- a/tests/integration/test_transposed_metric_log/test.py
+++ b/tests/integration/test_transposed_metric_log/test.py
@@ -131,6 +131,8 @@ def test_table_rotation(start_cluster):
 
     time.sleep(1)
     node1.query("SYSTEM FLUSH LOGS")
+    print(node1.query("SHOW TABLES FROM system"))
+
     assert int(node1.query("EXISTS TABLE system.metric_log").strip()) == 1
     assert int(node1.query("EXISTS TABLE system.metric_log_0").strip()) == 1
     assert int(node1.query("EXISTS TABLE system.metric_log_1").strip()) == 1
@@ -149,15 +151,6 @@ def test_table_rotation(start_cluster):
     assert "SystemMetricLogView" in node1.query("SHOW CREATE TABLE system.metric_log_1")
     assert "ProfileEvent_Query" in node1.query("SHOW CREATE TABLE system.metric_log_1")
     assert int(node1.query("SELECT count() FROM system.metric_log_1 WHERE not ignore(*)").strip()) > 0
-
-    assert "SystemMetricLogView" not in node1.query("SHOW CREATE TABLE system.metric_log_2")
-    assert "ProfileEvent_Query" in node1.query("SHOW CREATE TABLE system.metric_log_2")
-
-    assert "SystemMetricLogView" not in node1.query("SHOW CREATE TABLE system.metric_log_3")
-    assert "metric" in node1.query("SHOW CREATE TABLE system.metric_log_3")
-
-    assert "SystemMetricLogView" not in node1.query("SHOW CREATE TABLE system.metric_log_4")
-    assert "ProfileEvent_Query" in node1.query("SHOW CREATE TABLE system.metric_log_4")
 
     node1.query("DROP TABLE system.transposed_metric_log_0")
     node1.query("CREATE TABLE system.transposed_metric_log_2 as system.transposed_metric_log")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now if source table for system.metric_log view is dropped, view itself will return 0 rows. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
