### PR TITLE
Replace outdated env vars in MinIO config

### DIFF
--- a/tests/integration/compose/docker_compose_minio.yml
+++ b/tests/integration/compose/docker_compose_minio.yml
@@ -7,8 +7,8 @@ services:
     expose:
       - ${MINIO_PORT:-9001}
     environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: ClickHouse_Minio_P@ssw0rd
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: ClickHouse_Minio_P@ssw0rd
       MINIO_PROMETHEUS_AUTH_TYPE: public
     command: server --console-address 127.0.0.1:19001 --address :9001 --certs-dir /certs /data1-1
     depends_on:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://min.io/docs/minio/linux/reference/minio-server/settings/deprecated.html#envvar.MINIO_ACCESS_KEY
