### PR TITLE
Fix compatiblity value for max_merge_delayed_streams_for_parallel_write (MT)

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -714,7 +714,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         {
             /// Release closed. Please use 25.5
             {"refresh_parts_interval", 0, 0, "A new setting"},
-            {"max_merge_delayed_streams_for_parallel_write", 1000, 100, "New setting"},
+            {"max_merge_delayed_streams_for_parallel_write", 1000, 40, "New setting"},
             {"max_postpone_time_for_failed_replicated_fetches_ms", 1ULL * 60 * 1000, 1ULL * 60 * 1000, "Added new setting to enable postponing fetch tasks in the replication queue."},
             {"max_postpone_time_for_failed_replicated_merges_ms", 1ULL * 60 * 1000, 1ULL * 60 * 1000, "Added new setting to enable postponing merge tasks in the replication queue."},
             {"max_postpone_time_for_failed_replicated_tasks_ms", 5ULL * 60 * 1000, 5ULL * 60 * 1000, "Added new setting to enable postponing tasks in the replication queue."},


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)