### PR TITLE
Disable OpenSSL init and cleanup for AWS SDK

### DIFF
--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -1303,6 +1303,7 @@ set(SSL_SRC
 # SRP API is deprecated in OpenSSL 3.0.
 # https://docs.openssl.org/3.1/man3/SRP_Calc_B/#history
 add_definitions(-DOPENSSL_NO_DEPRECATED)
+add_definitions(-DOPENSSL_API_COMPAT=30000) # 3.0
 add_definitions(-DOPENSSL_NO_ENGINE)
 add_definitions(-DOPENSSL_NO_SRP)
 

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -1303,7 +1303,6 @@ set(SSL_SRC
 # SRP API is deprecated in OpenSSL 3.0.
 # https://docs.openssl.org/3.1/man3/SRP_Calc_B/#history
 add_definitions(-DOPENSSL_NO_DEPRECATED)
-add_definitions(-DOPENSSL_API_COMPAT=30000) # 3.0
 add_definitions(-DOPENSSL_NO_ENGINE)
 add_definitions(-DOPENSSL_NO_SRP)
 

--- a/src/Common/OpenSSLHelpers.cpp
+++ b/src/Common/OpenSSLHelpers.cpp
@@ -8,6 +8,7 @@
 #include <openssl/evp.h>
 #include <openssl/sha.h>
 #include <openssl/kdf.h>
+#include <openssl/core_names.h>
 
 
 namespace DB
@@ -73,7 +74,7 @@ std::vector<uint8_t> hmacSHA256(const std::vector<uint8_t> & key, const std::str
         throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MAC_CTX_new failed: {}", getOpenSSLErrors());
 
     OSSL_PARAM params[] = {
-        OSSL_PARAM_utf8_string("digest", const_cast<char*>("SHA256"), 0),
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, const_cast<char*>("SHA256"), 0),
         OSSL_PARAM_END
     };
 

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -918,9 +918,17 @@ ClientFactory::ClientFactory()
     aws_options.cryptoOptions = Aws::CryptoOptions{};
     aws_options.cryptoOptions.initAndCleanupOpenSSL = false;
 
+    aws_options.httpOptions = Aws::HttpOptions{};
+    aws_options.httpOptions.initAndCleanupCurl = false;
+    aws_options.httpOptions.httpClientFactory_create_fn = []() { return std::make_shared<PocoHTTPClientFactory>(); };
+
+    aws_options.loggingOptions = Aws::LoggingOptions{};
+    aws_options.loggingOptions.logger_create_fn = []() { return std::make_shared<AWSLogger>(false); };
+
+    aws_options.ioOptions = Aws::IoOptions{};
+    aws_options.ioOptions.tlsConnectionOptions_create_fn = []() { return nullptr; };
+
     Aws::InitAPI(aws_options);
-    Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>(false));
-    Aws::Http::SetHttpClientFactory(std::make_shared<PocoHTTPClientFactory>());
 }
 
 ClientFactory::~ClientFactory()

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -926,6 +926,7 @@ ClientFactory::ClientFactory()
     aws_options.loggingOptions.logger_create_fn = []() { return std::make_shared<AWSLogger>(false); };
 
     aws_options.ioOptions = Aws::IoOptions{};
+    /// We don't need to initialize TLS, because we use PocoHTTPClientFactory
     aws_options.ioOptions.tlsConnectionOptions_create_fn = []() { return nullptr; };
 
     Aws::InitAPI(aws_options);

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -1,10 +1,10 @@
 #include <IO/S3/Client.h>
-#include <aws/core/Aws.h>
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 
 #if USE_AWS_S3
 
+#include <aws/core/Aws.h>
 #include <aws/core/client/CoreErrors.h>
 #include <aws/s3/model/HeadBucketRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -1,4 +1,5 @@
 #include <IO/S3/Client.h>
+#include <aws/core/Aws.h>
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 
@@ -913,6 +914,10 @@ void ClientCacheRegistry::clearCacheForAll()
 ClientFactory::ClientFactory()
 {
     aws_options = Aws::SDKOptions{};
+
+    aws_options.cryptoOptions = Aws::CryptoOptions{};
+    aws_options.cryptoOptions.initAndCleanupOpenSSL = false;
+
     Aws::InitAPI(aws_options);
     Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>(false));
     Aws::Http::SetHttpClientFactory(std::make_shared<PocoHTTPClientFactory>());


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Relates to https://github.com/ClickHouse/ClickHouse/issues/80160
