### PR TITLE
Add Metrics for Disk Readonly Status

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -216,9 +216,8 @@ BackgroundSchedulePool::~BackgroundSchedulePool()
             // Notify all delayed tasks that the owning BackgroundSchedulePool is being destroyed.
             // This prevents any further use of the pool (e.g., cancelDelayedTask) from within
             // BackgroundSchedulePoolTaskInfo::deactivate(), avoiding use-after-free errors.
-            for (auto & task : delayed_tasks) {
+            for (auto & task : delayed_tasks)
                 task.second->pool_shutdown = true;
-            }
             shutdown = true;
         }
 

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -57,8 +57,8 @@ void BackgroundSchedulePoolTaskInfo::deactivate()
 
     deactivated = true;
     scheduled = false;
-
-    if (delayed)
+    /// Only necessary to cancel the task before the pool is being destroyed
+    if (delayed && !pool_shutdown)
         pool.cancelDelayedTask(*this, lock_schedule);
 }
 
@@ -213,7 +213,12 @@ BackgroundSchedulePool::~BackgroundSchedulePool()
         {
             std::lock_guard lock_tasks(tasks_mutex);
             std::lock_guard lock_delayed_tasks(delayed_tasks_mutex);
-
+            // Notify all delayed tasks that the owning BackgroundSchedulePool is being destroyed.
+            // This prevents any further use of the pool (e.g., cancelDelayedTask) from within
+            // BackgroundSchedulePoolTaskInfo::deactivate(), avoiding use-after-free errors.
+            for (auto & task : delayed_tasks) {
+                task.second->pool_shutdown = true;
+            }
             shutdown = true;
         }
 

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -142,6 +142,7 @@ private:
     /// Invariants:
     /// * If deactivated is true then scheduled, delayed and executing are all false.
     /// * scheduled and delayed cannot be true at the same time.
+    bool pool_shutdown TSA_GUARDED_BY(schedule_mutex) = false;  // Pool is being destroyed.
     bool deactivated TSA_GUARDED_BY(schedule_mutex) = false;
     bool scheduled TSA_GUARDED_BY(schedule_mutex) = false;
     bool delayed TSA_GUARDED_BY(schedule_mutex) = false;

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -26,7 +26,7 @@
 #include <IO/WriteHelpers.h>
 #include <pcg_random.hpp>
 #include <Common/logger_useful.h>
-
+#include <Poco/DirectoryIterator.h>
 
 namespace CurrentMetrics
 {
@@ -214,7 +214,21 @@ std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes)
     }
 
     LOG_TRACE(logger, "Could not reserve {} on local disk {}. Not enough unreserved space", ReadableSize(bytes), backQuote(name));
-
+    if (name == "test1")
+    {
+        try
+        {
+            Poco::DirectoryIterator end;
+            for (Poco::DirectoryIterator it(disk_path); it != end; ++it)
+            {
+                LOG_INFO(logger, "Reserve failed in disk_path {}: {}", disk_path, it.name());
+            }
+        }
+        catch (const std::exception & e)
+        {
+            LOG_WARNING(logger, "Reserve failed  Failed to list {}: {}", disk_path, e.what());
+        }
+    }
 
     return {};
 }
@@ -617,6 +631,22 @@ try
 catch (const std::exception & e)
 {
     LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}, exception: {}", disk_path, e.what());
+    if (disk_path == "/var/lib/clickhouse/path1/")
+    {
+        try
+        {
+            Poco::DirectoryIterator end;
+            for (Poco::DirectoryIterator it(disk_path); it != end; ++it)
+            {
+                LOG_INFO(logger, "Disk Local can read Found file in path {}: {}", disk_path, it.name());
+            }
+        }
+        catch (const std::exception & e)
+        {
+            LOG_WARNING(logger, "Disk Local can read Failed to list {}: {}", disk_path, e.what());
+        }
+    }
+
     return false;
 }
 catch (...)

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -631,15 +631,19 @@ try
 catch (const std::exception & e)
 {
     LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}, exception: {}", disk_path, e.what());
-    if (disk_path == "/var/lib/clickhouse/path1/")
+    if (disk_path == "/var/lib/clickhouse/path1/" || disk_path == "/var/lib/clickhouse/path2/" )
     {
         try
         {
             Poco::DirectoryIterator end;
+            bool found = false;
             for (Poco::DirectoryIterator it(disk_path); it != end; ++it)
             {
+                found = true;
                 LOG_INFO(logger, "Disk Local can read Found file in path {}: {}", disk_path, it.name());
             }
+            if (!found)
+                LOG_INFO(logger, "Disk LOCAL cannot find any file in path {}", disk_path);
         }
         catch (const std::exception & e)
         {

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -544,7 +544,7 @@ DiskLocal::DiskLocal(
     const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
     : DiskLocal(name_, path_, keep_free_space_bytes_, config, config_prefix)
 {
-    auto local_disk_check_period_ms = config.getUInt("local_disk_check_period_ms", 0);
+    auto local_disk_check_period_ms = config.getUInt("local_disk_check_period_ms", 60000);
     if (local_disk_check_period_ms > 0)
         disk_checker = std::make_unique<DiskLocalCheckThread>(this, context, local_disk_check_period_ms);
 }

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -4,6 +4,7 @@
 #include <Interpreters/Context.h>
 #include <Common/logger_useful.h>
 #include <Core/BackgroundSchedulePool.h>
+#include <Common/formatReadable.h>
 
 namespace DB
 {
@@ -24,6 +25,11 @@ void DiskLocalCheckThread::startup()
     need_stop = false;
     retry = 0;
     task->activateAndSchedule();
+    LOG_INFO(
+        log,
+        "Disk check started for disk {} with period {}",
+        disk->getName(),
+        formatReadableTime(static_cast<double>(check_period_ms) * 1e6 /* ns */));
 }
 
 void DiskLocalCheckThread::run()

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -27,7 +27,7 @@ void DiskLocalCheckThread::startup()
     task->activateAndSchedule();
     LOG_INFO(
         log,
-        "Disk check started for disk {} with period {}",
+        "Disk check started for disk [{}] with period {}",
         disk->getName(),
         formatReadableTime(static_cast<double>(check_period_ms) * 1e6 /* ns */));
 }

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -43,15 +43,23 @@ void DiskLocalCheckThread::run()
     LOG_INFO(log, "Disk {} seems to be readable: {} . writable: {}", disk->getName(), can_read, can_write);
     if (can_read)
     {
-        if (disk->getName() == "test1")
+        if (disk->getName() == "test1" || disk->getName() == "test2")
         {
-            std::string disk_path =  "/var/lib/clickhouse/path1/";
+            std::string disk_path =
+                (disk->getName() == "test1" ? "/var/lib/clickhouse/path1/" : "/var/lib/clickhouse/path2/");
             try
             {
                 Poco::DirectoryIterator end;
+                bool found = false;
                 for (Poco::DirectoryIterator it(disk_path); it != end; ++it)
                 {
-                    LOG_INFO(log, "DiskLocalCheckThread found file in path {}: {}", disk_path, it.name());
+                    LOG_INFO(log, "DiskLocalCheckThread found file for disk {} in path {}: {}",
+                             disk->getName(), disk_path, it.name());
+                    found = true;
+                }
+                if(!found) {
+                    LOG_INFO(log, "DiskLocalCheckThread did not found file for disk {} in path {}",
+                             disk->getName(), disk_path);
                 }
             }
             catch (const std::exception & e)

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -41,6 +41,7 @@ void DiskLocalCheckThread::run()
     bool can_write = disk->canWrite();
     if (can_read)
     {
+        LOG_INFO(log, "Disk {} seems to be unreadable.", disk->getName());
         if (disk->broken)
             LOG_INFO(log, "Disk {0} seems to be fine. It can be recovered using `SYSTEM RESTART DISK {0}`", disk->getName());
         retry = 0;

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -251,6 +251,12 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     new_values[fmt::format("DiskUnreserved_{}", name)] = { *unreserved,
                         "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information." };
             }
+            auto readonly = disk->isReadOnly();
+            auto broken = disk->isBroken();
+            new_values[fmt::format("DiskReadonly_{}", name)] = { readonly,
+                                                             "Whether or not the disk is in readonly status." };
+            new_values[fmt::format("DiskBroken_{}", name)] = { broken,
+                                                                "Whether or not the disk in broken status." };
 
 #if USE_AWS_S3
             if (auto s3_client = disk->tryGetS3StorageClient())

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -12,7 +12,11 @@ import string
 import subprocess
 import sys
 from typing import Any
-
+import threading
+import time
+from datetime import datetime
+import re
+import glob
 from integration_test_images import get_docker_env
 
 
@@ -172,7 +176,6 @@ def check_iptables_legacy() -> None:
         print(f"Error: '{iptables_path}' not found")
         sys.exit(1)
 
-
 def docker_kill_handler_handler(signum: Any, frame: Any) -> None:
     _, _ = signum, frame
     subprocess.check_call(
@@ -181,6 +184,52 @@ def docker_kill_handler_handler(signum: Any, frame: Any) -> None:
     )
     raise KeyboardInterrupt("Killed by Ctrl+C")
 
+LOG_PREFIX = "[Test from ChangWu]"
+
+def get_hostname():
+    try:
+        return subprocess.check_output("hostname", shell=True).decode().strip()
+    except Exception:
+        return "unknown-host"
+
+def get_ip():
+    try:
+        ip = subprocess.check_output("hostname -I", shell=True).decode().strip().split()[0]
+        return ip
+    except Exception:
+        return "unknown-ip"
+
+def current_time():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+def log(msg):
+    print(f"{LOG_PREFIX} [{current_time()}] {msg}", flush=True)
+
+def monitor_directory(path, interval=1):
+    log(f"Started monitoring: {path}")
+    prev_snapshot = {}
+    while True:
+        current_snapshot = {}
+        for root, _, files in os.walk(path):
+            for name in files:
+                file_path = os.path.join(root, name)
+                try:
+                    current_snapshot[file_path] = os.stat(file_path).st_mtime
+                except FileNotFoundError:
+                    continue
+
+        for path_now, mtime in current_snapshot.items():
+            if path_now not in prev_snapshot:
+                log(f"Created: {path_now}")
+            elif prev_snapshot[path_now] != mtime:
+                log(f"Modified: {path_now}")
+
+        for path_old in prev_snapshot:
+            if path_old not in current_snapshot:
+                log(f"Deleted: {path_old}")
+
+        prev_snapshot = current_snapshot
+        time.sleep(interval)
 
 signal.signal(signal.SIGINT, docker_kill_handler_handler)
 
@@ -501,4 +550,17 @@ if __name__ == "__main__":
         subprocess.check_call(cmd_pre_pull, shell=True)
 
     print(("Running pytest container as: '" + cmd + "'."))
+
+    print(f"Running pytest container as: '{cmd}'.")
+
+    log(f"Monitoring started on host: {get_hostname()}, IP: {get_ip()}")
+
+    base_path_template = "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/integration/test_disks_app_func/_instances-0-gw{idx}/disks_app_test/database"
+
+    for i in range(5):
+        path = base_path_template.format(idx=i)
+        # Just start monitoring thread regardless of whether the path exists now
+        thread = threading.Thread(target=monitor_directory, args=(path, 1), daemon=True)
+        thread.start()
+
     subprocess.check_call(cmd, shell=True, bufsize=0)

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -231,6 +231,30 @@ def monitor_directory(path, interval=1):
         prev_snapshot = current_snapshot
         time.sleep(interval)
 
+def print_directory_tree(path):
+    max_depth=2
+    indent="  "
+    def _print_tree(current_path, depth):
+        if depth > max_depth:
+            return
+        try:
+            entries = sorted(os.listdir(current_path))
+        except PermissionError:
+            logging.warning(f"{indent * depth}[Permission Denied]: {current_path}")
+            return
+
+        for entry in entries:
+            full_path = os.path.join(current_path, entry)
+            logging.info(f"{indent * depth}- {entry}")
+            if os.path.isdir(full_path):
+                _print_tree(full_path, depth + 1)
+
+    while True:
+        logging.info(f"\n--- Directory tree for: {path} ---")
+        _print_tree(path, depth=1)
+        time.sleep(10)
+
+
 signal.signal(signal.SIGINT, docker_kill_handler_handler)
 
 # Integration tests runner should allow to run tests on several versions of ClickHouse.
@@ -560,7 +584,7 @@ if __name__ == "__main__":
     for i in range(5):
         path = base_path_template.format(idx=i)
         # Just start monitoring thread regardless of whether the path exists now
-        thread = threading.Thread(target=monitor_directory, args=(path, 1), daemon=True)
+        thread = threading.Thread(target=print_directory_tree, args=(path), daemon=True)
         thread.start()
 
     subprocess.check_call(cmd, shell=True, bufsize=0)

--- a/tests/integration/test_disks_app_func/test.py
+++ b/tests/integration/test_disks_app_func/test.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from helpers.cluster import ClickHouseCluster
 
@@ -182,6 +183,7 @@ def init_data_s3_rm_rec(source):
 
 
 def test_disks_app_func_ld(started_cluster):
+    logging.info("Start to test test_disks_app_func_ld")
     source = cluster.instances["disks_app_test"]
 
     out = source.exec_in_container(
@@ -212,7 +214,7 @@ def test_disks_app_func_ld(started_cluster):
             "switch-disk local; list-disks",
         ]
     )
-
+    logging.info("Start to test test_disks_app_func_ld")
     disks = list(
         map(lambda x: x.strip(), filter(lambda x: len(x) > 1, out.split("\n")))
     )
@@ -229,7 +231,9 @@ def test_disks_app_func_ld(started_cluster):
     ]
 
 
+
 def test_disks_app_func_ls(started_cluster):
+    logging.info("Start to test test_disks_app_func_ls")
     source = cluster.instances["disks_app_test"]
 
     remove_recurive(source, "test1", ".")
@@ -246,9 +250,10 @@ def test_disks_app_func_ls(started_cluster):
 
     assert ".:\nstore\n" in out
     assert "\n./store:\n" in out
-
+    logging.info("Finish to test test_disks_app_func_ls")
 
 def test_disks_app_func_cp(started_cluster):
+    logging.info("Start to test test_disks_app_func_cp")
     source = cluster.instances["disks_app_test"]
 
     touch(source, "test1", "path1")
@@ -282,9 +287,10 @@ def test_disks_app_func_cp(started_cluster):
     out = ls(source, "test1", ".")
 
     assert "path1" not in out
-
+    logging.info("Finish to test test_disks_app_func_cp")
 
 def test_disks_app_func_ln(started_cluster):
+    logging.info("Start to test test_disks_app_func_ln")
     source = cluster.instances["disks_app_test"]
 
     init_data(source)
@@ -297,17 +303,18 @@ def test_disks_app_func_ln(started_cluster):
             "link data/default/test_table data/default/z_tester",
         ]
     )
-
+    logging.info("Finish to test test_disks_app_func_ln")
     out = source.exec_in_container(
         ["/usr/bin/clickhouse", "disks", "--save-logs", "--query", "list data/default/"]
     )
-
+    logging.info("Finish to test test_disks_app_func_ln_2")
     files = out.split("\n")
 
     assert "z_tester" in files
 
 
 def test_disks_app_func_rm(started_cluster):
+    logging.info("Start to test test_disks_app_func_rm")
     source = cluster.instances["disks_app_test"]
 
     write(source, "test2", "path3")
@@ -321,9 +328,11 @@ def test_disks_app_func_rm(started_cluster):
     out = ls(source, "test2", ".")
 
     assert "path3" not in out
+    logging.info("Finish to test test_disks_app_func_rm")
 
 
 def test_disks_app_func_rm_shared_recursive(started_cluster):
+    logging.info("Start to test test_disks_app_func_rm_shared_recursive")
     source = cluster.instances["disks_app_test"]
 
     init_data_s3_rm_rec(source)
@@ -352,9 +361,11 @@ def test_disks_app_func_rm_shared_recursive(started_cluster):
     assert out == ".:\n\n"
 
     remove(source, "test3", ". --recursive")
+    logging.info("Finish to test test_disks_app_func_rm_shared_recursive")
 
 
 def test_disks_app_func_mv(started_cluster):
+    logging.info("Start to test test_disks_app_func_mv")
     source = cluster.instances["disks_app_test"]
 
     init_data(source)
@@ -375,7 +386,7 @@ def test_disks_app_func_mv(started_cluster):
             "move store old_store",
         ]
     )
-
+    logging.info("Finish to test test_disks_app_func_mv")
     out = ls(source, "test1", ".")
 
     files = out.split("\n")
@@ -386,6 +397,7 @@ def test_disks_app_func_mv(started_cluster):
 
 
 def test_disks_app_func_read_write(started_cluster):
+    logging.info("Start to test test_disks_app_func_read_write")
     source = cluster.instances["disks_app_test"]
 
     write(source, "test1", "5.txt")
@@ -401,13 +413,15 @@ def test_disks_app_func_read_write(started_cluster):
             "read 5.txt",
         ]
     )
-
+    logging.info("Finish to test test_disks_app_func_read_write")
     files = out.split("\n")
 
     assert files[0] == "tester"
 
 
+
 def test_remote_disk_list(started_cluster):
+    logging.info("Start to test test_remote_disk_list")
     source = cluster.instances["disks_app_test"]
     init_data_s3(source, "test4")
 
@@ -421,3 +435,4 @@ def test_remote_disk_list(started_cluster):
 
     assert ".:\nstore\n" in out
     assert "\n./store:\n" in out
+    logging.info("Finish to test test_remote_disk_list")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add metrics for disk readonly and broken status and by default enable disk checker

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Refer https://github.com/ClickHouse/ClickHouse/issues/79953 for the details.