### PR TITLE
Add conversion_time mode to windowFunnel

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/parametric-functions.md
+++ b/docs/en/sql-reference/aggregate-functions/parametric-functions.md
@@ -326,13 +326,14 @@ windowFunnel(window, [mode, [mode, ... ]])(timestamp, cond1, cond2, ..., condN)
   - `'strict_increase'` — Apply conditions only to events with strictly increasing timestamps.
   - `'strict_once'` — Count each event only once in the chain even if it meets the condition several times.
   - `'allow_reentry'` — Ignore events that violate the strict order. E.g. in the case of A->A->B->C, it finds A->B->C by ignoring the redundant A and the max event level is 3.
+  - `'conversion_time'` — Return a named tuple containing the maximum level reached and the conversion times between consecutive steps. See the **Returned value** section for details.
 
 **Returned value**
 
-The maximum number of consecutive triggered conditions from the chain within the sliding time window.
-All the chains in the selection are analyzed.
+- If the `'conversion_time'` mode is **not** specified: The maximum number of consecutive triggered conditions from the chain within the sliding time window. Type: `UInt8`.
+- If the `'conversion_time'` mode **is** specified: A named [Tuple](../../sql-reference/data-types/tuple.md) containing the maximum level reached and the conversion times (in the same units as the `timestamp` column difference) between consecutive steps that were actually completed as part of the funnel path that reached the maximum level. The tuple structure is `Tuple(max_level UInt8, time_1_to_2 UInt64, time_2_to_3 UInt64, ..., time_N-1_to_N UInt64)`. If a step transition was not completed, the corresponding time value will be `0`.
 
-Type: `Integer`.
+All the chains in the selection are analyzed.
 
 **Example**
 
@@ -422,7 +423,85 @@ GROUP BY level
 ORDER BY level ASC;
 ```
 
-## retention {#retention}
+**Example (`conversion_time`)**
+
+Determine the maximum funnel step reached and the time taken between steps for users booking a trip.
+
+Set the following chain of events:
+
+1.  User searches for flights (`eventName = 'search_flights'`).
+2.  User selects a flight (`eventName = 'select_flight'`).
+3.  User completes booking (`eventName = 'book_flight'`).
+
+Input table (`trip_events`):
+
+```text
+┌─user_id─┬───────────event_time─┬─eventName───────┐
+│       1 │ 2023-10-27 10:00:00  │ search_flights  │
+│       1 │ 2023-10-27 10:00:10  │ select_flight   │
+│       1 │ 2023-10-27 10:00:35  │ book_flight     │
+│       2 │ 2023-10-27 11:00:00  │ search_flights  │
+│       2 │ 2023-10-27 11:00:15  │ select_flight   │
+│       2 │ 2023-10-27 11:01:00  │ book_flight     │ -- Outside 30s window from step 1
+│       3 │ 2023-10-27 12:00:00  │ search_flights  │
+└─────────┴──────────────────────┴─────────────────┘
+```
+
+Query using `conversion_time` with a 30-second window:
+
+```sql
+SELECT
+    user_id,
+    windowFunnel(30, 'conversion_time')(
+        event_time,
+        eventName = 'search_flights',
+        eventName = 'select_flight',
+        eventName = 'book_flight'
+    ) AS funnel_result
+FROM trip_events
+GROUP BY user_id
+ORDER BY user_id;
+```
+
+Result:
+
+```text
+┌─user_id─┬─funnel_result─┐
+│       1 │ (3,10,25)     │
+│       2 │ (2,15,0)      │ -- Step 3 was outside the window
+│       3 │ (1,0,0)       │ -- Only reached step 1
+└─────────┴───────────────┘
+```
+
+We can also query the named elements directly:
+
+```sql
+SELECT
+    user_id,
+    windowFunnel(30, 'conversion_time')(
+        event_time,
+        eventName = 'search_flights',
+        eventName = 'select_flight',
+        eventName = 'book_flight'
+    ) AS funnel_result,
+    funnel_result.max_level,
+    funnel_result.time_1_to_2
+FROM trip_events
+GROUP BY user_id
+ORDER BY user_id;
+```
+
+Result:
+
+```text
+┌─user_id─┬─funnel_result─┬─max_level─┬─time_1_to_2─┐
+│       1 │ (3,10,25)     │         3 │          10 │
+│       2 │ (2,15,0)      │         2 │          15 │
+│       3 │ (1,0,0)       │         1 │           0 │
+└─────────┴───────────────┴───────────┴─────────────┘
+```
+
+## retention
 
 The function takes as arguments a set of conditions from 1 to 32 arguments of type `UInt8` that indicate whether a certain condition was met for the event.
 Any condition can be specified as an argument (as in [WHERE](/sql-reference/statements/select/where)).

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -303,23 +303,23 @@ private:
     struct FunnelResult
     {
         UInt8 max_level = 0;
-        std::vector<UInt64> conversion_times;
+        VectorWithMemoryTracking<UInt64> conversion_times;
     };
 
     /// The algorithm works in O(n) time, but the overall function works in O(n * log(n)) due to sorting.
     FunnelResult getEventLevelNonStrictOnce(const AggregateFunctionWindowFunnelData<T>::TimestampEvents & events_list) const
     {
         /// candidate_events_timestamp stores {first_event_ts, last_event_ts} for the latest candidate sequence reaching level i+1.
-        std::vector<std::optional<std::pair<T, T>>> candidate_events_timestamp(events_size);
+        VectorWithMemoryTracking<std::optional<std::pair<T, T>>> candidate_events_timestamp(events_size);
 
         /// Stores the specific timestamps for each step of the sequence that achieved the current overall_max_level.
-        std::vector<std::optional<T>> winning_sequence_timestamps(events_size);
+        VectorWithMemoryTracking<std::optional<T>> winning_sequence_timestamps(events_size);
         UInt8 overall_max_level = 0;
 
         // Helper lambda calculates based on stored winning_sequence_timestamps for the best sequence found
-        auto calculate_conversion_times = [&](UInt8 current_max_level) -> std::vector<UInt64>
+        auto calculate_conversion_times = [&](UInt8 current_max_level) -> VectorWithMemoryTracking<UInt64>
         {
-            std::vector<UInt64> times;
+            VectorWithMemoryTracking<UInt64> times;
             if (need_conversion_time && current_max_level > 1)
             {
                 times.resize(events_size - 1, 0);
@@ -502,9 +502,9 @@ private:
         VectorWithMemoryTracking<ListWithMemoryTracking<EventMatchTimeWindow>> event_sequences(events_size);
 
         // Helper lambda to calculate conversion times from a winning sequence
-        auto calculate_conversion_times = [&](const EventMatchTimeWindow & winning_seq, UInt8 current_max_level) -> std::vector<UInt64>
+        auto calculate_conversion_times = [&](const EventMatchTimeWindow & winning_seq, UInt8 current_max_level) -> VectorWithMemoryTracking<UInt64>
         {
-            std::vector<UInt64> times;
+            VectorWithMemoryTracking<UInt64> times;
             if (need_conversion_time && current_max_level > 1)
             {
                 times.resize(events_size - 1, 0); // Initialize all times to 0

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -306,16 +306,17 @@ private:
         std::vector<T> conversion_times;
     };
 
-    /// Loop through the entire events_list, update the event timestamp value
-    /// The level path must be 1---2---3---...---check_events_size, find the max event level that satisfied the path in the sliding window.
-    /// If found, returns the max event level, else return 0.
     /// The algorithm works in O(n) time, but the overall function works in O(n * log(n)) due to sorting.
     FunnelResult getEventLevelNonStrictOnce(const AggregateFunctionWindowFunnelData<T>::TimestampEvents & events_list) const
     {
-        /// events_timestamp stores the timestamp of the first and previous i-th level event happen within time window
-        VectorWithMemoryTracking<std::optional<std::pair<UInt64, UInt64>>> events_timestamp(events_size);
+        /// candidate_events_timestamp stores {first_event_ts, last_event_ts} for the latest candidate sequence reaching level i+1.
+        std::vector<std::optional<std::pair<T, T>>> candidate_events_timestamp(events_size);
 
-        // Helper lambda to calculate conversion times
+        /// Stores the specific timestamps for each step of the sequence that achieved the current overall_max_level.
+        std::vector<std::optional<T>> winning_sequence_timestamps(events_size);
+        UInt8 overall_max_level = 0;
+
+        // Helper lambda calculates based on stored winning_sequence_timestamps for the best sequence found
         auto calculate_conversion_times = [&](UInt8 current_max_level) -> std::vector<T>
         {
             std::vector<T> times;
@@ -324,75 +325,154 @@ private:
                 times.resize(events_size - 1, 0);
                 for (size_t i = 0; i < current_max_level - 1; ++i)
                 {
-                    if (events_timestamp[i].has_value() && events_timestamp[i + 1].has_value())
+                    // Ensure both current and next step timestamps exist in the stored best sequence
+                    if (winning_sequence_timestamps[i].has_value() && winning_sequence_timestamps[i+1].has_value())
                     {
-                        times[i] = events_timestamp[i + 1]->second - events_timestamp[i]->second;
+                         // Calculate difference from the consistent sequence timestamps
+                         times[i] = *winning_sequence_timestamps[i+1] - *winning_sequence_timestamps[i];
                     }
                 }
             }
+            else if (conversion_time) // Ensure vector has correct size even if max_level <= 1
+            {
+                // Resize to events_size - 1, initialized to 0
+                times.resize(events_size - 1, 0);
+            }
+            // If not conversion_time, times remains empty, which is fine.
             return times;
         };
 
-        bool first_event = false;
-        for (size_t i = 0; i < events_list.size(); ++i)
+        bool first_event_occurred = false; // Track if any event 1 has occurred in strict_order mode
+
+        for (const auto & event_pair : events_list)
         {
-            const T & timestamp = events_list[i].first;
-            const auto & event_idx = events_list[i].second - 1;
-            if (strict_order && event_idx == -1)
+            const T & timestamp = event_pair.first;
+            const auto & event_type = event_pair.second; // This is 1-based event type
+            const UInt8 event_idx = event_type - 1; // 0-based index, max value is events_size-1 (<= 31)
+            const UInt8 current_event_level = event_idx + 1;
+
+            bool extended_winner = false;
+            bool promoted_candidate = false;
+
+            if (strict_order && event_type == 0)
             {
-                if (first_event)
-                    break;
-                continue;
+                if (first_event_occurred)
+                    break; // Stop processing sequence if non-matching event occurs after first event
+                continue; // Ignore non-matching events before the first event
             }
+
+            // If strict_deduplication, and this event's level has already been achieved by the winning sequence,
+            // stop processing further events for this funnel.
+            if (strict_deduplication && event_idx > 0 && winning_sequence_timestamps[event_idx].has_value())
+            {
+                break;
+            }
+
+            // --- A. Try to extend the current winning sequence ---
             if (event_idx == 0)
             {
-                events_timestamp[0] = std::make_pair(static_cast<UInt64>(timestamp), static_cast<UInt64>(timestamp));
-                first_event = true;
-            }
-            else if (strict_deduplication && events_timestamp[event_idx].has_value())
-            {
-                /// A duplicate event was found — stop processing. See #37177.
-                break;
-            }
-            else if (strict_order && first_event && !events_timestamp[event_idx - 1].has_value())
-            {
-                // If allow_reentry is set, we ignore "future steps" that appear too early.
-                if (allow_reentry)
-                    continue;
-                // Intervention detected. Stop processing this path according to strict_order.
-                break;
-            }
-            else if (events_timestamp[event_idx - 1].has_value())
-            {
-                auto first_timestamp = events_timestamp[event_idx - 1]->first;
-                bool time_matched = timestamp <= first_timestamp + window;
-                if (strict_increase)
-                    time_matched = time_matched && events_timestamp[event_idx - 1]->second < timestamp;
-                if (time_matched)
+                first_event_occurred = true; // Mark that the first event has happened (for strict_order)
+
+                if (overall_max_level < 1) // First event establishes level 1
                 {
-                    events_timestamp[event_idx] = std::make_pair(first_timestamp, static_cast<UInt64>(timestamp));
-                    if (event_idx + 1 == events_size)
+                    overall_max_level = 1;
+                    winning_sequence_timestamps.assign(events_size, std::nullopt);
+                    winning_sequence_timestamps[0] = timestamp;
+                    extended_winner = true;
+                }
+            }
+            else if (overall_max_level >= event_idx && winning_sequence_timestamps[event_idx - 1].has_value())
+            {
+                // Check if previous step exists in the current winning sequence
+                const T first_winning_ts = winning_sequence_timestamps[0].value();
+                const T prev_winning_ts = winning_sequence_timestamps[event_idx - 1].value();
+
+                bool time_check = timestamp <= first_winning_ts + window;
+                bool strict_check = (!strict_increase || timestamp > prev_winning_ts);
+
+                if (time_check && strict_check)
+                {
+                    if (current_event_level > overall_max_level)
                     {
-                        auto times = calculate_conversion_times(events_size);
-                        return FunnelResult{events_size, std::move(times)};
+                        // New max level achieved by extending the winner
+                        overall_max_level = current_event_level;
+                        winning_sequence_timestamps[event_idx] = timestamp;
+                        extended_winner = true;
                     }
                 }
             }
-        }
 
-        UInt8 max_level = 0;
-        for (size_t event = events_timestamp.size(); event > 0; --event)
-        {
-            if (events_timestamp[event - 1].has_value())
+            // --- B. Update candidate paths ---
+            bool candidate_can_progress = false;
+            T first_ts_for_this_candidate = 0;
+
+            if (event_idx == 0)
             {
-                max_level = event;
+                candidate_can_progress = true;
+                first_ts_for_this_candidate = timestamp;
+            }
+            else if (candidate_events_timestamp[event_idx - 1].has_value())
+            {
+                const T first_candidate_ts = candidate_events_timestamp[event_idx - 1]->first;
+                const T prev_candidate_ts = candidate_events_timestamp[event_idx - 1]->second;
+
+                bool time_check = timestamp <= first_candidate_ts + window;
+                bool strict_check = (!strict_increase || timestamp > prev_candidate_ts);
+
+                if (time_check && strict_check)
+                {
+                    candidate_can_progress = true;
+                    first_ts_for_this_candidate = first_candidate_ts;
+                }
+            }
+
+            if (candidate_can_progress)
+            {
+                // Update the candidate path for this level
+                candidate_events_timestamp[event_idx] = {first_ts_for_this_candidate, timestamp};
+            }
+
+            // --- C. Check if a candidate overtook the winner ---
+            if (candidate_can_progress && current_event_level > overall_max_level)
+            {
+                // Candidate achieved a new max level, higher than the winner
+                overall_max_level = current_event_level;
+
+                // Rebuild winning_sequence_timestamps from the promoted candidate path
+                winning_sequence_timestamps.assign(events_size, std::nullopt);
+                for (UInt8 k = 0; k <= event_idx; ++k)
+                {
+                    if (candidate_events_timestamp[k].has_value())
+                        winning_sequence_timestamps[k] = candidate_events_timestamp[k]->second; // Use the timestamp of the event completing step k+1
+                }
+                promoted_candidate = true;
+            }
+
+            if (strict_order && event_idx > 0 && first_event_occurred && !candidate_events_timestamp[event_idx - 1].has_value())
+            {
+                // If allow_reentry is set, ignore events that violate strict order.
+                if (allow_reentry)
+                    continue;
+                // If an event arrived when its prerequisite wasn't met in the candidate path *after* the first event occurred.
                 break;
+            }
+
+            // --- D. Early exit if max level reached ---
+            // Need to check if the level was *just* reached in this iteration
+            if (overall_max_level == events_size && (extended_winner || promoted_candidate))
+            {
+                FunnelResult result;
+                result.max_level = overall_max_level;
+                result.conversion_times = calculate_conversion_times(overall_max_level);
+                return result;
             }
         }
 
+        // Return the highest level found and its corresponding conversion times.
         FunnelResult result;
-        result.max_level = max_level;
-        result.conversion_times = calculate_conversion_times(max_level);
+        result.max_level = overall_max_level; // Use the max level found during the iteration
+        // Calculate conversion times based on the stored best sequence timestamps
+        result.conversion_times = calculate_conversion_times(overall_max_level);
 
         return result;
     }

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -298,7 +298,7 @@ private:
     bool allow_reentry;
 
     /// When enabled, returns conversion times between funnel steps
-    bool conversion_time;
+    bool need_conversion_time;
 
     struct FunnelResult
     {
@@ -320,7 +320,7 @@ private:
         auto calculate_conversion_times = [&](UInt8 current_max_level) -> std::vector<T>
         {
             std::vector<T> times;
-            if (conversion_time && current_max_level > 1)
+            if (need_conversion_time && current_max_level > 1)
             {
                 times.resize(events_size - 1, 0);
                 for (size_t i = 0; i < current_max_level - 1; ++i)
@@ -333,7 +333,7 @@ private:
                     }
                 }
             }
-            else if (conversion_time) // Ensure vector has correct size even if max_level <= 1
+            else if (need_conversion_time) // Ensure vector has correct size even if max_level <= 1
             {
                 // Resize to events_size - 1, initialized to 0
                 times.resize(events_size - 1, 0);
@@ -348,18 +348,20 @@ private:
         {
             const T & timestamp = event_pair.first;
             const auto & event_type = event_pair.second; // This is 1-based event type
-            const UInt8 event_idx = event_type - 1; // 0-based index, max value is events_size-1 (<= 31)
-            const UInt8 current_event_level = event_idx + 1;
 
-            bool extended_winner = false;
-            bool promoted_candidate = false;
-
+            // Handle for non-matching events in strict_order mode
             if (strict_order && event_type == 0)
             {
                 if (first_event_occurred)
                     break; // Stop processing sequence if non-matching event occurs after first event
                 continue; // Ignore non-matching events before the first event
             }
+
+            const UInt8 event_idx = static_cast<UInt8>(event_type - 1); // 0-based index, max value is events_size-1 (<= 31)
+            const UInt8 current_event_level = static_cast<UInt8>(event_idx + 1);
+
+            bool extended_winner = false;
+            bool promoted_candidate = false;
 
             // If strict_deduplication, and this event's level has already been achieved by the winning sequence,
             // stop processing further events for this funnel.
@@ -503,7 +505,7 @@ private:
         auto calculate_conversion_times = [&](const EventMatchTimeWindow & winning_seq, UInt8 current_max_level) -> std::vector<T>
         {
             std::vector<T> times;
-            if (conversion_time && current_max_level > 1)
+            if (need_conversion_time && current_max_level > 1)
             {
                 times.resize(events_size - 1, 0); // Initialize all times to 0
                 for (size_t i = 0; i < current_max_level - 1; ++i)
@@ -615,8 +617,8 @@ private:
         FunnelResult result;
         result.max_level = max_level;
 
-        // If conversion_time is enabled and we found a successful funnel path
-        if (conversion_time && max_level > 1)
+        // If conversion time is enabled and we found a successful funnel path
+        if (need_conversion_time && max_level > 1)
         {
             // Get the first valid sequence that reached the max_level
             if (!event_sequences[max_level - 1].empty())
@@ -628,7 +630,7 @@ private:
             if (result.conversion_times.empty())
                  result.conversion_times.resize(events_size - 1, 0);
         }
-        else if (conversion_time) // Ensure vector has correct size even if max_level <= 1
+        else if (need_conversion_time) // Ensure vector has correct size even if max_level <= 1
         {
              result.conversion_times.resize(events_size - 1, 0);
         }
@@ -669,7 +671,7 @@ public:
         strict_order = false;
         strict_increase = false;
         allow_reentry = false;
-        conversion_time = false;
+        need_conversion_time = false;
 
         for (size_t i = 1; i < params.size(); ++i)
         {
@@ -686,7 +688,7 @@ public:
                 /// Checked in factory
                 chassert(Data::strict_once_enabled);
             else if (option == "conversion_time")
-                conversion_time = true;
+                need_conversion_time = true;
             else if (option == "strict")
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "strict is replaced with strict_deduplication in Aggregate function {}", getName());
             else
@@ -770,7 +772,7 @@ public:
     {
         auto result = getEventLevel(this->data(place));
 
-        if (!conversion_time)
+        if (!need_conversion_time)
         {
             // just insert the max level
             assert_cast<ColumnUInt8 &>(to).getData().push_back(result.max_level);

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -16,8 +16,6 @@
 
 #include <list>
 
-#include <list>
-
 namespace DB
 {
 struct Settings;

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -303,7 +303,7 @@ private:
     struct FunnelResult
     {
         UInt8 max_level = 0;
-        std::vector<T> conversion_times;
+        std::vector<UInt64> conversion_times;
     };
 
     /// The algorithm works in O(n) time, but the overall function works in O(n * log(n)) due to sorting.
@@ -317,9 +317,9 @@ private:
         UInt8 overall_max_level = 0;
 
         // Helper lambda calculates based on stored winning_sequence_timestamps for the best sequence found
-        auto calculate_conversion_times = [&](UInt8 current_max_level) -> std::vector<T>
+        auto calculate_conversion_times = [&](UInt8 current_max_level) -> std::vector<UInt64>
         {
-            std::vector<T> times;
+            std::vector<UInt64> times;
             if (need_conversion_time && current_max_level > 1)
             {
                 times.resize(events_size - 1, 0);
@@ -329,7 +329,7 @@ private:
                     if (winning_sequence_timestamps[i].has_value() && winning_sequence_timestamps[i+1].has_value())
                     {
                          // Calculate difference from the consistent sequence timestamps
-                         times[i] = *winning_sequence_timestamps[i+1] - *winning_sequence_timestamps[i];
+                         times[i] = static_cast<UInt64>(*winning_sequence_timestamps[i+1]) - static_cast<UInt64>(*winning_sequence_timestamps[i]);
                     }
                 }
             }
@@ -389,8 +389,8 @@ private:
                 const T first_winning_ts = winning_sequence_timestamps[0].value();
                 const T prev_winning_ts = winning_sequence_timestamps[event_idx - 1].value();
 
-                bool time_check = timestamp <= first_winning_ts + window;
-                bool strict_check = (!strict_increase || timestamp > prev_winning_ts);
+                bool time_check = static_cast<UInt64>(timestamp) <= static_cast<UInt64>(first_winning_ts) + window;
+                bool strict_check = (!strict_increase || static_cast<UInt64>(timestamp) > static_cast<UInt64>(prev_winning_ts));
 
                 if (time_check && strict_check)
                 {
@@ -418,8 +418,8 @@ private:
                 const T first_candidate_ts = candidate_events_timestamp[event_idx - 1]->first;
                 const T prev_candidate_ts = candidate_events_timestamp[event_idx - 1]->second;
 
-                bool time_check = timestamp <= first_candidate_ts + window;
-                bool strict_check = (!strict_increase || timestamp > prev_candidate_ts);
+                bool time_check = static_cast<UInt64>(timestamp) <= static_cast<UInt64>(first_candidate_ts) + window;
+                bool strict_check = (!strict_increase || static_cast<UInt64>(timestamp) > static_cast<UInt64>(prev_candidate_ts));
 
                 if (time_check && strict_check)
                 {
@@ -502,9 +502,9 @@ private:
         VectorWithMemoryTracking<ListWithMemoryTracking<EventMatchTimeWindow>> event_sequences(events_size);
 
         // Helper lambda to calculate conversion times from a winning sequence
-        auto calculate_conversion_times = [&](const EventMatchTimeWindow & winning_seq, UInt8 current_max_level) -> std::vector<T>
+        auto calculate_conversion_times = [&](const EventMatchTimeWindow & winning_seq, UInt8 current_max_level) -> std::vector<UInt64>
         {
-            std::vector<T> times;
+            std::vector<UInt64> times;
             if (need_conversion_time && current_max_level > 1)
             {
                 times.resize(events_size - 1, 0); // Initialize all times to 0
@@ -513,7 +513,7 @@ private:
                     // Ensure both current and next step timestamps exist
                     if (winning_seq.step_timestamps[i].has_value() && winning_seq.step_timestamps[i+1].has_value())
                     {
-                         times[i] = *winning_seq.step_timestamps[i+1] - *winning_seq.step_timestamps[i];
+                         times[i] = static_cast<UInt64>(*winning_seq.step_timestamps[i+1]) - static_cast<UInt64>(*winning_seq.step_timestamps[i]);
                     }
                 }
             }

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -609,7 +609,7 @@ private:
         {
             if (!event_sequences[event - 1].empty())
             {
-                max_level = event;
+                max_level = static_cast<UInt8>(event);
                 break;
             }
         }

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -3,6 +3,7 @@
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <base/range.h>
 
 #include <Columns/ColumnsNumber.h>
@@ -15,6 +16,7 @@
 
 #include <list>
 
+#include <list>
 
 namespace DB
 {
@@ -295,14 +297,42 @@ private:
     // Allow re-entry/skipping of future steps
     bool allow_reentry;
 
+    /// When enabled, returns conversion times between funnel steps
+    bool conversion_time;
+
+    struct FunnelResult
+    {
+        UInt8 max_level = 0;
+        std::vector<T> conversion_times;
+    };
+
     /// Loop through the entire events_list, update the event timestamp value
     /// The level path must be 1---2---3---...---check_events_size, find the max event level that satisfied the path in the sliding window.
     /// If found, returns the max event level, else return 0.
     /// The algorithm works in O(n) time, but the overall function works in O(n * log(n)) due to sorting.
-    UInt8 getEventLevelNonStrictOnce(const AggregateFunctionWindowFunnelData<T>::TimestampEvents & events_list) const
+    FunnelResult getEventLevelNonStrictOnce(const AggregateFunctionWindowFunnelData<T>::TimestampEvents & events_list) const
     {
         /// events_timestamp stores the timestamp of the first and previous i-th level event happen within time window
         VectorWithMemoryTracking<std::optional<std::pair<UInt64, UInt64>>> events_timestamp(events_size);
+
+        // Helper lambda to calculate conversion times
+        auto calculate_conversion_times = [&](UInt8 current_max_level) -> std::vector<T>
+        {
+            std::vector<T> times;
+            if (conversion_time && current_max_level > 1)
+            {
+                times.resize(events_size - 1, 0);
+                for (size_t i = 0; i < current_max_level - 1; ++i)
+                {
+                    if (events_timestamp[i].has_value() && events_timestamp[i + 1].has_value())
+                    {
+                        times[i] = events_timestamp[i + 1]->second - events_timestamp[i]->second;
+                    }
+                }
+            }
+            return times;
+        };
+
         bool first_event = false;
         for (size_t i = 0; i < events_list.size(); ++i)
         {
@@ -321,28 +351,16 @@ private:
             }
             else if (strict_deduplication && events_timestamp[event_idx].has_value())
             {
-                /// A duplicate event was found — return the current max level reached.
-                /// The old code incorrectly returned events_list[i-1].second which is just
-                /// the condition index of the previous event in the sorted list, not the
-                /// actual max funnel level. See #37177.
-                for (size_t event = events_timestamp.size(); event > 0; --event)
-                {
-                    if (events_timestamp[event - 1].has_value())
-                        return static_cast<UInt8>(event);
-                }
-                return 0;
+                /// A duplicate event was found — stop processing. See #37177.
+                break;
             }
             else if (strict_order && first_event && !events_timestamp[event_idx - 1].has_value())
             {
-                // If allow_reentry is set, we ignore "future steps" that appear too early,
+                // If allow_reentry is set, we ignore "future steps" that appear too early.
                 if (allow_reentry)
                     continue;
-
-                for (size_t event = 0; event < events_timestamp.size(); ++event)
-                {
-                    if (!events_timestamp[event].has_value())
-                        return static_cast<UInt8>(event);
-                }
+                // Intervention detected. Stop processing this path according to strict_order.
+                break;
             }
             else if (events_timestamp[event_idx - 1].has_value())
             {
@@ -354,20 +372,32 @@ private:
                 {
                     events_timestamp[event_idx] = std::make_pair(first_timestamp, static_cast<UInt64>(timestamp));
                     if (event_idx + 1 == events_size)
-                        return events_size;
+                    {
+                        auto times = calculate_conversion_times(events_size);
+                        return FunnelResult{events_size, std::move(times)};
+                    }
                 }
             }
         }
 
+        UInt8 max_level = 0;
         for (size_t event = events_timestamp.size(); event > 0; --event)
         {
             if (events_timestamp[event - 1].has_value())
-                return static_cast<UInt8>(event);
+            {
+                max_level = event;
+                break;
+            }
         }
-        return 0;
+
+        FunnelResult result;
+        result.max_level = max_level;
+        result.conversion_times = calculate_conversion_times(max_level);
+
+        return result;
     }
 
-    UInt8 getEventLevelStrictOnce(const AggregateFunctionWindowFunnelStrictOnceData<T>::TimestampEvents & events_list) const
+    FunnelResult getEventLevelStrictOnce(const AggregateFunctionWindowFunnelStrictOnceData<T>::TimestampEvents & events_list) const
     {
         /// Stores the timestamp of the first and last i-th level event happen within time window
         struct EventMatchTimeWindow
@@ -375,6 +405,7 @@ private:
             UInt64 first_timestamp;
             UInt64 last_timestamp;
             std::array<UInt64, MAX_EVENTS> event_path;
+            std::array<std::optional<T>, MAX_EVENTS> step_timestamps; // Store timestamp for each step
 
             EventMatchTimeWindow() = default;
             EventMatchTimeWindow(UInt64 first_ts, UInt64 last_ts)
@@ -387,6 +418,25 @@ private:
         /// The second occurrence of 'a' should be counted only once in one sequence.
         /// However, we do not know in advance if the next event will be 'b' or 'end', so we try to keep both paths.
         VectorWithMemoryTracking<ListWithMemoryTracking<EventMatchTimeWindow>> event_sequences(events_size);
+
+        // Helper lambda to calculate conversion times from a winning sequence
+        auto calculate_conversion_times = [&](const EventMatchTimeWindow & winning_seq, UInt8 current_max_level) -> std::vector<T>
+        {
+            std::vector<T> times;
+            if (conversion_time && current_max_level > 1)
+            {
+                times.resize(events_size - 1, 0); // Initialize all times to 0
+                for (size_t i = 0; i < current_max_level - 1; ++i)
+                {
+                    // Ensure both current and next step timestamps exist
+                    if (winning_seq.step_timestamps[i].has_value() && winning_seq.step_timestamps[i+1].has_value())
+                    {
+                         times[i] = *winning_seq.step_timestamps[i+1] - *winning_seq.step_timestamps[i];
+                    }
+                }
+            }
+            return times;
+        };
 
         bool has_first_event = false;
         for (size_t i = 0; i < events_list.size(); ++i)
@@ -407,30 +457,21 @@ private:
             {
                 auto & event_seq = event_sequences[0].emplace_back(static_cast<UInt64>(timestamp), static_cast<UInt64>(timestamp));
                 event_seq.event_path[0] = unique_id;
+                event_seq.step_timestamps[0] = timestamp; // Store timestamp for step 0
                 has_first_event = true;
             }
             else if (strict_deduplication && !event_sequences[event_idx].empty())
             {
-                /// Same fix as in getEventLevelNonStrictOnce — return actual max level,
-                /// not the previous event's type. See #37177.
-                for (size_t event = event_sequences.size(); event > 0; --event)
-                {
-                    if (!event_sequences[event - 1].empty())
-                        return static_cast<UInt8>(event);
-                }
-                return 0;
+                /// A duplicate event was found — stop processing. See #37177.
+                break;
             }
             else if (strict_order && has_first_event && event_sequences[event_idx - 1].empty())
             {
                 // If allow_reentry is set, ignore strict order violation for this specific match.
                 if (allow_reentry)
                     continue;
-
-                for (size_t event = 0; event < event_sequences.size(); ++event)
-                {
-                    if (event_sequences[event].empty())
-                        return static_cast<UInt8>(event);
-                }
+                // Intervention detected. Stop processing events for this path.
+                break;
             }
             else if (!event_sequences[event_idx - 1].empty())
             {
@@ -466,29 +507,61 @@ private:
 
                         auto & new_seq = event_sequences[event_idx].emplace_back(first_ts, static_cast<UInt64>(timestamp));
                         new_seq.event_path = std::move(prev_path);
+                        new_seq.step_timestamps = it->step_timestamps;
+                        new_seq.step_timestamps[event_idx] = timestamp;
+
                         if (event_idx + 1 == events_size)
-                            return events_size;
+                        {
+                             // Calculate times before returning early
+                             auto times = calculate_conversion_times(new_seq, events_size);
+                             return FunnelResult{events_size, std::move(times)};
+                        }
                     }
                     ++it;
                 }
             }
         }
 
+        UInt8 max_level = 0;
         for (size_t event = event_sequences.size(); event > 0; --event)
         {
             if (!event_sequences[event - 1].empty())
-                return static_cast<UInt8>(event);
+            {
+                max_level = event;
+                break;
+            }
         }
-        return 0;
+
+        FunnelResult result;
+        result.max_level = max_level;
+
+        // If conversion_time is enabled and we found a successful funnel path
+        if (conversion_time && max_level > 1)
+        {
+            // Get the first valid sequence that reached the max_level
+            if (!event_sequences[max_level - 1].empty())
+            {
+                const auto& winning_sequence = event_sequences[max_level - 1].front();
+                result.conversion_times = calculate_conversion_times(winning_sequence, max_level);
+            }
+            // Ensure conversion_times has the correct size even if calculation failed
+            if (result.conversion_times.empty())
+                 result.conversion_times.resize(events_size - 1, 0);
+        }
+        else if (conversion_time) // Ensure vector has correct size even if max_level <= 1
+        {
+             result.conversion_times.resize(events_size - 1, 0);
+        }
+
+        return result;
     }
 
-
-    UInt8 getEventLevel(Data & data) const
+    FunnelResult getEventLevel(Data & data) const
     {
         if (data.size() == 0)
-            return 0;
+            return FunnelResult{0, {}};
         if (!strict_order && events_size == 1)
-            return 1;
+            return FunnelResult{1, {}};
 
         data.sort();
 
@@ -505,7 +578,9 @@ public:
     }
 
     AggregateFunctionWindowFunnel(const DataTypes & arguments, const Array & params)
-        : IAggregateFunctionDataHelper<Data, AggregateFunctionWindowFunnel<T, Data>>(arguments, params, std::make_shared<DataTypeUInt8>())
+        : IAggregateFunctionDataHelper<Data, AggregateFunctionWindowFunnel<T, Data>>(arguments, params,
+          // We'll decide on the return type based on conversion_time flag
+          getReturnType(arguments, params))
     {
         events_size = static_cast<UInt8>(arguments.size() - 1);
         window = params.at(0).safeGet<UInt64>();
@@ -514,6 +589,8 @@ public:
         strict_order = false;
         strict_increase = false;
         allow_reentry = false;
+        conversion_time = false;
+
         for (size_t i = 1; i < params.size(); ++i)
         {
             String option = params.at(i).safeGet<String>();
@@ -528,6 +605,8 @@ public:
             else if (option == "strict_once")
                 /// Checked in factory
                 chassert(Data::strict_once_enabled);
+            else if (option == "conversion_time")
+                conversion_time = true;
             else if (option == "strict")
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "strict is replaced with strict_deduplication in Aggregate function {}", getName());
             else
@@ -539,6 +618,33 @@ public:
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "allow_reentry option requires strict_order to be enabled in Aggregate function {}", getName());
         }
+    }
+
+    static DataTypePtr getReturnType(const DataTypes & arguments, const Array & params)
+    {
+        bool has_conversion_time = false;
+        for (size_t i = 1; i < params.size(); ++i)
+            if (params.at(i).safeGet<String>() == "conversion_time")
+                has_conversion_time = true;
+
+        if (!has_conversion_time)
+            return std::make_shared<DataTypeUInt8>();
+
+        DataTypes tuple_types;
+        Strings tuple_names;
+
+        tuple_types.push_back(std::make_shared<DataTypeUInt8>());
+        tuple_names.push_back("max_level");
+
+        size_t events_size = arguments.size() - 1;
+        // Add conversion time slots
+        for (size_t i = 0; i < events_size - 1; ++i)
+        {
+            tuple_types.push_back(std::make_shared<DataTypeUInt64>());
+            tuple_names.push_back("time_" + toString(i + 1) + "_to_" + toString(i + 2));
+        }
+
+        return std::make_shared<DataTypeTuple>(tuple_types, tuple_names);
     }
 
     bool allocatesMemoryInArena() const override { return false; }
@@ -582,7 +688,28 @@ public:
 
     void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
     {
-        assert_cast<ColumnUInt8 &>(to).getData().push_back(getEventLevel(this->data(place)));
+        auto result = getEventLevel(this->data(place));
+
+        if (!conversion_time)
+        {
+            // just insert the max level
+            assert_cast<ColumnUInt8 &>(to).getData().push_back(result.max_level);
+        }
+        else
+        {
+            // insert tuple (max_level, conversion_times...)
+            auto & tuple_col = assert_cast<ColumnTuple &>(to);
+            auto & level_col = assert_cast<ColumnUInt8 &>(tuple_col.getColumn(0));
+            level_col.getData().push_back(result.max_level);
+
+            // add conversion times to the tuple
+            for (size_t i = 0; i < events_size - 1; ++i)
+            {
+                auto & time_col = assert_cast<ColumnUInt64 &>(tuple_col.getColumn(i + 1));
+                UInt64 time_val = (i < result.conversion_times.size()) ? static_cast<UInt64>(result.conversion_times[i]) : 0;
+                time_col.getData().push_back(time_val);
+            }
+        }
     }
 };
 

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -198,3 +198,59 @@ select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', ev
 from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
 [3, 1]
 drop table funnel_test_reentry;
+DROP TABLE IF EXISTS funnel_test_conv_time;
+CREATE TABLE funnel_test_conv_time (user_id UInt64, event_time UInt32, eventName String) ENGINE = Memory;
+INSERT INTO funnel_test_conv_time VALUES (1, 0, 'event1'), (1, 5, 'event2'), (1, 15, 'event3');
+INSERT INTO funnel_test_conv_time VALUES (2, 100, 'event1'), (2, 110, 'event2'), (2, 145, 'event3');
+INSERT INTO funnel_test_conv_time VALUES (3, 200, 'event1');
+INSERT INTO funnel_test_conv_time VALUES (4, 300, 'event1'), (4, 305, 'event2'), (4, 315, 'event3'), (4, 320, 'event1'), (4, 322, 'event2'), (4, 330, 'event3');
+INSERT INTO funnel_test_conv_time VALUES (5, 400, 'event1'), (5, 405, 'event2'), (5, 440, 'event1'), (5, 442, 'event2'), (5, 450, 'event3');
+SELECT
+    user_id,
+    windowFunnel(30, 'conversion_time')(
+        event_time,
+        eventName = 'event1',
+        eventName = 'event2',
+        eventName = 'event3'
+    ) AS funnel_result
+FROM funnel_test_conv_time
+GROUP BY user_id
+ORDER BY user_id;
+1	(3,5,10)
+2	(2,10,0)
+3	(1,0,0)
+4	(3,5,10)
+5	(3,2,8)
+SELECT
+    user_id,
+    windowFunnel(30, 'conversion_time')(
+        event_time,
+        eventName = 'event1',
+        eventName = 'event2',
+        eventName = 'event3'
+    ) AS funnel_result,
+    funnel_result.max_level,
+    funnel_result.time_1_to_2,
+    funnel_result.time_2_to_3
+FROM funnel_test_conv_time
+GROUP BY user_id
+ORDER BY user_id;
+1	(3,5,10)	3	5	10
+2	(2,10,0)	2	10	0
+3	(1,0,0)	1	0	0
+4	(3,5,10)	3	5	10
+5	(3,2,8)	3	2	8
+INSERT INTO funnel_test_conv_time VALUES (6, 500, 'event1'), (6, 501, 'event1'), (6, 505, 'event2'), (6, 510, 'event3');
+SELECT
+    user_id,
+    windowFunnel(30, 'strict_once', 'conversion_time')(
+        event_time,
+        eventName = 'event1',
+        eventName = 'event2',
+        eventName = 'event3'
+    ) AS funnel_result
+FROM funnel_test_conv_time
+WHERE user_id = 6
+GROUP BY user_id;
+6	(3,5,5)
+DROP TABLE funnel_test_conv_time;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -291,3 +291,9 @@ INSERT INTO conv_strict_dedup VALUES (1, 'a'), (2, 'b'), (3, 'b'), (4, 'c');
 SELECT windowFunnel(10, 'strict_deduplication', 'conversion_time')(ts, event='a', event='b', event='c') FROM conv_strict_dedup;
 (2,1,0)
 DROP TABLE conv_strict_dedup;
+DROP TABLE IF EXISTS funnel_test_large_dt;
+CREATE TABLE funnel_test_large_dt (ts DateTime, ev String) ENGINE = Memory;
+INSERT INTO funnel_test_large_dt VALUES ('2106-02-07 06:28:05', 'a'), ('2106-02-07 06:28:06', 'b'), ('2106-02-07 06:28:07', 'c');
+SELECT windowFunnel(100, 'conversion_time')(ts, ev='a', ev='b', ev='c') FROM funnel_test_large_dt;
+(3,1,1)
+DROP TABLE funnel_test_large_dt;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -254,3 +254,17 @@ WHERE user_id = 6
 GROUP BY user_id;
 6	(3,5,5)
 DROP TABLE funnel_test_conv_time;
+DROP TABLE IF EXISTS funnel_test_overlap;
+CREATE TABLE funnel_test_overlap (ts UInt32, event String) ENGINE = Memory;
+INSERT INTO funnel_test_overlap VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'a'), (5, 'b'), (6, 'd');
+SELECT
+    windowFunnel(10, 'conversion_time')(
+        ts,
+        event = 'a',
+        event = 'b',
+        event = 'c',
+        event = 'd'
+    ) AS funnel_result
+FROM funnel_test_overlap;
+(4,1,1,3)
+DROP TABLE funnel_test_overlap;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -268,3 +268,26 @@ SELECT
 FROM funnel_test_overlap;
 (4,1,1,3)
 DROP TABLE funnel_test_overlap;
+DROP TABLE IF EXISTS conv_strict_order;
+CREATE TABLE conv_strict_order (dt UInt32, user UInt32, event String) ENGINE = Memory;
+INSERT INTO conv_strict_order VALUES (1, 1, 'a'), (2, 1, 'b'), (3, 1, 'c');
+INSERT INTO conv_strict_order VALUES (1, 2, 'a'), (2, 2, 'd'), (3, 2, 'b'), (4, 2, 'c');
+INSERT INTO conv_strict_order VALUES (1, 3, 'a'), (1, 3, 'b'), (2, 3, 'c');
+SELECT user, windowFunnel(100, 'strict_order', 'conversion_time')(dt, event='a', event='b', event='c') AS s
+FROM conv_strict_order GROUP BY user ORDER BY user FORMAT JSONCompactEachRow;
+[1, {"max_level":3,"time_1_to_2":"1","time_2_to_3":"1"}]
+[2, {"max_level":1,"time_1_to_2":"0","time_2_to_3":"0"}]
+[3, {"max_level":3,"time_1_to_2":"0","time_2_to_3":"1"}]
+DROP TABLE conv_strict_order;
+DROP TABLE IF EXISTS conv_strict_increase;
+CREATE TABLE conv_strict_increase (ts UInt32, event String) ENGINE = Memory;
+INSERT INTO conv_strict_increase VALUES (1, 'a'), (1, 'b'), (2, 'c');
+SELECT windowFunnel(10, 'strict_increase', 'conversion_time')(ts, event='a', event='b', event='c') FROM conv_strict_increase;
+(1,0,0)
+DROP TABLE conv_strict_increase;
+DROP TABLE IF EXISTS conv_strict_dedup;
+CREATE TABLE conv_strict_dedup (ts UInt32, event String) ENGINE = Memory;
+INSERT INTO conv_strict_dedup VALUES (1, 'a'), (2, 'b'), (3, 'b'), (4, 'c');
+SELECT windowFunnel(10, 'strict_deduplication', 'conversion_time')(ts, event='a', event='b', event='c') FROM conv_strict_dedup;
+(2,1,0)
+DROP TABLE conv_strict_dedup;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -198,6 +198,7 @@ select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', ev
 from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
 [3, 1]
 drop table funnel_test_reentry;
+SET enable_analyzer = 1;
 DROP TABLE IF EXISTS funnel_test_conv_time;
 CREATE TABLE funnel_test_conv_time (user_id UInt64, event_time UInt32, eventName String) ENGINE = Memory;
 INSERT INTO funnel_test_conv_time VALUES (1, 0, 'event1'), (1, 5, 'event2'), (1, 15, 'event3');

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -276,9 +276,9 @@ INSERT INTO conv_strict_order VALUES (1, 2, 'a'), (2, 2, 'd'), (3, 2, 'b'), (4, 
 INSERT INTO conv_strict_order VALUES (1, 3, 'a'), (1, 3, 'b'), (2, 3, 'c');
 SELECT user, windowFunnel(100, 'strict_order', 'conversion_time')(dt, event='a', event='b', event='c') AS s
 FROM conv_strict_order GROUP BY user ORDER BY user FORMAT JSONCompactEachRow;
-[1, {"max_level":3,"time_1_to_2":"1","time_2_to_3":"1"}]
-[2, {"max_level":1,"time_1_to_2":"0","time_2_to_3":"0"}]
-[3, {"max_level":3,"time_1_to_2":"0","time_2_to_3":"1"}]
+[1, {"max_level":3,"time_1_to_2":1,"time_2_to_3":1}]
+[2, {"max_level":1,"time_1_to_2":0,"time_2_to_3":0}]
+[3, {"max_level":3,"time_1_to_2":0,"time_2_to_3":1}]
 DROP TABLE conv_strict_order;
 DROP TABLE IF EXISTS conv_strict_increase;
 CREATE TABLE conv_strict_increase (ts UInt32, event String) ENGINE = Memory;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
@@ -151,3 +151,58 @@ select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', ev
 from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
 drop table funnel_test_reentry;
 
+DROP TABLE IF EXISTS funnel_test_conv_time;
+CREATE TABLE funnel_test_conv_time (user_id UInt64, event_time UInt32, eventName String) ENGINE = Memory;
+
+INSERT INTO funnel_test_conv_time VALUES (1, 0, 'event1'), (1, 5, 'event2'), (1, 15, 'event3');
+
+INSERT INTO funnel_test_conv_time VALUES (2, 100, 'event1'), (2, 110, 'event2'), (2, 145, 'event3');
+
+INSERT INTO funnel_test_conv_time VALUES (3, 200, 'event1');
+
+INSERT INTO funnel_test_conv_time VALUES (4, 300, 'event1'), (4, 305, 'event2'), (4, 315, 'event3'), (4, 320, 'event1'), (4, 322, 'event2'), (4, 330, 'event3');
+
+INSERT INTO funnel_test_conv_time VALUES (5, 400, 'event1'), (5, 405, 'event2'), (5, 440, 'event1'), (5, 442, 'event2'), (5, 450, 'event3');
+
+SELECT
+    user_id,
+    windowFunnel(30, 'conversion_time')(
+        event_time,
+        eventName = 'event1',
+        eventName = 'event2',
+        eventName = 'event3'
+    ) AS funnel_result
+FROM funnel_test_conv_time
+GROUP BY user_id
+ORDER BY user_id;
+
+SELECT
+    user_id,
+    windowFunnel(30, 'conversion_time')(
+        event_time,
+        eventName = 'event1',
+        eventName = 'event2',
+        eventName = 'event3'
+    ) AS funnel_result,
+    funnel_result.max_level,
+    funnel_result.time_1_to_2,
+    funnel_result.time_2_to_3
+FROM funnel_test_conv_time
+GROUP BY user_id
+ORDER BY user_id;
+
+INSERT INTO funnel_test_conv_time VALUES (6, 500, 'event1'), (6, 501, 'event1'), (6, 505, 'event2'), (6, 510, 'event3');
+
+SELECT
+    user_id,
+    windowFunnel(30, 'strict_once', 'conversion_time')(
+        event_time,
+        eventName = 'event1',
+        eventName = 'event2',
+        eventName = 'event3'
+    ) AS funnel_result
+FROM funnel_test_conv_time
+WHERE user_id = 6
+GROUP BY user_id;
+
+DROP TABLE funnel_test_conv_time;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
@@ -206,3 +206,19 @@ WHERE user_id = 6
 GROUP BY user_id;
 
 DROP TABLE funnel_test_conv_time;
+
+DROP TABLE IF EXISTS funnel_test_overlap;
+CREATE TABLE funnel_test_overlap (ts UInt32, event String) ENGINE = Memory;
+INSERT INTO funnel_test_overlap VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'a'), (5, 'b'), (6, 'd');
+
+SELECT
+    windowFunnel(10, 'conversion_time')(
+        ts,
+        event = 'a',
+        event = 'b',
+        event = 'c',
+        event = 'd'
+    ) AS funnel_result
+FROM funnel_test_overlap;
+
+DROP TABLE funnel_test_overlap;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
@@ -243,3 +243,9 @@ CREATE TABLE conv_strict_dedup (ts UInt32, event String) ENGINE = Memory;
 INSERT INTO conv_strict_dedup VALUES (1, 'a'), (2, 'b'), (3, 'b'), (4, 'c');
 SELECT windowFunnel(10, 'strict_deduplication', 'conversion_time')(ts, event='a', event='b', event='c') FROM conv_strict_dedup;
 DROP TABLE conv_strict_dedup;
+
+DROP TABLE IF EXISTS funnel_test_large_dt;
+CREATE TABLE funnel_test_large_dt (ts DateTime, ev String) ENGINE = Memory;
+INSERT INTO funnel_test_large_dt VALUES ('2106-02-07 06:28:05', 'a'), ('2106-02-07 06:28:06', 'b'), ('2106-02-07 06:28:07', 'c');
+SELECT windowFunnel(100, 'conversion_time')(ts, ev='a', ev='b', ev='c') FROM funnel_test_large_dt;
+DROP TABLE funnel_test_large_dt;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
@@ -151,6 +151,7 @@ select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', ev
 from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
 drop table funnel_test_reentry;
 
+SET enable_analyzer = 1;
 DROP TABLE IF EXISTS funnel_test_conv_time;
 CREATE TABLE funnel_test_conv_time (user_id UInt64, event_time UInt32, eventName String) ENGINE = Memory;
 

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
@@ -222,3 +222,24 @@ SELECT
 FROM funnel_test_overlap;
 
 DROP TABLE funnel_test_overlap;
+
+DROP TABLE IF EXISTS conv_strict_order;
+CREATE TABLE conv_strict_order (dt UInt32, user UInt32, event String) ENGINE = Memory;
+INSERT INTO conv_strict_order VALUES (1, 1, 'a'), (2, 1, 'b'), (3, 1, 'c');
+INSERT INTO conv_strict_order VALUES (1, 2, 'a'), (2, 2, 'd'), (3, 2, 'b'), (4, 2, 'c');
+INSERT INTO conv_strict_order VALUES (1, 3, 'a'), (1, 3, 'b'), (2, 3, 'c');
+SELECT user, windowFunnel(100, 'strict_order', 'conversion_time')(dt, event='a', event='b', event='c') AS s
+FROM conv_strict_order GROUP BY user ORDER BY user FORMAT JSONCompactEachRow;
+DROP TABLE conv_strict_order;
+
+DROP TABLE IF EXISTS conv_strict_increase;
+CREATE TABLE conv_strict_increase (ts UInt32, event String) ENGINE = Memory;
+INSERT INTO conv_strict_increase VALUES (1, 'a'), (1, 'b'), (2, 'c');
+SELECT windowFunnel(10, 'strict_increase', 'conversion_time')(ts, event='a', event='b', event='c') FROM conv_strict_increase;
+DROP TABLE conv_strict_increase;
+
+DROP TABLE IF EXISTS conv_strict_dedup;
+CREATE TABLE conv_strict_dedup (ts UInt32, event String) ENGINE = Memory;
+INSERT INTO conv_strict_dedup VALUES (1, 'a'), (2, 'b'), (3, 'b'), (4, 'c');
+SELECT windowFunnel(10, 'strict_deduplication', 'conversion_time')(ts, event='a', event='b', event='c') FROM conv_strict_dedup;
+DROP TABLE conv_strict_dedup;


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/63732

### Changelog category:
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `'conversion_time'` mode to the `windowFunnel` aggregate function to calculate time between funnel steps. The function now returns a named tuple `(max_level, time_1_to_2, ...)` when this mode is enabled.

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
