### PR TITLE
Fix UUIDs in Cassandra dictionaries

### DIFF
--- a/src/Dictionaries/CassandraSource.cpp
+++ b/src/Dictionaries/CassandraSource.cpp
@@ -270,6 +270,9 @@ void CassandraSource::assertTypes(const CassResultPtr & result)
             if (expected == CASS_VALUE_TYPE_TEXT && (got == CASS_VALUE_TYPE_ASCII || got == CASS_VALUE_TYPE_VARCHAR))
                 continue;
 
+            if (expected == CASS_VALUE_TYPE_UUID && got == CASS_VALUE_TYPE_TIMEUUID)
+                continue;
+
             const auto & column_name = description.sample_block.getColumnsWithTypeAndName()[i].name;
             throw Exception(ErrorCodes::TYPE_MISMATCH,
                 "Type mismatch for column {} : expected Cassandra type {}",

--- a/src/Dictionaries/CassandraSource.cpp
+++ b/src/Dictionaries/CassandraSource.cpp
@@ -137,9 +137,9 @@ void CassandraSource::insertValue(IColumn & column, ValueType type, const CassVa
         {
             CassUuid value;
             cass_value_get_uuid(cass_value, &value);
-            std::array<char, CASS_UUID_STRING_LENGTH> uuid_str;
+            std::array<char, CASS_UUID_STRING_LENGTH> uuid_str; // null terminated
             cass_uuid_string(value, uuid_str.data());
-            assert_cast<ColumnUUID &>(column).insert(parse<UUID>(uuid_str.data(), uuid_str.size()));
+            assert_cast<ColumnUUID &>(column).insert(parse<UUID>(uuid_str.data(), uuid_str.size()-1));
             break;
         }
         default:

--- a/src/Dictionaries/CassandraSource.cpp
+++ b/src/Dictionaries/CassandraSource.cpp
@@ -139,7 +139,7 @@ void CassandraSource::insertValue(IColumn & column, ValueType type, const CassVa
             cass_value_get_uuid(cass_value, &value);
             std::array<char, CASS_UUID_STRING_LENGTH> uuid_str; // null terminated
             cass_uuid_string(value, uuid_str.data());
-            assert_cast<ColumnUUID &>(column).insert(parse<UUID>(uuid_str.data(), uuid_str.size()-1));
+            assert_cast<ColumnUUID &>(column).insert(parse<UUID>(uuid_str.data(), uuid_str.size() - 1));
             break;
         }
         default:


### PR DESCRIPTION
1- Cassandra is unable to parse UUIDs and will throw an "expected EOF" error for any dictionary containing them.
- `CASS_UUID_STRING_LENGTH` is defined as `37` to account for a null terminator. 
- The `parse` function wants a size `36` UUID, otherwise it will throw an `expected EOF` error. 

```
CREATE OR REPLACE DICTIONARY test ON CLUSTER '{cluster}'
(
	`key` String,
	`value` UUID
)
PRIMARY KEY `ip`
SOURCE(CASSANDRA(
	...
))
LIFETIME(300)
LAYOUT(COMPLEX_KEY_HASHED());
```
```
SELECT * FROM test;
```
```
Cannot parse input: expected 'eof' before: '\0': While executing Cassandra. 
(CANNOT_PARSE_INPUT_ASSERTION_FAILED)
```


2- `TIMEUUID` is identical in Cassandra to `UUID`. 
- However, ClickHouse explicitly only allows UUID. This PR relaxes that requirement and considers `TIMEUUID` synonymous with `UUID`.
- Resolves https://github.com/ClickHouse/ClickHouse/issues/71472

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix UUID & TIMEUUID columns in Cassandra dictionaries