### PR TITLE
use python instead of sed in test script

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1174,7 +1174,10 @@ class MergeTreeSettingsRandomizer:
 
 
 def replace_in_file(filename, what, with_what):
-    os.system(f"LC_ALL=C sed -i -e 's|{what}|{with_what}|g' {filename}")
+    with open(filename, "rb") as f:
+        data = f.read()
+    with open(filename, "wb") as f:
+        f.write(data.replace(what.encode(), with_what.encode()))
 
 
 class TestResult:


### PR DESCRIPTION
On BSD like platforms(MacOS) `sed -i` requires an explicit arg, so currently test run produces a garbage `*.stdout-e` file
for every executed test.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
