### PR TITLE
Fix test `02479_race_condition_between_insert_and_droppin_mv.sh`

### DIFF
--- a/tests/queries/0_stateless/02479_race_condition_between_insert_and_droppin_mv.sh
+++ b/tests/queries/0_stateless/02479_race_condition_between_insert_and_droppin_mv.sh
@@ -9,10 +9,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+TIMEOUT=50
+
 function insert {
     i=0
     offset=500
-    while true;
+    local TIMELIMIT=$((SECONDS+TIMEOUT))
+    while [ $SECONDS -lt "$TIMELIMIT" ]
     do
         ${CLICKHOUSE_CLIENT} -q "INSERT INTO test_race_condition_landing SELECT number, toString(number), toString(number) from system.numbers limit $i, $offset settings ignore_materialized_views_with_dropped_target_table=1"
         i=$(( $i + $RANDOM % 100 + 400 ))
@@ -21,7 +24,8 @@ function insert {
 
 function drop_mv {
     index=$1
-    while true;
+    local TIMELIMIT=$((SECONDS+TIMEOUT))
+    while [ $SECONDS -lt "$TIMELIMIT" ]
     do
         ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS test_race_condition_mv_$index"
         ${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW IF NOT EXISTS test_race_condition_mv1_$index TO test_race_condition_target AS select count() as number FROM (SELECT a.number, a.n, a.n2, b.number, b.n, b.n2, c.number, c.n, c.n2 FROM test_race_condition_landing a CROSS JOIN test_race_condition_landing b CROSS JOIN test_race_condition_landing c)"
@@ -38,16 +42,14 @@ ${CLICKHOUSE_CLIENT} -q "CREATE TABLE test_race_condition_landing (number Int64,
 export -f drop_mv;
 export -f insert;
 
-TIMEOUT=50
-
 for i in {1..4}
 do
-    timeout $TIMEOUT bash -c "drop_mv $i" &
+    drop_mv $i &
 done
 
 for i in {1..4}
 do
-    timeout $TIMEOUT bash -c "insert 20" &
+    insert 20 &
 done
 
 wait


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

`timeout` terminates the commands, but at the same time, the server can continue to run queries, issued by these commands. This is why the next queries will be in the race conditions with them. Using `timeout` in our tests is almost always wrong.