### PR TITLE
Fix bad test `01417_freeze_partition_verbose`

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3238 
+personal_ws-1.1 en 3238
 AArch
 ACLs
 ALTERs
@@ -1850,7 +1850,6 @@ formatter
 formatters
 fqdn
 frac
-freezed
 frictionless
 fromDaysSinceYearZero
 fromModifiedJulianDay

--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -233,7 +233,7 @@ For more information about backups and restoring data, see the [Data Backup](/op
 ALTER TABLE table_name [ON CLUSTER cluster] UNFREEZE [PARTITION 'part_expr'] WITH NAME 'backup_name'
 ```
 
-Removes `freezed` partitions with the specified name from the disk. If the `PARTITION` clause is omitted, the query removes the backup of all partitions at once.
+Removes `frozen` partitions with the specified name from the disk. If the `PARTITION` clause is omitted, the query removes the backup of all partitions at once.
 
 ## CLEAR INDEX IN PARTITION {#clear-index-in-partition}
 

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -339,7 +339,7 @@ SYSTEM START MOVES [ON CLUSTER cluster_name] [[db.]merge_tree_family_table_name]
 
 ### SYSTEM UNFREEZE {#query_language-system-unfreeze}
 
-Clears freezed backup with the specified name from all the disks. See more about unfreezing separate parts in [ALTER TABLE table_name UNFREEZE WITH NAME ](/sql-reference/statements/alter/partition#unfreeze-partition)
+Clears a frozen backup with the specified name from all the disks. See more about unfreezing separate parts in [ALTER TABLE table_name UNFREEZE WITH NAME ](/sql-reference/statements/alter/partition#unfreeze-partition)
 
 ```sql
 SYSTEM UNFREEZE WITH NAME <backup_name>

--- a/src/Storages/Freeze.cpp
+++ b/src/Storages/Freeze.cpp
@@ -137,19 +137,17 @@ BlockIO Unfreezer::systemUnfreeze(const String & backup_name)
                         config_key);
     }
 
-    auto disks_map = local_context->getDisksMap();
-    Disks disks;
-    for (auto & [name, disk]: disks_map)
-    {
-        disks.push_back(disk);
-    }
     auto backup_path = fs::path(backup_directory_prefix) / escapeForFileName(backup_name);
     auto store_paths = {backup_path / "store", backup_path / "data"};
 
     PartitionCommandsResultInfo result_info;
 
-    for (const auto & disk: disks)
+    auto disks_map = local_context->getDisksMap();
+    for (auto & [_, disk] : disks_map)
     {
+        if (disk->isReadOnly() || disk->isWriteOnce())
+            continue;
+
         for (const auto & store_path : store_paths)
         {
             if (!disk->existsDirectory(store_path))
@@ -164,9 +162,7 @@ BlockIO Unfreezer::systemUnfreeze(const String & backup_name)
                     auto current_result_info = unfreezePartitionsFromTableDirectory(
                         [](const String &) { return true; }, backup_name, {disk}, table_directory);
                     for (auto & command_result : current_result_info)
-                    {
                         command_result.command_type = "SYSTEM UNFREEZE";
-                    }
                     result_info.insert(
                         result_info.end(),
                         std::make_move_iterator(current_result_info.begin()),
@@ -190,7 +186,7 @@ BlockIO Unfreezer::systemUnfreeze(const String & backup_name)
     return result;
 }
 
-bool Unfreezer::removeFreezedPart(DiskPtr disk, const String & path, const String & part_name, ContextPtr local_context, zkutil::ZooKeeperPtr zookeeper)
+bool Unfreezer::removeFrozenPart(DiskPtr disk, const String & path, const String & part_name, ContextPtr local_context, zkutil::ZooKeeperPtr zookeeper)
 {
     if (disk->supportZeroCopyReplication())
     {
@@ -231,7 +227,7 @@ PartitionCommandsResultInfo Unfreezer::unfreezePartitionsFromTableDirectory(Merg
 
             const auto & path = it->path();
 
-            bool keep_shared = removeFreezedPart(disk, path, partition_directory, local_context, zookeeper);
+            bool keep_shared = removeFrozenPart(disk, path, partition_directory, local_context, zookeeper);
 
             result.push_back(PartitionCommandResultInfo{
                 .command_type = "UNFREEZE PART",

--- a/src/Storages/Freeze.h
+++ b/src/Storages/Freeze.h
@@ -40,7 +40,7 @@ private:
     zkutil::ZooKeeperPtr zookeeper;
     LoggerPtr log = getLogger("Unfreezer");
     static constexpr std::string_view backup_directory_prefix = "shadow";
-    static bool removeFreezedPart(DiskPtr disk, const String & path, const String & part_name, ContextPtr local_context, zkutil::ZooKeeperPtr zookeeper);
+    static bool removeFrozenPart(DiskPtr disk, const String & path, const String & part_name, ContextPtr local_context, zkutil::ZooKeeperPtr zookeeper);
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1160,7 +1160,7 @@ public:
     /// Overridden in StorageReplicatedMergeTree
     virtual MutableDataPartPtr tryToFetchIfShared(const IMergeTreeDataPart &, const DiskPtr &, const String &) { return nullptr; }
 
-    /// Check shared data usage on other replicas for detached/freezed part
+    /// Check shared data usage on other replicas for detached/frozen part
     /// Remove local files and remote files if needed
     virtual bool removeDetachedPart(DiskPtr disk, const String & path, const String & part_name);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The `SYSTEM UNFREEZE` command will not try to look up parts in readonly and write-once disks. This closes #80430