### PR TITLE
Fix flaky test_keeper_auth/test.py::test_partial_auth[get_genuine_zk]

### DIFF
--- a/tests/integration/test_keeper_auth/test.py
+++ b/tests/integration/test_keeper_auth/test.py
@@ -401,21 +401,17 @@ def test_partial_auth(started_cluster, get_zk):
     finally:
         auth_connection.delete("/test_partial_acl/subnode")
         auth_connection.delete("/test_partial_acl")
-
-        auth_connection.set_acls(
-            "/test_partial_acl_delete",
-            acls=[
-                make_acl(
-                    "auth",
-                    "",
-                    read=True,
-                    write=True,
-                    create=True,
-                    delete=True,
-                    admin=True,
-                )
-            ],
+        acl = make_acl(
+            "auth",
+            "",
+            read=True,
+            write=True,
+            create=True,
+            delete=True,
+            admin=True,
         )
+        auth_connection.set_acls("/test_partial_acl_delete", acls=[acl])
+        auth_connection.set_acls("/test_partial_acl_delete/subnode", acls=[acl])
         auth_connection.delete("/test_partial_acl_delete/subnode")
         auth_connection.delete("/test_partial_acl_delete")
         zk_stop_and_close(auth_connection)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Grant full permissions to test_partial_acl_delete/subnode before deleting.

Closes #78981

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
