### PR TITLE
Support DESCRIBE SELECT without parentheses around SELECT

### DIFF
--- a/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -134,7 +134,7 @@ BlockIO InterpreterDescribeQuery::execute()
 void InterpreterDescribeQuery::fillColumnsFromSubquery(const ASTTableExpression & table_expression)
 {
     Block sample_block;
-    auto select_query = table_expression.subquery->children.at(0);
+    auto select_query = table_expression.subquery;
     auto current_context = getContext();
 
     if (settings[Setting::allow_experimental_analyzer])

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -1,3 +1,4 @@
+#include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
 
 #include <Parsers/CommonParsers.h>
@@ -28,6 +29,12 @@ bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
     auto query = std::make_shared<ASTDescribeQuery>();
 
     s_table.ignore(pos, expected);
+
+    if (ParserSelectWithUnionQuery().parse(pos, query->table_expression, expected))
+    {
+        node = query;
+        return true;
+    }
 
     if (!ParserTableExpression().parse(pos, query->table_expression, expected))
         return false;

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
 
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserDescribeTableQuery.h>
@@ -20,23 +21,23 @@ bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserSetQuery parser_settings(true);
 
-    ASTPtr database;
-    ASTPtr table;
+    ASTPtr select;
 
     if (!s_describe.ignore(pos, expected) && !s_desc.ignore(pos, expected))
         return false;
 
     auto query = std::make_shared<ASTDescribeQuery>();
-
     s_table.ignore(pos, expected);
 
-    if (ParserSelectWithUnionQuery().parse(pos, query->table_expression, expected))
+    if (ParserSelectWithUnionQuery().parse(pos, select, expected))
     {
-        node = query;
-        return true;
+        auto table_expr = std::make_shared<ASTTableExpression>();
+        table_expr->subquery = select;
+        table_expr->children.push_back(select);
+        query->table_expression = table_expr;
+        query->children.push_back(query->table_expression);
     }
-
-    if (!ParserTableExpression().parse(pos, query->table_expression, expected))
+    else if (!ParserTableExpression().parse(pos, query->table_expression, expected))
         return false;
 
     /// For compatibility with SELECTs, where SETTINGS can be in front of FORMAT

--- a/tests/queries/0_stateless/03445_describe_select.reference
+++ b/tests/queries/0_stateless/03445_describe_select.reference
@@ -1,0 +1,4 @@
+1	UInt8					
+1	UInt8					
+number	UInt64					
+example	String					

--- a/tests/queries/0_stateless/03445_describe_select.sql
+++ b/tests/queries/0_stateless/03445_describe_select.sql
@@ -1,0 +1,6 @@
+DESCRIBE SELECT 1 FORMAT TSV;
+DESCRIBE (SELECT 1) FORMAT TSV;
+
+CREATE TABLE test_table (number UInt64, example String) ENGINE = Memory;
+DESCRIBE test_table FORMAT TSV;
+DROP TABLE test_table;


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/58382.

### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `DESCRIBE SELECT` in addition to `DESCRIBE (SELECT ...)`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
