### PR TITLE
Fix building gtest_coordination_storage under clang 20

### DIFF
--- a/src/Coordination/tests/gtest_coordination_storage.cpp
+++ b/src/Coordination/tests/gtest_coordination_storage.cpp
@@ -879,11 +879,11 @@ TYPED_TEST(CoordinationTest, TestUncommittedStateBasicCrud)
     storage.preprocessRequest(create_request, 0, 0, 1);
     storage.preprocessRequest(create_request, 0, 0, 2);
 
-    ASSERT_FALSE(get_committed_data());
+    ASSERT_EQ(get_committed_data(), std::nullopt);
 
     const auto after_create_get = preprocess_get(3);
 
-    ASSERT_FALSE(get_committed_data());
+    ASSERT_EQ(get_committed_data(), std::nullopt);
 
     const auto set_request = std::make_shared<ZooKeeperSetRequest>();
     set_request->path = path;
@@ -892,7 +892,7 @@ TYPED_TEST(CoordinationTest, TestUncommittedStateBasicCrud)
 
     const auto after_set_get = preprocess_get(5);
 
-    ASSERT_FALSE(get_committed_data());
+    ASSERT_EQ(get_committed_data(), std::nullopt);
 
     const auto remove_request = std::make_shared<ZooKeeperRemoveRequest>();
     remove_request->path = path;
@@ -901,7 +901,7 @@ TYPED_TEST(CoordinationTest, TestUncommittedStateBasicCrud)
 
     const auto after_remove_get = preprocess_get(8);
 
-    ASSERT_FALSE(get_committed_data());
+    ASSERT_EQ(get_committed_data(), std::nullopt);
 
     {
         const auto responses = storage.processRequest(create_request, 0, 1);
@@ -957,7 +957,7 @@ TYPED_TEST(CoordinationTest, TestUncommittedStateBasicCrud)
         ASSERT_EQ(get_response.error, Error::ZNONODE);
     }
 
-    ASSERT_FALSE(get_committed_data());
+    ASSERT_EQ(get_committed_data(), std::nullopt);
 }
 
 #endif


### PR DESCRIPTION
There is some ICE in clang20 - https://pastila.nl/?000c4303/40789a5e0753d3a7271ed99e4cade125#uNDOMr4Lrc/cjxEym4Vrag==

I wonder why this does not pops up in CI - https://github.com/ClickHouse/ClickHouse/pull/77352, I've seen this on linux/macos.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)