### PR TITLE
Prevent use-after-free in BackgroundSchedulePool::TaskInfo by tracking pool shutdown

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -57,8 +57,8 @@ void BackgroundSchedulePoolTaskInfo::deactivate()
 
     deactivated = true;
     scheduled = false;
-
-    if (delayed)
+    /// Only necessary to cancel the task before the pool is being destroyed
+    if (delayed && !pool_shutdown)
         pool.cancelDelayedTask(*this, lock_schedule);
 }
 
@@ -213,7 +213,12 @@ BackgroundSchedulePool::~BackgroundSchedulePool()
         {
             std::lock_guard lock_tasks(tasks_mutex);
             std::lock_guard lock_delayed_tasks(delayed_tasks_mutex);
-
+            // Notify all delayed tasks that the owning BackgroundSchedulePool is being destroyed.
+            // This prevents any further use of the pool (e.g., cancelDelayedTask) from within
+            // BackgroundSchedulePoolTaskInfo::deactivate(), avoiding use-after-free errors.
+            for (auto & task : delayed_tasks) {
+                task.second->pool_shutdown = true;
+            }
             shutdown = true;
         }
 

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -142,6 +142,7 @@ private:
     /// Invariants:
     /// * If deactivated is true then scheduled, delayed and executing are all false.
     /// * scheduled and delayed cannot be true at the same time.
+    bool pool_shutdown TSA_GUARDED_BY(schedule_mutex) = false;  // Pool is being destroyed.
     bool deactivated TSA_GUARDED_BY(schedule_mutex) = false;
     bool scheduled TSA_GUARDED_BY(schedule_mutex) = false;
     bool delayed TSA_GUARDED_BY(schedule_mutex) = false;


### PR DESCRIPTION
This patch adds a `pool_shutdown` flag to BackgroundSchedulePool::TaskInfo to indicate when the owning `BackgroundSchedulePool` is being destroyed. This prevents calling `cancelDelayedTask()` on an already-destroyed pool from within `TaskInfo::deactivate()`.

Also:
- Set `pool_shutdown = true` for all delayed tasks during pool destruction.
- Guarded `pool_shutdown` with `schedule_mutex` and grouped it with other task state flags.
- Improved code safety and future maintainability.

This prevents a use-after-free crash in rare cases when a delayed task
is still pending while the BackgroundSchedulePool is shutting down.
Already reported in issue https://github.com/ClickHouse/ClickHouse/issues/80066

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent use-after-free in BackgroundSchedulePool::TaskInfo by tracking pool shutdown


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
