### PR TITLE
docs(pr-documentation): fix misplaced link for replacingmergetree in …

### DIFF
--- a/docs/en/engines/table-engines/index.md
+++ b/docs/en/engines/table-engines/index.md
@@ -29,7 +29,7 @@ Engines in the family:
 | MergeTree Engines                                                                                                                         |
 |-------------------------------------------------------------------------------------------------------------------------------------------|
 | [MergeTree](/engines/table-engines/mergetree-family/mergetree)                                                          |
-| [ReplacingMergeTree](/engines/table-engines/mergetree-family/replication)                               |
+| [ReplacingMergeTree](/engines/table-engines/mergetree-family/replacingmergetree)                               |
 | [SummingMergeTree](/engines/table-engines/mergetree-family/summingmergetree)                                     |
 | [AggregatingMergeTree](/engines/table-engines/mergetree-family/aggregatingmergetree)                         |
 | [CollapsingMergeTree](/engines/table-engines/mergetree-family/collapsingmergetree)               |


### PR DESCRIPTION
…table-engines index

This PR should be labeled pr-documentation
### Changelog category (leave one):
- Documentation


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix misplaced link for replacingmergetree in table-engines index

### Documentation entry for user-facing changes
The documentation for docs/engines/table-engines has been updated so the  ReplacingMergeTree category is linking to the correct page, as it was previously linking to the replication documentation.