### PR TITLE
Fix flaky test_refreshable_mv/test.py::test_adding_replica

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -445,12 +445,7 @@ def test_adding_replica(started_cluster, cleanup):
     assert node2.query("select * from re.a order by all") == "0\n10\n"
 
     node1.query("system stop view re.a")
-    r = node2.query(
-        "system wait view re.a;"
-        "system refresh view re.a;"
-        "system wait view re.a;"
-        "select last_refresh_replica from system.view_refreshes")
-    assert r == "2\n"
+    node2.query_with_retry("select last_refresh_replica from system.view_refreshes", check_callback=lambda x: x == "2\n", sleep_time=1, retry_count=20)
 
 def test_replicated_db_startup_race(started_cluster, cleanup):
     for node in nodes:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79908&sha=718c16cd5fabc90f66356100b45c713f45159be8&name_0=PR&name_1=Integration%20tests%20%28release%2C%204%2F4%29

`system wait view re.a` no node2 could throw "cancelled" if the `system stop view re.a` on node1 interrupted a refresh.