### PR TITLE
Set merged parts log level to trace

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -509,7 +509,7 @@ std::expected<MergeSelectorChoice, SelectMergeFailure> MergeTreeDataMergerMutato
         });
     }
 
-    LOG_INFO(log, "Selected {} parts from {} to {}", parts.size(), parts.front().name, parts.back().name);
+    LOG_TRACE(log, "Selected {} parts from {} to {}", parts.size(), parts.front().name, parts.back().name);
     return MergeSelectorChoice{std::move(parts), MergeType::Regular, final};
 }
 
@@ -649,7 +649,7 @@ MergeTreeData::DataPartPtr MergeTreeDataMergerMutator::renameMergedTemporaryPart
                     new_data_part->name, replaced_parts[i]->name, parts[i]->name);
     }
 
-    LOG_INFO(log, "Merged {} parts: [{}, {}] -> {}", parts.size(), parts.front()->name, parts.back()->name, new_data_part->name);
+    LOG_TRACE(log, "Merged {} parts: [{}, {}] -> {}", parts.size(), parts.front()->name, parts.back()->name, new_data_part->name);
     return new_data_part;
 }
 


### PR DESCRIPTION
See https://github.com/ClickHouse/ClickHouse/pull/80062 and https://github.com/ClickHouse/ClickHouse/issues/77351

Note that https://github.com/ClickHouse/ClickHouse/blob/3c02c1f1abd5bf46f6285af6e56472ada8e9e91a/src/Storages/MergeTree/MergeProjectionPartsTask.cpp#L67
is DEBUG instead of TRACE. Let me know if I need to change any of the 3 messages.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Changed log level of a merged parts message from INFO to TRACE.

