### PR TITLE
Fix setting query plan step for join transforms in some places

### DIFF
--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -121,6 +121,7 @@ public:
     /// If collector is used, it will collect only newly-added processors, but not processors from pipelines.
     /// Process right stream to fill JoinPtr and then process left pipeline using it
     static std::unique_ptr<QueryPipelineBuilder> joinPipelinesRightLeft(
+        IQueryPlanStep * step,
         std::unique_ptr<QueryPipelineBuilder> left,
         std::unique_ptr<QueryPipelineBuilder> right,
         JoinPtr join,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The issue right now is that some clearly join-related transforms (like `JoiningTransform`, for example) are linked to the `ExpressionStep` because it happens to be the last step of the right plan sub-tree.

