### PR TITLE
fix optimize_read_in_order supported nulls direction check

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -425,10 +425,12 @@ SortingInputOrder buildInputOrderFromSortDescription(
         if (sort_column_description.collator)
             break;
 
-        /// Since sorting key columns are always sorted with NULLS LAST, reading in order
-        /// supported only for ASC NULLS LAST ("in order"), and DESC NULLS FIRST ("reverse")
-        const auto column_is_nullable = sorting_key.data_types[next_sort_key]->isNullable();
-        if (column_is_nullable && sort_column_description.nulls_direction != sort_column_description.direction)
+        /// Since sorting key columns are always sorted with
+        // ASC NULLS LAST ("in order") or DESC NULLS FIRST ("reverse")
+        /// supported only this direction, other cases are represented as nulls_direction==-1
+        /// Also actual for floating point values NaN.
+        const auto column_is_nullable = sorting_key.data_types[next_sort_key]->isNullable() || isFloat(*sorting_key.data_types[next_sort_key]);
+        if (column_is_nullable && sort_column_description.nulls_direction == -1)
             break;
 
         /// Direction for current sort key.

--- a/tests/queries/0_stateless/00940_order_by_read_in_order_query_plan.reference
+++ b/tests/queries/0_stateless/00940_order_by_read_in_order_query_plan.reference
@@ -44,7 +44,7 @@ select * from tab order by (a + b) * c, sin(a / b);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c, sin(a / b)) where explain like '%sort description%';
   Prefix sort description: multiply(plus(a, b), c) ASC, sin(divide(a, b)) ASC
   Result sort description: multiply(plus(a, b), c) ASC, sin(divide(a, b)) ASC
-select * from tab order by (a + b) * c desc, sin(a / b) desc;
+select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first;
 4	4	4	4
 4	4	4	4
 3	3	3	3
@@ -55,8 +55,8 @@ select * from tab order by (a + b) * c desc, sin(a / b) desc;
 1	1	1	1
 0	0	0	0
 0	0	0	0
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(a, b), c) DESC
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first) where explain like '%sort description%';
+  Prefix sort description: multiply(plus(a, b), c) DESC, sin(divide(a, b)) DESC
   Result sort description: multiply(plus(a, b), c) DESC, sin(divide(a, b)) DESC
 -- Exact match, mixed direction
 select * from tab order by (a + b) * c desc, sin(a / b);
@@ -168,8 +168,8 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c, 
   Prefix sort description: multiply(plus(a, b), c) ASC
   Result sort description: multiply(plus(a, b), c) ASC, intDiv(sin(divide(a, b)), 2) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc;
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(a, b), c) DESC
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc nulls first) where explain like '%sort description%';
+  Prefix sort description: multiply(plus(a, b), c) DESC, intDiv(sin(divide(a, b)), 2) DESC
   Result sort description: multiply(plus(a, b), c) DESC, intDiv(sin(divide(a, b)), 2) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2)) where explain like '%sort description%';

--- a/tests/queries/0_stateless/00940_order_by_read_in_order_query_plan.reference
+++ b/tests/queries/0_stateless/00940_order_by_read_in_order_query_plan.reference
@@ -56,7 +56,7 @@ select * from tab order by (a + b) * c desc, sin(a / b) desc;
 0	0	0	0
 0	0	0	0
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(a, b), c) DESC, sin(divide(a, b)) DESC
+  Prefix sort description: multiply(plus(a, b), c) DESC
   Result sort description: multiply(plus(a, b), c) DESC, sin(divide(a, b)) DESC
 -- Exact match, mixed direction
 select * from tab order by (a + b) * c desc, sin(a / b);
@@ -169,7 +169,7 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c, 
   Result sort description: multiply(plus(a, b), c) ASC, intDiv(sin(divide(a, b)), 2) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc;
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(a, b), c) DESC, intDiv(sin(divide(a, b)), 2) DESC
+  Prefix sort description: multiply(plus(a, b), c) DESC
   Result sort description: multiply(plus(a, b), c) DESC, intDiv(sin(divide(a, b)), 2) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2)) where explain like '%sort description%';

--- a/tests/queries/0_stateless/00940_order_by_read_in_order_query_plan.sql
+++ b/tests/queries/0_stateless/00940_order_by_read_in_order_query_plan.sql
@@ -23,8 +23,8 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c d
 select * from tab order by (a + b) * c, sin(a / b);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c, sin(a / b)) where explain like '%sort description%';
 
-select * from tab order by (a + b) * c desc, sin(a / b) desc;
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc) where explain like '%sort description%';
+select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first;
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first) where explain like '%sort description%';
 
 -- Exact match, mixed direction
 select * from tab order by (a + b) * c desc, sin(a / b);
@@ -68,7 +68,7 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c d
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
 
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc;
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc nulls first) where explain like '%sort description%';
 
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2)) where explain like '%sort description%';

--- a/tests/queries/0_stateless/02911_analyzer_order_by_read_in_order_query_plan.reference
+++ b/tests/queries/0_stateless/02911_analyzer_order_by_read_in_order_query_plan.reference
@@ -44,7 +44,7 @@ select * from tab order by (a + b) * c, sin(a / b);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c, sin(a / b)) where explain like '%sort description%';
   Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) ASC, sin(divide(__table1.a, __table1.b)) ASC
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) ASC, sin(divide(__table1.a, __table1.b)) ASC
-select * from tab order by (a + b) * c desc, sin(a / b) desc;
+select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first;
 4	4	4	4
 4	4	4	4
 3	3	3	3
@@ -55,8 +55,8 @@ select * from tab order by (a + b) * c desc, sin(a / b) desc;
 1	1	1	1
 0	0	0	0
 0	0	0	0
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first) where explain like '%sort description%';
+  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, sin(divide(__table1.a, __table1.b)) DESC
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, sin(divide(__table1.a, __table1.b)) DESC
 -- Exact match, mixed direction
 select * from tab order by (a + b) * c desc, sin(a / b);
@@ -168,8 +168,8 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c, 
   Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) ASC
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) ASC, intDiv(sin(divide(__table1.a, __table1.b)), 2_UInt8) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc;
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc nulls first) where explain like '%sort description%';
+  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, intDiv(sin(divide(__table1.a, __table1.b)), 2_UInt8) DESC
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, intDiv(sin(divide(__table1.a, __table1.b)), 2_UInt8) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2)) where explain like '%sort description%';

--- a/tests/queries/0_stateless/02911_analyzer_order_by_read_in_order_query_plan.reference
+++ b/tests/queries/0_stateless/02911_analyzer_order_by_read_in_order_query_plan.reference
@@ -56,7 +56,7 @@ select * from tab order by (a + b) * c desc, sin(a / b) desc;
 0	0	0	0
 0	0	0	0
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, sin(divide(__table1.a, __table1.b)) DESC
+  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, sin(divide(__table1.a, __table1.b)) DESC
 -- Exact match, mixed direction
 select * from tab order by (a + b) * c desc, sin(a / b);
@@ -169,7 +169,7 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c, 
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) ASC, intDiv(sin(divide(__table1.a, __table1.b)), 2_UInt8) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc;
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
-  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, intDiv(sin(divide(__table1.a, __table1.b)), 2_UInt8) DESC
+  Prefix sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC
   Result sort description: multiply(plus(__table1.a, __table1.b), __table1.c) DESC, intDiv(sin(divide(__table1.a, __table1.b)), 2_UInt8) DESC
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2)) where explain like '%sort description%';

--- a/tests/queries/0_stateless/02911_analyzer_order_by_read_in_order_query_plan.sql
+++ b/tests/queries/0_stateless/02911_analyzer_order_by_read_in_order_query_plan.sql
@@ -23,8 +23,8 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c d
 select * from tab order by (a + b) * c, sin(a / b);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c, sin(a / b)) where explain like '%sort description%';
 
-select * from tab order by (a + b) * c desc, sin(a / b) desc;
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc) where explain like '%sort description%';
+select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first;
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, sin(a / b) desc nulls first) where explain like '%sort description%';
 
 -- Exact match, mixed direction
 select * from tab order by (a + b) * c desc, sin(a / b);
@@ -68,7 +68,7 @@ select * from (explain plan actions = 1 select * from tab order by (a + b) * c d
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
 
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc;
-select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc) where explain like '%sort description%';
+select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), 2) desc nulls first) where explain like '%sort description%';
 
 -- select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2);
 select * from (explain plan actions = 1 select * from tab order by (a + b) * c desc, intDiv(sin(a / b), -2)) where explain like '%sort description%';

--- a/tests/queries/0_stateless/03257_reverse_sorting_key.reference
+++ b/tests/queries/0_stateless/03257_reverse_sorting_key.reference
@@ -1,19 +1,17 @@
 3
 8
 Sorting (Sorting for ORDER BY)
-Sort description: __table1.i DESC
+Prefix sort description: __table1.i DESC
+Result sort description: __table1.i DESC
 (Expression)
 ExpressionTransform
   (Limit)
   Limit
     (Sorting)
-    MergeSortingTransform
-      LimitsCheckingTransform
-        PartialSortingTransform
-          (Expression)
-          ExpressionTransform
-            (ReadFromMergeTree)
-            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+      (Expression)
+      ExpressionTransform
+        (ReadFromMergeTree)
+        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 99
 98
 97
@@ -40,19 +38,17 @@ ExpressionTransform
 3	1003
 6
 Sorting (Sorting for ORDER BY)
-Prefix sort description: __table1.i ASC
+Prefix sort description: __table1.i ASC, __table1.j DESC
 Result sort description: __table1.i ASC, __table1.j DESC
 (Expression)
 ExpressionTransform
   (Limit)
   Limit
     (Sorting)
-    FinishSortingTransform
-      PartialSortingTransform
-        (Expression)
-        ExpressionTransform
-          (ReadFromMergeTree)
-          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+      (Expression)
+      ExpressionTransform
+        (ReadFromMergeTree)
+        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 0	1090
 0	1080
 0	1070

--- a/tests/queries/0_stateless/03257_reverse_sorting_key.reference
+++ b/tests/queries/0_stateless/03257_reverse_sorting_key.reference
@@ -1,17 +1,19 @@
 3
 8
 Sorting (Sorting for ORDER BY)
-Prefix sort description: __table1.i DESC
-Result sort description: __table1.i DESC
+Sort description: __table1.i DESC
 (Expression)
 ExpressionTransform
   (Limit)
   Limit
     (Sorting)
-      (Expression)
-      ExpressionTransform
-        (ReadFromMergeTree)
-        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+    MergeSortingTransform
+      LimitsCheckingTransform
+        PartialSortingTransform
+          (Expression)
+          ExpressionTransform
+            (ReadFromMergeTree)
+            MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 99
 98
 97
@@ -38,17 +40,19 @@ ExpressionTransform
 3	1003
 6
 Sorting (Sorting for ORDER BY)
-Prefix sort description: __table1.i ASC, __table1.j DESC
+Prefix sort description: __table1.i ASC
 Result sort description: __table1.i ASC, __table1.j DESC
 (Expression)
 ExpressionTransform
   (Limit)
   Limit
     (Sorting)
-      (Expression)
-      ExpressionTransform
-        (ReadFromMergeTree)
-        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+    FinishSortingTransform
+      PartialSortingTransform
+        (Expression)
+        ExpressionTransform
+          (ReadFromMergeTree)
+          MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 0	1090
 0	1080
 0	1070

--- a/tests/queries/0_stateless/03257_reverse_sorting_key.sql
+++ b/tests/queries/0_stateless/03257_reverse_sorting_key.sql
@@ -17,8 +17,8 @@ select * from x1 where i = 3;
 
 select count() from x1 where i between 3 and 10;
 
-select trimLeft(explain) from (explain actions=1 select * from x1 order by i desc limit 5) where explain ilike '%sort%' settings max_threads=1, enable_analyzer=1;
-explain pipeline select * from x1 order by i desc limit 5 settings max_threads=1;
+select trimLeft(explain) from (explain actions=1 select * from x1 order by i desc nulls first limit 5) where explain ilike '%sort%' settings max_threads=1, enable_analyzer=1;
+explain pipeline select * from x1 order by i desc nulls first limit 5 settings max_threads=1;
 
 select * from x1 order by i desc limit 5;
 
@@ -37,8 +37,8 @@ select * from x2 where j = 1003;
 
 select count() from x2 where i between 3 and 10 and j between 1003 and 1008;
 
-select trimLeft(explain) from (explain actions=1 select * from x2 order by i, j desc limit 5) where explain ilike '%sort%' settings max_threads=1, enable_analyzer=1;
-explain pipeline select * from x2 order by i, j desc limit 5 settings max_threads=1;
+select trimLeft(explain) from (explain actions=1 select * from x2 order by i, j desc nulls first limit 5) where explain ilike '%sort%' settings max_threads=1, enable_analyzer=1;
+explain pipeline select * from x2 order by i, j desc nulls first limit 5 settings max_threads=1;
 
 select * from x2 order by i, j desc limit 5;
 

--- a/tests/queries/0_stateless/03513_read_in_order_nullable.reference
+++ b/tests/queries/0_stateless/03513_read_in_order_nullable.reference
@@ -1,64 +1,64 @@
---- desc, last
+--- table asc, query desc, last
 1
 0
 \N
---- desc, first
+--- table asc, query desc, first
 \N
 1
 0
---- asc, last
+--- table asc, query asc, last
 0
 1
 \N
---- asc, first
+--- table asc, query asc, first
 \N
 0
 1
---- desc, last
+--- table desc, query desc, last
 1
 0
 \N
---- desc, first
+--- table desc, query desc, first
 \N
 1
 0
---- asc, last
+--- table desc, query asc, last
 0
 1
 \N
---- asc, first
+--- table desc, query asc, first
 \N
 0
 1
---- desc, last
+--- table asc, query desc, last
 1
 0
 nan
---- desc, first
+--- table asc, query desc, first
 nan
 1
 0
---- asc, last
+--- table asc, query asc, last
 0
 1
 nan
---- asc, first
+--- table asc, query asc, first
 nan
 0
 1
---- desc, last
+--- table desc, query desc, last
 1
 0
 nan
---- desc, first
+--- table desc, query desc, first
 nan
 1
 0
---- asc, last
+--- table desc, query asc, last
 0
 1
 nan
---- asc, first
+--- table desc, query asc, first
 nan
 0
 1

--- a/tests/queries/0_stateless/03513_read_in_order_nullable.reference
+++ b/tests/queries/0_stateless/03513_read_in_order_nullable.reference
@@ -1,0 +1,64 @@
+--- desc, last
+1
+0
+\N
+--- desc, first
+\N
+1
+0
+--- asc, last
+0
+1
+\N
+--- asc, first
+\N
+0
+1
+--- desc, last
+1
+0
+\N
+--- desc, first
+\N
+1
+0
+--- asc, last
+0
+1
+\N
+--- asc, first
+\N
+0
+1
+--- desc, last
+1
+0
+nan
+--- desc, first
+nan
+1
+0
+--- asc, last
+0
+1
+nan
+--- asc, first
+nan
+0
+1
+--- desc, last
+1
+0
+nan
+--- desc, first
+nan
+1
+0
+--- asc, last
+0
+1
+nan
+--- asc, first
+nan
+0
+1

--- a/tests/queries/0_stateless/03513_read_in_order_nullable.sql
+++ b/tests/queries/0_stateless/03513_read_in_order_nullable.sql
@@ -1,0 +1,54 @@
+SET optimize_read_in_order = 1;
+SET max_threads = 1;
+
+CREATE TABLE t0 (c0 Nullable(Int64)) ENGINE = MergeTree() ORDER BY c0 SETTINGS allow_nullable_key=1;
+INSERT INTO TABLE t0 VALUES (0);
+INSERT INTO TABLE t0 VALUES (NULL), (1);
+
+SELECT '--- desc, last';
+SELECT * FROM t0 ORDER BY c0 DESC NULLS LAST;
+SELECT '--- desc, first';
+SELECT * FROM t0 ORDER BY c0 DESC NULLS FIRST;
+SELECT '--- asc, last';
+SELECT * FROM t0 ORDER BY c0 ASC NULLS LAST;
+SELECT '--- asc, first';
+SELECT * FROM t0 ORDER BY c0 ASC NULLS FIRST;
+
+CREATE TABLE t1 (c0 Nullable(Int64)) ENGINE = MergeTree() ORDER BY c0 DESC SETTINGS allow_nullable_key=1, allow_experimental_reverse_key=1;
+INSERT INTO TABLE t1 VALUES (0);
+INSERT INTO TABLE t1 VALUES (NULL), (1);
+
+SELECT '--- desc, last';
+SELECT * FROM t1 ORDER BY c0 DESC NULLS LAST;
+SELECT '--- desc, first';
+SELECT * FROM t1 ORDER BY c0 DESC NULLS FIRST;
+SELECT '--- asc, last';
+SELECT * FROM t1 ORDER BY c0 ASC NULLS LAST;
+SELECT '--- asc, first';
+SELECT * FROM t1 ORDER BY c0 ASC NULLS FIRST;
+
+CREATE TABLE f0 (c0 Float64) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO TABLE f0 VALUES (0);
+INSERT INTO TABLE f0 VALUES (0/0), (1);
+
+SELECT '--- desc, last';
+SELECT * FROM f0 ORDER BY c0 DESC NULLS LAST;
+SELECT '--- desc, first';
+SELECT * FROM f0 ORDER BY c0 DESC NULLS FIRST;
+SELECT '--- asc, last';
+SELECT * FROM f0 ORDER BY c0 ASC NULLS LAST;
+SELECT '--- asc, first';
+SELECT * FROM f0 ORDER BY c0 ASC NULLS FIRST;
+
+CREATE TABLE f1 (c0 Float64) ENGINE = MergeTree() ORDER BY c0 DESC SETTINGS allow_experimental_reverse_key=1;
+INSERT INTO TABLE f1 VALUES (0);
+INSERT INTO TABLE f1 VALUES (0/0), (1);
+
+SELECT '--- desc, last';
+SELECT * FROM f1 ORDER BY c0 DESC NULLS LAST;
+SELECT '--- desc, first';
+SELECT * FROM f1 ORDER BY c0 DESC NULLS FIRST;
+SELECT '--- asc, last';
+SELECT * FROM f1 ORDER BY c0 ASC NULLS LAST;
+SELECT '--- asc, first';
+SELECT * FROM f1 ORDER BY c0 ASC NULLS FIRST;

--- a/tests/queries/0_stateless/03513_read_in_order_nullable.sql
+++ b/tests/queries/0_stateless/03513_read_in_order_nullable.sql
@@ -5,50 +5,50 @@ CREATE TABLE t0 (c0 Nullable(Int64)) ENGINE = MergeTree() ORDER BY c0 SETTINGS a
 INSERT INTO TABLE t0 VALUES (0);
 INSERT INTO TABLE t0 VALUES (NULL), (1);
 
-SELECT '--- desc, last';
+SELECT '--- table asc, query desc, last';
 SELECT * FROM t0 ORDER BY c0 DESC NULLS LAST;
-SELECT '--- desc, first';
+SELECT '--- table asc, query desc, first';
 SELECT * FROM t0 ORDER BY c0 DESC NULLS FIRST;
-SELECT '--- asc, last';
+SELECT '--- table asc, query asc, last';
 SELECT * FROM t0 ORDER BY c0 ASC NULLS LAST;
-SELECT '--- asc, first';
+SELECT '--- table asc, query asc, first';
 SELECT * FROM t0 ORDER BY c0 ASC NULLS FIRST;
 
 CREATE TABLE t1 (c0 Nullable(Int64)) ENGINE = MergeTree() ORDER BY c0 DESC SETTINGS allow_nullable_key=1, allow_experimental_reverse_key=1;
 INSERT INTO TABLE t1 VALUES (0);
 INSERT INTO TABLE t1 VALUES (NULL), (1);
 
-SELECT '--- desc, last';
+SELECT '--- table desc, query desc, last';
 SELECT * FROM t1 ORDER BY c0 DESC NULLS LAST;
-SELECT '--- desc, first';
+SELECT '--- table desc, query desc, first';
 SELECT * FROM t1 ORDER BY c0 DESC NULLS FIRST;
-SELECT '--- asc, last';
+SELECT '--- table desc, query asc, last';
 SELECT * FROM t1 ORDER BY c0 ASC NULLS LAST;
-SELECT '--- asc, first';
+SELECT '--- table desc, query asc, first';
 SELECT * FROM t1 ORDER BY c0 ASC NULLS FIRST;
 
 CREATE TABLE f0 (c0 Float64) ENGINE = MergeTree() ORDER BY c0;
 INSERT INTO TABLE f0 VALUES (0);
 INSERT INTO TABLE f0 VALUES (0/0), (1);
 
-SELECT '--- desc, last';
+SELECT '--- table asc, query desc, last';
 SELECT * FROM f0 ORDER BY c0 DESC NULLS LAST;
-SELECT '--- desc, first';
+SELECT '--- table asc, query desc, first';
 SELECT * FROM f0 ORDER BY c0 DESC NULLS FIRST;
-SELECT '--- asc, last';
+SELECT '--- table asc, query asc, last';
 SELECT * FROM f0 ORDER BY c0 ASC NULLS LAST;
-SELECT '--- asc, first';
+SELECT '--- table asc, query asc, first';
 SELECT * FROM f0 ORDER BY c0 ASC NULLS FIRST;
 
 CREATE TABLE f1 (c0 Float64) ENGINE = MergeTree() ORDER BY c0 DESC SETTINGS allow_experimental_reverse_key=1;
 INSERT INTO TABLE f1 VALUES (0);
 INSERT INTO TABLE f1 VALUES (0/0), (1);
 
-SELECT '--- desc, last';
+SELECT '--- table desc, query desc, last';
 SELECT * FROM f1 ORDER BY c0 DESC NULLS LAST;
-SELECT '--- desc, first';
+SELECT '--- table desc, query desc, first';
 SELECT * FROM f1 ORDER BY c0 DESC NULLS FIRST;
-SELECT '--- asc, last';
+SELECT '--- table desc, query asc, last';
 SELECT * FROM f1 ORDER BY c0 ASC NULLS LAST;
-SELECT '--- asc, first';
+SELECT '--- table desc, query asc, first';
 SELECT * FROM f1 ORDER BY c0 ASC NULLS FIRST;


### PR DESCRIPTION
Closes #72089
Fix check on nulls direction when we can't use read-in-order optimization.
Also, check it for floating point values due to NaN.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed wrong sorting in tables with a nullable key and enabled optimize_read_in_order.
