### PR TITLE
Metrics and Logs for Readonly and Broken Disks

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -436,8 +436,8 @@
     M(StatelessWorkerThreads, "Number of threads in the stateless worker thread pool.") \
     M(StatelessWorkerThreadsActive, "Number of threads in the stateless worker thread pool running a task.") \
     M(StatelessWorkerThreadsScheduled, "Number of queued or active jobs in the stateless worker thread pool.") \
-    M(ReadonlyDisks, "How many disks are marked as readonly by disk check thread(if enabled)") \
-    M(BrokenDisks, "How many disks are marked as broken by disk check thread(if enabled)") \
+    M(ReadonlyDisks, "How many disks are marked as readonly during disk check.") \
+    M(BrokenDisks, "How many disks are marked as broken during disk check.") \
 
 #ifdef APPLY_FOR_EXTERNAL_METRICS
     #define APPLY_FOR_METRICS(M) APPLY_FOR_BUILTIN_METRICS(M) APPLY_FOR_EXTERNAL_METRICS(M)

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -436,8 +436,8 @@
     M(StatelessWorkerThreads, "Number of threads in the stateless worker thread pool.") \
     M(StatelessWorkerThreadsActive, "Number of threads in the stateless worker thread pool running a task.") \
     M(StatelessWorkerThreadsScheduled, "Number of queued or active jobs in the stateless worker thread pool.") \
-    M(ReadonlyDisks, "How many disks are marked as readonly during disk check.") \
-    M(BrokenDisks, "How many disks are marked as broken during disk check.") \
+    M(ReadonlyDisks, "Number of disks that were marked as readonly during disk check.") \
+    M(BrokenDisks, "Number of disks disks that were marked as broken during disk check.") \
 
 #ifdef APPLY_FOR_EXTERNAL_METRICS
     #define APPLY_FOR_METRICS(M) APPLY_FOR_BUILTIN_METRICS(M) APPLY_FOR_EXTERNAL_METRICS(M)

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -436,6 +436,8 @@
     M(StatelessWorkerThreads, "Number of threads in the stateless worker thread pool.") \
     M(StatelessWorkerThreadsActive, "Number of threads in the stateless worker thread pool running a task.") \
     M(StatelessWorkerThreadsScheduled, "Number of queued or active jobs in the stateless worker thread pool.") \
+    M(ReadonlyDisks, "How many disks are marked as readonly by disk check thread(if enabled)") \
+    M(BrokenDisks, "How many disks are marked as broken by disk check thread(if enabled)") \
 
 #ifdef APPLY_FOR_EXTERNAL_METRICS
     #define APPLY_FOR_METRICS(M) APPLY_FOR_BUILTIN_METRICS(M) APPLY_FOR_EXTERNAL_METRICS(M)

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -624,27 +624,27 @@ catch (...)
     try
     {
         Poco::Pipe out_pipe;
-        Poco::ProcessHandle ph = Poco::Process::launch("ls", {"-l", disk_path}, nullptr, &out_pipe, nullptr);
+        Poco::ProcessHandle ph = Poco::Process::launch("ls", {"-lA", disk_path}, nullptr, &out_pipe, nullptr);
 
         constexpr size_t BUF_SIZE = 4096;
         char buffer[BUF_SIZE];
-        std::ostringstream ss;
-        int n = 0;
+        WriteBufferFromOwnString out;
 
+        int n = 0;
         while ((n = out_pipe.readBytes(buffer, BUF_SIZE)) > 0)
         {
-            ss.write(buffer, n);
+            out.write(buffer, n);
         }
 
-        ph.wait(); // Ensure child process exits
+        ph.wait();
 
-        LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}. Directory contents:\n{}", disk_path, ss.str());
+        LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}. Directory contents:\n{}", disk_path, out.str());
     }
     catch (...)
     {
         LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}, and failed to list contents due to internal error.", disk_path);
     }
-    //LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}", disk_path);
+    LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}", disk_path);
     return false;
 }
 

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -27,6 +27,9 @@
 #include <pcg_random.hpp>
 #include <Common/logger_useful.h>
 
+#include <Poco/Process.h>
+#include <Poco/Pipe.h>
+
 
 namespace CurrentMetrics
 {
@@ -618,7 +621,30 @@ try
 }
 catch (...)
 {
-    LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}", disk_path);
+    try
+    {
+        Poco::Pipe out_pipe;
+        Poco::ProcessHandle ph = Poco::Process::launch("ls", {"-l", disk_path}, nullptr, &out_pipe, nullptr);
+
+        constexpr size_t BUF_SIZE = 4096;
+        char buffer[BUF_SIZE];
+        std::ostringstream ss;
+        int n = 0;
+
+        while ((n = out_pipe.readBytes(buffer, BUF_SIZE)) > 0)
+        {
+            ss.write(buffer, n);
+        }
+
+        ph.wait(); // Ensure child process exits
+
+        LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}. Directory contents:\n{}", disk_path, ss.str());
+    }
+    catch (...)
+    {
+        LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}, and failed to list contents due to internal error.", disk_path);
+    }
+    //LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}", disk_path);
     return false;
 }
 

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -624,7 +624,7 @@ catch (...)
     try
     {
         Poco::Pipe out_pipe;
-        Poco::ProcessHandle ph = Poco::Process::launch("ls", {"-lA", disk_path}, nullptr, &out_pipe, nullptr);
+        Poco::ProcessHandle ph = Poco::Process::launch("ls", {"-lA --time-style=full-iso", disk_path}, nullptr, &out_pipe, nullptr);
 
         constexpr size_t BUF_SIZE = 4096;
         char buffer[BUF_SIZE];

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -536,7 +536,7 @@ DiskLocal::DiskLocal(const String & name_, const String & path_, UInt64 keep_fre
     : IDisk(name_, config, config_prefix)
     , disk_path(path_)
     , keep_free_space_bytes(keep_free_space_bytes_)
-    , logger(getLogger(fmt::format("DiskLocal({})", name_)))
+    , logger(getLogger("DiskLocal"))
     , data_source_description(getLocalDataSourceDescription(disk_path))
 {
 }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -536,7 +536,7 @@ DiskLocal::DiskLocal(const String & name_, const String & path_, UInt64 keep_fre
     : IDisk(name_, config, config_prefix)
     , disk_path(path_)
     , keep_free_space_bytes(keep_free_space_bytes_)
-    , logger(getLogger("DiskLocal"))
+    , logger(getLogger(fmt::format("DiskLocal({})", name_)))
     , data_source_description(getLocalDataSourceDescription(disk_path))
 {
 }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -27,9 +27,6 @@
 #include <pcg_random.hpp>
 #include <Common/logger_useful.h>
 
-#include <Poco/Process.h>
-#include <Poco/Pipe.h>
-
 
 namespace CurrentMetrics
 {
@@ -621,29 +618,6 @@ try
 }
 catch (...)
 {
-    try
-    {
-        Poco::Pipe out_pipe;
-        Poco::ProcessHandle ph = Poco::Process::launch("ls", {"-lA --time-style=full-iso", disk_path}, nullptr, &out_pipe, nullptr);
-
-        constexpr size_t BUF_SIZE = 4096;
-        char buffer[BUF_SIZE];
-        WriteBufferFromOwnString out;
-
-        int n = 0;
-        while ((n = out_pipe.readBytes(buffer, BUF_SIZE)) > 0)
-        {
-            out.write(buffer, n);
-        }
-
-        ph.wait();
-
-        LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}. Directory contents:\n{}", disk_path, out.str());
-    }
-    catch (...)
-    {
-        LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}, and failed to list contents due to internal error.", disk_path);
-    }
     LOG_WARNING(logger, "Cannot achieve read over the disk directory: {}", disk_path);
     return false;
 }

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -54,7 +54,6 @@ void DiskLocalCheckThread::run()
     bool can_write = disk->canWrite();
     if (can_read)
     {
-        LOG_INFO(log, "Disk {} can be read...", disk->getName());
         if (disk->broken)
             LOG_INFO(log, "Disk {0} seems to be fine. It can be recovered using `SYSTEM RESTART DISK {0}`", disk->getName());
         retry = 0;
@@ -69,7 +68,6 @@ void DiskLocalCheckThread::run()
     }
     else if (!disk->broken && retry < DISK_CHECK_ERROR_RETRY_TIME)
     {
-        LOG_INFO(log, "Disk {} found broken, but will retry...", disk->getName());
         ++retry;
         task->scheduleAfter(DISK_CHECK_ERROR_SLEEP_MS);
     }

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -54,6 +54,7 @@ void DiskLocalCheckThread::run()
     bool can_write = disk->canWrite();
     if (can_read)
     {
+        LOG_INFO(log, "Disk {} can be read...", disk->getName());
         if (disk->broken)
             LOG_INFO(log, "Disk {0} seems to be fine. It can be recovered using `SYSTEM RESTART DISK {0}`", disk->getName());
         retry = 0;
@@ -68,6 +69,7 @@ void DiskLocalCheckThread::run()
     }
     else if (!disk->broken && retry < DISK_CHECK_ERROR_RETRY_TIME)
     {
+        LOG_INFO(log, "Disk {} found broken, but will retry...", disk->getName());
         ++retry;
         task->scheduleAfter(DISK_CHECK_ERROR_SLEEP_MS);
     }

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -185,12 +185,6 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     new_values[fmt::format("DiskUnreserved_{}", name)] = { *unreserved,
                         "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information." };
             }
-            auto readonly = disk->isReadOnly();
-            auto broken = disk->isBroken();
-            new_values[fmt::format("DiskReadonly_{}", name)] = { readonly,
-                                                                "Whether or not the disk is marked as readonly by disk checker(if enabled)" };
-            new_values[fmt::format("DiskBroken_{}", name)] = { broken,
-                                                              "Whether or not the disk is marked as broken by disk checker(if enabled)" };
 
 #if USE_AWS_S3
             if (auto s3_client = disk->tryGetS3StorageClient())

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -185,6 +185,12 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     new_values[fmt::format("DiskUnreserved_{}", name)] = { *unreserved,
                         "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information." };
             }
+            auto readonly = disk->isReadOnly();
+            auto broken = disk->isBroken();
+            new_values[fmt::format("DiskReadonly_{}", name)] = { readonly,
+                                                                "Whether or not the disk is marked as readonly by disk checker(if enabled)" };
+            new_values[fmt::format("DiskBroken_{}", name)] = { broken,
+                                                              "Whether or not the disk is marked as broken by disk checker(if enabled)" };
 
 #if USE_AWS_S3
             if (auto s3_client = disk->tryGetS3StorageClient())

--- a/tests/integration/test_disk_checker/config.xml
+++ b/tests/integration/test_disk_checker/config.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+    <local_disk_check_period_ms>10000</local_disk_check_period_ms>
+    <path>/var/lib/clickhouse/</path>
+    <storage_configuration>
+        <disks>
+            <test1>
+                <type>local</type>
+                <path>/var/lib/clickhouse/path1/</path>
+            </test1>
+        </disks>
+        <policies>
+            <test1>
+                <volumes>
+                    <main>
+                        <disk>test1</disk>
+                    </main>
+                </volumes>
+            </test1>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_disk_checker/config.xml
+++ b/tests/integration/test_disk_checker/config.xml
@@ -1,5 +1,5 @@
 <clickhouse>
-    <local_disk_check_period_ms>10000</local_disk_check_period_ms>
+    <local_disk_check_period_ms>1000</local_disk_check_period_ms>
     <path>/var/lib/clickhouse/</path>
     <storage_configuration>
         <disks>

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -110,9 +110,16 @@ def test_disk_readonly_prometheus_status(started_cluster):
     output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
     logging.info(f"Initial permissions for {disk_path}: {output}")
 
+    contents = node.exec_in_container(["ls", "-la", disk_path]).strip()
+    logging.info(f"Contents of {disk_path}:\n{contents}")
+
+
     # Step 1: Remove write permission to simulate broken disk
     node.exec_in_container(["chmod", "555", disk_path])
     logging.info(f"Changed permissions to 555 on {disk_path} to simulate readonly disk")
+
+    contents = node.exec_in_container(["ls", "-la", disk_path]).strip()
+    logging.info(f"Contents of {disk_path}:\n{contents}")
 
     output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
     logging.info(f"After changed to readonly,  permissions for {disk_path}: {output}")

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -1,0 +1,147 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+import os
+import time
+import logging
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    global cluster
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "test_disk_checker",
+            main_configs=["config.xml"],
+            with_minio=False,
+            with_zookeeper=True,
+            with_remote_database_disk=False,  # The tests work on the local disk and check local files
+        )
+        cluster.start()
+
+        # local disk requires its `path` directory to exist.
+        # the two paths below belong to `test1` and `test2` disks
+        node = cluster.instances["test_disk_checker"]
+        node.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"mkdir -p /var/lib/clickhouse/path1",
+            ]
+        )
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_disk_checker_started_log(started_cluster):
+    node = cluster.instances["test_disk_checker"]
+
+    # This is the log string we expect (case-sensitive grep)
+
+    expected_log = "Disk check for disk test1 started with period 10.00s"
+
+    count = node.count_in_log(expected_log)
+
+    # Make sure it exists in the logs
+    logging.info(f"DiskChecker log count: {count}")
+    assert int(count) > 0, "DiskChecker did not start or log not found"
+
+def wait_for_file(node, filepath, timeout=30):
+    for _ in range(timeout):
+        res = node.exec_in_container(["bash", "-c", f"test -f {filepath} && echo exists || echo missing"]).strip()
+        if res == "exists":
+            return True
+        time.sleep(1)
+    return False
+
+def wait_for_log(node, expected_log, timeout=30):
+    for _ in range(timeout):
+        count = int(node.count_in_log(expected_log))
+        if count > 0:
+            return True
+        time.sleep(1)
+    return False
+
+def wait_for_metrics(node, metric_name, expected_value, timeout=30):
+    for _ in range(timeout):
+        try:
+            result = node.query(f"SELECT value FROM system.metrics WHERE metric = '{metric_name}'").strip()
+            value = int(result)
+            logging.info(f"wait_for_metrics for metric_name {metric_name}, "
+                         f"current value {value}, expected {expected_value}")
+            if value == expected_value:
+                return True
+        except Exception as e:
+            logging.debug(f"wait_for_metrics: Exception querying metric {metric_name}: {e}")
+        time.sleep(1)
+    return False
+
+def test_disk_readonly_prometheus_status(started_cluster):
+    node = cluster.instances["test_disk_checker"]
+    disk_name = "test1"
+    # Based on your config, disk name is 'test1' and path inside container is:
+    disk_path = "/var/lib/clickhouse/path1"
+    disk_checker_path = os.path.join(disk_path, ".disk_checker_file")
+    disk_checker_backup_path = disk_checker_path + ".bak"
+
+    # Ensure .disk_checker_file exists initially if we have set local_disk_check_period_ms
+    assert wait_for_file(node, disk_checker_path), ".disk_checker_file was not created in time"
+
+    # Step 2: Move away .disk_checker_file to simulate readonly disk
+    node.exec_in_container(["mv", disk_checker_path, disk_checker_backup_path])
+    logging.info("Moved .disk_checker_file away to simulate disk readonly")
+
+    # Wait some seconds to let ClickHouse detect the change
+
+    # We should find the readonly log
+    expected_log = f"Disk {disk_name} is readonly"
+    assert wait_for_log(node, expected_log), "DiskChecker did not find expected log"
+
+    count = node.count_in_log(expected_log)
+    logging.info(f"DiskChecker found the disk {disk_name} readonly log count: {count}")
+    assert int(count) > 0, f"DiskChecker did not found the log indicating disk {disk_name} is readonly"
+
+    # Check Prometheus metrics for readonly disk
+    assert wait_for_metrics(node, "ReadonlyDisks", 1), "ReadonlyDisks metric did not reach 1"
+
+    # Step 3: Move the .disk_checker_file back to restore disk readable status
+    node.exec_in_container(["mv", disk_checker_backup_path, disk_checker_path])
+    logging.info("Restored .disk_checker_file to simulate disk back to normal")
+
+    # Check Prometheus metrics again, disk should no longer be readonly
+    assert wait_for_metrics(node, "ReadonlyDisks", 0), "ReadonlyDisks metric did not reach 0"
+
+def test_disk_broken_prometheus_status(started_cluster):
+    node = cluster.instances["test_disk_checker"]
+
+    disk_path = "/var/lib/clickhouse/path1"
+    disk_name = "test1"
+
+    output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
+    logging.info(f"Initial permissions for {disk_path}: {output}")
+
+
+    # Step 1: Remove write permission to simulate broken disk
+    node.exec_in_container(["chmod", "555", disk_path])
+    logging.info(f"Changed permissions to 555 on {disk_path} to simulate broken disk")
+
+    output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
+    logging.info(f"After changed to Readonly,  permissions for {disk_path}: {output}")
+
+    expected_log = f"Disk {disk_name} marked as broken"
+    assert wait_for_log(node, expected_log), "DiskChecker did not find expected log for broken disk"
+    assert wait_for_metrics(node, "BrokenDisks", 1), "BrokenDisks metric did not reach 1"
+
+    # Step 2: Restore permissions
+    node.exec_in_container(["chmod", "775", disk_path])
+    logging.info(f"Restored permissions to 775 on {disk_path}")
+
+    output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
+    logging.info(f"After changed to 775 again,  permissions for {disk_path}: {output}")
+
+    assert wait_for_metrics(node, "BrokenDisks", 0), "BrokenDisks metric did not reach 0"
+
+

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -107,10 +107,10 @@ def test_disk_readonly_prometheus_status(started_cluster):
     disk_path = "/var/lib/clickhouse/path1"
     disk_name = "test1"
 
-    output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
+    output = node.exec_in_container(["ls", "-ld --time-style=full-iso", disk_path]).strip()
     logging.info(f"Initial permissions for {disk_path}: {output}")
 
-    contents = node.exec_in_container(["ls", "-la", disk_path]).strip()
+    contents = node.exec_in_container(["ls", "-lA --time-style=full-iso", disk_path]).strip()
     logging.info(f"Contents of {disk_path}:\n{contents}")
 
 
@@ -118,10 +118,10 @@ def test_disk_readonly_prometheus_status(started_cluster):
     node.exec_in_container(["chmod", "555", disk_path])
     logging.info(f"Changed permissions to 555 on {disk_path} to simulate readonly disk")
 
-    contents = node.exec_in_container(["ls", "-la", disk_path]).strip()
+    contents = node.exec_in_container(["ls", "-lA --time-style=full-iso", disk_path]).strip()
     logging.info(f"Contents of {disk_path}:\n{contents}")
 
-    output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
+    output = node.exec_in_container(["ls", "-ld --time-style=full-iso", disk_path]).strip()
     logging.info(f"After changed to readonly,  permissions for {disk_path}: {output}")
 
     # We should find the readonly log
@@ -139,7 +139,7 @@ def test_disk_readonly_prometheus_status(started_cluster):
     node.exec_in_container(["chmod", "775", disk_path])
     logging.info(f"Restored permissions to 775 on {disk_path}")
 
-    output = node.exec_in_container(["ls", "-ld", disk_path]).strip()
+    output = node.exec_in_container(["ls", "-ld --time-style=full-iso", disk_path]).strip()
     logging.info(f"After changed to 775 again,  permissions for {disk_path}: {output}")
 
     # Check Prometheus metrics again, disk should no longer be readonly
@@ -157,14 +157,16 @@ def test_disk_broken_prometheus_status(started_cluster):
     # Based on your config, disk name is 'test1' and path inside container is:
     disk_path = "/var/lib/clickhouse/path1"
     disk_checker_path = os.path.join(disk_path, ".disk_checker_file")
-    disk_checker_backup_path = disk_checker_path + ".bak"
+    from datetime import datetime
+    formatted_time = datetime.now.strftime('%Y_%m_%d_%H_%M_%S_%f')[:-3]
+    disk_checker_backup_path = disk_checker_path + "_" + formatted_time + ".bak"
 
     # Ensure .disk_checker_file exists initially if we have set local_disk_check_period_ms
     assert wait_for_file(node, disk_checker_path), ".disk_checker_file was not created in time"
 
     # Step 2: Move away .disk_checker_file to simulate readonly disk
     node.exec_in_container(["mv", disk_checker_path, disk_checker_backup_path])
-    logging.info("Moved .disk_checker_file away to simulate disk broken")
+    logging.info(f"Moved .disk_checker_file away to {disk_checker_backup_path} simulate disk broken ")
 
     # Wait some seconds to let ClickHouse detect the change
     expected_log = f"Disk {disk_name} marked as broken"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Metrics for number of readonly and broken disks.
Indicator logs when DiskLocalCheckThread is started

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
Issue is here: https://github.com/ClickHouse/ClickHouse/issues/80390
