### PR TITLE
Add support for settings in postgresql storage engine

### DIFF
--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -521,7 +521,8 @@ void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory)
 
         if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, args.context))
         {
-            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, args.context, false);
+            PostgreSQLSettings postgresql_settings;
+            configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, postgresql_settings, args.context, false);
         }
         else
         {

--- a/src/Storages/PostgreSQL/PostgreSQLSettings.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLSettings.cpp
@@ -1,0 +1,111 @@
+#include <Core/BaseSettings.h>
+#include <Core/BaseSettingsFwdMacrosImpl.h>
+#include <Core/Settings.h>
+#include <Common/Exception.h>
+#include <Interpreters/Context.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Parsers/ASTFunction.h>
+#include <Storages/PostgreSQL/PostgreSQLSettings.h>
+#include <Common/NamedCollections/NamedCollections.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_SETTING;
+}
+
+#define LIST_OF_POSTGRESQL_SETTINGS(DECLARE, ALIAS) \
+    DECLARE(UInt64, connection_pool_size, 16, "Size of connection pool (if all connections are in use, the query will wait until some connection will be freed).", 0) \
+    DECLARE(UInt64, connection_max_tries, 3, "Number of retries for pool with failover", 0) \
+    DECLARE(UInt64, connection_wait_timeout, 5, "Timeout (in seconds) for waiting for free connection (in case of there is already connection_pool_size active connections), 0 - do not wait.", 0) \
+    DECLARE(Bool, connection_auto_close, true, "Auto-close connection after query execution, i.e. disable connection reuse.", 0)                                      \
+    DECLARE(UInt64, connect_timeout, DBMS_DEFAULT_CONNECT_TIMEOUT_SEC, "Connect timeout (in seconds)", 0) \
+    DECLARE(UInt64, read_write_timeout, DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, "Read/write timeout (in seconds)", 0)                                                       \
+
+DECLARE_SETTINGS_TRAITS(PostgreSQLSettingsTraits, LIST_OF_POSTGRESQL_SETTINGS)
+IMPLEMENT_SETTINGS_TRAITS(PostgreSQLSettingsTraits, LIST_OF_POSTGRESQL_SETTINGS)
+
+struct PostgreSQLSettingsImpl : public BaseSettings<PostgreSQLSettingsTraits>
+{
+};
+
+#define INITIALIZE_SETTING_EXTERN(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) PostgreSQLSettings##TYPE NAME = &PostgreSQLSettingsImpl ::NAME;
+
+namespace PostgreSQLSetting
+{
+LIST_OF_POSTGRESQL_SETTINGS(INITIALIZE_SETTING_EXTERN, SKIP_ALIAS)
+}
+
+#undef INITIALIZE_SETTING_EXTERN
+
+PostgreSQLSettings::PostgreSQLSettings() : impl(std::make_unique<PostgreSQLSettingsImpl>())
+{
+}
+
+PostgreSQLSettings::PostgreSQLSettings(const PostgreSQLSettings & settings) : impl(std::make_unique<PostgreSQLSettingsImpl>(*settings.impl))
+{
+}
+
+PostgreSQLSettings::PostgreSQLSettings(PostgreSQLSettings && settings) noexcept : impl(std::make_unique<PostgreSQLSettingsImpl>(std::move(*settings.impl)))
+{
+}
+
+PostgreSQLSettings::~PostgreSQLSettings() = default;
+
+POSTGRESQL_SETTINGS_SUPPORTED_TYPES(PostgreSQLSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)
+
+
+void PostgreSQLSettings::loadFromQuery(const ASTSetQuery & settings_def)
+{
+    impl->applyChanges(settings_def.changes);
+}
+
+void PostgreSQLSettings::loadFromQuery(ASTStorage & storage_def)
+{
+    if (storage_def.settings)
+    {
+        try
+        {
+            loadFromQuery(*storage_def.settings);
+        }
+        catch (Exception & e)
+        {
+            if (e.code() == ErrorCodes::UNKNOWN_SETTING)
+                e.addMessage("for storage " + storage_def.engine->name);
+            throw;
+        }
+    }
+    else
+    {
+        auto settings_ast = std::make_shared<ASTSetQuery>();
+        settings_ast->is_standalone = false;
+        storage_def.set(storage_def.settings, settings_ast);
+    }
+}
+
+std::vector<std::string_view> PostgreSQLSettings::getAllRegisteredNames() const
+{
+    std::vector<std::string_view> all_settings;
+    for (const auto & setting_field : impl->all())
+        all_settings.push_back(setting_field.getName());
+    return all_settings;
+}
+
+void PostgreSQLSettings::loadFromNamedCollection(const NamedCollection & named_collection)
+{
+    for (const auto & setting : impl->all())
+    {
+        const auto & setting_name = setting.getName();
+        if (named_collection.has(setting_name))
+            impl->set(setting_name, named_collection.get<String>(setting_name));
+    }
+}
+
+bool PostgreSQLSettings::hasBuiltin(std::string_view name)
+{
+    return PostgreSQLSettingsImpl::hasBuiltin(name);
+}
+}

--- a/src/Storages/PostgreSQL/PostgreSQLSettings.h
+++ b/src/Storages/PostgreSQL/PostgreSQLSettings.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <Core/BaseSettingsFwdMacros.h>
+#include <Core/SettingsEnums.h>
+#include <Core/SettingsFields.h>
+
+namespace Poco::Util
+{
+    class AbstractConfiguration;
+}
+
+
+namespace DB
+{
+class ASTStorage;
+class ASTSetQuery;
+class Context;
+using ContextPtr = std::shared_ptr<const Context>;
+class NamedCollection;
+struct PostgreSQLSettingsImpl;
+
+/// List of available types supported in PostgreSQLSettings object
+#define POSTGRESQL_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
+    M(CLASS_NAME, Bool) \
+    M(CLASS_NAME, UInt64)
+
+POSTGRESQL_SETTINGS_SUPPORTED_TYPES(PostgreSQLSettings, DECLARE_SETTING_TRAIT)
+
+
+/** Settings for the PostgreSQL family of engines.
+  */
+struct PostgreSQLSettings
+{
+    PostgreSQLSettings();
+    PostgreSQLSettings(const PostgreSQLSettings & settings);
+    PostgreSQLSettings(PostgreSQLSettings && settings) noexcept;
+    ~PostgreSQLSettings();
+
+    POSTGRESQL_SETTINGS_SUPPORTED_TYPES(PostgreSQLSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)
+
+    std::vector<std::string_view> getAllRegisteredNames() const;
+
+    void loadFromQuery(ASTStorage & storage_def);
+    void loadFromQuery(const ASTSetQuery & settings_def);
+    void loadFromNamedCollection(const NamedCollection & named_collection);
+
+    static bool hasBuiltin(std::string_view name);
+
+private:
+    std::unique_ptr<PostgreSQLSettingsImpl> impl;
+};
+
+
+}

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -588,7 +588,8 @@ void registerStorageMaterializedPostgreSQL(StorageFactory & factory)
         else
             metadata.primary_key = KeyDescription::getKeyFromAST(args.storage_def->order_by->ptr(), metadata.columns, args.getContext());
 
-        auto configuration = StoragePostgreSQL::getConfiguration(args.engine_args, args.getContext());
+        PostgreSQLSettings postgresql_settings;
+        auto configuration = StoragePostgreSQL::getConfiguration(args.engine_args, args.getContext(), postgresql_settings);
         auto connection_info = postgres::formatConnectionString(
             configuration.database,
             configuration.host,

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -39,6 +39,7 @@
 
 #include <Parsers/getInsertQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTCreateQuery.h>
 
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
@@ -51,6 +52,7 @@
 #include <Storages/transformQueryForExternalDatabase.h>
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <Storages/NamedCollectionsHelpers.h>
+#include <Storages/PostgreSQL/PostgreSQLSettings.h>
 
 #include <Databases/PostgreSQL/fetchPostgreSQLTableStructure.h>
 
@@ -67,6 +69,11 @@ namespace Setting
     extern const SettingsUInt64 postgresql_connection_pool_retries;
     extern const SettingsUInt64 postgresql_connection_pool_size;
     extern const SettingsUInt64 postgresql_connection_pool_wait_timeout;
+}
+
+namespace PostgreSQLSetting
+{
+    extern const PostgreSQLSettingsUInt64 connection_pool_size;
 }
 
 namespace ErrorCodes
@@ -86,11 +93,13 @@ StoragePostgreSQL::StoragePostgreSQL(
     const String & comment,
     ContextPtr context_,
     const String & remote_table_schema_,
-    const String & on_conflict_)
+    const String & on_conflict_,
+    const PostgreSQLSettings & postgresql_settings_)
     : IStorage(table_id_)
     , remote_table_name(remote_table_name_)
     , remote_table_schema(remote_table_schema_)
     , on_conflict(on_conflict_)
+    , postgresql_settings(std::make_unique<PostgreSQLSettings>(postgresql_settings_))
     , pool(std::move(pool_))
     , log(getLogger("StoragePostgreSQL (" + table_id_.getFullTableName() + ")"))
 {
@@ -603,15 +612,21 @@ SinkToStoragePtr StoragePostgreSQL::write(
     return std::make_shared<PostgreSQLSink>(metadata_snapshot, pool->get(), remote_table_name, remote_table_schema, on_conflict);
 }
 
-StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult(const NamedCollection & named_collection, ContextPtr context_, bool require_table)
+StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult(
+    const NamedCollection & named_collection, PostgreSQLSettings & storage_settings, ContextPtr context_, bool require_table)
 {
     StoragePostgreSQL::Configuration configuration;
+
     ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> required_arguments = {"user", "username", "password", "database", "db"};
     if (require_table)
         required_arguments.insert("table");
 
-    validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(
-        named_collection, required_arguments, {"schema", "on_conflict", "addresses_expr", "host", "hostname", "port", "use_table_cache"});
+    ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> optional_arguments = {"schema", "on_conflict", "addresses_expr", "host", "hostname", "port", "use_table_cache"};
+    auto postgresql_settings_names = storage_settings.getAllRegisteredNames();
+    for (const auto & name : postgresql_settings_names)
+        optional_arguments.insert(name);
+
+    validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(named_collection, required_arguments, optional_arguments);
 
     configuration.addresses_expr = named_collection.getOrDefault<String>("addresses_expr", "");
     if (configuration.addresses_expr.empty())
@@ -638,12 +653,12 @@ StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult
     return configuration;
 }
 
-StoragePostgreSQL::Configuration StoragePostgreSQL::getConfiguration(ASTs engine_args, ContextPtr context)
+StoragePostgreSQL::Configuration StoragePostgreSQL::getConfiguration(ASTs engine_args, ContextPtr context, PostgreSQLSettings & storage_settings)
 {
     StoragePostgreSQL::Configuration configuration;
     if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
     {
-        configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, context);
+        configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, storage_settings, context);
     }
     else
     {
@@ -690,8 +705,20 @@ void registerStoragePostgreSQL(StorageFactory & factory)
 {
     factory.registerStorage("PostgreSQL", [](const StorageFactory::Arguments & args)
     {
-        auto configuration = StoragePostgreSQL::getConfiguration(args.engine_args, args.getLocalContext());
+        PostgreSQLSettings postgresql_settings;
+        auto configuration = StoragePostgreSQL::getConfiguration(args.engine_args, args.getLocalContext(), postgresql_settings);
+
+        if (args.storage_def->settings)
+            postgresql_settings.loadFromQuery(*args.storage_def);
+
         const auto & settings = args.getContext()->getSettingsRef();
+
+        if (!settings[Setting::postgresql_connection_pool_size])
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "postgresql_connection_pool_size cannot be zero.");
+
+        if (!postgresql_settings[PostgreSQLSetting::connection_pool_size])
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "connection_pool_size cannot be zero.");
+
         auto pool = std::make_shared<postgres::PoolWithFailover>(
             configuration,
             settings[Setting::postgresql_connection_pool_size],
@@ -709,11 +736,14 @@ void registerStoragePostgreSQL(StorageFactory & factory)
             args.comment,
             args.getContext(),
             configuration.schema,
-            configuration.on_conflict);
+            configuration.on_conflict,
+            postgresql_settings);
     },
     {
+        .supports_settings = true,
         .supports_schema_inference = true,
         .source_access_type = AccessType::POSTGRES,
+        .has_builtin_setting_fn = PostgreSQLSettings::hasBuiltin,
     });
 }
 

--- a/src/Storages/StoragePostgreSQL.h
+++ b/src/Storages/StoragePostgreSQL.h
@@ -5,6 +5,7 @@
 #if USE_LIBPQXX
 #include <Interpreters/Context.h>
 #include <Storages/IStorage.h>
+#include <Storages/PostgreSQL/PostgreSQLSettings.h>
 
 namespace Poco
 {
@@ -19,6 +20,7 @@ using PoolWithFailoverPtr = std::shared_ptr<PoolWithFailover>;
 
 namespace DB
 {
+struct PostgreSQLSettings;
 class NamedCollection;
 
 class StoragePostgreSQL final : public IStorage
@@ -33,7 +35,8 @@ public:
         const String & comment,
         ContextPtr context_,
         const String & remote_table_schema_ = "",
-        const String & on_conflict = "");
+        const String & on_conflict = "",
+        const PostgreSQLSettings & postgresql_settings_ = {});
 
     String getName() const override { return "PostgreSQL"; }
 
@@ -64,9 +67,11 @@ public:
         String addresses_expr;
     };
 
-    static Configuration getConfiguration(ASTs engine_args, ContextPtr context);
+    static Configuration getConfiguration(ASTs engine_args, ContextPtr context, PostgreSQLSettings & storage_settings);
 
-    static Configuration processNamedCollectionResult(const NamedCollection & named_collection, ContextPtr context_, bool require_table = true);
+    static Configuration processNamedCollectionResult(
+        const NamedCollection & named_collection, PostgreSQLSettings & storage_settings,
+        ContextPtr context_, bool require_table = true);
 
     static ColumnsDescription getTableStructureFromData(
         const postgres::PoolWithFailoverPtr & pool_,
@@ -78,6 +83,7 @@ private:
     String remote_table_name;
     String remote_table_schema;
     String on_conflict;
+    std::unique_ptr<PostgreSQLSettings> postgresql_settings;
     postgres::PoolWithFailoverPtr pool;
 
     LoggerPtr log;

--- a/src/TableFunctions/TableFunctionPostgreSQL.cpp
+++ b/src/TableFunctions/TableFunctionPostgreSQL.cpp
@@ -6,6 +6,7 @@
 #include <Core/PostgreSQL/PoolWithFailover.h>
 #include <Core/Settings.h>
 #include <Storages/StoragePostgreSQL.h>
+#include <Storages/PostgreSQL/PostgreSQLSettings.h>
 #include <Parsers/ASTFunction.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Common/Exception.h>
@@ -64,7 +65,8 @@ StoragePtr TableFunctionPostgreSQL::executeImpl(const ASTPtr & /*ast_function*/,
         String{},
         context,
         configuration->schema,
-        configuration->on_conflict);
+        configuration->on_conflict,
+        PostgreSQLSettings{});
 
     result->startup();
     return result;
@@ -83,7 +85,8 @@ void TableFunctionPostgreSQL::parseArguments(const ASTPtr & ast_function, Contex
     if (!func_args.arguments)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function 'PostgreSQL' must have arguments.");
 
-    configuration.emplace(StoragePostgreSQL::getConfiguration(func_args.arguments->children, context));
+    PostgreSQLSettings postgresql_settings;
+    configuration.emplace(StoragePostgreSQL::getConfiguration(func_args.arguments->children, context, postgresql_settings));
     const auto & settings = context->getSettingsRef();
     connection_pool = std::make_shared<postgres::PoolWithFailover>(
         *configuration,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

I noticed this [PR](https://github.com/ClickHouse/ClickHouse/pull/52711) which hasn't got update for a while now which was solving this issue: https://github.com/ClickHouse/ClickHouse/issues/52343 Hence I thought to give it a try myself.
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
