### PR TITLE
Add error_message for deduplicated parts in system.part_log

### DIFF
--- a/tests/queries/0_stateless/02124_insert_deduplication_token_replica.reference
+++ b/tests/queries/0_stateless/02124_insert_deduplication_token_replica.reference
@@ -1,6 +1,7 @@
 create replica 1 and check deduplication
 two inserts with exact data, one inserted, one deduplicated by data digest
 1	1001
+The part was deduplicated
 two inserts with the same dedup token, one inserted, one deduplicated by the token
 1	1001
 1	1001

--- a/tests/queries/0_stateless/02124_insert_deduplication_token_replica.sql
+++ b/tests/queries/0_stateless/02124_insert_deduplication_token_replica.sql
@@ -13,6 +13,13 @@ INSERT INTO insert_dedup_token1 VALUES(1, 1001);
 INSERT INTO insert_dedup_token1 VALUES(1, 1001);
 SELECT * FROM insert_dedup_token1 ORDER BY id;
 
+SYSTEM FLUSH LOGS system.part_log;
+SELECT DISTINCT exception FROM system.part_log
+WHERE table = 'insert_dedup_token1'
+  AND database = currentDatabase()
+  AND event_type = 'NewPart'
+  AND error = 389;
+
 select 'two inserts with the same dedup token, one inserted, one deduplicated by the token';
 set insert_deduplication_token = '1';
 INSERT INTO insert_dedup_token1 VALUES(1, 1001);


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add error message that the part was deduplicated

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
