### PR TITLE
Fix using incorrect paths when renaming an Atomic database

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -673,8 +673,8 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
     }
 
     auto new_name_escaped = escapeForFileName(new_name);
-    auto old_database_metadata_path = root_path / "metadata" / (escapeForFileName(getDatabaseName()) + ".sql");
-    auto new_database_metadata_path = root_path / "metadata" / (new_name_escaped + ".sql");
+    auto old_database_metadata_path = fs::path("metadata") / (escapeForFileName(getDatabaseName()) + ".sql");
+    auto new_database_metadata_path = fs::path("metadata") / (new_name_escaped + ".sql");
     db_disk->moveFile(old_database_metadata_path, new_database_metadata_path);
 
     String old_path_to_table_symlinks;

--- a/tests/integration/test_database_disk/configs/database_disk.xml
+++ b/tests/integration/test_database_disk/configs/database_disk.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <database_disk>
+        <disk>custom_db_disk</disk>
+    </database_disk>
+    <storage_configuration>
+        <disks>
+            <custom_db_disk>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disks/default/</path>
+            </custom_db_disk>
+        </disks>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_database_disk/test.py
+++ b/tests/integration/test_database_disk/test.py
@@ -1,0 +1,54 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/database_disk.xml"],
+    with_remote_database_disk=False,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_rename_database_with_database_disk(started_cluster):
+    db_disk_path = node1.query(
+        "SELECT path FROM system.disks WHERE name='custom_db_disk'"
+    ).strip()
+
+    def list_file_in_metadata_dir():
+        return node1.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f'ls "{db_disk_path}/metadata/"',
+            ],
+            privileged=True,
+            user="root",
+        )
+
+    node1.query("DROP DATABASE IF EXISTS test SYNC")
+    node1.query("CREATE DATABASE test ENGINE=Atomic")
+
+    node1.query("RENAME DATABASE test TO test_rename")
+    metadata_files = list_file_in_metadata_dir()
+    assert "test.sql" not in metadata_files
+    assert "test_rename.sql" in metadata_files
+
+    node1.query("RENAME DATABASE test_rename TO test")
+    metadata_files = list_file_in_metadata_dir()
+    assert "test.sql" in metadata_files
+    assert "test_rename.sql" not in metadata_files
+
+    node1.query("DROP DATABASE IF EXISTS test SYNC")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix using incorrect paths when renaming an Atomic database.

Currently, we use a disk to store metadata files for databases. The disk might have its own `path` which is not the same as the default path (`/var/lib/clickhouse`). So we should not add the default path to the DB metadata paths when renaming a DB.

It was introduced in https://github.com/ClickHouse/ClickHouse/pull/71722

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
