### PR TITLE
fix flaky test_database_hms

### DIFF
--- a/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
@@ -1,7 +1,6 @@
 services:
   spark-iceberg:
     image: tabulario/spark-iceberg
-    container_name: spark-iceberg
     build: spark/
     depends_on:
       hive:
@@ -19,8 +18,10 @@ services:
 
   hive:
     build: ./../../hms_extensions/
-    container_name: hive
     restart: unless-stopped
+    depends_on:
+      minio:
+        condition: service_started
     ports:
       - "9083:9083"
     environment:
@@ -28,10 +29,10 @@ services:
       SERVICE_OPTS: "-Dmetastore.warehouse.dir=s3a://warehouse/data/"
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/9083"]
-      interval: 1s
+      interval: 2s
       timeout: 5s
-      retries: 10
-      start_period: 30s
+      retries: 15
+      start_period: 45s
 
   minio:
     image: minio/minio
@@ -52,7 +53,6 @@ services:
     depends_on:
       - minio
     image: minio/mc
-    container_name: mc
     environment:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=minio123

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -1,7 +1,6 @@
 services:
   spark-iceberg:
     image: tabulario/spark-iceberg
-    container_name: spark-iceberg
     build: spark/
     depends_on:
       rest:
@@ -51,7 +50,6 @@ services:
     depends_on:
       - minio
     image: minio/mc
-    container_name: mc
     environment:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd


### PR DESCRIPTION
Try and fix flaky test `test_database_hms`.

```
...
E                Container roottestdatabasehms-gw1-mc-1  Creating
E                Container hive  Created
E                Container roottestdatabasehms-gw1-node1-1  Created
E                Container spark-iceberg  Creating
E                Container roottestdatabasehms-gw1-mc-1  Created
E                Container spark-iceberg  Created
E                Container hive  Starting
E                Container roottestdatabasehms-gw1-minio-1  Starting
E                Container roottestdatabasehms-gw1-node1-1  Starting
E                Container hive  Started
E                Container roottestdatabasehms-gw1-node1-1  Started
E                Container roottestdatabasehms-gw1-minio-1  Started
E                Container hive  Waiting
E                Container roottestdatabasehms-gw1-mc-1  Starting
E                Container roottestdatabasehms-gw1-mc-1  Started
E                Container hive  Error
E               dependency failed to start: container hive is unhealthy
```
Try to add minio as dependency for hive as it looks like it depends on minio(s3) for storage. Try and adjust the health check duration for hive container. Also, a fix a separate issue as described in https://github.com/ClickHouse/ClickHouse/pull/79843 and https://github.com/ClickHouse/ClickHouse/pull/79889, which is to avoid explicitly specifying container_name (hardcoding). It's been observed that on CI sometimes, it's possible for the container from previous test to prevent the creation of container if name is fixed.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
