### PR TITLE
Adding new csvToJSONString scalar function

### DIFF
--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -1109,6 +1109,62 @@ Result:
 - [output_format_json_quote_denormals](/operations/settings/formats#output_format_json_quote_denormals)
 
 
+### csvToJSONString {#csvtojsonstring}
+
+Parses a CSV-formatted string into its separate fields and transforms it into a JSON string.
+The first parameter has to be a string constant/literal describing the field names. This is, 
+essentially, the content of a CSV header using the same formatting and separators as the actual
+data. The second parameter is the CSV string that should be parsed into its separate fields. 
+The output then matches the field names to the parsed output fields.
+
+This function is useful if you have a [String](../data-types/string.md) column with still unparsed
+CSV data and need to extract its fields at runtime. The output can be used in conjunction with the
+JSON functions to access specific field information. Note that this processing is more robust
+than simply splitting the string by the delimiting character as it considers these delimiters also
+within quoted strings.
+
+The third function parameter is an optional [String](../data-types/string.md) and allows the
+overriding of CSV format settings per function invocation instance instead of using the query-level
+settings. 
+
+The standard [CSV format settings](../../interfaces/formats/CSV/CSV.md) apply to the CSV parsing 
+of this function.
+
+**Syntax**
+
+```sql
+csvToJSONString(fieldNames, csvString)
+csvToJSONString(fieldNames, csvString, options)
+```
+
+**Arguments**
+
+- `fieldNames` — The field names (essentially CSV header) that should be merged into the JSON output. You can omit fields from the output by providing an empty field name at its position, like `field1,,field3` to omit `field2` in the output. This parameter has to be a non-nullable [String](../data-types/string.md) constant.
+- `csvString` - The name of the [String](../data-types/string.md) column or literal that contains the CSV that should be parsed. The column can be nullable.
+- `options` - Allows overwriting CSV parsing options. There is one additional `detect_types` option that defaults to true. It allows to disable the automatic detection of native JSON data types in the output by setting it to false.
+
+**Returned value**
+
+- JSON representation of the CSV data as a [String](../data-types/string.md). The return value is only nullable if the input `csvString` is also nullable.
+
+**Example**
+
+Query:
+
+```sql
+SELECT csvToJSONString('name,age', 'John,42');
+SELECT csvToJSONString('name|age', 'Clark|15') SETTINGS format_csv_delimiter='|';
+SELECT csvToJSONString('name$age', 'Clark$15', 'format_csv_delimiter="$",detect_types=false');
+```
+
+Result:
+
+```text
+{"age":42,"name":"John"}
+{"age":15,"name":"Clark"}
+{"age":"15","name":"Clark"}
+```
+
 ### JSONArrayLength {#jsonarraylength}
 
 Returns the number of elements in the outermost JSON array. The function returns NULL if input JSON string is invalid.

--- a/src/Client/BuzzHouse/Generator/ServerSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/ServerSettings.cpp
@@ -949,6 +949,7 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
         {{"format_csv_delimiter", CHSetting(nastyStrings, {}, false)},
          {"format_csv_allow_single_quotes", CHSetting(trueOrFalse, {}, false)},
          {"format_csv_allow_double_quotes", CHSetting(trueOrFalse, {}, false)},
+         {"format_csv_custom_quotes", CHSetting(nastyStrings, {}, false)},
          {"format_csv_null_representation", CHSetting(nastyStrings, {}, false)},
          {"format_tsv_null_representation", CHSetting(nastyStrings, {}, false)},
          {"input_format_binary_decode_types_in_binary_format", CHSetting(trueOrFalse, {}, false)},

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -23,6 +23,9 @@ If it is set to true, allow strings in single quotes.
     DECLARE(Bool, format_csv_allow_double_quotes, true, R"(
 If it is set to true, allow strings in double quotes.
 )", 0) \
+    DECLARE(Bool, format_csv_custom_quotes, '\0', R"(
+The character to use as quote charatacter in CSV data instead of standard single or double quotes.
+)", 0) \
     DECLARE(Bool, output_format_csv_serialize_tuple_into_separate_columns, true, R"(
 If it set to true, then Tuples in CSV format are serialized as separate columns (that is, their nesting in the tuple is lost)
 )", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -106,6 +106,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.avro.output_rows_in_file = settings[Setting::output_format_avro_rows_in_file];
     format_settings.csv.allow_double_quotes = settings[Setting::format_csv_allow_double_quotes];
     format_settings.csv.allow_single_quotes = settings[Setting::format_csv_allow_single_quotes];
+    format_settings.csv.custom_quotes = settings[Setting::format_csv_custom_quotes];
     format_settings.csv.serialize_tuple_into_separate_columns = settings[Setting::output_format_csv_serialize_tuple_into_separate_columns];
     format_settings.csv.deserialize_separate_columns_into_tuple = settings[Setting::input_format_csv_deserialize_separate_columns_into_tuple];
     format_settings.csv.crlf_end_of_line = settings[Setting::output_format_csv_crlf_end_of_line];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -166,6 +166,7 @@ struct FormatSettings
         char delimiter = ',';
         bool allow_single_quotes = true;
         bool allow_double_quotes = true;
+        char custom_quotes = '\0';
         bool serialize_tuple_into_separate_columns = true;
         bool deserialize_separate_columns_into_tuple = true;
         bool empty_as_default = false;

--- a/src/Functions/csvToJsonString.cpp
+++ b/src/Functions/csvToJsonString.cpp
@@ -1,0 +1,407 @@
+#include "Columns/ColumnNullable.h"
+#include "Columns/ColumnString.h"
+#include "FunctionHelpers.h"
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <Formats/FormatFactory.h>
+#include <Formats/FormatSettings.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/Context.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/NumberParser.h>
+#include <Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int BAD_ARGUMENTS;
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+namespace
+{
+/** Converts a CSV string to a JSON string.
+  * The function takes two or three arguments:
+  * - fieldNames: A comma-separated string of field names (must be a string constant)
+  * - csvValue: A comma-separated string of values (nullable)
+  * - optional key/value parameters to control the CSV parsing behavior
+  *
+  * The function returns a JSON string where the field names are mapped to their corresponding values.
+  * Unless disabled, the function attempts to detect the types of values and convert them appropriately:
+  * - Numbers are converted to JSON numbers
+  * - "true" and "false" are converted to JSON booleans
+  * - All other values are treated as strings
+  * 
+  * Example:
+  * csvToJSONString('name,age', 'John,42') => '{"name":"John","age":42}'
+  * csvToJSONString('name|age', 'John|42') SETTINGS format_csv_delimiter = '|' => '{"name":"John","age":42}'
+  * csvToJSONString('name$age', 'John$42', 'delimiter="$"') => '{"name":"John","age":42}'
+  */
+class FunctionCsvToJsonString final : public IFunction
+{
+private:
+    ContextPtr context;
+
+    /** Splits a CSV string into a vector of strings according to the provided settings.
+      * @param s The input CSV string to split
+      * @param vectorBuffer A pre-allocated vector to store the split fields
+      * @param settings CSV format settings that control parsing behavior (delimiter, quotes, etc)
+      */
+    static void splitCSV(const StringRef & s, Strings & vectorBuffer, const FormatSettings::CSV & settings)
+    {
+        ReadBufferFromMemory buf(s.data, s.size);
+        vectorBuffer.clear();
+
+        while (!buf.eof())
+        {
+            String field;
+            readCSVString(field, buf, settings);
+            vectorBuffer.push_back(field);
+
+            // Skip delimiter if not at end
+            if (!buf.eof() && *buf.position() == settings.delimiter)
+                ++buf.position();
+        }
+    }
+
+    /** Merges a vector of field names and values into a JSON String.
+      * @param fieldNames A vector of field names
+      * @param fieldValues A vector of field values
+      * @param settings CSV format settings to get the null representation
+      * @param dest A reference to the destination stringstream to store the JSON result
+      * @param detectTypes A boolean flag to determine if types should be detected and converted
+      */
+    static void mergeAsJSON(
+        const Strings & fieldNames,
+        const Strings & fieldValues,
+        const FormatSettings::CSV & settings,
+        std::stringstream & dest,
+        bool detectTypes)
+    {
+        const auto n = std::min(fieldNames.size(), fieldValues.size());
+        Poco::JSON::Object json;
+
+        for (size_t i = 0; i < n; ++i)
+        {
+            if (fieldNames.at(i).empty())
+            {
+                continue;
+            }
+
+            auto key = fieldNames.at(i);
+            auto value = fieldValues.at(i);
+
+            if (value == settings.null_representation)
+            {
+                json.set(key, Poco::Dynamic::Var()); // Sets null value
+            }
+            else
+            {
+                if (detectTypes)
+                {
+                    double num;
+                    if (Poco::NumberParser::tryParseFloat(value, num))
+                    {
+                        json.set(key, num);
+                    }
+                    else if (value == "true")
+                    {
+                        json.set(key, true);
+                    }
+                    else if (value == "false")
+                    {
+                        json.set(key, false);
+                    }
+                    else
+                    {
+                        json.set(key, value);
+                    }
+                }
+                else
+                {
+                    json.set(key, value);
+                }
+            }
+        }
+
+        dest.str(""); // reset std::stringstream
+        json.stringify(dest);
+    }
+
+    /** Parses CSV parsing options from a string and updates the settings.
+      * @param optionsStr The input string containing CSV parsing options
+      * @param settings Reference to the FormatSettings::CSV object to update
+      * @param detectTypes Reference to the boolean flag to update
+      */
+    static void parseOptions(const String & optionsStr, FormatSettings::CSV & settings, bool & detectTypes)
+    {
+        auto config
+            = KeyValuePairExtractorBuilder().withKeyValueDelimiter('=').withItemDelimiters({',', ';'}).withQuotingCharacter('"').buildWithoutEscaping();
+
+        auto keys = ColumnString::create();
+        auto values = ColumnString::create();
+        const auto numPairs = config.extract(optionsStr, keys, values);
+
+        auto toBoolean = [](const StringRef & settingName, const StringRef & value) -> bool
+        {
+            if (value == "true" || value == "on")
+            {
+                return true;
+            }
+            else if (value == "false" || value == "off")
+            {
+                return false;
+            }
+
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS, "Invalid value for {} boolean format setting: {}", settingName.toString(), value.toString());
+        };
+
+        for (size_t i = 0; i < numPairs; ++i)
+        {
+            auto key = Poco::toLower(keys->getDataAt(i).toString());
+            auto value = values->getDataAt(i).toString();
+
+            // remove the format prefix if present
+            if (key.starts_with("format_csv_"))
+            {
+                key = key.substr(11);
+            }
+
+            if (key == "delimiter" || key == "custom_delimiter")
+            {
+                if (value.size() == 1)
+                {
+                    settings.delimiter = value[0];
+                    settings.custom_delimiter = "";
+                }
+                else
+                {
+                    settings.custom_delimiter = value;
+                    settings.delimiter = '\0';
+                }
+            }
+            else if (key == "custom_quotes" || key == "quotes" || key == "quote" || key == "quotechar")
+            {
+                // by default, we allow both single and double quotes...
+                // ...specifying one will disable the other
+                if (value == "'")
+                {
+                    settings.allow_double_quotes = false;
+                    settings.custom_quotes = '\0';
+                }
+                else if (value == "\"")
+                {
+                    settings.allow_single_quotes = false;
+                    settings.custom_quotes = '\0';
+                }
+                else
+                {
+                    if (value.size() == 1)
+                    {
+                        settings.allow_double_quotes = false;
+                        settings.allow_single_quotes = false;
+                        settings.custom_quotes = value.c_str()[0];
+                    }
+                    else
+                    {
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Quote must be a single quote character, got {}", value);
+                    }
+                }
+            }
+            else if (key == "allow_single_quotes" || key == "allowsingleQuotes")
+            {
+                settings.allow_single_quotes = toBoolean(key, value);
+            }
+            else if (key == "allow_double_quotes" || key == "allowdoublequotes")
+            {
+                settings.allow_double_quotes = toBoolean(key, value);
+            }
+            else if (key == "null_representation" || key == "null" || key == "nullrepresentation")
+            {
+                settings.null_representation = value;
+            }
+            else if (key == "detect_types" || key == "detecttypes")
+            {
+                detectTypes = toBoolean(key, value);
+            }
+            else if (key == "trim_whitespaces" || key == "trimwhitespaces")
+            {
+                settings.trim_whitespaces = toBoolean(key, value);
+            }
+            else
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown option: {} in function {}", keys->getDataAt(i).toString(), name);
+            }
+        }
+    }
+
+public:
+    static constexpr auto name = "csvToJSONString";
+
+    explicit FunctionCsvToJsonString(ContextPtr context_)
+        : context(std::move(context_))
+    {
+    }
+    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionCsvToJsonString>(context); }
+
+    String getName() const override { return name; }
+
+    // this function supports two or three arguments
+    size_t getNumberOfArguments() const override { return 0; }
+    virtual bool isVariadic() const override { return true; }
+
+    // we do our own null handling for inputs
+    virtual bool useDefaultImplementationForNulls() const override { return false; }
+
+    // col:0 is the list of field names, col:2 is a String for invocation-specific format options...
+    // ...both must be constants
+    virtual ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0, 2}; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        if (arguments.size() < 2 || arguments.size() > 3)
+        {
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires 2 or 3 arguments, got {}", getName(), arguments.size());
+        }
+
+        // First argument must be a non-null string (field names)
+        if (!WhichDataType(arguments[0]).isStringOrFixedString())
+        {
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "First argument (field names) of function {} must be String constant, got {}",
+                getName(),
+                arguments[0]->getName());
+        }
+
+        // Second argument must be (nullable) string (CSV values) or just NULL (nothing)
+        if (auto type = WhichDataType(removeNullable(arguments[1])); !(type.isStringOrFixedString() || type.isNothing()))
+        {
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Second argument (csv values) of function {} must be String or Null, got {}",
+                getName(),
+                arguments[1]->getName());
+        }
+
+        // Third argument (if present) must be a String (options)
+        if (arguments.size() == 3 && !WhichDataType(removeNullable(arguments[2])).isStringOrFixedString())
+        {
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Third argument (options) of function {} must be String or Null, got {}",
+                getName(),
+                arguments[2]->getName());
+        }
+
+        // function either returns nullable string if CSV input is nullable, or a string otherwise
+        return WhichDataType(arguments[1]).isNullable() ? makeNullable(std::make_shared<DataTypeString>())
+                                                        : std::make_shared<DataTypeString>();
+    }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    {
+        if (!input_rows_count)
+        {
+            return ColumnString::create(); // fast path for empty input
+        }
+
+        FormatSettings::CSV settings = getFormatSettings(context).csv; // default settings
+        std::stringstream dest;
+        bool detectTypes = true;
+
+        // did we receive a non-null option third argument with CSV parsing options?
+        if (arguments.size() == 3)
+        {
+            if (const auto * constOptions = checkAndGetColumnConst<ColumnString>(removeNullable(arguments[2].column).get()); constOptions)
+            {
+                parseOptions(constOptions->getValue<String>(), settings, detectTypes);
+            }
+        }
+
+        // we expect the field names to be a string constant
+        if (const auto * constFieldNames = checkAndGetColumnConst<ColumnString>(arguments[0].column.get()); constFieldNames)
+        {
+            const auto fieldNamesStr = constFieldNames->getDataAt(0);
+            Strings fieldNames;
+            fieldNames.reserve(128);
+
+            // parse out the field names (just once)
+            splitCSV(fieldNamesStr, fieldNames, settings);
+
+            // buffer for split CSV values
+            Strings vectorBuffer;
+            vectorBuffer.reserve(128);
+
+            // csv value also provided as a string constant?
+            if (const auto * constCSV = checkAndGetColumnConst<ColumnString>(arguments[1].column.get()); constCSV)
+            {
+                splitCSV(constCSV->getValue<String>(), vectorBuffer, settings);
+                mergeAsJSON(fieldNames, vectorBuffer, settings, dest, detectTypes);
+                return DataTypeString().createColumnConst(input_rows_count, dest.str());
+            }
+
+            // csv value provided as a string (or nullable string) column
+            if (const auto * colCSV = checkAndGetColumn<ColumnString>(removeNullable(arguments[1].column).get()))
+            {
+                // Check if input is nullable to determine result column type
+                const auto * colNullable = typeid_cast<const ColumnNullable *>(arguments[1].column.get());
+                const auto * null_map = colNullable ? &colNullable->getNullMapData() : nullptr;
+
+                // Create appropriate string result column type (either nullable or not)
+                MutableColumnPtr resultCol;
+                if (colNullable)
+                {
+                    resultCol = ColumnNullable::create(ColumnString::create(), ColumnUInt8::create());
+                }
+                else
+                {
+                    resultCol = ColumnString::create();
+                }
+
+                for (size_t i = 0; i < input_rows_count; ++i)
+                {
+                    if (null_map && (*null_map)[i])
+                    {
+                        resultCol->insertDefault();
+                    }
+                    else
+                    {
+                        StringRef input = colCSV->getDataAt(i);
+                        splitCSV(input, vectorBuffer, settings);
+                        mergeAsJSON(fieldNames, vectorBuffer, settings, dest, detectTypes);
+                        resultCol->insertData(dest.str().data(), dest.str().length());
+                    }
+                }
+
+                return resultCol;
+            }
+
+            // col:1 (csv input) is neither String nor ConstString: must be NULL Constant -> return NULL column
+            auto null_col = ColumnNullable::create(ColumnString::create(), ColumnUInt8::create());
+            null_col->insertDefault();
+            return ColumnConst::create(std::move(null_col), input_rows_count);
+        }
+
+        // we should never get here as the framework ensures that col:0 and col:2 are constant
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Function {} failed to validate arguments", getName());
+    }
+};
+
+}
+
+REGISTER_FUNCTION(csvToJSONString)
+{
+    factory.registerFunction<FunctionCsvToJsonString>();
+}
+}

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -637,7 +637,7 @@ void readStringUntilEquals(String & s, ReadBuffer & buf);
 /** Read string in CSV format.
   * Parsing rules:
   * - string could be placed in quotes; quotes could be single: ' if FormatSettings::CSV::allow_single_quotes is true
-  *   or double: " if FormatSettings::CSV::allow_double_quotes is true;
+  *   or double: " if FormatSettings::CSV::allow_double_quotes is true or if FormatSettings::CSV::custom_quotes is set;
   * - or string could be unquoted - this is determined by first character;
   * - if string is unquoted, then:
   *     - If settings.custom_delimiter is not specified, it is read until next settings.delimiter, either until end of line (CR or LF) or until end of stream;

--- a/tests/queries/0_stateless/03442_csvToJSONString.reference
+++ b/tests/queries/0_stateless/03442_csvToJSONString.reference
@@ -1,0 +1,26 @@
+1	{"id":"Key1","name":"John","property":42}
+1	{"id":"Key2","name":"Bob","property":true}
+1	{"id":"Key3","name":"Alice","property":false}
+1	{"id":"Key4","name":"Charlie","property":"something"}
+2	{"id":"Key5","name":"Rudolf","property":17}
+3	{"id":"Key5","name":"Rudolf","property":17}
+4	{"id":"Key5","name":"Rudolf","property":"17"}
+5	{"name":"John","property":42}
+5	{"name":"Bob","property":true}
+6	{"id":"Key1","name":"John"}
+6	{"id":"Key2","name":"Bob"}
+7	{"id":"Key1","property":42}
+7	{"id":"Key2","property":true}
+8	{"id":"The,key,with\\"quotes","name":",;\'","property":null}
+9	{"f1":"Key3","f2":false,"f3":"Alice"}
+10	{}
+11	{"id":3,"name":"end quote missing","property":true}
+12	{"id":"foo","name":"bar","property":""}
+13	String
+14	{"col1":"Field1.0","col2":"Field1.1","col3":null}
+14	{"col1":"Field2.0","col2":null,"col3":"Field2.2"}
+14	{"col1":null,"col2":"Field3.1","col3":"Field3.2"}
+14	\N
+15	\N
+16	Nullable(String)
+17	{"col1":"fiel1","col2":"field$2","col3":42,"col4":null}

--- a/tests/queries/0_stateless/03442_csvToJSONString.sql
+++ b/tests/queries/0_stateless/03442_csvToJSONString.sql
@@ -1,0 +1,68 @@
+DROP TABLE IF EXISTS csv_to_json_test;
+
+----------------------------------------------------------------------------------------------
+-- first test with non-nullable String data
+----------------------------------------------------------------------------------------------
+CREATE TABLE csv_to_json_test (entry Int32, csv String) ENGINE = Memory;
+
+INSERT INTO csv_to_json_test
+VALUES
+    (1, 'Key1,42,John'),
+    (2, 'Key2,true,Bob'),
+    (3, 'Key3,false,Alice'),
+    (4, 'Key4,something,Charlie'),
+    (5, 'Key5|17|Rudolf'),
+    (6, '"The,key,with""quotes","\\N",",;''"');
+
+-- with default and with SETTINGS override
+SELECT 1 as T, csvToJSONString ('id,property,name', csv) AS json FROM csv_to_json_test WHERE entry < 5 ORDER BY entry;
+SELECT 2 as T, csvToJSONString ('id|property|name', csv, 'delimiter="|"') AS json FROM csv_to_json_test WHERE entry == 5;
+SELECT 3 as T, csvToJSONString ('id|property|name', csv, 'delimiter="|",detectTypes=true') AS json FROM csv_to_json_test WHERE entry == 5;
+SELECT 4 as T, csvToJSONString ('id|property|name', csv, 'delimiter="|",detectTypes=false') AS json FROM csv_to_json_test WHERE entry == 5;
+
+-- skip fields in the output
+SELECT 5 as T, csvToJSONString (',property,name', csv) AS json FROM csv_to_json_test WHERE entry < 3 ORDER BY entry;
+SELECT 6 as T, csvToJSONString ('id,,name', csv) AS json FROM csv_to_json_test WHERE entry < 3 ORDER BY entry;
+SELECT 7 as T, csvToJSONString ('id,property', csv) AS json FROM csv_to_json_test WHERE entry < 3 ORDER BY entry;
+
+-- really messed-up but valid CSV content
+SELECT 8 as T, csvToJSONString ('id,property,name', csv) AS json FROM csv_to_json_test WHERE entry == 6;
+SELECT 9 as T, csvToJSONString ('f1,f2,f3,f4,f5', csv) AS json FROM csv_to_json_test WHERE entry == 3;
+SELECT 10 as T, csvToJSONString ('id,property,name', '') AS json;
+SELECT 11 as T, csvToJSONString ('id,property,name', '3,true,"end quote missing') AS json;
+
+-- empty (not null) CSV fields are empty JSON strings (here property)
+SELECT 12 as T, csvToJSONString ('id,property,name', 'foo,,bar') AS json;
+
+-- should be just "String" (output is non-nullable if input is non-nullable)
+SELECT 13 as T, toTypeName(csvToJSONString ('id,property,name', csv)) AS type FROM csv_to_json_test LIMIT 1;
+
+DROP TABLE csv_to_json_test;
+
+----------------------------------------------------------------------------------------------
+-- second, try with nullable string input
+----------------------------------------------------------------------------------------------
+CREATE TABLE csv_to_json_test_nullable (entry Int32, csv Nullable(String)) ENGINE = Memory;
+
+INSERT INTO csv_to_json_test_nullable
+VALUES
+    (1, 'Field1.0,Field1.1,\\N'),
+    (2, 'Field2.0,\\N,Field2.2'),
+    (3, '\\N,Field3.1,Field3.2'),
+    (4, NULL);
+
+-- ensure that null-values in CSV (\\N) are detected as well as full CSV can be NULL
+SELECT 14 as T, csvToJSONString('col1,col2,col3', csv) AS JSON from csv_to_json_test_nullable;
+SELECT 15 as T, csvToJSONString('c1,c2', NULL) AS JSON;
+
+-- should be "Nullable(String)" (output is nullable if input is nullable)
+SELECT 16 as T, toTypeName(csvToJSONString ('id,property,name', csv)) AS type FROM csv_to_json_test_nullable LIMIT 1;
+
+DROP TABLE csv_to_json_test_nullable;
+
+----------------------------------------------------------------------------------------------
+-- third, more on options
+----------------------------------------------------------------------------------------------
+SELECT 17 as T, csvToJSONString ('col1!col2!col3!col4', 
+                                 '$fiel1$!$field$$2$!42!NIL', 
+                                 'delimiter="!",custom_quotes="$",format_csv_null_representation="NIL"') AS json;


### PR DESCRIPTION
This PR is adding a new `csvToJSONString` scalar function, addressing our following use case:
We store CSV data as a single-column string table in Clickhouse, as the data was (in these scenarios) not parsed when ingested into the system (I know, suboptimal in the first place). The data is potentially rarely read, was machine-generated, and therefore just ingested to be on the "safe" side if it ever needs to be analyzed, trying to avoid the parsing overhead at ingestion time.
Long story short, we:
1) Do not have the original CSV header - this needs to be provided and applied at query runtime
2) Store the whole CSV line as a single string (column)
3) Want to extract all (or a subset) of that CSV string at query time by converting it into a JSON string and then using JSONExtract or similar to gain access to the information

The field names (CSV header) are provided as a first parameter, while the CSV data row (or literal) is provided as the second parameter.

There actually may be multiple CSV string columns in our table, each using slightly different CSV format settings. While the function uses the system settings (or query-level overrides) for CSV parsing, we need the capability to support two different settings in the same query. That is why the scalar function supports an optional third parameter, allowing for overriding parameters on the function-invocation level.

### Changelog category (leave one):
New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
New csvToJSONString scalar function to transform CSV data into JSON strings.

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)