### PR TITLE
CI: Add build digest into ci data

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -1,4 +1,7 @@
-from ci.jobs.scripts.clickhouse_version import CHVersion
+import copy
+
+from ci.defs.job_configs import JobConfigs
+from ci.praktika.digest import Digest
 from ci.praktika.info import Info
 from ci.praktika.utils import Shell
 
@@ -18,6 +21,13 @@ if __name__ == "__main__":
     if changed_files_str:
         changed_files = changed_files_str.split("\n")
         info.store_custom_data("changed_files", changed_files)
+
+    # hack to get build digest
+    some_build_job = copy.deepcopy(JobConfigs.build_jobs[0])
+    some_build_job.run_in_docker = ""
+    some_build_job.provides = []
+    digest = Digest().calc_job_digest(some_build_job, {}, {}).split("-")[0]
+    info.store_custom_data("build_digest", digest)
 
     if info.git_branch == "master" and info.repo_name == "ClickHouse/ClickHouse":
         # store previous commits for perf tests


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

calculate and store build digest, so that other job can use it if needed (for instance as a docker server tag)
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
