### PR TITLE
Remove `format_alter_commands_with_parentheses` server setting

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -353,7 +353,6 @@ try
     initTTYBuffer(
         toProgressOption(config().getString("progress", "default")), toProgressOption(config().getString("progress-table", "default")));
     initKeystrokeInterceptor();
-    ASTAlterCommand::setFormatAlterCommandsWithParentheses(true);
 
     {
         // All that just to set DB::CurrentThread::get().getGlobalContext()

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -107,7 +107,6 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ("backslash", "add a backslash at the end of each line of the formatted query")
             ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
             ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
-            ("format_alter_operations_with_parentheses", po::value<bool>()->default_value(true), "If set to `true`, then alter operations will be surrounded by parentheses in formatted queries. This makes the parsing of formatted alter queries less ambiguous.")
         ;
 
         Settings cmd_settings;
@@ -134,7 +133,6 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         bool obfuscate = options.count("obfuscate");
         bool backslash = options.count("backslash");
         bool allow_settings_after_format_in_insert = options.count("allow_settings_after_format_in_insert");
-        bool format_alter_operations_with_parentheses = options["format_alter_operations_with_parentheses"].as<bool>();
 
         if (quiet && (hilite || oneline || obfuscate))
         {
@@ -159,8 +157,6 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             std::cerr << "Option 'max_line_length' must be less than 256." << std::endl;
             return 2;
         }
-
-        ASTAlterCommand::setFormatAlterCommandsWithParentheses(format_alter_operations_with_parentheses);
 
         String query;
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -617,7 +617,6 @@ try
     initTTYBuffer(toProgressOption(getClientConfiguration().getString("progress", "default")),
         toProgressOption(config().getString("progress-table", "default")));
     initKeystrokeInterceptor();
-    ASTAlterCommand::setFormatAlterCommandsWithParentheses(true);
 
     /// try to load user defined executable functions, throw on error and die
     try

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -217,7 +217,6 @@ namespace ServerSetting
     extern const ServerSettingsInt32 dns_cache_update_period;
     extern const ServerSettingsUInt32 dns_max_consecutive_failures;
     extern const ServerSettingsBool enable_azure_sdk_logging;
-    extern const ServerSettingsBool format_alter_operations_with_parentheses;
     extern const ServerSettingsUInt64 global_profiler_cpu_time_period_ns;
     extern const ServerSettingsUInt64 global_profiler_real_time_period_ns;
     extern const ServerSettingsUInt64 http_connections_soft_limit;
@@ -983,8 +982,6 @@ try
 
     ServerSettings server_settings;
     server_settings.loadSettingsFromConfig(config());
-
-    ASTAlterCommand::setFormatAlterCommandsWithParentheses(server_settings[ServerSetting::format_alter_operations_with_parentheses]);
 
     StackTrace::setShowAddresses(server_settings[ServerSetting::show_addresses_in_stack_traces]);
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -898,7 +898,6 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     )", 0) \
     DECLARE(UInt32, max_database_replicated_create_table_thread_pool_size, 1, R"(The number of threads to create tables during replica recovery in DatabaseReplicated. Zero means number of threads equal number of cores.)", 0) \
     DECLARE(Bool, database_replicated_allow_detach_permanently, true, R"(Allow detaching tables permanently in Replicated databases)", 0) \
-    DECLARE(Bool, format_alter_operations_with_parentheses, true, R"(If set to `true`, then alter operations will be surrounded by parentheses in formatted queries. This makes the parsing of formatted alter queries less ambiguous.)", 0) \
     DECLARE(String, default_replica_path, "/clickhouse/tables/{uuid}/{shard}", R"(
     The path to the table in ZooKeeper.
 

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -80,12 +80,8 @@ bool needToFormatWithParentheses(ASTAlterCommand::Type type)
 
 void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    scope_guard closing_bracket_guard;
-    if (format_alter_commands_with_parentheses || needToFormatWithParentheses(type))
-    {
-        ostr << "(";
-        closing_bracket_guard = make_scope_guard(std::function<void(void)>([&ostr]() { ostr << ")"; }));
-    }
+    ostr << "(";
+    auto closing_bracket_guard = make_scope_guard(std::function<void(void)>([&ostr]() { ostr << ")"; }));
 
     if (type == ASTAlterCommand::ADD_COLUMN)
     {

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -228,16 +228,10 @@ public:
 
     ASTPtr clone() const override;
 
-    // This function is only meant to be called during application startup
-    // For reasons see https://github.com/ClickHouse/ClickHouse/pull/59532
-    static void setFormatAlterCommandsWithParentheses(bool value) { format_alter_commands_with_parentheses = value; }
-
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     void forEachPointerToChild(std::function<void(void**)> f) override;
-
-    static inline bool format_alter_commands_with_parentheses = false;
 };
 
 class ASTAlterQuery : public ASTQueryWithTableAndOutput, public ASTQueryWithOnCluster

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -174,12 +174,30 @@ INSTANTIATE_TEST_SUITE_P(ParserAlterCommand_MODIFY_COMMENT, ParserTest,
             {
                 // Empty comment value
                 "MODIFY COMMENT ''",
-                "MODIFY COMMENT ''",
+                "(MODIFY COMMENT '')",
             },
             {
                 // Non-empty comment value
                 "MODIFY COMMENT 'some comment value'",
-                "MODIFY COMMENT 'some comment value'",
+                "(MODIFY COMMENT 'some comment value')",
+            }
+        }
+)));
+
+INSTANTIATE_TEST_SUITE_P(ParserAlterCommand_MODIFY_COMMENT_WITH_PARENS, ParserTest,
+    ::testing::Combine(
+        ::testing::Values(std::make_shared<ParserAlterCommand>(true)),
+        ::testing::ValuesIn(std::initializer_list<ParserTestCase>
+        {
+            {
+                // Empty comment value
+                "(MODIFY COMMENT '')",
+                "(MODIFY COMMENT '')",
+            },
+            {
+                // Non-empty comment value
+                "(MODIFY COMMENT 'some comment value')",
+                "(MODIFY COMMENT 'some comment value')",
             }
         }
 )));

--- a/tests/queries/0_stateless/03325_alter_ast_format.sql
+++ b/tests/queries/0_stateless/03325_alter_ast_format.sql
@@ -1,3 +1,2 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/74369
--- Note that this is fixed by enabling format_alter_operations_with_parentheses. Otherwise in debug mode it'd throw a LOGICAL_ERROR
 ALTER TABLE t22 (DELETE WHERE ('叫' = c1) OR ((792.3673220441809 = c0) AND (c0 = c1))), (MODIFY SETTING persistent = 1), (UPDATE  c1 = 'would' WHERE NOT f2()), (MODIFY SETTING persistent = 0); -- { serverError UNKNOWN_TABLE }

--- a/tests/queries/0_stateless/03326_alter_ast_format_bin.reference
+++ b/tests/queries/0_stateless/03326_alter_ast_format_bin.reference
@@ -3,13 +3,3 @@ ALTER TABLE t22
     (MODIFY SETTING persistent = 1),
     (UPDATE c1 = 'would' WHERE NOT f2()),
     (MODIFY SETTING persistent = 0)
-ALTER TABLE t22
-    DELETE WHERE ('叫' = c1) OR ((792.3673220441809 = c0) AND (c0 = c1)),
-    MODIFY SETTING persistent = 1,
-    UPDATE c1 = 'would' WHERE NOT f2(),
-    MODIFY SETTING persistent = 0
-ALTER TABLE t22
-    (DELETE WHERE ('叫' = c1) OR ((792.3673220441809 = c0) AND (c0 = c1))),
-    (MODIFY SETTING persistent = 1),
-    (UPDATE c1 = 'would' WHERE NOT f2()),
-    (MODIFY SETTING persistent = 0)

--- a/tests/queries/0_stateless/03326_alter_ast_format_bin.sh
+++ b/tests/queries/0_stateless/03326_alter_ast_format_bin.sh
@@ -7,5 +7,3 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 QUERY="ALTER TABLE t22 (DELETE WHERE ('叫' = c1) OR ((792.3673220441809 = c0) AND (c0 = c1))), (MODIFY SETTING persistent = 1), (UPDATE  c1 = 'would' WHERE NOT f2()), (MODIFY SETTING persistent = 0);"
 
 $CLICKHOUSE_FORMAT --query "${QUERY}"
-$CLICKHOUSE_FORMAT --format_alter_operations_with_parentheses=0 --query "${QUERY}"
-$CLICKHOUSE_FORMAT --format_alter_operations_with_parentheses=1 --query "${QUERY}"


### PR DESCRIPTION
The setting was introduced and set false by default in 24.2. It was enabled by default in 25.2. As there are no LTS versions that doesn't support the new format, we can remove the setting.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Remove `format_alter_commands_with_parentheses` server setting. The setting was introduced and disabled by default in 24.2. It was enabled by default in 25.2. As there are no LTS versions that don't support the new format, we can remove the setting.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
