### PR TITLE
Add `enable_user_name_access_type` setting for compatibility.

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -306,6 +306,9 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
     setSettingsConstraintsReplacePrevious(config_.getBool("access_control_improvements.settings_constraints_replace_previous", true));
     setTableEnginesRequireGrant(config_.getBool("access_control_improvements.table_engines_require_grant", false));
 
+    /// Set `true` by default because the feature is backward incompatible only when older version replicas are in the same cluster.
+    setEnableUserNameAccessType(config_.getBool("access_control_improvements.enable_user_name_access_type", true));
+
     addStoragesFromMainConfig(config_, config_path_, get_zookeeper_function_);
 
     role_cache = std::make_unique<RoleCache>(*this, config_.getInt("access_control_improvements.role_cache_expiration_time_seconds", 600));
@@ -771,6 +774,15 @@ int AccessControl::getBcryptWorkfactor() const
     return bcrypt_workfactor;
 }
 
+void AccessControl::setEnableUserNameAccessType(bool enable_user_name_access_type_)
+{
+    enable_user_name_access_type = enable_user_name_access_type_;
+}
+
+bool AccessControl::isEnabledUserNameAccessType() const
+{
+    return enable_user_name_access_type;
+}
 
 std::shared_ptr<const ContextAccess> AccessControl::getContextAccess(const ContextAccessParams & params) const
 {

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -173,7 +173,7 @@ public:
     void setBcryptWorkfactor(int workfactor_);
     int getBcryptWorkfactor() const;
 
-    /// Compatability setting
+    /// Compatibility setting
     void setEnableUserNameAccessType(bool enable_user_name_access_type_);
     bool isEnabledUserNameAccessType() const;
 

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -173,6 +173,10 @@ public:
     void setBcryptWorkfactor(int workfactor_);
     int getBcryptWorkfactor() const;
 
+    /// Compatability setting
+    void setEnableUserNameAccessType(bool enable_user_name_access_type_);
+    bool isEnabledUserNameAccessType() const;
+
     /// Enables logic that users without permissive row policies can still read rows using a SELECT query.
     /// For example, if there are two users A, B and a row policy is defined only for A, then
     /// if this setting is true the user B will see all rows, and if this setting is false the user B will see no rows.
@@ -284,6 +288,7 @@ private:
     std::atomic<AuthenticationType> default_password_type = AuthenticationType::SHA256_PASSWORD;
     std::atomic_bool allow_experimental_tier_settings = true;
     std::atomic_bool allow_beta_tier_settings = true;
+    std::atomic_bool enable_user_name_access_type = true;
 };
 
 }

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -1,5 +1,6 @@
 #include <Access/AccessControl.h>
 #include <Access/Common/AccessRightsElement.h>
+#include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
@@ -154,7 +155,7 @@ void AccessRightsElement::formatONClause(WriteBuffer & buffer, bool hilite) cons
             && !access_control.isEnabledUserNameAccessType())
         {
             if (!anyParameter())
-                getLogger("AccessRightsElement")->warning(
+                LOG_WARNING(getLogger("AccessRightsElement"),
                     "Converting {} to *.* because the setting `enable_user_name_access_type` is `false`. "
                     "Consider turning this setting on, if your cluster contains no replicas older than 25.1",
                     parameter);

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -1,7 +1,9 @@
+#include <Access/AccessControl.h>
 #include <Access/Common/AccessRightsElement.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
+#include <Interpreters/Context.h>
 #include <Parsers/IAST.h>
 
 
@@ -139,16 +141,36 @@ void AccessRightsElement::formatColumnNames(WriteBuffer & buffer) const
 
 void AccessRightsElement::formatONClause(WriteBuffer & buffer, bool hilite) const
 {
+    const auto context = Context::getGlobalContextInstance();
+    const auto & access_control = context->getAccessControl();
+
     buffer << (hilite ? IAST::hilite_keyword : "") << "ON " << (hilite ? IAST::hilite_none : "");
     if (isGlobalWithParameter())
     {
-        if (anyParameter())
-            buffer << "*";
+        /// Special check for backward compatibility.
+        /// If `enable_user_name_access_type` is set to false, we will dump `GRANT CREATE USER ON *` as `GRANT CREATE USER ON *.*`.
+        /// This will allow us to run old replicas in the same cluster.
+        if (access_flags.getParameterType() == AccessFlags::USER_NAME
+            && !access_control.isEnabledUserNameAccessType())
+        {
+            if (!anyParameter())
+                getLogger("AccessRightsElement")->warning(
+                    "Converting {} to *.* because the setting `enable_user_name_access_type` is `false`. "
+                    "Consider turning this setting on, if your cluster contains no replicas older than 25.1",
+                    parameter);
+
+            buffer << "*.*";
+        }
         else
         {
-            buffer << backQuoteIfNeed(parameter);
-            if (wildcard)
+            if (anyParameter())
                 buffer << "*";
+            else
+            {
+                buffer << backQuoteIfNeed(parameter);
+                if (wildcard)
+                    buffer << "*";
+            }
         }
     }
     else if (anyDatabase())

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -156,10 +156,10 @@ void AccessRightsElement::formatONClause(WriteBuffer & buffer, bool hilite) cons
         /// If `enable_user_name_access_type` is set to false, we will dump `GRANT CREATE USER ON *` as `GRANT CREATE USER ON *.*`.
         /// This will allow us to run old replicas in the same cluster.
         if (access_flags.getParameterType() == AccessFlags::USER_NAME
-            && is_enabled_user_name_access_type)
+            && !is_enabled_user_name_access_type)
         {
             if (!anyParameter())
-                LOG_INFO(getLogger("AccessRightsElement"),
+                LOG_WARNING(getLogger("AccessRightsElement"),
                     "Converting {} to *.* because the setting `enable_user_name_access_type` is `false`. "
                     "Consider turning this setting on, if your cluster contains no replicas older than 25.1",
                     parameter);

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -159,7 +159,7 @@ void AccessRightsElement::formatONClause(WriteBuffer & buffer, bool hilite) cons
             && is_enabled_user_name_access_type)
         {
             if (!anyParameter())
-                LOG_WARNING(getLogger("AccessRightsElement"),
+                LOG_INFO(getLogger("AccessRightsElement"),
                     "Converting {} to *.* because the setting `enable_user_name_access_type` is `false`. "
                     "Consider turning this setting on, if your cluster contains no replicas older than 25.1",
                     parameter);

--- a/tests/integration/test_enable_user_name_access_type/configs/access_control_settings.xml
+++ b/tests/integration/test_enable_user_name_access_type/configs/access_control_settings.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <access_control_improvements>
+        <enable_user_name_access_type>0</enable_user_name_access_type>
+    </access_control_improvements>
+</clickhouse>

--- a/tests/integration/test_enable_user_name_access_type/test.py
+++ b/tests/integration/test_enable_user_name_access_type/test.py
@@ -1,0 +1,28 @@
+from helpers.cluster import ClickHouseCluster
+
+
+def test_startup_scripts():
+    cluster = ClickHouseCluster(__file__)
+
+    node = cluster.add_instance(
+        "node",
+        main_configs=[
+            "configs/access_control_settings.xml",
+        ],
+        macros={"replica": "node", "shard": "node"},
+        with_zookeeper=True,
+    )
+
+    try:
+        cluster.start()
+        node.query("CREATE USER foobar")
+        node.query("GRANT CREATE USER ON * TO foobar")
+        assert (
+                node.query(
+                    "SHOW GRANTS FOR foobar"
+                )
+                == "GRANT CREATE USER ON *.* TO foobar\n"
+        )
+        node.query("DROP USER foobar")
+    finally:
+        cluster.shutdown()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `access_control_improvements.enable_user_name_access_type` setting. This setting allows enabling/disabling of precise grants for users/roles, introduced in https://github.com/ClickHouse/ClickHouse/pull/72246. You may want to turn this setting off in case you have a cluster with the replicas older than 25.1


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
