### PR TITLE
Fix LogSeriesLimiter cleanup logic to run only once per interval

### DIFF
--- a/src/Common/LoggingFormatStringHelpers.cpp
+++ b/src/Common/LoggingFormatStringHelpers.cpp
@@ -101,7 +101,7 @@ LogSeriesLimiter::LogSeriesLimiter(LoggerPtr logger_, size_t allowed_count_, tim
 
     if (last_cleanup < cutoff_time) // will also be triggered when last_cleanup is zero
     {        
-        std::erase_if(series_records, [old](const auto & elem) { return get<0>(elem.second) < cutoff_time; });
+        std::erase_if(series_records, [cutoff_time](const auto & elem) { return get<0>(elem.second) < cutoff_time; });
         last_cleanup = now;
     }
 

--- a/src/Common/LoggingFormatStringHelpers.cpp
+++ b/src/Common/LoggingFormatStringHelpers.cpp
@@ -90,20 +90,18 @@ LogSeriesLimiter::LogSeriesLimiter(LoggerPtr logger_, size_t allowed_count_, tim
     }
 
     time_t now = time(nullptr);
+    static const time_t cleanup_delay_s = 600;
+    time_t cutoff_time = now - cleanup_delay_s; // entries older than this are stale
+
     UInt128 name_hash = sipHash128(logger->name().c_str(), logger->name().size());
 
     std::lock_guard lock(mutex);
 
-    if (last_cleanup == 0)
-        last_cleanup = now;
-
     auto & series_records = getSeriesRecords();
 
-    static const time_t cleanup_delay_s = 600;
-    if (last_cleanup + cleanup_delay_s >= now)
-    {
-        time_t old = now - cleanup_delay_s;
-        std::erase_if(series_records, [old](const auto & elem) { return get<0>(elem.second) < old; });
+    if (last_cleanup < cutoff_time) // will also be triggered when last_cleanup is zero
+    {        
+        std::erase_if(series_records, [old](const auto & elem) { return get<0>(elem.second) < cutoff_time; });
         last_cleanup = now;
     }
 

--- a/src/Common/LoggingFormatStringHelpers.cpp
+++ b/src/Common/LoggingFormatStringHelpers.cpp
@@ -100,7 +100,7 @@ LogSeriesLimiter::LogSeriesLimiter(LoggerPtr logger_, size_t allowed_count_, tim
     auto & series_records = getSeriesRecords();
 
     if (last_cleanup < cutoff_time) // will also be triggered when last_cleanup is zero
-    {        
+    {
         std::erase_if(series_records, [cutoff_time](const auto & elem) { return get<0>(elem.second) < cutoff_time; });
         last_cleanup = now;
     }


### PR DESCRIPTION
### Changelog category (leave one):

* Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Prevent `LogSeriesLimiter` from doing cleanup on every construction, avoiding lock contention and performance regressions in high-concurrency scenarios.

### Documentation entry for user-facing changes

In the last months, the use of the logging rate limiter (`LogSeriesLimiter`) was expanded to more parts of the code. However, due to a mistake in its cleanup check, the removal of old entries was being triggered **every single time** a limiter was created. This caused heavy lock contention and a noticeable slowdown under high-concurrency insert + logging workloads—users saw performance regressions when upgrading from 24.8 to 25.3.

Backports will likely be needed; more details to follow.