### PR TITLE
Fix crash in MySQL authentication

### DIFF
--- a/src/Core/MySQL/Authentication.cpp
+++ b/src/Core/MySQL/Authentication.cpp
@@ -197,6 +197,7 @@ void Sha256Password::authenticate(
             throw Exception(ErrorCodes::OPENSSL_ERROR, "Failed to decrypt auth data: {}", getOpenSSLErrors());
 
         plaintext.resize(plaintext_length);
+        password.resize(plaintext_length);
 
         for (size_t i = 0; i < plaintext_length; ++i)
         {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in MySQL authentication in unreleased version

Relates to https://github.com/ClickHouse/ClickHouse/pull/78591.
