### PR TITLE
CI: change docs-builder base image to match Vercel environment

### DIFF
--- a/ci/docker/docs-builder/Dockerfile
+++ b/ci/docker/docs-builder/Dockerfile
@@ -1,5 +1,7 @@
 # docker build -t clickhouse/docs-builder .
-FROM node:20-bookworm-slim
+
+# To match the same environment that Vercel is using
+FROM amazonlinux
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ci/docker/docs-builder/Dockerfile
+++ b/ci/docker/docs-builder/Dockerfile
@@ -19,7 +19,8 @@ RUN dnf install -y --allowerasing \
     make \
     nodejs \
     tar \
-    gzip
+    gzip \
+    file
     
 RUN npm install --global yarn && \
     dnf clean all && \

--- a/ci/docker/docs-builder/Dockerfile
+++ b/ci/docker/docs-builder/Dockerfile
@@ -1,21 +1,29 @@
 # docker build -t clickhouse/docs-builder .
 
 # To match the same environment that Vercel is using
-FROM amazonlinux
+FROM amazonlinux:2023
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN dnf update -y
+
+# Install dependencies using dnf (Amazon Linux 2023 package manager)
+RUN dnf install -y --allowerasing \
     git \
-    openssh-client \
+    openssh-clients \
     python3 \
-    python3-venv \
+    python3-pip \
     rsync \
     curl \
     ca-certificates \
-    build-essential \
-    g++ \
-    make && \
-    rm -rf /var/lib/apt/lists/*
+    gcc \
+    gcc-c++ \
+    make \
+    nodejs \
+    tar \
+    gzip
+    
+RUN npm install --global yarn && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /root/.npm /tmp/*
 
 ARG CACHE_INVALIDATOR=0
 
@@ -23,6 +31,7 @@ ARG CACHE_INVALIDATOR=0
 RUN groupadd -r clickhouse && \
     useradd -r -g clickhouse -m -d /home/clickhouse -s /sbin/nologin -c "ClickHouse user" clickhouse
 
+# Set yarn registry (Needs yarn installed first, moved install earlier)
 RUN yarn config set registry https://registry.npmjs.org
 ENV HOME=/opt/clickhouse-docs
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
docs-builder base image should match the image used by Vercel otherwise changes which appear to be working in one environment can fail in another. e.g 

https://s3.amazonaws.com/clickhouse-test-reports/PRs/79024/6ae10b77fd33ab42ea38de31950758d62377a93b//docs_check/job.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
