### PR TITLE
tests: enable debugging via BASH_XTRACEFD only if bash is new enough

### DIFF
--- a/tests/queries/shell_config.sh
+++ b/tests/queries/shell_config.sh
@@ -214,7 +214,8 @@ function run_with_error()
     return 0
 }
 
-if [[ -n $CLICKHOUSE_BASH_TRACING_FILE ]]; then
+# BASH_XTRACEFD is supported only since 4.1
+if [[ -n $CLICKHOUSE_BASH_TRACING_FILE ]] && [[ ${BASH_VERSINFO[0]} -gt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 1) ]]; then
     exec 3>"$CLICKHOUSE_BASH_TRACING_FILE"
     # It will be also nice to have stderr in the tracing output, but:
     # - exec 2>&3


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/79015