### PR TITLE
cctools: use default prefix for gdb to fix debug symbols lookup

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -5,7 +5,7 @@ ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
 
 # If the cctools is updated, then first build it in the CI, then update here in a different commit
-COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /cctools /cctools
+COPY --from=clickhouse/cctools:a551cc7348883028fb53 /cctools /cctools
 
 # A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
 RUN apt-get update \

--- a/ci/docker/fasttest/Dockerfile
+++ b/ci/docker/fasttest/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
 # Give suid to gdb to grant it attach permissions
 RUN chmod u+s /opt/gdb/bin/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -2,7 +2,7 @@
 
 # This is a hack to significantly reduce the build time of the clickhouse/binary-builder
 # It's based on the assumption that we don't care of the cctools version so much
-# It event does not depend on the clickhouse/fasttest in the `docker/images.json`
+# It even does not depend on the clickhouse/fasttest in the `docker/images.json`
 ARG FROM_TAG=latest
 FROM clickhouse/fasttest:$FROM_TAG AS builder
 
@@ -53,10 +53,13 @@ RUN apt-get update \
 RUN wget https://sourceware.org/pub/gdb/releases/gdb-$GDB_VERSION.tar.gz \
     && tar -xvf gdb-$GDB_VERSION.tar.gz \
     && cd gdb-$GDB_VERSION \
-    && ./configure --prefix=/opt/gdb \
+    && ./configure --prefix=/usr \
     && make -j $(nproc) \
-    && make install \
+    && make install DESTDIR=/opt/gdb \
     && rm -fr gdb-$GDB_VERSION gdb-$GDB_VERSION.tar.gz
+
+# just in case
+RUN /opt/gdb/bin/gdb --version
 
 FROM scratch
 COPY --from=builder /cctools /cctools

--- a/docker/test/integration/base/Dockerfile
+++ b/docker/test/integration/base/Dockerfile
@@ -73,5 +73,5 @@ maxClientCnxns=80' > /opt/zookeeper/conf/zoo.cfg && \
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -86,7 +86,7 @@ COPY modprobe.sh /usr/local/bin/modprobe
 COPY dockerd-entrypoint.sh /usr/local/bin/
 COPY misc/ /misc/
 
-COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"
 
 # Same options as in test/base/Dockerfile

--- a/docker/test/performance-comparison/Dockerfile
+++ b/docker/test/performance-comparison/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir /fg && cd /fg \
 
 COPY run.sh /
 
-COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"
 
 CMD ["bash", "/run.sh"]

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -80,5 +80,5 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-COPY --from=clickhouse/cctools:13cfebfd8f1bbc65ab49 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"


### PR DESCRIPTION
    $ strace -fe file gdb --batch -p 105 |& grep debug
    newfstatat(AT_FDCWD, "/opt/gdb/bin/../lib/debug", 0xfffffc3cc8c0, 0) = -1 ENOENT (No such file or directory)
    readlinkat(AT_FDCWD, "/opt/gdb/lib/debug", 0xfffffc3cb060, 1023) = -1 ENOENT (No such file or directory)
    readlinkat(AT_FDCWD, "/opt/gdb/lib/debug", 0xfffffc3cbf50, 1023) = -1 ENOENT (No such file or directory)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)