### PR TITLE
Proper `ASTSelectWithUnionQuery::clone()`

### DIFF
--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -17,7 +17,7 @@ ASTPtr ASTSelectWithUnionQuery::clone() const
     res->children.push_back(res->list_of_selects);
 
     res->union_mode = union_mode;
-
+    res->is_normalized = is_normalized;
     res->list_of_modes = list_of_modes;
     res->set_of_modes = set_of_modes;
 


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper implementation of `ASTSelectWithUnionQuery::clone()` method now takes into account `is_normalized` field as well. This might help with https://github.com/ClickHouse/ClickHouse/issues/77569

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
