### PR TITLE
Stateless tests: fix flaky tests with async insert enabled

### DIFF
--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -81,7 +81,7 @@ function insert()
         table=$($CLICKHOUSE_CLIENT -q "select database || '.' || name from system.tables where database like '${CLICKHOUSE_DATABASE}%' order by rand() limit 1")
         if [ -z "$table" ]; then continue; fi
         $CLICKHOUSE_CLIENT -q \
-        "insert into $table values ($RANDOM)" 2>&1| grep -Fa "Exception: " | grep -Fv UNKNOWN_DATABASE | grep -Fv UNKNOWN_TABLE | grep -Fv TABLE_IS_READ_ONLY | grep -Fv TABLE_IS_DROPPED
+        "insert into $table values ($RANDOM)" 2>&1| grep -Fa "Exception: " | grep -Fv UNKNOWN_DATABASE | grep -Fv UNKNOWN_TABLE | grep -Fv TABLE_IS_READ_ONLY | grep -Fv TABLE_IS_DROPPED | grep -Fv TABLE_UUID_MISMATCH
     done
 }
 

--- a/tests/queries/0_stateless/01443_merge_truncate_long.sh
+++ b/tests/queries/0_stateless/01443_merge_truncate_long.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-async-insert
+# no-async-insert: https://github.com/ClickHouse/ClickHouse/issues/80105
 
 set -e
 

--- a/tests/queries/0_stateless/02155_h3_to_center_child.sql
+++ b/tests/queries/0_stateless/02155_h3_to_center_child.sql
@@ -1,4 +1,5 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-async-insert
+-- no-async-insert: https://github.com/ClickHouse/ClickHouse/issues/80105
 
 DROP TABLE IF EXISTS h3_indexes;
 


### PR DESCRIPTION
1. Fix 01111_create_drop_replicated_db_stress. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=76b851b81c72b8bbaadc1c0999e24fc647b58aad&name_0=MasterCI&name_1=Stateless%20tests%20%28debug%2C%20AsyncInsert%2C%20s3%20storage%29
2. Disable [02155_h3_to_center_child](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=338bc8f51b2c84d0d0f435f1301f63672521a78c&name_0=MasterCI&name_1=Stateless%20tests%20%28debug%2C%20AsyncInsert%2C%20s3%20storage%29) [01443_merge_truncate_long](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b884cb9da21967a0fac8b382eff8786fdde4328e&name_0=MasterCI&name_1=Stateless%20tests%20%28debug%2C%20AsyncInsert%2C%20s3%20storage%29) because of timeouts https://github.com/ClickHouse/ClickHouse/issues/80105

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
