### PR TITLE
Fix failure of `02415_all_new_functions_must_have_version_information`

### DIFF
--- a/src/Functions/coverage.cpp
+++ b/src/Functions/coverage.cpp
@@ -122,6 +122,7 @@ See https://clang.llvm.org/docs/SanitizerCoverage.html for more information.
 )",
             .examples{
                 {"functions", "SELECT DISTINCT demangle(addressToSymbol(arrayJoin(coverageCurrent())))", ""}},
+            .introduced_in = {23, 11},
             .category = FunctionDocumentation::Category::Introspection
         });
 
@@ -138,6 +139,7 @@ In contrast to `coverageCurrent` it cannot be reset with the `SYSTEM RESET COVER
 
 See the `coverageCurrent` function for the details.
 )",
+            .introduced_in = {23, 11},
             .category = FunctionDocumentation::Category::Introspection
         });
 
@@ -154,6 +156,7 @@ You can use this function, and the `coverage` function to compare and calculate 
 
 See the `coverageCurrent` function for the details.
 )",
+            .introduced_in = {23, 11},
             .category = FunctionDocumentation::Category::Introspection
         });
 }


### PR DESCRIPTION
Fixes https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79908&sha=718c16cd5fabc90f66356100b45c713f45159be8&name_0=PR&name_1=Stateless%20tests%20%28coverage%2C%206%2F6%29

Fallout of https://github.com/ClickHouse/ClickHouse/pull/79839

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)