### PR TITLE
Make test_check_replicated_does_not_block_shutdown less flaky and faster

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -348,7 +348,11 @@ def rabbitmq_debuginfo(rabbitmq_id, cookie):
 
 async def check_nats_is_available(nats_port, ssl_ctx=None):
     nc = await nats_connect_ssl(
-        nats_port, user="click", password="house", ssl_ctx=ssl_ctx, max_reconnect_attempts=1
+        nats_port,
+        user="click",
+        password="house",
+        ssl_ctx=ssl_ctx,
+        max_reconnect_attempts=1,
     )
     available = nc.is_connected
     await nc.close()
@@ -365,7 +369,7 @@ async def nats_connect_ssl(nats_port, user, password, ssl_ctx=None, **connect_op
         user=user,
         password=password,
         tls=ssl_ctx,
-        **connect_options
+        **connect_options,
     )
     return nc
 
@@ -1414,15 +1418,11 @@ class ClickHouseCluster:
         )
         return self.base_minio_cmd
 
-    def setup_glue_catalog_cmd(
-        self, instance, env_variables, docker_compose_yml_dir
-    ):
+    def setup_glue_catalog_cmd(self, instance, env_variables, docker_compose_yml_dir):
         self.base_cmd.extend(
             [
                 "--file",
-                p.join(
-                    docker_compose_yml_dir, "docker_compose_glue_catalog.yml"
-                ),
+                p.join(docker_compose_yml_dir, "docker_compose_glue_catalog.yml"),
             ]
         )
         self.base_iceberg_catalog_cmd = self.compose_cmd(
@@ -1728,7 +1728,10 @@ class ClickHouseCluster:
             with_rabbitmq=with_rabbitmq,
             with_nats=with_nats,
             with_nginx=with_nginx,
-            with_secrets=with_secrets or with_kerberos_kdc or with_kerberized_kafka or with_kafka_sasl,
+            with_secrets=with_secrets
+            or with_kerberos_kdc
+            or with_kerberized_kafka
+            or with_kafka_sasl,
             with_mongo=with_mongo,
             with_redis=with_redis,
             with_minio=with_minio,
@@ -1873,7 +1876,9 @@ class ClickHouseCluster:
 
         if with_kafka_sasl and not self.with_kafka_sasl:
             cmds.append(
-                self.setup_kafka_sasl_cmd(instance, env_variables, docker_compose_yml_dir)
+                self.setup_kafka_sasl_cmd(
+                    instance, env_variables, docker_compose_yml_dir
+                )
             )
 
         if with_kerberized_kafka and not self.with_kerberized_kafka:
@@ -2434,10 +2439,14 @@ class ClickHouseCluster:
         raise RuntimeError("Cannot wait RabbitMQ container")
 
     def stop_rabbitmq_app(self, timeout=120):
-        run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout)
+        run_rabbitmqctl(
+            self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout
+        )
 
     def start_rabbitmq_app(self, timeout=120):
-        run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, "start_app", timeout)
+        run_rabbitmqctl(
+            self.rabbitmq_docker_id, self.rabbitmq_cookie, "start_app", timeout
+        )
         self.wait_rabbitmq_to_start()
 
     def reset_rabbitmq(self, timeout=120):
@@ -2529,7 +2538,10 @@ class ClickHouseCluster:
 
     def wait_mongo_to_start(self, timeout=30, secure=False):
         connection_str = "mongodb://{user}:{password}@{host}:{port}".format(
-            host="localhost", port=self.mongo_port, user=mongo_user, password=urllib.parse.quote_plus(mongo_pass)
+            host="localhost",
+            port=self.mongo_port,
+            user=mongo_user,
+            password=urllib.parse.quote_plus(mongo_pass),
         )
         if secure:
             connection_str += "/?tls=true&tlsAllowInvalidCertificates=true"
@@ -2577,7 +2589,9 @@ class ClickHouseCluster:
                         )
                         errors = minio_client.remove_objects(bucket, delete_object_list)
                         for error in errors:
-                            logging.error(f"Error occurred when deleting object {error}")
+                            logging.error(
+                                f"Error occurred when deleting object {error}"
+                            )
                         minio_client.remove_bucket(bucket)
                     minio_client.make_bucket(bucket)
                     logging.debug("S3 bucket '%s' created", bucket)
@@ -3283,10 +3297,10 @@ class ClickHouseCluster:
 
     @contextmanager
     def pause_container(self, instance_name):
-        '''Use it as following:
+        """Use it as following:
         with cluster.pause_container(name):
             useful_stuff()
-        '''
+        """
         self._pause_container(instance_name)
         try:
             yield
@@ -3358,6 +3372,12 @@ class ClickHouseCluster:
         for n in zk_nodes:
             logging.info("Stopping zookeeper node: %s", n)
             subprocess_check_call(self.base_zookeeper_cmd + ["stop", n])
+
+    # Faster than waiting for clean stop
+    def kill_zookeeper_nodes(self, zk_nodes):
+        for n in zk_nodes:
+            logging.info("Killing zookeeper node: %s", n)
+            subprocess_check_call(self.base_zookeeper_cmd + ["kill", n])
 
     def start_zookeeper_nodes(self, zk_nodes):
         for n in zk_nodes:
@@ -4601,13 +4621,15 @@ class ClickHouseInstance:
                 delimiter = d
                 break
         else:
-            raise Exception(
-                f"Couldn't find a suitable delimiter"
-            )
+            raise Exception(f"Couldn't find a suitable delimiter")
         replace = shlex.quote(replace)
         replacement = shlex.quote(replacement)
         self.exec_in_container(
-            ["bash", "-c", f"sed -i 's{delimiter}'{replace}'{delimiter}'{replacement}'{delimiter}g' {path_to_config}"]
+            [
+                "bash",
+                "-c",
+                f"sed -i 's{delimiter}'{replace}'{delimiter}'{replacement}'{delimiter}g' {path_to_config}",
+            ]
         )
 
     def create_dir(self):
@@ -4674,7 +4696,9 @@ class ClickHouseInstance:
             write_embedded_config("0_common_max_cpu_load.xml", users_d_dir)
 
         use_old_analyzer = os.environ.get("CLICKHOUSE_USE_OLD_ANALYZER") is not None
-        use_distributed_plan = os.environ.get("CLICKHOUSE_USE_DISTRIBUTED_PLAN") is not None
+        use_distributed_plan = (
+            os.environ.get("CLICKHOUSE_USE_DISTRIBUTED_PLAN") is not None
+        )
 
         # If specific version was used there can be no
         # enable_analyzer setting, so do this only if it was

--- a/tests/integration/test_check_table/test.py
+++ b/tests/integration/test_check_table/test.py
@@ -395,7 +395,7 @@ def test_check_replicated_does_not_block_shutdown(started_cluster, engine):
             query_id,
         )
 
-        cluster.stop_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
+        cluster.kill_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
         err = node1.query_and_get_error(
             f"INSERT INTO {table_name} SELECT number, number FROM numbers(10) SETTINGS insert_keeper_max_retries=0"
         )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make test_check_replicated_does_not_block_shutdown less flaky and faster


In some [cases](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79488&sha=e1bd7caf32224c074ac5946837113965e8cf2896&name_0=PR&name_1=Integration%20tests%20%28asan%2C%20old%20analyzer%2C%206%2F6%29) shutting down keeper services might take a long time (over 1 minute) so the CHECK TABLE query finishes before there is a keeper failure. Let's try killing the nodes instead.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
