### PR TITLE
Fix test test_backup_restore_on_cluster/test_concurrency.py::test_concurrent_backups_on_same_node

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -121,10 +121,12 @@ def test_concurrent_backups_on_same_node():
 
     ids_list = "[" + ", ".join([f"'{id}'" for id in ids]) + "]"
 
+    # Wait until all the concurrent BACKUP commands have finished.
     assert_eq_with_retry(
         node0,
         f"SELECT status FROM system.backups WHERE status == 'CREATING_BACKUP' AND id IN {ids_list}",
         "",
+        retry_count=100,
     )
 
     assert node0.query(
@@ -154,11 +156,13 @@ def test_concurrent_backups_on_different_nodes():
         )
         ids.append(id)
 
+    # Wait until all the concurrent BACKUP commands have finished.
     for i in range(num_concurrent_backups):
         assert_eq_with_retry(
             nodes[i],
             f"SELECT status FROM system.backups WHERE status == 'CREATING_BACKUP' AND id = '{ids[i]}'",
             "",
+            retry_count=100,
         )
 
     for i in range(num_concurrent_backups):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix test `test_backup_restore_on_cluster/test_concurrency.py::test_concurrent_backups_on_same_node`.

Example of failure ([see](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=78910&sha=1d39efb2a7cc792fb440f24786b4de27c09fe7d3&name_0=PR&name_1=Integration%20tests%20%28tsan%2C%202%2F6%29)):

```
>       assert_eq_with_retry(
            node0,
            f"SELECT status FROM system.backups WHERE status == 'CREATING_BACKUP' AND id IN {ids_list}",
            "",
        )

...

E               AssertionError: '' != 'CREATING_BACKUP
E               CREATING_BACKUP
E               CREATING_BACKUP
E               CREATING_BACKUP'
E               @@ -0,0 +1,4 @@
E               +CREATING_BACKUP
E               +CREATING_BACKUP
E               +CREATING_BACKUP
E               +CREATING_BACKUP
```