### PR TITLE
Avoid triggering watches on failed multi requests in Keeper

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -2767,7 +2767,7 @@ KeeperResponsesForSessions processWatches(
 {
     KeeperResponsesForSessions result;
 
-    if (std::get_if<FailedMultiDelta>(&deltas.front().operation))
+    if (deltas.empty() || std::get_if<FailedMultiDelta>(&deltas.front().operation))
         return result;
 
     const auto & subrequests = zk_request.requests;

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -1368,40 +1368,40 @@ auto callOnConcreteRequestType(const Coordination::ZooKeeperRequest & zk_request
     switch (zk_request.getOpNum())
     {
         case Coordination::OpNum::Heartbeat:
-            return function(dynamic_cast<const Coordination::ZooKeeperHeartbeatRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperHeartbeatRequest &>(zk_request));
         case Coordination::OpNum::Sync:
-            return function(dynamic_cast<const Coordination::ZooKeeperSyncRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperSyncRequest &>(zk_request));
         case Coordination::OpNum::Get:
-            return function(dynamic_cast<const Coordination::ZooKeeperGetRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperGetRequest &>(zk_request));
         case Coordination::OpNum::Create:
         case Coordination::OpNum::CreateIfNotExists:
-            return function(dynamic_cast<const Coordination::ZooKeeperCreateRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperCreateRequest &>(zk_request));
         case Coordination::OpNum::Remove:
-            return function(dynamic_cast<const Coordination::ZooKeeperRemoveRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperRemoveRequest &>(zk_request));
         case Coordination::OpNum::RemoveRecursive:
-            return function(dynamic_cast<const Coordination::ZooKeeperRemoveRecursiveRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperRemoveRecursiveRequest &>(zk_request));
         case Coordination::OpNum::Exists:
-            return function(dynamic_cast<const Coordination::ZooKeeperExistsRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperExistsRequest &>(zk_request));
         case Coordination::OpNum::Set:
-            return function(dynamic_cast<const Coordination::ZooKeeperSetRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperSetRequest &>(zk_request));
         case Coordination::OpNum::List:
         case Coordination::OpNum::FilteredList:
         case Coordination::OpNum::SimpleList:
-            return function(dynamic_cast<const Coordination::ZooKeeperListRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperListRequest &>(zk_request));
         case Coordination::OpNum::Check:
         case Coordination::OpNum::CheckNotExists:
-            return function(dynamic_cast<const Coordination::ZooKeeperCheckRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperCheckRequest &>(zk_request));
         case Coordination::OpNum::Multi:
         case Coordination::OpNum::MultiRead:
-            return function(dynamic_cast<const Coordination::ZooKeeperMultiRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperMultiRequest &>(zk_request));
         case Coordination::OpNum::Auth:
-            return function(dynamic_cast<const Coordination::ZooKeeperAuthRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperAuthRequest &>(zk_request));
         case Coordination::OpNum::Close:
-            return function(dynamic_cast<const Coordination::ZooKeeperCloseRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperCloseRequest &>(zk_request));
         case Coordination::OpNum::SetACL:
-            return function(dynamic_cast<const Coordination::ZooKeeperSetACLRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperSetACLRequest &>(zk_request));
         case Coordination::OpNum::GetACL:
-            return function(dynamic_cast<const Coordination::ZooKeeperGetACLRequest &>(zk_request));
+            return function(static_cast<const Coordination::ZooKeeperGetACLRequest &>(zk_request));
         default:
             throw Exception{DB::ErrorCodes::LOGICAL_ERROR, "Unexpected request type: {}", zk_request.getOpNum()};
     }
@@ -2767,6 +2767,9 @@ KeeperResponsesForSessions processWatches(
 {
     KeeperResponsesForSessions result;
 
+    if (std::get_if<FailedMultiDelta>(&deltas.front().operation))
+        return result;
+
     const auto & subrequests = zk_request.requests;
     for (const auto & generic_request : subrequests)
     {
@@ -3336,8 +3339,7 @@ KeeperResponsesForSessions KeeperStorage<Container>::processRequest(
                     static constexpr std::array list_requests{
                         Coordination::OpNum::List, Coordination::OpNum::SimpleList, Coordination::OpNum::FilteredList};
 
-                    auto is_list_watch
-                        = std::find(list_requests.begin(), list_requests.end(), zk_request->getOpNum()) != list_requests.end();
+                    auto is_list_watch = std::ranges::contains(list_requests, zk_request->getOpNum());
 
                     auto & watches_type = is_list_watch ? list_watches : watches;
 

--- a/tests/integration/test_keeper_watches/configs/keeper_config1.xml
+++ b/tests/integration/test_keeper_watches/configs/keeper_config1.xml
@@ -1,0 +1,25 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <min_session_timeout_ms>5000</min_session_timeout_ms>
+            <snapshot_distance>75</snapshot_distance>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_watches/test.py
+++ b/tests/integration/test_keeper_watches/test.py
@@ -1,0 +1,102 @@
+import time
+
+import pytest
+from kazoo.exceptions import BadVersionError
+
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+
+# from kazoo.protocol.serialization import Connect, read_buffer, write_buffer
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/keeper_config1.xml"],
+    stay_alive=True,
+    use_keeper=False,
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def destroy_zk_client(zk):
+    try:
+        if zk:
+            zk.stop()
+            zk.close()
+    except:
+        pass
+
+
+def wait_nodes():
+    keeper_utils.wait_nodes(cluster, [node])
+
+
+def get_fake_zk(nodename, timeout=30.0):
+    return keeper_utils.get_fake_zk(cluster, nodename, timeout=timeout)
+
+
+def test_keeper_watches(started_cluster):
+    wait_nodes()
+
+    node_zk = get_fake_zk(node.name)
+
+    if node_zk.exists("/watchednode"):
+        node_zk.delete("/watchednode")
+
+    node_zk.create("/watchednode")
+    watch_triggers = 0
+
+    def watch_callback(event):
+        if event.type == "CHANGED":
+            nonlocal watch_triggers
+            watch_triggers += 1
+
+    def set_watch():
+        node_zk.get("/watchednode", watch=watch_callback)
+
+    def assert_watch_triggers(expected_count):
+        for _ in range(100):
+            assert watch_triggers <= expected_count
+            if watch_triggers == expected_count:
+                break
+            time.sleep(0.5)
+        else:
+            assert watch_triggers == expected_count
+
+    set_watch()
+    node_zk.set("/watchednode", b"new_data")
+    assert_watch_triggers(1)
+
+    set_watch()
+    with pytest.raises(BadVersionError):
+        node_zk.set("/watchednode", b"new_data", version=9999)
+    time.sleep(1)
+    assert_watch_triggers(1)
+
+    set_watch()
+    tx = node_zk.transaction()
+    tx.set_data("/watchednode", b"new_data2")
+    tx.commit()
+    assert_watch_triggers(2)
+
+    set_watch()
+    tx = node_zk.transaction()
+    tx.set_data("/watchednode", b"new_data2", version=9998)
+    results = tx.commit()
+    assert len(results) == 1 and isinstance(results[0], BadVersionError)
+    time.sleep(1)
+    assert_watch_triggers(2)
+
+    destroy_zk_client(node_zk)
+    node_zk = None
+    time.sleep(1)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keeper fix: Avoid triggering watches on failed multi requests.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
