### PR TITLE
fix data race on vptr SignalListener::run

### DIFF
--- a/src/Daemon/BaseDaemon.h
+++ b/src/Daemon/BaseDaemon.h
@@ -125,7 +125,7 @@ protected:
     virtual void logRevision() const;
 
     /// thread safe
-    virtual void handleSignal(int signal_id);
+    void handleSignal(int signal_id);
 
     /// initialize termination process and signal handlers
     virtual void initializeTerminationAndSignalProcessing();


### PR DESCRIPTION
fixes https://github.com/ClickHouse/ClickHouse/issues/79245
When `SignalListener::run` calls virtual method `daemon->handleSignal` the instance daemon is half way destroyed.
Destruction of `class DB::Server` work concurrently with look up in vptr table. 

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix data race on vptr SignalListener::run

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
