### PR TITLE
Docs: rename slug for `system.error_log` doc

### DIFF
--- a/ci/jobs/docs_job.py
+++ b/ci/jobs/docs_job.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         Result.from_commands_run(
             name=testname,
             command=[
-                "yarn build-api-doc",
                 "yarn build-swagger",
                 "export DOCUSAURUS_IGNORE_SSG_WARNINGS=true && yarn build-docs",
             ],

--- a/docs/en/operations/system-tables/error_log.md
+++ b/docs/en/operations/system-tables/error_log.md
@@ -2,7 +2,7 @@
 description: 'System table containing the history of error values from table `system.errors`,
   periodically flushed to disk.'
 keywords: ['system table', 'error_log']
-slug: /operations/system-tables/error-log
+slug: /operations/system-tables/system-error-log
 title: 'system.error_log'
 ---
 

--- a/docs/en/operations/system-tables/error_log.md
+++ b/docs/en/operations/system-tables/error_log.md
@@ -2,7 +2,7 @@
 description: 'System table containing the history of error values from table `system.errors`,
   periodically flushed to disk.'
 keywords: ['system table', 'error_log']
-slug: /operations/system-tables/error_log
+slug: /operations/system-tables/error-log
 title: 'system.error_log'
 ---
 


### PR DESCRIPTION
Navigating to this slug externally gives a 403 by Cloudflare as a security measure. (Navigating to the page internally works fine). Changing the slug to see if it makes a difference.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
