### PR TITLE
Add executable  UDF names to the `used_functions` column in the `system.query_log`.

### DIFF
--- a/tests/integration/test_executable_udf_names_in_used_functions_column/config/executable_user_defined_functions_config.xml
+++ b/tests/integration/test_executable_udf_names_in_used_functions_column/config/executable_user_defined_functions_config.xml
@@ -1,0 +1,2 @@
+<clickhouse>
+</clickhouse>

--- a/tests/integration/test_executable_udf_names_in_used_functions_column/functions/test_function_config.xml
+++ b/tests/integration/test_executable_udf_names_in_used_functions_column/functions/test_function_config.xml
@@ -1,0 +1,45 @@
+<functions>
+    <function>
+        <type>executable</type>
+        <name>test_function_bash</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input.sh</command>
+    </function>
+
+    <function>
+        <type>executable_pool</type>
+        <name>test_function_pool_bash</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input.sh</command>
+    </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input.py</command>
+    </function>
+
+    <function>
+        <type>executable_pool</type>
+        <name>test_function_pool_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input.py</command>
+    </function>
+</functions>

--- a/tests/integration/test_executable_udf_names_in_used_functions_column/test.py
+++ b/tests/integration/test_executable_udf_names_in_used_functions_column/test.py
@@ -66,7 +66,8 @@ def check_executable_udf_functions(functions):
         assert False
     execute_udf = "SELECT {}" if len(functions) == 1 else "SELECT concat({})"
     execute_udf = execute_udf.format(','.join(map(lambda function : "{}(1)".format(function), functions)))
-    node.query(execute_udf)
+    query_id = uuid.uuid4().hex
+    node.query(execute_udf, query_id=query_id)
     node.query("SYSTEM FLUSH LOGS")
 
     used_functions = set(map(repr, functions))
@@ -74,7 +75,7 @@ def check_executable_udf_functions(functions):
         used_functions.add("\'concat\'")
 
     query_result = node.query("SELECT used_functions FROM system.query_log "
-                              "WHERE type = \'QueryFinish\' AND query = \'{}\'".format(execute_udf))
+                              "WHERE type = \'QueryFinish\' AND query_id = \'{}\'".format(query_id))
     query_result = set(query_result[1:len(query_result) - 2].split(','))
     assert query_result == used_functions
 

--- a/tests/integration/test_executable_udf_names_in_used_functions_column/test.py
+++ b/tests/integration/test_executable_udf_names_in_used_functions_column/test.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import time
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", stay_alive=True, main_configs=[])
+
+
+def skip_test_msan(instance):
+    if instance.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with vfork")
+
+
+def copy_file_to_container(local_path, dist_path, container_id):
+    os.system(
+        "docker cp {local} {cont_id}:{dist}".format(
+            local=local_path, cont_id=container_id, dist=dist_path
+        )
+    )
+
+
+config = """<clickhouse>
+    <user_defined_executable_functions_config>/etc/clickhouse-server/functions/test_function_config.xml</user_defined_executable_functions_config>
+</clickhouse>"""
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        node.replace_config(
+            "/etc/clickhouse-server/config.d/executable_user_defined_functions_config.xml",
+            config,
+        )
+
+        copy_file_to_container(
+            os.path.join(SCRIPT_DIR, "functions/."),
+            "/etc/clickhouse-server/functions",
+            node.docker_id,
+        )
+        copy_file_to_container(
+            os.path.join(SCRIPT_DIR, "user_scripts/."),
+            "/var/lib/clickhouse/user_scripts",
+            node.docker_id,
+        )
+
+        node.restart_clickhouse()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def check_executable_udf_functions(functions):
+    if not functions:
+        assert False
+    execute_udf = "SELECT {}" if len(functions) == 1 else "SELECT concat({})"
+    execute_udf = execute_udf.format(','.join(map(lambda function : "{}(1)".format(function), functions)))
+    node.query(execute_udf)
+    node.query("SYSTEM FLUSH LOGS")
+
+    used_functions = set(map(repr, functions))
+    if len(functions) > 1:
+        used_functions.add("\'concat\'")
+
+    query_result = node.query("SELECT used_functions FROM system.query_log "
+                              "WHERE type = \'QueryFinish\' AND query = \'{}\'".format(execute_udf))
+    query_result = set(query_result[1:len(query_result) - 2].split(','))
+    assert query_result == used_functions
+
+
+def test_executable_function_single(started_cluster):
+    skip_test_msan(node)
+    check_executable_udf_functions(["test_function_bash"])
+
+
+def test_executable_function_multiple(started_cluster):
+    skip_test_msan(node)
+    check_executable_udf_functions(["test_function_bash", "test_function_python"])
+
+
+def test_executable_function_multiple_pool(started_cluster):
+    skip_test_msan(node)
+    check_executable_udf_functions(["test_function_bash", "test_function_python", "test_function_pool_bash", "test_function_pool_python"])
+
+
+def test_executable_function_duplicate(started_cluster):
+    skip_test_msan(node)
+    check_executable_udf_functions(["test_function_bash", "test_function_bash"])

--- a/tests/integration/test_executable_udf_names_in_used_functions_column/user_scripts/input.py
+++ b/tests/integration/test_executable_udf_names_in_used_functions_column/user_scripts/input.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+
+import sys
+
+if __name__ == "__main__":
+    for line in sys.stdin:
+        print(line, end="")
+        sys.stdout.flush()

--- a/tests/integration/test_executable_udf_names_in_used_functions_column/user_scripts/input.sh
+++ b/tests/integration/test_executable_udf_names_in_used_functions_column/user_scripts/input.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while read read_data;
+    do printf "$read_data\n";
+done


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Executable User Defined Functions (eUDF) names are not added to the `used_functions` column of the `system.query_log` table, unlike other functions. This PR implements the addition of the eUDF name if the eUDF was used in the request.
