### PR TITLE
Select important fields instead of all for query 'SHOW CLUSTER <name>'

### DIFF
--- a/docs/en/sql-reference/statements/show.md
+++ b/docs/en/sql-reference/statements/show.md
@@ -500,7 +500,7 @@ The `SHOW CLUSTER(S)` statement returns a list of clusters.
 All available clusters are listed in the [`system.clusters`](../../operations/system-tables/clusters.md) table.
 
 :::note
-The `SHOW CLUSTER name` query displays the contents of `system.clusters` table for the specified cluster name.
+The `SHOW CLUSTER name` query displays `cluster`, `shard_num`, `replica_num`, `host_name`, `host_address`, and `port` of the `system.clusters` table for the specified cluster name.
 :::
 
 ### Syntax {#syntax-20}
@@ -546,16 +546,10 @@ Row 1:
 ──────
 cluster:                 test_shard_localhost
 shard_num:               1
-shard_weight:            1
 replica_num:             1
 host_name:               localhost
 host_address:            127.0.0.1
 port:                    9000
-is_local:                1
-user:                    default
-default_database:
-errors_count:            0
-estimated_recovery_time: 0
 ```
 
 ## SHOW SETTINGS {#show-settings}

--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -87,7 +87,8 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
     if (query.cluster)
     {
         WriteBufferFromOwnString rewritten_query;
-        rewritten_query << "SELECT * FROM system.clusters";
+        rewritten_query
+            << "SELECT cluster, shard_num, replica_num, host_name, host_address, port FROM system.clusters";
 
         auto cluster_name_expanded = getContext()->getMacros()->expand(query.cluster_str);
 

--- a/tests/queries/0_stateless/01293_show_clusters.reference
+++ b/tests/queries/0_stateless/01293_show_clusters.reference
@@ -1,3 +1,3 @@
 test_shard_bind_host
-test_cluster_one_shard_two_replicas	1		1	0	1	127.0.0.1	127.0.0.1	9000	1
-test_cluster_one_shard_two_replicas	1		1	0	2	127.0.0.2	127.0.0.2	9000	0
+test_cluster_one_shard_two_replicas	1	1	127.0.0.1	127.0.0.1	9000
+test_cluster_one_shard_two_replicas	1	2	127.0.0.2	127.0.0.2	9000

--- a/tests/queries/0_stateless/01293_show_clusters.sh
+++ b/tests/queries/0_stateless/01293_show_clusters.sh
@@ -7,4 +7,4 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT -q "show clusters like 'test_shard%' limit 1"
 # cluster,shard_num,shard_weight,internal_replication,replica_num,host_name,host_address,port,is_local,user,default_database[,errors_count,slowdowns_count,estimated_recovery_time]
 # use a cluster with static IPv4
-$CLICKHOUSE_CLIENT -q "show cluster 'test_cluster_one_shard_two_replicas'" | cut -f-10
+$CLICKHOUSE_CLIENT -q "show cluster 'test_cluster_one_shard_two_replicas'"

--- a/tests/queries/0_stateless/03409_show_cluster_with_macros.reference
+++ b/tests/queries/0_stateless/03409_show_cluster_with_macros.reference
@@ -1,4 +1,4 @@
 Output of: SHOW CLUSTER '{default_cluster_macro}'
-test_shard_localhost	1	1	localhost	127.0.0.1	9000
+test_shard_localhost	1	1	localhost	9000
 to match Output of: SHOW CLUSTER 'test_shard_localhost'
-test_shard_localhost	1	1	localhost	127.0.0.1	9000
+test_shard_localhost	1	1	localhost	9000

--- a/tests/queries/0_stateless/03409_show_cluster_with_macros.reference
+++ b/tests/queries/0_stateless/03409_show_cluster_with_macros.reference
@@ -1,4 +1,4 @@
 Output of: SHOW CLUSTER '{default_cluster_macro}'
-test_shard_localhost	1		1	0	1	localhost	9000	1
+test_shard_localhost	1	1	localhost	127.0.0.1	9000
 to match Output of: SHOW CLUSTER 'test_shard_localhost'
-test_shard_localhost	1		1	0	1	localhost	9000	1
+test_shard_localhost	1	1	localhost	127.0.0.1	9000

--- a/tests/queries/0_stateless/03409_show_cluster_with_macros.sh
+++ b/tests/queries/0_stateless/03409_show_cluster_with_macros.sh
@@ -6,8 +6,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "Output of: SHOW CLUSTER '{default_cluster_macro}'"
 
-$CLICKHOUSE_CLIENT -q "show cluster '{default_cluster_macro}'"
+$CLICKHOUSE_CLIENT -q "show cluster '{default_cluster_macro}'" | cut -f1-4,6
 
 echo "to match Output of: SHOW CLUSTER 'test_shard_localhost'"
 
-$CLICKHOUSE_CLIENT -q "show cluster 'test_shard_localhost'"
+$CLICKHOUSE_CLIENT -q "show cluster 'test_shard_localhost'" | cut -f1-4,6

--- a/tests/queries/0_stateless/03409_show_cluster_with_macros.sh
+++ b/tests/queries/0_stateless/03409_show_cluster_with_macros.sh
@@ -6,11 +6,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "Output of: SHOW CLUSTER '{default_cluster_macro}'"
 
-# cluster,shard_num,shard_name,shard_weight,internal_replication,replica_num,host_name,[host_address,]port,is_local,user[,default_database,errors_count,slowdowns_count,estimated_recovery_time,...]
-# skipping "host_address" makes the test insensitive to IPv4/IPv6 addresses
-
-$CLICKHOUSE_CLIENT -q "show cluster '{default_cluster_macro}'" | cut -f-7,9-10
+$CLICKHOUSE_CLIENT -q "show cluster '{default_cluster_macro}'"
 
 echo "to match Output of: SHOW CLUSTER 'test_shard_localhost'"
 
-$CLICKHOUSE_CLIENT -q "show cluster 'test_shard_localhost'" | cut -f-7,9-10
+$CLICKHOUSE_CLIENT -q "show cluster 'test_shard_localhost'"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Select important fields for query `'SHOW CLUSTER <name>'` instead of all fields.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
