### PR TITLE
Support s3_plain_rewritable as a database disk

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -90,6 +90,9 @@ static struct InitFiu
     PAUSEABLE(database_replicated_startup_pause) \
     ONCE(keeper_leader_sets_invalid_digest) \
     ONCE(parallel_replicas_wait_for_unused_replicas) \
+    REGULAR(plain_object_storage_copy_fail_on_file_move) \
+    REGULAR(plain_object_storage_copy_temp_source_file_fail_on_file_move) \
+    REGULAR(plain_object_storage_copy_temp_target_file_fail_on_file_move)
 
 
 namespace FailPoints

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -431,7 +431,12 @@ struct ReplaceFileObjectStorageOperation final : public IDiskObjectStorageOperat
     {
         if (metadata_storage.existsFile(path_to))
         {
-            objects_to_remove = metadata_storage.getStorageObjects(path_to);
+            if (metadata_storage.getType() != MetadataStorageType::PlainRewritable
+                && metadata_storage.getType() != MetadataStorageType::Plain)
+            {
+                //  MetadataStorageFromPlainObjectStorageTransaction removes the source objects by itself.
+                objects_to_remove = metadata_storage.getStorageObjects(path_to);
+            }
             tx->replaceFile(path_from, path_to);
         }
         else

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -21,6 +21,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int FILE_DOESNT_EXIST;
+    extern const int UNSUPPORTED_METHOD;
 }
 
 namespace
@@ -240,10 +241,33 @@ void MetadataStorageFromPlainObjectStorageTransaction::moveFile(const std::strin
         throwNotImplemented();
 
     if (metadata_storage.existsDirectory(path_from))
+    {
         moveDirectory(path_from, path_to);
-    else
-        throwNotImplemented();
+        return;
+    }
+
+    addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageMoveFileOperation>(
+        false, path_from, path_to, *metadata_storage.getPathMap(), object_storage));
 }
+
+void MetadataStorageFromPlainObjectStorageTransaction::replaceFile(const std::string & path_from, const std::string & path_to)
+{
+    if (metadata_storage.object_storage->isWriteOnce())
+        throwNotImplemented();
+
+    if (metadata_storage.object_metadata_cache)
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Replacing file is not supported with object metadata cache");
+
+    if (metadata_storage.existsDirectory(path_from))
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Replacing from directory is not supported {}", path_from);
+
+    if (metadata_storage.existsDirectory(path_to))
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Replacing to directory is not supported {}", path_to);
+
+    addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageMoveFileOperation>(
+        true, path_from, path_to, *metadata_storage.getPathMap(), object_storage));
+}
+
 
 void MetadataStorageFromPlainObjectStorageTransaction::createEmptyMetadataFile(const std::string & path)
 {

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
@@ -151,6 +151,8 @@ public:
 
     void moveFile(const std::string & path_from, const std::string & path_to) override;
 
+    void replaceFile(const std::string & path_from, const std::string & path_to) override;
+
     UnlinkMetadataFileOperationOutcomePtr unlinkMetadata(const std::string & path) override;
 
     void commit() override;

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -1,4 +1,5 @@
-#include "MetadataStorageFromPlainObjectStorageOperations.h"
+#include <Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h>
+
 #include <Disks/ObjectStorages/InMemoryDirectoryPathMap.h>
 #include <Disks/ObjectStorages/StoredObject.h>
 #include <IO/ReadSettings.h>
@@ -11,8 +12,10 @@
 #include <Poco/Timestamp.h>
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
-#include <Common/SharedLockGuard.h>
 #include <Common/LockMemoryExceptionInThread.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/SharedLockGuard.h>
+#include <Common/getRandomASCIIString.h>
 #include <Common/logger_useful.h>
 
 namespace DB
@@ -30,6 +33,9 @@ namespace FailPoints
 {
 extern const char plain_object_storage_write_fail_on_directory_create[];
 extern const char plain_object_storage_write_fail_on_directory_move[];
+extern const char plain_object_storage_copy_fail_on_file_move[];
+extern const char plain_object_storage_copy_temp_source_file_fail_on_file_move[];
+extern const char plain_object_storage_copy_temp_target_file_fail_on_file_move[];
 }
 
 namespace
@@ -394,5 +400,153 @@ void MetadataStorageFromPlainObjectStorageCopyFileOperation::undo(std::unique_lo
 
     object_storage->removeObjectIfExists(StoredObject(remote_path_to));
     path_map.removeFile(path_to);
+}
+
+
+MetadataStorageFromPlainObjectStorageMoveFileOperation::MetadataStorageFromPlainObjectStorageMoveFileOperation(
+    bool replaceable_,
+    std::filesystem::path path_from_,
+    std::filesystem::path path_to_,
+    InMemoryDirectoryPathMap & path_map_,
+    ObjectStoragePtr object_storage_)
+    : replaceable(replaceable_)
+    , path_from(path_from_)
+    , remote_path_from(object_storage_->generateObjectKeyForPath(path_from_, std::nullopt).serialize())
+    , path_to(path_to_)
+    , remote_path_to(object_storage_->generateObjectKeyForPath(path_to_, std::nullopt).serialize())
+    , path_map(path_map_)
+    , object_storage(object_storage_)
+{
+    {
+        auto tmp_path_from = path_to.string() + ".move_from." + getRandomASCIIString(16);
+        tmp_remote_path_from = object_storage->generateObjectKeyForPath(tmp_path_from, std::nullopt).serialize();
+    }
+    {
+        auto tmp_path_to = path_to.string() + ".move_to." + getRandomASCIIString(16);
+        tmp_remote_path_to = object_storage->generateObjectKeyForPath(tmp_path_to, std::nullopt).serialize();
+    }
+}
+
+void MetadataStorageFromPlainObjectStorageMoveFileOperation::execute(std::unique_lock<SharedMutex> & /*metadata_lock*/)
+{
+    LOG_TEST(
+        getLogger("MetadataStorageFromPlainObjectStorageMoveFileOperation"),
+        "Moving file (replaceable = {}) from '{}' to '{}'",
+        replaceable,
+        path_from,
+        path_to);
+
+    if (!path_map.existsFile(path_from))
+        throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Metadata object for the source path '{}' does not exist", path_from);
+
+    const auto directory_to = path_to.parent_path();
+    if (!path_map.existsLocalPath(directory_to))
+        throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Metadata object for the target directory path '{}' does not exist", path_to);
+
+    const auto read_settings = getReadSettingsForMetadata();
+    const auto write_settings = getWriteSettingsForMetadata();
+
+    if (path_map.existsFile(path_to))
+    {
+        if (!replaceable)
+            throw Exception(ErrorCodes::FILE_ALREADY_EXISTS, "Target file '{}' already exists", path_to);
+
+        fiu_do_on(FailPoints::plain_object_storage_copy_temp_target_file_fail_on_file_move, {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injecting fault when moving from '{}' to '{}'", path_from, path_to);
+        });
+
+        object_storage->copyObject(
+            /*object_from=*/StoredObject(remote_path_to),
+            /*object_to=*/StoredObject(tmp_remote_path_to),
+            read_settings,
+            write_settings);
+        moved_existing_target_file = true;
+        object_storage->removeObjectIfExists(StoredObject(remote_path_to));
+    }
+    else
+    {
+        [[maybe_unused]] bool added = path_map.addFile(path_to);
+        chassert(added);
+    }
+
+    {
+        fiu_do_on(FailPoints::plain_object_storage_copy_temp_source_file_fail_on_file_move, {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injecting fault when moving from '{}' to '{}'", path_from, path_to);
+        });
+
+        object_storage->copyObject(
+            /*object_from=*/StoredObject(remote_path_from),
+            /*object_to=*/StoredObject(tmp_remote_path_from),
+            read_settings,
+            write_settings);
+        moved_existing_source_file = true;
+    }
+
+    {
+        fiu_do_on(FailPoints::plain_object_storage_copy_fail_on_file_move, {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injecting fault when moving from '{}' to '{}'", path_from, path_to);
+        });
+        object_storage->copyObject(
+            /*object_from=*/StoredObject(remote_path_from), /*object_to=*/StoredObject(remote_path_to), read_settings, write_settings);
+        object_storage->removeObjectIfExists(StoredObject(remote_path_from));
+        moved_file = true;
+    }
+
+    path_map.removeFile(path_from);
+}
+
+void MetadataStorageFromPlainObjectStorageMoveFileOperation::undo(std::unique_lock<SharedMutex> & /*metadata_lock*/)
+{
+    path_map.addFile(path_from);
+
+    const auto read_settings = getReadSettings();
+    const auto write_settings = getWriteSettings();
+
+    if (moved_file)
+    {
+        LOG_WARNING(
+            getLogger("MetadataStorageFromPlainObjectStorageMoveFileOperation"),
+            "Removing file '{}' that was moved (replaceable = {}) from '{}",
+            path_to,
+            replaceable,
+            path_from);
+
+        object_storage->removeObjectIfExists(StoredObject(remote_path_to));
+    }
+
+    if (moved_existing_source_file)
+    {
+        object_storage->copyObject(
+            /*object_from=*/StoredObject(tmp_remote_path_from),
+            /*object_to=*/StoredObject(remote_path_from),
+            read_settings,
+            write_settings);
+
+        object_storage->removeObjectIfExists(StoredObject(tmp_remote_path_from));
+    }
+
+    if (moved_existing_target_file)
+    {
+        object_storage->copyObject(
+            /*object_from=*/StoredObject(tmp_remote_path_to),
+            /*object_to=*/StoredObject(remote_path_to),
+            read_settings,
+            write_settings);
+
+        object_storage->removeObjectIfExists(StoredObject(tmp_remote_path_to));
+    }
+    else
+    {
+        path_map.removeFile(path_to);
+    }
+}
+
+void MetadataStorageFromPlainObjectStorageMoveFileOperation::finalize()
+{
+    if (moved_existing_source_file)
+        object_storage->removeObjectIfExists(StoredObject(tmp_remote_path_from));
+
+    if (moved_existing_target_file)
+        object_storage->removeObjectIfExists(StoredObject(tmp_remote_path_to));
 }
 }

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
@@ -146,4 +146,61 @@ public:
     void execute(std::unique_lock<SharedMutex> & metadata_lock) override;
     void undo(std::unique_lock<SharedMutex> & metadata_lock) override;
 };
+
+/**
+ * @brief MetadataStorageFromPlainObjectStorageMoveFileOperation move file from {path_from, remote_path_from} to {path_to, remote_path_to}.
+ *  If `replacable` is enabled, the target file will be replaced if exists. If disabled, the target file must not exist.
+ *  Both source and target files must not be directories.
+ */
+class MetadataStorageFromPlainObjectStorageMoveFileOperation final : public IMetadataOperation
+{
+private:
+    bool replaceable{false};
+    std::filesystem::path path_from;
+    std::filesystem::path remote_path_from;
+    std::filesystem::path path_to;
+    std::filesystem::path remote_path_to;
+    std::filesystem::path tmp_remote_path_from;
+    std::filesystem::path tmp_remote_path_to;
+    InMemoryDirectoryPathMap & path_map;
+    ObjectStoragePtr object_storage;
+
+
+    bool moved_existing_source_file{false};
+    bool moved_existing_target_file{false};
+    bool moved_file{false};
+
+public:
+    MetadataStorageFromPlainObjectStorageMoveFileOperation(
+        bool replaceable_,
+        std::filesystem::path path_from_,
+        std::filesystem::path path_to_,
+        InMemoryDirectoryPathMap & path_map_,
+        ObjectStoragePtr object_storage_);
+    /**
+     * @brief Move a file from remote_path_from to remote_path_to
+     *  1. Copy remote_path_to (if exists) to tmp_remote_path_from, which is used to restore the target file in case of failure.
+     *  2. Copy remote_path_from to tmp_remote_path_to, which is used to restore the source file in case of failure.
+     *  3. Copy remote_path_from to remote_path_to.
+     *  4. Remove remote_path_to.
+     *  5. Update path_map
+     * @param metadata_lock the lock of metadata.
+     */
+    void execute(std::unique_lock<SharedMutex> & metadata_lock) override;
+    /**
+     * @brief Undo the `execute` logic:
+     *  1. If remote_path_from is copied to remote_path_to, remove remote_path_to
+     *  2. Restore remote_path_from from tmp_remote_path_from if it is copied.
+     *  3. Restore remote_path_to from tmp_remote_path_to if it is copied.
+     *  5. Update path_map
+     * @param metadata_lock the lock of metadata.
+     */
+    void undo(std::unique_lock<SharedMutex> & metadata_lock) override;
+    /**
+     * @brief Finalize `execute` logic
+     *  1. Remove tmp_remote_path_from if exists
+     *  2. Remove tmp_remote_path_to if exists
+     */
+    void finalize() override;
+};
 }

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -290,7 +290,6 @@ fi
 if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
     ln -sf $SRC_PATH/users.d/database_replicated.xml $DEST_SERVER_PATH/users.d/
     ln -sf $SRC_PATH/config.d/database_replicated.xml $DEST_SERVER_PATH/config.d/
-    ln -sf $SRC_PATH/config.d/remote_database_disk.xml $DEST_SERVER_PATH/config.d/
     rm $DEST_SERVER_PATH/config.d/zookeeper.xml
     rm $DEST_SERVER_PATH/config.d/keeper_port.xml
 
@@ -337,6 +336,13 @@ if [[ "$BUGFIX_VALIDATE_CHECK" -eq 1 ]]; then
 
     remove_keeper_config "remove_recursive" "[[:digit:]]\+"
     remove_keeper_config "use_xid_64" "[[:digit:]]\+"
+fi
+
+# Enable remote_database_disk in DEBUG and ASAN build
+build_opts=$(clickhouse-server local -q "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
+if [[ "$build_opts" != *NDEBUG* && "$build_opts" == *-fsanitize=address* ]]; then
+    ln -sf $SRC_PATH/config.d/remote_database_disk.xml $DEST_SERVER_PATH/config.d/
+    echo "Installed remote_database_disk.xml config"
 fi
 
 ln -sf $SRC_PATH/client_config.xml $DEST_CLIENT_PATH/config.xml

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -538,6 +538,7 @@ class ClickHouseCluster:
         self.minio_ip = None
         self.minio_bucket = "root"
         self.minio_bucket_2 = "root2"
+        self.minio_bucket_db_disk = "root-db-disk"
         self.minio_port = 9001
         self.minio_client = None  # type: Minio
         self.minio_redirect_host = "proxy1"
@@ -1436,12 +1437,11 @@ class ClickHouseCluster:
         )
         return self.base_glue_catalog_cmd
 
-
     def setup_hms_catalog_cmd(
          self, instance, env_variables, docker_compose_yml_dir
      ):
-         self.with_hms_catalog = True
-         self.base_cmd.extend(
+        self.with_hms_catalog = True
+        self.base_cmd.extend(
              [
                  "--file",
                  p.join(
@@ -1450,14 +1450,13 @@ class ClickHouseCluster:
              ]
          )
 
-         self.base_iceberg_hms_cmd = self.compose_cmd(
+        self.base_iceberg_hms_cmd = self.compose_cmd(
              "--env-file",
              instance.env_file,
              "--file",
              p.join(docker_compose_yml_dir, "docker_compose_iceberg_hms_catalog.yml"),
          )
-         return self.base_iceberg_hms_cmd
-
+        return self.base_iceberg_hms_cmd
 
     def setup_iceberg_catalog_cmd(
         self, instance, env_variables, docker_compose_yml_dir
@@ -1638,7 +1637,10 @@ class ClickHouseCluster:
         with_nginx=False,
         with_redis=False,
         with_minio=False,
-        with_remote_database_disk=False,  # Currently, there is no remote storage can be used for the database disk. We disabled it as default.
+        # The config is defined in tests/integration/helpers/remote_database_disk.xml
+        # However, some tests cannot use with_remote_database_disk by their configs: e.g using secure keeper
+        # So, we set the default value of with_remote_database_disk to None and try to enable it if possible in DEBUG and ASAN build (i.e. if not explicitly set to false)
+        with_remote_database_disk=None,
         with_azurite=False,
         with_cassandra=False,
         with_ldap=False,
@@ -1713,7 +1715,18 @@ class ClickHouseCluster:
             with_remote_database_disk = False
 
         if with_remote_database_disk is None:
-            with_remote_database_disk = False
+            build_opts = subprocess.check_output(
+                f"""{self.server_bin_path} local -q "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'" """,
+                stderr=subprocess.STDOUT,
+                shell=True,
+            ).decode()
+            with_remote_database_disk = ("NDEBUG" not in build_opts) and (
+                "-fsanitize=address" in build_opts
+            )
+
+        if with_remote_database_disk:
+            logging.debug(f"Instance {name}, with_remote_database_disk enabled")
+            with_minio = True
 
         if not env_variables:
             env_variables = {}
@@ -2621,7 +2634,6 @@ class ClickHouseCluster:
                 logging.debug("Can't connect to Mongo " + str(ex))
                 time.sleep(1)
 
-
     def wait_custom_minio_to_start(self, buckets, host, port, timeout=180):
         ip = self.get_instance_ip(host)
         minio_client = Minio(
@@ -2646,7 +2658,6 @@ class ClickHouseCluster:
                 logging.debug("Can't connect to Minio: %s", str(ex))
                 time.sleep(1)
 
-
         raise Exception("Can't wait Minio to start")
 
     def wait_minio_to_start(self, timeout=180, secure=False):
@@ -2670,7 +2681,11 @@ class ClickHouseCluster:
 
                 logging.debug("Connected to Minio.")
 
-                buckets = [self.minio_bucket, self.minio_bucket_2]
+                buckets = [
+                    self.minio_bucket,
+                    self.minio_bucket_2,
+                    self.minio_bucket_db_disk,
+                ]
 
                 for bucket in buckets:
                     if minio_client.bucket_exists(bucket):
@@ -2976,6 +2991,32 @@ class ClickHouseCluster:
                 self.wait_zookeeper_to_start()
                 for command in self.pre_zookeeper_commands:
                     self.run_kazoo_commands_with_retries(command, repeats=5)
+
+            for instance in list(self.instances.values()):
+                if instance.with_remote_database_disk:
+                    logging.debug(
+                        f"Setup with_remote_database_disk, instance {instance.name}"
+                    )
+                    config_file_path = os.path.join(
+                        HELPERS_DIR, "remote_database_disk.xml"
+                    )
+                    with open(config_file_path, "r") as config_source_file:
+                        data = config_source_file.read()
+                    data = data.format(
+                        host=self.minio_host,
+                        port=str(self.minio_port),
+                        bucket=self.minio_bucket_db_disk,
+                        shard="{shard}",
+                        replica="{replica}",
+                    )
+                    instance_config_dir = os.path.join(instance.path, "configs")
+                    target_config_file_path = os.path.join(
+                        instance_config_dir,
+                        "config.d",
+                        "remote_database_disk.xml",
+                    )
+                    with open(target_config_file_path, "w") as config_target_file:
+                        config_target_file.write(data)
 
             if self.with_mysql_client and self.base_mysql_client_cmd:
                 logging.debug("Setup MySQL Client")
@@ -3679,6 +3720,11 @@ class ClickHouseInstance:
         )
         self.secrets_dir = p.abspath(p.join(base_path, "secrets"))
         self.macros = macros if macros is not None else {}
+        if with_remote_database_disk:
+            if "shard" not in self.macros:
+                self.macros["shard"] = "default"
+            if "replica" not in self.macros:
+                self.macros["replica"] = self.name
         self.with_zookeeper = with_zookeeper
         self.zookeeper_config_path = zookeeper_config_path
 

--- a/tests/integration/helpers/remote_database_disk.xml
+++ b/tests/integration/helpers/remote_database_disk.xml
@@ -1,2 +1,17 @@
 <clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk_db_remote>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain_rewritable</metadata_type>
+                <endpoint>http://{host}:{port}/{bucket}/test-{shard}|{replica}</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </disk_db_remote>
+        </disks>
+    </storage_configuration>
+    <database_disk>
+        <disk>disk_db_remote</disk>
+    </database_disk>
 </clickhouse>

--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -86,8 +86,15 @@ def test_system_tables(start_cluster):
         },
     ]
     if node1.with_remote_database_disk:
+        db_disk_path = node1.query(
+            "SELECT path FROM system.disks WHERE name='disk_db_remote'"
+        ).strip()
         expected_disks_data.append(
-            {"name": "disk_db_remote", "path": "", "keep_free_space": "0"}
+            {
+                "name": "disk_db_remote",
+                "path": f"{db_disk_path}",
+                "keep_free_space": "0",
+            }
         )
 
     click_disk_data = json.loads(

--- a/tests/queries/0_stateless/02801_backup_native_copy.sh
+++ b/tests/queries/0_stateless/02801_backup_native_copy.sh
@@ -12,6 +12,15 @@ client_opts=(
   --send_logs_level 'error'
 )
 
+use_s3_plain_rewriteable_as_db_disk=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.disks WHERE name='disk_db_remote' AND type = 'ObjectStorage' AND object_storage_type='S3' AND metadata_type='PlainRewritable'" | tr -d '[:space:]')
+
+# When using s3_plain_rewriteable as a db_disk, even when allow_s3_native_copy=false, we still copy metadata files.
+if [ "$use_s3_plain_rewriteable_as_db_disk" = "1" ]; then
+    metadata_s3_copy_object_events_without_s3_native_copy=2
+else
+    metadata_s3_copy_object_events_without_s3_native_copy=0
+fi
+
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     drop table if exists data;
     create table data (key Int) engine=MergeTree() order by tuple() settings disk='s3_disk';
@@ -58,7 +67,7 @@ query_id=$(random_str 10)
 $CLICKHOUSE_CLIENT --format Null "${client_opts[@]}" --query_id "$query_id" -q "RESTORE TABLE data AS data_no_native_copy FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy') SETTINGS allow_s3_native_copy=false"
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     SYSTEM FLUSH LOGS query_log;
-    SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
+    SELECT query, ProfileEvents['S3CopyObject']>$metadata_s3_copy_object_events_without_s3_native_copy FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
 "
 # RESTORE from incremental backup
 query_id=$(random_str 10)
@@ -71,5 +80,5 @@ query_id=$(random_str 10)
 $CLICKHOUSE_CLIENT --format Null "${client_opts[@]}" --query_id "$query_id" -q "RESTORE TABLE data AS data_no_native_copy_inc FROM S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data_no_native_copy_inc') SETTINGS allow_s3_native_copy=false"
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     SYSTEM FLUSH LOGS query_log;
-    SELECT query, ProfileEvents['S3CopyObject']>0 FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
+    SELECT query, ProfileEvents['S3CopyObject']>$metadata_s3_copy_object_events_without_s3_native_copy FROM system.query_log WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id'
 "

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
@@ -64,9 +64,19 @@ ${CLICKHOUSE_CLIENT} -q "DETACH TABLE mv"
 
 data_path=$(${CLICKHOUSE_CLIENT} -q "SELECT path FROM system.disks WHERE name = 'default'")
 
-#cat $mv_metadata_path
-sed -i -e 's/`timestamp` DateTime,/`timestamp` DateTime64(9),/g' -e 's/`c12` Nullable(String)/`c12` String/g' "$data_path$mv_metadata_path"
-#cat $mv_metadata_path
+data_path=$(${CLICKHOUSE_CLIENT} -q "SELECT path FROM system.disks WHERE name = 'default'")
+
+if [ -e "$data_path$mv_metadata_path" ]; then
+    #cat $mv_metadata_path
+    sed -i -e 's/`timestamp` DateTime,/`timestamp` DateTime64(9),/g' -e 's/`c12` Nullable(String)/`c12` String/g' "$data_path$mv_metadata_path"
+    #cat $mv_metadata_path
+else
+    # Using a remote DB disk
+    config="${BASH_SOURCE[0]/.sh/.xml}"
+    mv_metadata=$(clickhouse-disks -C "$config" --disk "disk_db_remote" --save-logs --query "read $mv_metadata_path") 
+    mv_metadata_updated=$(echo $mv_metadata | sed -e 's/`timestamp` DateTime,/`timestamp` DateTime64(9),/g' -e 's/`c12` Nullable(String)/`c12` String/g')
+    echo $mv_metadata_updated | clickhouse-disks -C "$config" --disk "disk_db_remote" --save-logs --query "write --path-to $mv_metadata_path"
+fi
 
 ${CLICKHOUSE_CLIENT} -q "ATTACH TABLE mv"
 

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.xml
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.xml
@@ -1,7 +1,4 @@
 <clickhouse>
-    <database_disk>
-        <disk>disk_db_remote</disk>
-    </database_disk>
     <storage_configuration>
         <disks>
             <disk_db_remote>
@@ -14,4 +11,14 @@
             </disk_db_remote>
         </disks>
     </storage_configuration>
+    <macros>
+        <shard>s1</shard>
+        <replica>r1</replica>
+    </macros>
+    <zookeeper>
+        <node index="1">
+            <host>localhost</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
 </clickhouse>

--- a/tests/queries/0_stateless/03167_improvement_table_name_too_long.sh
+++ b/tests/queries/0_stateless/03167_improvement_table_name_too_long.sh
@@ -6,10 +6,15 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 allowed_name_length=$($CLICKHOUSE_CLIENT -mn --query="SELECT getMaxTableNameLengthForDatabase('$CLICKHOUSE_DATABASE')")
 excess_length=$((allowed_name_length + 1))  # Ensure exceeding the limit
-
 long_table_name=$(openssl rand -base64 $((3 * excess_length)) | tr -dc A-Za-z | head -c $excess_length)
 allowed_table_name=$(openssl rand -base64 $((3 * allowed_name_length)) | tr -dc A-Za-z | head -c $allowed_name_length)
 
 $CLICKHOUSE_CLIENT -mn --query="CREATE TABLE $long_table_name (id UInt32, long_table_name String) Engine=MergeTree() order by id;" 2>&1 | grep -o -m 1 'ARGUMENT_OUT_OF_BOUND'
-$CLICKHOUSE_CLIENT -mn --query="CREATE TABLE $allowed_table_name (id UInt32, allowed_table_name String) Engine=MergeTree() order by id;"
-$CLICKHOUSE_CLIENT -mn --query="DROP TABLE $allowed_table_name;"
+
+use_s3_plain_rewriteable_as_db_disk=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.disks WHERE name='disk_db_remote' AND type = 'ObjectStorage' AND object_storage_type='S3' AND metadata_type='PlainRewritable'" | tr -d '[:space:]') 
+# When using s3_plain_rewriteable as a db_disk, minio doesn't allow the path segment to have more than 255 characters
+# Refer: https://github.com/minio/minio/blob/ddd9a84cd769e6bed67f5fe860f8f3c7527a6971/cmd/xl-storage.go#L154-L167
+if [ "$use_s3_plain_rewriteable_as_db_disk" == "0" ]; then
+    $CLICKHOUSE_CLIENT -mn --query="CREATE TABLE $allowed_table_name (id UInt32, allowed_table_name String) Engine=MergeTree() order by id;"
+    $CLICKHOUSE_CLIENT -mn --query="DROP TABLE $allowed_table_name;"
+fi


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement methods `moveFile` and `replaceFile` in s3_plain_rewritable to support it as a database disk.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
