### PR TITLE
Pretty print for clickhouse-extract-from-config

### DIFF
--- a/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.reference
+++ b/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.reference
@@ -6,3 +6,11 @@ Not found: merge_tree.anything_yaml
 
 File not found: I hope such path will never exists, since it does not even contain a single slash
 I hope such path will never exists, since it does not even contain a single slash
+# pretty xml
+# merge_tree.comment
+xml
+# merge_tree
+<merge_tree>
+    <comment>xml</comment>
+</merge_tree>
+Not found: merge_tree.anything_yaml

--- a/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh
+++ b/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh
@@ -18,3 +18,10 @@ $CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_yaml --config $
 
 $CLICKHOUSE_BINARY extract-from-config --key include_from --config ${prefix}_bad_include_from.xml |& grep -o 'File not found: I hope such path will never exists, since it does not even contain a single slash'
 $CLICKHOUSE_BINARY extract-from-config --key include_from --config ${prefix}_bad_include_from.xml --try
+
+echo "# pretty xml"
+echo "# merge_tree.comment"
+$CLICKHOUSE_BINARY extract-from-config --key merge_tree.comment --config $prefix.xml --pretty
+echo "# merge_tree"
+$CLICKHOUSE_BINARY extract-from-config --key merge_tree --config $prefix.xml --pretty
+$CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_yaml --config $prefix.yaml --pretty |& grep -o 'Not found: merge_tree.anything_yaml'


### PR DESCRIPTION
For example:

```bash
>>> clickhouse-extract-from-config -c preprocessed_config.xml -k zookeeper --pretty
<zookeeper>
    <identity>XXX</identity>
    <node>
        <host>keeper</host>
        <port>9181</port>
    </node>
</zookeeper>

# without pretty
>>> clickhouse-extract-from-config -c preprocessed_config.xml -k zookeeper                                                               

        XXX
        
            keeper
            9181
        
    

```


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Pretty print for clickhouse-extract-from-config

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Refs: https://github.com/ClickHouse/ClickHouse/issues/78206