### PR TITLE
Remove guard pages from fibers and alternative stack for signals in threads

### DIFF
--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -57,7 +57,7 @@ boost::context::stack_context FiberStack::allocate() const
     if (!data)
         throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate FiberStack");
 
-    if (guardPagesEnabled())
+    if constexpr (guardPagesEnabled())
     {
         /// TODO: make reports on illegal guard page access more clear.
         /// Currently we will see segfault and almost random stacktrace.

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -46,7 +46,7 @@ boost::context::stack_context FiberStack::allocate() const
 {
     size_t num_pages = 1 + (stack_size - 1) / page_size;
 
-    if (guardPagesEnabled())
+    if constexpr (guardPagesEnabled())
         /// Add one page at bottom that will be used as guard-page
         num_pages += 1;
 

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -91,7 +91,7 @@ void FiberStack::deallocate(boost::context::stack_context & sctx) const
 #endif
     void * data = static_cast< char * >(sctx.sp) - sctx.size;
 
-    if (guardPagesEnabled())
+    if constexpr (guardPagesEnabled())
         memoryGuardRemove(data, page_size);
 
     free(data);

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -36,29 +36,32 @@ boost::context::stack_context FiberStack::allocate() const
     size_t num_pages = 1 + (stack_size - 1) / page_size;
     size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
 
-    void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (MAP_FAILED == vp)
-        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
+    void * data = aligned_alloc(page_size, num_bytes);
 
+    if (!data)
+        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate FiberStack");
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
     /// TODO: make reports on illegal guard page access more clear.
     /// Currently we will see segfault and almost random stacktrace.
     try
     {
-        memoryGuardInstall(vp, page_size);
+        memoryGuardInstall(data, page_size);
     }
     catch (...)
     {
-        ::munmap(vp, num_bytes);
+        free(data);
         throw;
     }
+#endif
 
     /// Do not count guard page in memory usage.
     auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
-    trace.onAlloc(vp, num_pages * page_size);
+    trace.onAlloc(data, num_pages * page_size);
 
     boost::context::stack_context sctx;
     sctx.size = num_bytes;
-    sctx.sp = static_cast< char * >(vp) + sctx.size;
+    sctx.sp = static_cast< char * >(data) + sctx.size;
 #if defined(BOOST_USE_VALGRIND)
     sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
 #endif
@@ -70,10 +73,15 @@ void FiberStack::deallocate(boost::context::stack_context & sctx) const
 #if defined(BOOST_USE_VALGRIND)
     VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
 #endif
-    void * vp = static_cast< char * >(sctx.sp) - sctx.size;
-    ::munmap(vp, sctx.size);
+    void * data = static_cast< char * >(sctx.sp) - sctx.size;
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
+        memoryGuardRemove(data, page_size);
+#endif
+
+    free(data);
 
     /// Do not count guard page in memory usage.
     auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
-    trace.onFree(vp, sctx.size - page_size);
+    trace.onFree(data, sctx.size - page_size);
 }

--- a/src/Common/FiberStack.h
+++ b/src/Common/FiberStack.h
@@ -14,12 +14,6 @@ public:
     /// way. We will have 80 pages with 4KB page size.
     static constexpr size_t default_stack_size = 320 * 1024; /// 64KB was not enough for tests
 
-#ifdef DEBUG_OR_SANITIZER_BUILD
-    static constexpr size_t guarded_pages = 1;
-#else
-    static constexpr size_t guarded_pages = 0;
-#endif
-
     explicit FiberStack(size_t stack_size_ = default_stack_size);
 
     boost::context::stack_context allocate() const;

--- a/src/Common/FiberStack.h
+++ b/src/Common/FiberStack.h
@@ -14,6 +14,12 @@ public:
     /// way. We will have 80 pages with 4KB page size.
     static constexpr size_t default_stack_size = 320 * 1024; /// 64KB was not enough for tests
 
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    static constexpr size_t guarded_pages = 1;
+#else
+    static constexpr size_t guarded_pages = 0;
+#endif
+
     explicit FiberStack(size_t stack_size_ = default_stack_size);
 
     boost::context::stack_context allocate() const;

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -87,7 +87,7 @@ struct ThreadStack
     {
         auto size = std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ);
 
-        if (guardPagesEnabled())
+        if constexpr (guardPagesEnabled())
             size += 1;
 
         return size;

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -28,6 +28,15 @@ namespace ErrorCodes
 namespace
 {
 
+constexpr bool guardPagesEnabled()
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    return true;
+#else
+    return false;
+#endif
+}
+
 /// For aarch64 16K is not enough (likely due to tons of registers)
 constexpr size_t UNWIND_MINSIGSTKSZ = 32 << 10;
 
@@ -52,28 +61,37 @@ struct ThreadStack
         if (!data)
             throw ErrnoException(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate ThreadStack");
 
-#ifdef DEBUG_OR_SANITIZER_BUILD
-        try
+        if (guardPagesEnabled())
         {
-            /// Since the stack grows downward, we need to protect the first page
-            memoryGuardInstall(data, page_size);
+            try
+            {
+                /// Since the stack grows downward, we need to protect the first page
+                memoryGuardInstall(data, page_size);
+            }
+            catch (...)
+            {
+                free(data);
+                throw;
+            }
         }
-        catch (...)
-        {
-            free(data);
-            throw;
-        }
-#endif
     }
     ~ThreadStack()
     {
-#ifdef DEBUG_OR_SANITIZER_BUILD
-        memoryGuardRemove(data, getPageSize());
-#endif
+        if (guardPagesEnabled())
+            memoryGuardRemove(data, getPageSize());
+
         free(data);
     }
 
-    static size_t getSize() { return std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ); }
+    static size_t getSize()
+    {
+        auto size = std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ);
+
+        if (guardPagesEnabled())
+            size += 1;
+
+        return size;
+    }
     void * getData() const { return data; }
 
 private:

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -77,7 +77,7 @@ struct ThreadStack
     }
     ~ThreadStack()
     {
-        if (guardPagesEnabled())
+        if constexpr (guardPagesEnabled())
             memoryGuardRemove(data, getPageSize());
 
         free(data);

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -47,24 +47,29 @@ struct ThreadStack
 {
     ThreadStack()
     {
-        data = aligned_alloc(getPageSize(), getSize());
+        auto page_size = getPageSize();
+        data = aligned_alloc(page_size, getSize());
         if (!data)
             throw ErrnoException(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate ThreadStack");
 
+#ifdef DEBUG_OR_SANITIZER_BUILD
         try
         {
             /// Since the stack grows downward, we need to protect the first page
-            memoryGuardInstall(data, getPageSize());
+            memoryGuardInstall(data, page_size);
         }
         catch (...)
         {
             free(data);
             throw;
         }
+#endif
     }
     ~ThreadStack()
     {
+#ifdef DEBUG_OR_SANITIZER_BUILD
         memoryGuardRemove(data, getPageSize());
+#endif
         free(data);
     }
 

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -61,7 +61,7 @@ struct ThreadStack
         if (!data)
             throw ErrnoException(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate ThreadStack");
 
-        if (guardPagesEnabled())
+        if constexpr (guardPagesEnabled())
         {
             try
             {


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove guard pages for threads and async_socket_for_remote/use_hedge_requests. Change the allocation method in `FiberStack` from `mmap` to `aligned_alloc`. Since this splits VMAs and under heavy load vm.max_map_count can be reached.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
