### PR TITLE
docs: clarify the use case of tupleHammingDistance

### DIFF
--- a/docs/en/sql-reference/functions/hash-functions.md
+++ b/docs/en/sql-reference/functions/hash-functions.md
@@ -1312,7 +1312,7 @@ Result:
 
 Splits a ASCII string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1350,7 +1350,7 @@ Result:
 
 Splits a ASCII string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1388,7 +1388,7 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1426,7 +1426,7 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1608,7 +1608,7 @@ Result:
 
 Splits a ASCII string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1646,7 +1646,7 @@ Result:
 
 Splits a ASCII string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1684,7 +1684,7 @@ Result:
 
 Splits a UTF-8 string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1722,7 +1722,7 @@ Result:
 
 Splits a UTF-8 string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum hashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/hash-functions.md
+++ b/docs/en/sql-reference/functions/hash-functions.md
@@ -1312,7 +1312,7 @@ Result:
 
 Splits a ASCII string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1350,7 +1350,7 @@ Result:
 
 Splits a ASCII string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1388,7 +1388,7 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1426,7 +1426,7 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1608,7 +1608,7 @@ Result:
 
 Splits a ASCII string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1646,7 +1646,7 @@ Result:
 
 Splits a ASCII string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1684,7 +1684,7 @@ Result:
 
 Splits a UTF-8 string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 
@@ -1722,7 +1722,7 @@ Result:
 
 Splits a UTF-8 string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used for detection of semi-duplicate strings with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance). For two strings: if one of the returned hashes is the same for both strings, we think that those strings are the same.
+Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
 
 **Syntax**
 

--- a/docs/en/sql-reference/functions/hash-functions.md
+++ b/docs/en/sql-reference/functions/hash-functions.md
@@ -1312,7 +1312,7 @@ Result:
 
 Splits a ASCII string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1350,7 +1350,7 @@ Result:
 
 Splits a ASCII string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1388,7 +1388,7 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1426,7 +1426,7 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols and calculates hash values for each n-gram. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1608,7 +1608,7 @@ Result:
 
 Splits a ASCII string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1646,7 +1646,7 @@ Result:
 
 Splits a ASCII string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1684,7 +1684,7 @@ Result:
 
 Splits a UTF-8 string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case sensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 
@@ -1722,7 +1722,7 @@ Result:
 
 Splits a UTF-8 string into parts (shingles) of `shinglesize` words and calculates hash values for each word shingle. Uses `hashnum` minimum hashes to calculate the minimum hash and `hashnum` maximum hashes to calculate the maximum hash. Returns a tuple with these hashes. Is case insensitive.
 
-Can be used with [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content.
+Can be used with a hamming distance function like (e.g.) [tupleHammingDistance](../functions/tuple-functions.md/#tuplehammingdistance) for estimation of duplicate or highly-similar (`0`), partially-similar (`1`), and dissimilar (`2`) content. Other hamming distance functions like (e.g.) [bitHammingDistance](../functions/bit-functions.md/#bithammingdistance) can be used to compare two minimum or two maximum simhashes (optionally adding both hamming distances together) to generate a more accurate estimation between `0..64` (or `0..128` when added together), where `0` equates to highly-similar or duplicate content and `64` (or `128`) equates to dissimilar content.
 
 **Syntax**
 


### PR DESCRIPTION
The mention of tupleHammingDistance for comparing similarity of strings can be confusing for beginners (like myself). This change makes it clear that tupleHammingDistance in particular is only useful for broad categorization when used in combination with the various minhash functions that mention it.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)