### PR TITLE
turn debug mode for jemalloc on debug build

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -34,10 +34,25 @@ if (OS_LINUX)
     # avoid spurious latencies and additional work associated with
     # MADV_DONTNEED. See
     # https://github.com/ClickHouse/ClickHouse/issues/11121 for motivation.
-    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:false,background_thread:true")
-else()
-    set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000")
-endif()
+    if (NDEBUG)
+        set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:false,background_thread:true")
+    else ()
+        set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:false,background_thread:true,tcache:false")
+    endif ()
+else ()
+    if (NDEBUG)
+        set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000")
+    else ()
+        set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,tcache:false")
+    endif ()
+endif ()
+
+if (NOT NDEBUG)
+    message(STATUS "USE JEMALLOC_DEBUG")
+    add_compile_definitions(JEMALLOC_DEBUG=1)
+endif ()
+
+
 # CACHE variable is empty to allow changing defaults without the necessity
 # to purge cache
 set (JEMALLOC_CONFIG_MALLOC_CONF_OVERRIDE "" CACHE STRING "Change default configuration string of JEMalloc" )


### PR DESCRIPTION
Try to enable `JEMALLOC_DEBUG` flag for jemalloc.
https://github.com/jemalloc/jemalloc/wiki/Use-Case:-Find-a-memory-corruption-bug

It is really hard to detect double free without allocator support. With `JEMALLOC_DEBUG=1` it is possible detect some cases. Not all cases could be detected, but it is better then nothing.

When double free is happen on release build the program crashes in unpredictable random place. It impossible to investigate. 

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
To have a chance to detect double free, enable debug mode in jemalloc in debug builds.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
