### PR TITLE
Add url_base setting to support relative URLs in table functions

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -94,6 +94,11 @@ We are writing a URL column with the String type (average size of 60 bytes per v
 This is an expert-level setting, and you shouldn't change it if you're just getting started with ClickHouse.
 :::
 )", 0) \
+    DECLARE(String, url_base, "", R"(
+Base URL for resolving relative URLs in table functions like url() or urlCluster().
+For example, if url_base is 'https://abc.xyz/def/', 
+a path-relative URL 'data.csv' will resolve to 'https://abc.xyz/def/data.csv'.
+)", 0) \
     DECLARE(UInt64, max_compress_block_size, 1048576, R"(
 The maximum size of blocks of uncompressed data before compressing for writing to a table. By default, 1,048,576 (1 MiB). Specifying a smaller block size generally leads to slightly reduced compression ratio, the compression and decompression speed increases slightly due to cache locality, and memory consumption is reduced.
 


### PR DESCRIPTION
### Changelog category:
- New Feature

### Changelog entry:
Added support for resolving relative URLs in table functions like `url()` and `urlCluster()` using a new setting `url_base`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

**Motivation:**  
Previously, the `url()` and `urlCluster()` table functions only supported absolute URLs. This change enables support for path-relative (`data.csv`), host-relative (`/test/data.csv`), and schema-relative (`//example.com/data.csv`) URLs by introducing a new setting `url_base`. This provides flexibility when using relative file paths in structured deployments or dynamic environments.

**Parameters:**  
- `url_base` — a global setting that specifies the base URL to resolve relative paths. For example:
  - `url_base = 'https://abc.xyz/def/'`  
    - `data.csv` → `https://abc.xyz/def/data.csv`  
    - `/test/data.csv` → `https://abc.xyz/test/data.csv`  
    - `//example.com/data.csv` → `https://example.com/data.csv`  

**Example use:**
```sql
SET url_base = 'https://example.com/data/';

SELECT * FROM url('file.csv', 'CSV', 'id UInt32, name String');
-- will fetch: https://example.com/data/file.csv
