### PR TITLE
avoid duplication in the MergeTreeIndexCondition::alwaysUnknownOrTrue impls

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -212,14 +212,13 @@ bool MergeTreeIndexConditionBloomFilter::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
-        [](RPNElement::Function function)
-        {
-            return (
-                function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS
-                || function == RPNElement::FUNCTION_HAS || function == RPNElement::FUNCTION_HAS_ANY
-                || function == RPNElement::FUNCTION_HAS_ALL || function == RPNElement::FUNCTION_IN
-                || function == RPNElement::FUNCTION_NOT_IN);
-        });
+        {RPNElement::FUNCTION_EQUALS,
+         RPNElement::FUNCTION_NOT_EQUALS,
+         RPNElement::FUNCTION_HAS,
+         RPNElement::FUNCTION_HAS_ANY,
+         RPNElement::FUNCTION_HAS_ALL,
+         RPNElement::FUNCTION_IN,
+         RPNElement::FUNCTION_NOT_IN});
 }
 
 bool MergeTreeIndexConditionBloomFilter::mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule) const

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -210,49 +210,16 @@ MergeTreeIndexConditionBloomFilter::MergeTreeIndexConditionBloomFilter(
 
 bool MergeTreeIndexConditionBloomFilter::alwaysUnknownOrTrue() const
 {
-    std::vector<bool> rpn_stack;
-
-    for (const auto & element : rpn)
-    {
-        if (element.function == RPNElement::FUNCTION_UNKNOWN
-            || element.function == RPNElement::ALWAYS_TRUE)
+    return rpnEvaluatesAlwaysUnknownOrTrue(
+        rpn,
+        [&](RPNElement::Function function)
         {
-            rpn_stack.push_back(true);
-        }
-        else if (element.function == RPNElement::FUNCTION_EQUALS
-            || element.function == RPNElement::FUNCTION_NOT_EQUALS
-            || element.function == RPNElement::FUNCTION_HAS
-            || element.function == RPNElement::FUNCTION_HAS_ANY
-            || element.function == RPNElement::FUNCTION_HAS_ALL
-            || element.function == RPNElement::FUNCTION_IN
-            || element.function == RPNElement::FUNCTION_NOT_IN
-            || element.function == RPNElement::ALWAYS_FALSE)
-        {
-            rpn_stack.push_back(false);
-        }
-        else if (element.function == RPNElement::FUNCTION_NOT)
-        {
-            // do nothing
-        }
-        else if (element.function == RPNElement::FUNCTION_AND)
-        {
-            auto arg1 = rpn_stack.back();
-            rpn_stack.pop_back();
-            auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 && arg2;
-        }
-        else if (element.function == RPNElement::FUNCTION_OR)
-        {
-            auto arg1 = rpn_stack.back();
-            rpn_stack.pop_back();
-            auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 || arg2;
-        }
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function type in KeyCondition::RPNElement");
-    }
-
-    return rpn_stack[0];
+            return (
+                function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS
+                || function == RPNElement::FUNCTION_HAS || function == RPNElement::FUNCTION_HAS_ANY
+                || function == RPNElement::FUNCTION_HAS_ALL || function == RPNElement::FUNCTION_IN
+                || function == RPNElement::FUNCTION_NOT_IN);
+        });
 }
 
 bool MergeTreeIndexConditionBloomFilter::mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule) const

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -212,7 +212,7 @@ bool MergeTreeIndexConditionBloomFilter::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
-        [&](RPNElement::Function function)
+        [](RPNElement::Function function)
         {
             return (
                 function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -178,15 +178,16 @@ bool MergeTreeConditionBloomFilterText::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
-        [](RPNElement::Function function)
-        {
-            return (
-                function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS
-                || function == RPNElement::FUNCTION_HAS || function == RPNElement::FUNCTION_IN || function == RPNElement::FUNCTION_NOT_IN
-                || function == RPNElement::FUNCTION_MULTI_SEARCH || function == RPNElement::FUNCTION_MATCH
-                || function == RPNElement::FUNCTION_HAS_ANY || function == RPNElement::FUNCTION_HAS_ALL
-                || function == RPNElement::ALWAYS_FALSE);
-        });
+        {RPNElement::FUNCTION_EQUALS,
+         RPNElement::FUNCTION_NOT_EQUALS,
+         RPNElement::FUNCTION_HAS,
+         RPNElement::FUNCTION_IN,
+         RPNElement::FUNCTION_NOT_IN,
+         RPNElement::FUNCTION_MULTI_SEARCH,
+         RPNElement::FUNCTION_MATCH,
+         RPNElement::FUNCTION_HAS_ANY,
+         RPNElement::FUNCTION_HAS_ALL,
+         RPNElement::ALWAYS_FALSE});
 }
 
 /// Keep in-sync with MergeTreeIndexConditionGin::mayBeTrueOnTranuleInPart

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -178,7 +178,7 @@ bool MergeTreeConditionBloomFilterText::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
-        [&](RPNElement::Function function)
+        [](RPNElement::Function function)
         {
             return (
                 function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -176,52 +176,17 @@ MergeTreeConditionBloomFilterText::MergeTreeConditionBloomFilterText(
 /// Keep in-sync with MergeTreeConditionGinFilter::alwaysUnknownOrTrue
 bool MergeTreeConditionBloomFilterText::alwaysUnknownOrTrue() const
 {
-    /// Check like in KeyCondition.
-    std::vector<bool> rpn_stack;
-
-    for (const auto & element : rpn)
-    {
-        if (element.function == RPNElement::FUNCTION_UNKNOWN
-            || element.function == RPNElement::ALWAYS_TRUE)
+    return rpnEvaluatesAlwaysUnknownOrTrue(
+        rpn,
+        [&](RPNElement::Function function)
         {
-            rpn_stack.push_back(true);
-        }
-        else if (element.function == RPNElement::FUNCTION_EQUALS
-             || element.function == RPNElement::FUNCTION_NOT_EQUALS
-             || element.function == RPNElement::FUNCTION_HAS
-             || element.function == RPNElement::FUNCTION_IN
-             || element.function == RPNElement::FUNCTION_NOT_IN
-             || element.function == RPNElement::FUNCTION_MULTI_SEARCH
-             || element.function == RPNElement::FUNCTION_MATCH
-             || element.function == RPNElement::FUNCTION_HAS_ANY
-             || element.function == RPNElement::FUNCTION_HAS_ALL
-             || element.function == RPNElement::ALWAYS_FALSE)
-        {
-            rpn_stack.push_back(false);
-        }
-        else if (element.function == RPNElement::FUNCTION_NOT)
-        {
-            // do nothing
-        }
-        else if (element.function == RPNElement::FUNCTION_AND)
-        {
-            auto arg1 = rpn_stack.back();
-            rpn_stack.pop_back();
-            auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 && arg2;
-        }
-        else if (element.function == RPNElement::FUNCTION_OR)
-        {
-            auto arg1 = rpn_stack.back();
-            rpn_stack.pop_back();
-            auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 || arg2;
-        }
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function type in KeyCondition::RPNElement");
-    }
-
-    return rpn_stack[0];
+            return (
+                function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS
+                || function == RPNElement::FUNCTION_HAS || function == RPNElement::FUNCTION_IN || function == RPNElement::FUNCTION_NOT_IN
+                || function == RPNElement::FUNCTION_MULTI_SEARCH || function == RPNElement::FUNCTION_MATCH
+                || function == RPNElement::FUNCTION_HAS_ANY || function == RPNElement::FUNCTION_HAS_ALL
+                || function == RPNElement::ALWAYS_FALSE);
+        });
 }
 
 /// Keep in-sync with MergeTreeIndexConditionGin::mayBeTrueOnTranuleInPart

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -223,13 +223,13 @@ bool MergeTreeIndexConditionGin::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
-        [](RPNElement::Function function)
-        {
-            return (
-                function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS
-                || function == RPNElement::FUNCTION_HAS || function == RPNElement::FUNCTION_IN || function == RPNElement::FUNCTION_NOT_IN
-                || function == RPNElement::FUNCTION_MULTI_SEARCH || function == RPNElement::FUNCTION_MATCH);
-        });
+        {RPNElement::FUNCTION_EQUALS,
+         RPNElement::FUNCTION_NOT_EQUALS,
+         RPNElement::FUNCTION_HAS,
+         RPNElement::FUNCTION_IN,
+         RPNElement::FUNCTION_NOT_IN,
+         RPNElement::FUNCTION_MULTI_SEARCH,
+         RPNElement::FUNCTION_MATCH});
 }
 
 bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranulePtr idx_granule,[[maybe_unused]] PostingsCacheForStore & cache_store) const

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -221,50 +221,15 @@ MergeTreeIndexConditionGin::MergeTreeIndexConditionGin(
 /// Keep in-sync with MergeTreeIndexConditionGin::alwaysUnknownOrTrue
 bool MergeTreeIndexConditionGin::alwaysUnknownOrTrue() const
 {
-    /// Check like in KeyCondition.
-    std::vector<bool> rpn_stack;
-
-    for (const auto & element : rpn)
-    {
-        if (element.function == RPNElement::FUNCTION_UNKNOWN
-            || element.function == RPNElement::ALWAYS_TRUE)
+    return rpnEvaluatesAlwaysUnknownOrTrue(
+        rpn,
+        [&](RPNElement::Function function)
         {
-            rpn_stack.push_back(true);
-        }
-        else if (element.function == RPNElement::FUNCTION_EQUALS
-             || element.function == RPNElement::FUNCTION_NOT_EQUALS
-             || element.function == RPNElement::FUNCTION_HAS
-             || element.function == RPNElement::FUNCTION_IN
-             || element.function == RPNElement::FUNCTION_NOT_IN
-             || element.function == RPNElement::FUNCTION_MULTI_SEARCH
-             || element.function == RPNElement::FUNCTION_MATCH
-             || element.function == RPNElement::ALWAYS_FALSE)
-        {
-            rpn_stack.push_back(false);
-        }
-        else if (element.function == RPNElement::FUNCTION_NOT)
-        {
-            // do nothing
-        }
-        else if (element.function == RPNElement::FUNCTION_AND)
-        {
-            auto arg1 = rpn_stack.back();
-            rpn_stack.pop_back();
-            auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 && arg2;
-        }
-        else if (element.function == RPNElement::FUNCTION_OR)
-        {
-            auto arg1 = rpn_stack.back();
-            rpn_stack.pop_back();
-            auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 || arg2;
-        }
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function type in KeyCondition::RPNElement");
-    }
-
-    return rpn_stack[0];
+            return (
+                function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS
+                || function == RPNElement::FUNCTION_HAS || function == RPNElement::FUNCTION_IN || function == RPNElement::FUNCTION_NOT_IN
+                || function == RPNElement::FUNCTION_MULTI_SEARCH || function == RPNElement::FUNCTION_MATCH);
+        });
 }
 
 bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranulePtr idx_granule,[[maybe_unused]] PostingsCacheForStore & cache_store) const

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -223,7 +223,7 @@ bool MergeTreeIndexConditionGin::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
-        [&](RPNElement::Function function)
+        [](RPNElement::Function function)
         {
             return (
                 function == RPNElement::FUNCTION_EQUALS || function == RPNElement::FUNCTION_NOT_EQUALS

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -179,15 +179,15 @@ bool MergeTreeIndexConditionMinMax::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         condition.getRPN(),
-        [](KeyCondition::RPNElement::Function function)
-        {
-            return (
-                function == KeyCondition::RPNElement::FUNCTION_NOT_IN_RANGE || function == KeyCondition::RPNElement::FUNCTION_IN_RANGE
-                || function == KeyCondition::RPNElement::FUNCTION_IN_SET || function == KeyCondition::RPNElement::FUNCTION_NOT_IN_SET
-                || function == KeyCondition::RPNElement::FUNCTION_ARGS_IN_HYPERRECTANGLE
-                || function == KeyCondition::RPNElement::FUNCTION_POINT_IN_POLYGON || function == KeyCondition::RPNElement::FUNCTION_IS_NULL
-                || function == KeyCondition::RPNElement::FUNCTION_IS_NOT_NULL || function == KeyCondition::RPNElement::ALWAYS_FALSE);
-        });
+        {KeyCondition::RPNElement::FUNCTION_NOT_IN_RANGE,
+         KeyCondition::RPNElement::FUNCTION_IN_RANGE,
+         KeyCondition::RPNElement::FUNCTION_IN_SET,
+         KeyCondition::RPNElement::FUNCTION_NOT_IN_SET,
+         KeyCondition::RPNElement::FUNCTION_ARGS_IN_HYPERRECTANGLE,
+         KeyCondition::RPNElement::FUNCTION_POINT_IN_POLYGON,
+         KeyCondition::RPNElement::FUNCTION_IS_NULL,
+         KeyCondition::RPNElement::FUNCTION_IS_NOT_NULL,
+         KeyCondition::RPNElement::ALWAYS_FALSE});
 }
 
 bool MergeTreeIndexConditionMinMax::mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx_granule) const

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -179,7 +179,7 @@ bool MergeTreeIndexConditionMinMax::alwaysUnknownOrTrue() const
 {
     return rpnEvaluatesAlwaysUnknownOrTrue(
         condition.getRPN(),
-        [&](KeyCondition::RPNElement::Function function)
+        [](KeyCondition::RPNElement::Function function)
         {
             return (
                 function == KeyCondition::RPNElement::FUNCTION_NOT_IN_RANGE || function == KeyCondition::RPNElement::FUNCTION_IN_RANGE

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -177,7 +177,17 @@ MergeTreeIndexConditionMinMax::MergeTreeIndexConditionMinMax(
 
 bool MergeTreeIndexConditionMinMax::alwaysUnknownOrTrue() const
 {
-    return condition.alwaysUnknownOrTrue();
+    return rpnEvaluatesAlwaysUnknownOrTrue(
+        condition.getRPN(),
+        [&](KeyCondition::RPNElement::Function function)
+        {
+            return (
+                function == KeyCondition::RPNElement::FUNCTION_NOT_IN_RANGE || function == KeyCondition::RPNElement::FUNCTION_IN_RANGE
+                || function == KeyCondition::RPNElement::FUNCTION_IN_SET || function == KeyCondition::RPNElement::FUNCTION_NOT_IN_SET
+                || function == KeyCondition::RPNElement::FUNCTION_ARGS_IN_HYPERRECTANGLE
+                || function == KeyCondition::RPNElement::FUNCTION_POINT_IN_POLYGON || function == KeyCondition::RPNElement::FUNCTION_IS_NULL
+                || function == KeyCondition::RPNElement::FUNCTION_IS_NOT_NULL || function == KeyCondition::RPNElement::ALWAYS_FALSE);
+        });
 }
 
 bool MergeTreeIndexConditionMinMax::mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx_granule) const

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -188,8 +188,9 @@ public:
         throw Exception(ErrorCodes::LOGICAL_ERROR, "calculateApproximateNearestNeighbors is not implemented for non-vector-similarity indexes");
     }
 
-    template <typename RPNElement, typename FUNC>
-    bool rpnEvaluatesAlwaysUnknownOrTrue(const std::vector<RPNElement> & rpn, FUNC && isMatchingRPNFunction) const
+    template <typename RPNElement>
+    bool rpnEvaluatesAlwaysUnknownOrTrue(
+        const std::vector<RPNElement> & rpn, std::function<bool(typename RPNElement::Function)> isMatchingRPNFunction) const
     {
         std::vector<Internal::RPNEvaluationIndexUsefulnessState> rpn_stack;
         rpn_stack.reserve(rpn.size() - 1);

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -13,6 +13,60 @@ constexpr auto INDEX_FILE_PREFIX = "skp_idx_";
 namespace DB
 {
 
+namespace Internal
+{
+
+enum class RPNEvaluationIndexUsefulnessState : uint8_t
+{
+    // the following states indicate if the index might be useful
+    TRUE,
+    FALSE,
+    // the following states indicate RPN always evaluates to TRUE or FALSE, they are used for short-circuit.
+    ALWAYS_TRUE,
+    ALWAYS_FALSE
+};
+
+[[nodiscard]] inline RPNEvaluationIndexUsefulnessState
+evalAndRpnIndexStates(const RPNEvaluationIndexUsefulnessState & lhs, const RPNEvaluationIndexUsefulnessState & rhs)
+{
+    if (lhs == RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE || rhs == RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE)
+    {
+        // short circuit
+        return RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE;
+    }
+    else if (lhs == RPNEvaluationIndexUsefulnessState::TRUE || rhs == RPNEvaluationIndexUsefulnessState::TRUE)
+    {
+        return RPNEvaluationIndexUsefulnessState::TRUE;
+    }
+    else if (lhs == RPNEvaluationIndexUsefulnessState::FALSE || rhs == RPNEvaluationIndexUsefulnessState::FALSE)
+    {
+        return RPNEvaluationIndexUsefulnessState::FALSE;
+    }
+    chassert(lhs == RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE && rhs == RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE);
+    return RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE;
+}
+
+[[nodiscard]] inline RPNEvaluationIndexUsefulnessState
+evalOrRpnIndexStates(const RPNEvaluationIndexUsefulnessState & lhs, const RPNEvaluationIndexUsefulnessState & rhs)
+{
+    if (lhs == RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE || rhs == RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE)
+    {
+        // short circuit
+        return RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE;
+    }
+    else if (lhs == RPNEvaluationIndexUsefulnessState::TRUE || rhs == RPNEvaluationIndexUsefulnessState::TRUE)
+    {
+        return RPNEvaluationIndexUsefulnessState::TRUE;
+    }
+    else if (lhs == RPNEvaluationIndexUsefulnessState::FALSE || rhs == RPNEvaluationIndexUsefulnessState::FALSE)
+    {
+        return RPNEvaluationIndexUsefulnessState::FALSE;
+    }
+    chassert(lhs == RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE && rhs == RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE);
+    return RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE;
+}
+}
+
 class ActionsDAG;
 class Block;
 class IDataPartStorage;
@@ -132,6 +186,56 @@ public:
     virtual std::vector<UInt64> calculateApproximateNearestNeighbors(MergeTreeIndexGranulePtr /*granule*/) const
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "calculateApproximateNearestNeighbors is not implemented for non-vector-similarity indexes");
+    }
+
+    template <typename RPNElement, typename FUNC>
+    bool rpnEvaluatesAlwaysUnknownOrTrue(const std::vector<RPNElement> & rpn, FUNC && isMatchingRPNFunction) const
+    {
+        std::vector<Internal::RPNEvaluationIndexUsefulnessState> rpn_stack;
+        rpn_stack.reserve(rpn.size() - 1);
+
+        for (const auto & element : rpn)
+        {
+            if (element.function == RPNElement::ALWAYS_TRUE)
+            {
+                rpn_stack.emplace_back(Internal::RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE);
+            }
+            else if (element.function == RPNElement::ALWAYS_FALSE)
+            {
+                rpn_stack.emplace_back(Internal::RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE);
+            }
+            else if (element.function == RPNElement::FUNCTION_UNKNOWN)
+            {
+                rpn_stack.emplace_back(Internal::RPNEvaluationIndexUsefulnessState::FALSE);
+            }
+            else if (isMatchingRPNFunction(element.function))
+            {
+                rpn_stack.push_back(Internal::RPNEvaluationIndexUsefulnessState::TRUE);
+            }
+            else if (element.function == RPNElement::FUNCTION_NOT)
+            {
+                // do nothing
+            }
+            else if (element.function == RPNElement::FUNCTION_AND)
+            {
+                auto lhs = rpn_stack.back();
+                rpn_stack.pop_back();
+                auto rhs = rpn_stack.back();
+                rpn_stack.back() = evalAndRpnIndexStates(lhs, rhs);
+            }
+            else if (element.function == RPNElement::FUNCTION_OR)
+            {
+                auto lhs = rpn_stack.back();
+                rpn_stack.pop_back();
+                auto rhs = rpn_stack.back();
+                rpn_stack.back() = evalOrRpnIndexStates(lhs, rhs);
+            }
+            else
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function type in RPNElement");
+        }
+
+        chassert(rpn_stack.size() == 1);
+        return rpn_stack.front() != Internal::RPNEvaluationIndexUsefulnessState::TRUE;
     }
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -27,7 +27,7 @@ enum class RPNEvaluationIndexUsefulnessState : uint8_t
 };
 
 [[nodiscard]] inline RPNEvaluationIndexUsefulnessState
-evalAndRpnIndexStates(const RPNEvaluationIndexUsefulnessState & lhs, const RPNEvaluationIndexUsefulnessState & rhs)
+evalAndRpnIndexStates(RPNEvaluationIndexUsefulnessState lhs, RPNEvaluationIndexUsefulnessState rhs)
 {
     if (lhs == RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE || rhs == RPNEvaluationIndexUsefulnessState::ALWAYS_FALSE)
     {
@@ -47,7 +47,7 @@ evalAndRpnIndexStates(const RPNEvaluationIndexUsefulnessState & lhs, const RPNEv
 }
 
 [[nodiscard]] inline RPNEvaluationIndexUsefulnessState
-evalOrRpnIndexStates(const RPNEvaluationIndexUsefulnessState & lhs, const RPNEvaluationIndexUsefulnessState & rhs)
+evalOrRpnIndexStates(RPNEvaluationIndexUsefulnessState lhs, RPNEvaluationIndexUsefulnessState rhs)
 {
     if (lhs == RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE || rhs == RPNEvaluationIndexUsefulnessState::ALWAYS_TRUE)
     {
@@ -190,7 +190,7 @@ public:
 
     template <typename RPNElement>
     bool rpnEvaluatesAlwaysUnknownOrTrue(
-        const std::vector<RPNElement> & rpn, std::function<bool(typename RPNElement::Function)> isMatchingRPNFunction) const
+        const std::vector<RPNElement> & rpn, const std::unordered_set<typename RPNElement::Function> & matchingFunctions) const
     {
         std::vector<Internal::RPNEvaluationIndexUsefulnessState> rpn_stack;
         rpn_stack.reserve(rpn.size() - 1);
@@ -209,7 +209,7 @@ public:
             {
                 rpn_stack.emplace_back(Internal::RPNEvaluationIndexUsefulnessState::FALSE);
             }
-            else if (isMatchingRPNFunction(element.function))
+            else if (matchingFunctions.contains(element.function))
             {
                 rpn_stack.push_back(Internal::RPNEvaluationIndexUsefulnessState::TRUE);
             }
@@ -236,6 +236,10 @@ public:
         }
 
         chassert(rpn_stack.size() == 1);
+        /*
+         * In case the result is `ALWAYS_TRUE`, it means we don't need any indices at all, it might be a constant result.
+         * Thus, we only check against the `TRUE` to determine the usefulness of the index condition.
+         */
         return rpn_stack.front() != Internal::RPNEvaluationIndexUsefulnessState::TRUE;
     }
 };


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The `alwaysUnknownOrTrue` is implemented by each child class and some of them were using the same implementation (the code was duplicated).

This PR comes the discussion in PR https://github.com/ClickHouse/ClickHouse/pull/78304#discussion_r2021190298.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
