### PR TITLE
Increase number of messages to avoid flakiness

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -202,7 +202,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
     """
     )
 
-    messages_num = 200000
+    messages_num = 300000
     rabbitmq_monitor.set_expectations(published=messages_num, delivered=messages_num)
     deadline = time.monotonic() + 180
     while time.monotonic() < deadline:
@@ -282,7 +282,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
     """
     )
 
-    messages_num = 200000
+    messages_num = 300000
     rabbitmq_monitor.set_expectations(published=messages_num, delivered=messages_num)
     deadline = time.monotonic() + 180
     while time.monotonic() < deadline:


### PR DESCRIPTION
Seems all messages might still be consumed before suspending and resuming the RabbitMQ server:

https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/9bb046e3b5be96376333dd145b1868c28e4257dc//integration_tests_release_1_4/integration_run_test_storage_rabbitmq_test_failed_connection_py_0.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
