### PR TITLE
Disable CPU overload checks for all tests

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -144,9 +144,6 @@ ln -sf $SRC_PATH/users.d/limits.yaml $DEST_SERVER_PATH/users.d/
 if [[ $(is_fast_build) == 1 ]]; then
     ln -sf $SRC_PATH/users.d/limits_fast.yaml $DEST_SERVER_PATH/users.d/
 fi
-if check_clickhouse_version 25.4; then
-    ln -sf $SRC_PATH/users.d/max_cpu_load.xml $DEST_SERVER_PATH/users.d/
-fi
 
 if [[ -n "$USE_OLD_ANALYZER" ]] && [[ "$USE_OLD_ANALYZER" -eq 1 ]]; then
     ln -sf $SRC_PATH/users.d/analyzer.xml $DEST_SERVER_PATH/users.d/

--- a/tests/config/users.d/max_cpu_load.xml
+++ b/tests/config/users.d/max_cpu_load.xml
@@ -1,9 +1,0 @@
-<!-- Increase max possible CPU load in tests -->
-<clickhouse>
-    <profiles>
-        <default>
-            <min_os_cpu_wait_time_ratio_to_throw>10</min_os_cpu_wait_time_ratio_to_throw>
-            <max_os_cpu_wait_time_ratio_to_throw>20</max_os_cpu_wait_time_ratio_to_throw>
-        </default>
-    </profiles>
-</clickhouse>

--- a/tests/integration/helpers/0_common_max_cpu_load.xml
+++ b/tests/integration/helpers/0_common_max_cpu_load.xml
@@ -1,9 +1,0 @@
-<!-- Increase max possible CPU load in tests -->
-<clickhouse>
-    <profiles>
-        <default>
-            <min_os_cpu_wait_time_ratio_to_throw>10</min_os_cpu_wait_time_ratio_to_throw>
-            <max_os_cpu_wait_time_ratio_to_throw>20</max_os_cpu_wait_time_ratio_to_throw>
-        </default>
-    </profiles>
-</clickhouse>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4749,8 +4749,6 @@ class ClickHouseInstance:
         if self.with_installed_binary:
             # Ignore CPU overload in this case
             write_embedded_config("0_common_min_cpu_busy_time.xml", self.config_d_dir)
-        else:
-            write_embedded_config("0_common_max_cpu_load.xml", users_d_dir)
 
         use_old_analyzer = os.environ.get("CLICKHOUSE_USE_OLD_ANALYZER") is not None
         use_distributed_plan = (

--- a/tests/integration/test_settings_profile/test.py
+++ b/tests/integration/test_settings_profile/test.py
@@ -464,7 +464,7 @@ def test_show_profiles():
     )
 
     query_expected_response = [
-        "CREATE SETTINGS PROFILE `default` SETTINGS min_os_cpu_wait_time_ratio_to_throw = 10., max_os_cpu_wait_time_ratio_to_throw = 20.\n",
+        "CREATE SETTINGS PROFILE `default`\n",
     ]
     assert (
         instance.query("SHOW CREATE SETTINGS PROFILE default")
@@ -472,14 +472,14 @@ def test_show_profiles():
     )
 
     query_expected_response = [
-        "CREATE SETTINGS PROFILE `default` SETTINGS min_os_cpu_wait_time_ratio_to_throw = 10., max_os_cpu_wait_time_ratio_to_throw = 20.\n"
+        "CREATE SETTINGS PROFILE `default`\n"
         "CREATE SETTINGS PROFILE `readonly` SETTINGS readonly = 1\n"
         "CREATE SETTINGS PROFILE `xyz`\n",
     ]
     assert instance.query("SHOW CREATE PROFILES") in query_expected_response
 
     expected_access = (
-        "CREATE SETTINGS PROFILE `default` SETTINGS min_os_cpu_wait_time_ratio_to_throw = 10., max_os_cpu_wait_time_ratio_to_throw = 20.\n"
+        "CREATE SETTINGS PROFILE `default`\n"
         "CREATE SETTINGS PROFILE `readonly` SETTINGS readonly = 1\n"
         "CREATE SETTINGS PROFILE `xyz`\n"
     )


### PR DESCRIPTION
CPU overload detection contributes to flakiness of tests especially on slower debug and sanitizer builds.
Let's not enable this feature by default for all tests

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
