### PR TITLE
fix flaky test_database_glue (followup)

### DIFF
--- a/tests/integration/compose/docker_compose_glue_catalog.yml
+++ b/tests/integration/compose/docker_compose_glue_catalog.yml
@@ -30,7 +30,6 @@ services:
     depends_on:
       - minio
     image: minio/mc
-    container_name: mc
     environment:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=minio123

--- a/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
@@ -52,7 +52,6 @@ services:
     depends_on:
       - minio
     image: minio/mc
-    container_name: mc
     environment:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=minio123

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -51,7 +51,6 @@ services:
     depends_on:
       - minio
     image: minio/mc
-    container_name: mc
     environment:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd


### PR DESCRIPTION
Follow up for https://github.com/ClickHouse/ClickHouse/pull/79843. Now it fails for the container_name `mc`, so avoid specifying container name for `mc` service in docker-compose.

https://s3.amazonaws.com/clickhouse-test-reports/PRs/79867/a7812783c0c1f7f8ff582141aa2d0593e3d8ce38//integration_tests_release_4_4/integration_run_parallel1_0.log
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
