### PR TITLE
Backport test_storage_rabbitmq/test_failed_connection from master into 25.4

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -348,14 +348,18 @@ def rabbitmq_debuginfo(rabbitmq_id, cookie):
 
 async def check_nats_is_available(nats_port, ssl_ctx=None):
     nc = await nats_connect_ssl(
-        nats_port, user="click", password="house", ssl_ctx=ssl_ctx
+        nats_port,
+        user="click",
+        password="house",
+        ssl_ctx=ssl_ctx,
+        max_reconnect_attempts=1,
     )
     available = nc.is_connected
     await nc.close()
     return available
 
 
-async def nats_connect_ssl(nats_port, user, password, ssl_ctx=None):
+async def nats_connect_ssl(nats_port, user, password, ssl_ctx=None, **connect_options):
     if not ssl_ctx:
         ssl_ctx = ssl.create_default_context()
         ssl_ctx.check_hostname = False
@@ -365,6 +369,7 @@ async def nats_connect_ssl(nats_port, user, password, ssl_ctx=None):
         user=user,
         password=password,
         tls=ssl_ctx,
+        **connect_options,
     )
     return nc
 
@@ -543,6 +548,7 @@ class ClickHouseCluster:
         self.spark_session = None
         self.with_iceberg_catalog = False
         self.with_glue_catalog = False
+        self.with_hms_catalog = False
 
         self.with_azurite = False
         self.azurite_container = "azurite-container"
@@ -1413,15 +1419,11 @@ class ClickHouseCluster:
         )
         return self.base_minio_cmd
 
-    def setup_glue_catalog_cmd(
-        self, instance, env_variables, docker_compose_yml_dir
-    ):
+    def setup_glue_catalog_cmd(self, instance, env_variables, docker_compose_yml_dir):
         self.base_cmd.extend(
             [
                 "--file",
-                p.join(
-                    docker_compose_yml_dir, "docker_compose_glue_catalog.yml"
-                ),
+                p.join(docker_compose_yml_dir, "docker_compose_glue_catalog.yml"),
             ]
         )
         self.base_iceberg_catalog_cmd = self.compose_cmd(
@@ -1431,6 +1433,28 @@ class ClickHouseCluster:
             p.join(docker_compose_yml_dir, "docker_compose_glue_catalog.yml"),
         )
         return self.base_iceberg_catalog_cmd
+
+
+    def setup_hms_catalog_cmd(
+         self, instance, env_variables, docker_compose_yml_dir
+     ):
+         self.base_cmd.extend(
+             [
+                 "--file",
+                 p.join(
+                     docker_compose_yml_dir, "docker_compose_iceberg_hms_catalog.yml"
+                 ),
+             ]
+         )
+
+         self.base_iceberg_hms_cmd = self.compose_cmd(
+             "--env-file",
+             instance.env_file,
+             "--file",
+             p.join(docker_compose_yml_dir, "docker_compose_iceberg_hms_catalog.yml"),
+         )
+         return self.base_iceberg_hms_cmd
+
 
     def setup_iceberg_catalog_cmd(
         self, instance, env_variables, docker_compose_yml_dir
@@ -1620,6 +1644,7 @@ class ClickHouseCluster:
         with_prometheus=False,
         with_iceberg_catalog=False,
         with_glue_catalog=False,
+        with_hms_catalog=False,
         handle_prometheus_remote_write=False,
         handle_prometheus_remote_read=False,
         use_old_analyzer=None,
@@ -1727,7 +1752,10 @@ class ClickHouseCluster:
             with_rabbitmq=with_rabbitmq,
             with_nats=with_nats,
             with_nginx=with_nginx,
-            with_secrets=with_secrets or with_kerberos_kdc or with_kerberized_kafka or with_kafka_sasl,
+            with_secrets=with_secrets
+            or with_kerberos_kdc
+            or with_kerberized_kafka
+            or with_kafka_sasl,
             with_mongo=with_mongo,
             with_redis=with_redis,
             with_minio=with_minio,
@@ -1740,6 +1768,7 @@ class ClickHouseCluster:
             with_ldap=with_ldap,
             with_iceberg_catalog=with_iceberg_catalog,
             with_glue_catalog=with_glue_catalog,
+            with_hms_catalog=with_hms_catalog,
             use_old_analyzer=use_old_analyzer,
             use_distributed_plan=use_distributed_plan,
             server_bin_path=self.server_bin_path,
@@ -1872,7 +1901,9 @@ class ClickHouseCluster:
 
         if with_kafka_sasl and not self.with_kafka_sasl:
             cmds.append(
-                self.setup_kafka_sasl_cmd(instance, env_variables, docker_compose_yml_dir)
+                self.setup_kafka_sasl_cmd(
+                    instance, env_variables, docker_compose_yml_dir
+                )
             )
 
         if with_kerberized_kafka and not self.with_kerberized_kafka:
@@ -1932,6 +1963,13 @@ class ClickHouseCluster:
         if with_glue_catalog and not self.with_glue_catalog:
             cmds.append(
                 self.setup_glue_catalog_cmd(
+                    instance, env_variables, docker_compose_yml_dir
+                )
+            )
+
+        if with_hms_catalog and not self.with_hms_catalog:
+            cmds.append(
+                self.setup_hms_catalog_cmd(
                     instance, env_variables, docker_compose_yml_dir
                 )
             )
@@ -2416,7 +2454,7 @@ class ClickHouseCluster:
                     return True
             except Exception as ex:
                 logging.debug("RabbitMQ await_startup failed, %s:", ex)
-                time.sleep(0.5)
+                time.sleep(0.1)
 
         start = time.time()
         while time.time() - start < timeout:
@@ -2433,16 +2471,23 @@ class ClickHouseCluster:
         raise RuntimeError("Cannot wait RabbitMQ container")
 
     def stop_rabbitmq_app(self, timeout=120):
-        run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout)
+        run_rabbitmqctl(
+            self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout
+        )
 
     def start_rabbitmq_app(self, timeout=120):
-        run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, "start_app", timeout)
+        run_rabbitmqctl(
+            self.rabbitmq_docker_id, self.rabbitmq_cookie, "start_app", timeout
+        )
         self.wait_rabbitmq_to_start()
 
     def reset_rabbitmq(self, timeout=120):
         self.stop_rabbitmq_app()
         run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, "reset", timeout)
         self.start_rabbitmq_app()
+
+    def run_rabbitmqctl(self, command):
+        run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, command)
 
     def wait_nats_is_available(self, max_retries=5):
         retries = 0
@@ -2525,7 +2570,10 @@ class ClickHouseCluster:
 
     def wait_mongo_to_start(self, timeout=30, secure=False):
         connection_str = "mongodb://{user}:{password}@{host}:{port}".format(
-            host="localhost", port=self.mongo_port, user=mongo_user, password=urllib.parse.quote_plus(mongo_pass)
+            host="localhost",
+            port=self.mongo_port,
+            user=mongo_user,
+            password=urllib.parse.quote_plus(mongo_pass),
         )
         if secure:
             connection_str += "/?tls=true&tlsAllowInvalidCertificates=true"
@@ -2573,7 +2621,9 @@ class ClickHouseCluster:
                         )
                         errors = minio_client.remove_objects(bucket, delete_object_list)
                         for error in errors:
-                            logging.error(f"Error occurred when deleting object {error}")
+                            logging.error(
+                                f"Error occurred when deleting object {error}"
+                            )
                         minio_client.remove_bucket(bucket)
                     minio_client.make_bucket(bucket)
                     logging.debug("S3 bucket '%s' created", bucket)
@@ -3279,10 +3329,10 @@ class ClickHouseCluster:
 
     @contextmanager
     def pause_container(self, instance_name):
-        '''Use it as following:
+        """Use it as following:
         with cluster.pause_container(name):
             useful_stuff()
-        '''
+        """
         self._pause_container(instance_name)
         try:
             yield
@@ -3354,6 +3404,12 @@ class ClickHouseCluster:
         for n in zk_nodes:
             logging.info("Stopping zookeeper node: %s", n)
             subprocess_check_call(self.base_zookeeper_cmd + ["stop", n])
+
+    # Faster than waiting for clean stop
+    def kill_zookeeper_nodes(self, zk_nodes):
+        for n in zk_nodes:
+            logging.info("Killing zookeeper node: %s", n)
+            subprocess_check_call(self.base_zookeeper_cmd + ["kill", n])
 
     def start_zookeeper_nodes(self, zk_nodes):
         for n in zk_nodes:
@@ -3451,6 +3507,7 @@ class ClickHouseInstance:
         with_ldap,
         with_iceberg_catalog,
         with_glue_catalog,
+        with_hms_catalog,
         use_old_analyzer,
         use_distributed_plan,
         server_bin_path,
@@ -4597,13 +4654,15 @@ class ClickHouseInstance:
                 delimiter = d
                 break
         else:
-            raise Exception(
-                f"Couldn't find a suitable delimiter"
-            )
+            raise Exception(f"Couldn't find a suitable delimiter")
         replace = shlex.quote(replace)
         replacement = shlex.quote(replacement)
         self.exec_in_container(
-            ["bash", "-c", f"sed -i 's{delimiter}'{replace}'{delimiter}'{replacement}'{delimiter}g' {path_to_config}"]
+            [
+                "bash",
+                "-c",
+                f"sed -i 's{delimiter}'{replace}'{delimiter}'{replacement}'{delimiter}g' {path_to_config}",
+            ]
         )
 
     def create_dir(self):
@@ -4670,7 +4729,9 @@ class ClickHouseInstance:
             write_embedded_config("0_common_max_cpu_load.xml", users_d_dir)
 
         use_old_analyzer = os.environ.get("CLICKHOUSE_USE_OLD_ANALYZER") is not None
-        use_distributed_plan = os.environ.get("CLICKHOUSE_USE_DISTRIBUTED_PLAN") is not None
+        use_distributed_plan = (
+            os.environ.get("CLICKHOUSE_USE_DISTRIBUTED_PLAN") is not None
+        )
 
         # If specific version was used there can be no
         # enable_analyzer setting, so do this only if it was

--- a/tests/integration/test_storage_rabbitmq/test_failed_connection.py
+++ b/tests/integration/test_storage_rabbitmq/test_failed_connection.py
@@ -1,13 +1,16 @@
 import logging
 import time
+import json
+import threading
 
 import pytest
+import pika
 
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
-
-DEFAULT_TIMEOUT_SEC = 60
+DEFAULT_TIMEOUT_SEC = 120
+CLICKHOUSE_VIEW_TIMEOUT_SEC = 240
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(
@@ -44,23 +47,124 @@ instance3 = cluster.add_instance(
 # Helpers
 
 
-def suspend_rabbitmq(rabbitmq_cluster):
+class RabbitMQMonitor:
+    # The RabbitMQMonitor class aims to trace all published and delivered events of RabbitMQ
+    # It servers as an additional check to see whether the error happens in ClickHouse or
+    # in the RabbitMQ server itself.
+
+    published = set()
+    delivered = set()
+    connection = None
+    channel = None
+    queue_name = None
+    rabbitmq_cluster = None
+    expected_published = None
+    expected_delivered = None
+    consume_thread = None
+    stop_event = threading.Event()
+
+    def _consume(self, timeout=180):
+        logging.debug("RabbitMQMonitor: Consuming trace RabbitMQ messages in a working thread...")
+        deadline = time.monotonic() + timeout
+        _published = 0
+        _delivered = 0
+        while time.monotonic() < deadline and not self.stop_event.is_set():
+            method, properties, body = self.channel.basic_get(self.queue_name, auto_ack=True)
+            if method and properties and body:
+                # logging.debug(f"Message received! method {method}, properties {properties}, body {body}")
+                message = json.loads(body.decode("utf-8"))
+                assert message["key"] == message["value"]
+                value = int(message["key"])
+                if "deliver" in method.routing_key:
+                    self.delivered.add(value)
+                    _delivered += 1
+                    # logging.debug(f"Message delivered: {value}")
+                elif "publish" in method.routing_key:
+                    self.published.add(value)
+                    _published += 1
+                    # logging.debug(f"Message published: {value}")
+            else:
+                time.sleep(0.1)
+        logging.debug(f"RabbitMQMonitor: Consumed {_published}/{len(self.published)} published messages and {_delivered}/{len(self.delivered)} delivered messages in this iteration")
+
+    def _run(self):
+        logging.debug("RabbitMQMonitor: Creating a new connection for RabbitMQ")
+        credentials = pika.PlainCredentials("root", "clickhouse")
+        parameters = pika.ConnectionParameters(
+            self.rabbitmq_cluster.rabbitmq_ip, self.rabbitmq_cluster.rabbitmq_port, "/", credentials
+        )
+        self.connection = pika.BlockingConnection(parameters)
+        self.channel = self.connection.channel()
+
+        if not self.queue_name:
+            queue_res = self.channel.queue_declare(queue="", durable=True)
+            self.queue_name = queue_res.method.queue
+            logging.debug(f"RabbitMQMonitor: Created debug queue to monitor RabbitMQ published and delivered messages: {self.queue_name}")
+
+        self.channel.queue_bind(exchange="amq.rabbitmq.trace", queue=self.queue_name, routing_key="publish.#")
+        self.channel.queue_bind(exchange="amq.rabbitmq.trace", queue=self.queue_name, routing_key="deliver.#")
+        self._consume()
+
+    def set_expectations(self, published, delivered):
+        self.expected_published = published
+        self.expected_delivered = delivered
+
+    def check(self):
+        self.stop_event.set()
+        self.consume_thread.join()
+
+        def _get_non_present(my_set, amount):
+            non_present = list()
+            for i in range(amount):
+                if i not in my_set:
+                    non_present.append(i)
+                    if (len(non_present) >= 10):
+                        break
+            return non_present
+
+        if self.expected_published and self.expected_published != len(self.published):
+            logging.warning(f"RabbitMQMonitor: {len(self.published)}/{self.expected_published} (got/expected) messages published. Sample of not published: {_get_non_present(self.published, self.expected_published)}")
+        if self.expected_delivered and self.expected_delivered != len(self.delivered):
+            logging.warning(f"RabbitMQMonitor: {len(self.delivered)}/{self.expected_delivered} (got/expected) messages delivered. Sample of not delivered: {_get_non_present(self.delivered, self.expected_delivered)}")
+
+    def start(self, rabbitmq_cluster):
+        self.rabbitmq_cluster = rabbitmq_cluster
+        self.stop_event.clear()
+        self.consume_thread = threading.Thread(target=self._run)
+        logging.debug("RabbitMQMonitor: Starting consuming thread...")
+        self.consume_thread.start()
+
+    def stop(self):
+        if self.connection:
+            if not self.stop_event.is_set():
+                self.stop_event.set()
+                self.consume_thread.join()
+            self.channel.close()
+            self.channel = None
+            self.connection.close()
+            self.connection = None
+
+
+def suspend_rabbitmq(rabbitmq_cluster, rabbitmq_monitor):
+    rabbitmq_monitor.stop()
     rabbitmq_cluster.stop_rabbitmq_app()
 
 
-def resume_rabbitmq(rabbitmq_cluster):
+def resume_rabbitmq(rabbitmq_cluster, rabbitmq_monitor):
     rabbitmq_cluster.start_rabbitmq_app()
     rabbitmq_cluster.wait_rabbitmq_to_start()
+    rabbitmq_monitor.start(rabbitmq_cluster)
 
 
 # Fixtures
-
 
 @pytest.fixture(scope="module")
 def rabbitmq_cluster():
     try:
         cluster.start()
+        cluster.run_rabbitmqctl("trace_on")
         logging.debug("rabbitmq_id is {}".format(instance.cluster.rabbitmq_docker_id))
+        logging.getLogger("pika").propagate = False
         yield cluster
 
     finally:
@@ -68,19 +172,30 @@ def rabbitmq_cluster():
 
 
 @pytest.fixture(autouse=True)
-def rabbitmq_setup_teardown():
+def rabbitmq_monitor():
     logging.debug("RabbitMQ is available - running test")
     instance.query("CREATE DATABASE test")
     instance3.query("CREATE DATABASE test")
-    yield  # run test
+    monitor = RabbitMQMonitor()
+    monitor.start(cluster)
+    yield monitor
     instance.query("DROP DATABASE test SYNC")
     instance3.query("DROP DATABASE test SYNC")
+    monitor.check()
+    monitor.stop()
     cluster.reset_rabbitmq()
 
 
 # Tests
 
-def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
+def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster, rabbitmq_monitor):
+    """
+    This test checks that after inserting through a RabbitMQ Engine, we can keep consuming from it
+    automatically after suspending and resuming the RabbitMQ server. To do that, we need the
+    consumption to be slow enough (hence, the rabbitmq_max_block_size = 1) so that we can check that
+    something has already been consumed before suspending RabbitMQ server, but not so fast so that
+    everything is consumed before suspending and resuming the RabbitMQ server.
+    """
     instance.query(
         """
         DROP TABLE IF EXISTS test.consume;
@@ -90,28 +205,30 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
         CREATE TABLE test.consume (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
-                     rabbitmq_flush_interval_ms=500,
-                     rabbitmq_max_block_size = 100,
-                     rabbitmq_exchange_name = 'producer_reconnect',
-                     rabbitmq_format = 'JSONEachRow',
-                     rabbitmq_num_consumers = 2,
-                     rabbitmq_row_delimiter = '\\n';
+                    rabbitmq_flush_interval_ms=1000,
+                    rabbitmq_max_block_size = 1,
+                    rabbitmq_exchange_name = 'producer_reconnect',
+                    rabbitmq_format = 'JSONEachRow',
+                    rabbitmq_num_consumers = 2,
+                    rabbitmq_row_delimiter = '\\n';
         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
             SELECT * FROM test.consume;
         DROP TABLE IF EXISTS test.producer_reconnect;
         CREATE TABLE test.producer_reconnect (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
-                     rabbitmq_exchange_name = 'producer_reconnect',
-                     rabbitmq_persistent = '1',
-                     rabbitmq_flush_interval_ms=1000,
-                     rabbitmq_format = 'JSONEachRow',
-                     rabbitmq_row_delimiter = '\\n';
+                    rabbitmq_exchange_name = 'producer_reconnect',
+                    rabbitmq_persistent = '1',
+                    rabbitmq_flush_interval_ms=1000,
+                    rabbitmq_max_block_size = 1,
+                    rabbitmq_format = 'JSONEachRow',
+                    rabbitmq_row_delimiter = '\\n';
     """
     )
 
-    messages_num = 200000
-    deadline = time.monotonic() + 180
+    messages_num = 10000
+    rabbitmq_monitor.set_expectations(published=None, delivered=messages_num)
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
         try:
             instance.query(
@@ -125,24 +242,29 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
                 raise
     else:
         pytest.fail(
-            f"Time limit of 180 seconds reached. The query could not be executed successfully."
+            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The query could not be executed successfully."
         )
 
-    deadline = time.monotonic() + 180
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
         number = int(instance.query("SELECT count() FROM test.view"))
         if number != 0:
-            if number == messages_num:
-                pytest.fail("The RabbitMQ messages have been consumed before suspending the RabbitMQ server")
+            logging.debug(f"{number}/{messages_num} before suspending RabbitMQ")
             break
         time.sleep(0.1)
     else:
-        pytest.fail(f"Time limit of 180 seconds reached. The count is still 0.")
+        pytest.fail(f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The count is still 0.")
 
-    suspend_rabbitmq(rabbitmq_cluster)
-    resume_rabbitmq(rabbitmq_cluster)
+    suspend_rabbitmq(rabbitmq_cluster, rabbitmq_monitor)
 
-    deadline = time.monotonic() + 180
+    number = int(instance.query("SELECT count() FROM test.view"))
+    logging.debug(f"{number}/{messages_num} after suspending RabbitMQ")
+    if number == messages_num:
+        pytest.fail("All RabbitMQ messages have been consumed before resuming the RabbitMQ server")
+
+    resume_rabbitmq(rabbitmq_cluster, rabbitmq_monitor)
+
+    deadline = time.monotonic() + CLICKHOUSE_VIEW_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result = instance.query("SELECT count(DISTINCT key) FROM test.view")
         if int(result) == messages_num:
@@ -151,7 +273,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of 180 seconds reached. The result did not match the expected value."
+            f"Time limit of {CLICKHOUSE_VIEW_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
         )
 
     instance.query(
@@ -166,20 +288,27 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     )
 
 
-def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
+def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster, rabbitmq_monitor):
+    """
+    This test checks that after inserting through a RabbitMQ Engine, we can keep consuming from it
+    automatically after suspending and resuming the RabbitMQ server. To do that, we need the
+    consumption to be slow enough (hence, the rabbitmq_max_block_size = 1) so that we can check that
+    something has already been consumed before suspending RabbitMQ server, but not so fast so that
+    everything is consumed before suspending and resuming the RabbitMQ server.
+    """
     instance.query(
         """
         DROP TABLE IF EXISTS test.consumer_reconnect;
         CREATE TABLE test.consumer_reconnect (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
-                     rabbitmq_exchange_name = 'consumer_reconnect',
-                     rabbitmq_num_consumers = 10,
-                     rabbitmq_flush_interval_ms = 100,
-                     rabbitmq_max_block_size = 100,
-                     rabbitmq_num_queues = 10,
-                     rabbitmq_format = 'JSONEachRow',
-                     rabbitmq_row_delimiter = '\\n';
+                    rabbitmq_exchange_name = 'consumer_reconnect',
+                    rabbitmq_num_consumers = 2,
+                    rabbitmq_flush_interval_ms = 1000,
+                    rabbitmq_max_block_size = 1,
+                    rabbitmq_num_queues = 10,
+                    rabbitmq_format = 'JSONEachRow',
+                    rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree
             ORDER BY key;
@@ -188,8 +317,9 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     """
     )
 
-    messages_num = 200000
-    deadline = time.monotonic() + 180
+    messages_num = 10000
+    rabbitmq_monitor.set_expectations(published=None, delivered=messages_num)
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
         try:
             instance.query(
@@ -203,22 +333,27 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
                 raise
     else:
         pytest.fail(
-            f"Time limit of 180 seconds reached. The query could not be executed successfully."
+            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The query could not be executed successfully."
         )
 
-    deadline = time.monotonic() + 180
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
         number = int(instance.query("SELECT count() FROM test.view"))
         if number != 0:
-            if number == messages_num:
-                pytest.fail("The RabbitMQ messages have been consumed before suspending the RabbitMQ server")
+            logging.debug(f"{number}/{messages_num} before suspending RabbitMQ")
             break
         time.sleep(0.1)
     else:
-        pytest.fail(f"Time limit of 180 seconds reached. The count is still 0.")
+        pytest.fail(f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The count is still 0.")
 
-    suspend_rabbitmq(rabbitmq_cluster)
-    resume_rabbitmq(rabbitmq_cluster)
+    suspend_rabbitmq(rabbitmq_cluster, rabbitmq_monitor)
+
+    number = int(instance.query("SELECT count() FROM test.view"))
+    logging.debug(f"{number}/{messages_num} after suspending RabbitMQ")
+    if number == messages_num:
+        pytest.fail("All RabbitMQ messages have been consumed before resuming the RabbitMQ server")
+
+    resume_rabbitmq(rabbitmq_cluster, rabbitmq_monitor)
 
     # while int(instance.query('SELECT count() FROM test.view')) == 0:
     #    time.sleep(0.1)
@@ -226,7 +361,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     # kill_rabbitmq()
     # revive_rabbitmq()
 
-    deadline = time.monotonic() + 180
+    deadline = time.monotonic() + CLICKHOUSE_VIEW_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result = instance.query("SELECT count(DISTINCT key) FROM test.view").strip()
         if int(result) == messages_num:
@@ -235,7 +370,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of 180 seconds reached. The result did not match the expected value."
+            f"Time limit of {CLICKHOUSE_VIEW_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
         )
 
     instance.query(


### PR DESCRIPTION
Backport test_storage_rabbitmq/test_failed_connection from master into 25.4

After many PRs to fix the test in master, let's backport it to 25.4

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
