### PR TITLE
Fix possible dtor of nullptr in GraphiteRollupSortedAlgorithm dtor

### DIFF
--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
@@ -9,17 +9,6 @@
 namespace DB
 {
 
-namespace
-{
-const Graphite::AggregationPattern * extract_aggregation_pattern_function(const std::optional<Graphite::RollupRule> & rule)
-{
-    if (!rule.has_value())
-        return nullptr;
-    const Graphite::AggregationPattern * aggregation_pattern = std::get<1>(rule.value());
-    return aggregation_pattern;
-}
-}
-
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
@@ -154,7 +143,7 @@ IMergingAlgorithm::Status GraphiteRollupSortedAlgorithm::merge()
             if (graphite_rollup_merged_data.wasGroupStarted())
                 accumulateRow(current_subgroup_newest_row);
 
-            Graphite::RollupRule next_rule = graphite_rollup_merged_data.currentRule().value_or(Graphite::RollupRule(nullptr, nullptr));
+            Graphite::RollupRule next_rule = graphite_rollup_merged_data.currentRule();
             if (new_path)
                 next_rule = selectPatternForPath(this->params, next_path);
 
@@ -255,16 +244,19 @@ void GraphiteRollupSortedAlgorithm::GraphiteRollupMergedData::startNextGroup(
     const ColumnRawPtrs & raw_columns, size_t row,
     Graphite::RollupRule next_rule, ColumnsDefinition & def)
 {
+    const Graphite::AggregationPattern * aggregation_pattern = std::get<1>(next_rule);
+
     /// Copy unmodified column values (including path column).
     for (size_t j : def.unmodified_column_numbers)
         columns[j]->insertFrom(*raw_columns[j], row);
 
-    current_rule = next_rule;
-    if (const Graphite::AggregationPattern * aggregation_pattern = extract_aggregation_pattern_function(current_rule))
+    if (aggregation_pattern)
     {
         aggregation_pattern->function->create(place_for_aggregate_state.data());
+        aggregate_state_created = true;
     }
 
+    current_rule = next_rule;
     was_group_started = true;
 }
 
@@ -277,11 +269,12 @@ void GraphiteRollupSortedAlgorithm::GraphiteRollupMergedData::insertRow(
     columns[def.version_column_num]->insertFrom(*row_ref_version_column, row.row_num);
 
     auto & value_column = columns[def.value_column_num];
-    if (const Graphite::AggregationPattern * aggregation_pattern = extract_aggregation_pattern_function(current_rule))
+    const Graphite::AggregationPattern * aggregation_pattern = std::get<1>(current_rule);
+    if (aggregate_state_created && aggregation_pattern)
     {
         aggregation_pattern->function->insertResultInto(place_for_aggregate_state.data(), *value_column, nullptr);
         aggregation_pattern->function->destroy(place_for_aggregate_state.data());
-        current_rule = std::nullopt;
+        aggregate_state_created = false;
     }
     else
         value_column->insertFrom(*(*row.all_columns)[def.value_column_num], row.row_num);
@@ -295,7 +288,8 @@ void GraphiteRollupSortedAlgorithm::GraphiteRollupMergedData::insertRow(
 
 void GraphiteRollupSortedAlgorithm::GraphiteRollupMergedData::accumulateRow(RowRef & row, ColumnsDefinition & def)
 {
-    if (const Graphite::AggregationPattern * aggregation_pattern = extract_aggregation_pattern_function(current_rule))
+    const Graphite::AggregationPattern * aggregation_pattern = std::get<1>(current_rule);
+    if (aggregate_state_created && aggregation_pattern)
     {
         auto & column = (*row.all_columns)[def.value_column_num];
         aggregation_pattern->function->add(place_for_aggregate_state.data(), &column, row.row_num, nullptr);
@@ -304,7 +298,8 @@ void GraphiteRollupSortedAlgorithm::GraphiteRollupMergedData::accumulateRow(RowR
 
 GraphiteRollupSortedAlgorithm::GraphiteRollupMergedData::~GraphiteRollupMergedData()
 {
-    if (const Graphite::AggregationPattern * aggregation_pattern = extract_aggregation_pattern_function(current_rule))
+    const Graphite::AggregationPattern * aggregation_pattern = std::get<1>(current_rule);
+    if (aggregate_state_created && aggregation_pattern)
         aggregation_pattern->function->destroy(place_for_aggregate_state.data());
 }
 

--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
@@ -4,6 +4,8 @@
 #include <Processors/Merges/Algorithms/MergedData.h>
 #include <Common/AlignedBuffer.h>
 
+#include <optional>
+
 namespace DB
 {
 
@@ -63,13 +65,12 @@ public:
         void accumulateRow(RowRef & row, ColumnsDefinition & def);
         bool wasGroupStarted() const { return was_group_started; }
 
-        const Graphite::RollupRule & currentRule() const { return current_rule; }
+        const std::optional<Graphite::RollupRule> & currentRule() const { return current_rule; }
         void allocMemForAggregates(size_t size, size_t alignment) { place_for_aggregate_state.reset(size, alignment); }
 
     private:
-        Graphite::RollupRule current_rule = {nullptr, nullptr};
+        std::optional<Graphite::RollupRule> current_rule = std::nullopt;
         AlignedBuffer place_for_aggregate_state;
-        bool aggregate_state_created = false; /// Invariant: if true then current_rule is not NULL.
         bool was_group_started = false;
     };
 

--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
@@ -4,8 +4,6 @@
 #include <Processors/Merges/Algorithms/MergedData.h>
 #include <Common/AlignedBuffer.h>
 
-#include <optional>
-
 namespace DB
 {
 
@@ -65,12 +63,13 @@ public:
         void accumulateRow(RowRef & row, ColumnsDefinition & def);
         bool wasGroupStarted() const { return was_group_started; }
 
-        const std::optional<Graphite::RollupRule> & currentRule() const { return current_rule; }
+        const Graphite::RollupRule & currentRule() const { return current_rule; }
         void allocMemForAggregates(size_t size, size_t alignment) { place_for_aggregate_state.reset(size, alignment); }
 
     private:
-        std::optional<Graphite::RollupRule> current_rule = std::nullopt;
+        Graphite::RollupRule current_rule = {nullptr, nullptr};
         AlignedBuffer place_for_aggregate_state;
+        bool aggregate_state_created = false; /// Invariant: if true then current_rule is not NULL.
         bool was_group_started = false;
     };
 


### PR DESCRIPTION
The `MemorySanitizer` reports use-of-uninitialized-value of the aggregation pattern function in GraphiteRollupSortedAlgorithm dtor. This might happen in case `startNextGroup` called with a valid aggregation pattern function first (then `aggregate_state_created` was set to true), later without invoking any function in between (e.g. `insertRow`), the `startNextGroup` function is called again with a nullptr valued aggregation pattern function. The `aggregation_state_created` was never set to false and was never reset to false in `startNextGroup` either. So, we might have a nullptr valued aggregation pattern function and `aggregation_state_created` was set to true. This might lead to invoke the `destroy` method on the nullptr value function.
This is the rare case and probably it's false-positive report from `MemorySanitizer`.

To avoid it, we can add extra checks to verify the aggregation pattern function is not `nullptr`.

Fixes #78901

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
