### PR TITLE
tests: do not run 02536_system_sync_file_cache in parallel

### DIFF
--- a/tests/queries/0_stateless/02536_system_sync_file_cache.sql
+++ b/tests/queries/0_stateless/02536_system_sync_file_cache.sql
@@ -1,3 +1,3 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-parallel
 -- no-fasttest: Will perform 'sync' syscall (it can take time)
 system sync file cache;


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79545&sha=49d2be1ef444a50ff2cb61cee828c2a4bbb8fe19&name_0=PR&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)