### PR TITLE
Replacing PROJECT_SOURCE_DIR with ClickHouse_SOURCE_DIR

### DIFF
--- a/contrib/zlib-ng-cmake/CMakeLists.txt
+++ b/contrib/zlib-ng-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (SOURCE_DIR ${PROJECT_SOURCE_DIR}/contrib/zlib-ng)
+set (SOURCE_DIR ${ClickHouse_SOURCE_DIR}/contrib/zlib-ng)
 
 add_definitions(-DZLIB_COMPAT)
 add_definitions(-DWITH_GZFILEOP)

--- a/contrib/zlib-ng-cmake/CMakeLists.txt
+++ b/contrib/zlib-ng-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (SOURCE_DIR ${ClickHouse_SOURCE_DIR}/contrib/zlib-ng)
+set (SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/zlib-ng")
 
 add_definitions(-DZLIB_COMPAT)
 add_definitions(-DWITH_GZFILEOP)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Replacing _PROJECT_SOURCE_DIR_ with a unified _ClickHouse_SOURCE_DIR_ variable. As in other files CMakeLists.txt a unified variable _ClickHouse_SOURCE_DIR_  is used from the contrib folder, so you need to change it here as well.