### PR TITLE
fix data race in poco::JSON::stringify

### DIFF
--- a/base/poco/JSON/include/Poco/JSON/Array.h
+++ b/base/poco/JSON/include/Poco/JSON/Array.h
@@ -208,7 +208,7 @@ namespace JSON
         //  The reason we have this flag here (rather than as argument to stringify())
         //  is because Array can be returned stringified from a Dynamic::Var:toString(),
         //  so it must know whether to escape unicode or not.
-        bool _escapeUnicode;
+        std::atomic<bool> _escapeUnicode;
     };
 
 

--- a/base/poco/JSON/include/Poco/JSON/Object.h
+++ b/base/poco/JSON/include/Poco/JSON/Object.h
@@ -18,6 +18,7 @@
 #define JSON_Object_INCLUDED
 
 
+#include <atomic>
 #include <deque>
 #include <iostream>
 #include <map>
@@ -292,7 +293,7 @@ namespace JSON
         //  The reason for this flag (rather than as argument to stringify()) is
         //  because Object can be returned stringified from Dynamic::Var::toString(),
         //  so it must know whether to escape unicode or not.
-        bool _escapeUnicode;
+        std::atomic<bool> _escapeUnicode;
         mutable StructPtr _pStruct;
         mutable bool _modified;
     };

--- a/base/poco/JSON/src/Object.cpp
+++ b/base/poco/JSON/src/Object.cpp
@@ -33,7 +33,7 @@ Object::Object(int options):
 
 Object::Object(const Object& other) : _values(other._values),
 	_preserveInsOrder(other._preserveInsOrder),
-	_escapeUnicode(other._escapeUnicode),
+	_escapeUnicode(other._escapeUnicode.load()),
 	_pStruct(!other._modified ? other._pStruct : 0),
 	_modified(other._modified)
 {
@@ -48,7 +48,7 @@ Object::Object(Object&& other) :
 	_values(std::move(other._values)),
 	_keys(std::move(other._keys)),
 	_preserveInsOrder(other._preserveInsOrder),
-	_escapeUnicode(other._escapeUnicode),
+	_escapeUnicode(other._escapeUnicode.load()),
 	_pStruct(!other._modified ? other._pStruct : 0),
 	_modified(other._modified)
 {
@@ -63,7 +63,7 @@ Object &Object::operator= (Object &&other)
 		_values = other._values;
 		_preserveInsOrder = other._preserveInsOrder;
 		syncKeys(other._keys);
-		_escapeUnicode = other._escapeUnicode;
+		_escapeUnicode = other._escapeUnicode.load();
 		_pStruct = !other._modified ? other._pStruct : 0;
 		_modified = other._modified;
 		other.clear();
@@ -87,7 +87,7 @@ Object &Object::operator= (const Object &other)
 		_values = other._values;
 		_keys = other._keys;
 		_preserveInsOrder = other._preserveInsOrder;
-		_escapeUnicode = other._escapeUnicode;
+		_escapeUnicode = other._escapeUnicode.load();
 		_pStruct = !other._modified ? other._pStruct : 0;
 		_modified = other._modified;
 	}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

In Iceberg metadata cache, we will share the Poco::JSON::ObjectPtr and assume every operation about this object is thread safe. But not true for `poco::JSON::stringify` : https://pastila.nl/?00008354/808410138781862abfa64fc97f4ad40f#YCOul49EF2DASagKg3STeQ==

It will modify a member called `_escapeUnicode` to mark if to escape unicode.
The fix will make this member atomic.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
