### PR TITLE
Fix improper serialization of nested numeric fields as strings in MongoDB documents. Remove maximum depth limit for documents from MongoDB.

### DIFF
--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -166,7 +166,6 @@ MongoDBSource::MongoDBSource(
     , cursor{collection.find(query, options)}
     , sample_block{sample_block_}
     , max_block_size{max_block_size_}
-    , json_format_settings{createJSONFormatSettings()}
 {
     for (const auto & idx : collections::range(0, sample_block.columns()))
     {

--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -166,18 +166,8 @@ MongoDBSource::MongoDBSource(
     , cursor{collection.find(query, options)}
     , sample_block{sample_block_}
     , max_block_size{max_block_size_}
-    , db_json_format_settings{
-        .json = {
-            .max_depth = 0,
-            .quote_64bit_integers = false,
-        }
-    }
-    , json_format_settings{
-        db_json_format_settings,
-        0,
-        true,
-        true,
-    }
+    , db_json_format_settings{.json= {.max_depth = 0, .quote_64bit_integers = false}}
+    , json_format_settings{db_json_format_settings, 0, true, true}
 {
     for (const auto & idx : collections::range(0, sample_block.columns()))
     {

--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -166,6 +166,7 @@ MongoDBSource::MongoDBSource(
     , cursor{collection.find(query, options)}
     , sample_block{sample_block_}
     , max_block_size{max_block_size_}
+    , json_format_settings{createJSONFormatSettings()}
 {
     for (const auto & idx : collections::range(0, sample_block.columns()))
     {

--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -166,6 +166,18 @@ MongoDBSource::MongoDBSource(
     , cursor{collection.find(query, options)}
     , sample_block{sample_block_}
     , max_block_size{max_block_size_}
+    , db_json_format_settings{
+        .json = {
+            .max_depth = 0,
+            .quote_64bit_integers = false,
+        }
+    }
+    , json_format_settings{
+        db_json_format_settings,
+        0,
+        true,
+        true,
+    }
 {
     for (const auto & idx : collections::range(0, sample_block.columns()))
     {

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -49,51 +49,11 @@ private:
     std::unordered_map<size_t, std::pair<size_t, std::pair<DataTypePtr, Field>>> arrays_info;
     const UInt64 max_block_size;
 
-    JSONBuilder::FormatSettings json_format_settings;
+    JSONBuilder::FormatSettings json_format_settings{{.json= {
+        .quote_64bit_integers=false,
+        .max_depth=0,
+    }}, 0, true, true};;
     bool all_read = false;
-
-    static JSONBuilder::FormatSettings createJSONFormatSettings()
-    {
-        auto settings = DB::FormatSettings{};
-        settings.json = FormatSettings::JSON{
-            0,  // max_depth
-            false, // array_of_rows
-            false,  // quote_64bit_integers [changed]
-            false, // quote_64bit_floats
-            false,  // quote_denormals [changed]
-            false, // quote_decimals
-            true,  // escape_forward_slashes
-            false, // read_named_tuples_as_objects
-            false, // use_string_type_for_ambiguous_paths_in_named_tuples_inference_from_objects
-            true,  // write_named_tuples_as_objects
-            false, // skip_null_value_in_named_tuples
-            false, // defaults_for_missing_elements_in_named_tuple
-            false, // ignore_unknown_keys_in_named_tuple
-            false, // serialize_as_strings
-            true,  // read_bools_as_numbers
-            true,  // read_bools_as_strings
-            true,  // read_numbers_as_strings
-            true,  // read_objects_as_strings
-            true,  // read_arrays_as_strings
-            false, // try_infer_numbers_from_strings
-            true,  // validate_types_from_metadata
-            false, // validate_utf8
-            false, // allow_deprecated_object_type
-            false, // allow_json_type
-            false, // valid_output_on_exception
-            false, // compact_allow_variable_number_of_columns
-            false, // try_infer_objects_as_tuples
-            true,  // infer_incomplete_types_as_strings
-            true,  // throw_on_bad_escape_sequence
-            true,  // ignore_unnecessary_fields
-            false, // empty_as_default
-            false, // type_json_skip_duplicated_paths
-            true,  // pretty_print
-            ' ',   // pretty_print_indent
-            4      // pretty_print_indent_multiplier
-        };
-        return JSONBuilder::FormatSettings{settings, 0, true, true};
-    }
 };
 
 }

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -49,10 +49,12 @@ private:
     std::unordered_map<size_t, std::pair<size_t, std::pair<DataTypePtr, Field>>> arrays_info;
     const UInt64 max_block_size;
 
-    JSONBuilder::FormatSettings json_format_settings{{.json= {
-        .quote_64bit_integers=false,
-        .max_depth=0,
-    }}, 0, true, true};;
+    JSONBuilder::FormatSettings json_format_settings{
+            {.json = {.quote_64bit_integers = false, .max_depth = 0}},
+            0,
+            true,
+            true,
+    };
     bool all_read = false;
 };
 

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -48,14 +48,15 @@ private:
     Block sample_block;
     std::unordered_map<size_t, std::pair<size_t, std::pair<DataTypePtr, Field>>> arrays_info;
     const UInt64 max_block_size;
+    bool all_read = false;
 
-    JSONBuilder::FormatSettings json_format_settings{
+    const JSONBuilder::FormatSettings json_format_settings
+    {
             {.json = {.quote_64bit_integers = false, .max_depth = 0}},
             0,
             true,
             true,
     };
-    bool all_read = false;
 };
 
 }

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -49,8 +49,51 @@ private:
     std::unordered_map<size_t, std::pair<size_t, std::pair<DataTypePtr, Field>>> arrays_info;
     const UInt64 max_block_size;
 
-    JSONBuilder::FormatSettings json_format_settings = {{}, 0, true, true};
+    JSONBuilder::FormatSettings json_format_settings;
     bool all_read = false;
+
+    static JSONBuilder::FormatSettings createJSONFormatSettings()
+    {
+        auto settings = DB::FormatSettings{};
+        settings.json = FormatSettings::JSON{
+            0,  // max_depth
+            false, // array_of_rows
+            false,  // quote_64bit_integers [changed]
+            false, // quote_64bit_floats
+            false,  // quote_denormals [changed]
+            false, // quote_decimals
+            true,  // escape_forward_slashes
+            false, // read_named_tuples_as_objects
+            false, // use_string_type_for_ambiguous_paths_in_named_tuples_inference_from_objects
+            true,  // write_named_tuples_as_objects
+            false, // skip_null_value_in_named_tuples
+            false, // defaults_for_missing_elements_in_named_tuple
+            false, // ignore_unknown_keys_in_named_tuple
+            false, // serialize_as_strings
+            true,  // read_bools_as_numbers
+            true,  // read_bools_as_strings
+            true,  // read_numbers_as_strings
+            true,  // read_objects_as_strings
+            true,  // read_arrays_as_strings
+            false, // try_infer_numbers_from_strings
+            true,  // validate_types_from_metadata
+            false, // validate_utf8
+            false, // allow_deprecated_object_type
+            false, // allow_json_type
+            false, // valid_output_on_exception
+            false, // compact_allow_variable_number_of_columns
+            false, // try_infer_objects_as_tuples
+            true,  // infer_incomplete_types_as_strings
+            true,  // throw_on_bad_escape_sequence
+            true,  // ignore_unnecessary_fields
+            false, // empty_as_default
+            false, // type_json_skip_duplicated_paths
+            true,  // pretty_print
+            ' ',   // pretty_print_indent
+            4      // pretty_print_indent_multiplier
+        };
+        return JSONBuilder::FormatSettings{settings, 0, true, true};
+    }
 };
 
 }

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -52,7 +52,7 @@ private:
 
     const JSONBuilder::FormatSettings json_format_settings
     {
-            {.json = {.quote_64bit_integers = false, .max_depth = 0}},
+            {.json = {.max_depth = 0, .quote_64bit_integers = false}},
             0,
             true,
             true,

--- a/src/Processors/Sources/MongoDBSource.h
+++ b/src/Processors/Sources/MongoDBSource.h
@@ -50,13 +50,8 @@ private:
     const UInt64 max_block_size;
     bool all_read = false;
 
-    const JSONBuilder::FormatSettings json_format_settings
-    {
-            {.json = {.max_depth = 0, .quote_64bit_integers = false}},
-            0,
-            true,
-            true,
-    };
+    const DB::FormatSettings db_json_format_settings;
+    const JSONBuilder::FormatSettings json_format_settings;
 };
 
 }

--- a/tests/integration/test_storage_mongodb/test.py
+++ b/tests/integration/test_storage_mongodb/test.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import json
 import uuid
@@ -1227,3 +1228,47 @@ def test_password_masking(started_cluster):
         == "CREATE DICTIONARY default.mongodb_dictionary_password_masking (`_id` String) PRIMARY KEY _id SOURCE(MONGODB(HOST \\'127.0.0.1\\' PORT 27017 USER \\'testuser\\' PASSWORD \\'[HIDDEN]\\' DB \\'example\\' COLLECTION \\'test_clickhouse\\' OPTIONS \\'ssl=true\\')) LIFETIME(MIN 0 MAX 0) LAYOUT(FLAT())\n"
     )
     node.query("DROP DICTIONARY IF EXISTS mongodb_dictionary_password_masking;")
+
+
+def test_json_serialization(started_cluster):
+    mongo_connection = get_mongo_connection(started_cluster)
+    db = mongo_connection["test"]
+    db.command("dropAllUsersFromDatabase")
+    db.command("createUser", "root", pwd=mongo_pass, roles=["readWrite"])
+    json_serialization_table = db["json_serialization_table"]
+
+    date = datetime.datetime.strptime("2025-05-17 13:14:15", "%Y-%m-%d %H:%M:%S")
+
+    def create_dataset(mongo, root) -> dict:
+        return {
+            "type_string": "Type string",
+            "type_oid": bson.ObjectId("60f7e65e16b1c1d1c8a2b6b3") if mongo else "60f7e65e16b1c1d1c8a2b6b3",
+            "type_binary": bson.Binary(b"binarydata", subtype=0) if mongo else base64.b64encode(b"binarydata").decode(),
+            "type_bool": True,
+            "type_int32": 123,
+            "type_int64": bson.int64.Int64(2**63 - 1) if mongo else int(2**63 - 1),
+            "type_double": float(3.141592653589793238),
+            "type_date": date if mongo else date.strftime("%Y-%m-%d %H:%M:%S"),
+            "type_timestamp": bson.timestamp.Timestamp(date, 1) if mongo else date.strftime("%Y-%m-%d %H:%M:%S"),
+            "type_document": {"nested_doc": create_dataset(mongo, False)} if root else {},
+            "type_array": [create_dataset(mongo, False)] if root else [],
+            "type_regex": bson.regex.Regex(r"^pattern.*$", "i") if mongo else {"^pattern.*$": "i"},
+            "type_null": None,
+        }
+
+    json_serialization_table.insert_one({"dataset": create_dataset(True, True)})
+    node = started_cluster.instances["node"]
+    node.query(
+        f"""
+        CREATE OR REPLACE TABLE json_serialization_table(
+            dataset String
+        ) ENGINE = MongoDB('mongo1:27017', 'test', 'json_serialization_table', 'root', '{mongo_pass}')
+        """
+    )
+
+    assert node.query(f"SELECT COUNT() FROM json_serialization_table") == "1\n"
+    assert (node.query(f"SELECT dataset FROM json_serialization_table")[:-1]
+            == json.dumps(create_dataset(False, True), separators=(',', ':')))
+
+    node.query("DROP TABLE json_serialization_table")
+    json_serialization_table.drop()


### PR DESCRIPTION
Resolves: #79944

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix improper serialization of nested numeric fields as strings in MongoDB documents. Remove maximum depth limit for documents from MongoDB.