### PR TITLE
try to fix flaky test test_database_glue

### DIFF
--- a/tests/integration/compose/docker_compose_glue_catalog.yml
+++ b/tests/integration/compose/docker_compose_glue_catalog.yml
@@ -14,7 +14,6 @@ services:
       start_period: 30s
   minio:
     image: minio/minio
-    container_name: minio
     environment:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123

--- a/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
@@ -35,7 +35,6 @@ services:
 
   minio:
     image: minio/minio
-    container_name: minio
     environment:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -35,7 +35,6 @@ services:
       start_period: 30s
   minio:
     image: minio/minio
-    container_name: minio
     environment:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd


### PR DESCRIPTION
Try to fix `test_database_glue`. At least a couple of test failures are because of container name already existing. Avoid specifying the container_name explicitly for `minio` services across a few docker_compose files. I wasn't able to reproduce this locally (running multiple counts and in parallel and grouping a few tests together). Though, I suspect that it might be a race that happens on CI due to left over containers from previous tests that use the minio setup. For example, if you look at the logs below, `test_database_iceberg` runs before `test_database_glue`.

- https://s3.amazonaws.com/clickhouse-test-reports/PRs/79556/f748c86e7d6c75150435178cda8d5e133eddc2e9//integration_tests_aarch64_distributed_plan_4_4/integration_run_parallel1_0.log
- https://s3.amazonaws.com/clickhouse-test-reports/PRs/79773/9108c17601e1c60f36ca9713a937e0755f4aff51//integration_tests_release_4_4/integration_run_parallel1_0.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
