### PR TITLE
Support altering database on cluster

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -265,6 +265,13 @@ BlockIO InterpreterAlterQuery::executeToDatabase(const ASTAlterQuery & alter)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong parameter type in ALTER DATABASE query");
     }
 
+    if (!alter.cluster.empty())
+    {
+        DDLQueryOnClusterParams params;
+        params.access_to_check = getRequiredAccess();
+        return executeDDLQueryOnCluster(query_ptr, getContext(), params);
+    }
+
     if (!alter_commands.empty())
     {
         /// Only ALTER SETTING and ALTER COMMENT is supported.

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -1068,6 +1068,14 @@ bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     {
         if (!parseDatabaseAsAST(pos, expected, query->database))
             return false;
+
+        String cluster_str;
+        if (ParserKeyword(Keyword::ON).ignore(pos, expected))
+        {
+            if (!ASTQueryWithOnCluster::parse(pos, cluster_str, expected))
+                return false;
+        }
+        query->cluster = cluster_str;
     }
     else
     {

--- a/tests/integration/test_alter_database_on_cluster/configs/remote_servers.xml
+++ b/tests/integration/test_alter_database_on_cluster/configs/remote_servers.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_alter_database_on_cluster/test.py
+++ b/tests/integration/test_alter_database_on_cluster/test.py
@@ -1,0 +1,106 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster, QueryRuntimeException
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 1},
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 2},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def create_database(node, db_name: str, engine: str, comment: str):
+    if engine == "Atomic":
+        node.query(
+            f"CREATE DATABASE {db_name} ON CLUSTER test_cluster ENGINE = Atomic COMMENT '{comment}'"
+        )
+        return
+
+    if engine == "Lazy":
+        node.query(
+            f"CREATE DATABASE {db_name} ON CLUSTER test_cluster ENGINE = Lazy(1) COMMENT '{comment}'"
+        )
+        return
+
+    if engine == "Memory":
+        node.query(
+            f"CREATE DATABASE {db_name} ON CLUSTER test_cluster ENGINE = Memory COMMENT '{comment}'"
+        )
+        return
+
+    if engine == "Replicated":
+        node.query(
+            f"CREATE DATABASE {db_name} ON CLUSTER test_cluster "
+            + r"ENGINE = Replicated('/db/test', '{shard}', '{replica}')"
+            + f" COMMENT '{comment}'"
+        )
+        return
+
+    raise QueryRuntimeException(f"Not supported engine {engine}")
+
+
+@pytest.mark.parametrize("engine", ["Atomic", "Lazy", "Memory", "Replicated"])
+def test_alter_database_comment(started_cluster, engine):
+    node1.query("DROP DATABASE IF EXISTS test")
+    node2.query("DROP DATABASE IF EXISTS test")
+
+    create_database(node1, "test", engine, "initial comment")
+
+    modified_comment = "modified comment"
+    node1.query(
+        f"ALTER DATABASE test ON CLUSTER test_cluster (MODIFY COMMENT '{modified_comment}')"
+    )
+
+    assert (
+        node1.query("SELECT comment FROM system.databases WHERE name='test'").strip()
+        == modified_comment
+    )
+    assert (
+        node2.query("SELECT comment FROM system.databases WHERE name='test'").strip()
+        == modified_comment
+    )
+
+    node1.query(f"DETACH DATABASE test ON CLUSTER test_cluster")
+
+    assert (
+        node1.query("SELECT count() FROM system.databases WHERE name='test'").strip()
+        == "0"
+    )
+    assert (
+        node2.query("SELECT count() FROM system.databases WHERE name='test'").strip()
+        == "0"
+    )
+
+    node1.query(f"ATTACH DATABASE test ON CLUSTER test_cluster")
+
+    assert (
+        node1.query("SELECT comment FROM system.databases WHERE name='test'").strip()
+        == modified_comment
+    )
+    assert (
+        node2.query("SELECT comment FROM system.databases WHERE name='test'").strip()
+        == modified_comment
+    )
+
+    node1.query("DROP DATABASE IF EXISTS test")
+    node2.query("DROP DATABASE IF EXISTS test")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support altering database on cluster.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
