### PR TITLE
Make test 03344_clickhouse_extract_from_config_try platform independent

### DIFF
--- a/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh
+++ b/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh
@@ -9,12 +9,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 prefix=$CUR_DIR/"$(basename "${BASH_SOURCE[0]}" .sh)"
 
 $CLICKHOUSE_BINARY extract-from-config --key merge_tree.comment --config $prefix.xml
-$CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_xml --config $prefix.xml |& grep -o 'Not found: merge_tree.anything_xml'
+$CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_xml --config $prefix.xml 2>&1 | grep -o 'Not found: merge_tree.anything_xml'
 $CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_xml --config $prefix.xml --try
 
 $CLICKHOUSE_BINARY extract-from-config --key merge_tree.comment --config $prefix.yaml
-$CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_yaml --config $prefix.yaml |& grep -o 'Not found: merge_tree.anything_yaml'
+$CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_yaml --config $prefix.yaml 2>&1 | grep -o 'Not found: merge_tree.anything_yaml'
 $CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_yaml --config $prefix.yaml --try
 
-$CLICKHOUSE_BINARY extract-from-config --key include_from --config ${prefix}_bad_include_from.xml |& grep -o 'File not found: I hope such path will never exists, since it does not even contain a single slash'
+$CLICKHOUSE_BINARY extract-from-config --key include_from --config ${prefix}_bad_include_from.xml 2>&1 | grep -o 'File not found: I hope such path will never exists, since it does not even contain a single slash'
 $CLICKHOUSE_BINARY extract-from-config --key include_from --config ${prefix}_bad_include_from.xml --try


### PR DESCRIPTION
Running this test on my machine failed due to usage of |& syntax due to older bash version.

```
/Users/samaysharma/Work/ClickHouse/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh: line 12: syntax error near unexpected token `&'
/Users/samaysharma/Work/ClickHouse/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh: line 12: `$CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_xml --config $prefix.xml |& grep -o 'Not found: merge_tree.anything_xml''
```

Switched it to 2>&1 | as that seems to be more widely supported across different shells and versions. Making this change made the test pass for me locally.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
