### PR TITLE
Stateless tests: mark blacklisted tests as failed when they succeed

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -26,10 +26,6 @@ RETRIES_SIGN = "Some tests were restarted"
 #         out = csv.writer(f, delimiter="\t")
 #         out.writerow(status)
 
-BROKEN_TESTS_ANALYZER_TECH_DEBT = [
-    "01624_soft_constraints",
-]
-
 
 class FTResultsProcessor:
     @dataclasses.dataclass
@@ -50,7 +46,6 @@ class FTResultsProcessor:
         self.tests_output_file = f"{wd}/test_result.txt"
         # self.test_results_parsed_file = f"{wd}/test_result.tsv"
         # self.status_file = f"{wd}/check_status.tsv"
-        self.broken_tests = BROKEN_TESTS_ANALYZER_TECH_DEBT
 
     def _process_test_output(self):
         total = 0
@@ -97,19 +92,11 @@ class FTResultsProcessor:
 
                     total += 1
                     if TIMEOUT_SIGN in line:
-                        if test_name in self.broken_tests:
-                            success += 1
-                            test_results.append((test_name, "BROKEN", test_time, []))
-                        else:
-                            failed += 1
-                            test_results.append((test_name, "Timeout", test_time, []))
+                        failed += 1
+                        test_results.append((test_name, "Timeout", test_time, []))
                     elif FAIL_SIGN in line:
-                        if test_name in self.broken_tests:
-                            success += 1
-                            test_results.append((test_name, "BROKEN", test_time, []))
-                        else:
-                            failed += 1
-                            test_results.append((test_name, "FAIL", test_time, []))
+                        failed += 1
+                        test_results.append((test_name, "FAIL", test_time, []))
                     elif UNKNOWN_SIGN in line:
                         unknown += 1
                         test_results.append((test_name, "FAIL", test_time, []))
@@ -117,21 +104,8 @@ class FTResultsProcessor:
                         skipped += 1
                         test_results.append((test_name, "SKIPPED", test_time, []))
                     else:
-                        if OK_SIGN in line and test_name in self.broken_tests:
-                            skipped += 1
-                            test_results.append(
-                                (
-                                    test_name,
-                                    "NOT_FAILED",
-                                    test_time,
-                                    [
-                                        "This test passed. Update analyzer_tech_debt.txt.\n"
-                                    ],
-                                )
-                            )
-                        else:
-                            success += int(OK_SIGN in line)
-                            test_results.append((test_name, "OK", test_time, []))
+                        success += int(OK_SIGN in line)
+                        test_results.append((test_name, "OK", test_time, []))
                     test_end = False
                 elif (
                     len(test_results) > 0

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3319,9 +3319,7 @@ def main(args):
     blacklist_check = []
 
     if args.no_parallel_replicas is True:
-        blacklist = try_get_skip_list(
-            base_dir, "../parallel_replicas_blacklist.txt"
-        )
+        blacklist = try_get_skip_list(base_dir, "../parallel_replicas_blacklist.txt")
         blacklist_check.extend(blacklist)
 
     for suite in sorted(os.listdir(base_dir), key=suite_key_func):

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3318,6 +3318,8 @@ def main(args):
     skip_list = []
     blacklist_check = []
 
+    blacklist_check.extend(try_get_skip_list(base_dir, "../analyzer_tech_debt.txt"))
+
     if args.no_parallel_replicas is True:
         blacklist = try_get_skip_list(base_dir, "../parallel_replicas_blacklist.txt")
         blacklist_check.extend(blacklist)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -875,6 +875,7 @@ class TestStatus(enum.Enum):
     UNKNOWN = "UNKNOWN"
     OK = "OK"
     SKIPPED = "SKIPPED"
+    NOT_FAILED = "NOT_FAILED"
 
 
 class FailureReason(enum.Enum):
@@ -917,6 +918,10 @@ class FailureReason(enum.Enum):
     # UNKNOWN reasons
     NO_REFERENCE = "no reference file"
     INTERNAL_ERROR = "Test internal error: "
+    NOT_FAILED = (
+        "The test succeeded, but it is listed in parallel_replicas_blacklist.txt or async_insert_blacklist.txt. "
+        "Please remove it from the list"
+    )
 
 
 def threshold_generator(always_on_prob, always_off_prob, min_val, max_val):
@@ -1543,7 +1548,7 @@ class TestCase:
 
         return None
 
-    def process_result_impl(self, proc, total_time: float):
+    def process_result_impl(self, proc, total_time: float) -> TestResult:
         kill_output = ""
         if proc:
             if proc.returncode is None:
@@ -2050,6 +2055,13 @@ class TestCase:
             if result.status == TestStatus.FAIL:
                 result.description = self.add_info_about_settings(result.description)
 
+            if self.name in suite.blacklist_check:
+                if result.status == TestStatus.OK:
+                    result.status = TestStatus.NOT_FAILED
+                    result.reason = FailureReason.NOT_FAILED
+                if result.status == TestStatus.FAIL:
+                    result.status = TestStatus.SKIPPED
+
             self._cleanup(result.status == TestStatus.OK)
 
             return result
@@ -2328,6 +2340,10 @@ class TestSuite:
         self.skip_list: List[str] = []
         self.cloud_skip_list: List[str] = []
         self.private_skip_list: List[str] = []
+        # List of tests included in a blacklist.
+        # They will be run, and if they succeed, the status will be changed to FAIL to notify
+        # that the changes in PR fixes this test.
+        self.blacklist_check: List[str] = []
 
         if args.run_by_hash_num is not None and args.run_by_hash_total is not None:
             if args.run_by_hash_num > args.run_by_hash_total:
@@ -2523,12 +2539,18 @@ def run_tests_array(
         + colored(" SKIPPED ", args, "cyan", attrs=["bold"])
         + CL_SQUARE_BRACKET
     )
+    MSG_NOT_FAILED = (
+        OP_SQUARE_BRACKET
+        + colored(" NOT_FAILED ", args, "red", attrs=["bold"])
+        + CL_SQUARE_BRACKET
+    )
 
     MESSAGES = {
         TestStatus.FAIL: MSG_FAIL,
         TestStatus.UNKNOWN: MSG_UNKNOWN,
         TestStatus.OK: MSG_OK,
         TestStatus.SKIPPED: MSG_SKIPPED,
+        TestStatus.NOT_FAILED: MSG_NOT_FAILED,
     }
 
     passed_total = 0
@@ -3186,6 +3208,32 @@ def try_get_skip_list(base_dir, name, remove_comment=True):
     return test_names_to_skip
 
 
+def get_blacklisted_tests(blacklist_path):
+    regular_tests = []
+    flaky_tests = []
+
+    if not os.path.exists(blacklist_path):
+        return regular_tests, flaky_tests
+
+    with open(blacklist_path, "r", encoding="utf-8") as fd:
+        lines = fd.read().split("\n")
+
+    current_list = regular_tests
+    for line in lines:
+        if line == "" or line[0] == " ":
+            continue
+
+        line = line.strip()
+
+        if line == "###FLAKY###":
+            current_list = flaky_tests
+            continue
+
+        current_list.append(line)
+
+    return regular_tests, flaky_tests
+
+
 def main(args):
     exit_code = multiprocessing.Value("i", 0)
     server_died = multiprocessing.Event()
@@ -3294,12 +3342,14 @@ def main(args):
     cloud_skip_list = try_get_skip_list(base_dir, "../queries-no-cloud-tests.txt")
     private_skip_list = try_get_skip_list(base_dir, "../queries-no-private-tests.txt")
     skip_list = []
+    blacklist_check = []
 
     if args.no_parallel_replicas is True:
-        skip_list_parallel_replicas = try_get_skip_list(
-            base_dir, "../parallel_replicas_blacklist.txt"
+        blacklist, flaky_list = get_blacklisted_tests(
+            os.path.join(base_dir, "../parallel_replicas_blacklist.txt")
         )
-        skip_list.extend(skip_list_parallel_replicas)
+        blacklist_check.extend(blacklist)
+        skip_list.extend(flaky_list)
 
     for suite in sorted(os.listdir(base_dir), key=suite_key_func):
         if server_died.is_set():
@@ -3312,6 +3362,7 @@ def main(args):
         test_suite.skip_list = skip_list
         test_suite.cloud_skip_list = cloud_skip_list
         test_suite.private_skip_list = private_skip_list
+        test_suite.blacklist_check = blacklist_check
         total_tests_run += do_run_tests(
             args.jobs, test_suite, args, exit_code, restarted_tests, server_died
         )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3208,32 +3208,6 @@ def try_get_skip_list(base_dir, name, remove_comment=True):
     return test_names_to_skip
 
 
-def get_blacklisted_tests(blacklist_path):
-    regular_tests = []
-    flaky_tests = []
-
-    if not os.path.exists(blacklist_path):
-        return regular_tests, flaky_tests
-
-    with open(blacklist_path, "r", encoding="utf-8") as fd:
-        lines = fd.read().split("\n")
-
-    current_list = regular_tests
-    for line in lines:
-        if line == "" or line[0] == " ":
-            continue
-
-        line = line.strip()
-
-        if line == "###FLAKY###":
-            current_list = flaky_tests
-            continue
-
-        current_list.append(line)
-
-    return regular_tests, flaky_tests
-
-
 def main(args):
     exit_code = multiprocessing.Value("i", 0)
     server_died = multiprocessing.Event()
@@ -3345,11 +3319,10 @@ def main(args):
     blacklist_check = []
 
     if args.no_parallel_replicas is True:
-        blacklist, flaky_list = get_blacklisted_tests(
-            os.path.join(base_dir, "../parallel_replicas_blacklist.txt")
+        blacklist = try_get_skip_list(
+            base_dir, "../parallel_replicas_blacklist.txt"
         )
         blacklist_check.extend(blacklist)
-        skip_list.extend(flaky_list)
 
     for suite in sorted(os.listdir(base_dir), key=suite_key_func):
         if server_died.is_set():

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -513,7 +513,6 @@
 
 00955_test_final_mark_use
 01624_soft_constraints
-02968_file_log_multiple_read
 03031_minmax_index_for_pointinpolygon
 
     ORDER BY ALL is missing for multiple queries
@@ -542,3 +541,4 @@
     Tests listed after this tag are always disabled
 ###FLAKY###
 
+02968_file_log_multiple_read

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -538,3 +538,7 @@
 00443_optimize_final_vertical_merge
 01660_join_or_any
 01801_s3_cluster
+
+    Tests listed after this tag are always disabled
+###FLAKY###
+

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -537,8 +537,3 @@
 00443_optimize_final_vertical_merge
 01660_join_or_any
 01801_s3_cluster
-
-    Tests listed after this tag are always disabled
-###FLAKY###
-
-02968_file_log_multiple_read

--- a/tests/queries/0_stateless/02968_file_log_multiple_read.sh
+++ b/tests/queries/0_stateless/02968_file_log_multiple_read.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel-replicas
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
The current issue with `parallel_replicas_blacklist.txt` is that tests listed there might remain blacklisted even after being fixed. This PR adds logic to always execute blacklisted tests and handling the result as follows:
- If a blacklisted test fails: mark the test as skipped since this is the expected behavior.
- If a blacklisted test succeeds: set a special status `NOT_FAILED` and display an appropriate error message. This indicates that the test has been fixed and should be manually removed from the blacklist.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
