### PR TITLE
Docs: Import VersionHistory and SettingsInfo components

### DIFF
--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -6,6 +6,8 @@ title: 'MergeTree tables settings'
 
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 import BetaBadge from '@theme/badges/BetaBadge';
+import SettingsInfoBlock from '@theme/SettingsInfoBlock/SettingsInfoBlock';
+import VersionHistory from '@theme/VersionHistory/VersionHistory';
 
 System table `system.merge_tree_settings` shows the globally set MergeTree settings.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

We now have a version history drop down on the session settings page and are using Click-UI tables which look a bit neater than the markdown ones. This PR adds imports for these components to the merge-tree settings page so we can do the same for merge-tree settings.

![Screenshot 2025-04-17 at 12 08 51](https://github.com/user-attachments/assets/9fd8d443-0ccd-4cff-8282-43d9a7e5b29b)

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
