### PR TITLE
Revert "Fix taking full part if part contains less than 'limit' rows"

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1190,7 +1190,7 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder(
 
                 /// We take full part if it contains enough marks or
                 /// if we know limit and part contains less than 'limit' rows.
-                bool take_full_part = marks_in_part <= need_marks || (input_order_info->limit && input_order_info->limit > part.getRowsCount());
+                bool take_full_part = marks_in_part <= need_marks || (input_order_info->limit && input_order_info->limit < part.getRowsCount());
 
                 /// We take the whole part if it is small enough.
                 if (take_full_part)

--- a/tests/queries/0_stateless/02499_monotonicity_toUnixTimestamp64.sh
+++ b/tests/queries/0_stateless/02499_monotonicity_toUnixTimestamp64.sh
@@ -13,7 +13,8 @@ $CLICKHOUSE_CLIENT --optimize_trivial_insert_select 1 -q "create table t(ts Date
 max_block_size=8192
 
 query_id="${CLICKHOUSE_DATABASE}_02499_$RANDOM$RANDOM"
-$CLICKHOUSE_CLIENT --query_id="$query_id" -q "select ts from t order by toUnixTimestamp64Nano(ts) limit 10 format Null settings max_block_size = $max_block_size, optimize_read_in_order = 1, max_threads = 1;"
+$CLICKHOUSE_CLIENT --query_id="$query_id" -q "select ts from t order by toUnixTimestamp64Nano(ts) limit 10 format Null settings max_block_size = $max_block_size, optimize_read_in_order = 1;"
 
 $CLICKHOUSE_CLIENT -q "system flush logs query_log;"
 $CLICKHOUSE_CLIENT --param_query_id="$query_id" -q "select read_rows <= $max_block_size from system.query_log where event_date >= yesterday() and current_database = '$CLICKHOUSE_DATABASE' and query_id = {query_id:String} and type = 'QueryFinish';"
+


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#62812

Closes: #78579

---

Existing perf tests for in-order reading confirmed the issue.

<img width="1727" alt="Screenshot 2025-04-25 at 16 06 40" src="https://github.com/user-attachments/assets/f6d1681c-d78c-480f-b680-9daa654b832e" />

Another way to demonstrate a really strange behaviour:

```
EXPLAIN PIPELINE
SELECT *
FROM hits
ORDER BY CounterID DESC
LIMIT 100
SETTINGS max_threads = 4

    ┌─explain───────────────────────────────────────────────────────────────────────────────────────────┐
 1. │ (Expression)                                                                                      │
 2. │ ExpressionTransform                                                                               │
 3. │   (Limit)                                                                                         │
 4. │   Limit                                                                                           │
 5. │     (Sorting)                                                                                     │
 6. │     MergingSortedTransform 5 → 1                                                                  │
 7. │       (Expression)                                                                                │
 8. │       ExpressionTransform × 5                                                                     │
 9. │         (ReadFromMergeTree)                                                                       │
10. │         ReverseTransform                                                                          │
11. │           MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) 0 → 1                 │
12. │             ReverseTransform                                                                      │
13. │               MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) 0 → 1             │
14. │                 ReverseTransform                                                                  │
15. │                   MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) 0 → 1         │
16. │                     ReverseTransform × 2                                                          │
17. │                       MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) × 2 0 → 1 │
    └───────────────────────────────────────────────────────────────────────────────────────────────────┘
```

```
EXPLAIN PIPELINE
SELECT *
FROM hits
ORDER BY CounterID DESC
LIMIT 100000000
SETTINGS max_threads = 4

    ┌─explain───────────────────────────────────────────────────────────────────────────────┐
 1. │ (Expression)                                                                          │
 2. │ ExpressionTransform                                                                   │
 3. │   (Limit)                                                                             │
 4. │   Limit                                                                               │
 5. │     (Sorting)                                                                         │
 6. │     MergingSortedTransform 2 → 1                                                      │
 7. │       (Expression)                                                                    │
 8. │       ExpressionTransform × 2                                                         │
 9. │         (ReadFromMergeTree)                                                           │
10. │         ReverseTransform × 2                                                          │
11. │           MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) × 2 0 → 1 │
    └───────────────────────────────────────────────────────────────────────────────────────┘
```

In other words, we use less threads to read more data.