### PR TITLE
add a bound check to ColumnString before resizing

### DIFF
--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -41,10 +41,6 @@ ColumnString::ColumnString(const ColumnString & src)
             last_offset, chars.size());
 }
 
-#if !defined(DEBUG_OR_SANITIZER_BUILD)
-void ColumnString::insertManyFrom(const IColumn & src, size_t position, size_t length)
-#else
-
 void ColumnString::insert(const Field & x)
 {
     const String & s = x.safeGet<String>();
@@ -61,6 +57,9 @@ void ColumnString::insert(const Field & x)
     offsets.push_back(new_size);
 }
 
+#if !defined(DEBUG_OR_SANITIZER_BUILD)
+void ColumnString::insertManyFrom(const IColumn & src, size_t position, size_t length)
+#else
 void ColumnString::doInsertManyFrom(const IColumn & src, size_t position, size_t length)
 #endif
 {

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -53,7 +53,7 @@ void ColumnString::insert(const Field & x)
 
     /// First check if new_size won't overflow before resizing.
     if (size_to_append > std::numeric_limits<size_t>::max() - old_size)
-        throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "ColumnString array size too large for resizing, it will overflow.");
+        throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "ColumnString array size is too large for resizing, it will overflow.");
 
     const size_t new_size = old_size + size_to_append;
     chars.resize(new_size);

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -21,11 +21,6 @@ class SipHash;
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 class Arena;
 
 /** Column for String values.
@@ -136,21 +131,7 @@ public:
         return sizeAt(n) == 1;
     }
 
-    void insert(const Field & x) override
-    {
-        const String & s = x.safeGet<String>();
-        const size_t old_size = chars.size();
-        const size_t size_to_append = s.size() + 1;
-
-        /// First check if new_size won't overflow before resizing.
-        if (size_to_append > std::numeric_limits<size_t>::max() - old_size)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "ColumnString Field size too large for resizing, it will overflow.");
-
-        const size_t new_size = old_size + size_to_append;
-        chars.resize(new_size);
-        memcpy(chars.data() + old_size, s.c_str(), size_to_append);
-        offsets.push_back(new_size);
-    }
+    void insert(const Field & x) override;
 
     bool tryInsert(const Field & x) override
     {


### PR DESCRIPTION
It's possible to crash if the new size to resize overflows. For example:
```
0. ./build_docker/./src/Common/SignalHandlers.cpp:108: signalHandler(int, siginfo_t*, void*)
1. ?
2. ./build_docker/./contrib/jemalloc/src/pac.c:166: pac_alloc_impl.llvm.11250059452872311555
3. ./build_docker/./contrib/jemalloc/src/arena.c:842: arena_slab_alloc
4. ./build_docker/./contrib/jemalloc/src/arena.c:1037: arena_cache_bin_fill_small
5. ./build_docker/./contrib/jemalloc/src/tcache.c:238: tcache_alloc_small_hard
6. ./build_docker/./contrib/jemalloc/src/jemalloc.c:2722: malloc_default
7. ./build_docker/./src/Common/Allocator.cpp:150: Allocator<false, false>::alloc(unsigned long, unsigned long)
8. void DB::PODArrayBase<8ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::reserveForNextSize<>()
9. ./src/Columns/ColumnString.h:134: DB::ColumnString::insert(DB::Field const&)
10. ./build_docker/./src/DataTypes/IDataType.cpp:59: DB::IDataType::createColumnConst(unsigned long, DB::Field const&) const
11. DB::FunctionComparison<DB::EqualsOp, DB::NameEquals>::executeImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const
... <TRUNCATED for brevity>
26. DB::FunctionComparison<DB::EqualsOp, DB::NameEquals>::executeImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const
```
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
