### PR TITLE
setting to disable core dumps

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -272,8 +272,11 @@ void BaseDaemon::initialize(Application & self)
         struct rlimit rlim;
         if (getrlimit(RLIMIT_CORE, &rlim))
             throw Poco::Exception("Cannot getrlimit");
+
         /// 1 GiB by default. If more - it writes to disk too long.
-        rlim.rlim_cur = config().getUInt64("core_dump.size_limit", 1024 * 1024 * 1024);
+        rlim.rlim_cur = config().getBool("core_dump.enabled", true)
+            ? config().getUInt64("core_dump.size_limit", 1024 * 1024 * 1024)
+            : 0;
 
         if (rlim.rlim_cur && setrlimit(RLIMIT_CORE, &rlim))
         {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a setting to enable/disable core dump generation. This setting is needed so that ClickHouse Cloud users can opt out of core dump collection.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
