### PR TITLE
Backport Poco fix for concurrent SecureStreamSocket access

### DIFF
--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -236,16 +236,21 @@ namespace Net
         /// to be able to re-use it again.
 
     private:
+        using MutexT = Poco::FastMutex;
+        using LockT = MutexT::ScopedLock;
+        using UnLockT = Poco::ScopedLockWithUnlock<MutexT>;
+
         SecureSocketImpl(const SecureSocketImpl &);
         SecureSocketImpl & operator=(const SecureSocketImpl &);
 
         mutable std::recursive_mutex _mutex;
-        SSL * _pSSL; // GUARDED_BY _mutex
+        std::atomic<SSL *> _pSSL;
         Poco::AutoPtr<SocketImpl> _pSocket;
         Context::Ptr _pContext;
         bool _needHandshake;
         std::string _peerHostName;
         Session::Ptr _pSession;
+        mutable MutexT _ssl_mutex;
 
         friend class SecureStreamSocketImpl;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SecureStreamSocket connection issues.

```
DB::NetException: SSL connection unexpectedly closed, while writing to socket (172.31.27.39:34020 -> 18.203.209.74:9440): (wsshno4ufr.eu-west-1.aws.clickhouse-staging.com:9440, 18.203.209.74, local address: 172.31.27.39:34020)
An error occurred while processing the query 'SELECT 1': Code: 210. DB::NetException: SSL connection unexpectedly closed, while writing to socket (172.31.27.39:34020 -> 18.203.209.74:9440): (wsshno4ufr.eu-west-1.aws.clickhouse-staging.com:9440, 18.203.209.74, local address: 172.31.27.39:34020). (NETWORK_ERROR) (version 25.5.1.958 (official build))
```

Related https://github.com/pocoproject/poco/issues/4435
Backports https://github.com/pocoproject/poco/pull/4512