### PR TITLE
CI: Remove deprecated CI job filter for docs only update

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -19,11 +19,10 @@ def only_docs(changed_files):
     return True
 
 
-ONLY_DOCS_JOBS = [
+DO_NOT_TEST_JOBS = [
     JobNames.STYLE_CHECK,
     JobNames.DOCKER_BUILDS_ARM,
     JobNames.DOCKER_BUILDS_AMD,
-    JobNames.Docs,
 ]
 
 PRELIMINARY_JOBS = [
@@ -56,10 +55,7 @@ def should_skip_job(job_name):
         print("WARNING: no changed files found for PR - do not filter jobs")
         return False, ""
 
-    if only_docs(changed_files) and job_name not in ONLY_DOCS_JOBS:
-        return True, "Docs only update"
-
-    if Labels.DO_NOT_TEST in _info_cache.pr_labels and job_name not in ONLY_DOCS_JOBS:
+    if Labels.DO_NOT_TEST in _info_cache.pr_labels and job_name not in DO_NOT_TEST_JOBS:
         return True, f"Skipped, labeled with '{Labels.DO_NOT_TEST}'"
 
     if Labels.NO_FAST_TESTS in _info_cache.pr_labels and job_name in PRELIMINARY_JOBS:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI now automatically filters jobs based on changed files and job digests, so a special job filter for PRs with doc changes is no longer required.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
