### PR TITLE
Fix test_storage_rabbitmq/test_failed_connection.py

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -32,11 +32,10 @@ SLEEP_BETWEEN_RETRIES = 5
 PARALLEL_GROUP_SIZE = 100
 CLICKHOUSE_BINARY_PATH = "usr/bin/clickhouse"
 
-FLAKY_TRIES_COUNT = 2  # run whole pytest several times
-FLAKY_REPEAT_COUNT = 3  # runs test case in single module several times
-MAX_TIME_SECONDS = 3600
+FLAKY_TRIES_COUNT = 250  # run whole pytest several times
+FLAKY_REPEAT_COUNT = 4  # runs test case in single module several times
 
-MAX_TIME_IN_SANDBOX = 20 * 60  # 20 minutes
+MAX_TIME_IN_SANDBOX = 20 * 600  # 20 minutes
 TASK_TIMEOUT = 8 * 60 * 60  # 8 hours
 
 NO_CHANGES_MSG = "Nothing to run"

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -32,10 +32,11 @@ SLEEP_BETWEEN_RETRIES = 5
 PARALLEL_GROUP_SIZE = 100
 CLICKHOUSE_BINARY_PATH = "usr/bin/clickhouse"
 
-FLAKY_TRIES_COUNT = 250  # run whole pytest several times
-FLAKY_REPEAT_COUNT = 4  # runs test case in single module several times
+FLAKY_TRIES_COUNT = 2  # run whole pytest several times
+FLAKY_REPEAT_COUNT = 3  # runs test case in single module several times
+MAX_TIME_SECONDS = 3600
 
-MAX_TIME_IN_SANDBOX = 20 * 600  # 20 minutes
+MAX_TIME_IN_SANDBOX = 20 * 60  # 20 minutes
 TASK_TIMEOUT = 8 * 60 * 60  # 8 hours
 
 NO_CHANGES_MSG = "Nothing to run"

--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -9,7 +9,7 @@ from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 DEFAULT_TIMEOUT_SEC = 120
-RABBITMQ_CONSUMPTION_TIMEOUT_SEC = 240
+CLICKHOUSE_VIEW_TIMEOUT_SEC = 240
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(
@@ -252,7 +252,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
 
     resume_rabbitmq(rabbitmq_cluster, rabbitmq_monitor)
 
-    deadline = time.monotonic() + RABBITMQ_CONSUMPTION_TIMEOUT_SEC
+    deadline = time.monotonic() + CLICKHOUSE_VIEW_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result = instance.query("SELECT count(DISTINCT key) FROM test.view")
         if int(result) == messages_num:
@@ -261,7 +261,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of {RABBITMQ_CONSUMPTION_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
+            f"Time limit of {CLICKHOUSE_VIEW_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
         )
 
     instance.query(
@@ -349,7 +349,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
     # kill_rabbitmq()
     # revive_rabbitmq()
 
-    deadline = time.monotonic() + RABBITMQ_CONSUMPTION_TIMEOUT_SEC
+    deadline = time.monotonic() + CLICKHOUSE_VIEW_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result = instance.query("SELECT count(DISTINCT key) FROM test.view").strip()
         if int(result) == messages_num:
@@ -358,7 +358,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of {RABBITMQ_CONSUMPTION_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
+            f"Time limit of {CLICKHOUSE_VIEW_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
         )
 
     instance.query(

--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -8,10 +8,8 @@ import pika
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
-# Disable the below two tests until fixed, because they are too broken
-pytestmark = pytest.mark.skip
-
 DEFAULT_TIMEOUT_SEC = 120
+RABBITMQ_CONSUMPTION_TIMEOUT_SEC = 240
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(
@@ -65,8 +63,10 @@ class RabbitMQMonitor:
     def _consume(self, timeout=180):
         logging.debug("RabbitMQMonitor: Consuming trace RabbitMQ messages...")
         deadline = time.monotonic() + timeout
+        _published = 0
+        _delivered = 0
         while time.monotonic() < deadline:
-            method, properties, body = self.channel.basic_get(self.queue_name, True)
+            method, properties, body = self.channel.basic_get(self.queue_name, auto_ack=True)
             if method and properties and body:
                 # logging.debug(f"Message received! method {method}, properties {properties}, body {body}")
                 message = json.loads(body.decode("utf-8"))
@@ -74,13 +74,15 @@ class RabbitMQMonitor:
                 value = int(message["key"])
                 if "deliver" in method.routing_key:
                     self.delivered.add(value)
+                    _delivered += 1
                     # logging.debug(f"Message delivered: {value}")
                 elif "publish" in method.routing_key:
                     self.published.add(value)
+                    _published += 1
                     # logging.debug(f"Message published: {value}")
             else:
                 break
-        logging.debug(f"RabbitMQMonitor: Consumed {len(self.published)} published messages and {len(self.delivered)} delivered messages")
+        logging.debug(f"RabbitMQMonitor: Consumed {_published}/{len(self.published)} published messages and {_delivered}/{len(self.delivered)} delivered messages in this iteration")
 
     def set_expectations(self, published, delivered):
         self.expected_published = published
@@ -174,7 +176,6 @@ def rabbitmq_monitor():
 
 # Tests
 
-@pytest.mark.skip(reason="Too flaky. Disable for now")
 def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, rabbitmq_monitor):
     """
     This test checks that after inserting through a RabbitMQ Engine, we can keep consuming from it
@@ -213,7 +214,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
     """
     )
 
-    messages_num = 10000
+    messages_num = 5000
     rabbitmq_monitor.set_expectations(published=messages_num, delivered=messages_num)
     deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
@@ -251,7 +252,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
 
     resume_rabbitmq(rabbitmq_cluster, rabbitmq_monitor)
 
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    deadline = time.monotonic() + RABBITMQ_CONSUMPTION_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result = instance.query("SELECT count(DISTINCT key) FROM test.view")
         if int(result) == messages_num:
@@ -260,7 +261,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
+            f"Time limit of {RABBITMQ_CONSUMPTION_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
         )
 
     instance.query(
@@ -275,7 +276,6 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, r
     )
 
 
-@pytest.mark.skip(reason="Too flaky. Disable for now")
 def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, rabbitmq_monitor):
     """
     This test checks that after inserting through a RabbitMQ Engine, we can keep consuming from it
@@ -305,7 +305,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
     """
     )
 
-    messages_num = 10000
+    messages_num = 5000
     rabbitmq_monitor.set_expectations(published=messages_num, delivered=messages_num)
     deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
@@ -349,7 +349,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
     # kill_rabbitmq()
     # revive_rabbitmq()
 
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    deadline = time.monotonic() + RABBITMQ_CONSUMPTION_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result = instance.query("SELECT count(DISTINCT key) FROM test.view").strip()
         if int(result) == messages_num:
@@ -358,7 +358,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, r
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
+            f"Time limit of {RABBITMQ_CONSUMPTION_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
         )
 
     instance.query(


### PR DESCRIPTION
Context: latest attempt of fixing it by making sure that not all messages are consumed after RabbitMQ's suspension by increasing the number of messages from 1000 to 10000 shows 2 things here:
- https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/81d263c261f6a898f8624435e9a4a6448b54b16b//integration_tests_tsan_2_6/integration_run_test_storage_rabbitmq_test_failed_connection_py_0.log
- https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/60579e2ebf15400b3fcc53d9bcb2f87976e1b1ec//integration_tests_tsan_2_6/integration_run_test_storage_rabbitmq_test_failed_connection_py_0.log

1. Stopping RabbitMQ on the CI takes a while, so slightly more than 1000 messages might be consumed at that point
2. We might need slightly more than 60sec to consume all messages

Give some extra slack to ensure not all messages are consumed after suspending RabbitMQ by having 5000 messages instead of 1000 (too few) or 10000 (too much).

Give extra timeout to consume the rest of messages once RabbitMQ server is back. It was using 60s by default before, I increased it significantly to prevent worst cases.

Related to #71049 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
