### PR TITLE
Allow to specify storage settings for DatabaseCatalog

### DIFF
--- a/ci/jobs/scripts/check_style/check-settings-style
+++ b/ci/jobs/scripts/check_style/check-settings-style
@@ -37,7 +37,7 @@ ALL_DECLARATION_FILES="
     $ROOT_PATH/src/Storages/MySQL/MySQLSettings.cpp
     $ROOT_PATH/src/Storages/NATS/NATSSettings.cpp
     $ROOT_PATH/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
-    $ROOT_PATH/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
+    $ROOT_PATH/src/Storages/ObjectStorage/StorageObjectStorageSettings.h
     $ROOT_PATH/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.cpp
     $ROOT_PATH/src/Storages/RabbitMQ/RabbitMQSettings.cpp
     $ROOT_PATH/src/Storages/RocksDB/RocksDBSettings.cpp

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -380,6 +380,8 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
     const auto configuration = getConfiguration(storage_type);
 
     auto storage_settings = std::make_shared<StorageObjectStorageSettings>();
+    storage_settings->loadFromSettingsChanges(settings.allChanged());
+
     if (auto table_specific_properties = table_metadata.getDataLakeSpecificProperties();
         table_specific_properties.has_value())
     {

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -4,6 +4,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Databases/DataLake/DatabaseDataLakeSettings.h>
+#include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 #include <Common/Exception.h>
 
 namespace DB
@@ -28,7 +29,8 @@ namespace ErrorCodes
     DECLARE(String, storage_endpoint, "", "Object storage endpoint", 0) \
 
 #define LIST_OF_DATABASE_ICEBERG_SETTINGS(M, ALIAS) \
-    DATABASE_ICEBERG_RELATED_SETTINGS(M, ALIAS)
+    DATABASE_ICEBERG_RELATED_SETTINGS(M, ALIAS) \
+    LIST_OF_STORAGE_OBJECT_STORAGE_SETTINGS(M, ALIAS) \
 
 DECLARE_SETTINGS_TRAITS(DatabaseDataLakeSettingsTraits, LIST_OF_DATABASE_ICEBERG_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(DatabaseDataLakeSettingsTraits, LIST_OF_DATABASE_ICEBERG_SETTINGS)
@@ -86,6 +88,14 @@ void DatabaseDataLakeSettings::loadFromQuery(const ASTStorage & storage_def)
             throw;
         }
     }
+}
+
+SettingsChanges DatabaseDataLakeSettings::allChanged() const
+{
+    SettingsChanges changes;
+    for (const auto & setting : impl->allChanged())
+        changes.emplace_back(setting.getName(), setting.getValue());
+    return changes;
 }
 
 }

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.h
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.h
@@ -2,6 +2,7 @@
 
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/FormatFactorySettings.h>
+#include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
 
@@ -19,7 +20,11 @@ class SettingsChanges;
     M(CLASS_NAME, Bool) \
     M(CLASS_NAME, DatabaseDataLakeCatalogType) \
 
-DATABASE_ICEBERG_SETTINGS_SUPPORTED_TYPES(DatabaseDataLakeSettings, DECLARE_SETTING_TRAIT)
+#define LIST_OF_DATABASE_ICEBERG_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
+    DATABASE_ICEBERG_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
+    STORAGE_OBJECT_STORAGE_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M)
+
+LIST_OF_DATABASE_ICEBERG_SETTINGS_SUPPORTED_TYPES(DatabaseDataLakeSettings, DECLARE_SETTING_TRAIT)
 
 struct DatabaseDataLakeSettings
 {
@@ -33,6 +38,8 @@ struct DatabaseDataLakeSettings
     void loadFromQuery(const ASTStorage & storage_def);
 
     void applyChanges(const SettingsChanges & changes);
+
+    SettingsChanges allChanged() const;
 
 private:
     std::unique_ptr<DatabaseDataLakeSettingsImpl> impl;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
@@ -11,37 +11,6 @@
 namespace DB
 {
 
-// clang-format off
-
-#define STORAGE_OBJECT_STORAGE_RELATED_SETTINGS(DECLARE, ALIAS) \
-    DECLARE(Bool, allow_dynamic_metadata_for_data_lakes, false, R"(
-If enabled, indicates that metadata is taken from iceberg specification that is pulled from cloud before each query.
-)", 0) \
-    DECLARE(Bool, allow_experimental_delta_kernel_rs, false, R"(
-If enabled, the engine would use delta-kernel-rs for DeltaLake metadata parsing
-)", 0) \
-    DECLARE(Bool, delta_lake_read_schema_same_as_table_schema, false, R"(
-Whether delta-lake read schema is the same as table schema.
-)", 0) \
-    DECLARE(String, iceberg_metadata_file_path, "", R"(
-Explicit path to desired Iceberg metadata file, should be relative to path in object storage. Make sense for table function use case only.
-)", 0) \
-    DECLARE(String, iceberg_metadata_table_uuid, "", R"(
-Explicit table UUID to read metadata for. Ignored if iceberg_metadata_file_path is set.
-)", 0) \
-    DECLARE(Bool, iceberg_recent_metadata_file_by_last_updated_ms_field, false, R"(
-If enabled, the engine would use the metadata file with the most recent last_updated_ms json field. Does not make sense to use with iceberg_metadata_file_path.
-)", 0) \
-    DECLARE(Bool, iceberg_use_version_hint, false, R"(
-Get latest metadata path from version-hint.text file.
-)", 0) \
-
-// clang-format on
-
-#define LIST_OF_STORAGE_OBJECT_STORAGE_SETTINGS(M, ALIAS) \
-    STORAGE_OBJECT_STORAGE_RELATED_SETTINGS(M, ALIAS) \
-    LIST_OF_ALL_FORMAT_SETTINGS(M, ALIAS)
-
 DECLARE_SETTINGS_TRAITS(StorageObjectStorageSettingsTraits, LIST_OF_STORAGE_OBJECT_STORAGE_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(StorageObjectStorageSettingsTraits, LIST_OF_STORAGE_OBJECT_STORAGE_SETTINGS)
 
@@ -93,4 +62,14 @@ bool StorageObjectStorageSettings::hasBuiltin(std::string_view name)
 {
     return StorageObjectStorageSettingsImpl::hasBuiltin(name);
 }
+
+void StorageObjectStorageSettings::loadFromSettingsChanges(const SettingsChanges & changes)
+{
+    for (const auto & [name, value] : changes)
+    {
+        if (impl->has(name))
+            impl->set(name, value);
+    }
+}
+
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.h
@@ -44,6 +44,33 @@ class SettingsChanges;
     M(CLASS_NAME, UInt64Auto) \
     M(CLASS_NAME, URI)
 
+// clang-format off
+
+#define STORAGE_OBJECT_STORAGE_RELATED_SETTINGS(DECLARE, ALIAS) \
+    DECLARE(Bool, allow_dynamic_metadata_for_data_lakes, false, R"(
+If enabled, indicates that metadata is taken from iceberg specification that is pulled from cloud before each query.
+)", 0) \
+    DECLARE(Bool, allow_experimental_delta_kernel_rs, false, R"(
+If enabled, the engine would use delta-kernel-rs for DeltaLake metadata parsing
+)", 0) \
+    DECLARE(Bool, delta_lake_read_schema_same_as_table_schema, false, R"(
+Whether delta-lake read schema is the same as table schema.
+)", 0) \
+    DECLARE(String, iceberg_metadata_file_path, "", R"(
+Explicit path to desired Iceberg metadata file, should be relative to path in object storage. Make sense for table function use case only.
+)", 0) \
+    DECLARE(String, iceberg_metadata_table_uuid, "", R"(
+Explicit table UUID to read metadata for. Ignored if iceberg_metadata_file_path is set.
+)", 0) \
+    DECLARE(Bool, iceberg_recent_metadata_file_by_last_updated_ms_field, false, R"(
+If enabled, the engine would use the metadata file with the most recent last_updated_ms json field. Does not make sense to use with iceberg_metadata_file_path.
+)", 0) \
+    DECLARE(Bool, iceberg_use_version_hint, false, R"(
+Get latest metadata path from version-hint.text file.
+)", 0) \
+
+// clang-format on
+
 STORAGE_OBJECT_STORAGE_SETTINGS_SUPPORTED_TYPES(StorageObjectStorageSettings, DECLARE_SETTING_TRAIT)
 
 struct StorageObjectStorageSettings
@@ -57,6 +84,8 @@ struct StorageObjectStorageSettings
 
     void loadFromQuery(ASTSetQuery & settings_ast);
 
+    void loadFromSettingsChanges(const SettingsChanges & changes);
+
     Field get(const std::string & name);
 
     static bool hasBuiltin(std::string_view name);
@@ -66,5 +95,9 @@ private:
 };
 
 using StorageObjectStorageSettingsPtr = std::shared_ptr<StorageObjectStorageSettings>;
+
+#define LIST_OF_STORAGE_OBJECT_STORAGE_SETTINGS(M, ALIAS) \
+    STORAGE_OBJECT_STORAGE_RELATED_SETTINGS(M, ALIAS) \
+    LIST_OF_ALL_FORMAT_SETTINGS(M, ALIAS)
 
 }

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -36,13 +36,13 @@ def started_cluster():
             user_configs=[],
             image="clickhouse/integration-test-with-unity-catalog",
             with_installed_binary=False,
-            tag=os.environ.get("DOCKER_BASE_WITH_UNITY_CATALOG_TAG", "latest")
+            tag=os.environ.get("DOCKER_BASE_WITH_UNITY_CATALOG_TAG", "latest"),
         )
 
         logging.info("Starting cluster...")
         cluster.start()
 
-        start_unity_catalog(cluster.instances['node1'])
+        start_unity_catalog(cluster.instances["node1"])
 
         yield cluster
 
@@ -68,65 +68,156 @@ cd /spark-3.5.4-bin-hadoop3 && bin/spark-sql --name "s3-uc-test" \\
     --conf "spark.sql.defaultCatalog=unity" \\
     -S -e "{query_text}" | grep -v 'loading settings'
 """,
-        ], nothrow=ignore_exit_code
+        ],
+        nothrow=ignore_exit_code,
     )
 
+
 def execute_multiple_spark_queries(node, queries_list, ignore_exit_code=False):
-    return execute_spark_query(node, ';'.join(queries_list), ignore_exit_code)
+    return execute_spark_query(node, ";".join(queries_list), ignore_exit_code)
+
 
 def test_embedded_database_and_tables(started_cluster):
-    node1 = started_cluster.instances['node1']
-    node1.query("create database unity_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false", settings={"allow_experimental_database_unity_catalog": "1"})
-    default_tables = list(sorted(node1.query("SHOW TABLES FROM unity_test LIKE 'default%'", settings={'use_hive_partitioning':'0'}).strip().split('\n')))
+    node1 = started_cluster.instances["node1"]
+    node1.query(
+        "create database unity_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false",
+        settings={"allow_experimental_database_unity_catalog": "1"},
+    )
+    default_tables = list(
+        sorted(
+            node1.query(
+                "SHOW TABLES FROM unity_test LIKE 'default%'",
+                settings={"use_hive_partitioning": "0"},
+            )
+            .strip()
+            .split("\n")
+        )
+    )
     print("Default tables", default_tables)
-    assert default_tables == ['default.marksheet', 'default.marksheet_uniform', 'default.numbers', 'default.user_countries']
+    assert default_tables == [
+        "default.marksheet",
+        "default.marksheet_uniform",
+        "default.numbers",
+        "default.user_countries",
+    ]
 
     for table in default_tables:
         if table == "default.marksheet_uniform":
             continue
         assert "DeltaLake" in node1.query(f"show create table unity_test.`{table}`")
-        if table in ('default.marksheet', 'default.user_countries'):
-            data_clickhouse = TSV(node1.query(f"SELECT * FROM unity_test.`{table}` ORDER BY 1,2,3"))
-            data_spark = TSV(execute_spark_query(node1, f"SELECT * FROM unity.{table} ORDER BY 1,2,3"))
+        if table in ("default.marksheet", "default.user_countries"):
+            data_clickhouse = TSV(
+                node1.query(f"SELECT * FROM unity_test.`{table}` ORDER BY 1,2,3")
+            )
+            data_spark = TSV(
+                execute_spark_query(
+                    node1, f"SELECT * FROM unity.{table} ORDER BY 1,2,3"
+                )
+            )
             print("Data ClickHouse\n", data_clickhouse)
             print("Data Spark\n", data_spark)
             assert data_clickhouse == data_spark
 
 
 def test_multiple_schemes_tables(started_cluster):
-    node1 = started_cluster.instances['node1']
-    execute_multiple_spark_queries(node1, [f'CREATE SCHEMA test_schema{i}' for i in range(10)], True)
-    execute_multiple_spark_queries(node1, [f'CREATE TABLE test_schema{i}.test_table{i} (col1 int, col2 double) using Delta location \'/tmp/test_schema{i}/test_table{i}\'' for i in range(10)], True)
-    execute_multiple_spark_queries(node1, [f'INSERT INTO test_schema{i}.test_table{i} VALUES ({i}, {i}.0)' for i in range(10)], True)
+    node1 = started_cluster.instances["node1"]
+    execute_multiple_spark_queries(
+        node1, [f"CREATE SCHEMA test_schema{i}" for i in range(10)], True
+    )
+    execute_multiple_spark_queries(
+        node1,
+        [
+            f"CREATE TABLE test_schema{i}.test_table{i} (col1 int, col2 double) using Delta location '/tmp/test_schema{i}/test_table{i}'"
+            for i in range(10)
+        ],
+        True,
+    )
+    execute_multiple_spark_queries(
+        node1,
+        [
+            f"INSERT INTO test_schema{i}.test_table{i} VALUES ({i}, {i}.0)"
+            for i in range(10)
+        ],
+        True,
+    )
 
-    node1.query("create database multi_schema_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false", settings={"allow_experimental_database_unity_catalog": "1"})
-    multi_schema_tables = list(sorted(node1.query("SHOW TABLES FROM multi_schema_test LIKE 'test_schema%'", settings={'use_hive_partitioning':'0'}).strip().split('\n')))
+    node1.query(
+        "create database multi_schema_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false",
+        settings={"allow_experimental_database_unity_catalog": "1"},
+    )
+    multi_schema_tables = list(
+        sorted(
+            node1.query(
+                "SHOW TABLES FROM multi_schema_test LIKE 'test_schema%'",
+                settings={"use_hive_partitioning": "0"},
+            )
+            .strip()
+            .split("\n")
+        )
+    )
     print(multi_schema_tables)
 
     for i, table in enumerate(multi_schema_tables):
-        assert node1.query(f"SELECT col1 FROM multi_schema_test.`{table}`").strip() == str(i)
-        assert int(node1.query(f"SELECT col2 FROM multi_schema_test.`{table}`").strip()) == i
+        assert node1.query(
+            f"SELECT col1 FROM multi_schema_test.`{table}`"
+        ).strip() == str(i)
+        assert (
+            int(node1.query(f"SELECT col2 FROM multi_schema_test.`{table}`").strip())
+            == i
+        )
 
 
-def test_complex_table_schema(started_cluster):
-    node1 = started_cluster.instances['node1']
-    execute_spark_query(node1, "CREATE SCHEMA schema_with_complex_tables", ignore_exit_code=True)
+@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
+def test_complex_table_schema(started_cluster, use_delta_kernel):
+    node1 = started_cluster.instances["node1"]
+    execute_spark_query(
+        node1, "CREATE SCHEMA schema_with_complex_tables", ignore_exit_code=True
+    )
     schema = "event_date DATE, event_time TIMESTAMP, hits ARRAY<integer>, ids MAP<int, string>, really_complex STRUCT<f1:int,f2:string>"
     create_query = f"CREATE TABLE schema_with_complex_tables.complex_table ({schema}) using Delta location '/tmp/complex_schema/complex_table'"
     execute_spark_query(node1, create_query, ignore_exit_code=True)
-    execute_spark_query(node1, "insert into schema_with_complex_tables.complex_table SELECT to_date('2024-10-01', 'yyyy-MM-dd'), to_timestamp('2024-10-01 00:12:00'), array(42, 123, 77), map(7, 'v7', 5, 'v5'), named_struct(\\\"f1\\\", 34, \\\"f2\\\", 'hello')", ignore_exit_code=True)
+    execute_spark_query(
+        node1,
+        "insert into schema_with_complex_tables.complex_table SELECT to_date('2024-10-01', 'yyyy-MM-dd'), to_timestamp('2024-10-01 00:12:00'), array(42, 123, 77), map(7, 'v7', 5, 'v5'), named_struct(\\\"f1\\\", 34, \\\"f2\\\", 'hello')",
+        ignore_exit_code=True,
+    )
 
-    node1.query("create database complex_schema engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false", settings={"allow_experimental_database_unity_catalog": "1"})
+    node1.query(
+        "create database complex_schema engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false, allow_experimental_delta_kernel_rs=1",
+        settings={"allow_experimental_database_unity_catalog": "1"},
+    )
 
-    complex_schema_tables = list(sorted(node1.query("SHOW TABLES FROM complex_schema LIKE 'schema_with_complex_tables%'", settings={'use_hive_partitioning':'0'}).strip().split('\n')))
+    complex_schema_tables = list(
+        sorted(
+            node1.query(
+                "SHOW TABLES FROM complex_schema LIKE 'schema_with_complex_tables%'",
+                settings={"use_hive_partitioning": "0"},
+            )
+            .strip()
+            .split("\n")
+        )
+    )
 
     assert len(complex_schema_tables) == 1
 
-    print(node1.query("SHOW CREATE TABLE complex_schema.`schema_with_complex_tables.complex_table`"))
-    complex_data = node1.query("SELECT * FROM complex_schema.`schema_with_complex_tables.complex_table`").strip().split('\t')
+    print(
+        node1.query(
+            "SHOW CREATE TABLE complex_schema.`schema_with_complex_tables.complex_table`"
+        )
+    )
+    complex_data = (
+        node1.query(
+            "SELECT * FROM complex_schema.`schema_with_complex_tables.complex_table`"
+        )
+        .strip()
+        .split("\t")
+    )
     print(complex_data)
     assert complex_data[0] == "2024-10-01"
     assert complex_data[1] == "2024-10-01 00:12:00.000000"
     assert complex_data[2] == "[42,123,77]"
     assert complex_data[3] == "{7:'v7',5:'v5'}"
     assert complex_data[4] == "(34,'hello')"
+
+    if use_delta_kernel:
+        assert node1.contains_in_log(f"DeltaLakeMetadata: Initializing snapshot")

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -36,13 +36,13 @@ def started_cluster():
             user_configs=[],
             image="clickhouse/integration-test-with-unity-catalog",
             with_installed_binary=False,
-            tag=os.environ.get("DOCKER_BASE_WITH_UNITY_CATALOG_TAG", "latest"),
+            tag=os.environ.get("DOCKER_BASE_WITH_UNITY_CATALOG_TAG", "latest")
         )
 
         logging.info("Starting cluster...")
         cluster.start()
 
-        start_unity_catalog(cluster.instances["node1"])
+        start_unity_catalog(cluster.instances['node1'])
 
         yield cluster
 
@@ -68,156 +68,65 @@ cd /spark-3.5.4-bin-hadoop3 && bin/spark-sql --name "s3-uc-test" \\
     --conf "spark.sql.defaultCatalog=unity" \\
     -S -e "{query_text}" | grep -v 'loading settings'
 """,
-        ],
-        nothrow=ignore_exit_code,
+        ], nothrow=ignore_exit_code
     )
-
 
 def execute_multiple_spark_queries(node, queries_list, ignore_exit_code=False):
-    return execute_spark_query(node, ";".join(queries_list), ignore_exit_code)
-
+    return execute_spark_query(node, ';'.join(queries_list), ignore_exit_code)
 
 def test_embedded_database_and_tables(started_cluster):
-    node1 = started_cluster.instances["node1"]
-    node1.query(
-        "create database unity_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false",
-        settings={"allow_experimental_database_unity_catalog": "1"},
-    )
-    default_tables = list(
-        sorted(
-            node1.query(
-                "SHOW TABLES FROM unity_test LIKE 'default%'",
-                settings={"use_hive_partitioning": "0"},
-            )
-            .strip()
-            .split("\n")
-        )
-    )
+    node1 = started_cluster.instances['node1']
+    node1.query("create database unity_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false", settings={"allow_experimental_database_unity_catalog": "1"})
+    default_tables = list(sorted(node1.query("SHOW TABLES FROM unity_test LIKE 'default%'", settings={'use_hive_partitioning':'0'}).strip().split('\n')))
     print("Default tables", default_tables)
-    assert default_tables == [
-        "default.marksheet",
-        "default.marksheet_uniform",
-        "default.numbers",
-        "default.user_countries",
-    ]
+    assert default_tables == ['default.marksheet', 'default.marksheet_uniform', 'default.numbers', 'default.user_countries']
 
     for table in default_tables:
         if table == "default.marksheet_uniform":
             continue
         assert "DeltaLake" in node1.query(f"show create table unity_test.`{table}`")
-        if table in ("default.marksheet", "default.user_countries"):
-            data_clickhouse = TSV(
-                node1.query(f"SELECT * FROM unity_test.`{table}` ORDER BY 1,2,3")
-            )
-            data_spark = TSV(
-                execute_spark_query(
-                    node1, f"SELECT * FROM unity.{table} ORDER BY 1,2,3"
-                )
-            )
+        if table in ('default.marksheet', 'default.user_countries'):
+            data_clickhouse = TSV(node1.query(f"SELECT * FROM unity_test.`{table}` ORDER BY 1,2,3"))
+            data_spark = TSV(execute_spark_query(node1, f"SELECT * FROM unity.{table} ORDER BY 1,2,3"))
             print("Data ClickHouse\n", data_clickhouse)
             print("Data Spark\n", data_spark)
             assert data_clickhouse == data_spark
 
 
 def test_multiple_schemes_tables(started_cluster):
-    node1 = started_cluster.instances["node1"]
-    execute_multiple_spark_queries(
-        node1, [f"CREATE SCHEMA test_schema{i}" for i in range(10)], True
-    )
-    execute_multiple_spark_queries(
-        node1,
-        [
-            f"CREATE TABLE test_schema{i}.test_table{i} (col1 int, col2 double) using Delta location '/tmp/test_schema{i}/test_table{i}'"
-            for i in range(10)
-        ],
-        True,
-    )
-    execute_multiple_spark_queries(
-        node1,
-        [
-            f"INSERT INTO test_schema{i}.test_table{i} VALUES ({i}, {i}.0)"
-            for i in range(10)
-        ],
-        True,
-    )
+    node1 = started_cluster.instances['node1']
+    execute_multiple_spark_queries(node1, [f'CREATE SCHEMA test_schema{i}' for i in range(10)], True)
+    execute_multiple_spark_queries(node1, [f'CREATE TABLE test_schema{i}.test_table{i} (col1 int, col2 double) using Delta location \'/tmp/test_schema{i}/test_table{i}\'' for i in range(10)], True)
+    execute_multiple_spark_queries(node1, [f'INSERT INTO test_schema{i}.test_table{i} VALUES ({i}, {i}.0)' for i in range(10)], True)
 
-    node1.query(
-        "create database multi_schema_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false",
-        settings={"allow_experimental_database_unity_catalog": "1"},
-    )
-    multi_schema_tables = list(
-        sorted(
-            node1.query(
-                "SHOW TABLES FROM multi_schema_test LIKE 'test_schema%'",
-                settings={"use_hive_partitioning": "0"},
-            )
-            .strip()
-            .split("\n")
-        )
-    )
+    node1.query("create database multi_schema_test engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false", settings={"allow_experimental_database_unity_catalog": "1"})
+    multi_schema_tables = list(sorted(node1.query("SHOW TABLES FROM multi_schema_test LIKE 'test_schema%'", settings={'use_hive_partitioning':'0'}).strip().split('\n')))
     print(multi_schema_tables)
 
     for i, table in enumerate(multi_schema_tables):
-        assert node1.query(
-            f"SELECT col1 FROM multi_schema_test.`{table}`"
-        ).strip() == str(i)
-        assert (
-            int(node1.query(f"SELECT col2 FROM multi_schema_test.`{table}`").strip())
-            == i
-        )
+        assert node1.query(f"SELECT col1 FROM multi_schema_test.`{table}`").strip() == str(i)
+        assert int(node1.query(f"SELECT col2 FROM multi_schema_test.`{table}`").strip()) == i
 
 
-@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
-def test_complex_table_schema(started_cluster, use_delta_kernel):
-    node1 = started_cluster.instances["node1"]
-    execute_spark_query(
-        node1, "CREATE SCHEMA schema_with_complex_tables", ignore_exit_code=True
-    )
+def test_complex_table_schema(started_cluster):
+    node1 = started_cluster.instances['node1']
+    execute_spark_query(node1, "CREATE SCHEMA schema_with_complex_tables", ignore_exit_code=True)
     schema = "event_date DATE, event_time TIMESTAMP, hits ARRAY<integer>, ids MAP<int, string>, really_complex STRUCT<f1:int,f2:string>"
     create_query = f"CREATE TABLE schema_with_complex_tables.complex_table ({schema}) using Delta location '/tmp/complex_schema/complex_table'"
     execute_spark_query(node1, create_query, ignore_exit_code=True)
-    execute_spark_query(
-        node1,
-        "insert into schema_with_complex_tables.complex_table SELECT to_date('2024-10-01', 'yyyy-MM-dd'), to_timestamp('2024-10-01 00:12:00'), array(42, 123, 77), map(7, 'v7', 5, 'v5'), named_struct(\\\"f1\\\", 34, \\\"f2\\\", 'hello')",
-        ignore_exit_code=True,
-    )
+    execute_spark_query(node1, "insert into schema_with_complex_tables.complex_table SELECT to_date('2024-10-01', 'yyyy-MM-dd'), to_timestamp('2024-10-01 00:12:00'), array(42, 123, 77), map(7, 'v7', 5, 'v5'), named_struct(\\\"f1\\\", 34, \\\"f2\\\", 'hello')", ignore_exit_code=True)
 
-    node1.query(
-        "create database complex_schema engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false, allow_experimental_delta_kernel_rs=1",
-        settings={"allow_experimental_database_unity_catalog": "1"},
-    )
+    node1.query("create database complex_schema engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false", settings={"allow_experimental_database_unity_catalog": "1"})
 
-    complex_schema_tables = list(
-        sorted(
-            node1.query(
-                "SHOW TABLES FROM complex_schema LIKE 'schema_with_complex_tables%'",
-                settings={"use_hive_partitioning": "0"},
-            )
-            .strip()
-            .split("\n")
-        )
-    )
+    complex_schema_tables = list(sorted(node1.query("SHOW TABLES FROM complex_schema LIKE 'schema_with_complex_tables%'", settings={'use_hive_partitioning':'0'}).strip().split('\n')))
 
     assert len(complex_schema_tables) == 1
 
-    print(
-        node1.query(
-            "SHOW CREATE TABLE complex_schema.`schema_with_complex_tables.complex_table`"
-        )
-    )
-    complex_data = (
-        node1.query(
-            "SELECT * FROM complex_schema.`schema_with_complex_tables.complex_table`"
-        )
-        .strip()
-        .split("\t")
-    )
+    print(node1.query("SHOW CREATE TABLE complex_schema.`schema_with_complex_tables.complex_table`"))
+    complex_data = node1.query("SELECT * FROM complex_schema.`schema_with_complex_tables.complex_table`").strip().split('\t')
     print(complex_data)
     assert complex_data[0] == "2024-10-01"
     assert complex_data[1] == "2024-10-01 00:12:00.000000"
     assert complex_data[2] == "[42,123,77]"
     assert complex_data[3] == "{7:'v7',5:'v5'}"
     assert complex_data[4] == "(34,'hello')"
-
-    if use_delta_kernel:
-        assert node1.contains_in_log(f"DeltaLakeMetadata: Initializing snapshot")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to specify storage settings for `DatabaseCatalog`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
