### PR TITLE
tests: fix 03396_s3_do_not_retry_dns_errors flakiness

### DIFF
--- a/tests/queries/0_stateless/03396_s3_do_not_retry_dns_errors.sh
+++ b/tests/queries/0_stateless/03396_s3_do_not_retry_dns_errors.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
+# Tag no-fasttest - requires S3
+# Tag no-parallel - in case of parallel test DROP TABLE execution time is unpredictable (due to other tables can be queued for removal)
 
 # Test from https://github.com/ClickHouse/ClickHouse/issues/68663
 


### PR DESCRIPTION
CI found [1] that DROP TABLE takes more then 20 seconds, likely this is due to other tables in the queue for removal, since other tests can run in parallel, let's forbid this.

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79575&sha=23d16cead0485fcdf33c19b234e6d6e6d7235c1b&name_0=PR&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
