### PR TITLE
Add `PARTITION BY` into `INTO OUTFILE` clause

### DIFF
--- a/docs/en/sql-reference/statements/select/into-outfile.md
+++ b/docs/en/sql-reference/statements/select/into-outfile.md
@@ -14,7 +14,7 @@ Compressed files are supported. Compression type is detected by the extension of
 **Syntax**
 
 ```sql
-SELECT <expr_list> INTO OUTFILE file_name [AND STDOUT] [APPEND | TRUNCATE] [PARTITION BY <partition_by_expr_list>] [COMPRESSION type [LEVEL level]]
+SELECT <expr_list> INTO OUTFILE file_name [APPEND | TRUNCATE] [AND STDOUT] [PARTITION BY <partition_by_expr_list>] [COMPRESSION type [LEVEL level]]
 ```
 
 `file_name` and `type` are string literals. Supported compression types are: `'none'`, `'gzip'`, `'deflate'`, `'br'`, `'xz'`, `'zstd'`, `'lz4'`, `'bz2'`.

--- a/docs/en/sql-reference/statements/select/into-outfile.md
+++ b/docs/en/sql-reference/statements/select/into-outfile.md
@@ -21,7 +21,7 @@ SELECT <expr_list> INTO OUTFILE file_name [APPEND | TRUNCATE] [AND STDOUT] [PART
 
 `level` is a numeric literal. Positive integers in following ranges are supported: `1-12` for `lz4` type, `1-22` for `zstd` type and `1-9` for other compression types.
 
-## PARTITION BY
+## PARTITION BY {#partition-by}
 
 If specified result of `SELECT` query is partitioned using `partition_by_expr_list`, each partition goes to a separate file. `file_name` used as a template to get actual filename for each partition.  Each placeholder `{a}` in `file_name` will be substituted with `ToString(a)` value of column `a`. Column can be referred by expression name or alias. 
 

--- a/docs/en/sql-reference/statements/select/into-outfile.md
+++ b/docs/en/sql-reference/statements/select/into-outfile.md
@@ -81,11 +81,11 @@ INTO OUTFILE 'name_{_partition_id}' TRUNCATE PARTITION BY number % 2"
 $ ls name*
 name_0  name_1
 $ cat name_0
-0	1
-0	2
-2	5
-2	6
+0   1
+0   2
+2   5
+2   6
 $ cat name_1
-1	3
-1	4
+1   3
+1   4
 ```

--- a/docs/en/sql-reference/statements/select/into-outfile.md
+++ b/docs/en/sql-reference/statements/select/into-outfile.md
@@ -14,12 +14,28 @@ Compressed files are supported. Compression type is detected by the extension of
 **Syntax**
 
 ```sql
-SELECT <expr_list> INTO OUTFILE file_name [AND STDOUT] [APPEND | TRUNCATE] [COMPRESSION type [LEVEL level]]
+SELECT <expr_list> INTO OUTFILE file_name [AND STDOUT] [APPEND | TRUNCATE] [PARTITION BY <partition_by_expr_list>] [COMPRESSION type [LEVEL level]]
 ```
 
 `file_name` and `type` are string literals. Supported compression types are: `'none'`, `'gzip'`, `'deflate'`, `'br'`, `'xz'`, `'zstd'`, `'lz4'`, `'bz2'`.
 
 `level` is a numeric literal. Positive integers in following ranges are supported: `1-12` for `lz4` type, `1-22` for `zstd` type and `1-9` for other compression types.
+
+## PARTITION BY
+
+If specified result of `SELECT` query is partitioned using `partition_by_expr_list`, each partition goes to a separate file. `file_name` used as a template to get actual filename for each partition.  Each placeholder `{a}` in `file_name` will be substituted with `ToString(a)` value of column `a`. Column can be referred by expression name or alias. 
+
+
+Template rules:
+- All expression from `partition_by_expr_list` must be used in the template.
+- Symbols `{` and `}` in`file_name` that does not belong to any placeholder must be escaped by backslash `\` (escaping only affect `{` and `}`)
+- if there is only one key in `<partition_by_expr_list>`, it also can be referred to in the template using `{_partition_id}` placeholder
+- values are substituted as is, so clients may want to escape partition key, that can have bad character for theirs OS filename
+
+When using `PARTITION BY` and open/writing to a file error occurs, there is not rollback. ClickHouse can not check in advance which files will be used, so user may want to use `APPEND` or `TRUNCATE` options, or prefix `file_name` with empty directory.
+
+
+`PARTITION BY` does not support Extremes and Totals.
 
 ## Implementation Details {#implementation-details}
 
@@ -29,18 +45,47 @@ SELECT <expr_list> INTO OUTFILE file_name [AND STDOUT] [APPEND | TRUNCATE] [COMP
 - If `AND STDOUT` is mentioned in the query then the output that is written to the file is also displayed on standard output. If used with compression, the plaintext is displayed on standard output.
 - If `APPEND` is mentioned in the query then the output is appended to an existing file. If compression is used, append cannot be used.
 - When writing to a file that already exists, `APPEND` or `TRUNCATE` must be used.
+- Compression & format guessing with `PARTITION BY` use template rather than actual file name
+
 
 **Example**
 
-Execute the following query using [command-line client](../../../interfaces/cli.md):
+Execute the following queries using [command-line client](../../../interfaces/cli.md):
 
 ```bash
-clickhouse-client --query="SELECT 1,'ABC' INTO OUTFILE 'select.gz' FORMAT CSV;"
-zcat select.gz 
+$ clickhouse-client --query="SELECT 1,'ABC' INTO OUTFILE 'select.gz' FORMAT CSV;"
+$ zcat select.gz 
+1,"ABC"
 ```
 
-Result:
+```bash
+clickhouse-client --query="SELECT * FROM VALUES('a UInt8, b UInt8, c UInt8', (1, 1, 40), (1, 2, 41), (2, 1, 42), (2, 2, 43))
+INTO OUTFILE 'name_{a}_{alias}' TRUNCATE PARTITION BY a, b as alias FORMAT CSVWithNames"
+$ ls name*
+name_1_1  name_1_2  name_2_1  name_2_2
+$ cat name*
+"a","b","c"
+1,1,40
+"a","b","c"
+1,2,41
+"a","b","c"
+2,1,42
+"a","b","c"
+2,2,43
+```
 
-```text
-1,"ABC"
+
+```bash
+$ clickhouse-client --query="SELECT * FROM VALUES('a UInt8, b UInt8', (0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6))
+INTO OUTFILE 'name_{_partition_id}' TRUNCATE PARTITION BY number % 2"
+$ ls name*
+name_0  name_1
+$ cat name_0
+0	1
+0	2
+2	5
+2	6
+$ cat name_1
+1	3
+1	4
 ```

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -753,7 +753,8 @@ try
         if (select_into_file_partition_by)
         {
             auto* manager = dynamic_cast<DynamicWriteBufferManager*>(out_file_buf.get());
-            OutputFormatForPath creator = [=, this](const String & out_filepath) {
+            OutputFormatForPath creator = [=, this](const String & out_filepath)
+            {
                 auto write_buffer = outfile_buf_factory(out_filepath);
                 auto format = client_context->getOutputFormat(current_format, *write_buffer, block);
                 manager->addWriteBuffer(std::move(write_buffer));

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1243,6 +1243,11 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
                         out_file);
                 }
             }
+
+            if (query_with_output->partition_by)
+            {
+                throwIfTemplateIsNotValid(out_file, query_with_output->partition_by);
+            }
         }
     }
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -52,6 +52,7 @@
 #include <Processors/Formats/Impl/NullFormat.h>
 #include <Processors/Formats/IInputFormat.h>
 #include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
+#include <Processors/Formats/PartitionOutputFormat.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
@@ -70,6 +71,7 @@
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/CompressionMethod.h>
 #include <IO/ForkWriteBuffer.h>
+#include <IO/DynamicWriteBufferManager.h>
 
 #include <Access/AccessControl.h>
 #include <Storages/ColumnsDescription.h>
@@ -157,7 +159,7 @@ void cleanupTempFile(const DB::ASTPtr & parsed_query, const String & tmp_file)
 {
     if (const auto * query_with_output = dynamic_cast<const DB::ASTQueryWithOutput *>(parsed_query.get()))
     {
-        if (query_with_output->is_outfile_truncate && query_with_output->out_file)
+        if (query_with_output->is_outfile_truncate && query_with_output->out_file && !query_with_output->partition_by)
         {
             if (fs::exists(tmp_file))
                 fs::remove(tmp_file);
@@ -169,7 +171,7 @@ void performAtomicRename(const DB::ASTPtr & parsed_query, const String & out_fil
 {
     if (const auto * query_with_output = dynamic_cast<const DB::ASTQueryWithOutput *>(parsed_query.get()))
     {
-        if (query_with_output->is_outfile_truncate && query_with_output->out_file)
+        if (query_with_output->is_outfile_truncate && query_with_output->out_file && !query_with_output->partition_by)
         {
             const auto & tmp_file_node = query_with_output->out_file->as<DB::ASTLiteral &>();
             String tmp_file = tmp_file_node.value.safeGet<std::string>();
@@ -647,14 +649,20 @@ try
 
         select_into_file = false;
         select_into_file_and_stdout = false;
+        bool select_into_file_partition_by = false;
         String current_format = default_output_format;
+
+        using WriteBufferByPath = std::function<std::unique_ptr<WriteBuffer>(const String & buffer_filepath)>;
+        WriteBufferByPath outfile_buf_factory;
+        ASTPtr partition_by;
+        String out_file;
+
         /// The query can specify output format or output file.
         if (const auto * query_with_output = dynamic_cast<const ASTQueryWithOutput *>(parsed_query.get()))
         {
             if (query_with_output->out_file && isEmbeeddedClient())
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Out files are disabled when you are running client embedded into server.");
 
-            String out_file;
             if (query_with_output->out_file)
             {
                 select_into_file = true;
@@ -679,29 +687,45 @@ try
                     compression_level_node.value.tryGet<UInt64>(compression_level);
                 }
 
-                auto flags = O_WRONLY | O_EXCL;
+                outfile_buf_factory = [=, this](const String& out_filepath)
+                {
+                    auto flags = O_WRONLY | O_EXCL;
+                    auto file_exists = fs::exists(out_filepath);
+                    if (file_exists && query_with_output->is_outfile_append)
+                        flags |= O_APPEND;
+                    else if (file_exists && query_with_output->is_outfile_truncate)
+                        flags |= O_TRUNC;
+                    else
+                        flags |= O_CREAT;
 
-                auto file_exists = fs::exists(out_file);
-                if (file_exists && query_with_output->is_outfile_append)
-                    flags |= O_APPEND;
-                else if (file_exists && query_with_output->is_outfile_truncate)
-                    flags |= O_TRUNC;
-                else
-                    flags |= O_CREAT;
+                    auto res = wrapWriteBufferWithCompressionMethod(
+                        std::make_unique<WriteBufferFromFile>(out_filepath, DBMS_DEFAULT_BUFFER_SIZE, flags),
+                        compression_method,
+                        static_cast<int>(compression_level)
+                    );
 
-                chassert(out_file_buf.get() == nullptr);
-
-                out_file_buf = wrapWriteBufferWithCompressionMethod(
-                    std::make_unique<WriteBufferFromFile>(out_file, DBMS_DEFAULT_BUFFER_SIZE, flags),
-                    compression_method,
-                    static_cast<int>(compression_level)
-                );
-
+                    if (select_into_file_and_stdout)
+                    {
+                        res = std::make_unique<ForkWriteBuffer>(std::vector<WriteBufferPtr>{std::move(res),
+                                std::make_shared<WriteBufferFromFileDescriptor>(stdout_fd)});
+                    }
+                    return res;
+                };
                 if (query_with_output->is_into_outfile_with_stdout)
                 {
                     select_into_file_and_stdout = true;
-                    out_file_buf = std::make_unique<ForkWriteBuffer>(std::vector<WriteBufferPtr>{std::move(out_file_buf),
-                        std::make_shared<WriteBufferFromFileDescriptor>(stdout_fd)});
+                }
+
+                chassert(out_file_buf.get() == nullptr);
+                if (query_with_output->partition_by)
+                {
+                    out_file_buf = std::make_unique<DynamicWriteBufferManager>();
+                    select_into_file_partition_by = true;
+                    partition_by = query_with_output->partition_by;
+                }
+                else
+                {
+                    out_file_buf = outfile_buf_factory(out_file);
                 }
 
                 // We are writing to file, so default format is the same as in non-interactive mode.
@@ -726,26 +750,40 @@ try
         if (has_vertical_output_suffix)
             current_format = "Vertical";
 
-        bool logs_into_stdout = server_logs_file == "-";
-        bool extras_into_stdout = need_render_progress || logs_into_stdout;
-        bool select_only_into_file = select_into_file && !select_into_file_and_stdout;
+        if (select_into_file_partition_by)
+        {
+            auto* manager = dynamic_cast<DynamicWriteBufferManager*>(out_file_buf.get());
+            OutputFormatForPath creator = [=, this](const String & out_filepath) {
+                auto write_buffer = outfile_buf_factory(out_filepath);
+                auto format = client_context->getOutputFormat(current_format, *write_buffer, block);
+                manager->addWriteBuffer(std::move(write_buffer));
+                return format;
+            };
 
-        if (!out_file_buf && default_output_compression_method != CompressionMethod::None)
-            out_file_buf = wrapWriteBufferWithCompressionMethod(out_buf, default_output_compression_method, 3, 0);
-
-        auto format_settings = getFormatSettings(client_context);
-        format_settings.is_writing_to_terminal = stdout_is_a_tty;
-
-        /// It is not clear how to write progress and logs
-        /// intermixed with data with parallel formatting.
-        /// It may increase code complexity significantly.
-        if (!extras_into_stdout || select_only_into_file)
-            output_format = client_context->getOutputFormatParallelIfPossible(
-                current_format, out_file_buf ? *out_file_buf : *out_buf, block, format_settings);
+            output_format = std::make_shared<PartitionOutputFormat>(creator, *manager, block, out_file, partition_by, client_context);
+        }
         else
-            output_format = client_context->getOutputFormat(
-                current_format, out_file_buf ? *out_file_buf : *out_buf, block, format_settings);
+        {
+            bool logs_into_stdout = server_logs_file == "-";
+            bool extras_into_stdout = need_render_progress || logs_into_stdout;
+            bool select_only_into_file = select_into_file && !select_into_file_and_stdout;
 
+            if (!out_file_buf && default_output_compression_method != CompressionMethod::None)
+                out_file_buf = wrapWriteBufferWithCompressionMethod(out_buf, default_output_compression_method, 3, 0);
+
+            auto format_settings = getFormatSettings(client_context);
+            format_settings.is_writing_to_terminal = stdout_is_a_tty;
+
+            /// It is not clear how to write progress and logs
+            /// intermixed with data with parallel formatting.
+            /// It may increase code complexity significantly.
+            if (!extras_into_stdout || select_only_into_file)
+                output_format = client_context->getOutputFormatParallelIfPossible(
+                    current_format, out_file_buf ? *out_file_buf : *out_buf, block, format_settings);
+            else
+                output_format = client_context->getOutputFormat(
+                    current_format, out_file_buf ? *out_file_buf : *out_buf, block, format_settings);
+        }
         output_format->setAutoFlush();
 
         if ((!select_into_file || select_into_file_and_stdout)
@@ -1195,7 +1233,7 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
                         range.second);
             }
 
-            if (fs::exists(out_file))
+            if (!query_with_output->partition_by && fs::exists(out_file))
             {
                 if (!query_with_output->is_outfile_append && !query_with_output->is_outfile_truncate)
                 {

--- a/src/IO/DynamicWriteBufferManager.cpp
+++ b/src/IO/DynamicWriteBufferManager.cpp
@@ -20,8 +20,10 @@ void DynamicWriteBufferManager::addWriteBuffer(WriteBufferPtr && buffer)
     sources.push_back(std::move(buffer));
 }
 
-void DynamicWriteBufferManager::proxyNext() {
-    for (const WriteBufferPtr & buffer : sources) {
+void DynamicWriteBufferManager::proxyNext()
+{
+    for (const WriteBufferPtr & buffer : sources)
+    {
         buffer->next();
     }
 }

--- a/src/IO/DynamicWriteBufferManager.cpp
+++ b/src/IO/DynamicWriteBufferManager.cpp
@@ -1,0 +1,57 @@
+#include "DynamicWriteBufferManager.h"
+
+#include <Common/Exception.h>
+#include "IO/WriteBuffer.h"
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int LOGICAL_ERROR;
+}
+
+DynamicWriteBufferManager::DynamicWriteBufferManager() : WriteBuffer(nullptr, 0)
+{
+}
+
+void DynamicWriteBufferManager::addWriteBuffer(WriteBufferPtr && buffer)
+{
+    sources.push_back(std::move(buffer));
+}
+
+void DynamicWriteBufferManager::proxyNext() {
+    for (const WriteBufferPtr & buffer : sources) {
+        buffer->next();
+    }
+}
+
+void DynamicWriteBufferManager::nextImpl()
+{
+    throw Exception{ErrorCodes::LOGICAL_ERROR, "Cannot write to DynamicWriteBufferManager"};
+}
+
+void DynamicWriteBufferManager::finalizeImpl()
+{
+    for (const WriteBufferPtr & buffer : sources)
+    {
+        buffer->finalize();
+    }
+}
+
+void DynamicWriteBufferManager::cancelImpl() noexcept
+{
+    for (const WriteBufferPtr & buffer : sources)
+    {
+        buffer->cancel();
+    }
+}
+
+void DynamicWriteBufferManager::sync()
+{
+    for (const WriteBufferPtr & buffer : sources)
+    {
+        buffer->sync();
+    }
+}
+}

--- a/src/IO/DynamicWriteBufferManager.h
+++ b/src/IO/DynamicWriteBufferManager.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <vector>
+#include <IO/WriteBuffer.h>
+
+
+namespace DB
+{
+
+/** DynamicWriteBufferManager manage vector of WriteBufferPtr.
+  * Unlike ForkWriteBuffer it can not be used directly to write data:
+  * next/write should not be called on this buffer.
+  * But it is usefull to proxy finalize, cancel and sync calls to all
+  * WriteBuffers managed by this buffer
+  **/
+class DynamicWriteBufferManager : public WriteBuffer
+{
+public:
+    DynamicWriteBufferManager();
+    void addWriteBuffer(WriteBufferPtr && buffer);
+    void proxyNext();
+
+    void sync() override;
+protected:
+    void finalizeImpl() override;
+    void cancelImpl() noexcept override;
+
+private:
+    void nextImpl() override;
+
+    std::vector<WriteBufferPtr> sources;
+};
+
+}

--- a/src/IO/DynamicWriteBufferManager.h
+++ b/src/IO/DynamicWriteBufferManager.h
@@ -9,7 +9,7 @@ namespace DB
 /** DynamicWriteBufferManager manage vector of WriteBufferPtr.
   * Unlike ForkWriteBuffer it can not be used directly to write data:
   * next/write should not be called on this buffer.
-  * But it is usefull to proxy finalize, cancel and sync calls to all
+  * But it is useful to proxy finalize, cancel and sync calls to all
   * WriteBuffers managed by this buffer
   **/
 class DynamicWriteBufferManager : public WriteBuffer

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -13,6 +13,11 @@ void ASTQueryWithOutput::cloneOutputOptions(ASTQueryWithOutput & cloned) const
         cloned.out_file = out_file->clone();
         cloned.children.push_back(cloned.out_file);
     }
+    if (partition_by)
+    {
+        cloned.partition_by = partition_by->clone();
+        cloned.children.push_back(cloned.partition_by);
+    }
     if (format_ast)
     {
         cloned.format_ast = format_ast->clone();
@@ -54,6 +59,12 @@ void ASTQueryWithOutput::formatImpl(WriteBuffer & ostr, const FormatSettings & s
         if (is_into_outfile_with_stdout)
             ostr << " AND STDOUT";
         ostr << (s.hilite ? hilite_none : "");
+
+        if (partition_by)
+        {
+            ostr << (s.hilite ? hilite_keyword : "") << " PARTITION BY " << (s.hilite ? hilite_none : "");
+            partition_by->format(ostr, s, state, frame);
+        }
     }
 
     if (format_ast)
@@ -86,6 +97,7 @@ bool ASTQueryWithOutput::resetOutputASTIfExist(IAST & ast)
         };
 
         remove_if_exists(ast_with_output->out_file);
+        remove_if_exists(ast_with_output->partition_by);
         remove_if_exists(ast_with_output->format_ast);
         remove_if_exists(ast_with_output->settings_ast);
         remove_if_exists(ast_with_output->compression);

--- a/src/Parsers/ASTQueryWithOutput.h
+++ b/src/Parsers/ASTQueryWithOutput.h
@@ -18,6 +18,7 @@ public:
     bool is_into_outfile_with_stdout = false;
     bool is_outfile_append = false;
     bool is_outfile_truncate = false;
+    ASTPtr partition_by;
     ASTPtr format_ast;
     ASTPtr settings_ast;
     ASTPtr compression;

--- a/src/Parsers/ParserQueryWithOutput.cpp
+++ b/src/Parsers/ParserQueryWithOutput.cpp
@@ -129,6 +129,15 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
             query_with_output.is_into_outfile_with_stdout = true;
         }
 
+        ParserKeyword s_partition_by(Keyword::PARTITION_BY);
+        if (s_partition_by.ignore(pos, expected))
+        {
+            ParserNotEmptyExpressionList exp_list_p(false);
+            if (!exp_list_p.parse(pos, query_with_output.partition_by, expected))
+                return false;
+            query_with_output.children.push_back(query_with_output.partition_by);
+        }
+
         ParserKeyword s_compression_method(Keyword::COMPRESSION);
         if (s_compression_method.ignore(pos, expected))
         {

--- a/src/Processors/Formats/IOutputFormat.h
+++ b/src/Processors/Formats/IOutputFormat.h
@@ -111,6 +111,7 @@ public:
     }
 
 protected:
+    friend class PartitionOutputFormat;
     friend class ParallelFormattingOutputFormat;
 
     void writeSuffixIfNeeded()

--- a/src/Processors/Formats/PartitionOutputFormat.cpp
+++ b/src/Processors/Formats/PartitionOutputFormat.cpp
@@ -125,12 +125,15 @@ String formatTemplate(const String & out_file_template, const PartitionOutputFor
     return res;
 }
 
-const ASTs & getChildrensInPartitionBy(const ASTPtr & expr_list) {
-    if (expr_list->children.size() != 1) {
+const ASTs & getChildrensInPartitionBy(const ASTPtr & expr_list)
+{
+    if (expr_list->children.size() != 1)
+    {
         return expr_list->children;
     }
     const auto * func = expr_list->children.front()->as<ASTFunction>();
-    if (!func || func->name != "tuple") {
+    if (!func || func->name != "tuple")
+    {
         return expr_list->children;
     }
     return func->arguments->children;

--- a/src/Processors/Formats/PartitionOutputFormat.cpp
+++ b/src/Processors/Formats/PartitionOutputFormat.cpp
@@ -1,0 +1,237 @@
+#include "PartitionOutputFormat.h"
+
+#include <Columns/IColumn.h>
+#include <Common/ArenaUtils.h>
+#include <Common/Exception.h>
+#include <Common/PODArray.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/TreeRewriter.h>
+#include <Parsers/ASTFunction.h>
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/map.hpp>
+
+#include <ranges>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+const std::string PARTITION_ID_WILDCARD = "_partition_id";
+
+String formatTemplate(const String & out_file_template, const PartitionOutputFormat::Key & key, const absl::flat_hash_map<StringRef, size_t>& key_name_to_index)
+{
+    String res;
+    std::vector<bool> used(key.size());
+    size_t n = out_file_template.size();
+    std::vector<std::string> columns(
+        begin(std::views::keys(key_name_to_index)),
+        end(std::views::keys(key_name_to_index)));
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        char x = out_file_template[i];
+
+        if (x == '\\' && i + 1 < n)
+        {
+            if (out_file_template[i + 1] == '{')
+            {
+                ++i;
+                res.push_back('{');
+                continue;
+            }
+            if (out_file_template[i + 1] == '}')
+            {
+                ++i;
+                res.push_back('}');
+                continue;
+            }
+        }
+        if (x == '}')
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not escaped '}}' in out_file_template pattern at pos {}. Escape it using backslash '\'", i);
+        }
+        if (x != '{')
+        {
+            res.push_back(x);
+            continue;
+        }
+
+        std::string name;
+        bool found = false;
+        for (size_t j = i + 1; j < n; ++j)
+        {
+            x = out_file_template[j];
+            if (x == '\\' && j + 1 < n)
+            {
+                if (out_file_template[j + 1] == '{')
+                {
+                    ++j;
+                    name.push_back('{');
+                    continue;
+                }
+                if (out_file_template[j + 1] == '}')
+                {
+                    ++j;
+                    name.push_back('}');
+                    continue;
+                }
+            }
+            if (x == '{')
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not escaped '{{' inside out_file_template pattern at pos {}. Escape it using backslash '\'", j);
+            }
+            if (x != '}')
+            {
+                name.push_back(x);
+                continue;
+            }
+            found = true;
+            auto it = key_name_to_index.find(name);
+            size_t key_index = 0;
+            if (it != key_name_to_index.end()) key_index = it->second;
+            else
+            {
+                if (name != PARTITION_ID_WILDCARD)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected column name in out_file_template: {}. Available columns: {}.", name, boost::algorithm::join(columns, ", "));
+                if (key.size() != 1)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected column name in out_file_template: {}. Can only use {{_partition_id}} with one key. Available columns: {}.", name, boost::algorithm::join(columns, ", "));
+            }
+
+            used[key_index] = true;
+            res.append(key[key_index].toView());
+            i = j;
+            name.clear();
+            break;
+        }
+        if (!found)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "No matching '}}' for '{{' in out_file_template at pos {}", i);
+        }
+    }
+    if (!std::all_of(begin(used), end(used), std::identity{}))
+    {
+        auto missed_columns_view = key_name_to_index
+            | std::views::filter([&](const auto & pair) { return !used[pair.second];})
+            | std::views::keys;
+        std::vector<std::string> missed_columns(missed_columns_view.begin(), missed_columns_view.end());
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missed columns in out_file_template: {}. Must use all of them", boost::algorithm::join(missed_columns, ", "));
+    }
+    return res;
+}
+
+PartitionOutputFormat::PartitionOutputFormat(
+    const OutputFormatForPath & output_format_for_path_,
+    DynamicWriteBufferManager & write_buffers_manager_,
+    const Block & header_,
+    const String & out_file_template_,
+    const ASTPtr & partition_by,
+    const ContextPtr & context)
+    : IOutputFormat(header_, write_buffers_manager_), header(header_), out_file_template(out_file_template_), output_format_for_path(output_format_for_path_), write_buffers_manager(write_buffers_manager_)
+{
+    int i = 0;
+    for (const ASTPtr & expr : partition_by->children)
+    {
+        auto column = copyStringInArena(partition_keys_arena, expr->getAliasOrColumnName());
+        partition_key_name_to_index.emplace(column, i++);
+
+        ASTs arguments(1, expr);
+        ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
+        partition_by_expr_names.push_back(partition_by_string->getColumnName());
+
+        auto syntax_result = TreeRewriter(context).analyze(partition_by_string, header.getNamesAndTypesList());
+        partition_by_exprs.push_back(ExpressionAnalyzer(partition_by_string, syntax_result, context).getActions(false));
+    }
+}
+
+void PartitionOutputFormat::consume(Chunk chunk)
+{
+    Columns key_columns;
+    const auto & columns = chunk.getColumns();
+    for (size_t i = 0; i < partition_by_exprs.size(); ++i)
+    {
+        Block block_with_partition_by_expr = header.cloneWithoutColumns();
+        block_with_partition_by_expr.setColumns(columns);
+        partition_by_exprs[i]->execute(block_with_partition_by_expr);
+        key_columns.push_back(std::move(block_with_partition_by_expr.getByName(partition_by_expr_names[i]).column));
+    }
+
+    absl::flat_hash_map<Key, size_t, KeyHash> key_to_chunk_index;
+    IColumn::Selector selector;
+    for (size_t row = 0; row < chunk.getNumRows(); ++row)
+    {
+        Key key;
+        key.reserve(key_columns.size());
+        for (auto & key_column : key_columns)
+        {
+            key.push_back(key_column->getDataAt(row));
+        }
+        auto [it, _] = key_to_chunk_index.emplace(key, key_to_chunk_index.size());
+        selector.push_back(it->second);
+    }
+
+    Chunks sub_chunks;
+    sub_chunks.reserve(key_to_chunk_index.size());
+    for (size_t column_index = 0; column_index < columns.size(); ++column_index)
+    {
+        MutableColumns column_sub_chunks = columns[column_index]->scatter(key_to_chunk_index.size(), selector);
+        if (column_index == 0) /// Set sizes for sub-chunks.
+        {
+            for (const auto & column_sub_chunk : column_sub_chunks)
+            {
+                sub_chunks.emplace_back(Columns(), column_sub_chunk->size());
+            }
+        }
+        for (size_t sub_chunk_index = 0; sub_chunk_index < column_sub_chunks.size(); ++sub_chunk_index)
+        {
+            sub_chunks[sub_chunk_index].addColumn(std::move(column_sub_chunks[sub_chunk_index]));
+        }
+    }
+
+    for (const auto & [partition_key, index] : key_to_chunk_index)
+    {
+        getOrCreateOutputFormat(partition_key)->write(header.cloneWithColumns(sub_chunks[index].detachColumns()));
+    }
+}
+
+OutputFormatPtr PartitionOutputFormat::getOrCreateOutputFormat(const Key & key)
+{
+    auto it = partition_key_to_output_format.find(key);
+    if (it == partition_key_to_output_format.end())
+    {
+        auto filepath = formatTemplate(out_file_template, key, partition_key_name_to_index);
+        auto output_format = output_format_for_path(filepath);
+        std::tie(it, std::ignore) = partition_key_to_output_format.emplace(copyStringsInArena(partition_keys_arena, key), output_format);
+    }
+    return it->second;
+}
+
+void PartitionOutputFormat::finalizeImpl()
+{
+    for (auto & [_, output_format] : partition_key_to_output_format)
+    {
+        output_format->finalize();
+    }
+}
+
+void PartitionOutputFormat::flushImpl()
+{
+    write_buffers_manager.proxyNext();
+}
+
+std::vector<StringRef> copyStringsInArena(Arena & arena, const StringRefs & strings)
+{
+    std::vector<StringRef> res(strings.size());
+    for (size_t i = 0; i < strings.size(); ++i)
+    {
+        res[i] = copyStringInArena(arena, strings[i]);
+    }
+    return res;
+}
+
+}

--- a/src/Processors/Formats/PartitionOutputFormat.cpp
+++ b/src/Processors/Formats/PartitionOutputFormat.cpp
@@ -224,6 +224,20 @@ void PartitionOutputFormat::flushImpl()
     write_buffers_manager.proxyNext();
 }
 
+void throwIfTemplateIsNotValid(const String & out_file_template, const ASTPtr & partition_by)
+{
+    absl::flat_hash_map<StringRef, size_t> partition_key_name_to_index;
+    Arena arena;
+    size_t i = 0;
+    for (const ASTPtr & expr : partition_by->children)
+    {
+        StringRef column = copyStringInArena(arena, expr->getAliasOrColumnName());
+        partition_key_name_to_index.emplace(column, i++);
+    }
+    PartitionOutputFormat::Key dummy_key(partition_key_name_to_index.size());
+    formatTemplate(out_file_template, dummy_key, partition_key_name_to_index);
+}
+
 std::vector<StringRef> copyStringsInArena(Arena & arena, const StringRefs & strings)
 {
     std::vector<StringRef> res(strings.size());

--- a/src/Processors/Formats/PartitionOutputFormat.h
+++ b/src/Processors/Formats/PartitionOutputFormat.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <IO/WriteBuffer.h>
+#include <Columns/IColumn.h>
+#include <Common/Arena.h>
+#include <Common/SipHash.h>
+#include <Core/Block.h>
+#include <Parsers/IAST_fwd.h>
+#include <Processors/Formats/IOutputFormat.h>
+#include <Processors/Port.h>
+#include <IO/DynamicWriteBufferManager.h>
+#include <Interpreters/ExpressionActions.h>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace DB
+{
+
+using OutputFormatPtr = std::shared_ptr<IOutputFormat>;
+using OutputFormatForPath = std::function<OutputFormatPtr(const String & name)>;
+
+class PartitionOutputFormat : public IOutputFormat
+{
+public:
+
+    using Key = StringRefs;
+
+    struct KeyHash
+    {
+        size_t operator()(const StringRefs & key) const
+        {
+            SipHash hash;
+            hash.update(key.size());
+            for (const auto & part : key)
+                hash.update(part.toView());
+            return hash.get64();
+        }
+    };
+
+    PartitionOutputFormat(
+        const OutputFormatForPath & output_format_for_path_,
+        DynamicWriteBufferManager & write_buffers_manager_,
+        const Block & header_,
+        const String & out_file_template_,
+        const ASTPtr & partition_by,
+        const ContextPtr & context);
+
+    String getName() const override { return "PartitionOutputFormat"; }
+
+protected:
+    void consume(Chunk chunk) override;
+    void finalizeImpl() override;
+    void flushImpl() override;
+
+private:
+    OutputFormatPtr getOrCreateOutputFormat(const Key & key);
+    Key copyKeyToArena(const Key & key);
+
+    absl::flat_hash_map<Key, OutputFormatPtr, KeyHash> partition_key_to_output_format;
+    absl::flat_hash_map<StringRef, size_t> partition_key_name_to_index;
+    Arena partition_keys_arena;
+
+    std::vector<ExpressionActionsPtr> partition_by_exprs;
+    std::vector<String> partition_by_expr_names;
+
+    Block header;
+    String out_file_template;
+    OutputFormatForPath output_format_for_path;
+    DynamicWriteBufferManager& write_buffers_manager;
+};
+
+std::vector<StringRef> copyStringsInArena(Arena & arena, const StringRefs & strings);
+
+};

--- a/src/Processors/Formats/PartitionOutputFormat.h
+++ b/src/Processors/Formats/PartitionOutputFormat.h
@@ -69,6 +69,8 @@ private:
     DynamicWriteBufferManager& write_buffers_manager;
 };
 
+void throwIfTemplateIsNotValid(const String & out_file_template, const ASTPtr & partition_by);
+
 std::vector<StringRef> copyStringsInArena(Arena & arena, const StringRefs & strings);
 
 };

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.reference
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.reference
@@ -87,9 +87,9 @@ performing test: escape__heredoc
 file: heredoc_{42}
 42
 performing test: no_precheck_for_tempalte_itself
-file: {42}
 file: 42
 42
+file: {42}
 performing test: simple_append
 file: 42
 42

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.reference
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.reference
@@ -42,6 +42,19 @@ x	3	3
 y	1	4
 y	2	5
 y	3	6
+performing test: simple__tulpe
+file: 1_1
+x	1	1
+file: 1_4
+y	1	4
+file: 2_2
+x	2	2
+file: 2_5
+y	2	5
+file: 3_3
+x	3	3
+file: 3_6
+y	3	6
 performing test: simple__all_keys
 file: 1_1_x
 x	1	1

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.reference
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.reference
@@ -1,0 +1,98 @@
+performing test: simple__identifier
+file: x
+x	1	1
+x	2	2
+x	3	3
+file: y
+y	1	4
+y	2	5
+y	3	6
+performing test: simple__partition_id
+file: x
+x	1	1
+x	2	2
+x	3	3
+file: y
+y	1	4
+y	2	5
+y	3	6
+performing test: simple__expr_with_alias
+file: 0
+x	2	2
+y	2	5
+file: 1
+x	1	1
+x	3	3
+y	1	4
+y	3	6
+performing test: simple__expr_without_alias
+file: 0
+x	2	2
+y	2	5
+file: 1
+x	1	1
+x	3	3
+y	1	4
+y	3	6
+performing test: simple__const
+file: 42
+x	1	1
+x	2	2
+x	3	3
+y	1	4
+y	2	5
+y	3	6
+performing test: simple__all_keys
+file: 1_1_x
+x	1	1
+file: 2_2_x
+x	2	2
+file: 3_3_x
+x	3	3
+file: 4_1_y
+y	1	4
+file: 5_2_y
+y	2	5
+file: 6_3_y
+y	3	6
+performing test: simple__can_reuse
+file: x_x
+x	1	1
+x	2	2
+x	3	3
+file: y_y
+y	1	4
+y	2	5
+y	3	6
+performing test: escape__outside
+file: outside_{ 42 }
+42
+performing test: escape__inside
+file: inside_42
+42
+performing test: escape__heredoc
+file: heredoc_{42}
+42
+performing test: no_precheck_for_tempalte_itself
+file: {42}
+file: 42
+42
+performing test: simple_append
+file: 42
+42
+42
+performing test: simple_truncate
+file: 42
+42
+performing test: simple_format_with_prefix_and_suffix
+file: 42
+[
+{"42":42}
+]
+perform file exist test
+1
+perform wrong template test
+1
+1
+1
+1

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
@@ -19,15 +19,19 @@ function perform()
     code=$?
 
     if [ "$code" -eq 0 ]; then
-        for f in "${CLICKHOUSE_TMP_OUTPUT}"/*
-        do
-            echo "file: $(basename "$f")"
-            if [ "$sort" -eq 1 ]; then
-                sort < "$f"
-            else
-                cat "$f"
-            fi
-        done
+        (
+            # define order for `{` char
+            export LC_ALL=C
+            for f in "${CLICKHOUSE_TMP_OUTPUT}"/*
+            do
+                echo "file: $(basename "$f")"
+                if [ "$sort" -eq 1 ]; then
+                    sort < "$f"
+                else
+                    cat "$f"
+                fi
+            done
+        )
     else
         echo "query failed"
     fi

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
@@ -4,6 +4,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# empty directory inside CLICKHOUSE_TMP
+CLICKHOUSE_TMP_OUTPUT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_NAME}"
+mkdir "${CLICKHOUSE_TMP_OUTPUT}"
+
 function perform()
 {
     local test_id=$1
@@ -15,7 +19,7 @@ function perform()
     code=$?
 
     if [ "$code" -eq 0 ]; then
-        for f in "${CLICKHOUSE_TMP}"/*
+        for f in "${CLICKHOUSE_TMP_OUTPUT}"/*
         do
             echo "file: $(basename "$f")"
             if [ "$sort" -eq 1 ]; then
@@ -27,53 +31,53 @@ function perform()
     else
         echo "query failed"
     fi
-    rm -f "${CLICKHOUSE_TMP}"/*
+    rm -f "${CLICKHOUSE_TMP_OUTPUT}"/*
 }
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS \`${CLICKHOUSE_TEST_NAME}\`;"
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE \`${CLICKHOUSE_TEST_NAME}\` (a String, b UInt64, c UInt64) Engine=Memory;"
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO \`${CLICKHOUSE_TEST_NAME}\` VALUES ('x', 1, 1), ('x', 2, 2), ('x', 3, 3), ('y', 1, 4), ('y', 2, 5), ('y', 3, 6);"
 
-perform "simple__identifier" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}' PARTITION BY a;"
-perform "simple__partition_id" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{_partition_id}' PARTITION BY a;"
+perform "simple__identifier" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{a}' PARTITION BY a;"
+perform "simple__partition_id" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{_partition_id}' PARTITION BY a;"
 
-perform "simple__expr_with_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{mod}' PARTITION BY b % 2 as mod;"
-perform "simple__expr_without_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{modulo(b, 2)}' PARTITION BY modulo(b, 2);"
-perform "simple__const" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' PARTITION BY 42;"
+perform "simple__expr_with_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{mod}' PARTITION BY b % 2 as mod;"
+perform "simple__expr_without_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{modulo(b, 2)}' PARTITION BY modulo(b, 2);"
+perform "simple__const" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{42}' PARTITION BY 42;"
 
-perform "simple__tulpe" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{b}_{c}' PARTITION BY (b, c);"
+perform "simple__tulpe" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{b}_{c}' PARTITION BY (b, c);"
 
-perform "simple__all_keys" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{c}_{b}_{a}' PARTITION BY a, b, c;"
-perform "simple__can_reuse" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}_{a}' PARTITION BY a;"
+perform "simple__all_keys" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{c}_{b}_{a}' PARTITION BY a, b, c;"
+perform "simple__can_reuse" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{a}_{a}' PARTITION BY a;"
 
-perform "escape__outside" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/outside_\{ {42} \}' PARTITION BY 42"
-perform "escape__inside" "SELECT 42 as \` {42} \` INTO OUTFILE '${CLICKHOUSE_TMP}/inside_{ \{42\} }' PARTITION BY \` {42} \`"
-perform "escape__heredoc" "SELECT 42 INTO OUTFILE \$heredoc\$${CLICKHOUSE_TMP}/heredoc_\{{42}\}\$heredoc\$ PARTITION BY 42"
+perform "escape__outside" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/outside_\{ {42} \}' PARTITION BY 42"
+perform "escape__inside" "SELECT 42 as \` {42} \` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/inside_{ \{42\} }' PARTITION BY \` {42} \`"
+perform "escape__heredoc" "SELECT 42 INTO OUTFILE \$heredoc\$${CLICKHOUSE_TMP_OUTPUT}/heredoc_\{{42}\}\$heredoc\$ PARTITION BY 42"
 
-touch "${CLICKHOUSE_TMP}/{42}"
-perform "no_precheck_for_tempalte_itself" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' PARTITION BY 42;"
+touch "${CLICKHOUSE_TMP_OUTPUT}/{42}"
+perform "no_precheck_for_tempalte_itself" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{42}' PARTITION BY 42;"
 
-echo 42 > "${CLICKHOUSE_TMP}/42"
-perform "simple_append" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' APPEND PARTITION BY 42;"
+echo 42 > "${CLICKHOUSE_TMP_OUTPUT}/42"
+perform "simple_append" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{42}' APPEND PARTITION BY 42;"
 
-echo 42 > "${CLICKHOUSE_TMP}/42"
-perform "simple_truncate" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' TRUNCATE PARTITION BY 42;"
+echo 42 > "${CLICKHOUSE_TMP_OUTPUT}/42"
+perform "simple_truncate" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{42}' TRUNCATE PARTITION BY 42;"
 
-perform "simple_format_with_prefix_and_suffix" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}'  PARTITION BY 42 FORMAT JSONEachRow SETTINGS output_format_json_array_of_rows = 1" 0
+perform "simple_format_with_prefix_and_suffix" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{42}'  PARTITION BY 42 FORMAT JSONEachRow SETTINGS output_format_json_array_of_rows = 1" 0
 
 echo "perform file exist test"
 
-touch "${CLICKHOUSE_TMP}/y_2"
-${CLICKHOUSE_CLIENT} --query "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}_{b}' PARTITION BY a, b;" 2>&1 | grep -Fc "File exists"
-rm "${CLICKHOUSE_TMP}"/*
+touch "${CLICKHOUSE_TMP_OUTPUT}/y_2"
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/{a}_{b}' PARTITION BY a, b;" 2>&1 | grep -Fc "File exists"
+rm "${CLICKHOUSE_TMP_OUTPUT}"/*
 
 echo "perform wrong template test"
 
-${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP}/outfile' PARTITION BY a;" 2>&1 | grep -Fc "Missed columns"
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/outfile' PARTITION BY a;" 2>&1 | grep -Fc "Missed columns"
 
-${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP}/outfile_{}' PARTITION BY a;" 2>&1 | grep -Fc "Unexpected column name"
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/outfile_{}' PARTITION BY a;" 2>&1 | grep -Fc "Unexpected column name"
 
-${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP}/outfile_{b}' PARTITION BY a;" 2>&1 | grep -Fc "Unexpected column name"
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/outfile_{b}' PARTITION BY a;" 2>&1 | grep -Fc "Unexpected column name"
 
-${CLICKHOUSE_CLIENT} --query "SELECT 1 as a, 2 as b INTO OUTFILE '${CLICKHOUSE_TMP}/outfile_{_partition_id}_{b}' PARTITION BY a, b;" 2>&1 | grep -Fc "Can only use {_partition_id} with one key"
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a, 2 as b INTO OUTFILE '${CLICKHOUSE_TMP_OUTPUT}/outfile_{_partition_id}_{b}' PARTITION BY a, b;" 2>&1 | grep -Fc "Can only use {_partition_id} with one key"
 

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
@@ -41,6 +41,8 @@ perform "simple__expr_with_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INT
 perform "simple__expr_without_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{modulo(b, 2)}' PARTITION BY modulo(b, 2);"
 perform "simple__const" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' PARTITION BY 42;"
 
+perform "simple__tulpe" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{b}_{c}' PARTITION BY (b, c);"
+
 perform "simple__all_keys" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{c}_{b}_{a}' PARTITION BY a, b, c;"
 perform "simple__can_reuse" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}_{a}' PARTITION BY a;"
 

--- a/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
+++ b/tests/queries/0_stateless/03267_into_outfile_partition_by.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+function perform()
+{
+    local test_id=$1
+    local query=$2
+    local sort=${3:-1}
+
+    echo "performing test: $test_id"
+    ${CLICKHOUSE_CLIENT} --query "$query"
+    code=$?
+
+    if [ "$code" -eq 0 ]; then
+        for f in "${CLICKHOUSE_TMP}"/*
+        do
+            echo "file: $(basename "$f")"
+            if [ "$sort" -eq 1 ]; then
+                sort < "$f"
+            else
+                cat "$f"
+            fi
+        done
+    else
+        echo "query failed"
+    fi
+    rm -f "${CLICKHOUSE_TMP}"/*
+}
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS \`${CLICKHOUSE_TEST_NAME}\`;"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE \`${CLICKHOUSE_TEST_NAME}\` (a String, b UInt64, c UInt64) Engine=Memory;"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO \`${CLICKHOUSE_TEST_NAME}\` VALUES ('x', 1, 1), ('x', 2, 2), ('x', 3, 3), ('y', 1, 4), ('y', 2, 5), ('y', 3, 6);"
+
+perform "simple__identifier" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}' PARTITION BY a;"
+perform "simple__partition_id" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{_partition_id}' PARTITION BY a;"
+
+perform "simple__expr_with_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{mod}' PARTITION BY b % 2 as mod;"
+perform "simple__expr_without_alias" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{modulo(b, 2)}' PARTITION BY modulo(b, 2);"
+perform "simple__const" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' PARTITION BY 42;"
+
+perform "simple__all_keys" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{c}_{b}_{a}' PARTITION BY a, b, c;"
+perform "simple__can_reuse" "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}_{a}' PARTITION BY a;"
+
+perform "escape__outside" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/outside_\{ {42} \}' PARTITION BY 42"
+perform "escape__inside" "SELECT 42 as \` {42} \` INTO OUTFILE '${CLICKHOUSE_TMP}/inside_{ \{42\} }' PARTITION BY \` {42} \`"
+perform "escape__heredoc" "SELECT 42 INTO OUTFILE \$heredoc\$${CLICKHOUSE_TMP}/heredoc_\{{42}\}\$heredoc\$ PARTITION BY 42"
+
+touch "${CLICKHOUSE_TMP}/{42}"
+perform "no_precheck_for_tempalte_itself" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' PARTITION BY 42;"
+
+echo 42 > "${CLICKHOUSE_TMP}/42"
+perform "simple_append" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' APPEND PARTITION BY 42;"
+
+echo 42 > "${CLICKHOUSE_TMP}/42"
+perform "simple_truncate" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}' TRUNCATE PARTITION BY 42;"
+
+perform "simple_format_with_prefix_and_suffix" "SELECT 42 INTO OUTFILE '${CLICKHOUSE_TMP}/{42}'  PARTITION BY 42 FORMAT JSONEachRow SETTINGS output_format_json_array_of_rows = 1" 0
+
+echo "perform file exist test"
+
+touch "${CLICKHOUSE_TMP}/y_2"
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM \`${CLICKHOUSE_TEST_NAME}\` INTO OUTFILE '${CLICKHOUSE_TMP}/{a}_{b}' PARTITION BY a, b;" 2>&1 | grep -Fc "File exists"
+rm "${CLICKHOUSE_TMP}"/*
+
+echo "perform wrong template test"
+
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP}/outfile' PARTITION BY a;" 2>&1 | grep -Fc "Missed columns"
+
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP}/outfile_{}' PARTITION BY a;" 2>&1 | grep -Fc "Unexpected column name"
+
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a INTO OUTFILE '${CLICKHOUSE_TMP}/outfile_{b}' PARTITION BY a;" 2>&1 | grep -Fc "Unexpected column name"
+
+${CLICKHOUSE_CLIENT} --query "SELECT 1 as a, 2 as b INTO OUTFILE '${CLICKHOUSE_TMP}/outfile_{_partition_id}_{b}' PARTITION BY a, b;" 2>&1 | grep -Fc "Can only use {_partition_id} with one key"
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
`src/Processors/Formats/PartitionOutputFormat.h` is mostly copied from `src/Storages/PartitionedSink.h`, but key for partitioning is `std::vector<StringRef>` instead of just `StringRef`.

Let me know if it needs more test, or I am missing something. 



### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `PARTITION BY` into `INTO OUTFILE` clause. Resolves https://github.com/ClickHouse/ClickHouse/issues/30274

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
