### PR TITLE
Fix creating tables in test_cancel_backup

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -617,12 +617,12 @@ def test_error_leaves_no_trash():
 
 # A backup must be stopped if Zookeeper is disconnected longer than `failure_after_host_disconnected_for_seconds`.
 def test_long_disconnection_stops_backup():
+    create_and_fill_table(random_node(), num_parts=100)
+
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
         # Config "faster_zk_disconnect_detect.xml" is used in this test to decrease number of retries when reconnecting to ZooKeeper.
         # Without this config this test can take several minutes (instead of seconds) to run.
         config_manager.add_main_config(nodes, "configs/faster_zk_disconnect_detect.xml")
-
-        create_and_fill_table(random_node(), num_parts=100)
 
         initiator = random_node()
         print(f"Using {get_node_name(initiator)} as initiator")
@@ -675,6 +675,8 @@ def test_long_disconnection_stops_backup():
 
 # A backup must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_backup():
+    create_and_fill_table(random_node())
+
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
         use_faster_zk_disconnect_detect = random.choice([True, False])
         if use_faster_zk_disconnect_detect:
@@ -682,8 +684,6 @@ def test_short_disconnection_doesnt_stop_backup():
             config_manager.add_main_config(
                 nodes, "configs/faster_zk_disconnect_detect.xml"
             )
-
-        create_and_fill_table(random_node())
 
         initiator = random_node()
         print(f"Using {get_node_name(initiator)} as initiator")


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix creating tables in `test_backup_restore_on_cluster/test_cancel_backup.py`

Example of failure ([see](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=80115&sha=7e696bf2c6486d238ebfeddc330d6ae4e1eb211c&name_0=PR&name_1=Integration%20tests%20%28aarch64%2C%20distributed%20plan%2C%204%2F4%29)):

```
    def test_short_disconnection_doesnt_stop_backup():
        with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
            use_faster_zk_disconnect_detect = random.choice([True, False])
            if use_faster_zk_disconnect_detect:
                print("Using faster_zk_disconnect_detect.xml")
                config_manager.add_main_config(
                    nodes, "configs/faster_zk_disconnect_detect.xml"
                )
    
>           create_and_fill_table(random_node())

test_backup_restore_on_cluster/test_cancel_backup.py:686: 

...

E           helpers.client.QueryRuntimeException: Client failed! Return code: 231, stderr: Received exception from server (version 25.6.1):
E           Code: 999. DB::Exception: Received from 172.16.2.6:9000. DB::Exception: There was an error on [node1:9000]: Code: 999. Coordination::Exception: Session expired. (KEEPER_EXCEPTION) (version 25.6.1.1). Stack trace:
E           
E           0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000db608c8
E           1. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000922247c
E           2. DB::DDLOnClusterQueryStatusSource::handleNonZeroStatusCode(DB::ExecutionStatus const&, String const&) @ 0x00000000117b3748
E           3. DB::DistributedQueryStatusSource::generate() @ 0x00000000113ca224
E           4. DB::ISource::tryGenerate() @ 0x000000001298eaac
E           5. DB::ISource::work() @ 0x000000001298e698
E           6. DB::ExecutionThreadContext::executeTask() @ 0x00000000129a5c98
E           7. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x000000001299b770
E           8. DB::PipelineExecutor::execute(unsigned long, bool) @ 0x000000001299a504
E           9. void std::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x00000000129aaaf0
E           10. ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker() @ 0x000000000dc84a94
E           11. void* std::__thread_proxy[abi:ne190107]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x000000000dc8b37c
E           12. ? @ 0x000000000007d5b8
E           13. ? @ 0x00000000000e5edc
```