### PR TITLE
ch and clickhouse shortcuts are now responsive

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -74,7 +74,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 DerivePointerAlignment: false
 DisableFormat: false
-#IndentRequiresClause: false
+IndentRequiresClause: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 MacroBlockBegin: ''

--- a/.clang-format
+++ b/.clang-format
@@ -74,7 +74,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 DerivePointerAlignment: false
 DisableFormat: false
-IndentRequiresClause: false
+#IndentRequiresClause: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 MacroBlockBegin: ''

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -143,8 +143,8 @@ std::pair<std::string_view, std::string_view> clickhouse_client_args[] = {{"h", 
 bool isClickhouseApp(std::string_view app_suffix, std::vector<char *> & argv)
 {
     for (const auto & [alias, name] : clickhouse_short_names)
-    if (app_suffix == name
-        && !argv.empty() && (alias == argv[0] || endsWith(argv[0], "/" + std::string(alias))))
+        if (app_suffix == name
+            && !argv.empty() && (alias == argv[0] || endsWith(argv[0], "/" + std::string(alias))))
             return true;
 
     /// Use app if the first arg 'app' is passed (the arg should be quietly removed)
@@ -179,6 +179,7 @@ extern "C"
     {
         return nullptr;
     }
+
     void * dlmopen(long, const char *, int) // NOLINT
     {
         return nullptr;
@@ -188,6 +189,7 @@ extern "C"
     {
         return 0;
     }
+
     const char * dlerror()
     {
         return "ClickHouse does not allow dynamic library loading";

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -71,14 +71,13 @@ int mainEntryClickHouseRestart(int argc, char ** argv);
 namespace
 {
 
-using MainFunc = int (*)(int, char**);
+using MainFunc = int (*)(int, char **);
 
 /// Add an item here to register new application.
 /// This list has a "priority" - e.g. we need to disambiguate clickhouse --format being
 /// either clickouse-format or clickhouse-{local, client} --format.
 /// Currently we will prefer the latter option.
-std::pair<std::string_view, MainFunc> clickhouse_applications[] =
-{
+std::pair<std::string_view, MainFunc> clickhouse_applications[] = {
     {"local", mainEntryClickHouseLocal},
     {"client", mainEntryClickHouseClient},
     {"benchmark", mainEntryClickHouseBenchmark},
@@ -97,7 +96,7 @@ std::pair<std::string_view, MainFunc> clickhouse_applications[] =
     {"zookeeper-dump-tree", mainEntryClickHouseZooKeeperDumpTree},
     {"zookeeper-remove-by-list", mainEntryClickHouseZooKeeperRemoveByList},
 
-    // keeper
+// keeper
 #if ENABLE_CLICKHOUSE_KEEPER
     {"keeper", mainEntryClickHouseKeeper},
 #endif
@@ -130,27 +129,19 @@ int printHelp(int, char **)
 }
 
 /// Add an item here to register a new short name
-std::pair<std::string_view, std::string_view> clickhouse_short_names[] =
-{
+std::pair<std::string_view, std::string_view> clickhouse_short_names[] = {
     {"chl", "local"},
     {"chc", "client"},
 };
 
-std::pair<std::string_view, std::string_view> clickhouse_client_args[] =
-{
-    {"h", "host"},
-    {"", "port"},
-    {"u", "user"},
-    {"", "password"}
-};
+std::pair<std::string_view, std::string_view> clickhouse_client_args[] = {{"h", "host"}, {"", "port"}, {"u", "user"}, {"", "password"}};
 
 }
 
 bool isClickhouseApp(std::string_view app_suffix, std::vector<char *> & argv)
 {
     for (const auto & [alias, name] : clickhouse_short_names)
-        if (app_suffix == name
-            && !argv.empty() && (alias == argv[0] || endsWith(argv[0], "/" + std::string(alias))))
+        if (app_suffix == name && !argv.empty() && (alias == argv[0] || endsWith(argv[0], "/" + std::string(alias))))
             return true;
 
     /// Use app if the first arg 'app' is passed (the arg should be quietly removed)
@@ -179,27 +170,26 @@ bool isClickhouseApp(std::string_view app_suffix, std::vector<char *> & argv)
 /// because it is insane.
 
 #if !defined(USE_MUSL)
-extern "C"
+extern "C" {
+void * dlopen(const char *, int)
 {
-    void * dlopen(const char *, int)
-    {
-        return nullptr;
-    }
+    return nullptr;
+}
 
-    void * dlmopen(long, const char *, int) // NOLINT
-    {
-        return nullptr;
-    }
+void * dlmopen(long, const char *, int) // NOLINT
+{
+    return nullptr;
+}
 
-    int dlclose(void *)
-    {
-        return 0;
-    }
+int dlclose(void *)
+{
+    return 0;
+}
 
-    const char * dlerror()
-    {
-        return "ClickHouse does not allow dynamic library loading";
-    }
+const char * dlerror()
+{
+    return "ClickHouse does not allow dynamic library loading";
+}
 }
 #endif
 
@@ -207,8 +197,11 @@ extern "C"
 /// Some of these messages are non-actionable for the users, such as:
 /// <jemalloc>: Number of CPUs detected is not deterministic. Per-CPU arena disabled.
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
-extern "C" void (*malloc_message)(void *, const char *s);
-__attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
+extern "C" void (*malloc_message)(void *, const char * s);
+__attribute__((constructor(0))) void init_je_malloc_message()
+{
+    malloc_message = [](void *, const char *) {};
+}
 #endif
 
 /// This allows to implement assert to forbid initialization of a class in static constructors.
@@ -272,10 +265,9 @@ int main(int argc_, char ** argv_)
     /// shortcuts and runs clickhouse-client in this case
     ///
     /// clickhouse (ch) --host (-h) / --port / --user (-u) / --password
-    if (
-    main_func == printHelp && !argv.empty() && (std::string_view(argv[0]) == "ch" ||
-    std::string_view(argv[0]) == "clickhouse" || endsWith(argv[0], "/ch") ||
-    endsWith(argv[0], "/clickhouse")))
+    if (main_func == printHelp && !argv.empty()
+        && (std::string_view(argv[0]) == "ch" || std::string_view(argv[0]) == "clickhouse" || endsWith(argv[0], "/ch")
+            || endsWith(argv[0], "/clickhouse")))
     {
         for (int i = 1; i < argc_; ++i)
         {
@@ -301,7 +293,7 @@ int main(int argc_, char ** argv_)
 
             if (main_func == mainEntryClickHouseClient)
                 break;
-            
+
             if (std::string_view(argv[i]).starts_with("clickhouse:"))
             {
                 main_func = mainEntryClickHouseClient;

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -268,6 +268,10 @@ int main(int argc_, char ** argv_)
     ///
     std::error_code ec;
 
+    /// Checks if client arguments are provided for "ch" and "clickhouse"
+    /// shortcuts and runs clickhouse-client in this case
+    ///
+    /// clickhouse (ch) --host (-h) / --port / --user (-u) / --password
     if (
     main_func == printHelp && !argv.empty() && (std::string_view(argv[0]) == "ch" ||
     std::string_view(argv[0]) == "clickhouse" || endsWith(argv[0], "/ch") ||

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -1,6 +1,5 @@
 #include <base/phdr_cache.h>
 #include <base/scope_guard.h>
-#include <base/argsToConfig.h>
 #include <Common/EnvironmentChecks.h>
 #include <Common/StringUtils.h>
 #include <Common/getHashOfLoadedBinary.h>
@@ -19,7 +18,6 @@
 #include <string_view>
 #include <utility> /// pair
 #include <vector>
-#include <regex>
 
 /// Universal executable for various clickhouse applications
 int mainEntryClickHouseBenchmark(int argc, char ** argv);

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -71,13 +71,14 @@ int mainEntryClickHouseRestart(int argc, char ** argv);
 namespace
 {
 
-using MainFunc = int (*)(int, char **);
+using MainFunc = int (*)(int, char**);
 
 /// Add an item here to register new application.
 /// This list has a "priority" - e.g. we need to disambiguate clickhouse --format being
 /// either clickouse-format or clickhouse-{local, client} --format.
 /// Currently we will prefer the latter option.
-std::pair<std::string_view, MainFunc> clickhouse_applications[] = {
+std::pair<std::string_view, MainFunc> clickhouse_applications[] =
+{
     {"local", mainEntryClickHouseLocal},
     {"client", mainEntryClickHouseClient},
     {"benchmark", mainEntryClickHouseBenchmark},
@@ -96,7 +97,7 @@ std::pair<std::string_view, MainFunc> clickhouse_applications[] = {
     {"zookeeper-dump-tree", mainEntryClickHouseZooKeeperDumpTree},
     {"zookeeper-remove-by-list", mainEntryClickHouseZooKeeperRemoveByList},
 
-// keeper
+    // keeper
 #if ENABLE_CLICKHOUSE_KEEPER
     {"keeper", mainEntryClickHouseKeeper},
 #endif
@@ -129,7 +130,8 @@ int printHelp(int, char **)
 }
 
 /// Add an item here to register a new short name
-std::pair<std::string_view, std::string_view> clickhouse_short_names[] = {
+std::pair<std::string_view, std::string_view> clickhouse_short_names[] =
+{
     {"chl", "local"},
     {"chc", "client"},
 };
@@ -141,7 +143,8 @@ std::pair<std::string_view, std::string_view> clickhouse_client_args[] = {{"h", 
 bool isClickhouseApp(std::string_view app_suffix, std::vector<char *> & argv)
 {
     for (const auto & [alias, name] : clickhouse_short_names)
-        if (app_suffix == name && !argv.empty() && (alias == argv[0] || endsWith(argv[0], "/" + std::string(alias))))
+    if (app_suffix == name
+        && !argv.empty() && (alias == argv[0] || endsWith(argv[0], "/" + std::string(alias))))
             return true;
 
     /// Use app if the first arg 'app' is passed (the arg should be quietly removed)
@@ -170,26 +173,25 @@ bool isClickhouseApp(std::string_view app_suffix, std::vector<char *> & argv)
 /// because it is insane.
 
 #if !defined(USE_MUSL)
-extern "C" {
-void * dlopen(const char *, int)
+extern "C"
 {
-    return nullptr;
-}
+    void * dlopen(const char *, int)
+    {
+        return nullptr;
+    }
+    void * dlmopen(long, const char *, int) // NOLINT
+    {
+        return nullptr;
+    }
 
-void * dlmopen(long, const char *, int) // NOLINT
-{
-    return nullptr;
-}
-
-int dlclose(void *)
-{
-    return 0;
-}
-
-const char * dlerror()
-{
-    return "ClickHouse does not allow dynamic library loading";
-}
+    int dlclose(void *)
+    {
+        return 0;
+    }
+    const char * dlerror()
+    {
+        return "ClickHouse does not allow dynamic library loading";
+    }
 }
 #endif
 
@@ -197,11 +199,8 @@ const char * dlerror()
 /// Some of these messages are non-actionable for the users, such as:
 /// <jemalloc>: Number of CPUs detected is not deterministic. Per-CPU arena disabled.
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
-extern "C" void (*malloc_message)(void *, const char * s);
-__attribute__((constructor(0))) void init_je_malloc_message()
-{
-    malloc_message = [](void *, const char *) {};
-}
+extern "C" void (*malloc_message)(void *, const char *s);
+__attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
 #endif
 
 /// This allows to implement assert to forbid initialization of a class in static constructors.

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -267,7 +267,11 @@ int main(int argc_, char ** argv_)
     ///     clickhouse /tmp/repro --enable-analyzer
     ///
     std::error_code ec;
-    if (main_func == printHelp && !argv.empty())
+
+    if (
+    main_func == printHelp && !argv.empty() && (std::string_view(argv[0]) == "ch" ||
+    std::string_view(argv[0]) == "clickhouse" || endsWith(argv[0], "/ch") ||
+    endsWith(argv[0], "/clickhouse")))
     {
         for (int i = 1; i < argc_; ++i)
         {

--- a/tests/queries/0_stateless/03313_issue_65252.reference
+++ b/tests/queries/0_stateless/03313_issue_65252.reference
@@ -1,16 +1,16 @@
 ----CLICKHOUSE SHORTCUT CHECKS-----
-ClickHouse local version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
+local
+client
+client
+client
+client
+client
+client
 ----CH SHORTCUT CHECKS-----
-ClickHouse local version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
-ClickHouse client version 25.1.1.1.
+local
+client
+client
+client
+client
+client
+client

--- a/tests/queries/0_stateless/03313_issue_65252.reference
+++ b/tests/queries/0_stateless/03313_issue_65252.reference
@@ -1,0 +1,16 @@
+----CLICKHOUSE SHORTCUT CHECKS-----
+ClickHouse local version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+----CH SHORTCUT CHECKS-----
+ClickHouse local version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.
+ClickHouse client version 25.1.1.1.

--- a/tests/queries/0_stateless/03313_issue_65252.sh
+++ b/tests/queries/0_stateless/03313_issue_65252.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+ver_kind() {
+    "$@" --version 2>&1 |       \
+        sed -nE 's/^ClickHouse[[:space:]]+([a-z]+)[[:space:]].*/\1/p'
+}
 
 echo "----CLICKHOUSE SHORTCUT CHECKS-----"
-$CLICKHOUSE_BINARY --version
-$CLICKHOUSE_BINARY --host sdfsadf --version
-$CLICKHOUSE_BINARY -h sdfsadf --version
-$CLICKHOUSE_BINARY --port 9000 --version
-$CLICKHOUSE_BINARY --user qwr --version
-$CLICKHOUSE_BINARY -u qwr --version
-$CLICKHOUSE_BINARY --password secret --version
+ver_kind "$CLICKHOUSE_BINARY"
+ver_kind "$CLICKHOUSE_BINARY" --host sdfsadf
+ver_kind "$CLICKHOUSE_BINARY" -h sdfsadf
+ver_kind "$CLICKHOUSE_BINARY" --port 9000
+ver_kind "$CLICKHOUSE_BINARY" --user qwr
+ver_kind "$CLICKHOUSE_BINARY" -u qwr
+ver_kind "$CLICKHOUSE_BINARY" --password secret
 
 export CH_TMP="${CLICKHOUSE_BINARY%clickhouse}ch"
 echo "----CH SHORTCUT CHECKS-----"
-$CH_TMP --version
-$CH_TMP --host sdfsadf --version
-$CH_TMP -h sdfsadf --version
-$CH_TMP --port 9000 --version
-$CH_TMP --user qwr --version
-$CH_TMP -u qwr --version
-$CH_TMP --password secret --version
+ver_kind "$CH_TMP"
+ver_kind "$CH_TMP" --host sdfsadf
+ver_kind "$CH_TMP" -h sdfsadf
+ver_kind "$CH_TMP" --port 9000
+ver_kind "$CH_TMP" --user qwr
+ver_kind "$CH_TMP" -u qwr
+ver_kind "$CH_TMP" --password secret

--- a/tests/queries/0_stateless/03313_issue_65252.sh
+++ b/tests/queries/0_stateless/03313_issue_65252.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+echo "----CLICKHOUSE SHORTCUT CHECKS-----"
+../../../build/programs/clickhouse --version
+../../../build/programs/clickhouse --host sdfsadf --version
+../../../build/programs/clickhouse -h sdfsadf --version
+../../../build/programs/clickhouse --port 9000 --version
+../../../build/programs/clickhouse --user qwr --version
+../../../build/programs/clickhouse -u qwr --version
+../../../build/programs/clickhouse --password secret --version
+
+echo "----CH SHORTCUT CHECKS-----"
+../../../build/programs/ch --version
+../../../build/programs/ch --host sdfsadf --version
+../../../build/programs/ch -h sdfsadf --version
+../../../build/programs/ch --port 9000 --version
+../../../build/programs/ch --user qwr --version
+../../../build/programs/ch -u qwr --version
+../../../build/programs/ch --password secret --version

--- a/tests/queries/0_stateless/03313_issue_65252.sh
+++ b/tests/queries/0_stateless/03313_issue_65252.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
-echo "----CLICKHOUSE SHORTCUT CHECKS-----"
-../../../build/programs/clickhouse --version
-../../../build/programs/clickhouse --host sdfsadf --version
-../../../build/programs/clickhouse -h sdfsadf --version
-../../../build/programs/clickhouse --port 9000 --version
-../../../build/programs/clickhouse --user qwr --version
-../../../build/programs/clickhouse -u qwr --version
-../../../build/programs/clickhouse --password secret --version
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
 
+
+echo "----CLICKHOUSE SHORTCUT CHECKS-----"
+$CLICKHOUSE_BINARY --version
+$CLICKHOUSE_BINARY --host sdfsadf --version
+$CLICKHOUSE_BINARY -h sdfsadf --version
+$CLICKHOUSE_BINARY --port 9000 --version
+$CLICKHOUSE_BINARY --user qwr --version
+$CLICKHOUSE_BINARY -u qwr --version
+$CLICKHOUSE_BINARY --password secret --version
+
+export CH_TMP="${CLICKHOUSE_BINARY%clickhouse}ch"
 echo "----CH SHORTCUT CHECKS-----"
-../../../build/programs/ch --version
-../../../build/programs/ch --host sdfsadf --version
-../../../build/programs/ch -h sdfsadf --version
-../../../build/programs/ch --port 9000 --version
-../../../build/programs/ch --user qwr --version
-../../../build/programs/ch -u qwr --version
-../../../build/programs/ch --password secret --version
+$CH_TMP --version
+$CH_TMP --host sdfsadf --version
+$CH_TMP -h sdfsadf --version
+$CH_TMP --port 9000 --version
+$CH_TMP --user qwr --version
+$CH_TMP -u qwr --version
+$CH_TMP --password secret --version


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`ch` and `clickhouse` shortcuts are now responsive to `--host`, `-h`, `--port`, `--user`, `-u`, `--password` arguments and to connection string. When passing these arguments it runs clickhouse-client.
Closes #65252 