### PR TITLE
Update splitting-merging-functions.md

### DIFF
--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -21,7 +21,7 @@ splitByChar(separator, s[, max_substrings]))
 
 **Arguments**
 
-- `separator` — The separator which should contain exactly one character. [String](../data-types/string.md).
+- `separator` — The separator must be a single-byte character. [String](../data-types/string.md).
 - `s` — The string to split. [String](../data-types/string.md).
 - `max_substrings` — An optional `Int64` defaulting to 0. If `max_substrings` > 0, the returned array will contain at most `max_substrings` substrings, otherwise the function will return as many substrings as possible.
 


### PR DESCRIPTION
Seems splitByChar can only accept single-byte separator.
```
SELECT splitByChar('€', '123') AS result
```
The result is
```
Received exception from server (version 25.4.1):
Code: 36. DB::Exception: Received from localhost:9000. DB::Exception: Illegal separator for function splitByChar. Must be exactly one byte.: In scope SELECT splitByChar('€', '123') AS result. (BAD_ARGUMENTS)
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)