### PR TITLE
tests: use local variables in *.lib to avoid overlaps with parent scope

### DIFF
--- a/tests/queries/0_stateless/mergetree_mutations.lib
+++ b/tests/queries/0_stateless/mergetree_mutations.lib
@@ -7,6 +7,7 @@ function wait_for_mutation()
     local database=$3
     database=${database:="${CLICKHOUSE_DATABASE}"}
 
+    local i
     for i in {1..100}
     do
         sleep 0.1
@@ -27,6 +28,7 @@ function wait_for_all_mutations()
     local database=$2
     database=${database:="${CLICKHOUSE_DATABASE}"}
 
+    local i
     for i in {1..200}
     do
         if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT coalesce(minOrNull(is_done), 1) FROM system.mutations WHERE database='$database' AND table like '$table'") -eq 1 ]]; then

--- a/tests/queries/0_stateless/mergetree_mutations.lib
+++ b/tests/queries/0_stateless/mergetree_mutations.lib
@@ -7,19 +7,16 @@ function wait_for_mutation()
     local database=$3
     database=${database:="${CLICKHOUSE_DATABASE}"}
 
-    local i
-    for i in {1..100}
+    for _ in {1..300}
     do
         sleep 0.1
         if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT min(is_done) FROM system.mutations WHERE database='$database' AND table='$table' AND mutation_id='$mutation_id'") -eq 1 ]]; then
-            break
+            return
         fi
-
-        if [[ $i -eq 100 ]]; then
-            echo "Timed out while waiting for mutation to execute!"
-        fi
-
     done
+
+    echo "Timed out while waiting for mutation to execute!"
+    ${CLICKHOUSE_CLIENT} -q "SELECT * FROM system.mutations WHERE database='$database' AND table like '$table' AND mutation_id='$mutation_id' AND is_done=0"
 }
 
 function wait_for_all_mutations()
@@ -28,20 +25,16 @@ function wait_for_all_mutations()
     local database=$2
     database=${database:="${CLICKHOUSE_DATABASE}"}
 
-    local i
-    for i in {1..200}
+    for _ in {1..600}
     do
         if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT coalesce(minOrNull(is_done), 1) FROM system.mutations WHERE database='$database' AND table like '$table'") -eq 1 ]]; then
-            break
+            return
         fi
-
-        if [[ $i -eq 200 ]]; then
-            echo "Timed out while waiting for mutation to execute!"
-            ${CLICKHOUSE_CLIENT} -q "SELECT * FROM system.mutations WHERE database='$database' AND table like '$table' AND is_done=0"
-        fi
-
         sleep 0.3
     done
+
+    echo "Timed out while waiting for mutation to execute!"
+    ${CLICKHOUSE_CLIENT} -q "SELECT * FROM system.mutations WHERE database='$database' AND table like '$table' AND is_done=0"
 }
 
 # vi: ft=bash

--- a/tests/queries/0_stateless/replication.lib
+++ b/tests/queries/0_stateless/replication.lib
@@ -17,7 +17,7 @@ function try_sync_replicas()
             WHERE (database = currentDatabase()) AND (table LIKE '$table_name_prefix%')
         ))")
     local tables_arr
-    readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' AND engine like '%Replicated%'")
+    readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' AND (engine like '%Replicated%' or engine like '%Shared%')")
 
     local t
     for t in "${tables_arr[@]}"

--- a/tests/queries/0_stateless/replication.lib
+++ b/tests/queries/0_stateless/replication.lib
@@ -4,9 +4,10 @@
 
 function try_sync_replicas()
 {
-    table_name_prefix=$1
-    time_left=$2
+    local table_name_prefix=$1
+    local time_left=$2
 
+    local empty_partitions_arr
     readarray -t empty_partitions_arr < <(${CLICKHOUSE_CLIENT} -q \
         "SELECT DISTINCT substr(new_part_name, 1, position(new_part_name, '_') - 1) AS partition_id
         FROM system.replication_queue
@@ -15,8 +16,10 @@ function try_sync_replicas()
             FROM system.parts
             WHERE (database = currentDatabase()) AND (table LIKE '$table_name_prefix%')
         ))")
+    local tables_arr
     readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' AND engine like '%Replicated%'")
 
+    local t
     for t in "${tables_arr[@]}"
     do
         for p in "${empty_partitions_arr[@]}"
@@ -32,7 +35,7 @@ function try_sync_replicas()
         $CLICKHOUSE_CLIENT -q "ALTER TABLE $t MODIFY SETTING max_replicated_merges_in_queue=0"
     done
 
-    i=0
+    local i=0
     for t in "${tables_arr[@]}"
     do
         $CLICKHOUSE_CLIENT --receive_timeout $time_left -q "SYSTEM SYNC REPLICA $t STRICT" || ($CLICKHOUSE_CLIENT -q \
@@ -40,6 +43,8 @@ function try_sync_replicas()
         pids[${i}]=$!
         i=$((i + 1))
     done
+
+    local pid
     for pid in "${pids[@]}"; do
         wait $pid || (echo "Failed to sync some replicas" && exit 1)
     done
@@ -48,21 +53,23 @@ function try_sync_replicas()
 
 function check_replication_consistency()
 {
-    table_name_prefix=$1
-    check_query_part=$2
+    local table_name_prefix=$1
+    local check_query_part=$2
 
+    local tables_arr
     # Try to kill some mutations because sometimes tests run too much (it's not guarenteed to kill all mutations, see below)
     # Try multiple replicas, because queries are not finished yet, and "global" KILL MUTATION may fail due to another query (like DROP TABLE)
     readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%'")
+    local t
     for t in "${tables_arr[@]}"
     do
         ${CLICKHOUSE_CLIENT} -q "KILL MUTATION WHERE database=currentDatabase() AND table='$t'" > /dev/null 2>/dev/null ||:
     done
 
     # Wait for all queries to finish (query may still be running if a thread is killed by timeout)
-    num_tries=0
+    local num_tries=0
     while [[ $($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE current_database=currentDatabase() AND query LIKE '%$table_name_prefix%'") -ne 1 ]]; do
-        sleep 1;
+        sleep 1
         num_tries=$((num_tries+1))
         if [ $num_tries -eq 250 ]; then
             echo "Queries for $table_name_prefix did not finish automatically after 250+ seconds"
@@ -78,7 +85,7 @@ function check_replication_consistency()
 
     # Do not check anything if all replicas are readonly,
     # because is this case all replicas are probably lost (it may happen and it's not a bug)
-    res=$($CLICKHOUSE_CLIENT -q "SELECT count() - sum(is_readonly) FROM system.replicas WHERE database=currentDatabase() AND table LIKE '$table_name_prefix%'")
+    local res=$($CLICKHOUSE_CLIENT -q "SELECT count() - sum(is_readonly) FROM system.replicas WHERE database=currentDatabase() AND table LIKE '$table_name_prefix%'")
     if [ $res -eq 0 ]; then
         # Print dummy lines
         echo "Replication did not hang: synced all replicas of $table_name_prefix"
@@ -96,12 +103,12 @@ function check_replication_consistency()
             break
         fi
     done
-    time_left=$((300 - num_tries))
+    local time_left=$((300 - num_tries))
 
     # Trigger pullLogsToQueue(...) and updateMutations(...) on some replica to make it pull all mutations, so it will be possible to kill them
-    some_table=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' ORDER BY rand() LIMIT 1")
+    local some_table=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' ORDER BY rand() LIMIT 1")
     $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA $some_table PULL" 1>/dev/null 2>/dev/null ||:
-    some_table=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' ORDER BY rand() LIMIT 1")
+    local some_table=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.tables WHERE database=currentDatabase() AND name like '$table_name_prefix%' ORDER BY rand() LIMIT 1")
     $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA $some_table PULL" 1>/dev/null 2>/dev/null ||:
 
     # Forcefully cancel mutations to avoid waiting for them to finish. Kills the remaining mutations

--- a/tests/queries/0_stateless/transactions.lib
+++ b/tests/queries/0_stateless/transactions.lib
@@ -5,26 +5,28 @@
 # Useful to run queries in parallel sessions
 function tx()
 {
-    tx_num=$1
-    query=$2
+    local tx_num=$1
+    local query=$2
 
-    session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
-    query_id="${session}_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
-    url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
-    url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&max_execution_time=90"
+    local session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
+    local query_id="${session}_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+    local url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
+    local url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&max_execution_time=90"
 
     ${CLICKHOUSE_CURL} --max-time 90 -sSk "$url" --data "$query" | sed "s/^/tx$tx_num\t/"
 }
 
 # Waits for the last query in session to finish
-function tx_wait() {
-    tx_num=$1
-
-    session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
+function tx_wait()
+{
+    local tx_num=$1
+    local session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
 
     # try get pid of previous query
-    query_pid=""
-    tmp_file_name="${CLICKHOUSE_TMP}/tmp_tx_${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}"
+    local query_pid=""
+    local tmp_file_name="${CLICKHOUSE_TMP}/tmp_tx_${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}"
+    local query_id_and_pid
+
     query_id_and_pid=$(grep -F "$session" "$tmp_file_name" 2>/dev/null | tail -1) ||:
     read -r query_id query_pid <<< "$query_id_and_pid" ||:
 
@@ -34,7 +36,7 @@ function tx_wait() {
     fi
 
     # there is no pid (or maybe we got wrong one), so wait using system.processes (it's less reliable)
-    count=0
+    local count=0
     while [[ $($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id LIKE '$session%'") -gt 0 ]]; do
         sleep 0.5
         count=$((count+1))
@@ -48,31 +50,31 @@ function tx_wait() {
 # Wait for previous query in session to finish, starts new one asynchronously
 function tx_async()
 {
-    tx_num=$1
-    query=$2
+    local tx_num=$1
+    local query=$2
 
     tx_wait "$tx_num"
 
-    session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
-    query_id="${session}_${RANDOM}"
-    url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
-    url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&max_execution_time=90"
+    local session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
+    local query_id="${session}_${RANDOM}"
+    local url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
+    local url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&max_execution_time=90"
 
     # We cannot be sure that query will actually start execution and appear in system.processes before the next call to tx_wait
     # Also we cannot use global map in bash to store last query_id for each tx_num, so we use tmp file...
-    tmp_file_name="${CLICKHOUSE_TMP}/tmp_tx_${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}"
+    local tmp_file_name="${CLICKHOUSE_TMP}/tmp_tx_${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}"
 
     # run query asynchronously
     ${CLICKHOUSE_CURL} --max-time 90 -sSk "$url" --data "$query" | sed "s/^/tx$tx_num\t/" &
-    query_pid=$!
+    local query_pid=$!
     echo -e "$query_id\t$query_pid" >> "$tmp_file_name"
 }
 
 # Wait for previous query in session to finish, execute the next one synchronously
 function tx_sync()
 {
-    tx_num=$1
-    query=$2
+    local tx_num=$1
+    local query=$2
     tx_wait "$tx_num"
     tx "$tx_num" "$query"
 }

--- a/tests/queries/shell_config.sh
+++ b/tests/queries/shell_config.sh
@@ -160,7 +160,7 @@ function wait_for_queries_to_finish()
 {
     local max_tries="${1:-20}"
     # Wait for all queries to finish (query may still be running if a thread is killed by timeout)
-    num_tries=0
+    local num_tries=0
     while [[ $($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE current_database=currentDatabase() AND query NOT LIKE '%system.processes%'") -ne 0 ]]; do
         sleep 0.5;
         num_tries=$((num_tries+1))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)