### PR TITLE
assert that important errors are logged

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -290,6 +290,16 @@ static void tryLogCurrentExceptionImpl(Poco::Logger * logger, const std::string 
     catch (...) // NOLINT(bugprone-empty-catch)
     {
     }
+
+    /// Mark the exception as logged.
+    try
+    {
+        throw;
+    }
+    catch (Exception & e)
+    {
+        e.markAsLogged();
+    }
 }
 
 void tryLogCurrentException(const char * log_name, const std::string & start_of_message, LogsLevel level)

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -283,7 +283,11 @@ Exception::~Exception()
         || error_code == ErrorCodes::CANNOT_WRITE_TO_FILE_DESCRIPTOR
     )
     {
-        chassert(logged);
+        if (!logged)
+        {
+            LOG_FATAL(getLogger("~Exception"), "Important exception was caught and not logged: {}", getExceptionMessage(*this, /* with_stacktrace= */true));
+            std::terminate();
+        }
     }
 #endif
 }

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -27,17 +27,6 @@ using LoggerRawPtr = Poco::Logger *;
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-    extern const int POTENTIALLY_BROKEN_DATA_PART;
-    extern const int REPLICA_ALREADY_EXISTS;
-    extern const int NOT_ENOUGH_SPACE;
-    extern const int CORRUPTED_DATA;
-    extern const int CHECKSUM_DOESNT_MATCH;
-    extern const int CANNOT_WRITE_TO_FILE_DESCRIPTOR;
-}
-
 class AtomicLogger;
 
 /// This flag can be set for testing purposes - to check that no exceptions are thrown.
@@ -73,25 +62,7 @@ public:
         message_format_string_args = msg.format_string_args;
     }
 
-    ~Exception() override
-    {
-#ifdef DEBUG_OR_SANITIZER_BUILD
-        const int error_code = code();
-        if (
-            error_code == ErrorCodes::LOGICAL_ERROR
-            || error_code == ErrorCodes::POTENTIALLY_BROKEN_DATA_PART
-            || error_code == ErrorCodes::REPLICA_ALREADY_EXISTS
-            || error_code == ErrorCodes::NOT_ENOUGH_SPACE
-            || error_code == ErrorCodes::CORRUPTED_DATA
-            || error_code == ErrorCodes::CHECKSUM_DOESNT_MATCH
-            || error_code == ErrorCodes::CANNOT_WRITE_TO_FILE_DESCRIPTOR
-        )
-        {
-            chassert(logged);
-        }
-#endif
-    }
-
+    ~Exception() override;
     Exception(const Exception &) = default;
     Exception & operator=(const Exception &) = default;
     Exception(Exception &&) = default;

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -6,6 +6,7 @@
 #include <Common/StackTrace.h>
 #include <Core/LogsLevel.h>
 
+#include <atomic>
 #include <cerrno>
 #include <exception>
 #include <vector>
@@ -172,14 +173,14 @@ public:
 
     std::vector<std::string> getMessageFormatStringArgs() const { return message_format_string_args; }
 
-    void markAsLogged() { logged = true; }
+    void markAsLogged() { logged->store(true, std::memory_order_relaxed); }
 
 private:
 #ifndef STD_EXCEPTION_HAS_STACK_TRACE
     StackTrace trace;
 #endif
     bool remote = false;
-    bool logged = false;
+    std::shared_ptr<std::atomic<bool>> logged = std::make_shared<std::atomic<bool>>(false);
 
     /// Number of this error among other errors with the same code and the same `remote` flag since the program startup.
     size_t error_index = static_cast<size_t>(-1);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Quite often, we catch exceptions and do not log them. While this is fine for some exceptions, we want to make sure that all the "important" exceptions (i.e., ones we alert on) are present in the logs. So, this change adds an assert to the destructor of `Exception` to make sure it's been logged if the error code is on the "important" list. The assert will only be enabled in debug and sanitizer builds.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
