### PR TITLE
Fix 01318_long_unsuccessful_mutation_zookeeper test flakiness

### DIFF
--- a/tests/queries/0_stateless/01318_long_unsuccessful_mutation_zookeeper.reference
+++ b/tests/queries/0_stateless/01318_long_unsuccessful_mutation_zookeeper.reference
@@ -3,4 +3,3 @@
 waiting	default	mutation_table	0000000000	(MODIFY COLUMN `value` UInt64)
 is_done	parts_to_do
 0	1
-MUTATE_PART	0_0_0_0_2

--- a/tests/queries/0_stateless/01318_long_unsuccessful_mutation_zookeeper.sh
+++ b/tests/queries/0_stateless/01318_long_unsuccessful_mutation_zookeeper.sh
@@ -70,6 +70,4 @@ done
 
 $CLICKHOUSE_CLIENT --query "SELECT is_done, parts_to_do FROM system.mutations where table='mutation_table' and database='$CLICKHOUSE_DATABASE' FORMAT TSVWithNames"
 
-$CLICKHOUSE_CLIENT --query "SELECT type, new_part_name FROM system.replication_queue WHERE table='mutation_table' and database='$CLICKHOUSE_DATABASE'"
-
 $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS mutation_table SYNC"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

My hypothesis for flakiness is `system.replication_queue` is not completely in sync with `system.mutations`. As parts get done in mutations, they get replicated later as no-op, so there is small time frame where these tables are not in sync.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
