### PR TITLE
Support recover lost replica by attach for Replicated database

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1167,7 +1167,7 @@ static UUID getTableUUIDIfReplicated(const String & metadata, ContextPtr context
     return create.uuid;
 }
 
-void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeeper, UInt32 our_log_ptr, UInt32 & max_log_ptr)
+void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeeper, UInt32 our_log_ptr, UInt32 & max_log_ptr, bool lost_according_to_digest)
 {
     waitDatabaseStarted();
 
@@ -1465,6 +1465,13 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
                 }
 
                 auto query_ast = parseQueryFromMetadataInZooKeeper(table_name, create_query_string);
+                
+                if (lost_according_to_digest)
+                {
+                    auto & create = query_ast->as<ASTCreateQuery &>();
+                    create.attach = true;
+                }
+
                 auto create_query_context = make_query_context();
 
                 NormalizeSelectWithUnionQueryVisitor::Data data{create_query_context->getSettingsRef()[Setting::union_default_mode]};

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -122,7 +122,7 @@ private:
     void checkTableEngine(const ASTCreateQuery & query, ASTStorage & storage, ContextPtr query_context) const;
 
 
-    void recoverLostReplica(const ZooKeeperPtr & current_zookeeper, UInt32 our_log_ptr, UInt32 & max_log_ptr);
+    void recoverLostReplica(const ZooKeeperPtr & current_zookeeper, UInt32 our_log_ptr, UInt32 & max_log_ptr, bool lost_according_to_digest = false);
 
     std::map<String, String> tryGetConsistentMetadataSnapshot(const ZooKeeperPtr & zookeeper, UInt32 & max_log_ptr) const;
 

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -178,7 +178,7 @@ void DatabaseReplicatedDDLWorker::initializeReplication()
         if (!is_new_replica)
             LOG_WARNING(log, "Replica seems to be lost: our_log_ptr={}, max_log_ptr={}, local_digest={}, zk_digest={}",
                         our_log_ptr, max_log_ptr, local_digest, digest);
-        database->recoverLostReplica(zookeeper, our_log_ptr, max_log_ptr);
+        database->recoverLostReplica(zookeeper, our_log_ptr, max_log_ptr, lost_according_to_digest);
         zookeeper->set(database->replica_path + "/log_ptr", toString(max_log_ptr));
         initializeLogPointer(DDLTaskBase::getLogEntryName(max_log_ptr));
     }


### PR DESCRIPTION
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The Replicated database records the uuid of the database and tables on zookeeper. The uuid of the database is used for the metadata directory of the table, and the uuid of the table is used for the data directory of the table and the zookeeper path of the replicated table.

In the current version(25.5.1.1), if the disk default(disk_name: default, path: /mnt/storage00/wzb/data/master/) where the metadata is located fails and data is lost, it is impossible to reuse the other healthy data directory(/mnt/storage01/wzb/data/master/store/57e/57e69a63-7530-4ed8-98af-61fe9e70b376/、/mnt/storage02/wzb/data/master/store/57e/57e69a63-7530-4ed8-98af-61fe9e70b376/) for lightweight recovery. 

```
52f72e5fb519 :) select * from system.databases where name = 'rp_1';\G

Row 1:
──────
name:          rp_1
engine:        Replicated
data_path:     /mnt/storage00/wzb/data/master/store/
metadata_path: store/3ce/3ce5926c-29a9-4304-b0ac-407ad0b39419/
uuid:          3ce5926c-29a9-4304-b0ac-407ad0b39419
engine_full:   Replicated('db_rp/test/rp_1', '{shard}', '{replica}')    

52f72e5fb519 :) select * from system.tables where name = 'rmt_1_1';\G

Row 1:
──────
database:                         rp_1
name:                             rmt_1_1
uuid:                             57e69a63-7530-4ed8-98af-61fe9e70b376
engine:                           ReplicatedMergeTree
data_paths:                       ['/mnt/storage00/wzb/data/master/store/57e/57e69a63-7530-4ed8-98af-61fe9e70b376/','/mnt/storage01/wzb/data/master/store/57e/57e69a63-7530-4ed8-98af-61fe9e70b376/','/mnt/storage02/wzb/data/master/store/57e/57e69a63-7530-4ed8-98af-61fe9e70b376/']
metadata_path:                    store/3ce/3ce5926c-29a9-4304-b0ac-407ad0b39419/rmt_1_1.sql
create_table_query:               CREATE TABLE rp_1.rmt_1_1 (`n` UInt64, `s` String, `name` String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}') ORDER BY n SETTINGS storage_policy = 'hot_and_cold', index_granularity = 8192

52f72e5fb519 :) select name,path from system.disks;

   ┌─name──────┬─path────────────────────────────┐
1. │ default   │ /mnt/storage00/wzb/data/master/ │
2. │ storage01 │ /mnt/storage01/wzb/data/master/ │
3. │ storage02 │ /mnt/storage02/wzb/data/master/ │
   └───────────┴─────────────────────────────────┘

```

Recovery can only be carried out by first cleaning up the data of the local disk and metadata of the zookeeper, and then by creating the database. If the data volume is very large, such recovery is very slow.

```
rm -rf /mnt/storage01/wzb/data/master/*
rm -rf /mnt/storage02/wzb/data/master/*
SYSTEM DROP DATABASE REPLICA '${replica}' FROM SHARD '${shard}';
SYSTEM DROP REPLICA '${replica}';
CREATE DATABASE rp_1 ENGINE = Replicated('db_rp/test/rp_1', '{shard}', '{replica}');
```

After my modification, it can be directly recovered through attach database, and other healthy data directories can be reused.
```
ATTACH DATABASE rp_1 UUID '3ce5926c-29a9-4304-b0ac-407ad0b39419' ENGINE = Replicated('db_rp/test/rp_1', '{shard}', '{replica}')
```
