### PR TITLE
Fix test_parts_delete_zookeeper

### DIFF
--- a/tests/integration/test_parts_delete_zookeeper/test.py
+++ b/tests/integration/test_parts_delete_zookeeper/test.py
@@ -84,6 +84,9 @@ def test_merge_doesnt_work_without_zookeeper(start_cluster, request):
         == "2\n"
     )
 
+    # Force creation of all *Log tables
+    node1.query(f"SYSTEM FLUSH LOGS")
+
     # Parts may be moved to Deleting state and then back in Outdated state.
     # But system.parts returns only Active and Outdated parts if _state column is not queried.
     with PartitionManager() as pm:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Query to system database can hang if system database metadata located in keeper.
