### PR TITLE
Improve bitmap function error messages

### DIFF
--- a/src/Functions/FunctionsBitmap.h
+++ b/src/Functions/FunctionsBitmap.h
@@ -862,6 +862,14 @@ public:
                             "First argument for function {} must be a bitmap but it has type {}",
                             getName(), arguments[0]->getName());
 
+        WhichDataType first_aggregate_argument(bitmap_type0->getArgumentsDataTypes()[0]);
+        if (!first_aggregate_argument.isNativeInt() && !first_aggregate_argument.isNativeUInt())
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "First argument for function {} must be a bitmap of an integer but it is a bitmap of {}",
+                getName(),
+                bitmap_type0->getArgumentsDataTypes()[0]->getName());
+
         WhichDataType which(arguments[1].get());
         if (!which.isNativeInt() && !which.isNativeUInt())
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,

--- a/tests/queries/0_stateless/03457_bitmapContains_nullable.sql
+++ b/tests/queries/0_stateless/03457_bitmapContains_nullable.sql
@@ -1,0 +1,36 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/19311
+WITH (SELECT groupBitmapState(number::Nullable(UInt8)) as n from numbers(1)) as n SELECT number as x, bitmapContains(n, x) FROM numbers(10); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+WITH
+    men AS
+        (
+            SELECT
+                toUInt32(number) AS id,
+                mod(id, 100) AS age,
+                mod(id, 1000) * 60 AS sal,
+                mod(id, 60) AS nat
+            FROM system.numbers
+            LIMIT 10
+        ),
+    t AS
+        (
+            SELECT
+                number AS n,
+                multiIf(n = 0, 0, n = 1, 6, n = 2, 30, NULL) AS lo,
+                multiIf(n = 0, 5, n = 1, 29, n = 2, 99, NULL) AS hi
+            FROM system.numbers
+            LIMIT 3
+        ),
+    t2 AS
+        (
+            SELECT
+                toString(n) AS name,
+                groupBitmapState(multiIf((age >= lo) AND (age <= hi), id, NULL)) AS bit_state
+            FROM men, t
+            GROUP BY n
+        )
+SELECT
+    name,
+    sumIf(sal, bitmapContains(bit_state, id))
+FROM men, t2
+GROUP BY name; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve bitmap function error messages

bitmap functions have never supported bitmaps created with nullable integers, but the error wasn't clear
Closes https://github.com/ClickHouse/ClickHouse/issues/19311

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
