### PR TITLE
log exceptions in thread pool worker

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -838,10 +838,16 @@ void ThreadPoolImpl<Thread>::ThreadFromThreadPool::worker()
         }
         catch (...)
         {
-            DB::tryLogCurrentException(__PRETTY_FUNCTION__);
-
             exception_from_job = std::current_exception();
             thread_trace_context.root_span.addAttribute(exception_from_job);
+
+            /// Log LOGICAL_ERRORs from jobs here to make sure they are captured at least once.
+            /// While this might lead to multiple log messages for the same error,
+            /// it's preferable to potentially missing the error entirely.
+            if (DB::getExceptionErrorCode(exception_from_job) == DB::ErrorCodes::LOGICAL_ERROR)
+            {
+                DB::tryLogException(exception_from_job, __PRETTY_FUNCTION__);
+            }
 
             /// job should be reset before decrementing scheduled_jobs to
             /// ensure that the Job destroyed before wait() returns.

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -838,6 +838,8 @@ void ThreadPoolImpl<Thread>::ThreadFromThreadPool::worker()
         }
         catch (...)
         {
+            DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+
             exception_from_job = std::current_exception();
             thread_trace_context.root_span.addAttribute(exception_from_job);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
