### PR TITLE
fix splitMultiPartQuery for queries ending with comment

### DIFF
--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -482,10 +482,20 @@ std::pair<const char *, bool> splitMultipartQuery(
             insert->end = pos;
         }
 
+       const auto * next_pos = pos;
+
+        while (isWhitespaceASCII(*next_pos) || *next_pos == ';')
+            ++next_pos;
+
+        Tokens tokens(next_pos, end, max_query_size, true);
+        IParser::Pos token_iterator(tokens, static_cast<uint32_t>(max_parser_depth), static_cast<uint32_t>(max_parser_backtracks));
+
+        if (token_iterator->isEnd())
+            pos = end;
+
         queries_list.emplace_back(queries.substr(begin - queries.data(), pos - begin));
 
-        while (isWhitespaceASCII(*pos) || *pos == ';')
-            ++pos;
+        pos = std::max(pos, next_pos);
     }
 
     return std::make_pair(begin, pos == end);

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -45,6 +45,8 @@ def setup_teardown():
     node1.query("DROP DATABASE test")
     node1.query("CREATE DATABASE test")
 
+def test_postgres_select_with_comment(started_cluster):
+    assert(node1.query("SELECT 1; /* some comment */").rstrip() == "1")
 
 def test_postgres_select_insert(started_cluster):
     cursor = started_cluster.postgres_conn.cursor()


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
 Fix a bug with splitMultipartQuery throwing an "Empty query" error for queries that ends with comment after semicolon (ex: select 1; /* some comment */)

