### PR TITLE
tests: attempt to fix hangs of postgres container (leads to tests timeouts)

### DIFF
--- a/tests/integration/compose/docker_compose_postgres.yml
+++ b/tests/integration/compose/docker_compose_postgres.yml
@@ -22,3 +22,19 @@ services:
             - type: ${POSTGRES_LOGS_FS:-tmpfs}
               source: ${POSTGRES_DIR:-}
               target: /postgres/
+        labels:
+            - "autoheal=true"
+    autoheal:
+      image: willfarrell/autoheal:latest
+      tty: true
+      restart: always
+      environment:
+        - AUTOHEAL_INTERVAL=5
+        # Due to pause/unpause we can have false-positive unhealthy containers.
+        # Let's start only after 10 minutes. Let's consider this as enough for tests.
+        - AUTOHEAL_START_PERIOD=600
+        - AUTOHEAL_DEFAULT_STOP_TIMEOUT=10
+        # docker API calls
+        - CURL_TIMEOUT=30
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Sometimes after pause/unpause postgres does not respond the healthcheck [1]:

    time="2025-04-19T21:55:59.978956920Z" level=debug msg="Calling POST /v1.46/containers/fc4c98917ee891cd27564cab1c248c66e443f1fc2e3f026b7de84762bc10e924/pause"
    time="2025-04-19T21:55:59.984831645Z" level=debug msg="CloseMonitorChannel: waiting for probe to stop"
    time="2025-04-19T21:55:59.984852523Z" level=debug msg="CloseMonitorChannel done"
    time="2025-04-19T21:55:59.984890483Z" level=debug msg=event module=libcontainerd namespace=moby topic=/tasks/paused
    time="2025-04-19T21:55:59.984910613Z" level=debug msg="Stop healthcheck monitoring for container fc4c98917ee891cd27564cab1c248c66e443f1fc2e3f026b7de84762bc10e924 (received while probing)"
    time="2025-04-19T21:55:59.985084214Z" level=error msg="stream copy error: reading from a closed fifo"
    time="2025-04-19T21:55:59.985264774Z" level=debug msg="Calling GET /v1.46/containers/fc4c98917ee891cd27564cab1c248c66e443f1fc2e3f026b7de84762bc10e924/json"
    time="2025-04-19T21:55:59.985291238Z" level=error msg="stream copy error: reading from a closed fifo"
    time="2025-04-19T21:55:59.985433994Z" level=debug msg="attach: stdout: end"
    time="2025-04-19T21:55:59.985495990Z" level=debug msg="attach: stderr: end"
    time="2025-04-19T21:55:59.985506632Z" level=debug msg="attach done"
    time="2025-04-19T21:56:00.039673414Z" level=debug msg="Calling HEAD /_ping"
    time="2025-04-19T21:56:00.040310748Z" level=debug msg="Calling GET /v1.46/info"
    time="2025-04-19T21:56:00.054755490Z" level=debug msg="Calling GET /v1.46/containers/json?filters=%7B%22label%22%3A%7B%22com.docker.compose.config-hash%22%3Atrue%2C%22com.docker.compose.oneoff%3DFalse%22%3Atrue%2C%22com.docker.compose.project%3Droottestpostgresqlreplicadatabaseengine1-gw0%22%3Atrue%2C%22com.docker.compose.service%3Dpostgres1%22%3Atrue%7D%7D"
    time="2025-04-19T21:56:00.055847976Z" level=debug msg="Calling POST /v1.46/containers/fc4c98917ee891cd27564cab1c248c66e443f1fc2e3f026b7de84762bc10e924/unpause"
    time="2025-04-19T21:56:29.976612151Z" level=warning msg="Health check for container fc4c98917ee891cd27564cab1c248c66e443f1fc2e3f026b7de84762bc10e924 error: timed out starting health check for container fc4c98917ee891cd27564cab1c248c66e443f1fc2e3f026b7de84762bc10e924"

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79349&sha=4a2ce10124c6cdc507305822d28248c49c71df47&name_0=PR&name_1=Integration%20tests%20%28asan%2C%20old%20analyzer%2C%203%2F6%29

There the DROP DATABASE hanged, likely due to postgres does not respond.

Let's try autoheal

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)