### PR TITLE
tests: fix 03393_max_merge_delayed_streams_for_parallel_write flakiness (disable for MSan)

### DIFF
--- a/tests/queries/0_stateless/03393_max_merge_delayed_streams_for_parallel_write.sql
+++ b/tests/queries/0_stateless/03393_max_merge_delayed_streams_for_parallel_write.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long, no-parallel, no-flaky-check
+-- Tags: no-fasttest, long, no-parallel, no-flaky-check, no-msan
 -- - no-fasttest -- S3 is required
 -- - no-flaky-check -- not compatible with ThreadFuzzer
 
@@ -10,26 +10,25 @@ engine = MergeTree
 partition by ()
 order by ()
 settings
-    -- cache has it's own problem (see filesystem_cache_prefer_bigger_buffer_size)
+    -- cache has it's own problems (see filesystem_cache_prefer_bigger_buffer_size)
     storage_policy = 's3_no_cache',
-    -- horizontal merges does opens all stream at once, so will still huge chunk of memory
+    -- horizontal merges does opens all stream at once, so will still use huge amount of memory
     min_rows_for_wide_part = 0,
     min_bytes_for_wide_part = 0,
     vertical_merge_algorithm_min_rows_to_activate = 0,
     vertical_merge_algorithm_min_columns_to_activate = 1,
     min_bytes_for_full_part_storage = 0,
     --- avoid excessive memory usage (due to default buffer size of 1MiB that is created for each column)
-    max_merge_delayed_streams_for_parallel_write = 1,
+    max_merge_delayed_streams_for_parallel_write = 100,
     -- avoid superfluous merges
     merge_selector_base = 1000
 ;
 
-SET max_execution_time = 300;
 insert into metric_log select * from generateRandom() limit 10;
 
 optimize table metric_log final;
 system flush logs part_log;
-select 'max_merge_delayed_streams_for_parallel_write=1' as test, * from system.part_log where table = 'metric_log' and database = currentDatabase() and event_date >= yesterday() and event_type = 'MergeParts' and peak_memory_usage > 100_000_000 format Vertical;
+select 'max_merge_delayed_streams_for_parallel_write=100' as test, * from system.part_log where table = 'metric_log' and database = currentDatabase() and event_date >= yesterday() and event_type = 'MergeParts' and peak_memory_usage > 1_000_000_000 format Vertical;
 
 alter table metric_log modify setting max_merge_delayed_streams_for_parallel_write = 10000;
 


### PR DESCRIPTION
Allow more parallel streams to speed the test (in release build it took 79 sec before the patch, after 26 sec).

And also it is too slow under MSan, let's disable it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)