### PR TITLE
fix flaky test_cgroup_limit

### DIFF
--- a/tests/integration/test_cgroup_limit/test.py
+++ b/tests/integration/test_cgroup_limit/test.py
@@ -1,12 +1,9 @@
-#!/usr/bin/env python3
-
 import logging
 import math
 import os
 import subprocess
-from tempfile import NamedTemporaryFile
 
-import pytest
+from helpers.test_tools import wait_condition
 
 
 def run_command_in_container(cmd, *args):
@@ -43,14 +40,17 @@ def run_with_cpu_limit(cmd, num_cpus, *args):
 
 def test_cgroup_cpu_limit():
     for num_cpus in (1, 2, 4, 2.8):
-        result = run_with_cpu_limit(
-            "clickhouse local -q \"select value from system.settings where name='max_threads'\"",
-            num_cpus,
-        )
-        expect_output = (r"\'auto({})\'".format(math.ceil(num_cpus))).encode()
-        assert (
-            result.strip() == expect_output
-        ), f"fail for cpu limit={num_cpus}, result={result.strip()}, expect={expect_output}"
+        def run_with_retry():
+            result = run_with_cpu_limit(
+                "clickhouse local -q \"select value from system.settings where name='max_threads'\"",
+                num_cpus,
+            )
+            expect_output = (r"\'auto({})\'".format(math.ceil(num_cpus))).encode()
+            return (
+                result.strip() == expect_output
+            ), f"fail for cpu limit={num_cpus}, result={result.strip()}, expect={expect_output}"
+
+        wait_condition(run_with_retry, lambda x:x, max_attempts=3, delay=0.2)
 
 
 # For manual run


### PR DESCRIPTION
Fix flaky test `test_cgroup_limit`:
https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/d2697c0ea112fd2b86bb65249801cbec1862991c//integration_tests_aarch64_distributed_plan_4_4/integration_run_parallel0_0.log

From [public cidb](https://play.clickhouse.com/play?user=play#CldJVEgKICAgICd0ZXN0X2Nncm91cF9saW1pdCcgQVMgbmFtZV9zdWJzdHIsCiAgICA5MCBBUyBpbnRlcnZhbF9kYXlzLAogICAgKCdTdGF0ZWxlc3MgdGVzdHMgKGFzYW4pJywgJ1N0YXRlbGVzcyB0ZXN0cyAoYWRkcmVzcyknLCAnU3RhdGVsZXNzIHRlc3RzIChhZGRyZXNzLCBhY3Rpb25zKScsICdJbnRlZ3JhdGlvbiB0ZXN0cyAoYXNhbikgWzEvM10nLCAnU3RhdGVsZXNzIHRlc3RzICh0c2FuKSBbMS8zXScpIEFTIGJhY2twb3J0X2FuZF9yZWxlYXNlX3NwZWNpZmljX2NoZWNrcwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkLAogICAgY291bnQoKSwKICAgIGdyb3VwVW5pcUFycmF5KHB1bGxfcmVxdWVzdF9udW1iZXIpIEFTIHBycywKICAgIGFueShyZXBvcnRfdXJsKQpGUk9NIGNoZWNrcwpXSEVSRSAoKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZSkgQU5EIChwdWxsX3JlcXVlc3RfbnVtYmVyIE5PVCBJTiAoCiAgICBTRUxFQ1QgcHVsbF9yZXF1ZXN0X251bWJlciBBUyBwcm4KICAgIEZST00gY2hlY2tzCiAgICBXSEVSRSAocHJuICE9IDApIEFORCAoKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZSkgQU5EIChjaGVja19uYW1lIElOIChiYWNrcG9ydF9hbmRfcmVsZWFzZV9zcGVjaWZpY19jaGVja3MpKQopKSBBTkQgKHBvc2l0aW9uKHRlc3RfbmFtZSwgbmFtZV9zdWJzdHIpID4gMCkgQU5EICh0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InLCAnRkxBS1knKSkKR1JPVVAgQlkgZApPUkRFUiBCWSBkIERFU0MK), it doesn't happen very frequently, but does seem to happen enough over last 3 months. Runs fine locally with multiple counts and in parallel, so it's possible very specific to ci. Ensure asserts with retries to try and unflake the test.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
