### PR TITLE
Query Condition Cache: Refactor and fixups

### DIFF
--- a/docs/en/operations/system-tables/query_condition_cache.md
+++ b/docs/en/operations/system-tables/query_condition_cache.md
@@ -18,7 +18,7 @@ Columns:
 - `table_uuid` ([String](../../sql-reference/data-types/string.md)) — The table UUID.
 - `part_name` ([String](../../sql-reference/data-types/string.md)) — The part name.
 - `condition` ([String](/sql-reference/data-types/string.md)) — The hashed filter condition. Only set if setting query_condition_cache_store_conditions_as_plaintext = true.
-- `condition_hash` ([String](/sql-reference/data-types/string.md)) — The hash of the filter condition.
+- `condition_hash` ([UInt64](/sql-reference/data-types/int-uint.md)) — The hash of the filter condition.
 - `entry_size` ([UInt64](../../sql-reference/data-types/int-uint.md)) — The size of the entry in bytes.
 - `matching_marks` ([String](../../sql-reference/data-types/string.md)) — Matching marks.
 

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -136,7 +136,7 @@ void ActionsDAG::Node::toTree(JSONBuilder::JSONMap & map) const
         map.add("Compiled", is_function_compiled);
 }
 
-size_t ActionsDAG::Node::getHash() const
+UInt64 ActionsDAG::Node::getHash() const
 {
     SipHash hash_state;
     updateHash(hash_state);

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -94,7 +94,7 @@ public:
         /// If result of this not is deterministic. Checks only this node, not a subtree.
         bool isDeterministic() const;
         void toTree(JSONBuilder::JSONMap & map) const;
-        size_t getHash() const;
+        UInt64 getHash() const;
         void updateHash(SipHash & hash_state) const;
     };
 

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -133,4 +133,16 @@ QueryConditionCache::Entry::Entry(size_t mark_count)
 {
 }
 
+QueryConditionCacheWriter::QueryConditionCacheWriter(
+    QueryConditionCachePtr query_condition_cache_)
+    : query_condition_cache(query_condition_cache_)
+{}
+
+void QueryConditionCacheWriter::write(
+    const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
+    const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark)
+{
+    query_condition_cache->write(table_id, part_name, condition_hash, condition, mark_ranges, marks_count, has_final_mark);
+}
+
 }

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -42,7 +42,7 @@ QueryConditionCache::QueryConditionCache(const String & cache_policy, size_t max
 }
 
 void QueryConditionCache::write(
-    const UUID & table_id, const String & part_name, size_t condition_hash, const String & condition,
+    const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
     const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark)
 {
     Key key = {table_id, part_name, condition_hash, condition};
@@ -74,7 +74,7 @@ void QueryConditionCache::write(
         toString(mark_ranges));
 }
 
-std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(const UUID & table_id, const String & part_name, size_t condition_hash)
+std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(const UUID & table_id, const String & part_name, UInt64 condition_hash)
 {
     Key key = {table_id, part_name, condition_hash, ""};
 

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -61,17 +61,16 @@ void QueryConditionCache::write(
     if (has_final_mark)
         entry->matching_marks[marks_count - 1] = false;
 
-    LOG_DEBUG(
+    LOG_TRACE(
         logger,
-        "{} entry for table_id: {}, part_name: {}, condition_hash: {}, condition: {}, marks_count: {}, has_final_mark: {}, ranges: {}",
+        "{} entry for table_id: {}, part_name: {}, condition_hash: {}, condition: {}, marks_count: {}, has_final_mark: {}",
         inserted ? "Inserted" : "Updated",
         table_id,
         part_name,
         condition_hash,
         condition,
         marks_count,
-        has_final_mark,
-        toString(mark_ranges));
+        has_final_mark);
 }
 
 std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(const UUID & table_id, const String & part_name, UInt64 condition_hash)
@@ -84,13 +83,12 @@ std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(cons
 
         std::shared_lock lock(entry->mutex);
 
-        LOG_DEBUG(
+        LOG_TRACE(
             logger,
-            "Read entry for table_uuid: {}, part: {}, condition_hash: {}, ranges: {}",
+            "Read entry for table_uuid: {}, part: {}, condition_hash: {}",
             table_id,
             part_name,
-            condition_hash,
-            toString(entry->matching_marks));
+            condition_hash);
 
         return {entry->matching_marks};
     }
@@ -98,7 +96,7 @@ std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(cons
     {
         ProfileEvents::increment(ProfileEvents::QueryConditionCacheMisses);
 
-        LOG_DEBUG(
+        LOG_TRACE(
             logger,
             "Could not find entry for table_uuid: {}, part: {}, condition_hash: {}",
             table_id,

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -13,6 +13,29 @@ namespace ProfileEvents
 namespace DB
 {
 
+bool QueryConditionCache::Key::operator==(const Key & other) const
+{
+    return table_id == other.table_id
+        && part_name == other.part_name
+        && condition_hash == other.condition_hash;
+}
+
+size_t QueryConditionCache::KeyHasher::operator()(const Key & key) const
+{
+    SipHash hash;
+    hash.update(key.table_id);
+    hash.update(key.part_name);
+    hash.update(key.condition_hash);
+    return hash.get64();
+}
+
+size_t QueryConditionCache::EntryWeight::operator()(const Entry & entry) const
+{
+    /// Estimate the memory size of `std::vector<bool>` (it uses bit-packing internally)
+    size_t memory = (entry.matching_marks.capacity() + 7) / 8; /// round up to bytes.
+    return memory + sizeof(decltype(entry.matching_marks));
+}
+
 QueryConditionCache::QueryConditionCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
     : cache(cache_policy, max_size_in_bytes, 0, size_ratio)
 {
@@ -107,31 +130,9 @@ size_t QueryConditionCache::maxSizeInBytes()
     return cache.maxSizeInBytes();
 }
 
-bool QueryConditionCache::Key::operator==(const Key & other) const
-{
-    return table_id == other.table_id
-        && part_name == other.part_name
-        && condition_hash == other.condition_hash;
-}
-
 QueryConditionCache::Entry::Entry(size_t mark_count)
     : matching_marks(mark_count, true) /// by default, all marks potentially are potential matches, i.e. we can't skip them
 {
 }
 
-size_t QueryConditionCache::KeyHasher::operator()(const Key & key) const
-{
-    SipHash hash;
-    hash.update(key.table_id);
-    hash.update(key.part_name);
-    hash.update(key.condition_hash);
-    return hash.get64();
-}
-
-size_t QueryConditionCache::QueryConditionCacheEntryWeight::operator()(const Entry & entry) const
-{
-    /// Estimate the memory size of `std::vector<bool>` (it uses bit-packing internally)
-    size_t memory = (entry.matching_marks.capacity() + 7) / 8; /// round up to bytes.
-    return memory + sizeof(decltype(entry.matching_marks));
-}
 }

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -33,7 +33,7 @@ private:
     {
         const UUID table_id;
         const String part_name;
-        const size_t condition_hash;
+        const UInt64 condition_hash;
 
         /// -- Additional members, conceptually not part of the key. Only included for pretty-printing
         ///    in system.query_condition_cache:
@@ -78,11 +78,11 @@ public:
 
     /// Add an entry to the cache. The passed marks represent ranges of the column with matches of the predicate.
     void write(
-        const UUID & table_id, const String & part_name, size_t condition_hash, const String & condition,
+        const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
         const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
 
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.
-    std::optional<MatchingMarks> read(const UUID & table_id, const String & part_name, size_t condition_hash);
+    std::optional<MatchingMarks> read(const UUID & table_id, const String & part_name, UInt64 condition_hash);
 
     /// For debugging and system tables
     std::vector<QueryConditionCache::Cache::KeyMapped> dump() const;

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -2,7 +2,8 @@
 
 #include <Common/CacheBase.h>
 #include <Storages/MergeTree/MarkRange.h>
-#include <shared_mutex>
+#include <memory>
+#include <mutex>
 
 namespace DB
 {
@@ -22,11 +23,6 @@ namespace DB
 ///     000001111111110000000000000
 class QueryConditionCache
 {
-public:
-    /// False means none of the rows in the mark match the predicate. We can skip such marks.
-    /// True means at least one row in the mark matches the predicate. We need to read such marks.
-    using MatchingMarks = std::vector<bool>;
-
 private:
     /// Key + entry represent a mark range result.
     struct Key
@@ -42,23 +38,13 @@ private:
         bool operator==(const Key & other) const;
     };
 
+    /// False means none of the rows in the mark match the predicate. We can skip such marks.
+    /// True means at least one row in the mark matches the predicate. We need to read such marks.
+    using MatchingMarks = std::vector<bool>;
+
     struct Entry
     {
         MatchingMarks matching_marks;
-        std::shared_mutex mutex; /// (*)
-
-        explicit Entry(size_t mark_count); /// (**)
-
-        /// (*) You might wonder why Entry has its own mutex considering that CacheBase locks internally already.
-        ///     The reason is that ClickHouse scans ranges within the same part in parallel. The first scan creates
-        ///     and inserts a new Key + Entry into the cache, the 2nd ... Nth scan find the existing Key and update
-        ///     its Entry for the new ranges. This can only be done safely in a synchronized fashion.
-
-        /// (**) About error handling: There could be an exception after the i-th scan and cache entries could
-        ///     (theoretically) be left in a corrupt state. If we are not careful, future scans queries could then
-        ///     skip too many ranges. To prevent this, it is important to initialize all marks of each entry as
-        ///     non-matching. In case of an exception, future scans will then not skip them.
-
     };
 
     struct KeyHasher
@@ -71,13 +57,14 @@ private:
         size_t operator()(const Entry & entry) const;
     };
 
-public:
     using Cache = CacheBase<Key, Entry, KeyHasher, EntryWeight>;
+    using EntryPtr = Cache::MappedPtr;
 
+public:
     QueryConditionCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.
-    std::optional<MatchingMarks> read(const UUID & table_id, const String & part_name, UInt64 condition_hash);
+    EntryPtr read(const UUID & table_id, const String & part_name, UInt64 condition_hash);
 
     /// For debugging and system tables
     std::vector<QueryConditionCache::Cache::KeyMapped> dump() const;
@@ -88,9 +75,7 @@ public:
     size_t maxSizeInBytes();
 
 private:
-    void write(
-        const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
-        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
+    void write(const Key & key, const MatchingMarks & matching_marks);
 
     Cache cache;
     LoggerPtr logger = getLogger("QueryConditionCache");
@@ -104,15 +89,26 @@ using QueryConditionCachePtr = std::shared_ptr<QueryConditionCache>;
 class QueryConditionCacheWriter
 {
 public:
-    explicit QueryConditionCacheWriter(QueryConditionCachePtr query_condition_cache_);
+    QueryConditionCacheWriter(
+        QueryConditionCachePtr query_condition_cache_,
+        UInt64 condition_hash_,
+        const String & condition_);
 
-    /// Add an entry to the cache. The passed marks represent ranges of the column with matches of the predicate.
-    void write(
-        const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
-        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
+    ~QueryConditionCacheWriter();
+
+    void write(const UUID & table_id, const String & part_name, const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
 
 private:
-    QueryConditionCachePtr query_condition_cache;
+    const QueryConditionCachePtr query_condition_cache;
+    const UInt64 condition_hash;
+    const String condition;
+
+    std::mutex mutex;
+    std::unordered_map<QueryConditionCache::Key, QueryConditionCache::MatchingMarks, QueryConditionCache::KeyHasher> buffer TSA_GUARDED_BY(mutex);
+
+    LoggerPtr logger = getLogger("QueryConditionCache");
 };
+
+using QueryConditionCacheWriterPtr = std::shared_ptr<QueryConditionCacheWriter>;
 
 }

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -66,13 +66,13 @@ private:
         size_t operator()(const Key & key) const;
     };
 
-    struct QueryConditionCacheEntryWeight
+    struct EntryWeight
     {
         size_t operator()(const Entry & entry) const;
     };
 
 public:
-    using Cache = CacheBase<Key, Entry, KeyHasher, QueryConditionCacheEntryWeight>;
+    using Cache = CacheBase<Key, Entry, KeyHasher, EntryWeight>;
 
     QueryConditionCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -76,11 +76,6 @@ public:
 
     QueryConditionCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 
-    /// Add an entry to the cache. The passed marks represent ranges of the column with matches of the predicate.
-    void write(
-        const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
-        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
-
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.
     std::optional<MatchingMarks> read(const UUID & table_id, const String & part_name, UInt64 condition_hash);
 
@@ -93,12 +88,31 @@ public:
     size_t maxSizeInBytes();
 
 private:
+    void write(
+        const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
+        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
+
     Cache cache;
     LoggerPtr logger = getLogger("QueryConditionCache");
 
+    friend class QueryConditionCacheWriter;
     friend class StorageSystemQueryConditionCache;
 };
 
 using QueryConditionCachePtr = std::shared_ptr<QueryConditionCache>;
+
+class QueryConditionCacheWriter
+{
+public:
+    explicit QueryConditionCacheWriter(QueryConditionCachePtr query_condition_cache_);
+
+    /// Add an entry to the cache. The passed marks represent ranges of the column with matches of the predicate.
+    void write(
+        const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
+        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
+
+private:
+    QueryConditionCachePtr query_condition_cache;
+};
 
 }

--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -318,7 +318,7 @@ size_t QueryResultCache::KeyHasher::operator()(const Key & key) const
     return key.ast_hash.low64;
 }
 
-size_t QueryResultCache::QueryResultCacheEntryWeight::operator()(const Entry & entry) const
+size_t QueryResultCache::EntryWeight::operator()(const Entry & entry) const
 {
     size_t res = 0;
     for (const auto & chunk : entry.chunks)
@@ -509,7 +509,7 @@ void QueryResultCacheWriter::finalizeWrite()
         return res;
     };
 
-    size_t new_entry_size_in_bytes = QueryResultCache::QueryResultCacheEntryWeight()(*query_result);
+    size_t new_entry_size_in_bytes = QueryResultCache::EntryWeight()(*query_result);
     size_t new_entry_size_in_rows = count_rows_in_chunks(*query_result);
 
     if ((new_entry_size_in_bytes > max_entry_size_in_bytes) || (new_entry_size_in_rows > max_entry_size_in_rows))
@@ -638,7 +638,7 @@ std::unique_ptr<SourceFromChunks> QueryResultCacheReader::getSourceExtremes()
 }
 
 QueryResultCache::QueryResultCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_)
-    : cache(std::make_unique<TTLCachePolicy<Key, Entry, KeyHasher, QueryResultCacheEntryWeight, IsStale>>(
+    : cache(std::make_unique<TTLCachePolicy<Key, Entry, KeyHasher, EntryWeight, IsStale>>(
           std::make_unique<PerUserTTLCachePolicyUserQuota>()))
 {
     updateConfiguration(max_size_in_bytes, max_entries, max_entry_size_in_bytes_, max_entry_size_in_rows_);

--- a/src/Interpreters/Cache/QueryResultCache.h
+++ b/src/Interpreters/Cache/QueryResultCache.h
@@ -129,7 +129,7 @@ private:
         size_t operator()(const Key & key) const;
     };
 
-    struct QueryResultCacheEntryWeight
+    struct EntryWeight
     {
         size_t operator()(const Entry & entry) const;
     };
@@ -141,7 +141,7 @@ private:
 
 public:
     /// query --> query result
-    using Cache = CacheBase<Key, Entry, KeyHasher, QueryResultCacheEntryWeight>;
+    using Cache = CacheBase<Key, Entry, KeyHasher, EntryWeight>;
 
     QueryResultCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
 

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -248,7 +248,7 @@ void FilterStep::updateOutputHeader()
         return;
 }
 
-void FilterStep::setConditionForQueryConditionCache(size_t condition_hash_, const String & condition_)
+void FilterStep::setConditionForQueryConditionCache(UInt64 condition_hash_, const String & condition_)
 {
     condition = {condition_hash_, condition_};
 }

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -173,7 +173,7 @@ void FilterStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQ
     pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type)
     {
         bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
-        return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals, nullptr, condition);
+        return std::make_shared<FilterTransform>(header, expression, filter_column_name, remove_filter_column, on_totals, nullptr, query_condition_cache_writer);
     });
 
     if (!blocksHaveEqualStructure(pipeline.getHeader(), *output_header))
@@ -248,9 +248,9 @@ void FilterStep::updateOutputHeader()
         return;
 }
 
-void FilterStep::setConditionForQueryConditionCache(UInt64 condition_hash_, const String & condition_)
+void FilterStep::setQueryConditionCacheWriter(QueryConditionCacheWriterPtr query_condition_cache_writer_)
 {
-    condition = {condition_hash_, condition_};
+    query_condition_cache_writer = query_condition_cache_writer_;
 }
 
 bool FilterStep::canUseType(const DataTypePtr & filter_type)

--- a/src/Processors/QueryPlan/FilterStep.h
+++ b/src/Processors/QueryPlan/FilterStep.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Processors/QueryPlan/ITransformingStep.h>
 #include <Interpreters/ActionsDAG.h>
+#include <Interpreters/Cache/QueryConditionCache.h>
 
 namespace DB
 {
@@ -26,7 +27,7 @@ public:
     const String & getFilterColumnName() const { return filter_column_name; }
     bool removesFilterColumn() const { return remove_filter_column; }
 
-    void setConditionForQueryConditionCache(UInt64 condition_hash_, const String & condition_);
+    void setQueryConditionCacheWriter(QueryConditionCacheWriterPtr query_condition_cache_writer_);
 
     static bool canUseType(const DataTypePtr & type);
 
@@ -42,7 +43,7 @@ private:
     String filter_column_name;
     bool remove_filter_column;
 
-    std::optional<std::pair<UInt64, String>> condition; /// for query condition cache
+    QueryConditionCacheWriterPtr query_condition_cache_writer;
 };
 
 }

--- a/src/Processors/QueryPlan/FilterStep.h
+++ b/src/Processors/QueryPlan/FilterStep.h
@@ -26,7 +26,7 @@ public:
     const String & getFilterColumnName() const { return filter_column_name; }
     bool removesFilterColumn() const { return remove_filter_column; }
 
-    void setConditionForQueryConditionCache(size_t condition_hash_, const String & condition_);
+    void setConditionForQueryConditionCache(UInt64 condition_hash_, const String & condition_);
 
     static bool canUseType(const DataTypePtr & type);
 
@@ -42,7 +42,7 @@ private:
     String filter_column_name;
     bool remove_filter_column;
 
-    std::optional<std::pair<size_t, String>> condition; /// for query condition cache
+    std::optional<std::pair<UInt64, String>> condition; /// for query condition cache
 };
 
 }

--- a/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
+++ b/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
@@ -52,7 +52,7 @@ void updateQueryConditionCache(const Stack & stack, const QueryPlanOptimizationS
     {
         if (auto * filter_step = typeid_cast<FilterStep *>(iter->node->step.get()))
         {
-            size_t condition_hash = filter_actions_dag->getOutputs()[0]->getHash();
+            UInt64 condition_hash = filter_actions_dag->getOutputs()[0]->getHash();
 
             String condition;
             if (optimization_settings.query_condition_cache_store_conditions_as_plaintext)

--- a/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
+++ b/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
@@ -40,7 +40,7 @@ void updateQueryConditionCache(const Stack & stack, const QueryPlanOptimizationS
     const auto & outputs = filter_actions_dag->getOutputs();
 
     /// Restrict to the case that ActionsDAG has a single output. This isn't technically necessary but de-risks the
-    /// implementatino a lot while not losing much usefulness.
+    /// implementation a lot while not losing much usefulness.
     if (outputs.size() != 1)
         return;
 

--- a/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
+++ b/src/Processors/QueryPlan/Optimizations/updateQueryConditionCache.cpp
@@ -2,6 +2,7 @@
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Storages/VirtualColumnUtils.h>
+#include <Interpreters/Cache/QueryConditionCache.h>
 
 namespace DB::QueryPlanOptimizations
 {
@@ -61,7 +62,10 @@ void updateQueryConditionCache(const Stack & stack, const QueryPlanOptimizationS
                 condition = outputs_names[0];
             }
 
-            filter_step->setConditionForQueryConditionCache(condition_hash, condition);
+            auto query_condition_cache = Context::getGlobalContextInstance()->getQueryConditionCache();
+            auto query_condition_cache_writer = std::make_shared<QueryConditionCacheWriter>(query_condition_cache, condition_hash, condition);
+            filter_step->setQueryConditionCacheWriter(query_condition_cache_writer);
+
             return;
         }
     }

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -67,7 +67,7 @@ FilterTransform::FilterTransform(
     bool remove_filter_column_,
     bool on_totals_,
     std::shared_ptr<std::atomic<size_t>> rows_filtered_,
-    std::optional<std::pair<size_t, String>> condition_)
+    std::optional<std::pair<UInt64, String>> condition_)
     : ISimpleTransform(
             header_,
             transformHeader(header_, expression_ ? &expression_->getActionsDAG() : nullptr, filter_column_name_, remove_filter_column_),

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -67,7 +67,7 @@ FilterTransform::FilterTransform(
     bool remove_filter_column_,
     bool on_totals_,
     std::shared_ptr<std::atomic<size_t>> rows_filtered_,
-    std::optional<std::pair<UInt64, String>> condition_)
+    QueryConditionCacheWriterPtr query_condition_cache_writer_)
     : ISimpleTransform(
             header_,
             transformHeader(header_, expression_ ? &expression_->getActionsDAG() : nullptr, filter_column_name_, remove_filter_column_),
@@ -77,7 +77,7 @@ FilterTransform::FilterTransform(
     , remove_filter_column(remove_filter_column_)
     , on_totals(on_totals_)
     , rows_filtered(rows_filtered_)
-    , condition(condition_)
+    , query_condition_cache_writer(query_condition_cache_writer_)
 {
     transformed_header = getInputPort().getHeader();
     if (expression)
@@ -87,9 +87,6 @@ FilterTransform::FilterTransform(
     auto & column = transformed_header.getByPosition(filter_column_position).column;
     if (column)
         constant_filter_description = ConstantFilterDescription(*column);
-
-    if (condition.has_value())
-        query_condition_cache = Context::getGlobalContextInstance()->getQueryConditionCache();
 }
 
 IProcessor::Status FilterTransform::prepare()
@@ -257,7 +254,7 @@ void FilterTransform::doTransform(Chunk & chunk)
 
 void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mark_ranges_info)
 {
-    if (!query_condition_cache)
+    if (!query_condition_cache_writer)
         return;
 
     if (!mark_ranges_info)
@@ -267,12 +264,9 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
         if (!buffered_mark_ranges_info)
             return;
 
-        QueryConditionCacheWriter writer(query_condition_cache);
-        writer.write(
+        query_condition_cache_writer->write(
             buffered_mark_ranges_info->table_uuid,
             buffered_mark_ranges_info->part_name,
-            condition->first,
-            condition->second,
             buffered_mark_ranges_info->mark_ranges,
             buffered_mark_ranges_info->marks_count,
             buffered_mark_ranges_info->has_final_mark);
@@ -293,12 +287,9 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
 
         if (buffered_mark_ranges_info->table_uuid != mark_ranges_info->table_uuid || buffered_mark_ranges_info->part_name != mark_ranges_info->part_name)
         {
-            QueryConditionCacheWriter writer(query_condition_cache);
-            writer.write(
+            query_condition_cache_writer->write(
                 buffered_mark_ranges_info->table_uuid,
                 buffered_mark_ranges_info->part_name,
-                condition->first,
-                condition->second,
                 buffered_mark_ranges_info->mark_ranges,
                 buffered_mark_ranges_info->marks_count,
                 buffered_mark_ranges_info->has_final_mark);

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -267,7 +267,8 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
         if (!buffered_mark_ranges_info)
             return;
 
-        query_condition_cache->write(
+        QueryConditionCacheWriter writer(query_condition_cache);
+        writer.write(
             buffered_mark_ranges_info->table_uuid,
             buffered_mark_ranges_info->part_name,
             condition->first,
@@ -292,7 +293,8 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
 
         if (buffered_mark_ranges_info->table_uuid != mark_ranges_info->table_uuid || buffered_mark_ranges_info->part_name != mark_ranges_info->part_name)
         {
-            query_condition_cache->write(
+            QueryConditionCacheWriter writer(query_condition_cache);
+            writer.write(
                 buffered_mark_ranges_info->table_uuid,
                 buffered_mark_ranges_info->part_name,
                 condition->first,

--- a/src/Processors/Transforms/FilterTransform.h
+++ b/src/Processors/Transforms/FilterTransform.h
@@ -23,7 +23,7 @@ public:
     FilterTransform(
         const Block & header_, ExpressionActionsPtr expression_, String filter_column_name_,
         bool remove_filter_column_, bool on_totals_ = false, std::shared_ptr<std::atomic<size_t>> rows_filtered_ = nullptr,
-        std::optional<std::pair<size_t, String>> condition_ = std::nullopt);
+        std::optional<std::pair<UInt64, String>> condition_ = std::nullopt);
 
     static Block
     transformHeader(const Block & header, const ActionsDAG * expression, const String & filter_column_name, bool remove_filter_column);
@@ -48,7 +48,7 @@ private:
     std::shared_ptr<std::atomic<size_t>> rows_filtered;
 
     /// If set, we need to update the query condition cache at runtime for every processed chunk
-    std::optional<std::pair<size_t, String>> condition;
+    std::optional<std::pair<UInt64, String>> condition;
 
     std::shared_ptr<QueryConditionCache> query_condition_cache;
 

--- a/src/Processors/Transforms/FilterTransform.h
+++ b/src/Processors/Transforms/FilterTransform.h
@@ -1,6 +1,8 @@
 #pragma once
-#include <Processors/ISimpleTransform.h>
+
 #include <Columns/FilterDescription.h>
+#include <Interpreters/Cache/QueryConditionCache.h>
+#include <Processors/ISimpleTransform.h>
 #include <Storages/MergeTree/MarkRange.h>
 
 namespace DB
@@ -23,7 +25,7 @@ public:
     FilterTransform(
         const Block & header_, ExpressionActionsPtr expression_, String filter_column_name_,
         bool remove_filter_column_, bool on_totals_ = false, std::shared_ptr<std::atomic<size_t>> rows_filtered_ = nullptr,
-        std::optional<std::pair<UInt64, String>> condition_ = std::nullopt);
+        QueryConditionCacheWriterPtr query_condition_cache_writer_ = nullptr);
 
     static Block
     transformHeader(const Block & header, const ActionsDAG * expression, const String & filter_column_name, bool remove_filter_column);
@@ -47,10 +49,7 @@ private:
 
     std::shared_ptr<std::atomic<size_t>> rows_filtered;
 
-    /// If set, we need to update the query condition cache at runtime for every processed chunk
-    std::optional<std::pair<UInt64, String>> condition;
-
-    std::shared_ptr<QueryConditionCache> query_condition_cache;
+    QueryConditionCacheWriterPtr query_condition_cache_writer;
 
     MarkRangesInfoPtr buffered_mark_ranges_info; /// Buffers mark info for chunks from the same table and part.
                                                  /// The goal is to write less often into the query condition cache (reduce lock contention).

--- a/src/Storages/MergeTree/MarkRange.cpp
+++ b/src/Storages/MergeTree/MarkRange.cpp
@@ -130,6 +130,7 @@ MarkRangesInfo::MarkRangesInfo(UUID table_uuid_, const String & part_name_, size
     , has_final_mark(has_final_mark_)
     , mark_ranges(mark_ranges_)
 {}
+
 void MarkRangesInfo::appendMarkRanges(const MarkRanges & mark_ranges_)
 {
     mark_ranges.insert(mark_ranges.end(), mark_ranges_.begin(), mark_ranges_.end());

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -915,7 +915,7 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 
     auto drop_mark_ranges =[&](const ActionsDAG::Node * dag)
     {
-        size_t condition_hash = dag->getHash();
+        UInt64 condition_hash = dag->getHash();
         Stats stats;
         for (auto it = parts_with_ranges.begin(); it != parts_with_ranges.end();)
         {

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -924,14 +924,14 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 
             const auto & data_part = part_with_ranges.data_part;
             auto storage_id = data_part->storage.getStorageID();
-            auto matching_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, condition_hash);
-            if (!matching_marks_opt)
+            auto entry = query_condition_cache->read(storage_id.uuid, data_part->name, condition_hash);
+            if (!entry)
             {
                 ++it;
                 continue;
             }
 
-            auto & matching_marks = *matching_marks_opt;
+            auto & matching_marks = entry->matching_marks;
             MarkRanges ranges;
             for (const auto & mark_range : part_with_ranges.ranges)
             {

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -187,7 +187,8 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                             auto query_condition_cache = Context::getGlobalContextInstance()->getQueryConditionCache();
                             auto data_part = task->getInfo().data_part;
 
-                            query_condition_cache->write(
+                            QueryConditionCacheWriter writer(query_condition_cache);
+                            writer.write(
                                 data_part->storage.getStorageID().uuid,
                                 data_part->name,
                                 output->getHash(),

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -7,6 +7,8 @@
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/RequestResponse.h>
 
+#include <Interpreters/Cache/QueryConditionCache.h>
+
 #include <Processors/Chunk.h>
 
 #include <boost/core/noncopyable.hpp>
@@ -116,6 +118,8 @@ private:
     MergeTreeReadTaskPtr task;
     /// A result of getHeader(). A chunk which this header is returned from read().
     Block result_header;
+
+    QueryConditionCacheWriterPtr query_condition_cache_writer;
 
     ReadStepsPerformanceCounters read_steps_performance_counters;
 

--- a/src/Storages/System/StorageSystemQueryConditionCache.cpp
+++ b/src/Storages/System/StorageSystemQueryConditionCache.cpp
@@ -51,7 +51,7 @@ void StorageSystemQueryConditionCache::fillData(MutableColumns & res_columns, Co
         res_columns[1]->insert(key.part_name);
         res_columns[2]->insert(key.condition);
         res_columns[3]->insert(key.condition_hash);
-        res_columns[4]->insert(QueryConditionCache::QueryConditionCacheEntryWeight()(*entry));
+        res_columns[4]->insert(QueryConditionCache::EntryWeight()(*entry));
 
         std::shared_lock lock(entry->mutex);
         res_columns[5]->insert(to_string(entry->matching_marks));

--- a/src/Storages/System/StorageSystemQueryConditionCache.cpp
+++ b/src/Storages/System/StorageSystemQueryConditionCache.cpp
@@ -52,8 +52,6 @@ void StorageSystemQueryConditionCache::fillData(MutableColumns & res_columns, Co
         res_columns[2]->insert(key.condition);
         res_columns[3]->insert(key.condition_hash);
         res_columns[4]->insert(QueryConditionCache::EntryWeight()(*entry));
-
-        std::shared_lock lock(entry->mutex);
         res_columns[5]->insert(to_string(entry->matching_marks));
     }
 }

--- a/src/Storages/System/StorageSystemQueryResultCache.cpp
+++ b/src/Storages/System/StorageSystemQueryResultCache.cpp
@@ -54,7 +54,7 @@ void StorageSystemQueryResultCache::fillData(MutableColumns & res_columns, Conte
 
         res_columns[0]->insert(key.query_string); /// approximates the original query string
         res_columns[1]->insert(key.query_id);
-        res_columns[2]->insert(QueryResultCache::QueryResultCacheEntryWeight()(*query_result));
+        res_columns[2]->insert(QueryResultCache::EntryWeight()(*query_result));
         res_columns[3]->insert(key.tag);
         res_columns[4]->insert(key.expires_at < std::chrono::system_clock::now());
         res_columns[5]->insert(key.is_shared);


### PR DESCRIPTION
A slightly tidier version of #79011. Kudos to @zhongyuankai 

Reviewer note: Please go through the commits. All of them are trivial except https://github.com/ClickHouse/ClickHouse/pull/79088/commits/03c5f441f26d2148c094c3230951f0f7a53c1179 This commit introduces QueryConditionCacheWriter which buffers inserts before they are eventually written into the QCC. The main point of this is that the actual cache entries now become immutable. This is less error-prone and reduces the space consumption per entry (we no longer need per-entry mutex).

EDIT: Let me assign myself as reviewer as this PR is a continuation of @zhongyuankai 's PR.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)