### PR TITLE
Fix `02354_vector_search_reference_vector_types` for parallel replicas

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_reference_vector_types.sql
+++ b/tests/queries/0_stateless/02354_vector_search_reference_vector_types.sql
@@ -3,8 +3,9 @@
 
 -- Tests that vector search queries work with reference vectors of different data types.
 
-set allow_experimental_vector_similarity_index = 1;
+SET allow_experimental_vector_similarity_index = 1;
 SET enable_analyzer = 1;
+SET parallel_replicas_local_plan=1; -- this setting is randomized, set it explicitly to have local plan for parallel replicas
 
 DROP TABLE IF EXISTS tab_f32;
 DROP TABLE IF EXISTS tab_bf16;


### PR DESCRIPTION
Test verifies the plan for a vector search query. Explicitly set `parallel_replicas_local_plan` to get determinism in parallel replicas test suite.
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)