### PR TITLE
Maybe fix test_refreshable_mat_view_replicated::test_real_wait_refresh flakiness

### DIFF
--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -412,10 +412,12 @@ def test_real_wait_refresh(
         expected_rows += 2
         expect_rows(expected_rows, table=tgt)
 
+    is_close = lambda x, y: x is not None and y is not None and abs(x.timestamp() - y.timestamp()) <= 3
+
     rmv2 = get_rmv_info(
         node,
         "test_rmv",
-        condition=lambda x: x["last_refresh_time"] == rmv["next_refresh_time"],
+        condition=lambda x: is_close(x["last_refresh_time"], rmv["next_refresh_time"]),
         # wait for refresh a little bit more than 10 seconds
         max_attempts=30,
         delay=0.5,
@@ -438,8 +440,8 @@ def test_real_wait_refresh(
 
     assert rmv2["exception"] is None
     assert rmv2["status"] in ["Scheduled", "Running"]
-    assert rmv2["last_success_time"] == rmv["next_refresh_time"]
-    assert rmv2["last_refresh_time"] == rmv["next_refresh_time"]
+    assert is_close(rmv2["last_success_time"], rmv["next_refresh_time"])
+    assert is_close(rmv2["last_refresh_time"], rmv["next_refresh_time"])
     assert rmv2["retry"] == 0 and rmv22["retry"] == 0
 
     for n in nodes:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/73430

The test relies on timing a lot, so some flakiness is unavoidable e.g. if the system is super overloaded and some operations get delayed by a few seconds. But without this PR, the test could probably fail even if everything is running smoothly and nothing is delayed.

Maybe it'll still be flaky after this, and it's hopeless, and the test should be removed, we'll see.

(IIUC, the idea of relying on timing is that there should be at least one test that sanity-checks that RMV timing logic works at all, without bypassing it with a mock clock.)