### PR TITLE
Docs: fix page showing two titles

### DIFF
--- a/docs/en/sql-reference/formats.mdx
+++ b/docs/en/sql-reference/formats.mdx
@@ -4,6 +4,7 @@ sidebar_position: 50
 sidebar_label: 'Input and Output Formats'
 title: 'Formats for Input and Output Data'
 description: 'Supported input and output formats'
+hide_title: true
 ---
 
 import Content from '../interfaces/formats.md';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Hides title on this page which is importing a snippet (showing two titles as a result)
![Screenshot 2025-05-07 at 10 10 11](https://github.com/user-attachments/assets/88b9c7e8-fccf-499d-abdd-845662a13b09)

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
