### PR TITLE
Increase number of messages to avoid flakiness

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -9,7 +9,7 @@ from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 
-DEFAULT_TIMEOUT_SEC = 60
+DEFAULT_TIMEOUT_SEC = 120
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(
@@ -213,7 +213,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
     """
     )
 
-    messages_num = 1000
+    messages_num = 10000
     rabbitmq_monitor.set_expectations(published=messages_num, delivered=messages_num)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -304,7 +304,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
     """
     )
 
-    messages_num = 1000
+    messages_num = 10000
     rabbitmq_monitor.set_expectations(published=messages_num, delivered=messages_num)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:


### PR DESCRIPTION
Even after running 5000 times the test on my AWS dev local machine successfully, this is flaky on the CI:
https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/ed719931842cdde75cded6ea3d1e86328c0249f0//integration_tests_aarch64_distributed_plan_3_4/integration_run_test_storage_rabbitmq_test_failed_connection_py_0.log

Let's increase the number of messages (at the expense of making the test slower) to ensure not all of them are consumed before resuming the RabbitMQ server.

Related to https://github.com/ClickHouse/ClickHouse/issues/71049

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
