### PR TITLE
Forbid Dynamic and JSON types in IN

### DIFF
--- a/src/Functions/in.cpp
+++ b/src/Functions/in.cpp
@@ -16,6 +16,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int LOGICAL_ERROR;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
 namespace
@@ -68,13 +69,11 @@ public:
         return 2;
     }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & /*arguments*/) const override
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
-        return std::make_shared<DataTypeUInt8>();
-    }
+        if (arguments[0]->hasDynamicSubcolumns())
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {}", arguments[0]->getName(), getName());
 
-    DataTypePtr getReturnTypeForDefaultImplementationForDynamic() const override
-    {
         return std::make_shared<DataTypeUInt8>();
     }
 
@@ -82,6 +81,11 @@ public:
     {
         /// Never return constant for -IgnoreSet functions to avoid constant folding.
         return !ignore_set;
+    }
+
+    bool useDefaultImplementationForDynamic() const override
+    {
+        return false;
     }
 
     bool useDefaultImplementationForNulls() const override { return null_is_skipped; }

--- a/tests/queries/0_stateless/03413_dynamic_in_in.sql
+++ b/tests/queries/0_stateless/03413_dynamic_in_in.sql
@@ -1,0 +1,15 @@
+select 42::Dynamic in 42; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select materialize(42)::Dynamic in 42; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select [42::Dynamic] in [42]; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select [materialize(42)::Dynamic] in [42]; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select tuple(map(42, 42::Dynamic)) in tuple(map(42, 42)); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select tuple(map(42, materialize(42)::Dynamic)) in tuple(map(42, 42)); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+select '{}'::JSON in '{}'; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select materialize('{}'::JSON)::Dynamic in '{}'; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select ['{}'::JSON] in ['{}']; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select [materialize('{}')::JSON] in ['{}']; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select tuple(map(42, '{}'::JSON)) in tuple(map(42, '{}')); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+select tuple(map(42, materialize('{}')::JSON)) in tuple(map(42, '{}')); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Forbid Dynamic and JSON types in IN. With current implementation of `IN` it can lead to incorrect results. Proper support of this types in `IN` is complicated and can be done in future.

Closes https://github.com/ClickHouse/ClickHouse/issues/78404

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
