### PR TITLE
check table name length only on initial create

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -394,17 +394,7 @@ void DatabaseOnDisk::checkMetadataFilenameAvailability(const String & to_table_n
 
 void DatabaseOnDisk::checkMetadataFilenameAvailabilityUnlocked(const String & to_table_name) const
 {
-    // Compute allowed max length directly
-    size_t allowed_max_length = computeMaxTableNameLength(database_name, getContext());
-    String table_metadata_path = getObjectMetadataPath(to_table_name);
-
-    const auto escaped_name_length = escapeForFileName(to_table_name).length();
-
-    if (escaped_name_length > allowed_max_length)
-        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
-                        "The max length of table name for database {} is {}, current length is {}",
-                        database_name, allowed_max_length, escaped_name_length);
-
+    const String table_metadata_path = getObjectMetadataPath(to_table_name);
     if (db_disk->existsFile(table_metadata_path))
     {
         fs::path detached_permanently_flag(table_metadata_path + detached_suffix);
@@ -913,5 +903,22 @@ void DatabaseOnDisk::alterDatabaseComment(const AlterCommand & command)
     DB::updateDatabaseCommentWithMetadataFile(shared_from_this(), command);
 }
 
+void DatabaseOnDisk::checkTableNameLength(const String & table_name) const
+{
+    std::lock_guard lock(mutex);
+    checkTableNameLengthUnlocked(table_name);
+}
+
+void DatabaseOnDisk::checkTableNameLengthUnlocked(const String & table_name) const TSA_REQUIRES(mutex)
+{
+    const size_t allowed_max_length = computeMaxTableNameLength(database_name, getContext());
+    const size_t escaped_name_length = escapeForFileName(table_name).length();
+    if (escaped_name_length > allowed_max_length)
+    {
+        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+            "The max length of table name for database {} is {}, current length is {}",
+            database_name, allowed_max_length, escaped_name_length);
+    }
+}
 
 }

--- a/src/Databases/DatabaseOnDisk.h
+++ b/src/Databases/DatabaseOnDisk.h
@@ -79,6 +79,9 @@ public:
     void checkMetadataFilenameAvailability(const String & to_table_name) const override;
     void checkMetadataFilenameAvailabilityUnlocked(const String & to_table_name) const TSA_REQUIRES(mutex);
 
+    void checkTableNameLength(const String & table_name) const override;
+    void checkTableNameLengthUnlocked(const String & table_name) const TSA_REQUIRES(mutex);
+
     void modifySettingsMetadata(const SettingsChanges & settings_changes, ContextPtr query_context);
 
     void alterDatabaseComment(const AlterCommand & alter_command) override;

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -245,6 +245,8 @@ public:
     /// Throws exception when table exists.
     virtual void checkMetadataFilenameAvailability(const String & /*table_name*/) const {}
 
+    /// Check if the table name exceeds the max allowed length
+    virtual void checkTableNameLength(const String & /*table_name*/) const {}
 
     /// Get the table for work. Return nullptr if there is no table.
     virtual StoragePtr tryGetTable(const String & name, ContextPtr context) const = 0;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1847,6 +1847,11 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
                 return false;
             throw;
         }
+
+        /// If this is an initial create, we also need to check the table name's length.
+        /// We are not checking this for secondary creates to avoid backward compatibility issues.
+        if (mode <= LoadingStrictnessLevel::CREATE)
+            database->checkTableNameLength(create.getTable());
     }
 
     data_path = database->getTableDataPath(create);

--- a/tests/integration/test_check_table_name_length/test.py
+++ b/tests/integration/test_check_table_name_length/test.py
@@ -8,7 +8,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster, QueryRuntimeException
 
 
-LARGE_TABLE_NAME_SIZE = 220
+LARGE_TABLE_NAME_LENGTH = 220
 
 
 cluster = ClickHouseCluster(__file__)
@@ -44,7 +44,7 @@ def test_backward_compatibility(start_cluster):
     because we only perform the check for initial create queries and skip it for secondary ones.
     """
 
-    table_name = generate_name(LARGE_TABLE_NAME_SIZE)
+    table_name = generate_name(LARGE_TABLE_NAME_LENGTH)
 
     # create database
     old_node.query("DROP DATABASE IF EXISTS rdb SYNC")
@@ -65,7 +65,7 @@ def test_check_table_name_length(start_cluster):
     Verify that the new node gets error trying to create a table with name that is too long.
     """
 
-    table_name = generate_name(LARGE_TABLE_NAME_SIZE)
+    table_name = generate_name(LARGE_TABLE_NAME_LENGTH)
 
     # create database
     new_node.query("DROP DATABASE IF EXISTS rdb2 SYNC")

--- a/tests/integration/test_check_table_name_length/test.py
+++ b/tests/integration/test_check_table_name_length/test.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import random
+import string
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster, QueryRuntimeException
+
+
+LARGE_TABLE_NAME_SIZE = 220
+
+
+cluster = ClickHouseCluster(__file__)
+old_node = cluster.add_instance(
+    "old_node",
+    image="clickhouse/clickhouse-server",
+    tag="24.9.2.42",
+    with_zookeeper=True,
+    with_installed_binary=True,
+)
+new_node = cluster.add_instance(
+    "new_node",
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def generate_name(length):
+    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(length))
+
+
+def test_backward_compatibility(start_cluster):
+    """
+    New node has table name length check, but recoverLostReplica should still work without any issues
+    because we only perform the check for initial create queries and skip it for secondary ones.
+    """
+
+    table_name = generate_name(LARGE_TABLE_NAME_SIZE)
+
+    # create database
+    old_node.query("DROP DATABASE IF EXISTS rdb SYNC")
+    old_node.query("CREATE DATABASE rdb ENGINE = Replicated('/test/rdb', 'shard1', 'replica' || '1')")
+
+    # create table with long name
+    old_node.query(f"DROP TABLE IF EXISTS rdb.{table_name}")
+    old_node.query(f"CREATE TABLE rdb.{table_name} (col String) Engine=MergeTree ORDER BY tuple()")
+
+    # recreate the database on the new replica, so it runs recoverLostReplica
+    new_node.query("DROP DATABASE IF EXISTS rdb SYNC")
+    new_node.query("CREATE DATABASE rdb ENGINE = Replicated('/test/rdb', 'shard1', 'replica' || '2')")
+    new_node.query("SYSTEM SYNC DATABASE REPLICA rdb")
+
+
+def test_check_table_name_length(start_cluster):
+    """
+    Verify that the new node gets error trying to create a table with name that is too long.
+    """
+
+    table_name = generate_name(LARGE_TABLE_NAME_SIZE)
+
+    # create database
+    new_node.query("DROP DATABASE IF EXISTS rdb2 SYNC")
+    new_node.query(
+        "CREATE DATABASE rdb2 ENGINE = Replicated('/test/rdb2', 'shard1', 'replica' || '1');"
+    )
+
+    # try to create table with long name
+    new_node.query(f"DROP TABLE IF EXISTS rdb2.{table_name}")
+    with pytest.raises(QueryRuntimeException, match="ARGUMENT_OUT_OF_BOUND"):
+        new_node.query(f"CREATE TABLE rdb2.{table_name} (col String) Engine=MergeTree ORDER BY tuple()")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Verify the table name's length only for initial create queries. Do not verify this for secondary creates to avoid backward compatibility issues.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
