### PR TITLE
tests: avoid data-race in bash in 01161_all_system_tables

### DIFF
--- a/tests/queries/0_stateless/01161_all_system_tables.sh
+++ b/tests/queries/0_stateless/01161_all_system_tables.sh
@@ -16,6 +16,8 @@ LIMIT=10000
 
 function run_selects()
 {
+    local tables_arr
+
     thread_num=$1
     readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT database || '.' || name FROM system.tables
     WHERE database in ('system', 'information_schema', 'INFORMATION_SCHEMA') and name != 'zookeeper' and name != 'models'

--- a/tests/queries/0_stateless/01161_all_system_tables.sh
+++ b/tests/queries/0_stateless/01161_all_system_tables.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, long
 # Tag no-parallel: since someone may create table in system database
 
 # Server may ignore some exceptions, but it still print exceptions to logs and (at least in CI) sends Error and Warning log messages to client


### PR DESCRIPTION
The test hangs in a very odd fashion, i.e. no queries are running and looks like the bash is the problem, let's try to fix this problem

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)