### PR TITLE
Introspection of .sh tests (via BASH_XTRACEFD)

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1870,6 +1870,9 @@ class TestCase:
         # because there are also output of per test database creation
         pattern = "{test} > {stdout} 2> {stderr}"
 
+        tests_env = os.environ.copy()
+        tests_env["CLICKHOUSE_BASH_TRACING_FILE"] = args.debug_log_file
+
         if self.ext == ".sql" and args.cloud:
             # Get at least some logs, because we don't have access to system.text_log and pods...
             pattern = (
@@ -1881,6 +1884,8 @@ class TestCase:
                 "{client} --send_logs_level={logs_level} {secure} --multiquery {options} < "
                 + pattern
             )
+
+        command = pattern.format(**params)
 
         # We want to calculate per-test code coverage. That's why we reset it before each test.
         if (
@@ -1894,10 +1899,8 @@ class TestCase:
                 retry_error_codes=True,
             )
 
-        command = pattern.format(**params)
-
         # pylint:disable-next=consider-using-with; TODO: fix
-        proc = Popen(command, shell=True, env=os.environ, start_new_session=True)
+        proc = Popen(command, shell=True, env=tests_env, start_new_session=True)
 
         try:
             proc.wait(args.timeout)


### PR DESCRIPTION
Sometimes it is hard to understand why the test failed, since all .sh tests written with a different style, and likely does not have debugging capabilities. We have them for .sql and .expect (via exp_internal), but not for .sh.

So the idea is to catch all the tracing (set -x) in a separate file with BASH_XTRACEFD, that way we will get all the command invocations from tests and match it with stderr/stdout and server logs.

Note, that I also tried to capture the stderr in the same file, but failed (see comments in the code), but anyway this helps on it's own, I've tried such approach before and it helps with debugging a lot.

Example:

    $ ../tests/clickhouse-test 01528_play
    ...
    Running about 1 stateless tests (Process-3).
    01528_play:                                                             [ FAIL ] 0.23 sec.
    Reason: result differs with reference:
    --- /src/ch/clickhouse/tests/queries/0_stateless/01528_play.reference   2025-02-16 07:53:58.109650830 +0100
    +++ /src/ch/clickhouse/tests/queries/0_stateless/01528_play.stdout      2025-04-11 09:24:59.935938529 +0200
    @@ -1 +1,2 @@
    +stdout
     clickhouse.com

    /src/ch/clickhouse/tests/queries/0_stateless/test_tj6rqi3n/01528_play.sh.debuglog:
    + [2025-04-11 09:24:59] [:7] echo stdout
    + [2025-04-11 09:24:59] [:8] curl -q -s --max-time 120 -sS http://localhost:8123/play
    + [2025-04-11 09:24:59] [:8] grep -o -F clickhouse.com

Fixes: https://github.com/ClickHouse/ClickHouse/issues/78627

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)