### PR TITLE
Fix flaky `03443_part_starting_offset`

### DIFF
--- a/tests/queries/0_stateless/03443_part_starting_offset.reference
+++ b/tests/queries/0_stateless/03443_part_starting_offset.reference
@@ -10,7 +10,7 @@ insert into test select number, 10 - number from numbers(5);
 insert into test select number, 10 - number from numbers(5);
 insert into test select number, 10 - number from numbers(5);
 -- verify _part_starting_offset and _part_offset in parent part and projection
-select _part, _part_starting_offset, _part_offset from test order by _part;
+select _part, _part_starting_offset, _part_offset from test order by all;
 all_1_1_0	0	0
 all_1_1_0	0	1
 all_1_1_0	0	2
@@ -36,7 +36,7 @@ all_5_5_0	20	1
 all_5_5_0	20	2
 all_5_5_0	20	3
 all_5_5_0	20	4
-select _part, _part_starting_offset, _part_offset from test where j = 8 order by _part;
+select _part, _part_starting_offset, _part_offset from test where j = 8 order by all;
 all_1_1_0	0	2
 all_2_2_0	5	2
 all_3_3_0	10	2

--- a/tests/queries/0_stateless/03443_part_starting_offset.sql
+++ b/tests/queries/0_stateless/03443_part_starting_offset.sql
@@ -13,8 +13,8 @@ insert into test select number, 10 - number from numbers(5);
 insert into test select number, 10 - number from numbers(5);
 
 -- verify _part_starting_offset and _part_offset in parent part and projection
-select _part, _part_starting_offset, _part_offset from test order by _part;
-select _part, _part_starting_offset, _part_offset from test where j = 8 order by _part;
+select _part, _part_starting_offset, _part_offset from test order by all;
+select _part, _part_starting_offset, _part_offset from test where j = 8 order by all;
 
 -- make sure key analysis works correctly
 select *, _part_starting_offset + _part_offset from test where _part_starting_offset + _part_offset = 8 settings parallel_replicas_local_plan = 0, max_rows_to_read = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This closes #79717

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
