### PR TITLE
Reduce locking in `HashTablesStatistics`

### DIFF
--- a/src/Interpreters/HashTablesStatistics.h
+++ b/src/Interpreters/HashTablesStatistics.h
@@ -80,10 +80,10 @@ public:
     std::optional<DB::HashTablesCacheStatistics> getCacheStats() const;
 
 private:
-    CachePtr getHashTableStatsCache(const Params & params, const std::lock_guard<std::mutex> &);
+    CachePtr getHashTableStatsCache(const Params & params);
 
     mutable std::mutex mutex;
-    CachePtr hash_table_stats;
+    CachePtr hash_table_stats TSA_GUARDED_BY(mutex);
 };
 
 template <typename Entry>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The original goal was to move logging outside the critical section, but then I noticed that it could be made much more granular.