### PR TITLE
Fix read from Materialized View with Distributed destination table and different header in analyzer

### DIFF
--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -160,11 +160,11 @@ struct SelectQueryInfo
     StorageLimits local_storage_limits;
 
     /// This is a leak of abstraction.
-    /// StorageMerge replaces storage into query_tree. However, column types may be changed for inner table.
+    /// StorageMerge/StorageBuffer/StorageMaterializedView replace storage into query_tree. However, column types may be changed for inner table.
     /// So, resolved query tree might have incompatible types.
     /// StorageDistributed uses this query tree to calculate a header, throws if we use storage snapshot.
-    /// To avoid this, we use initial merge_storage_snapshot.
-    StorageSnapshotPtr merge_storage_snapshot;
+    /// To avoid this, we use initial_storage_snapshot.
+    StorageSnapshotPtr initial_storage_snapshot;
 
     /// Cluster for the query.
     ClusterPtr cluster;

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -373,7 +373,7 @@ void StorageBuffer::read(
                     }
                 }
 
-                src_table_query_info.merge_storage_snapshot = storage_snapshot;
+                src_table_query_info.initial_storage_snapshot = storage_snapshot;
                 destination->read(
                         query_plan, columns_intersection, destination_snapshot, src_table_query_info,
                         local_context, processed_stage, max_block_size, num_streams);

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -862,7 +862,7 @@ void StorageDistributed::read(
             remote_storage_id = StorageID{remote_database, remote_table};
 
         auto query_tree_distributed = buildQueryTreeDistributed(modified_query_info,
-            query_info.merge_storage_snapshot ? query_info.merge_storage_snapshot : storage_snapshot,
+            query_info.initial_storage_snapshot ? query_info.initial_storage_snapshot : storage_snapshot,
             remote_storage_id,
             remote_table_function_ptr);
         header = InterpreterSelectQueryAnalyzer::getSampleBlock(query_tree_distributed, local_context, SelectQueryOptions(processed_stage).analyze());

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -368,7 +368,9 @@ void StorageMaterializedView::read(
     if (!has_inner_table && !storage_id.empty() && getInMemoryMetadataPtr()->sql_security_type)
         context->checkAccess(AccessType::SELECT, storage_id, column_names);
 
-    storage->read(query_plan, column_names, target_storage_snapshot, query_info, context, processed_stage, max_block_size, num_streams);
+    auto src_table_query_info = query_info;
+    src_table_query_info.initial_storage_snapshot = storage_snapshot;
+    storage->read(query_plan, column_names, target_storage_snapshot, src_table_query_info, context, processed_stage, max_block_size, num_streams);
 
     if (query_plan.isInitialized())
     {

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -880,7 +880,7 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
 
     SelectQueryInfo modified_query_info = query_info;
 
-    modified_query_info.merge_storage_snapshot = merge_storage_snapshot;
+    modified_query_info.initial_storage_snapshot = merge_storage_snapshot;
 
     if (modified_query_info.planner_context)
         modified_query_info.planner_context = std::make_shared<PlannerContext>(modified_context, modified_query_info.planner_context);

--- a/tests/queries/0_stateless/03412_materialized_view_to_distributed_different_headers.sql
+++ b/tests/queries/0_stateless/03412_materialized_view_to_distributed_different_headers.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t0;
 DROP VIEW IF EXISTS v0;
 CREATE TABLE t1 (c0 Int,c1 Int) ENGINE = MergeTree() ORDER BY tuple();
-CREATE TABLE t0 (c0 Int,c1 Int) ENGINE = Distributed('test_shard_localhost', default, t1, c0);
+CREATE TABLE t0 (c0 Int,c1 Int) ENGINE = Distributed('test_shard_localhost', currentDatabase(), t1, c0);
 CREATE MATERIALIZED VIEW v0 TO t0 (c0 LowCardinality(Int),c1 LowCardinality(Int)) AS (SELECT 1 AS c0, 1 AS c1);
 SELECT c0::Int FROM v0;
 DROP VIEW v0;

--- a/tests/queries/0_stateless/03412_materialized_view_to_distributed_different_headers.sql
+++ b/tests/queries/0_stateless/03412_materialized_view_to_distributed_different_headers.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t0;
+DROP VIEW IF EXISTS v0;
+CREATE TABLE t1 (c0 Int,c1 Int) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE t0 (c0 Int,c1 Int) ENGINE = Distributed('test_shard_localhost', default, t1, c0);
+CREATE MATERIALIZED VIEW v0 TO t0 (c0 LowCardinality(Int),c1 LowCardinality(Int)) AS (SELECT 1 AS c0, 1 AS c1);
+SELECT c0::Int FROM v0;
+DROP VIEW v0;
+DROP TABLE t0;
+DROP TABLE t1;
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix read from Materialized View with Distributed destination table and different header in analyzer.

Closes https://github.com/ClickHouse/ClickHouse/issues/78689

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
