### PR TITLE
Forbid incorrect use-case for `CaseWithExpression`

### DIFF
--- a/src/Functions/caseWithExpression.cpp
+++ b/src/Functions/caseWithExpression.cpp
@@ -11,6 +11,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int TOO_FEW_ARGUMENTS_FOR_FUNCTION;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -37,6 +38,11 @@ public:
     {
         if (args.empty())
             throw Exception(ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION, "Function {} expects at least 1 arguments", getName());
+
+        /// We expect an even number of arguments, with the first argument being the expression,
+        /// and the last argument being the ELSE branch, with the rest being pairs of WHEN and THEN branches.
+        if (args.size() < 4 || args.size() % 2 != 0)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {} expects an even number of arguments: (expr, when1, then1, ..., else)", getName());
 
         /// See the comments in executeImpl() to understand why we actually have to
         /// get the return type of a transform function.

--- a/tests/queries/0_stateless/03390_non_constant_case.sql
+++ b/tests/queries/0_stateless/03390_non_constant_case.sql
@@ -35,7 +35,7 @@ END = 1;
 SELECT DISTINCT caseWithExpression(1.1, toNullable(0.1), 'a', 1.1, 'b', materialize(2.1), toFixedString('c', 1), 'default' ) AS f;
 
 SELECT
-    caseWithExpression(NULL, materialize(NULL), NULL) AS f1,
+    caseWithExpression(NULL, materialize(NULL), NULL, NULL) AS f1,
     if(NULL, toDateTimeOrZero(NULL), NULL) AS f2
 FROM numbers(1);
 

--- a/tests/queries/0_stateless/03444_case_with_expression_exception.sql
+++ b/tests/queries/0_stateless/03444_case_with_expression_exception.sql
@@ -1,0 +1,1 @@
+SELECT caseWithExpression('C', 'A', true, 'B', false); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/70917
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
