### PR TITLE
tests: disable 03352_concurrent_rename_alter for PR

### DIFF
--- a/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
+++ b/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel-replicas
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
+++ b/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
@@ -15,6 +15,8 @@ $CLICKHOUSE_CLIENT --query "
         arr Array(Tuple(DateTime, UInt64, String, String)) TTL dt + INTERVAL 3 MONTHS
     )
     ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_rename_alter', '1') ORDER BY id;
+
+    INSERT INTO t_rename_alter (id) VALUES (1);
 "
 
 function insert1()

--- a/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
+++ b/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel-replicas
+# Tags: no-parallel-replicas, long
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
The problem is that during analysis on the initiator it will receive one set of fields, but when the query will be executed on the replica such field may not already exist (due to mutations with alter_sync=0/mutations_sync=0)

Also note about #75969, most of the crashes with PR run, however there is one without, so we are safe here, it should still reproduce crashes, but less frequently maybe.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)