### PR TITLE
Add retry logic to test_backup_restore_new::test_system_backups

### DIFF
--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -13,7 +13,7 @@ import pytest
 
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV, assert_eq_with_retry
+from helpers.test_tools import TSV, assert_eq_with_retry, wait_condition
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -1798,26 +1798,25 @@ def test_system_backups():
     id = instance.query(
         f"RESTORE TABLE test.table FROM {backup_name}", query_id=restore_query_id
     ).split("\t")[0]
-    restore_info = get_backup_info_from_system_backups(by_id=id)
-    restore_events = get_events_for_query(restore_query_id)
 
-    assert restore_info.name == escaped_backup_name
-    assert restore_info.status == "RESTORED"
-    assert restore_info.error == ""
-    assert restore_info.start_time < restore_info.end_time
-    assert restore_info.num_files == info.num_files
-    assert restore_info.total_size == info.total_size
-    assert restore_info.num_entries == info.num_entries
-    assert restore_info.uncompressed_size == info.uncompressed_size
-    assert restore_info.compressed_size == info.compressed_size
-    assert (
-        restore_info.files_read + restore_events["RestorePartsSkippedFiles"]
-        == restore_info.num_files
-    )
-    assert (
-        restore_info.bytes_read + restore_events["RestorePartsSkippedBytes"]
-        == restore_info.total_size
-    )
+    def verify_restore_info():
+        restore_info = get_backup_info_from_system_backups(by_id=id)
+        restore_events = get_events_for_query(restore_query_id)
+        return (
+            restore_info.name == escaped_backup_name and
+            restore_info.status == "RESTORED" and
+            restore_info.error == "" and
+            restore_info.start_time < restore_info.end_time and
+            restore_info.num_files == info.num_files and
+            restore_info.total_size == info.total_size and
+            restore_info.num_entries == info.num_entries and
+            restore_info.uncompressed_size == info.uncompressed_size and
+            restore_info.compressed_size == info.compressed_size and
+            restore_info.files_read + restore_events["RestorePartsSkippedFiles"] == restore_info.num_files and
+            restore_info.bytes_read + restore_events["RestorePartsSkippedBytes"] == restore_info.total_size
+        )
+
+    wait_condition(verify_restore_info, lambda x: x);
 
     # Failed backup.
     backup_name = new_backup_name()

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1816,7 +1816,7 @@ def test_system_backups():
             restore_info.bytes_read + restore_events["RestorePartsSkippedBytes"] == restore_info.total_size
         )
 
-    wait_condition(verify_restore_info, lambda x: x);
+    wait_condition(verify_restore_info, lambda x: x)
 
     # Failed backup.
     backup_name = new_backup_name()


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/75809

Verified that in the logs of the failed test, the behavior was correct. It seems just like the files_read value is not updated yet leading to assert failure (as each thread increments that value).

Added a `wait_condition` so we retry instead of immediately asserting.


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
