### PR TITLE
Setting enable_url_encoding is now effective across URL redirects

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -77,6 +77,7 @@ private:
 
     const size_t buffer_size;
     const size_t max_redirects;
+    const bool enable_url_encoding;
 
     const bool use_external_buffer;
     const bool http_skip_not_found_url;
@@ -154,6 +155,7 @@ public:
         const RemoteHostFilter * remote_host_filter_,
         size_t buffer_size_,
         size_t max_redirects_,
+        bool enable_url_encoding_,
         OutStreamCallback out_stream_callback_,
         bool use_external_buffer_,
         bool http_skip_not_found_url_,
@@ -208,6 +210,7 @@ class BuilderRWBufferFromHTTP
     const RemoteHostFilter * remote_host_filter = nullptr;
     size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE;
     size_t max_redirects = 0;
+    bool enable_url_encoding = false;
     ReadWriteBufferFromHTTP::OutStreamCallback out_stream_callback = nullptr;
     bool use_external_buffer = false;
     bool http_skip_not_found_url = false;
@@ -235,6 +238,7 @@ public:
     setterMember(withHostFilter, remote_host_filter)
     setterMember(withBufSize, buffer_size)
     setterMember(withRedirects, max_redirects)
+    setterMember(withEnableUrlEncoding, enable_url_encoding)
     setterMember(withOutCallback, out_stream_callback)
     setterMember(withHeaders, http_header_entries)
     setterMember(withExternalBuf, use_external_buffer)
@@ -256,6 +260,7 @@ public:
             remote_host_filter,
             buffer_size,
             max_redirects,
+            enable_url_encoding,
             out_stream_callback,
             use_external_buffer,
             http_skip_not_found_url,

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -81,6 +81,7 @@ namespace Setting
     extern const SettingsUInt64 output_format_compression_zstd_window_log;
     extern const SettingsBool use_cache_for_count_from_files;
     extern const SettingsInt64 zstd_window_log_max;
+    extern const SettingsBool enable_url_encoding;
 }
 
 namespace ErrorCodes
@@ -555,6 +556,7 @@ std::pair<Poco::URI, std::unique_ptr<ReadWriteBufferFromHTTP>> StorageURLSource:
                            .withHostFilter(&context_->getRemoteHostFilter())
                            .withBufSize(settings[Setting::max_read_buffer_size])
                            .withRedirects(settings[Setting::max_http_get_redirects])
+                           .withEnableUrlEncoding(settings[Setting::enable_url_encoding])
                            .withOutCallback(callback)
                            .withSkipNotFound(skip_url_not_found_error)
                            .withHeaders(headers)

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -81,7 +81,6 @@ namespace Setting
     extern const SettingsUInt64 output_format_compression_zstd_window_log;
     extern const SettingsBool use_cache_for_count_from_files;
     extern const SettingsInt64 zstd_window_log_max;
-    extern const SettingsBool enable_url_encoding;
 }
 
 namespace ErrorCodes


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/79548. More background in https://github.com/ClickHouse/ClickHouse/pull/52337
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- If reading from an URL involves multiple redirects, setting `enable_url_encoding` is correctly applied across all redirects in the chain.

