### PR TITLE
Don't crash if system log flush failed during shutdown

### DIFF
--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -79,7 +79,7 @@ public:
     SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConfiguration & config);
     SystemLogs(const SystemLogs & other) = default;
 
-    void flush(bool should_prepare_tables_anyway, const Strings & names);
+    void flush(bool should_prepare_tables_anyway, const Strings & names, bool ignore_errors = false);
     void flushAndShutdown();
     void shutdown();
     void handleCrash();


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

If a system table flush is stuck during server shutdown, just log the error and proceed with the shutdown, instead of crashing.