### PR TITLE
Tiny vector search cleanups

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/annindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/annindexes.md
@@ -179,7 +179,7 @@ The default value of the setting 256 works well in the majority of use cases.
 Higher setting values mean better accuracy at the cost of slower performance.
 
 If the query can use a vector similarity index, ClickHouse checks that the LIMIT `<N>` provided in SELECT queries is within reasonable bounds.
-More specifically, an error is returned if `<N>` is bigger than the value of setting [max_limit_for_ann_queries](../../../operations/settings/settings.md#max_limit_for_ann_queries) with default value 100.
+More specifically, an error is returned if `<N>` is bigger than the value of setting [max_limit_for_vector_search_queries](../../../operations/settings/settings.md#max_limit_for_vector_search_queries) with default value 100.
 Too large LIMITs can slow down searches and usually indicate a usage error.
 
 To check if a SELECT query uses a vector similarity index, you can prefix the query with `EXPLAIN indexes = 1`.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6580,7 +6580,7 @@ Allow experimental vector similarity index
     DECLARE(Bool, allow_experimental_codecs, false, R"(
 If it is set to true, allow to specify experimental compression codecs (but we don't have those yet and this option does nothing).
 )", EXPERIMENTAL) \
-    DECLARE(UInt64, max_limit_for_ann_queries, 1'000'000, R"(
+    DECLARE(UInt64, max_limit_for_vector_search_queries, 1'000, R"(
 SELECT queries with LIMIT bigger than this setting cannot use vector similarity indices. Helps to prevent memory overflows in vector similarity indices.
 )", EXPERIMENTAL) \
     DECLARE(UInt64, hnsw_candidate_list_size_for_search, 256, R"(
@@ -6798,6 +6798,7 @@ Experimental tsToGrid aggregate function for Prometheus-like timeseries resampli
     MAKE_OBSOLETE(M, Bool, allow_experimental_annoy_index, false) \
     MAKE_OBSOLETE(M, UInt64, max_threads_for_annoy_index_creation, 4) \
     MAKE_OBSOLETE(M, Int64, annoy_index_search_k_nodes, -1) \
+    MAKE_OBSOLETE(M, Int64, max_limit_for_ann_queries, -1) \
     MAKE_OBSOLETE(M, Bool, allow_experimental_usearch_index, false) \
     MAKE_OBSOLETE(M, Bool, optimize_move_functions_out_of_any, false) \
     MAKE_OBSOLETE(M, Bool, allow_experimental_undrop_table_query, true) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -80,6 +80,8 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"output_format_pretty_glue_chunks", "0", "auto", "A new setting to make Pretty formats prettier."},
             {"distributed_cache_read_only_from_current_az", true, true, "New setting"},
             {"parallel_hash_join_threshold", 0, 100'000, "New setting"},
+            {"max_limit_for_ann_queries", 1'000, 0, "Obsolete setting"},
+            {"max_limit_for_vector_search_queries", 1'000, 1'000, "New setting"},
             {"min_os_cpu_wait_time_ratio_to_throw", 0, 0, "Setting values were changed and backported to 25.4"},
             {"max_os_cpu_wait_time_ratio_to_throw", 0, 0, "Setting values were changed and backported to 25.4"},
             {"make_distributed_plan", 0, 0, "New experimental setting."},

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -31,7 +31,7 @@ struct Optimization
 {
     struct ExtraSettings
     {
-        size_t max_limit_for_ann_queries;
+        size_t max_limit_for_vector_search_queries;
         size_t use_index_for_in_with_subqueries_max_values;
         SizeLimits network_transfer_limits;
     };

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -41,7 +41,7 @@ namespace Setting
     extern const SettingsMaxThreads max_threads;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsString force_optimize_projection_name;
-    extern const SettingsUInt64 max_limit_for_ann_queries;
+    extern const SettingsUInt64 max_limit_for_vector_search_queries;
     extern const SettingsUInt64 query_plan_max_optimizations_to_apply;
     extern const SettingsBool query_plan_optimize_lazy_materialization;
     extern const SettingsUInt64 query_plan_max_limit_for_lazy_materialization;
@@ -106,7 +106,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     optimize_lazy_materialization = from[Setting::query_plan_optimize_lazy_materialization];
     max_limit_for_lazy_materialization = from[Setting::query_plan_max_limit_for_lazy_materialization];
 
-    max_limit_for_ann_queries = from[Setting::max_limit_for_ann_queries].value;
+    max_limit_for_vector_search_queries = from[Setting::max_limit_for_vector_search_queries].value;
     query_plan_join_shard_by_pk_ranges = from[Setting::query_plan_join_shard_by_pk_ranges].value;
 
     network_transfer_limits = SizeLimits(from[Setting::max_rows_to_transfer], from[Setting::max_bytes_to_transfer], from[Setting::transfer_overflow_mode]);

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -87,7 +87,7 @@ struct QueryPlanOptimizationSettings
     bool optimize_lazy_materialization = false;
     size_t max_limit_for_lazy_materialization = 0;
 
-    size_t max_limit_for_ann_queries;
+    size_t max_limit_for_vector_search_queries;
 
     /// Setting needed for Sets (JOIN -> IN optimization)
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -47,7 +47,7 @@ void optimizeTreeFirstPass(const QueryPlanOptimizationSettings & optimization_se
 
 
     Optimization::ExtraSettings extra_settings = {
-        optimization_settings.max_limit_for_ann_queries,
+        optimization_settings.max_limit_for_vector_search_queries,
         optimization_settings.use_index_for_in_with_subqueries_max_values,
         optimization_settings.network_transfer_limits,
     };

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -79,7 +79,7 @@ size_t tryUseVectorSearch(QueryPlan::Node * parent_node, QueryPlan::Nodes & /*no
     size_t n = limit_step->getLimitForSorting();
 
     /// Check that the LIMIT specified by the user isn't too big - otherwise the cost of vector search outweighs the benefit.
-    if (n > settings.max_limit_for_ann_queries)
+    if (n > settings.max_limit_for_vector_search_queries)
         return updated_layers;
 
     /// Not 100% sure but other sort types are likely not what we want

--- a/tests/queries/0_stateless/02354_vector_search_queries.reference
+++ b/tests/queries/0_stateless/02354_vector_search_queries.reference
@@ -59,7 +59,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
--- Setting "max_limit_for_ann_queries"
+-- Setting "max_limit_for_vector_search_queries"
 Expression (Project names)
   LazilyRead (Lazily Read)
     Limit (preliminary LIMIT (without OFFSET))

--- a/tests/queries/0_stateless/02354_vector_search_queries.sql
+++ b/tests/queries/0_stateless/02354_vector_search_queries.sql
@@ -69,14 +69,14 @@ FROM tab
 ORDER BY cosineDistance(vec, reference_vec)
 LIMIT 3;
 
-SELECT '-- Setting "max_limit_for_ann_queries"';
+SELECT '-- Setting "max_limit_for_vector_search_queries"';
 EXPLAIN indexes=1
 WITH [0.0, 2.0] as reference_vec
 SELECT id, vec, cosineDistance(vec, reference_vec)
 FROM tab
 ORDER BY cosineDistance(vec, reference_vec)
 LIMIT 3
-SETTINGS max_limit_for_ann_queries = 2; -- LIMIT 3 > 2 --> don't use the ann index
+SETTINGS max_limit_for_vector_search_queries = 2; -- LIMIT 3 > 2 --> don't use the ann index
 
 DROP TABLE tab;
 


### PR DESCRIPTION
This PR
- renames setting `max_limit_for_ann_queries` to `max_limit_for_vector_search` (for better readability)
- removes support for doing vector searches with the disabled analyzer (to remove some baggage from the code). The non-analyzer path will be removed anyways at some point.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)