### PR TITLE
Disable atexit hook for OpenSSL

### DIFF
--- a/src/Common/Crypto/OpenSSLInitializer.cpp
+++ b/src/Common/Crypto/OpenSSLInitializer.cpp
@@ -2,12 +2,12 @@
 
 #include "config.h"
 
-#include <Common/OpenSSLHelpers.h>
 #include <Common/Exception.h>
+#include <Common/OpenSSLHelpers.h>
 
 #if USE_SSL
-#    include <openssl/provider.h>
 #    include <openssl/crypto.h>
+#    include <openssl/provider.h>
 #    include <openssl/ssl.h>
 #endif
 
@@ -31,6 +31,10 @@ void OpenSSLInitializer::initialize()
 #if USE_SSL
     if (ref_count++ == 0)
     {
+        // Disable OpenSSL atexit hook.
+        // It may cause issues on shutdown, when some OpenSSL objects are still in use.
+        auto openssl_flags = OPENSSL_INIT_NO_ATEXIT;
+
         /// Loading OpenSSL config only if it is set explicitly.
         ///
         /// 'legacy' provider may be disabled in system config,
@@ -38,14 +42,15 @@ void OpenSSLInitializer::initialize()
         const char * env_openssl_conf = getenv("OPENSSL_CONF"); // NOLINT(concurrency-mt-unsafe)
         if (env_openssl_conf)
         {
-            if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, nullptr) == 0)
-                throw std::runtime_error(fmt::format("Failed to load OpenSSL config. {}", getOpenSSLErrors()));
+            openssl_flags |= OPENSSL_INIT_LOAD_CONFIG;
         }
         else
         {
-            if (OPENSSL_init_ssl(OPENSSL_INIT_NO_LOAD_CONFIG, nullptr) == 0)
-                throw std::runtime_error(fmt::format("Failed to initialize OpenSSL. {}", getOpenSSLErrors()));
+            openssl_flags |= OPENSSL_INIT_NO_LOAD_CONFIG;
         }
+
+        if (OPENSSL_init_ssl(openssl_flags, nullptr) == 0)
+            throw std::runtime_error(fmt::format("Failed to load OpenSSL config. {}", getOpenSSLErrors()));
 
         default_provider = OSSL_PROVIDER_load(nullptr, "default");
         if (!default_provider)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/80132