### PR TITLE
Force full storage for GIN tests

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -355,7 +355,6 @@
 02149_read_in_order_fixed_prefix
 02151_hash_table_sizes_stats
 02156_storage_merge_prewhere
-02346_gin_index_match_predicate
 02354_vector_search_subquery
 02421_explain_subquery
 02451_order_by_monotonic

--- a/tests/queries/0_stateless/02346_gin_index_bug47393.sql
+++ b/tests/queries/0_stateless/02346_gin_index_bug47393.sql
@@ -11,7 +11,8 @@ CREATE TABLE tab
 )
 ENGINE = MergeTree
 ORDER BY tuple()
-SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1;
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1,
+         min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab (str) VALUES ('I am inverted');
 

--- a/tests/queries/0_stateless/02346_gin_index_bug52019.sql
+++ b/tests/queries/0_stateless/02346_gin_index_bug52019.sql
@@ -12,7 +12,7 @@ CREATE TABLE tab (
 ENGINE = MergeTree
 ORDER BY id
 SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
-         min_bytes_for_full_part_storage = 0; -- GIN index works only with full parts.
+         min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab (id) VALUES (0);
 

--- a/tests/queries/0_stateless/02346_gin_index_bug54541.sql
+++ b/tests/queries/0_stateless/02346_gin_index_bug54541.sql
@@ -4,7 +4,16 @@ SET allow_experimental_full_text_index = 1;
 
 DROP TABLE IF EXISTS tab;
 
-CREATE TABLE tab (id UInt32, str String, INDEX idx str TYPE gin) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE tab
+(
+    id UInt32,
+    str String,
+    INDEX idx str TYPE gin
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
+
 INSERT INTO tab VALUES (0, 'a');
 SELECT * FROM tab WHERE str == 'b' AND 1.0;
 

--- a/tests/queries/0_stateless/02346_gin_index_bug59039.sql
+++ b/tests/queries/0_stateless/02346_gin_index_bug59039.sql
@@ -13,7 +13,8 @@ CREATE TABLE tab
 )
 ENGINE = MergeTree
 ORDER BY id
-SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi', min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi', min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 ALTER TABLE tab DROP INDEX text_idx;
 

--- a/tests/queries/0_stateless/02346_gin_index_detach_attach.sql
+++ b/tests/queries/0_stateless/02346_gin_index_detach_attach.sql
@@ -9,7 +9,8 @@ CREATE TABLE t
     INDEX inv_idx str TYPE gin(0) GRANULARITY 1
 )
 ENGINE = MergeTree
-ORDER BY key;
+ORDER BY key
+SETTINGS min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO t VALUES (1, 'Hello World');
 

--- a/tests/queries/0_stateless/02346_gin_index_legacy_name.sql
+++ b/tests/queries/0_stateless/02346_gin_index_legacy_name.sql
@@ -8,10 +8,10 @@ DROP TABLE IF EXISTS tab;
 
 -- Creation only works with the (old) setting enabled.
 SET allow_experimental_inverted_index = 0;
-CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE inverted(2)) ENGINE = MergeTree() ORDER BY k; -- { serverError ILLEGAL_INDEX }
+CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE inverted(2)) ENGINE = MergeTree() ORDER BY k SETTINGS min_bytes_for_full_part_storage = 0; -- { serverError ILLEGAL_INDEX }
 
 SET allow_experimental_inverted_index = 1;
-CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE inverted(2)) ENGINE = MergeTree() ORDER BY k;
+CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE inverted(2)) ENGINE = MergeTree() ORDER BY k SETTINGS min_bytes_for_full_part_storage = 0;
 INSERT INTO tab VALUES (1, 'ab') (2, 'bc');
 
 -- Detach and attach should work.
@@ -40,10 +40,10 @@ DROP TABLE tab;
 
 -- Creation only works with the (old) setting enabled.
 SET allow_experimental_full_text_index = 0;
-CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE full_text(2)) ENGINE = MergeTree() ORDER BY k; -- { serverError ILLEGAL_INDEX }
+CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE full_text(2)) ENGINE = MergeTree() ORDER BY k SETTINGS min_bytes_for_full_part_storage = 0; -- { serverError ILLEGAL_INDEX }
 
 SET allow_experimental_full_text_index = 1;
-CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE full_text(2)) ENGINE = MergeTree() ORDER BY k;
+CREATE TABLE tab(k UInt64, s String, INDEX idx(s) TYPE full_text(2)) ENGINE = MergeTree() ORDER BY k SETTINGS min_bytes_for_full_part_storage = 0;
 INSERT INTO tab VALUES (1, 'ab') (2, 'bc');
 
 -- Detach and attach should work.

--- a/tests/queries/0_stateless/02346_gin_index_match_predicate.sql
+++ b/tests/queries/0_stateless/02346_gin_index_match_predicate.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel-replicas
+
 -- Tests that match() utilizes the inverted index
 
 SET allow_experimental_full_text_index = true;
@@ -12,8 +14,8 @@ CREATE TABLE tab
 )
 ENGINE = MergeTree
 ORDER BY id
-SETTINGS index_granularity = 1;
-
+SETTINGS index_granularity = 1,
+         min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 INSERT INTO tab VALUES (1, 'Well, Hello ClickHouse !'), (2, 'Well, Hello World !'), (3, 'Good Weather !'), (4, 'Say Hello !'), (5, 'Its An OLAP Database'), (6, 'True World Champion');
 
 SELECT * FROM tab WHERE match(str, ' Hello (ClickHouse|World) ') ORDER BY id;

--- a/tests/queries/0_stateless/02346_gin_index_on_multiple_columns.sql
+++ b/tests/queries/0_stateless/02346_gin_index_on_multiple_columns.sql
@@ -10,7 +10,8 @@ CREATE TABLE tab (
     INDEX idx (v0, v1) TYPE gin GRANULARITY 1)
 ENGINE = MergeTree
 ORDER BY tuple()
-SETTINGS index_granularity = 1;
+SETTINGS index_granularity = 1,
+         min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab VALUES('0,0', '0,1')('2,2','2,3');
 

--- a/tests/queries/0_stateless/02346_gin_index_queries.sql
+++ b/tests/queries/0_stateless/02346_gin_index_queries.sql
@@ -12,7 +12,8 @@ DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE gin(2))
             ENGINE = MergeTree() ORDER BY k
-            SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+            SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
+                     min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab VALUES (101, 'Alick a01'), (102, 'Blick a02'), (103, 'Click a03'), (104, 'Dlick a04'), (105, 'Elick a05'), (106, 'Alick a06'), (107, 'Blick a07'), (108, 'Click a08'), (109, 'Dlick a09'), (110, 'Elick a10'), (111, 'Alick b01'), (112, 'Blick b02'), (113, 'Click b03'), (114, 'Dlick b04'), (115, 'Elick b05'), (116, 'Alick b06'), (117, 'Blick b07'), (118, 'Click b08'), (119, 'Dlick b09'), (120, 'Elick b10');
 
@@ -68,7 +69,8 @@ DROP TABLE IF EXISTS tab_x;
 
 CREATE TABLE tab_x(k UInt64, s String, INDEX af(s) TYPE gin())
     ENGINE = MergeTree() ORDER BY k
-    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
+             min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab_x VALUES (101, 'x Alick a01 y'), (102, 'x Blick a02 y'), (103, 'x Click a03 y'), (104, 'x Dlick a04 y'), (105, 'x Elick a05 y'), (106, 'x Alick a06 y'), (107, 'x Blick a07 y'), (108, 'x Click a08 y'), (109, 'x Dlick a09 y'), (110, 'x Elick a10 y'), (111, 'x Alick b01 y'), (112, 'x Blick b02 y'), (113, 'x Click b03 y'), (114, 'x Dlick b04 y'), (115, 'x Elick b05 y'), (116, 'x Alick b06 y'), (117, 'x Blick b07 y'), (118, 'x Click b08 y'), (119, 'x Dlick b09 y'), (120, 'x Elick b10 y');
 
@@ -121,7 +123,8 @@ DROP TABLE IF EXISTS tab;
 
 create table tab (k UInt64, s Array(String), INDEX af(s) TYPE gin(2))
     ENGINE = MergeTree() ORDER BY k
-    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
+             min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab SELECT rowNumberInBlock(), groupArray(s) FROM tab_x GROUP BY k%10;
 
@@ -148,7 +151,8 @@ DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab (k UInt64, s Map(String,String), INDEX af(mapKeys(s)) TYPE gin(2))
     ENGINE = MergeTree() ORDER BY k
-    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
+             min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab VALUES (101, {'Alick':'Alick a01'}), (102, {'Blick':'Blick a02'}), (103, {'Click':'Click a03'}), (104, {'Dlick':'Dlick a04'}), (105, {'Elick':'Elick a05'}), (106, {'Alick':'Alick a06'}), (107, {'Blick':'Blick a07'}), (108, {'Click':'Click a08'}), (109, {'Dlick':'Dlick a09'}), (110, {'Elick':'Elick a10'}), (111, {'Alick':'Alick b01'}), (112, {'Blick':'Blick b02'}), (113, {'Click':'Click b03'}), (114, {'Dlick':'Dlick b04'}), (115, {'Elick':'Elick b05'}), (116, {'Alick':'Alick b06'}), (117, {'Blick':'Blick b07'}), (118, {'Click':'Click b08'}), (119, {'Dlick':'Dlick b09'}), (120, {'Elick':'Elick b10'});
 
@@ -189,7 +193,8 @@ DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE gin(2))
     ENGINE = MergeTree() ORDER BY k
-    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
+             min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab VALUES (101, 'Alick a01'), (102, 'Blick a02'), (103, 'Click a03'), (104, 'Dlick a04'), (105, 'Elick a05'), (106, 'Alick a06'), (107, 'Blick a07'), (108, 'Click a08'), (109, 'Dlick a09'), (110, 'Elick b10'), (111, 'Alick b01'), (112, 'Blick b02'), (113, 'Click b03'), (114, 'Dlick b04'), (115, 'Elick b05'), (116, 'Alick b06'), (117, 'Blick b07'), (118, 'Click b08'), (119, 'Dlick b09'), (120, 'Elick b10');
 INSERT INTO tab VALUES (201, 'rick c01'), (202, 'mick c02'), (203, 'nick c03');
@@ -218,7 +223,8 @@ DROP TABLE IF EXISTS tab;
 CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE gin(2))
     ENGINE = MergeTree()
     ORDER BY k
-    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi',
+             min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO tab VALUES (101, 'Alick 好'), (102, 'clickhouse你好'), (103, 'Click 你'), (104, 'Dlick 你a好'), (105, 'Elick 好好你你'), (106, 'Alick 好a好a你a你');
 
@@ -248,11 +254,12 @@ DROP TABLE IF EXISTS tab;
 CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE gin(0, 12040))
                      Engine=MergeTree
                      ORDER BY (k)
+                     SETTINGS min_bytes_for_full_part_storage = 0
                      AS
-                         SELECT
-                         number,
-                         format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
-                         FROM numbers(1024);
+                         (SELECT
+                             number,
+                             format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
+                         FROM numbers(1024));
 SELECT count(s) FROM tab WHERE hasToken(s, '4C4B4B4B4B4B5040');
 DROP TABLE IF EXISTS tab;
 
@@ -261,8 +268,9 @@ DROP TABLE IF EXISTS tab;
 CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE gin(3, 123))
                      Engine=MergeTree
                      ORDER BY (k)
+                     SETTINGS min_bytes_for_full_part_storage = 0
                      AS
-                         SELECT
-                         number,
-                         format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
-                         FROM numbers(1024);  -- { serverError INCORRECT_QUERY }
+                         (SELECT
+                            number,
+                            format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
+                         FROM numbers(1024));  -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
@@ -128,8 +128,7 @@ CREATE TABLE 03165_token_ft
 )
 ENGINE = MergeTree
 ORDER BY id
--- Full text index works only with full parts.
-SETTINGS min_bytes_for_full_part_storage=0;
+SETTINGS min_bytes_for_full_part_storage = 0; -- GIN indexes currently don't work with packed parts
 
 INSERT INTO 03165_token_ft VALUES(1, 'Service is not ready');
 


### PR DESCRIPTION
Disables packed parts for all GIN index tests, see https://github.com/ClickHouse/ClickHouse/pull/79188#issuecomment-2804804143

Mental note to myself: Remove tests from `tests/queries-no-private-tests.txt`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)