### PR TITLE
Adds a log file for external http server

### DIFF
--- a/tests/integration/helpers/external_sources.py
+++ b/tests/integration/helpers/external_sources.py
@@ -490,11 +490,12 @@ class SourceHTTPBase(ExternalSource):
             [
                 "bash",
                 "-c",
-                "python3 /http_server.py --data-path={tbl} --schema={schema} --host={host} --port={port} --cert-path=/fake_cert.pem".format(
+                "python3 /http_server.py --data-path={tbl} --schema={schema} --host={host} --port={port} --cert-path=/fake_cert.pem {logs}".format(
                     tbl=path,
                     schema=self._get_schema(),
                     host=self.docker_hostname,
                     port=self.http_port,
+                    logs='>> /var/log/clickhouse-server/http_server.py.log 2>&1'
                 ),
             ],
             detach=True,

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -73,6 +73,7 @@ def started_cluster():
 @pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
+    assert False, 'fake fail to check if logging works'
 
 
 @pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -73,7 +73,6 @@ def started_cluster():
 @pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
-    assert False, 'fake fail to check if logging works'
 
 
 @pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))


### PR DESCRIPTION
For test test_dictionaries_all_layouts_separate_sources we use http_server.py as an external http source. Sometimes it is flaky, and the assumption is the HTTP server fails. To confirm that we can add a logger to HTTP server to check if the server failed for any reason. The logs will be stored with clickhouse server logs in a separate file. Tests already gathering all the files in that folder.

could show a problem with https://github.com/ClickHouse/clickhouse-private/issues/28248#event-17154101923

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

