### PR TITLE
Fix checking if a file is a direct child when loading  metdata in MetadataStorageFromPlainRewritableObjectStorage

### DIFF
--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -163,7 +163,7 @@ void MetadataStorageFromPlainRewritableObjectStorage::load(bool is_initial_load)
 
                     /// Load the list of files inside the directory.
                     fs::path full_remote_path = object_storage->getCommonKeyPrefix() / remote_path;
-                    size_t prefix_length = remote_path.string().size() + 1; /// randomlygenerated/
+                    size_t prefix_length = full_remote_path.string().size() + 1; /// <prefix>/<randomlygenerated>/
                     for (auto dir_iterator = object_storage->iterate(full_remote_path, 0); dir_iterator->isValid(); dir_iterator->next())
                     {
                         auto remote_file = dir_iterator->current();
@@ -178,7 +178,8 @@ void MetadataStorageFromPlainRewritableObjectStorage::load(bool is_initial_load)
                         }
 
                         /// Check that the file is a direct child.
-                        if (remote_file_path.substr(prefix_length) == filename)
+                        chassert(prefix_length < remote_file_path.size());
+                        if (std::string_view(remote_file_path.data() + prefix_length) == filename)
                             files.insert(std::move(filename));
                     }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If the storage is configured with a prefix, when checking if a file is a direct child of a directory, we should use the full remote path which includes the prefix.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
