### PR TITLE
Fix `03322_initial_query_start_time_check`

### DIFF
--- a/tests/queries/0_stateless/03322_initial_query_start_time_check.sql
+++ b/tests/queries/0_stateless/03322_initial_query_start_time_check.sql
@@ -1,4 +1,4 @@
--- Tags: shard
+-- Tags: shard, disabled
 
 DROP TABLE IF EXISTS tmp;
 

--- a/tests/queries/0_stateless/03322_initial_query_start_time_check.sql
+++ b/tests/queries/0_stateless/03322_initial_query_start_time_check.sql
@@ -1,9 +1,9 @@
--- Tags: shard, disabled
+-- Tags: shard
 
 DROP TABLE IF EXISTS tmp;
 
-CREATE OR REPLACE VIEW tmp AS SELECT initialQueryStartTime() as it, now() AS t FROM system.one WHERE NOT ignore(sleep(0.1));
-SELECT now()==max(t), initialQueryStartTime()==max(it), initialQueryStartTime()==min(it), initialQueryStartTime()>=now()-1 FROM (SELECT it, t FROM remote('127.0.0.{1..20}', currentDatabase(), tmp)) SETTINGS max_distributed_connections=1, async_socket_for_remote=0;
+CREATE OR REPLACE VIEW tmp AS SELECT initialQueryStartTime() as it, now() AS t FROM system.one WHERE NOT ignore(sleep(0.5));
+SELECT now()==max(t), initialQueryStartTime()==max(it), initialQueryStartTime()==min(it), initialQueryStartTime()>=now()-1 FROM (SELECT it, t FROM remote('127.0.0.{1..10}', currentDatabase(), tmp)) SETTINGS max_distributed_connections=1, async_socket_for_remote=0;
 
 DROP TABLE tmp;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable incorrect test `03322_initial_query_start_time_check`, introduced in https://github.com/ClickHouse/ClickHouse/pull/75087 This closes: https://github.com/ClickHouse/ClickHouse/issues/80287

The test heavily relies on timings and therefore cannot work correctly. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
