### PR TITLE
ci: fix "Digest does not match" for Replicated database in stress tests

### DIFF
--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -22,9 +22,18 @@ def get_options(i: int, upgrade_check: bool) -> str:
         options.append("--order=random")
 
     if i % 3 == 2 and not upgrade_check:
-        options.append(f'''--db-engine="Replicated('/test/db/test_{i}', 's1', 'r1')"''')
-        client_options.append("enable_deflate_qpl_codec=1")
-        client_options.append("enable_zstd_qat_codec=1")
+        client_options.extend([
+            "enable_deflate_qpl_codec=1",
+            "enable_zstd_qat_codec=1",
+            # For Replicated database
+            "distributed_ddl_output_mode=none",
+            "database_replicated_always_detach_permanently=1",
+        ])
+        options.extend([
+            "--replicated-database",
+            "--database",
+            f"test_{i}",
+        ])
 
     # If database name is not specified, new database is created for each functional test.
     # Run some threads with one database for all tests.

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1308,10 +1308,11 @@ class TestCase:
 
         if new_options != "":
             new_options += " --allow_repeated_settings"
-
             os.environ["CLICKHOUSE_CLIENT_OPT"] = (
                 self.base_client_options + new_options + " "
             )
+        elif client_options:
+            client_options += " --allow_repeated_settings"
 
         return client_options + new_options
 


### PR DESCRIPTION
The problem was that the tag that is added in https://github.com/ClickHouse/ClickHouse/pull/78741, was completely ignored by the stress tests, since it uses low-level way of running tests with Replicated database via `--db-engine`, let's use correct way -- `--replicated-database`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/64936