### PR TITLE
Fix rows_before_limit_at_least for LIMIT BY clause

### DIFF
--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1062,6 +1062,16 @@ void addPreliminarySortOrDistinctOrLimitStepsIfNeeded(
         addLimitByStep(query_plan, limit_by_analysis_result, query_node, true /*do_not_skip_offset*/);
     }
 
+    /// Do not apply PreLimit at first stage for LIMIT BY and `exact_rows_before_limit`,
+    /// as it may break `rows_before_limit_at_least` value during the second stage in
+    /// case it also contains LIMIT BY
+    const Settings & settings = planner_context->getQueryContext()->getSettingsRef();
+
+    if (query_node.hasLimitBy() && settings[Setting::exact_rows_before_limit])
+    {
+        return;
+    }
+
     /// WITH TIES simply not supported properly for preliminary steps, so let's disable it.
     if (query_node.hasLimit() && !query_node.hasLimitByOffset() && !query_node.isLimitWithTies())
         addPreliminaryLimitStep(query_plan, query_analysis_result, planner_context, true /*do_not_skip_offset*/);

--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -64,6 +64,9 @@ void LimitByTransform::transform(Chunk & chunk)
                 column = column->filter(filter, inserted_count);
     }
 
+    if (rows_before_limit_at_least)
+        rows_before_limit_at_least->add(inserted_count);
+
     chunk.setColumns(std::move(columns), inserted_count);
 }
 

--- a/src/Processors/Transforms/LimitByTransform.h
+++ b/src/Processors/Transforms/LimitByTransform.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Processors/ISimpleTransform.h>
+#include <Processors/RowsBeforeStepCounter.h>
 #include <Common/HashTable/HashMap.h>
 
 
@@ -14,6 +15,8 @@ public:
 
     String getName() const override { return "LimitByTransform"; }
 
+    void setRowsBeforeLimitCounter(RowsBeforeStepCounterPtr counter) override { rows_before_limit_at_least.swap(counter); }
+
 protected:
     void transform(Chunk & chunk) override;
 
@@ -24,6 +27,8 @@ private:
     std::vector<size_t> key_positions;
     const UInt64 group_length;
     const UInt64 group_offset;
+
+    RowsBeforeStepCounterPtr rows_before_limit_at_least;
 };
 
 }

--- a/src/QueryPipeline/QueryPipeline.cpp
+++ b/src/QueryPipeline/QueryPipeline.cpp
@@ -22,7 +22,7 @@
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Processors/Transforms/CountingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
-#include "Processors/Transforms/LimitByTransform.h"
+#include <Processors/Transforms/LimitByTransform.h>
 #include <Processors/Transforms/LimitsCheckingTransform.h>
 #include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Transforms/PartialSortingTransform.h>

--- a/src/QueryPipeline/QueryPipeline.cpp
+++ b/src/QueryPipeline/QueryPipeline.cpp
@@ -22,6 +22,7 @@
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Processors/Transforms/CountingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
+#include "Processors/Transforms/LimitByTransform.h"
 #include <Processors/Transforms/LimitsCheckingTransform.h>
 #include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Transforms/PartialSortingTransform.h>
@@ -178,7 +179,8 @@ static void initRowsBeforeLimit(IOutputFormat * output_format)
         ///   2. Limit ... PartialSorting: Set counter on PartialSorting
         ///   3. Limit ... TotalsHaving(with filter) ... Remote: Set counter on the input port of Limit
         ///   4. Limit ... Remote: Set counter on Remote
-        ///   5. Limit ... : Set counter on the input port of Limit
+        ///   5. Limit ... LimitBy: Set counter on LimitBy, as it may not be executed on initiator
+        ///   6. Limit ... : Set counter on the input port of Limit
 
         /// Case 1.
         if ((typeid_cast<RemoteSource *>(processor) || typeid_cast<DelayedSource *>(processor)) && !limit_processor)
@@ -222,6 +224,14 @@ static void initRowsBeforeLimit(IOutputFormat * output_format)
                 limit_candidates[limit_processor].push_back(limit_input_port);
                 continue;
             }
+
+            /// Case 5.
+            if (typeid_cast<LimitByTransform *>(processor))
+            {
+                processors.emplace_back(processor);
+                limit_candidates[limit_processor].push_back(limit_input_port);
+                continue;
+            }
         }
 
         /// Skip totals and extremes port for output format.
@@ -256,7 +266,7 @@ static void initRowsBeforeLimit(IOutputFormat * output_format)
         }
     }
 
-    /// Case 5.
+    /// Case 6.
     for (auto && [limit, ports] : limit_candidates)
     {
         /// If there are some input ports which don't have the counter, add it to LimitTransform.

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit.reference
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit.reference
@@ -1,0 +1,161 @@
+-- Assert total number of groups and records in unsorted
+10	50
+
+-- Assert rows_before_limit for unsorted ORDER BY + LIMIT BY + LIMIT
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 3
+}
+
+-- Assert rows_before_limit for unsorted ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 10
+}
+
+-- Assert rows_before_limit for unsorted HAVING + ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "40"],
+		[1, "41"],
+		[2, "42"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 7
+}
+
+-- Assert total number of groups and records in sorted
+10	50
+
+-- Assert rows_before_limit for sorted ORDER BY + LIMIT BY + LIMIT
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 3
+}
+
+-- Assert rows_before_limit for sorted ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 10
+}
+
+-- Assert rows_before_limit for sorted HAVING + ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "40"],
+		[1, "41"],
+		[2, "42"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 7
+}

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit.sql
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit.sql
@@ -1,0 +1,60 @@
+SET output_format_write_statistics = 0;
+
+DROP TABLE IF EXISTS 03408_unsorted;
+
+CREATE TABLE 03408_unsorted (id Int32, val String) ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part=1
+AS
+SELECT number % 10, leftPad(toString(number), 2, '0') FROM numbers(50);
+
+SELECT '-- Assert total number of groups and records in unsorted';
+SELECT uniqExact(id), count() FROM 03408_unsorted;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for unsorted ORDER BY + LIMIT BY + LIMIT';
+
+SELECT id, val FROM 03408_unsorted ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=0;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for unsorted ORDER BY + LIMIT BY + LIMIT, exact';
+
+SELECT id, val FROM 03408_unsorted ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=1;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for unsorted HAVING + ORDER BY + LIMIT BY + LIMIT, exact';
+
+SELECT id, val FROM 03408_unsorted GROUP BY id, val HAVING id < 7 ORDER BY id, val DESC LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=1;
+
+DROP TABLE 03408_unsorted;
+
+DROP TABLE IF EXISTS 03408_sorted;
+
+CREATE TABLE 03408_sorted (id Int32, val String) ENGINE = MergeTree ORDER BY (id, val) SETTINGS min_bytes_for_wide_part=1
+AS
+SELECT number % 10, leftPad(toString(number), 2, '0') FROM numbers(50);
+
+SELECT '';
+SELECT '-- Assert total number of groups and records in sorted';
+SELECT uniqExact(id), count() FROM 03408_sorted;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for sorted ORDER BY + LIMIT BY + LIMIT';
+
+SELECT id, val FROM 03408_sorted ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=0;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for sorted ORDER BY + LIMIT BY + LIMIT, exact';
+
+SELECT id, val FROM 03408_sorted ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=1;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for sorted HAVING + ORDER BY + LIMIT BY + LIMIT, exact';
+
+SELECT id, val FROM 03408_sorted GROUP BY id, val HAVING id < 7 ORDER BY id, val DESC LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=1;
+
+DROP TABLE 03408_sorted;

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.reference
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.reference
@@ -1,0 +1,107 @@
+-- Assert total number of groups and records in distributed
+10	100
+
+-- Assert rows_before_limit for distributed ORDER BY + LIMIT BY + LIMIT
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 3
+}
+
+-- Assert rows_before_limit for distributed ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 10
+}
+
+-- Assert rows_before_limit for distributed HAVING + ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "40"],
+		[1, "41"],
+		[2, "42"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 7
+}
+
+-- Assert rows_before_limit for distributed without LIMIT BY on initiator, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "max(val)",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "40"],
+		[0, "40"],
+		[1, "41"],
+		[1, "41"]
+	],
+
+	"rows": 4,
+
+	"rows_before_limit_at_least": 20
+}

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.sql
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.sql
@@ -1,0 +1,42 @@
+-- Tags: shard
+
+SET output_format_write_statistics = 0;
+
+DROP TABLE IF EXISTS 03408_local;
+DROP TABLE IF EXISTS 03408_dist;
+
+CREATE TABLE 03408_local (id Int32, val String) ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part=1
+AS
+SELECT number % 10, leftPad(toString(number), 2, '0') FROM numbers(50);
+
+CREATE TABLE 03408_dist(id Int32, val String) engine = Distributed(test_cluster_two_shards, currentDatabase(), 03408_local, id);
+
+SELECT '-- Assert total number of groups and records in distributed';
+SELECT uniqExact(id), count() FROM 03408_dist;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for distributed ORDER BY + LIMIT BY + LIMIT';
+
+SELECT id, val FROM 03408_dist ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=0;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for distributed ORDER BY + LIMIT BY + LIMIT, exact';
+
+SELECT id, val FROM 03408_dist ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=1;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for distributed HAVING + ORDER BY + LIMIT BY + LIMIT, exact';
+
+SELECT id, val FROM 03408_dist GROUP BY id, val HAVING id < 7 ORDER BY id, val DESC LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS max_block_size=1, exact_rows_before_limit=1;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for distributed without LIMIT BY on initiator, exact';
+
+SELECT id, max(val) FROM 03408_dist GROUP BY id ORDER BY id LIMIT 1 BY id LIMIT 4
+FORMAT JSONCompact SETTINGS max_block_size=1, exact_rows_before_limit = 1, distributed_group_by_no_merge=2;
+
+DROP TABLE 03408_local;
+DROP TABLE 03408_dist;

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_mem.reference
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_mem.reference
@@ -1,0 +1,54 @@
+-- Assert total number of groups and records in memory
+10	50
+
+-- Assert rows_before_limit for memory ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "00"],
+		[1, "01"],
+		[2, "02"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 10
+}
+
+-- Assert rows_before_limit for memory HAVING + ORDER BY + LIMIT BY + LIMIT, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "val",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "40"],
+		[1, "41"],
+		[2, "42"]
+	],
+
+	"rows": 3,
+
+	"rows_before_limit_at_least": 7
+}

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_mem.sql
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_mem.sql
@@ -1,0 +1,24 @@
+-- Tags: no-parallel-replicas
+
+SET output_format_write_statistics = 0;
+
+DROP TABLE IF EXISTS 03408_memory;
+
+CREATE TABLE 03408_memory (id Int32, val String) ENGINE = Memory
+AS
+SELECT number % 10, leftPad(toString(number), 2, '0') FROM numbers(50);
+
+SELECT '-- Assert total number of groups and records in memory';
+SELECT uniqExact(id), count() FROM 03408_memory;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for memory ORDER BY + LIMIT BY + LIMIT, exact';
+SELECT id, val FROM 03408_memory ORDER BY id, val LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS exact_rows_before_limit=1;
+
+SELECT '';
+SELECT '-- Assert rows_before_limit for memory HAVING + ORDER BY + LIMIT BY + LIMIT, exact';
+SELECT id, val FROM 03408_memory GROUP BY id, val HAVING id < 7 ORDER BY id, val DESC LIMIT 1 BY id LIMIT 3
+FORMAT JsonCompact SETTINGS exact_rows_before_limit=1;
+
+DROP TABLE 03408_memory;


### PR DESCRIPTION
Closes #25581 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
For queries with combination of `ORDER BY ... LIMIT BY ... LIMIT N`, when ORDER BY is executed as a PartialSorting, the counter `rows_before_limit_at_least` now reflects the number of rows consumed by LIMIT clause instead of number of rows consumed by sorting transform.