### PR TITLE
Organize Iceberg field name's literals better

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -3,7 +3,7 @@
 namespace Iceberg
 {
 #define DEFINE_ICEBERG_FIELD_NAME(name, strval) constexpr const char * F##name = #strval;
-#define DEFINE_ICEBERG_SUB_FIELD_NAME(name, subname) constexpr const char * F##name##_##subname = #name "." #subname;
+#define DEFINE_ICEBERG_SUB_FIELD_NAME(name, subname) constexpr const char * F##name##0##subname = #name "." #subname;
 #define DEFINE_ICEBERG_FIELD_NAME_SAME(name) constexpr const char * F##name = #name;
 
 DEFINE_ICEBERG_FIELD_NAME_SAME(sequence_number);
@@ -11,12 +11,20 @@ DEFINE_ICEBERG_FIELD_NAME_SAME(manifest_path);
 DEFINE_ICEBERG_FIELD_NAME(format_version, format-version);
 DEFINE_ICEBERG_FIELD_NAME(current_snapshot_id, current-snapshot-id);
 DEFINE_ICEBERG_FIELD_NAME(snapshot_id, snapshot-id);
+DEFINE_ICEBERG_FIELD_NAME(schema_id, schema-id);
+DEFINE_ICEBERG_FIELD_NAME(current_schema_id, current-schema-id);
+DEFINE_ICEBERG_FIELD_NAME(table_uuid, table-uuid);
+DEFINE_ICEBERG_FIELD_NAME(total_records, total-records);
+DEFINE_ICEBERG_FIELD_NAME(total_files_size, total-files-size);
 DEFINE_ICEBERG_FIELD_NAME(manifest_list, manifest-list);
 DEFINE_ICEBERG_FIELD_NAME(snapshot_log, snapshot-log);
 DEFINE_ICEBERG_FIELD_NAME(timestamp_ms, timestamp-ms);
 DEFINE_ICEBERG_FIELD_NAME_SAME(location);
 DEFINE_ICEBERG_FIELD_NAME_SAME(snapshots);
+DEFINE_ICEBERG_FIELD_NAME_SAME(schemas);
 DEFINE_ICEBERG_FIELD_NAME(last_updated_ms, last-update-ms);
+DEFINE_ICEBERG_FIELD_NAME(source_id, source-id);
+DEFINE_ICEBERG_FIELD_NAME_SAME(transform);
 DEFINE_ICEBERG_FIELD_NAME_SAME(status);
 DEFINE_ICEBERG_FIELD_NAME_SAME(data_file);
 DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, file_path);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -2,37 +2,43 @@
 
 namespace Iceberg
 {
-#define DEFINE_ICEBERG_FIELD_NAME(name, strval) constexpr const char * F##name = #strval;
-#define DEFINE_ICEBERG_SUB_FIELD_NAME(name, subname) constexpr const char * F##name##0##subname = #name "." #subname;
-#define DEFINE_ICEBERG_FIELD_NAME_SAME(name) constexpr const char * F##name = #name;
+/// This file define the field name appearing in Iceberg files.
+#define DEFINE_ICEBERG_FIELD_ALIAS(name, strval) constexpr const char * f_##name = #strval;
+#define DEFINE_ICEBERG_FIELD_COMPOUND(name, subname) constexpr const char * c_##name##_##subname = #name "." #subname;
+#define DEFINE_ICEBERG_FIELD(name) constexpr const char * f_##name = #name;
 
-DEFINE_ICEBERG_FIELD_NAME_SAME(sequence_number);
-DEFINE_ICEBERG_FIELD_NAME_SAME(manifest_path);
-DEFINE_ICEBERG_FIELD_NAME(format_version, format-version);
-DEFINE_ICEBERG_FIELD_NAME(current_snapshot_id, current-snapshot-id);
-DEFINE_ICEBERG_FIELD_NAME(snapshot_id, snapshot-id);
-DEFINE_ICEBERG_FIELD_NAME(schema_id, schema-id);
-DEFINE_ICEBERG_FIELD_NAME(current_schema_id, current-schema-id);
-DEFINE_ICEBERG_FIELD_NAME(table_uuid, table-uuid);
-DEFINE_ICEBERG_FIELD_NAME(total_records, total-records);
-DEFINE_ICEBERG_FIELD_NAME(total_files_size, total-files-size);
-DEFINE_ICEBERG_FIELD_NAME(manifest_list, manifest-list);
-DEFINE_ICEBERG_FIELD_NAME(snapshot_log, snapshot-log);
-DEFINE_ICEBERG_FIELD_NAME(timestamp_ms, timestamp-ms);
-DEFINE_ICEBERG_FIELD_NAME_SAME(location);
-DEFINE_ICEBERG_FIELD_NAME_SAME(snapshots);
-DEFINE_ICEBERG_FIELD_NAME_SAME(schemas);
-DEFINE_ICEBERG_FIELD_NAME(last_updated_ms, last-updated-ms);
-DEFINE_ICEBERG_FIELD_NAME(source_id, source-id);
-DEFINE_ICEBERG_FIELD_NAME_SAME(transform);
-DEFINE_ICEBERG_FIELD_NAME_SAME(status);
-DEFINE_ICEBERG_FIELD_NAME_SAME(data_file);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, file_path);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, content);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, partition);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, value_counts);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, column_sizes);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, null_value_counts);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, lower_bounds);
-DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, upper_bounds);
+/// These variables begin with 'f_', following the field name in Iceberg files.
+DEFINE_ICEBERG_FIELD(data_file);
+DEFINE_ICEBERG_FIELD(location);
+DEFINE_ICEBERG_FIELD(manifest_path);
+DEFINE_ICEBERG_FIELD(schemas);
+DEFINE_ICEBERG_FIELD(sequence_number);
+DEFINE_ICEBERG_FIELD(snapshots);
+DEFINE_ICEBERG_FIELD(status);
+DEFINE_ICEBERG_FIELD(summary);
+DEFINE_ICEBERG_FIELD(transform);
+/// These variables replace `-` with underscore `_` to be compatible with c++ code.
+DEFINE_ICEBERG_FIELD_ALIAS(format_version, format-version);
+DEFINE_ICEBERG_FIELD_ALIAS(current_snapshot_id, current-snapshot-id);
+DEFINE_ICEBERG_FIELD_ALIAS(snapshot_id, snapshot-id);
+DEFINE_ICEBERG_FIELD_ALIAS(parent_snapshot_id, parent-snapshot-id);
+DEFINE_ICEBERG_FIELD_ALIAS(snapshot_log, snapshot-log);
+DEFINE_ICEBERG_FIELD_ALIAS(schema_id, schema-id);
+DEFINE_ICEBERG_FIELD_ALIAS(current_schema_id, current-schema-id);
+DEFINE_ICEBERG_FIELD_ALIAS(table_uuid, table-uuid);
+DEFINE_ICEBERG_FIELD_ALIAS(total_records, total-records);
+DEFINE_ICEBERG_FIELD_ALIAS(total_files_size, total-files-size);
+DEFINE_ICEBERG_FIELD_ALIAS(manifest_list, manifest-list);
+DEFINE_ICEBERG_FIELD_ALIAS(timestamp_ms, timestamp-ms);
+DEFINE_ICEBERG_FIELD_ALIAS(last_updated_ms, last-updated-ms);
+DEFINE_ICEBERG_FIELD_ALIAS(source_id, source-id);
+/// These are compound fields like `data_file.file_path`, we use prefix 'c_' to distingish them.
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, file_path);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, content);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, partition);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, value_counts);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, column_sizes);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, null_value_counts);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, lower_bounds);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, upper_bounds);
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace Iceberg
+{
+#define DEFINE_ICEBERG_FIELD_NAME(name, strval) constexpr const char * F##name = #strval;
+#define DEFINE_ICEBERG_SUB_FIELD_NAME(name, subname) constexpr const char * F##name##_##subname = #name "." #subname;
+#define DEFINE_ICEBERG_FIELD_NAME_SAME(name) constexpr const char * F##name = #name;
+
+DEFINE_ICEBERG_FIELD_NAME_SAME(sequence_number);
+DEFINE_ICEBERG_FIELD_NAME_SAME(manifest_path);
+DEFINE_ICEBERG_FIELD_NAME(format_version, format-version);
+DEFINE_ICEBERG_FIELD_NAME(current_snapshot_id, current-snapshot-id);
+DEFINE_ICEBERG_FIELD_NAME(snapshot_id, snapshot-id);
+DEFINE_ICEBERG_FIELD_NAME(manifest_list, manifest-list);
+DEFINE_ICEBERG_FIELD_NAME(snapshot_log, snapshot-log);
+DEFINE_ICEBERG_FIELD_NAME(timestamp_ms, timestamp-ms);
+DEFINE_ICEBERG_FIELD_NAME_SAME(location);
+DEFINE_ICEBERG_FIELD_NAME_SAME(snapshots);
+DEFINE_ICEBERG_FIELD_NAME(last_updated_ms, last-update-ms);
+DEFINE_ICEBERG_FIELD_NAME_SAME(status);
+DEFINE_ICEBERG_FIELD_NAME_SAME(data_file);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, file_path);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, content);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, partition);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, value_counts);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, column_sizes);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, null_value_counts);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, lower_bounds);
+DEFINE_ICEBERG_SUB_FIELD_NAME(data_file, upper_bounds);
+}

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -22,7 +22,7 @@ DEFINE_ICEBERG_FIELD_NAME(timestamp_ms, timestamp-ms);
 DEFINE_ICEBERG_FIELD_NAME_SAME(location);
 DEFINE_ICEBERG_FIELD_NAME_SAME(snapshots);
 DEFINE_ICEBERG_FIELD_NAME_SAME(schemas);
-DEFINE_ICEBERG_FIELD_NAME(last_updated_ms, last-update-ms);
+DEFINE_ICEBERG_FIELD_NAME(last_updated_ms, last-updated-ms);
 DEFINE_ICEBERG_FIELD_NAME(source_id, source-id);
 DEFINE_ICEBERG_FIELD_NAME_SAME(transform);
 DEFINE_ICEBERG_FIELD_NAME_SAME(status);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -32,7 +32,7 @@ DEFINE_ICEBERG_FIELD_ALIAS(manifest_list, manifest-list);
 DEFINE_ICEBERG_FIELD_ALIAS(timestamp_ms, timestamp-ms);
 DEFINE_ICEBERG_FIELD_ALIAS(last_updated_ms, last-updated-ms);
 DEFINE_ICEBERG_FIELD_ALIAS(source_id, source-id);
-/// These are compound fields like `data_file.file_path`, we use prefix 'c_' to distingish them.
+/// These are compound fields like `data_file.file_path`, we use prefix 'c_' to distinguish them.
 DEFINE_ICEBERG_FIELD_COMPOUND(data_file, file_path);
 DEFINE_ICEBERG_FIELD_COMPOUND(data_file, content);
 DEFINE_ICEBERG_FIELD_COMPOUND(data_file, partition);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -274,7 +274,7 @@ static std::pair<Int32, String> getMetadataFileAndVersion(const std::string & pa
 
 enum class MostRecentMetadataFileSelectionWay
 {
-    BY_Flast_updated_ms,
+    BY_LAST_UPDATED_MS_FIELD,
     BY_METADATA_FILE_VERSION
 };
 
@@ -301,10 +301,10 @@ static std::pair<Int32, String> getLatestMetadataFileAndVersion(
     auto log = getLogger("IcebergMetadataFileResolver");
     MostRecentMetadataFileSelectionWay selection_way
         = configuration.getSettingsRef()[StorageObjectStorageSetting::iceberg_recent_metadata_file_by_last_updated_ms_field].value
-        ? MostRecentMetadataFileSelectionWay::BY_Flast_updated_ms
+        ? MostRecentMetadataFileSelectionWay::BY_LAST_UPDATED_MS_FIELD
         : MostRecentMetadataFileSelectionWay::BY_METADATA_FILE_VERSION;
     bool need_all_metadata_files_parsing
-        = (selection_way == MostRecentMetadataFileSelectionWay::BY_Flast_updated_ms) || table_uuid.has_value();
+        = (selection_way == MostRecentMetadataFileSelectionWay::BY_LAST_UPDATED_MS_FIELD) || table_uuid.has_value();
     const auto metadata_files = listFiles(*object_storage, configuration, "metadata", ".metadata.json");
     if (metadata_files.empty())
     {
@@ -353,7 +353,7 @@ static std::pair<Int32, String> getLatestMetadataFileAndVersion(
     /// Get the latest version of metadata file: v<V>.metadata.json
     const ShortMetadataFileInfo & latest_metadata_file_info = [&]()
     {
-        if (selection_way == MostRecentMetadataFileSelectionWay::BY_Flast_updated_ms)
+        if (selection_way == MostRecentMetadataFileSelectionWay::BY_LAST_UPDATED_MS_FIELD)
         {
             return *std::max_element(
                 metadata_files_with_versions.begin(),

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -2,6 +2,7 @@
 
 #if USE_AVRO
 
+#include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h>
@@ -105,21 +106,6 @@ namespace
 
 }
 
-constexpr const char * COLUMN_STATUS_NAME = "status";
-constexpr const char * COLUMN_TUPLE_DATA_FILE_NAME = "data_file";
-constexpr const char * COLUMN_SEQ_NUMBER_NAME = "sequence_number";
-
-constexpr const char * SUBCOLUMN_FILE_PATH_NAME = "data_file.file_path";
-constexpr const char * SUBCOLUMN_CONTENT_NAME = "data_file.content";
-constexpr const char * SUBCOLUMN_PARTITION_NAME = "data_file.partition";
-
-constexpr const char * SUBCOLUMN_VALUES_COUNT_NAME = "data_file.value_counts";
-constexpr const char * SUBCOLUMN_COLUMN_SIZES_NAME = "data_file.column_sizes";
-constexpr const char * SUBCOLUMN_NULL_VALUE_COUNTS_NAME = "data_file.null_value_counts";
-constexpr const char * SUBCOLUMN_LOWER_BOUNDS_NAME = "data_file.lower_bounds";
-constexpr const char * SUBCOLUMN_UPPER_BOUNDS_NAME = "data_file.upper_bounds";
-
-
 const std::vector<ManifestFileEntry> & ManifestFileContent::getFiles() const
 {
     return files;
@@ -146,16 +132,16 @@ ManifestFileContent::ManifestFileContent(
     this->schema_id = schema_id_;
     this->schema_object = schema_object_;
 
-    for (const auto & column_name : {COLUMN_STATUS_NAME, COLUMN_TUPLE_DATA_FILE_NAME})
+    for (const auto & column_name : {Fstatus, Fdata_file})
     {
         if (!manifest_file_deserializer.hasPath(column_name))
             throw Exception(
                 DB::ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", column_name);
     }
 
-    if (format_version_ > 1 && !manifest_file_deserializer.hasPath(COLUMN_SEQ_NUMBER_NAME))
+    if (format_version_ > 1 && !manifest_file_deserializer.hasPath(Fsequence_number))
         throw Exception(
-            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", COLUMN_SEQ_NUMBER_NAME);
+            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", Fsequence_number);
 
     Poco::JSON::Parser parser;
 
@@ -198,14 +184,14 @@ ManifestFileContent::ManifestFileContent(
         FileContentType content_type = FileContentType::DATA;
         if (format_version_ > 1)
         {
-            content_type = FileContentType(manifest_file_deserializer.getValueFromRowByName(i, SUBCOLUMN_CONTENT_NAME, TypeIndex::Int32).safeGet<UInt64>());
+            content_type = FileContentType(manifest_file_deserializer.getValueFromRowByName(i, Fdata_file_content, TypeIndex::Int32).safeGet<UInt64>());
             if (content_type != FileContentType::DATA)
                 throw Exception(
                     ErrorCodes::UNSUPPORTED_METHOD, "Cannot read Iceberg table: positional and equality deletes are not supported");
         }
-        const auto status = ManifestEntryStatus(manifest_file_deserializer.getValueFromRowByName(i, COLUMN_STATUS_NAME, TypeIndex::Int32).safeGet<UInt64>());
+        const auto status = ManifestEntryStatus(manifest_file_deserializer.getValueFromRowByName(i, Fstatus, TypeIndex::Int32).safeGet<UInt64>());
 
-        const auto file_path = getProperFilePathFromMetadataInfo(manifest_file_deserializer.getValueFromRowByName(i, SUBCOLUMN_FILE_PATH_NAME, TypeIndex::String).safeGet<String>(), common_path, table_location);
+        const auto file_path = getProperFilePathFromMetadataInfo(manifest_file_deserializer.getValueFromRowByName(i, Fdata_file_file_path, TypeIndex::String).safeGet<String>(), common_path, table_location);
 
         /// NOTE: This is weird, because in manifest file partition looks like this:
         /// {
@@ -219,7 +205,7 @@ ManifestFileContent::ManifestFileContent(
         ///    ....
         /// However, somehow parser ignores all these nested keys like "total_amount_trunc" or "decimal_10_2" and
         /// directly returns tuple of partition values. However it's exactly what we need.
-        Field partition_value = manifest_file_deserializer.getValueFromRowByName(i, SUBCOLUMN_PARTITION_NAME);
+        Field partition_value = manifest_file_deserializer.getValueFromRowByName(i, Fdata_file_partition);
         auto tuple = partition_value.safeGet<Tuple>();
 
         DB::Row partition_key_value;
@@ -228,7 +214,7 @@ ManifestFileContent::ManifestFileContent(
 
         std::unordered_map<Int32, ColumnInfo> columns_infos;
 
-        for (const auto & path : {SUBCOLUMN_VALUES_COUNT_NAME, SUBCOLUMN_COLUMN_SIZES_NAME, SUBCOLUMN_NULL_VALUE_COUNTS_NAME})
+        for (const auto & path : {Fdata_file_value_counts, Fdata_file_column_sizes, Fdata_file_null_value_counts})
         {
             if (manifest_file_deserializer.hasPath(path))
             {
@@ -238,9 +224,9 @@ ManifestFileContent::ManifestFileContent(
                     const auto & column_number_and_count = column_stats.safeGet<Tuple>();
                     Int32 number = column_number_and_count[0].safeGet<Int32>();
                     Int64 count = column_number_and_count[1].safeGet<Int64>();
-                    if (path == SUBCOLUMN_VALUES_COUNT_NAME)
+                    if (path == Fdata_file_value_counts)
                         columns_infos[number].rows_count = count;
-                    else if (path == SUBCOLUMN_COLUMN_SIZES_NAME)
+                    else if (path == Fdata_file_column_sizes)
                         columns_infos[number].bytes_size = count;
                     else
                         columns_infos[number].nulls_count = count;
@@ -249,7 +235,7 @@ ManifestFileContent::ManifestFileContent(
         }
 
         std::unordered_map<Int32, std::pair<Field, Field>> value_for_bounds;
-        for (const auto & path : {SUBCOLUMN_LOWER_BOUNDS_NAME, SUBCOLUMN_UPPER_BOUNDS_NAME})
+        for (const auto & path : {Fdata_file_lower_bounds, Fdata_file_upper_bounds})
         {
             if (manifest_file_deserializer.hasPath(path))
             {
@@ -260,7 +246,7 @@ ManifestFileContent::ManifestFileContent(
                     Int32 number = column_number_and_bound[0].safeGet<Int32>();
                     const Field & bound_value = column_number_and_bound[1];
 
-                    if (path == SUBCOLUMN_LOWER_BOUNDS_NAME)
+                    if (path == Fdata_file_lower_bounds)
                         value_for_bounds[number].first = bound_value;
                     else
                         value_for_bounds[number].second = bound_value;
@@ -300,7 +286,7 @@ ManifestFileContent::ManifestFileContent(
                     break;
                 case ManifestEntryStatus::EXISTING:
                 {
-                    auto value = manifest_file_deserializer.getValueFromRowByName(i, COLUMN_SEQ_NUMBER_NAME);
+                    auto value = manifest_file_deserializer.getValueFromRowByName(i, Fsequence_number);
                     if (value.isNull())
                         throw Exception(
                             DB::ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -132,16 +132,16 @@ ManifestFileContent::ManifestFileContent(
     this->schema_id = schema_id_;
     this->schema_object = schema_object_;
 
-    for (const auto & column_name : {Fstatus, Fdata_file})
+    for (const auto & column_name : {f_status, f_data_file})
     {
         if (!manifest_file_deserializer.hasPath(column_name))
             throw Exception(
                 DB::ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", column_name);
     }
 
-    if (format_version_ > 1 && !manifest_file_deserializer.hasPath(Fsequence_number))
+    if (format_version_ > 1 && !manifest_file_deserializer.hasPath(f_sequence_number))
         throw Exception(
-            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", Fsequence_number);
+            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", f_sequence_number);
 
     Poco::JSON::Parser parser;
 
@@ -162,12 +162,12 @@ ManifestFileContent::ManifestFileContent(
     {
         auto partition_specification_field = partition_specification->getObject(static_cast<UInt32>(i));
 
-        auto source_id = partition_specification_field->getValue<Int32>(Fsource_id);
+        auto source_id = partition_specification_field->getValue<Int32>(f_source_id);
         /// NOTE: tricky part to support RENAME column in partition key. Instead of some name
         /// we use column internal number as it's name.
         auto numeric_column_name = DB::backQuote(DB::toString(source_id));
         DB::NameAndTypePair manifest_file_column_characteristics = schema_processor.getFieldCharacteristics(schema_id, source_id);
-        auto partition_ast = getASTFromTransform(partition_specification_field->getValue<String>(Ftransform), numeric_column_name);
+        auto partition_ast = getASTFromTransform(partition_specification_field->getValue<String>(f_transform), numeric_column_name);
         /// Unsupported partition key expression
         if (partition_ast == nullptr)
             continue;
@@ -184,14 +184,14 @@ ManifestFileContent::ManifestFileContent(
         FileContentType content_type = FileContentType::DATA;
         if (format_version_ > 1)
         {
-            content_type = FileContentType(manifest_file_deserializer.getValueFromRowByName(i, Fdata_file0content, TypeIndex::Int32).safeGet<UInt64>());
+            content_type = FileContentType(manifest_file_deserializer.getValueFromRowByName(i, c_data_file_content, TypeIndex::Int32).safeGet<UInt64>());
             if (content_type != FileContentType::DATA)
                 throw Exception(
                     ErrorCodes::UNSUPPORTED_METHOD, "Cannot read Iceberg table: positional and equality deletes are not supported");
         }
-        const auto status = ManifestEntryStatus(manifest_file_deserializer.getValueFromRowByName(i, Fstatus, TypeIndex::Int32).safeGet<UInt64>());
+        const auto status = ManifestEntryStatus(manifest_file_deserializer.getValueFromRowByName(i, f_status, TypeIndex::Int32).safeGet<UInt64>());
 
-        const auto file_path = getProperFilePathFromMetadataInfo(manifest_file_deserializer.getValueFromRowByName(i, Fdata_file0file_path, TypeIndex::String).safeGet<String>(), common_path, table_location);
+        const auto file_path = getProperFilePathFromMetadataInfo(manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String).safeGet<String>(), common_path, table_location);
 
         /// NOTE: This is weird, because in manifest file partition looks like this:
         /// {
@@ -205,7 +205,7 @@ ManifestFileContent::ManifestFileContent(
         ///    ....
         /// However, somehow parser ignores all these nested keys like "total_amount_trunc" or "decimal_10_2" and
         /// directly returns tuple of partition values. However it's exactly what we need.
-        Field partition_value = manifest_file_deserializer.getValueFromRowByName(i, Fdata_file0partition);
+        Field partition_value = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_partition);
         auto tuple = partition_value.safeGet<Tuple>();
 
         DB::Row partition_key_value;
@@ -214,7 +214,7 @@ ManifestFileContent::ManifestFileContent(
 
         std::unordered_map<Int32, ColumnInfo> columns_infos;
 
-        for (const auto & path : {Fdata_file0value_counts, Fdata_file0column_sizes, Fdata_file0null_value_counts})
+        for (const auto & path : {c_data_file_value_counts, c_data_file_column_sizes, c_data_file_null_value_counts})
         {
             if (manifest_file_deserializer.hasPath(path))
             {
@@ -224,9 +224,9 @@ ManifestFileContent::ManifestFileContent(
                     const auto & column_number_and_count = column_stats.safeGet<Tuple>();
                     Int32 number = column_number_and_count[0].safeGet<Int32>();
                     Int64 count = column_number_and_count[1].safeGet<Int64>();
-                    if (path == Fdata_file0value_counts)
+                    if (path == c_data_file_value_counts)
                         columns_infos[number].rows_count = count;
-                    else if (path == Fdata_file0column_sizes)
+                    else if (path == c_data_file_column_sizes)
                         columns_infos[number].bytes_size = count;
                     else
                         columns_infos[number].nulls_count = count;
@@ -235,7 +235,7 @@ ManifestFileContent::ManifestFileContent(
         }
 
         std::unordered_map<Int32, std::pair<Field, Field>> value_for_bounds;
-        for (const auto & path : {Fdata_file0lower_bounds, Fdata_file0upper_bounds})
+        for (const auto & path : {c_data_file_lower_bounds, c_data_file_upper_bounds})
         {
             if (manifest_file_deserializer.hasPath(path))
             {
@@ -246,7 +246,7 @@ ManifestFileContent::ManifestFileContent(
                     Int32 number = column_number_and_bound[0].safeGet<Int32>();
                     const Field & bound_value = column_number_and_bound[1];
 
-                    if (path == Fdata_file0lower_bounds)
+                    if (path == c_data_file_lower_bounds)
                         value_for_bounds[number].first = bound_value;
                     else
                         value_for_bounds[number].second = bound_value;
@@ -286,7 +286,7 @@ ManifestFileContent::ManifestFileContent(
                     break;
                 case ManifestEntryStatus::EXISTING:
                 {
-                    auto value = manifest_file_deserializer.getValueFromRowByName(i, Fsequence_number);
+                    auto value = manifest_file_deserializer.getValueFromRowByName(i, f_sequence_number);
                     if (value.isNull())
                         throw Exception(
                             DB::ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

Looking at the constant name, I always forgot what the original string literal it is. A naming like F**** will always remind you what it is in the iceberg files :)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
