### PR TITLE
update how version is checked in macOSX

### DIFF
--- a/cmake/darwin/default_libs.cmake
+++ b/cmake/darwin/default_libs.cmake
@@ -17,10 +17,12 @@ find_package(Threads REQUIRED)
 
 if(NOT CMAKE_CROSSCOMPILING)
     execute_process(
-        COMMAND xcrun --sdk macosx --show-sdk-version
-        OUTPUT_VARIABLE OS_DARWIN_SDK_VERSION
+        COMMAND readlink -f /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+        OUTPUT_VARIABLE ACTUAL_SDK_PATH
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    string(REGEX MATCH "MacOSX([0-9]+\\.[0-9]+)" _ ${ACTUAL_SDK_PATH})
+    set(OS_DARWIN_SDK_VERSION ${CMAKE_MATCH_1})
     if(${OS_DARWIN_SDK_VERSION} MATCHES "^[0-9]+\\.[0-9]+")
         message(STATUS "Detected OSX SDK Version: ${OS_DARWIN_SDK_VERSION}")
     else ()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Currently when `clickhouse` is built on macos, it checks the command line tool version using 
`xcrun` but `xcrun` is not up to date with system's current updated CommandLineTools

In this PR, I have updated the way we find the version, I stumbled on this issue while trying to build clickhouse on my system
but I was getting `strchrnul` error from `Postgres` checked the cmake file for `postgres` there it was already handled only concern was version was not coming properly. After this is merged, folks can build it on macOS without using `devcontainers`

for reference: #78804 

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
