### PR TITLE
Slow down tests for distributed INSERT SELECT with PR to avoid flakiness

### DIFF
--- a/tests/queries/0_stateless/03394_pr_insert_select.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select.sql
@@ -10,7 +10,7 @@ CREATE TABLE t_mt_target (k UInt64, v String) ENGINE = MergeTree() ORDER BY ();
 INSERT INTO t_mt_source SELECT number as k, toString(number) as v FROM system.numbers LIMIT 1e6;
 select 'mt source table count()', count() from t_mt_source;
 
-SET enable_parallel_replicas = 1, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', max_parallel_replicas = 3;
+SET enable_parallel_replicas = 1, parallel_replicas_mark_segment_size = 128, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', max_parallel_replicas = 3;
 
 select '-- check result without local pipeline';
 INSERT INTO t_mt_target SELECT * FROM t_mt_source SETTINGS log_comment='cb01f13a-410c-4985-b233-35289776b58f', parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan=0;

--- a/tests/queries/0_stateless/03394_pr_insert_select_local_pipeline.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select_local_pipeline.sql
@@ -10,7 +10,7 @@ CREATE TABLE t_mt_target (k UInt64, v String) ENGINE = MergeTree() ORDER BY ();
 INSERT INTO t_mt_source SELECT number as k, toString(number) as v FROM system.numbers LIMIT 1e6;
 select 'mt source table count()', count() from t_mt_source;
 
-SET enable_parallel_replicas = 1, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', max_parallel_replicas = 3;
+SET enable_parallel_replicas = 1, parallel_replicas_mark_segment_size = 128, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', max_parallel_replicas = 3;
 
 select '-- check result with local pipeline';
 TRUNCATE TABLE t_mt_target;

--- a/tests/queries/0_stateless/03394_pr_insert_select_rmt.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select_rmt.sql
@@ -12,7 +12,7 @@ CREATE TABLE t_rmt_target (k UInt64, v String) ENGINE = ReplicatedMergeTree('/cl
 INSERT INTO t_rmt_source SELECT number as k, toString(number) as v FROM system.numbers LIMIT 1e6 settings parallel_distributed_insert_select=0;
 select 'rmt source table count()', count() from t_rmt_source;
 
-SET enable_parallel_replicas = 1, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', max_parallel_replicas = 3;
+SET enable_parallel_replicas = 1, parallel_replicas_mark_segment_size = 128, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', max_parallel_replicas = 3;
 
 select '-- check result without local pipeline';
 INSERT INTO t_rmt_target SELECT * FROM t_rmt_source SETTINGS log_comment='d3be4828-e074-437b-adc1-605f05d96f6b', parallel_replicas_local_plan=0;

--- a/tests/queries/0_stateless/03409_pr_insert_select_unavailable_node.sql
+++ b/tests/queries/0_stateless/03409_pr_insert_select_unavailable_node.sql
@@ -11,7 +11,7 @@ INSERT INTO t_mt_source SELECT number as k, toString(number) as v FROM system.nu
 select 'mt source table count()', count() from t_mt_source;
 
 -- use cluster with unavailable replica
-SET enable_parallel_replicas = 1, cluster_for_parallel_replicas = 'parallel_replicas';
+SET enable_parallel_replicas = 1, parallel_replicas_mark_segment_size = 128, cluster_for_parallel_replicas = 'parallel_replicas';
 
 -- to ensure that unavailable replica will not be chosen in subsequent INSERT SELECTs, so query count from query_log will match the test expectations
 SELECT k FROM t_mt_source SETTINGS max_parallel_replicas=11 FORMAT Null;

--- a/tests/queries/0_stateless/03409_pr_insert_select_unavailable_node_rmt.sql
+++ b/tests/queries/0_stateless/03409_pr_insert_select_unavailable_node_rmt.sql
@@ -4,7 +4,7 @@ SET enable_analyzer=1; -- parallel distributed insert select for replicated tabl
 SET parallel_distributed_insert_select=2;
 
 -- use cluster with unavailable replica
-SET enable_parallel_replicas = 1, cluster_for_parallel_replicas = 'parallel_replicas';
+SET enable_parallel_replicas = 1, parallel_replicas_mark_segment_size = 128, cluster_for_parallel_replicas = 'parallel_replicas';
 
 DROP TABLE IF EXISTS t_rmt_source SYNC;
 DROP TABLE IF EXISTS t_rmt_target SYNC;


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e40326ac4636c2ad775f4a987385c337c5c75d4f&name_0=MasterCI&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)