### PR TITLE
Always set prefix for S3 ListObject

### DIFF
--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -243,8 +243,7 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
 
     S3::ListObjectsV2Request request;
     request.SetBucket(uri.bucket);
-    if (path != "/")
-        request.SetPrefix(path);
+    request.SetPrefix(path);
     if (max_keys)
         request.SetMaxKeys(static_cast<int>(max_keys));
     else


### PR DESCRIPTION
**For the context see referenced issue**

The problem is that you may have a policy that forbids ListObject w/o prefix, so let's see will this work for MinIO

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Always set prefix for S3 ListObject

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/67975