### PR TITLE
Force DDL Entry fetch for DatabaseReplicated

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -468,13 +468,7 @@ DDLTaskPtr DatabaseReplicatedDDLWorker::initAndCheckTask(const String & entry_na
         return {};
     }
 
-    String node_data;
-    if (!zookeeper->tryGet(entry_path, node_data))
-    {
-        LOG_ERROR(log, "Cannot get log entry {}", entry_path);
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "should be unreachable");
-    }
-
+    String node_data = zookeeper->get(entry_path);
     task->entry.parse(node_data);
 
     if (task->entry.query.empty())


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not throw `LOGICAL_ERROR` if entry node was deleted. It can be deleted by concurrent cleanup thread running on another replica.
