### PR TITLE
cctools: do not rely on gdb location for debug symbols

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -5,7 +5,7 @@ ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
 
 # If the cctools is updated, then first build it in the CI, then update here in a different commit
-COPY --from=clickhouse/cctools:a551cc7348883028fb53 /cctools /cctools
+COPY --from=clickhouse/cctools:4670e95dde3de689f103 /cctools /cctools
 
 # A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
 RUN apt-get update \

--- a/ci/docker/fasttest/Dockerfile
+++ b/ci/docker/fasttest/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:4670e95dde3de689f103 /opt/gdb /opt/gdb
 # Give suid to gdb to grant it attach permissions
 RUN chmod u+s /opt/gdb/bin/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"

--- a/docker/packager/cctools/Dockerfile
+++ b/docker/packager/cctools/Dockerfile
@@ -53,9 +53,9 @@ RUN apt-get update \
 RUN wget https://sourceware.org/pub/gdb/releases/gdb-$GDB_VERSION.tar.gz \
     && tar -xvf gdb-$GDB_VERSION.tar.gz \
     && cd gdb-$GDB_VERSION \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/opt/gdb --with-separate-debug-dir=/usr/lib/debug \
     && make -j $(nproc) \
-    && make install DESTDIR=/opt/gdb \
+    && make install \
     && rm -fr gdb-$GDB_VERSION gdb-$GDB_VERSION.tar.gz
 
 # just in case

--- a/docker/test/integration/base/Dockerfile
+++ b/docker/test/integration/base/Dockerfile
@@ -73,5 +73,5 @@ maxClientCnxns=80' > /opt/zookeeper/conf/zoo.cfg && \
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:4670e95dde3de689f103 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -86,7 +86,7 @@ COPY modprobe.sh /usr/local/bin/modprobe
 COPY dockerd-entrypoint.sh /usr/local/bin/
 COPY misc/ /misc/
 
-COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:4670e95dde3de689f103 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"
 
 # Same options as in test/base/Dockerfile

--- a/docker/test/performance-comparison/Dockerfile
+++ b/docker/test/performance-comparison/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir /fg && cd /fg \
 
 COPY run.sh /
 
-COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:4670e95dde3de689f103 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"
 
 CMD ["bash", "/run.sh"]

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -80,5 +80,5 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-COPY --from=clickhouse/cctools:a551cc7348883028fb53 /opt/gdb /opt/gdb
+COPY --from=clickhouse/cctools:4670e95dde3de689f103 /opt/gdb /opt/gdb
 ENV PATH="/opt/gdb/bin:${PATH}"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/79372
Refs: https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html