### PR TITLE
Fix flaky 01780_column_sparse_pk (with parallel replicas)

### DIFF
--- a/tests/queries/0_stateless/01780_column_sparse_pk.sql
+++ b/tests/queries/0_stateless/01780_column_sparse_pk.sql
@@ -37,7 +37,7 @@ SELECT count(v), sum(v) FROM t_full_pk WHERE k = 0 OR k = 3 OR k = 7 OR k = 8;
 SET force_primary_key = 0;
 
 SELECT (k = NULL) OR (k = 1000) FROM t_sparse_pk LIMIT 3;
-SELECT range(k) FROM t_sparse_pk LIMIT 3;
+SELECT range(k) FROM t_sparse_pk ORDER BY k LIMIT 3;
 
 DROP TABLE IF EXISTS t_sparse_pk;
 DROP TABLE IF EXISTS t_full_pk;


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=979a47d3482d073d8ea6180e7f6da7fb44bca557&name_0=MasterCI&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
