### PR TITLE
ci: run only 10% (5 times) of test runs for long tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2329,13 +2329,11 @@ class TestSuite:
                 _ = x
                 return True
 
-        self.all_tests: List[str] = self.get_tests_list(
-            self.tests_in_suite_key_func, filter_func
-        )
+        all_tests = list(self.get_selected_tests(filter_func))
 
         all_tags_and_random_settings_limits = (
             self.read_test_tags_and_random_settings_limits(
-                self.suite_path, self.all_tests
+                self.suite_path, all_tests
             )
         )
         self.all_tags: Dict[str, Set[str]] = all_tags_and_random_settings_limits[0]
@@ -2344,6 +2342,10 @@ class TestSuite:
         )
         self.sequential_tests = []
         self.parallel_tests = []
+
+        self.all_tests = self.apply_test_runs(all_tests)
+        self.all_tests.sort(key=self.tests_in_suite_key_func)
+
         for test_name in self.all_tests:
             if self.is_sequential_test(test_name):
                 if not args.no_sequential:
@@ -2351,6 +2353,19 @@ class TestSuite:
             else:
                 if not args.no_parallel:
                     self.parallel_tests.append(test_name)
+
+    def apply_test_runs(self, all_tests):
+        test_runs = self.args.test_runs
+        long_test_runs = max(int(self.args.test_runs * self.args.long_test_runs_ratio), 1)
+
+        all_tests = map(lambda test: [test] * (long_test_runs if self.is_long_test(test) else test_runs), all_tests)
+        all_tests = [item for sublist in all_tests for item in sublist]
+        return all_tests
+
+    def is_long_test(self, test_name):
+        if test_name not in self.all_tags:
+            return False
+        return "long" in self.all_tags[test_name]
 
     def is_sequential_test(self, test_name):
         if args.sequential:
@@ -2365,16 +2380,6 @@ class TestSuite:
             or ("sequential" in self.all_tags[test_name])
             or ("stateful" in self.all_tags[test_name])
         )
-
-    def get_tests_list(self, sort_key, filter_func):
-        """
-        Return list of tests file names to run
-        """
-
-        all_tests = list(self.get_selected_tests(filter_func))
-        all_tests = all_tests * self.args.test_runs
-        all_tests.sort(key=sort_key)
-        return all_tests
 
     def get_selected_tests(self, filter_func):
         """
@@ -3530,6 +3535,13 @@ def parse_args():
         nargs="?",
         type=int,
         help="Run each test many times (useful for e.g. flaky check)",
+    )
+    parser.add_argument(
+        "--long-test-runs-ratio",
+        default=0.1,
+        nargs="?",
+        type=float,
+        help="Ratio from --test-runs for long tests",
     )
     parser.add_argument(
         "-U",


### PR DESCRIPTION
If it is a really long test (clickhouse-test define it as 180 seconds for execution), the with default flaky check of --test-runs 50, it will take 2.5 hours to excute, which is way too much, let's run them only 10% of retries.

Example: https://github.com/ClickHouse/ClickHouse/actions/runs/14397097786/job/40375284762?pr=79013

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)