### PR TITLE
fix flaky test 03442_alter_delete_empty_part_rmt

### DIFF
--- a/tests/queries/0_stateless/03442_alter_delete_empty_part_rmt.sql
+++ b/tests/queries/0_stateless/03442_alter_delete_empty_part_rmt.sql
@@ -15,7 +15,7 @@ ALTER TABLE t_delete_empty_part_rmt DELETE WHERE a = 2 OR b < 500;
 
 SELECT count() FROM t_delete_empty_part_rmt;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     part_name,


### PR DESCRIPTION
Fix flaky test `03442_alter_delete_empty_part_rmt` which was added in #79307. Try flushing just the `part_log` only instead of doing a flush of all logs before querying.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
