### PR TITLE
startup scripts mode thread local variable

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -54,6 +54,7 @@
 #include <Common/CPUID.h>
 #include <Common/HTTPConnectionPool.h>
 #include <Common/NamedCollections/NamedCollectionsFactory.h>
+#include <Common/StartupScriptMode.h>
 #include <Server/waitServersToFinish.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
 #include <Core/BackgroundSchedulePool.h>
@@ -826,6 +827,8 @@ void loadStartupScripts(const Poco::Util::AbstractConfiguration & config, Contex
 
         SetResultDetailsFunc callback;
         std::vector<String> skipped_startup_scripts;
+
+        auto startup_scripts_mode_guard = StartupScriptMode::getGuard();
 
         for (const auto & key : keys)
         {

--- a/src/Common/StartupScriptMode.h
+++ b/src/Common/StartupScriptMode.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+class StartupScriptMode
+{
+private:
+    static inline thread_local bool active = false;
+
+    struct Guard
+    {
+        Guard()
+        {
+            if (active)
+            {
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "startup scripts guard already initialized");
+            }
+            active = true;
+        }
+
+        ~Guard()
+        {
+            active = false;
+        }
+    };
+public:
+    static Guard getGuard()
+    {
+        return Guard{};
+    }
+
+    static bool isActive()
+    {
+        return active;
+    }
+};
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a thread-local variable that indicates if the current thread is executing a startup script.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
