### PR TITLE
Make userspace page cache resizing look at MemoryTracker::amount

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -325,10 +325,10 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
 
             /// Try to shrink the userspace page cache.
             DB::PageCache * page_cache_ptr = nullptr;
-            if (level == VariableContext::Global && will_be_rss > current_hard_limit && ((page_cache_ptr = page_cache.load(std::memory_order_relaxed))))
+            if (level == VariableContext::Global && (page_cache_ptr = page_cache.load(std::memory_order_relaxed)))
             {
                 ProfileEvents::increment(ProfileEvents::PageCacheOvercommitResize);
-                page_cache_ptr->autoResize(will_be_rss, current_hard_limit);
+                page_cache_ptr->autoResize(std::max(will_be, will_be_rss), current_hard_limit);
                 will_be = amount.load(std::memory_order_relaxed);
                 will_be_rss = rss.load(std::memory_order_relaxed);
                 if (will_be <= current_hard_limit && will_be_rss <= current_hard_limit)

--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -331,7 +331,7 @@ void MemoryWorker::backgroundThread()
         MemoryTracker::updateRSS(resident);
 
         if (page_cache)
-            page_cache->autoResize(resident, total_memory_tracker.getHardLimit());
+            page_cache->autoResize(std::max(resident, total_memory_tracker.get()), total_memory_tracker.getHardLimit());
 
 #if USE_JEMALLOC
         if (resident > total_memory_tracker.getHardLimit())

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -150,7 +150,7 @@ void PageCache::autoResize(Int64 memory_usage, size_t memory_limit)
     size_t peak;
     {
         std::lock_guard lock(mutex);
-        size_t usage_excluding_cache = memory_usage - std::min(cache_size, size_t(std::max(memory_usage, 0l)));
+        size_t usage_excluding_cache = memory_usage - std::min(cache_size, size_t(std::max(memory_usage, Int64(0))));
 
         if (history_window.count() <= 0)
         {

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -87,7 +87,7 @@ extern template class CacheBase<UInt128, PageCacheCell, UInt128TrivialHash, Page
 ///
 /// Implementation should be careful to always use MemoryTrackerBlockerInThread for all operations
 /// that lock the mutex or allocate memory. Otherwise we'll can deadlock when MemoryTracker calls
-/// autoResize().
+/// autoResize.
 class PageCache
 {
 private:
@@ -116,7 +116,7 @@ public:
 
     bool contains(const PageCacheKey & key, bool inject_eviction) const;
 
-    void autoResize(size_t memory_usage, size_t memory_limit);
+    void autoResize(Int64 memory_usage, size_t memory_limit);
 
     size_t defaultBlockSize() const { return default_block_size; }
     size_t defaultLookaheadBlocks() const { return default_lookahead_blocks; }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

MemoryTracker rejects allocations when `max(amount, rss) > limit`, but page cache used to auto-resize to only prevent `rss > limit`. Not sure why I did it this way (and why MemoryTracker does `max(amount, rss)`). This PR guesses that there was no good reason and makes the cache resizing use `max(amount, rss)`.