### PR TITLE
Fix destruction order in `(Aggregating|Summing)SortedAlgorithm`

### DIFF
--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.h
@@ -86,6 +86,11 @@ public:
         ColumnsDefinition(ColumnsDefinition &&) noexcept; /// Is needed because destructor is defined.
         ~ColumnsDefinition(); /// Is needed because otherwise std::vector's destructor uses incomplete types.
 
+        /// Memory pool for SimpleAggregateFunction
+        /// (only when allocates_memory_in_arena == true).
+        std::unique_ptr<Arena> arena;
+        size_t arena_size = 0;
+
         /// Columns with which numbers should not be aggregated.
         ColumnNumbers column_numbers_not_to_aggregate;
         std::vector<AggregateDescription> columns_to_aggregate;
@@ -124,11 +129,6 @@ private:
 
     private:
         ColumnsDefinition & def;
-
-        /// Memory pool for SimpleAggregateFunction
-        /// (only when allocates_memory_in_arena == true).
-        std::unique_ptr<Arena> arena;
-        size_t arena_size = 0;
 
         bool is_group_started = false;
 

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.h
@@ -45,6 +45,11 @@ public:
         ColumnsDefinition(ColumnsDefinition &&) noexcept; /// Is needed because destructor is defined.
         ~ColumnsDefinition(); /// Is needed because otherwise std::vector's destructor uses incomplete types.
 
+        /// Memory pool for SimpleAggregateFunction
+        /// (only when allocates_memory_in_arena == true).
+        std::unique_ptr<Arena> arena;
+        size_t arena_size = 0;
+
         /// Columns with which values should not be aggregated.
         ColumnNumbers column_numbers_not_to_aggregate;
         /// Columns which should be aggregated.
@@ -81,11 +86,6 @@ public:
 
     private:
         ColumnsDefinition & def;
-
-        /// Memory pool for SimpleAggregateFunction
-        /// (only when allocates_memory_in_arena == true).
-        std::unique_ptr<Arena> arena;
-        size_t arena_size = 0;
 
         bool is_group_started = false;
 

--- a/tests/queries/0_stateless/00915_simple_aggregate_function_summing_merge_tree.reference
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function_summing_merge_tree.reference
@@ -1,0 +1,45 @@
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+9	9
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+9	9
+SimpleAggregateFunction(sum, Float64)
+0	0
+1	2
+2	4
+3	6
+4	8
+5	10
+6	12
+7	14
+8	16
+9	18
+0	0
+1	2
+2	4
+3	6
+4	8
+5	10
+6	12
+7	14
+8	16
+9	18
+1	1	2	2.2.2.2	3	([1,2,3],[2,1,1])	([1,2,3],[1,1,2])	([1,2,3],[2,1,2])	[1,2,2,3,4]	[4,2,1,3]	{1:[2,1,3],2:[6,5,4]}
+10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5	([2,3,4],[2,1,1])	([2,3,4],[3,3,4])	([2,3,4],[4,3,4])	[]	[]	{}
+SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))
+with_overflow	1	0

--- a/tests/queries/0_stateless/00915_simple_aggregate_function_summing_merge_tree.sql
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function_summing_merge_tree.sql
@@ -1,0 +1,61 @@
+set optimize_throw_if_noop = 1;
+
+-- basic test
+drop table if exists simple;
+
+create table simple (id UInt64,val SimpleAggregateFunction(sum,Double)) engine=SummingMergeTree order by id;
+insert into simple select number,number from system.numbers limit 10;
+
+select * from simple;
+select * from simple final order by id;
+select toTypeName(val) from simple limit 1;
+
+-- merge
+insert into simple select number,number from system.numbers limit 10;
+
+select * from simple final order by id;
+
+optimize table simple final;
+select * from simple;
+
+-- complex types
+drop table if exists simple;
+
+create table simple (
+    id UInt64,
+    nullable_str SimpleAggregateFunction(anyLast,Nullable(String)),
+    low_str SimpleAggregateFunction(anyLast,LowCardinality(Nullable(String))),
+    ip SimpleAggregateFunction(anyLast,IPv4),
+    status SimpleAggregateFunction(groupBitOr, UInt32),
+    tup SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64))),
+    tup_min SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64))),
+    tup_max SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64))),
+    arr SimpleAggregateFunction(groupArrayArray, Array(Int32)),
+    uniq_arr SimpleAggregateFunction(groupUniqArrayArray, Array(Int32)),
+    map_uniq_arr SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))
+) engine=SummingMergeTree order by id;
+insert into simple values(1,'1','1','1.1.1.1', 1, ([1,2], [1,1]), ([1,2], [1,1]), ([1,2], [1,1]), [1,2], [1,2], {1: [1,2], 2: [5,6]});
+insert into simple values(1,null,'2','2.2.2.2', 2, ([1,3], [1,1]), ([1,3], [2,2]), ([1,3], [2,2]), [2,3,4], [2,3,4], {1: [2,3], 2: [4,5,6]});
+-- String longer then MAX_SMALL_STRING_SIZE (actual string length is 100)
+insert into simple values(10,'10','10','10.10.10.10', 4, ([2,3], [1,1]), ([2,3], [3,3]), ([2,3], [3,3]), [], [], {});
+insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20', 1, ([2, 4], [1,1]), ([2, 4], [4,4]), ([2, 4], [4,4]), [], [], {});
+
+select * from simple final order by id;
+select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(tup_min), toTypeName(tup_max), toTypeName(arr), toTypeName(uniq_arr), toTypeName(map_uniq_arr) from simple limit 1;
+
+optimize table simple final;
+
+drop table simple;
+
+drop table if exists with_overflow;
+create table with_overflow (
+    id UInt64,
+    s SimpleAggregateFunction(sumWithOverflow, UInt8)
+) engine SummingMergeTree order by id;
+
+insert into with_overflow select 1, 1 from numbers(256);
+
+optimize table with_overflow final;
+
+select 'with_overflow', * from with_overflow;
+drop table with_overflow;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the destruction order of data members of `AggregatingSortedAlgorithm` and `SummingSortedAlgorithm`.


Closes: #77132