### PR TITLE
Add azat to the trusted list

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/trusted.py
+++ b/ci/jobs/scripts/workflow_hooks/trusted.py
@@ -7,6 +7,7 @@ TRUSTED_CONTRIBUTORS = {
     e.lower()
     for e in [
         "amosbird",
+        "azat",
         "den-crane",  # Documentation contributor
         "taiyang-li",
         "ucasFL",  # Amos Bird's friend


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)