### PR TITLE
Fix test test_backup_restore_on_cluster/test_cancel_backup.py::test_long_disconnection_stops_backup

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -644,6 +644,7 @@ def test_long_disconnection_stops_backup():
             "CANNOT_READ_ALL_DATA",
             "NETWORK_ERROR",
             "TABLE_IS_READ_ONLY",
+            "NO_REPLICA_HAS_PART",
         ]
         no_trash_checker.check_zookeeper = False
 
@@ -720,6 +721,7 @@ def test_short_disconnection_doesnt_stop_backup():
             "CANNOT_READ_ALL_DATA",
             "NETWORK_ERROR",
             "TABLE_IS_READ_ONLY",
+            "NO_REPLICA_HAS_PART",
         ]
 
 
@@ -772,4 +774,5 @@ def test_short_disconnection_doesnt_stop_restore():
             "CANNOT_READ_ALL_DATA",
             "NETWORK_ERROR",
             "TABLE_IS_READ_ONLY",
+            "NO_REPLICA_HAS_PART",
         ]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix test `test_backup_restore_on_cluster/test_cancel_backup.py::test_long_disconnection_stops_backup`.

Example of failure ([see](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=78141&sha=8f1bee8da6e817e14ba58addd21cd9e309375219&name_0=PR&name_1=Integration%20tests%20%28aarch64%2C%203%2F4%29)):

```
>               assert (error in self.expect_errors) or (error in self.allow_errors)
E               AssertionError: assert ('NO_REPLICA_HAS_PART' in [] or 'NO_REPLICA_HAS_PART' in ['FAILED_TO_SYNC_BACKUP_OR_RESTORE', 'KEEPER_EXCEPTION', 'SOCKET_TIMEOUT', 'CANNOT_READ_ALL_DATA', 'NETWORK_ERROR', 'TABLE_IS_READ_ONLY'])
E                +  where [] = <test_backup_restore_on_cluster.test_cancel_backup.NoTrashChecker object at 0xffc69d4a5f60>.expect_errors
E                +  and   ['FAILED_TO_SYNC_BACKUP_OR_RESTORE', 'KEEPER_EXCEPTION', 'SOCKET_TIMEOUT', 'CANNOT_READ_ALL_DATA', 'NETWORK_ERROR', 'TABLE_IS_READ_ONLY'] = <test_backup_restore_on_cluster.test_cancel_backup.NoTrashChecker object at 0xffc69d4a5f60>.allow_errors
```