### PR TITLE
Fix UBSan failure on non-aligned PODArray null pointer

### DIFF
--- a/src/Common/PODArray.cpp
+++ b/src/Common/PODArray.cpp
@@ -42,7 +42,7 @@ ALWAYS_INLINE size_t minimum_memory_for_elements(size_t num_elements, size_t ele
 
 
 /// Used for left padding of PODArray when empty
-const char empty_pod_array[empty_pod_array_size]{};
+alignas(std::max_align_t) const char empty_pod_array[empty_pod_array_size]{};
 
 template class PODArray<UInt8, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
 template class PODArray<UInt16, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <numeric>
 
 #ifndef NDEBUG
 #include <sys/mman.h>
@@ -92,11 +93,12 @@ protected:
     /// Round padding up to an whole number of elements to simplify arithmetic.
     static constexpr size_t pad_right = integerRoundUp(pad_right_, ELEMENT_SIZE);
     /// pad_left is also rounded up to 16 bytes to maintain alignment of allocated memory.
-    static constexpr size_t pad_left = integerRoundUp(integerRoundUp(pad_left_, ELEMENT_SIZE), 16);
+    static constexpr size_t pad_left = integerRoundUp(pad_left, std::lcm(ELEMENT_SIZE, 16));
     /// Empty array will point to this static memory as padding and begin/end.
     static constexpr char * null = const_cast<char *>(empty_pod_array) + pad_left;
 
     static_assert(pad_left <= empty_pod_array_size && "Left Padding exceeds empty_pod_array_size. Is the element size too large?");
+    static_assert(pad_left % ELEMENT_SIZE == 0, "pad_left must be multiple of element alignment");
 
     // If we are using allocator with inline memory, the minimal size of
     // array must be in sync with the size of this memory.

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -93,7 +93,7 @@ protected:
     /// Round padding up to an whole number of elements to simplify arithmetic.
     static constexpr size_t pad_right = integerRoundUp(pad_right_, ELEMENT_SIZE);
     /// pad_left is also rounded up to 16 bytes to maintain alignment of allocated memory.
-    static constexpr size_t pad_left = integerRoundUp(pad_left, std::lcm(ELEMENT_SIZE, 16));
+    static constexpr size_t pad_left = integerRoundUp(pad_left_, std::lcm(ELEMENT_SIZE, 16));
     /// Empty array will point to this static memory as padding and begin/end.
     static constexpr char * null = const_cast<char *>(empty_pod_array) + pad_left;
 

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -68,7 +68,7 @@ namespace DB
   * TODO Allow greater alignment than alignof(T). Example: array of char aligned to page size.
   */
 static constexpr size_t empty_pod_array_size = 1024;
-extern const char empty_pod_array[empty_pod_array_size];
+alignas(std::max_align_t) extern const char empty_pod_array[empty_pod_array_size];
 
 namespace PODArrayDetails
 {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closes https://github.com/ClickHouse/ClickHouse/issues/80136
