### PR TITLE
test_remove_stale_moving_parts ignore non-existent directory during wait, wait longer

### DIFF
--- a/tests/integration/test_remove_stale_moving_parts/test.py
+++ b/tests/integration/test_remove_stale_moving_parts/test.py
@@ -51,12 +51,13 @@ def exec(node, cmd, path):
             "bash",
             "-c",
             f"{cmd} {path}",
-        ]
+        ],
+        nothrow=True,
     )
 
 
 def wait_part_is_stuck(node, table_moving_path, moving_part):
-    num_tries = 5
+    num_tries = 10
     while q(node, "SELECT part_name FROM system.moves").strip() != moving_part:
         if num_tries == 0:
             raise Exception("Part has not started to move")


### PR DESCRIPTION
The move is added to the system.moves tables before the actual move starts, so `/moving` dir can not exist right after system.moves check.

Closes: #78666
 
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

