### PR TITLE
Support settings 'disk' for DB which stores table metadata files of the DB

### DIFF
--- a/docs/en/engines/database-engines/atomic.md
+++ b/docs/en/engines/database-engines/atomic.md
@@ -19,7 +19,7 @@ On ClickHouse Cloud, the `Replicated` database engine is used by default.
 ## Creating a Database {#creating-a-database}
 
 ```sql
-CREATE DATABASE test [ENGINE = Atomic];
+CREATE DATABASE test [ENGINE = Atomic] [SETTINGS disk=...];
 ```
 
 ## Specifics and Recommendations {#specifics-and-recommendations}
@@ -71,6 +71,16 @@ EXCHANGE TABLES new_table AND old_table;
 ### ReplicatedMergeTree in Atomic Database {#replicatedmergetree-in-atomic-database}
 
 For [`ReplicatedMergeTree`](/engines/table-engines/mergetree-family/replication) tables, it is recommended not to specify the engine parameters for the path in ZooKeeper and the replica name. In this case, the configuration parameters [`default_replica_path`](../../operations/server-configuration-parameters/settings.md#default_replica_path) and [`default_replica_name`](../../operations/server-configuration-parameters/settings.md#default_replica_name) will be used. If you want to specify engine parameters explicitly, it is recommended to use the `{uuid}` macros. This ensures that unique paths are automatically generated for each table in ZooKeeper.
+
+### Metadata disk {#metadata-disk}
+When `disk` is specified in `SETTINGS`, the disk is used to store table metadata files.
+For example:
+
+```sql
+CREATE TABLE db (n UInt64) ENGINE = Atomic SETTINGS disk=disk(type='local', path='/var/lib/clickhouse-disks/db_disk');
+```
+If unspecified, the disk defined in `database_disk.disk` is used by default.
+
 
 ## See Also {#see-also}
 

--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -492,6 +492,8 @@ int DisksApp::main(const std::vector<String> & /*args*/)
     config().keys(keys);
     initializeHistoryFile();
 
+    Poco::AutoPtr<Poco::FileChannel> log_file{nullptr};
+
     if (config().has("save-logs"))
     {
         auto log_level = config().getString("log-level", "trace");
@@ -499,9 +501,19 @@ int DisksApp::main(const std::vector<String> & /*args*/)
 
         auto log_path = config().getString("logger.clickhouse-disks", "/var/log/clickhouse-server/clickhouse-disks.log");
 
+        log_file = new Poco::FileChannel;
+        log_file->setProperty(Poco::FileChannel::PROP_PATH, fs::weakly_canonical(log_path));
+        log_file->setProperty(Poco::FileChannel::PROP_ROTATION, "100M");
+        log_file->setProperty(Poco::FileChannel::PROP_ARCHIVE, "number");
+        log_file->setProperty(Poco::FileChannel::PROP_COMPRESS, "false");
+        log_file->setProperty(Poco::FileChannel::PROP_STREAMCOMPRESS, "false");
+        log_file->setProperty(Poco::FileChannel::PROP_FLUSH, "true");
+        log_file->setProperty(Poco::FileChannel::PROP_ROTATEONOPEN, "false");
+        log_file->open();
+
         Poco::AutoPtr<OwnPatternFormatter> pf = new OwnPatternFormatter;
-        Poco::AutoPtr<OwnFormattingChannel> log = new OwnFormattingChannel(pf, new Poco::FileChannel(log_path));
-        logger().setChannel(log);
+        Poco::AutoPtr<OwnFormattingChannel> log = new OwnFormattingChannel(pf, log_file);
+        Poco::Logger::root().setChannel(log);
     }
     else
     {
@@ -546,6 +558,9 @@ int DisksApp::main(const std::vector<String> & /*args*/)
     {
         processQueryText(query.value());
     }
+
+    if (log_file)
+        log_file->close();
 
     return Application::EXIT_OK;
 }

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -563,7 +563,7 @@
     </storage_configuration>
     -->
 
-    <!-- Database disk configuration example: -->
+    <!-- Default database disk storing metadata files: -->
     <!--
     <database_disk>
         <disk>default</disk>

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -563,6 +563,13 @@
     </storage_configuration>
     -->
 
+    <!-- Database disk configuration example: -->
+    <!--
+    <database_disk>
+        <disk>default</disk>
+    </database_disk>
+    -->
+
     <!-- Path to temporary data for processing heavy queries. -->
     <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
 

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -726,8 +726,8 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
     auto new_name_escaped = escapeForFileName(new_name);
     auto old_database_metadata_path = fs::path("metadata") / (escapeForFileName(getDatabaseName()) + ".sql");
     auto new_database_metadata_path = fs::path("metadata") / (new_name_escaped + ".sql");
-    auto global_db_disk = getContext()->getDatabaseDisk();
-    global_db_disk->moveFile(old_database_metadata_path, new_database_metadata_path);
+    auto default_db_disk = getContext()->getDatabaseDisk();
+    default_db_disk->moveFile(old_database_metadata_path, new_database_metadata_path);
 
     String old_path_to_table_symlinks;
 

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -1,18 +1,20 @@
 #include <filesystem>
-#include <base/isSharedPtrUnique.h>
+#include <Core/Settings.h>
 #include <Databases/DatabaseAtomic.h>
 #include <Databases/DatabaseFactory.h>
+#include <Databases/DatabaseMetadataDiskSettings.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseReplicated.h>
+#include <Disks/IStoragePolicy.h>
 #include <Interpreters/DDLTask.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/ExternalDictionariesLoader.h>
 #include <Interpreters/Context.h>
 #include <Storages/StorageMaterializedView.h>
-#include <Common/logger_useful.h>
+#include <base/isSharedPtrUnique.h>
 #include <Common/PoolId.h>
 #include <Common/atomicRename.h>
-#include <Core/Settings.h>
+#include <Common/logger_useful.h>
 
 
 namespace fs = std::filesystem;
@@ -39,6 +41,12 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+
+namespace DatabaseMetadataDiskSetting
+{
+extern const DatabaseMetadataDiskSettingsString disk;
+}
+
 class AtomicDatabaseTablesSnapshotIterator final : public DatabaseTablesSnapshotIterator
 {
 public:
@@ -49,18 +57,24 @@ public:
     UUID uuid() const override { return table()->getStorageID().uuid; }
 };
 
-DatabaseAtomic::DatabaseAtomic(String name_, String metadata_path_, UUID uuid, const String & logger_name, ContextPtr context_)
-    : DatabaseOrdinary(name_, metadata_path_, "store/", logger_name, context_)
-    , root_path(fs::weakly_canonical(context_->getPath()))
-    , path_to_table_symlinks(root_path / "data" / escapeForFileName(name_) / "")
-    , path_to_metadata_symlink(root_path / "metadata" / escapeForFileName(name_))
+DatabaseAtomic::DatabaseAtomic(
+    String name_,
+    String metadata_path_,
+    UUID uuid,
+    const String & logger_name,
+    ContextPtr context_,
+    DatabaseMetadataDiskSettings database_metadata_disk_settings_)
+    : DatabaseOrdinary(name_, metadata_path_, "store/", logger_name, context_, database_metadata_disk_settings_)
+    , path_to_table_symlinks(fs::path("data") / escapeForFileName(name_) / "")
+    , path_to_metadata_symlink(fs::path("metadata") / escapeForFileName(name_))
     , db_uuid(uuid)
 {
     assert(db_uuid != UUIDHelpers::Nil);
 }
 
-DatabaseAtomic::DatabaseAtomic(String name_, String metadata_path_, UUID uuid, ContextPtr context_)
-    : DatabaseAtomic(name_, std::move(metadata_path_), uuid, "DatabaseAtomic (" + name_ + ")", context_)
+DatabaseAtomic::DatabaseAtomic(
+    String name_, String metadata_path_, UUID uuid, ContextPtr context_, DatabaseMetadataDiskSettings database_metadata_disk_settings_)
+    : DatabaseAtomic(name_, std::move(metadata_path_), uuid, "DatabaseAtomic (" + name_ + ")", context_, database_metadata_disk_settings_)
 {
 }
 
@@ -72,6 +86,8 @@ void DatabaseAtomic::createDirectories()
 
 void DatabaseAtomic::createDirectoriesUnlocked()
 {
+    auto db_disk = getDisk();
+
     DatabaseOnDisk::createDirectoriesUnlocked();
     db_disk->createDirectories("metadata");
     if (db_disk->isSymlinkSupported())
@@ -100,6 +116,8 @@ void DatabaseAtomic::drop(ContextPtr)
 {
     waitDatabaseStarted();
     assert(TSA_SUPPRESS_WARNING_FOR_READ(tables).empty());
+
+    auto db_disk = getDisk();
     try
     {
         if (db_disk->isSymlinkSupported())
@@ -170,6 +188,7 @@ void DatabaseAtomic::dropTableImpl(ContextPtr local_context, const String & tabl
     String table_metadata_path = getObjectMetadataPath(table_name);
     String table_metadata_path_drop;
     StoragePtr table;
+    auto db_disk = getDisk();
     {
         std::lock_guard lock(mutex);
         table = getTableUnlocked(table_name);
@@ -198,7 +217,7 @@ void DatabaseAtomic::dropTableImpl(ContextPtr local_context, const String & tabl
 
     /// Notify DatabaseCatalog that table was dropped. It will remove table data in background.
     /// Cleanup is performed outside of database to allow easily DROP DATABASE without waiting for cleanup to complete.
-    DatabaseCatalog::instance().enqueueDroppedTableCleanup(table->getStorageID(), table, table_metadata_path_drop, sync);
+    DatabaseCatalog::instance().enqueueDroppedTableCleanup(table->getStorageID(), table, db_disk, table_metadata_path_drop, sync);
 }
 
 void DatabaseAtomic::renameTable(ContextPtr local_context, const String & table_name, IDatabase & to_database,
@@ -318,6 +337,8 @@ void DatabaseAtomic::renameTable(ContextPtr local_context, const String & table_
     if (txn && !local_context->isInternalSubquery())
         txn->commit();     /// Commit point (a sort of) for Replicated database
 
+    auto db_disk = getDisk();
+
     /// NOTE: replica will be lost if server crashes before the following rename
     /// TODO better detection and recovery
     if (exchange)
@@ -350,6 +371,8 @@ void DatabaseAtomic::commitCreateTable(const ASTCreateQuery & query, const Stora
                                        const String & table_metadata_tmp_path, const String & table_metadata_path,
                                        ContextPtr query_context)
 {
+    auto db_disk = getDisk();
+
     createDirectories();
     DetachedTables not_in_use;
     auto table_data_path = getTableDataPath(query);
@@ -388,6 +411,8 @@ void DatabaseAtomic::commitCreateTable(const ASTCreateQuery & query, const Stora
 void DatabaseAtomic::commitAlterTable(const StorageID & table_id, const String & table_metadata_tmp_path, const String & table_metadata_path,
                                       const String & /*statement*/, ContextPtr query_context)
 {
+    auto db_disk = getDisk();
+
     bool check_file_exists = true;
     SCOPE_EXIT({
         if (check_file_exists)
@@ -485,6 +510,8 @@ UUID DatabaseAtomic::tryGetTableUUID(const String & table_name) const
 
 void DatabaseAtomic::beforeLoadingMetadata(ContextMutablePtr /*context*/, LoadingStrictnessLevel mode)
 {
+    auto db_disk = getDisk();
+
     if (mode < LoadingStrictnessLevel::FORCE_RESTORE)
         return;
 
@@ -514,12 +541,14 @@ void DatabaseAtomic::beforeLoadingMetadata(ContextMutablePtr /*context*/, Loadin
 
 LoadTaskPtr DatabaseAtomic::startupDatabaseAsync(AsyncLoader & async_loader, LoadJobSet startup_after, LoadingStrictnessLevel mode)
 {
+    auto db_disk = getDisk();
+
     auto base = DatabaseOrdinary::startupDatabaseAsync(async_loader, std::move(startup_after), mode);
     auto job = makeLoadJob(
         base->goals(),
         TablesLoaderBackgroundStartupPoolId,
         fmt::format("startup Atomic database {}", getDatabaseName()),
-        [this, mode](AsyncLoader &, const LoadJobPtr &)
+        [this, mode, db_disk](AsyncLoader &, const LoadJobPtr &)
         {
             if (mode < LoadingStrictnessLevel::FORCE_RESTORE)
                 return;
@@ -571,8 +600,15 @@ void DatabaseAtomic::stopLoading()
 
 void DatabaseAtomic::tryCreateSymlink(const StoragePtr & table, bool if_data_path_exist)
 {
+    auto db_disk = getDisk();
+
     if (!db_disk->isSymlinkSupported())
         return;
+
+    if (table->getDataPaths().empty())
+        return;
+
+    const auto table_data_path = fs::path(table->getDataPaths().front()).lexically_normal();
 
     try
     {
@@ -582,16 +618,22 @@ void DatabaseAtomic::tryCreateSymlink(const StoragePtr & table, bool if_data_pat
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Table {} doesn't have data path to create symlink", table_name);
 
         String link = path_to_table_symlinks / escapeForFileName(table_name);
-        fs::path data = fs::proximate(table->getDataPaths()[0], path_to_table_symlinks);
+
+        LOG_DEBUG(
+            log,
+            "Trying to create a symlink for table {}, data_path {}, link {}",
+            table->getStorageID().getNameForLogs(),
+            table_data_path,
+            link);
 
         /// If it already points where needed.
-        if (db_disk->equivalentNoThrow(data, link))
+        if (db_disk->equivalentNoThrow(table_data_path, link))
             return;
 
-        if (if_data_path_exist && !db_disk->existsFileOrDirectory(data))
+        if (if_data_path_exist && !db_disk->existsFileOrDirectory(data_path))
             return;
 
-        db_disk->createDirectorySymlink(data, link);
+        db_disk->createDirectorySymlink(table_data_path, link);
     }
     catch (...)
     {
@@ -601,6 +643,8 @@ void DatabaseAtomic::tryCreateSymlink(const StoragePtr & table, bool if_data_pat
 
 void DatabaseAtomic::tryRemoveSymlink(const String & table_name)
 {
+    auto db_disk = getDisk();
+
     if (!db_disk->isSymlinkSupported())
         return;
 
@@ -617,6 +661,7 @@ void DatabaseAtomic::tryRemoveSymlink(const String & table_name)
 
 void DatabaseAtomic::tryCreateMetadataSymlink()
 {
+    auto db_disk = getDisk();
     if (!db_disk->isSymlinkSupported())
         return;
 
@@ -636,10 +681,13 @@ void DatabaseAtomic::tryCreateMetadataSymlink()
             if (db_disk->isSymlinkNoThrow(path_to_metadata_symlink))
                 db_disk->removeFileIfExists(path_to_metadata_symlink);
 
-            String symlink = fs::proximate(root_path / metadata_path, path_to_metadata_symlink.parent_path());
+            LOG_DEBUG(
+                log,
+                "Creating directory symlink, path_to_metadata_symlink: {}, metadata_path: {}",
+                path_to_metadata_symlink,
+                metadata_path);
 
-            LOG_TEST(log, "Creating directory symlink, path_to_metadata_symlink: {}, metadata_path: {}, symlink content: {}", path_to_metadata_symlink, metadata_path, symlink);
-            db_disk->createDirectorySymlink(symlink, path_to_metadata_symlink);
+            db_disk->createDirectorySymlink(metadata_path, path_to_metadata_symlink);
         }
         catch (...)
         {
@@ -663,8 +711,10 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
             DatabaseCatalog::instance().checkTableCanBeRemovedOrRenamed({database_name, table.first}, check_ref_deps, check_loading_deps);
     }
 
+
     try
     {
+        auto db_disk = getDisk();
         if (db_disk->isSymlinkSupported())
             db_disk->removeFileIfExists(path_to_metadata_symlink);
     }
@@ -676,7 +726,8 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
     auto new_name_escaped = escapeForFileName(new_name);
     auto old_database_metadata_path = fs::path("metadata") / (escapeForFileName(getDatabaseName()) + ".sql");
     auto new_database_metadata_path = fs::path("metadata") / (new_name_escaped + ".sql");
-    db_disk->moveFile(old_database_metadata_path, new_database_metadata_path);
+    auto global_db_disk = getContext()->getDatabaseDisk();
+    global_db_disk->moveFile(old_database_metadata_path, new_database_metadata_path);
 
     String old_path_to_table_symlinks;
 
@@ -703,11 +754,12 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
             snapshot.database = database_name;
         }
 
-        path_to_metadata_symlink = root_path / "metadata" / new_name_escaped;
+        path_to_metadata_symlink = fs::path("metadata") / new_name_escaped;
         old_path_to_table_symlinks = path_to_table_symlinks;
-        path_to_table_symlinks = root_path / "data" / new_name_escaped / "";
+        path_to_table_symlinks = fs::path("data") / new_name_escaped / "";
     }
 
+    auto db_disk = getDisk();
     if (db_disk->isSymlinkSupported())
     {
         db_disk->moveDirectory(old_path_to_table_symlinks, path_to_table_symlinks);
@@ -744,13 +796,15 @@ void registerDatabaseAtomic(DatabaseFactory & factory)
 {
     auto create_fn = [](const DatabaseFactory::Arguments & args)
     {
+        DatabaseMetadataDiskSettings database_metadata_disk_settings;
+        auto * engine_define = args.create_query.storage;
+        chassert(engine_define);
+        database_metadata_disk_settings.loadFromQuery(*engine_define, args.context, args.create_query.attach);
+
         return make_shared<DatabaseAtomic>(
-            args.database_name,
-            args.metadata_path,
-            args.uuid,
-            args.context);
+            args.database_name, args.metadata_path, args.uuid, args.context, database_metadata_disk_settings);
     };
-    factory.registerDatabase("Atomic", create_fn);
+    factory.registerDatabase("Atomic", create_fn, /*features=*/{.supports_settings = true});
 }
 
 }

--- a/src/Databases/DatabaseAtomic.h
+++ b/src/Databases/DatabaseAtomic.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Databases/DatabaseMetadataDiskSettings.h>
 #include <Databases/DatabaseOrdinary.h>
 #include <Databases/DatabasesCommon.h>
 #include <Storages/IStorage_fwd.h>
@@ -20,8 +21,19 @@ namespace DB
 class DatabaseAtomic : public DatabaseOrdinary
 {
 public:
-    DatabaseAtomic(String name_, String metadata_path_, UUID uuid, const String & logger_name, ContextPtr context_);
-    DatabaseAtomic(String name_, String metadata_path_, UUID uuid, ContextPtr context_);
+    DatabaseAtomic(
+        String name_,
+        String metadata_path_,
+        UUID uuid,
+        const String & logger_name,
+        ContextPtr context_,
+        DatabaseMetadataDiskSettings database_metadata_disk_settings_ = {});
+    DatabaseAtomic(
+        String name_,
+        String metadata_path_,
+        UUID uuid,
+        ContextPtr context_,
+        DatabaseMetadataDiskSettings database_metadata_disk_settings_ = {});
 
     String getEngineName() const override { return "Atomic"; }
     UUID getUUID() const override { return db_uuid; }
@@ -88,7 +100,6 @@ protected:
     NameToPathMap table_name_to_path TSA_GUARDED_BY(mutex);
 
     DetachedTables detached_tables TSA_GUARDED_BY(mutex);
-    std::filesystem::path root_path;
     std::filesystem::path path_to_table_symlinks;
     std::filesystem::path path_to_metadata_symlink;
     const UUID db_uuid;

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -31,9 +31,9 @@ namespace ErrorCodes
 
 void cckMetadataPathForOrdinary(const ASTCreateQuery & create, const String & metadata_path)
 {
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
+    auto global_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
 
-    if (!db_disk->isSymlinkSupported())
+    if (!global_db_disk->isSymlinkSupported())
         return;
 
     const String & engine_name = create.storage->engine->name;
@@ -42,10 +42,10 @@ void cckMetadataPathForOrdinary(const ASTCreateQuery & create, const String & me
     if (engine_name != "Ordinary")
         return;
 
-    if (!db_disk->isSymlink(metadata_path))
+    if (!global_db_disk->isSymlink(metadata_path))
         return;
 
-    String target_path = db_disk->readSymlink(metadata_path);
+    String target_path = global_db_disk->readSymlink(metadata_path);
     fs::path path_to_remove = metadata_path;
     if (path_to_remove.filename().empty())
         path_to_remove = path_to_remove.parent_path();

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -31,9 +31,9 @@ namespace ErrorCodes
 
 void cckMetadataPathForOrdinary(const ASTCreateQuery & create, const String & metadata_path)
 {
-    auto global_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
+    auto default_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
 
-    if (!global_db_disk->isSymlinkSupported())
+    if (!default_db_disk->isSymlinkSupported())
         return;
 
     const String & engine_name = create.storage->engine->name;
@@ -42,10 +42,10 @@ void cckMetadataPathForOrdinary(const ASTCreateQuery & create, const String & me
     if (engine_name != "Ordinary")
         return;
 
-    if (!global_db_disk->isSymlink(metadata_path))
+    if (!default_db_disk->isSymlink(metadata_path))
         return;
 
-    String target_path = global_db_disk->readSymlink(metadata_path);
+    String target_path = default_db_disk->readSymlink(metadata_path);
     fs::path path_to_remove = metadata_path;
     if (path_to_remove.filename().empty())
         path_to_remove = path_to_remove.parent_path();

--- a/src/Databases/DatabaseLazy.cpp
+++ b/src/Databases/DatabaseLazy.cpp
@@ -53,8 +53,9 @@ DatabaseLazy::DatabaseLazy(const String & name_, const String & metadata_path_, 
 
 void DatabaseLazy::loadStoredObjects(ContextMutablePtr local_context, LoadingStrictnessLevel /*mode*/)
 {
+    auto db_disk = getDisk();
     iterateMetadataFiles(
-        [this, &local_context](const String & file_name)
+        [this, &local_context, db_disk](const String & file_name)
         {
             const std::string table_name = unescapeForFileName(file_name.substr(0, file_name.size() - 4));
 
@@ -265,13 +266,13 @@ StoragePtr DatabaseLazy::loadTable(const String & table_name) const
     LOG_DEBUG(log, "Load table {} to cache.", backQuote(table_name));
 
     const String table_metadata_path = fs::path(getMetadataPath()) / (escapeForFileName(table_name) + ".sql");
-
+    auto db_disk = getDisk();
     try
     {
         StoragePtr table;
         auto context_copy = Context::createCopy(context); /// some tables can change context, but not LogTables
 
-        auto ast = parseQueryFromMetadata(log, getContext(), table_metadata_path, /*throw_on_error*/ true, /*remove_empty*/false);
+        auto ast = parseQueryFromMetadata(log, getContext(), db_disk, table_metadata_path, /*throw_on_error*/ true, /*remove_empty*/ false);
         if (ast)
         {
             const auto & ast_create = ast->as<const ASTCreateQuery &>();

--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -73,7 +73,8 @@ void DatabaseMemory::dropTable(
 
         if (table->storesDataOnDisk())
         {
-            db_disk->removeRecursive(getTableDataPath(table_name));
+            auto metdata_disk = getDisk();
+            metdata_disk->removeRecursive(getTableDataPath(table_name));
         }
     }
     catch (...)
@@ -128,6 +129,7 @@ UUID DatabaseMemory::tryGetTableUUID(const String & table_name) const
 
 void DatabaseMemory::removeDataPath(ContextPtr)
 {
+    auto db_disk = getDisk();
     db_disk->removeRecursive(data_path);
 }
 

--- a/src/Databases/DatabaseMetadataDiskSettings.cpp
+++ b/src/Databases/DatabaseMetadataDiskSettings.cpp
@@ -1,0 +1,88 @@
+#include <Databases/DatabaseMetadataDiskSettings.h>
+
+#include <Parsers/ASTCreateQuery.h>
+#include <Disks/DiskFromAST.h>
+#include <Parsers/isDiskFunction.h>
+#include <Parsers/FieldFromAST.h>
+#include <Disks/IDisk.h>
+#include <Interpreters/Context.h>
+#include <Core/BaseSettings.h>
+#include <Core/BaseSettingsFwdMacrosImpl.h>
+#include <Parsers/ASTFunction.h>
+
+namespace DB
+{
+#define LIST_OF_DATABASE_METADATA_DISK_SETTINGS(DECLARE, DECLARE_WITH_ALIAS) \
+    DECLARE(String, disk, "", R"(Name of disk storing table metadata files in the database.)", 0) \
+
+DECLARE_SETTINGS_TRAITS(DatabaseMetadataDiskSettingsTraits, LIST_OF_DATABASE_METADATA_DISK_SETTINGS)
+IMPLEMENT_SETTINGS_TRAITS(DatabaseMetadataDiskSettingsTraits, LIST_OF_DATABASE_METADATA_DISK_SETTINGS)
+
+struct DatabaseMetadataDiskSettingsImpl : public BaseSettings<DatabaseMetadataDiskSettingsTraits>
+{
+    void loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_attach);
+};
+
+#define INITIALIZE_SETTING_EXTERN(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, ...) \
+    DatabaseMetadataDiskSettings##TYPE NAME = &DatabaseMetadataDiskSettingsImpl ::NAME;
+
+namespace DatabaseMetadataDiskSetting
+{
+LIST_OF_DATABASE_METADATA_DISK_SETTINGS(INITIALIZE_SETTING_EXTERN, INITIALIZE_SETTING_EXTERN)
+}
+
+#undef INITIALIZE_SETTING_EXTERN
+
+void DatabaseMetadataDiskSettingsImpl::loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_attach)
+{
+    if (!storage_def.settings)
+        return;
+
+    auto changes = storage_def.settings->changes;
+    auto * value = changes.tryGet("disk");
+    if (!value)
+        return;
+
+    ASTPtr value_as_custom_ast = nullptr;
+    CustomType custom;
+    if (value->tryGet<CustomType>(custom) && 0 == strcmp(custom.getTypeName(), "AST"))
+        value_as_custom_ast = dynamic_cast<const FieldFromASTImpl &>(custom.getImpl()).ast;
+
+    if (value_as_custom_ast && isDiskFunction(value_as_custom_ast))
+    {
+        auto disk_name = DiskFromAST::createCustomDisk(value_as_custom_ast, context, is_attach);
+        *value = disk_name;
+    }
+    else
+    {
+        DiskFromAST::ensureDiskIsNotCustom(value->safeGet<String>(), context);
+    }
+    [[maybe_unused]] auto disk = context->getDisk(value->safeGet<String>());
+    chassert(disk);
+
+    applyChanges(changes);
+}
+
+
+DatabaseMetadataDiskSettings::DatabaseMetadataDiskSettings() : impl(std::make_unique<DatabaseMetadataDiskSettingsImpl>())
+{
+}
+
+DatabaseMetadataDiskSettings::DatabaseMetadataDiskSettings(const DatabaseMetadataDiskSettings & settings) : impl(std::make_unique<DatabaseMetadataDiskSettingsImpl>(*settings.impl))
+{
+}
+
+DatabaseMetadataDiskSettings::DatabaseMetadataDiskSettings(DatabaseMetadataDiskSettings && settings) noexcept
+    : impl(std::make_unique<DatabaseMetadataDiskSettingsImpl>(std::move(*settings.impl)))
+{
+}
+
+DatabaseMetadataDiskSettings::~DatabaseMetadataDiskSettings() = default;
+
+DATABASE_METADATA_SETTINGS_SUPPORTED_TYPES(DatabaseMetadataDiskSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)
+
+void DatabaseMetadataDiskSettings::loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_attach)
+{
+    impl->loadFromQuery(storage_def, context, is_attach);
+}
+}

--- a/src/Databases/DatabaseMetadataDiskSettings.h
+++ b/src/Databases/DatabaseMetadataDiskSettings.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Core/BaseSettingsFwdMacros.h>
+#include <Core/SettingsFields.h>
+#include <Parsers/ASTCreateQuery.h>
+
+namespace DB
+{
+class ASTStorage;
+class Context;
+struct MergeTreeSettings;
+struct DatabaseMetadataDiskSettingsImpl;
+
+/// List of available types supported in MetadataDiskSettings object
+#define DATABASE_METADATA_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
+    M(CLASS_NAME, String)
+
+DATABASE_METADATA_SETTINGS_SUPPORTED_TYPES(DatabaseMetadataDiskSettings, DECLARE_SETTING_TRAIT)
+
+struct DatabaseMetadataDiskSettings
+{
+    DatabaseMetadataDiskSettings();
+    DatabaseMetadataDiskSettings(const DatabaseMetadataDiskSettings & settings);
+    DatabaseMetadataDiskSettings(DatabaseMetadataDiskSettings && settings) noexcept;
+    ~DatabaseMetadataDiskSettings();
+
+    DATABASE_METADATA_SETTINGS_SUPPORTED_TYPES(DatabaseMetadataDiskSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)
+
+    void loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_attach);
+
+private:
+    std::unique_ptr<DatabaseMetadataDiskSettingsImpl> impl;
+};
+
+}

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -189,6 +189,7 @@ void DatabaseOnDisk::createDirectories()
 
 void DatabaseOnDisk::createDirectoriesUnlocked()
 {
+    auto db_disk = getDisk();
     db_disk->createDirectories(metadata_path);
     db_disk->createDirectories(data_path);
 }
@@ -207,6 +208,7 @@ void DatabaseOnDisk::createTable(
     const StoragePtr & table,
     const ASTPtr & query)
 {
+    auto db_disk = getDisk();
     createDirectories();
 
     const auto & create = query->as<ASTCreateQuery &>();
@@ -246,7 +248,7 @@ void DatabaseOnDisk::createTable(
 
     if (create.attach && db_disk->existsFileOrDirectory(table_metadata_path))
     {
-        ASTPtr ast_detached = parseQueryFromMetadata(log, local_context, table_metadata_path);
+        ASTPtr ast_detached = parseQueryFromMetadata(log, local_context, db_disk, table_metadata_path);
         auto & create_detached = ast_detached->as<ASTCreateQuery &>();
 
         // either both should be Nil, either values should be equal
@@ -267,7 +269,10 @@ void DatabaseOnDisk::createTable(
         /// Exclusive flags guarantees, that table is not created right now in another thread. Otherwise, exception will be thrown.
         const auto & settings = local_context->getSettingsRef();
         writeMetadataFile(
-            db_disk, /*file_path=*/table_metadata_tmp_path, /*content=*/statement, /*fsync_metadata=*/settings[Setting::fsync_metadata]);
+            db_disk,
+            /*file_path=*/table_metadata_tmp_path,
+            /*content=*/statement,
+            /*fsync_metadata=*/settings[Setting::fsync_metadata]);
     }
 
     commitCreateTable(create, table, table_metadata_tmp_path, table_metadata_path, local_context);
@@ -278,6 +283,7 @@ void DatabaseOnDisk::createTable(
 /// .sql.detached extension, is not needed anymore since we attached the table back
 void DatabaseOnDisk::removeDetachedPermanentlyFlag(ContextPtr, const String & table_name, const String & table_metadata_path, bool)
 {
+    auto db_disk = getDisk();
     try
     {
         fs::path detached_permanently_flag(table_metadata_path + detached_suffix);
@@ -294,6 +300,7 @@ void DatabaseOnDisk::commitCreateTable(const ASTCreateQuery & query, const Stora
                                        const String & table_metadata_tmp_path, const String & table_metadata_path,
                                        ContextPtr query_context)
 {
+    auto db_disk = getDisk();
     try
     {
         createDirectories();
@@ -321,6 +328,7 @@ void DatabaseOnDisk::detachTablePermanently(ContextPtr query_context, const Stri
     fs::path detached_permanently_flag(getObjectMetadataPath(table_name) + detached_suffix);
     try
     {
+        auto db_disk = getDisk();
         db_disk->createFile(detached_permanently_flag);
 
         std::lock_guard lock(mutex);
@@ -351,6 +359,7 @@ void DatabaseOnDisk::dropTable(ContextPtr local_context, const String & table_na
 
     StoragePtr table = detachTable(local_context, table_name);
 
+    auto db_disk = getDisk();
     bool renamed = false;
     try
     {
@@ -394,6 +403,7 @@ void DatabaseOnDisk::checkMetadataFilenameAvailability(const String & to_table_n
 
 void DatabaseOnDisk::checkMetadataFilenameAvailabilityUnlocked(const String & to_table_name) const
 {
+    auto db_disk = getDisk();
     const String table_metadata_path = getObjectMetadataPath(to_table_name);
     if (db_disk->existsFile(table_metadata_path))
     {
@@ -457,10 +467,11 @@ void DatabaseOnDisk::renameTable(
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Table was detached without locking, it's a bug");
 
     UUID prev_uuid = UUIDHelpers::Nil;
+    auto db_disk = getDisk();
     try
     {
         table_metadata_path = getObjectMetadataPath(table_name);
-        attach_query = parseQueryFromMetadata(log, local_context, table_metadata_path);
+        attach_query = parseQueryFromMetadata(log, local_context, db_disk, table_metadata_path);
         auto & create = attach_query->as<ASTCreateQuery &>();
         create.setDatabase(to_database.getDatabaseName());
         create.setTable(to_table_name);
@@ -548,13 +559,14 @@ ASTPtr DatabaseOnDisk::getCreateTableQueryImpl(const String & table_name, Contex
 
 ASTPtr DatabaseOnDisk::getCreateDatabaseQuery() const
 {
+    auto global_db_disk = getContext()->getDatabaseDisk();
     ASTPtr ast;
 
     const auto & settings = getContext()->getSettingsRef();
     {
         std::lock_guard lock(mutex);
         auto database_metadata_path = fs::path("metadata") / (escapeForFileName(database_name) + ".sql");
-        ast = parseQueryFromMetadata(log, getContext(), database_metadata_path, true);
+        ast = parseQueryFromMetadata(log, getContext(), global_db_disk, database_metadata_path, true);
         auto & ast_create_query = ast->as<ASTCreateQuery &>();
         ast_create_query.attach = false;
         ast_create_query.setDatabase(database_name);
@@ -582,6 +594,7 @@ void DatabaseOnDisk::drop(ContextPtr local_context)
 {
     waitDatabaseStarted();
 
+    auto db_disk = getDisk();
     assert(TSA_SUPPRESS_WARNING_FOR_READ(tables).empty());
     if (local_context->getSettingsRef()[Setting::force_remove_data_recursively_on_drop])
     {
@@ -617,6 +630,7 @@ String DatabaseOnDisk::getObjectMetadataPath(const String & object_name) const
 
 time_t DatabaseOnDisk::getObjectMetadataModificationTime(const String & object_name) const
 {
+    auto db_disk = getDisk();
     String table_metadata_path = getObjectMetadataPath(object_name);
     if (!db_disk->existsFileOrDirectory(table_metadata_path))
         return static_cast<time_t>(0);
@@ -637,6 +651,7 @@ time_t DatabaseOnDisk::getObjectMetadataModificationTime(const String & object_n
 
 void DatabaseOnDisk::iterateMetadataFiles(const IteratingFunction & process_metadata_file) const
 {
+    auto db_disk = getDisk();
     if (!db_disk->existsDirectory(metadata_path))
         return;
 
@@ -726,23 +741,22 @@ void DatabaseOnDisk::iterateMetadataFiles(const IteratingFunction & process_meta
 ASTPtr DatabaseOnDisk::parseQueryFromMetadata(
     LoggerPtr logger,
     ContextPtr local_context,
+    DiskPtr disk,
     const String & metadata_file_path,
     bool throw_on_error /*= true*/,
     bool remove_empty /*= false*/)
 {
-    auto db_disk = local_context->getDatabaseDisk();
-
-    if (!db_disk->existsFile(metadata_file_path))
+    if (!disk->existsFile(metadata_file_path))
     {
         if (!throw_on_error)
             return nullptr;
         int ec = ErrorCodes::FILE_DOESNT_EXIST;
-        if (auto disk_local = std::dynamic_pointer_cast<DiskLocal>(db_disk))
+        if (auto disk_local = std::dynamic_pointer_cast<DiskLocal>(disk))
             ec = errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE;
         ErrnoException::throwFromPath(ec, metadata_file_path, "Cannot open file {}", metadata_file_path);
     }
 
-    String query = readMetadataFile(db_disk, metadata_file_path);
+    String query = readMetadataFile(disk, metadata_file_path);
 
     /** Empty files with metadata are generated after a rough restart of the server.
       * Remove these files to slightly reduce the work of the admins on startup.
@@ -752,7 +766,7 @@ ASTPtr DatabaseOnDisk::parseQueryFromMetadata(
         if (logger)
             LOG_ERROR(logger, "File {} is empty. Removing.", metadata_file_path);
 
-        db_disk->removeFileIfExists(metadata_file_path);
+        disk->removeFileIfExists(metadata_file_path);
         return nullptr;
     }
 
@@ -808,7 +822,8 @@ ASTPtr DatabaseOnDisk::parseQueryFromMetadata(
 
 ASTPtr DatabaseOnDisk::getCreateQueryFromMetadata(const String & table_name, bool throw_on_error) const
 {
-    ASTPtr ast = parseQueryFromMetadata(log, getContext(), getObjectMetadataPath(table_name), throw_on_error);
+    auto db_disk = getDisk();
+    ASTPtr ast = parseQueryFromMetadata(log, getContext(), db_disk, getObjectMetadataPath(table_name), throw_on_error);
 
     if (ast)
     {
@@ -892,10 +907,14 @@ void DatabaseOnDisk::modifySettingsMetadata(const SettingsChanges & settings_cha
     fs::path metadata_file_tmp_path = fs::path("metadata") / (database_name_escaped + ".sql.tmp");
     fs::path metadata_file_path = fs::path("metadata") / (database_name_escaped + ".sql");
 
+    auto global_db_disk = getContext()->getDatabaseDisk();
     writeMetadataFile(
-        db_disk, /*file_path=*/metadata_file_tmp_path, /*content=*/statement, getContext()->getSettingsRef()[Setting::fsync_metadata]);
+        global_db_disk,
+        /*file_path=*/metadata_file_tmp_path,
+        /*content=*/statement,
+        getContext()->getSettingsRef()[Setting::fsync_metadata]);
 
-    db_disk->replaceFile(metadata_file_tmp_path, metadata_file_path);
+    global_db_disk->replaceFile(metadata_file_tmp_path, metadata_file_path);
 }
 
 void DatabaseOnDisk::alterDatabaseComment(const AlterCommand & command)

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -559,14 +559,14 @@ ASTPtr DatabaseOnDisk::getCreateTableQueryImpl(const String & table_name, Contex
 
 ASTPtr DatabaseOnDisk::getCreateDatabaseQuery() const
 {
-    auto global_db_disk = getContext()->getDatabaseDisk();
+    auto default_db_disk = getContext()->getDatabaseDisk();
     ASTPtr ast;
 
     const auto & settings = getContext()->getSettingsRef();
     {
         std::lock_guard lock(mutex);
         auto database_metadata_path = fs::path("metadata") / (escapeForFileName(database_name) + ".sql");
-        ast = parseQueryFromMetadata(log, getContext(), global_db_disk, database_metadata_path, true);
+        ast = parseQueryFromMetadata(log, getContext(), default_db_disk, database_metadata_path, true);
         auto & ast_create_query = ast->as<ASTCreateQuery &>();
         ast_create_query.attach = false;
         ast_create_query.setDatabase(database_name);
@@ -907,14 +907,14 @@ void DatabaseOnDisk::modifySettingsMetadata(const SettingsChanges & settings_cha
     fs::path metadata_file_tmp_path = fs::path("metadata") / (database_name_escaped + ".sql.tmp");
     fs::path metadata_file_path = fs::path("metadata") / (database_name_escaped + ".sql");
 
-    auto global_db_disk = getContext()->getDatabaseDisk();
+    auto default_db_disk = getContext()->getDatabaseDisk();
     writeMetadataFile(
-        global_db_disk,
+        default_db_disk,
         /*file_path=*/metadata_file_tmp_path,
         /*content=*/statement,
         getContext()->getSettingsRef()[Setting::fsync_metadata]);
 
-    global_db_disk->replaceFile(metadata_file_tmp_path, metadata_file_path);
+    default_db_disk->replaceFile(metadata_file_tmp_path, metadata_file_path);
 }
 
 void DatabaseOnDisk::alterDatabaseComment(const AlterCommand & command)

--- a/src/Databases/DatabaseOnDisk.h
+++ b/src/Databases/DatabaseOnDisk.h
@@ -71,9 +71,16 @@ public:
     String getTableDataPath(const ASTCreateQuery & query) const override { return getTableDataPath(query.getTable()); }
     String getMetadataPath() const override { return metadata_path; }
 
-    static ASTPtr parseQueryFromMetadata(LoggerPtr logger, ContextPtr context, const String & metadata_file_path, bool throw_on_error = true, bool remove_empty = false);
+    static ASTPtr parseQueryFromMetadata(
+        LoggerPtr logger,
+        ContextPtr context,
+        DiskPtr disk,
+        const String & metadata_file_path,
+        bool throw_on_error = true,
+        bool remove_empty = false);
 
-    static ASTPtr parseQueryFromMetadata(LoggerPtr logger, ContextPtr context, const String & metadata_file_path, const String & query, bool throw_on_error = true);
+    static ASTPtr parseQueryFromMetadata(
+        LoggerPtr logger, ContextPtr context, const String & metadata_file_path, const String & query, bool throw_on_error = true);
 
     /// will throw when the table we want to attach already exists (in active / detached / detached permanently form)
     void checkMetadataFilenameAvailability(const String & to_table_name) const override;

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -7,6 +7,7 @@
 #include <Databases/DDLDependencyVisitor.h>
 #include <Databases/DDLLoadingDependencyVisitor.h>
 #include <Databases/DatabaseFactory.h>
+#include <Databases/DatabaseMetadataDiskSettings.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseOrdinary.h>
 #include <Databases/DatabasesCommon.h>
@@ -18,8 +19,8 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
-#include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/FunctionNameNormalizer.h>
+#include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/NormalizeSelectWithUnionQueryVisitor.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTSetQuery.h>
@@ -71,17 +72,42 @@ namespace ErrorCodes
     extern const int UNEXPECTED_NODE_IN_ZOOKEEPER;
 }
 
+namespace DatabaseMetadataDiskSetting
+{
+extern const DatabaseMetadataDiskSettingsString disk;
+}
+
+
 static constexpr const char * const CONVERT_TO_REPLICATED_FLAG_NAME = "convert_to_replicated";
 
-DatabaseOrdinary::DatabaseOrdinary(const String & name_, const String & metadata_path_, ContextPtr context_)
-    : DatabaseOrdinary(name_, metadata_path_, std::filesystem::path("data") / escapeForFileName(name_) / "", "DatabaseOrdinary (" + name_ + ")", context_)
+DatabaseOrdinary::DatabaseOrdinary(
+    const String & name_, const String & metadata_path_, ContextPtr context_, DatabaseMetadataDiskSettings database_metadata_disk_settings_)
+    : DatabaseOrdinary(
+          name_,
+          metadata_path_,
+          std::filesystem::path("data") / escapeForFileName(name_) / "",
+          "DatabaseOrdinary (" + name_ + ")",
+          context_,
+          database_metadata_disk_settings_)
 {
 }
 
 DatabaseOrdinary::DatabaseOrdinary(
-    const String & name_, const String & metadata_path_, const String & data_path_, const String & logger, ContextPtr context_)
+    const String & name_,
+    const String & metadata_path_,
+    const String & data_path_,
+    const String & logger,
+    ContextPtr context_,
+    DatabaseMetadataDiskSettings database_metadata_disk_settings_)
     : DatabaseOnDisk(name_, metadata_path_, data_path_, logger, context_)
+    , database_metadata_disk_settings(database_metadata_disk_settings_)
 {
+    if (!database_metadata_disk_settings[DatabaseMetadataDiskSetting::disk].value.empty())
+        metadata_disk_ptr = getContext()->getDisk(database_metadata_disk_settings[DatabaseMetadataDiskSetting::disk].value);
+    else
+        metadata_disk_ptr = getContext()->getDatabaseDisk();
+
+    LOG_INFO(log, "Metadata disk {}, path {}", metadata_disk_ptr->getName(), metadata_disk_ptr->getPath());
 }
 
 void DatabaseOrdinary::loadStoredObjects(ContextMutablePtr, LoadingStrictnessLevel)
@@ -167,6 +193,8 @@ String DatabaseOrdinary::getConvertToReplicatedFlagPath(const String & name, boo
 
 void DatabaseOrdinary::convertMergeTreeToReplicatedIfNeeded(ASTPtr ast, const QualifiedTableName & qualified_name, const String & file_name)
 {
+    auto db_disk = getDisk();
+
     fs::path path(getMetadataPath());
     fs::path file_path(file_name);
     fs::path full_path = path / file_path;
@@ -186,7 +214,7 @@ void DatabaseOrdinary::convertMergeTreeToReplicatedIfNeeded(ASTPtr ast, const Qu
     auto convert_to_replicated_flag_path = getConvertToReplicatedFlagPath(qualified_name.table, false);
 
     auto storage_disks = policy->getDisks();
-    auto checking_disk = storage_disks.empty() ? db_disk : storage_disks[0];
+    auto checking_disk = storage_disks.empty() ? getDisk() : storage_disks[0];
     if (!checking_disk->existsFile(convert_to_replicated_flag_path))
         return;
 
@@ -221,11 +249,13 @@ void DatabaseOrdinary::convertMergeTreeToReplicatedIfNeeded(ASTPtr ast, const Qu
 
 void DatabaseOrdinary::loadTablesMetadata(ContextPtr local_context, ParsedTablesMetadata & metadata, bool is_startup)
 {
+    auto db_disk = getDisk();
+
     size_t prev_tables_count = metadata.parsed_tables.size();
     size_t prev_total_dictionaries = metadata.total_dictionaries;
     size_t prev_total_materialized_views = metadata.total_materialized_views;
 
-    auto process_metadata = [&metadata, is_startup, local_context, this](const String & file_name)
+    auto process_metadata = [&metadata, is_startup, local_context, db_disk, this](const String & file_name)
     {
         fs::path path(getMetadataPath());
         fs::path file_path(file_name);
@@ -233,7 +263,8 @@ void DatabaseOrdinary::loadTablesMetadata(ContextPtr local_context, ParsedTables
 
         try
         {
-            auto ast = parseQueryFromMetadata(log, local_context, full_path.string(), /*throw_on_error*/ true, /*remove_empty*/ false);
+            auto ast
+                = parseQueryFromMetadata(log, local_context, db_disk, full_path.string(), /*throw_on_error*/ true, /*remove_empty*/ false);
             if (ast)
             {
                 FunctionNameNormalizer::visit(ast.get());
@@ -398,7 +429,7 @@ void DatabaseOrdinary::restoreMetadataAfterConvertingToReplicated(StoragePtr tab
     auto convert_to_replicated_flag_path = getConvertToReplicatedFlagPath(name.table, true);
 
     auto storage_disks = table->getStoragePolicy()->getDisks();
-    auto checking_disk = storage_disks.empty() ? db_disk : storage_disks[0];
+    auto checking_disk = storage_disks.empty() ? getDisk() : storage_disks[0];
     if (!checking_disk->existsFile(convert_to_replicated_flag_path))
         return;
 
@@ -592,6 +623,7 @@ Strings DatabaseOrdinary::getAllTableNames(ContextPtr) const
 
 void DatabaseOrdinary::alterTable(ContextPtr local_context, const StorageID & table_id, const StorageInMemoryMetadata & metadata)
 {
+    auto db_disk = getDisk();
     waitDatabaseStarted();
 
     String table_name = table_id.table_name;
@@ -631,6 +663,7 @@ void DatabaseOrdinary::alterTable(ContextPtr local_context, const StorageID & ta
 
 void DatabaseOrdinary::commitAlterTable(const StorageID &, const String & table_metadata_tmp_path, const String & table_metadata_path, const String & /*statement*/, ContextPtr /*query_context*/)
 {
+    auto db_disk = getDisk();
     try
     {
         /// rename atomically replaces the old file with the new one.
@@ -654,11 +687,13 @@ void registerDatabaseOrdinary(DatabaseFactory & factory)
 
         args.context->addWarningMessageAboutDatabaseOrdinary(args.database_name);
 
-        return make_shared<DatabaseOrdinary>(
-            args.database_name,
-            args.metadata_path,
-            args.context);
+        DatabaseMetadataDiskSettings database_metadata_disk_settings;
+        auto * engine_define = args.create_query.storage;
+        chassert(engine_define);
+        database_metadata_disk_settings.loadFromQuery(*engine_define, args.context, args.create_query.attach);
+
+        return make_shared<DatabaseOrdinary>(args.database_name, args.metadata_path, args.context, database_metadata_disk_settings);
     };
-    factory.registerDatabase("Ordinary", create_fn);
+    factory.registerDatabase("Ordinary", create_fn, /*features=*/{.supports_settings = true});
 }
 }

--- a/src/Databases/DatabaseOrdinary.h
+++ b/src/Databases/DatabaseOrdinary.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Databases/DatabaseMetadataDiskSettings.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Common/ThreadPool.h>
 
@@ -14,10 +15,18 @@ namespace DB
 class DatabaseOrdinary : public DatabaseOnDisk
 {
 public:
-    DatabaseOrdinary(const String & name_, const String & metadata_path_, ContextPtr context);
     DatabaseOrdinary(
-        const String & name_, const String & metadata_path_, const String & data_path_,
-        const String & logger, ContextPtr context_);
+        const String & name_,
+        const String & metadata_path_,
+        ContextPtr context,
+        DatabaseMetadataDiskSettings database_metadata_disk_settings_ = {});
+    DatabaseOrdinary(
+        const String & name_,
+        const String & metadata_path_,
+        const String & data_path_,
+        const String & logger,
+        ContextPtr context_,
+        DatabaseMetadataDiskSettings database_metadata_disk_settings_ = {});
 
     String getEngineName() const override { return "Ordinary"; }
 
@@ -73,6 +82,8 @@ public:
         return permanently_detached_tables;
     }
 
+    DiskPtr getDisk() const override { return metadata_disk_ptr; }
+
     static void setMergeTreeEngine(ASTCreateQuery & create_query, ContextPtr context, bool replicated);
 
 protected:
@@ -91,6 +102,9 @@ protected:
     std::atomic<size_t> total_tables_to_startup{0};
     std::atomic<size_t> tables_started{0};
     AtomicStopwatch startup_watch;
+
+    DatabaseMetadataDiskSettings database_metadata_disk_settings;
+    DiskPtr metadata_disk_ptr;
 
 private:
     void convertMergeTreeToReplicatedIfNeeded(ASTPtr ast, const QualifiedTableName & qualified_name, const String & file_name);

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1616,6 +1616,7 @@ ASTPtr DatabaseReplicated::parseQueryFromMetadataOnDisk(const String & table_nam
 {
     auto file_path = getObjectMetadataPath(table_name);
     String description = fmt::format("in metadata {}", file_path);
+    auto db_disk = getDisk();
     String query = DB::readMetadataFile(db_disk, file_path);
     return parseQueryFromMetadata(table_name, query, description);
 }
@@ -1963,6 +1964,7 @@ void DatabaseReplicated::removeDetachedPermanentlyFlag(ContextPtr local_context,
 
 String DatabaseReplicated::readMetadataFile(const String & table_name) const
 {
+    auto db_disk = getDisk();
     auto file_path = getObjectMetadataPath(table_name);
     return DB::readMetadataFile(db_disk, file_path);
 }

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -305,18 +305,18 @@ void cleanupObjectDefinitionFromTemporaryFlags(ASTCreateQuery & query)
     query.out_file = nullptr;
 }
 
-String readMetadataFile(std::shared_ptr<IDisk> db_disk, const String & file_path)
+String readMetadataFile(std::shared_ptr<IDisk> disk, const String & file_path)
 {
-    auto read_buf = db_disk->readFile(file_path, getReadSettingsForMetadata());
+    auto read_buf = disk->readFile(file_path, getReadSettingsForMetadata());
     String content;
     readStringUntilEOF(content, *read_buf);
 
     return content;
 }
 
-void writeMetadataFile(std::shared_ptr<IDisk> db_disk, const String & file_path, std::string_view content, bool fsync_metadata)
+void writeMetadataFile(std::shared_ptr<IDisk> disk, const String & file_path, std::string_view content, bool fsync_metadata)
 {
-    auto out = db_disk->writeFile(file_path, content.size(), WriteMode::Rewrite, getWriteSettingsForMetadata());
+    auto out = disk->writeFile(file_path, content.size(), WriteMode::Rewrite, getWriteSettingsForMetadata());
     writeString(content, *out);
 
     out->next();
@@ -346,7 +346,9 @@ void updateDatabaseCommentWithMetadataFile(DatabasePtr db, const AlterCommand & 
 }
 
 DatabaseWithOwnTablesBase::DatabaseWithOwnTablesBase(const String & name_, const String & logger, ContextPtr context_)
-    : IDatabase(name_), WithContext(context_->getGlobalContext()), db_disk(context_->getDatabaseDisk()), log(getLogger(logger))
+    : IDatabase(name_)
+    , WithContext(context_->getGlobalContext())
+    , log(getLogger(logger))
 {
 }
 

--- a/src/Databases/DatabasesCommon.h
+++ b/src/Databases/DatabasesCommon.h
@@ -20,8 +20,8 @@ ASTPtr getCreateQueryFromStorage(const StoragePtr & storage, const ASTPtr & ast_
 /// Cleans a CREATE QUERY from temporary flags like "IF NOT EXISTS", "OR REPLACE", "AS SELECT" (for non-views), etc.
 void cleanupObjectDefinitionFromTemporaryFlags(ASTCreateQuery & query);
 
-String readMetadataFile(std::shared_ptr<IDisk> db_disk, const String & file_path);
-void writeMetadataFile(std::shared_ptr<IDisk> db_disk, const String & file_path, std::string_view content, bool fsync_metadata);
+String readMetadataFile(std::shared_ptr<IDisk> disk, const String & file_path);
+void writeMetadataFile(std::shared_ptr<IDisk> disk, const String & file_path, std::string_view content, bool fsync_metadata);
 
 void updateDatabaseCommentWithMetadataFile(DatabasePtr db, const AlterCommand & command);
 
@@ -54,7 +54,6 @@ public:
 protected:
     Tables tables TSA_GUARDED_BY(mutex);
     SnapshotDetachedTables snapshot_detached_tables TSA_GUARDED_BY(mutex);
-    std::shared_ptr<IDisk> db_disk;
     LoggerPtr log;
 
     DatabaseWithOwnTablesBase(const String & name_, const String & logger, ContextPtr context);

--- a/src/Databases/IDatabase.cpp
+++ b/src/Databases/IDatabase.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 #include <Databases/IDatabase.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/TableNameHints.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -215,5 +216,8 @@ ASTPtr IDatabase::getCreateTableQueryImpl(const String & /*name*/, ContextPtr /*
     return nullptr;
 }
 
-
+DiskPtr IDatabase::getDisk() const
+{
+    return Context::getGlobalContextInstance()->getDatabaseDisk();
+}
 }

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -2,6 +2,7 @@
 
 #include <Core/UUID.h>
 #include <Databases/LoadingStrictnessLevel.h>
+#include <Disks/IDisk.h>
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/QueryFlags.h>
 #include <Parsers/IAST_fwd.h>
@@ -424,6 +425,9 @@ public:
 
     /// Creates a table restored from backup.
     virtual void createTableRestoredFromBackup(const ASTPtr & create_table_query, ContextMutablePtr context, std::shared_ptr<IRestoreCoordination> restore_coordination, UInt64 timeout_ms);
+
+    /// Get the disk storing metedata files of the tables
+    virtual DiskPtr getDisk() const;
 
     virtual ~IDatabase();
 

--- a/src/Databases/MySQL/DatabaseMySQL.h
+++ b/src/Databases/MySQL/DatabaseMySQL.h
@@ -105,8 +105,6 @@ private:
     mutable std::vector<StoragePtr> outdated_tables;
     mutable std::map<String, ModifyTimeAndStorage> local_tables_cache;
 
-    std::shared_ptr<IDisk> db_disk;
-
     std::unordered_set<String> remove_or_detach_tables;
 
     void cleanOutdatedTables();

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -57,13 +57,13 @@ static const auto cleaner_reschedule_ms = 60000;
 static const auto reschedule_error_multiplier = 10;
 
 DatabasePostgreSQL::DatabasePostgreSQL(
-        ContextPtr context_,
-        const String & metadata_path_,
-        const ASTStorage * database_engine_define_,
-        const String & dbname_,
-        const StoragePostgreSQL::Configuration & configuration_,
-        postgres::PoolWithFailoverPtr pool_,
-        bool cache_tables_)
+    ContextPtr context_,
+    const String & metadata_path_,
+    const ASTStorage * database_engine_define_,
+    const String & dbname_,
+    const StoragePostgreSQL::Configuration & configuration_,
+    postgres::PoolWithFailoverPtr pool_,
+    bool cache_tables_)
     : IDatabase(dbname_)
     , WithContext(context_->getGlobalContext())
     , metadata_path(metadata_path_)
@@ -71,9 +71,9 @@ DatabasePostgreSQL::DatabasePostgreSQL(
     , configuration(configuration_)
     , pool(std::move(pool_))
     , cache_tables(cache_tables_)
-    , db_disk(getContext()->getDatabaseDisk())
     , log(getLogger("DatabasePostgreSQL(" + dbname_ + ")"))
 {
+    auto db_disk = getDisk();
     db_disk->createDirectories(metadata_path);
     cleaner_task = getContext()->getSchedulePool().createTask("PostgreSQLCleanerTask", [this]{ removeOutdatedTables(); });
     cleaner_task->deactivate();
@@ -236,6 +236,7 @@ StoragePtr DatabasePostgreSQL::fetchTable(const String & table_name, ContextPtr 
 
 void DatabasePostgreSQL::attachTable(ContextPtr /* context_ */, const String & table_name, const StoragePtr & storage, const String &)
 {
+    auto db_disk = getDisk();
     std::lock_guard lock{mutex};
 
     if (!checkPostgresTable(table_name))
@@ -291,6 +292,7 @@ void DatabasePostgreSQL::createTable(ContextPtr local_context, const String & ta
 
 void DatabasePostgreSQL::dropTable(ContextPtr, const String & table_name, bool /* sync */)
 {
+    auto db_disk = getDisk();
     std::lock_guard lock{mutex};
 
     if (!checkPostgresTable(table_name))
@@ -309,14 +311,16 @@ void DatabasePostgreSQL::dropTable(ContextPtr, const String & table_name, bool /
 }
 
 
-void DatabasePostgreSQL::drop(ContextPtr /*context*/)
+void DatabasePostgreSQL::drop(ContextPtr)
 {
+    auto db_disk = getDisk();
     db_disk->removeRecursive(getMetadataPath());
 }
 
 
 void DatabasePostgreSQL::loadStoredObjects(ContextMutablePtr /* context */, LoadingStrictnessLevel /*mode*/)
 {
+    auto db_disk = getDisk();
     {
         std::lock_guard lock{mutex};
         /// Check for previously dropped tables
@@ -375,6 +379,7 @@ void DatabasePostgreSQL::removeOutdatedTables()
         }
     }
 
+    auto db_disk = getDisk();
     for (auto iter = detached_or_dropped.begin(); iter != detached_or_dropped.end();)
     {
         if (!actual_tables.contains(*iter))

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.h
@@ -76,7 +76,6 @@ private:
     mutable Tables cached_tables;
     std::unordered_set<std::string> detached_or_dropped;
     BackgroundSchedulePoolTaskHolder cleaner_task;
-    std::shared_ptr<IDisk> db_disk;
     LoggerPtr log;
 
     String getTableNameForLogs(const String & table_name) const;

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -398,6 +398,8 @@ void DiskLocal::removeDirectory(const String & path)
 void DiskLocal::removeDirectoryIfExists(const String & path)
 {
     auto fs_path = fs::path(disk_path) / path;
+    if (!existsDirectory(fs_path))
+        return;
     if (0 != rmdir(fs_path.c_str()))
         if (errno != ENOENT)
             ErrnoException::throwFromPath(ErrorCodes::CANNOT_RMDIR, fs_path, "Cannot remove directory {}", fs_path);
@@ -449,7 +451,7 @@ void DiskLocal::createDirectorySymlink(const String & target, const String & lin
 {
     auto link_path_inside_disk = fs::path(disk_path) / link;
     /// Symlinks will be relative.
-    fs::create_directory_symlink(fs::proximate(link_path_inside_disk.parent_path() / target, link_path_inside_disk.parent_path()), link_path_inside_disk);
+    fs::create_directory_symlink(fs::proximate(fs::path(disk_path) / target, link_path_inside_disk.parent_path()), link_path_inside_disk);
 }
 
 String DiskLocal::readSymlink(const fs::path & path) const

--- a/src/Disks/ObjectStorages/MetadataStorageFactory.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFactory.cpp
@@ -101,9 +101,10 @@ void registerMetadataStorageFromDisk(MetadataStorageFactory & factory)
         auto metadata_keep_free_space_bytes = config.getUInt64(config_prefix + ".metadata_keep_free_space_bytes", 0);
 
         fs::create_directories(metadata_path);
-        auto metadata_disk = std::make_shared<DiskLocal>(name + "-metadata", metadata_path, metadata_keep_free_space_bytes, config, config_prefix);
+        auto db_disk
+            = std::make_shared<DiskLocal>(name + "-metadata", metadata_path, metadata_keep_free_space_bytes, config, config_prefix);
         auto key_compatibility_prefix = getObjectKeyCompatiblePrefix(*object_storage, config, config_prefix);
-        return std::make_shared<MetadataStorageFromDisk>(metadata_disk, key_compatibility_prefix);
+        return std::make_shared<MetadataStorageFromDisk>(db_disk, key_compatibility_prefix);
     });
 }
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -380,7 +380,7 @@ struct ContextSharedPart : boost::noncopyable
     ConfigurationPtr config TSA_GUARDED_BY(mutex);           /// Global configuration settings.
     String tmp_path TSA_GUARDED_BY(mutex);                   /// Path to the temporary files that occur when processing the request.
 
-    std::shared_ptr<IDisk> db_disk TSA_GUARDED_BY(mutex);
+    std::shared_ptr<IDisk> global_db_disk TSA_GUARDED_BY(mutex);
 
     /// All temporary files that occur when processing the requests accounted here.
     /// Child scopes for more fine-grained accounting are created per user/query/etc.
@@ -1194,8 +1194,8 @@ std::shared_ptr<IDisk> Context::getDatabaseDisk() const
 {
     {
         SharedLockGuard lock(shared->mutex);
-        if (shared->db_disk)
-            return shared->db_disk;
+        if (shared->global_db_disk)
+            return shared->global_db_disk;
     }
 
     // This is called first time early during the initialization.
@@ -1220,10 +1220,10 @@ std::shared_ptr<IDisk> Context::getDatabaseDisk() const
     }();
 
     std::lock_guard lock(shared->mutex);
-    if (shared->db_disk)
-        return shared->db_disk;
+    if (shared->global_db_disk)
+        return shared->global_db_disk;
 
-    return shared->db_disk = target_db_disk;
+    return shared->global_db_disk = target_db_disk;
 }
 
 String Context::getFilesystemCacheUser() const
@@ -5312,16 +5312,14 @@ void Context::checkCanBeDropped(const String & database, const String & table, c
     if (!max_size_to_drop || size <= max_size_to_drop)
         return;
 
-    auto db_disk = getDatabaseDisk();
-
     fs::path force_file(getFlagsPath() + "force_drop_table");
-    bool force_file_exists = db_disk->existsFile(force_file);
+    bool force_file_exists = fs::exists(force_file);
 
     if (force_file_exists)
     {
         try
         {
-            db_disk->removeFileIfExists(force_file);
+            fs::remove(force_file);
             return;
         }
         catch (...)

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -627,18 +627,18 @@ DatabasePtr DatabaseCatalog::detachDatabase(ContextPtr local_context, const Stri
 
     if (drop)
     {
-        auto db_disk = getContext()->getDatabaseDisk();
         UUID db_uuid = db->getUUID();
 
         /// Delete the database.
         db->drop(local_context);
 
+        auto global_db_disk = getContext()->getDatabaseDisk();
         /// Old ClickHouse versions did not store database.sql files
         /// Remove metadata dir (if exists) to avoid recreation of .sql file on server startup
         fs::path database_metadata_dir = fs::path("metadata") / escapeForFileName(database_name);
-        db_disk->removeDirectoryIfExists(database_metadata_dir);
+        global_db_disk->removeDirectoryIfExists(database_metadata_dir);
         fs::path database_metadata_file = fs::path("metadata") / (escapeForFileName(database_name) + ".sql");
-        db_disk->removeFileIfExists(database_metadata_file);
+        global_db_disk->removeFileIfExists(database_metadata_file);
 
         if (db_uuid != UUIDHelpers::Nil)
             removeUUIDMappingFinally(db_uuid);
@@ -695,19 +695,22 @@ void DatabaseCatalog::updateMetadataFile(const DatabasePtr & database)
 
     auto database_metadata_tmp_path = fs::path("metadata") / (escapeForFileName(database->getDatabaseName()) + ".sql.tmp");
     auto database_metadata_path = fs::path("metadata") / (escapeForFileName(database->getDatabaseName()) + ".sql");
-    auto db_disk = getContext()->getDatabaseDisk();
+    auto global_db_disk = getContext()->getDatabaseDisk();
 
     writeMetadataFile(
-        db_disk, /*file_path=*/database_metadata_tmp_path, /*content=*/statement, getContext()->getSettingsRef()[Setting::fsync_metadata]);
+        global_db_disk,
+        /*file_path=*/database_metadata_tmp_path,
+        /*content=*/statement,
+        getContext()->getSettingsRef()[Setting::fsync_metadata]);
 
     try
     {
         /// rename atomically replaces the old file with the new one.
-        db_disk->replaceFile(database_metadata_tmp_path, database_metadata_path);
+        global_db_disk->replaceFile(database_metadata_tmp_path, database_metadata_path);
     }
     catch (...)
     {
-        db_disk->removeFileIfExists(database_metadata_tmp_path);
+        global_db_disk->removeFileIfExists(database_metadata_tmp_path);
         throw;
     }
 }
@@ -1038,7 +1041,20 @@ void DatabaseCatalog::loadMarkedAsDroppedTables()
 {
     assert(!cleanup_task);
 
-    auto db_disk = getContext()->getDatabaseDisk();
+    std::map<String, std::pair<StorageID, DiskPtr>> dropped_metadata;
+    String path = fs::path("metadata_dropped") / "";
+
+    auto db_map = getDatabases();
+    std::set<DiskPtr> metadata_disk_list;
+    for (const auto & [_, db] : db_map)
+    {
+        auto db_disk = db->getDisk();
+        if (!db_disk->existsDirectory(path))
+            continue;
+
+        metadata_disk_list.insert(std::move(db_disk));
+    }
+
 
     /// /clickhouse_root/metadata_dropped/ contains files with metadata of tables,
     /// which where marked as dropped by Atomic databases.
@@ -1046,45 +1062,41 @@ void DatabaseCatalog::loadMarkedAsDroppedTables()
     /// and metadata still exists in ZooKeeper for ReplicatedMergeTree tables.
     /// If server restarts before such tables was completely dropped,
     /// we should load them and enqueue cleanup to remove data from store/ and metadata from ZooKeeper
-
-    std::map<String, StorageID> dropped_metadata;
-    String path = fs::path("metadata_dropped") / "";
-
-    if (!db_disk->existsDirectory(path))
-        return;
-
-    for (const auto it = db_disk->iterateDirectory(path); it->isValid(); it->next())
+    for (const auto & db_disk : metadata_disk_list)
     {
-        /// File name has the following format:
-        /// database_name.table_name.uuid.sql
+        for (const auto it = db_disk->iterateDirectory(path); it->isValid(); it->next())
+        {
+            /// File name has the following format:
+            /// database_name.table_name.uuid.sql
 
-        auto sub_path_filename = it->name();
+            auto sub_path_filename = it->name();
 
-        /// Ignore unexpected files
-        if (!sub_path_filename.ends_with(".sql"))
-            continue;
+            /// Ignore unexpected files
+            if (!sub_path_filename.ends_with(".sql"))
+                continue;
 
-        /// Process .sql files with metadata of tables which were marked as dropped
-        StorageID dropped_id = StorageID::createEmpty();
-        size_t dot_pos = sub_path_filename.find('.');
-        if (dot_pos == std::string::npos)
-            continue;
-        dropped_id.database_name = unescapeForFileName(sub_path_filename.substr(0, dot_pos));
+            /// Process .sql files with metadata of tables which were marked as dropped
+            StorageID dropped_id = StorageID::createEmpty();
+            size_t dot_pos = sub_path_filename.find('.');
+            if (dot_pos == std::string::npos)
+                continue;
+            dropped_id.database_name = unescapeForFileName(sub_path_filename.substr(0, dot_pos));
 
-        size_t prev_dot_pos = dot_pos;
-        dot_pos = sub_path_filename.find('.', prev_dot_pos + 1);
-        if (dot_pos == std::string::npos)
-            continue;
-        dropped_id.table_name = unescapeForFileName(sub_path_filename.substr(prev_dot_pos + 1, dot_pos - prev_dot_pos - 1));
+            size_t prev_dot_pos = dot_pos;
+            dot_pos = sub_path_filename.find('.', prev_dot_pos + 1);
+            if (dot_pos == std::string::npos)
+                continue;
+            dropped_id.table_name = unescapeForFileName(sub_path_filename.substr(prev_dot_pos + 1, dot_pos - prev_dot_pos - 1));
 
-        prev_dot_pos = dot_pos;
-        dot_pos = sub_path_filename.find('.', prev_dot_pos + 1);
-        if (dot_pos == std::string::npos)
-            continue;
-        dropped_id.uuid = parse<UUID>(sub_path_filename.substr(prev_dot_pos + 1, dot_pos - prev_dot_pos - 1));
+            prev_dot_pos = dot_pos;
+            dot_pos = sub_path_filename.find('.', prev_dot_pos + 1);
+            if (dot_pos == std::string::npos)
+                continue;
+            dropped_id.uuid = parse<UUID>(sub_path_filename.substr(prev_dot_pos + 1, dot_pos - prev_dot_pos - 1));
 
-        String full_path = path + sub_path_filename;
-        dropped_metadata.emplace(std::move(full_path), std::move(dropped_id));
+            String full_path = path + sub_path_filename;
+            dropped_metadata.emplace(std::move(full_path), std::pair{std::move(dropped_id), db_disk});
+        }
     }
 
     if (dropped_metadata.empty())
@@ -1095,7 +1107,10 @@ void DatabaseCatalog::loadMarkedAsDroppedTables()
     ThreadPoolCallbackRunnerLocal<void> runner(getDatabaseCatalogDropTablesThreadPool().get(), "DropTables");
     for (const auto & elem : dropped_metadata)
     {
-        runner([this, &elem](){ this->enqueueDroppedTableCleanup(elem.second, nullptr, elem.first); });
+        auto full_path = elem.first;
+        auto storage_id = elem.second.first;
+        auto db_disk = elem.second.second;
+        runner([this, full_path, storage_id, db_disk]() { this->enqueueDroppedTableCleanup(storage_id, nullptr, db_disk, full_path); });
     }
     runner.waitForAllToFinishAndRethrowFirstError();
 }
@@ -1125,13 +1140,12 @@ String DatabaseCatalog::getPathForMetadata(const StorageID & table_id) const
     return metadata_path + escapeForFileName(table_id.getTableName()) + ".sql";
 }
 
-void DatabaseCatalog::enqueueDroppedTableCleanup(StorageID table_id, StoragePtr table, String dropped_metadata_path, bool ignore_delay)
+void DatabaseCatalog::enqueueDroppedTableCleanup(
+    StorageID table_id, StoragePtr table, DiskPtr db_disk, String dropped_metadata_path, bool ignore_delay)
 {
     assert(table_id.hasUUID());
     assert(!table || table->getStorageID().uuid == table_id.uuid);
     assert(dropped_metadata_path == getPathForDroppedMetadata(table_id));
-
-    auto db_disk = getContext()->getDatabaseDisk();
 
     /// Table was removed from database. Enqueue removal of its data from disk.
     time_t drop_time;
@@ -1148,7 +1162,7 @@ void DatabaseCatalog::enqueueDroppedTableCleanup(StorageID table_id, StoragePtr 
         /// Try load table from metadata to drop it correctly (e.g. remove metadata from zk or remove data from all volumes)
         LOG_INFO(log, "Trying load partially dropped table {} from {}", table_id.getNameForLogs(), dropped_metadata_path);
         ASTPtr ast = DatabaseOnDisk::parseQueryFromMetadata(
-            log, getContext(), dropped_metadata_path, /*throw_on_error*/ false, /*remove_empty*/ false);
+            log, getContext(), db_disk, dropped_metadata_path, /*throw_on_error*/ false, /*remove_empty*/ false);
         auto * create = typeid_cast<ASTCreateQuery *>(ast.get());
         assert(!create || create->uuid == table_id.uuid);
 
@@ -1185,17 +1199,18 @@ void DatabaseCatalog::enqueueDroppedTableCleanup(StorageID table_id, StoragePtr 
     {
         /// Insert it before first_async_drop_in_queue, so sync drop queries will have priority over async ones,
         /// but the queue will remain fair for multiple sync drop queries.
-        tables_marked_dropped.emplace(first_async_drop_in_queue, TableMarkedAsDropped{table_id, table, dropped_metadata_path, drop_time});
+        tables_marked_dropped.emplace(
+            first_async_drop_in_queue, TableMarkedAsDropped{table_id, table, db_disk, dropped_metadata_path, drop_time});
     }
     else
     {
-        tables_marked_dropped.push_back
-        ({
-            table_id,
-            table,
-            dropped_metadata_path,
-            drop_time + static_cast<time_t>(getContext()->getServerSettings()[ServerSetting::database_atomic_delay_before_drop_table_sec])
-        });
+        tables_marked_dropped.push_back(
+            {table_id,
+             table,
+             db_disk,
+             dropped_metadata_path,
+             drop_time
+                 + static_cast<time_t>(getContext()->getServerSettings()[ServerSetting::database_atomic_delay_before_drop_table_sec])});
         if (first_async_drop_in_queue == tables_marked_dropped.end())
             --first_async_drop_in_queue;
     }
@@ -1210,7 +1225,7 @@ void DatabaseCatalog::enqueueDroppedTableCleanup(StorageID table_id, StoragePtr 
 
 void DatabaseCatalog::undropTable(StorageID table_id)
 {
-    auto db_disk = getContext()->getDatabaseDisk();
+    auto db_disk = getDatabase(table_id.database_name)->getDisk();
 
     String latest_metadata_dropped_path;
     TableMarkedAsDropped dropped_table;
@@ -1432,7 +1447,7 @@ void DatabaseCatalog::dropTableDataTask()
 
 void DatabaseCatalog::dropTableFinally(const TableMarkedAsDropped & table)
 {
-    auto db_disk = getContext()->getDatabaseDisk();
+    auto db_disk = table.db_disk;
 
     if (table.table)
     {

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -223,7 +223,8 @@ public:
 
     String getPathForDroppedMetadata(const StorageID & table_id) const;
     String getPathForMetadata(const StorageID & table_id) const;
-    void enqueueDroppedTableCleanup(StorageID table_id, StoragePtr table, String dropped_metadata_path, bool ignore_delay = false);
+    void enqueueDroppedTableCleanup(
+        StorageID table_id, StoragePtr table, DiskPtr db_disk, String dropped_metadata_path, bool ignore_delay = false);
     void undropTable(StorageID table_id);
 
     void waitTableFinallyDropped(const UUID & uuid);
@@ -252,6 +253,7 @@ public:
     {
         StorageID table_id = StorageID::createEmpty();
         StoragePtr table;
+        DiskPtr db_disk;
         String metadata_path;
         time_t drop_time{};
     };

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -230,23 +230,23 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
                             db_num_limit, db_count);
     }
 
-    auto db_disk = getContext()->getDatabaseDisk();
+    auto global_db_disk = getContext()->getDatabaseDisk();
 
     /// Will write file with database metadata, if needed.
     String database_name_escaped = escapeForFileName(database_name);
     fs::path metadata_dir_path("metadata");
     fs::path store_dir_path("store");
-    db_disk->createDirectories(metadata_dir_path);
+    global_db_disk->createDirectories(metadata_dir_path);
     fs::path metadata_file_tmp_path = metadata_dir_path / (database_name_escaped + ".sql.tmp");
     fs::path metadata_file_path = metadata_dir_path / (database_name_escaped + ".sql");
 
     fs::path metadata_path;
     if (!create.storage && create.attach)
     {
-        if (!db_disk->existsFile(metadata_file_path))
+        if (!global_db_disk->existsFile(metadata_file_path))
             throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE, "Database engine must be specified for ATTACH DATABASE query");
         /// Short syntax: try read database definition from file
-        auto ast = DatabaseOnDisk::parseQueryFromMetadata(nullptr, getContext(), metadata_file_path);
+        auto ast = DatabaseOnDisk::parseQueryFromMetadata(nullptr, getContext(), global_db_disk, metadata_file_path);
         create = ast->as<ASTCreateQuery &>();
         if (create.table || !create.storage)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "Metadata file {} contains incorrect CREATE DATABASE query", metadata_file_path.string());
@@ -293,7 +293,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
 
         metadata_path = store_dir_path / DatabaseCatalog::getPathForUUID(create.uuid);
 
-        if (!create.attach && db_disk->existsDirectory(metadata_path) && !db_disk->isDirectoryEmpty(metadata_path))
+        if (!create.attach && global_db_disk->existsDirectory(metadata_path) && !global_db_disk->isDirectoryEmpty(metadata_path))
             throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Metadata directory {} already exists and is not empty", metadata_path.string());
     }
     else
@@ -327,7 +327,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
                         "Enable allow_experimental_database_materialized_postgresql to use it");
     }
 
-    bool need_write_metadata = !create.attach || !db_disk->existsFile(metadata_file_path);
+    bool need_write_metadata = !create.attach || !global_db_disk->existsFile(metadata_file_path);
     bool need_lock_uuid = internal || need_write_metadata;
     auto mode = getLoadingStrictnessLevel(create.attach, force_attach, has_force_restore_data_flag, /*secondary*/ false);
 
@@ -356,11 +356,11 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         String statement = statement_buf.str();
 
         /// Needed to make database creation retriable if it fails after the file is created
-        db_disk->removeFileIfExists(metadata_file_tmp_path);
+        global_db_disk->removeFileIfExists(metadata_file_tmp_path);
 
         /// Exclusive flag guarantees, that database is not created right now in another thread.
         writeMetadataFile(
-            db_disk,
+            global_db_disk,
             /*file_path=*/metadata_file_tmp_path,
             /*content=*/statement,
             /*fsync_metadata=*/getContext()->getSettingsRef()[Setting::fsync_metadata]);
@@ -393,7 +393,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         if (need_write_metadata)
         {
             /// Prevents from overwriting metadata of detached database
-            db_disk->moveFile(metadata_file_tmp_path, metadata_file_path);
+            global_db_disk->moveFile(metadata_file_tmp_path, metadata_file_path);
             renamed = true;
         }
     }
@@ -401,8 +401,8 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     {
         if (renamed)
         {
-            assert(db_disk->existsFile(metadata_file_path));
-            db_disk->removeFileIfExists(metadata_file_path);
+            assert(global_db_disk->existsFile(metadata_file_path));
+            global_db_disk->removeFileIfExists(metadata_file_path);
         }
         if (added)
             DatabaseCatalog::instance().detachDatabase(getContext(), database_name, false, false);
@@ -2532,7 +2532,7 @@ void InterpreterCreateQuery::convertMergeTreeTableIfPossible(ASTCreateQuery & cr
     DatabaseOrdinary::setMergeTreeEngine(create, getContext(), to_replicated);
 
     /// Save new metadata
-    auto db_disk = getContext()->getDatabaseDisk();
+    auto db_disk = database->getDisk();
     String table_metadata_path = database->getObjectMetadataPath(create.getTable());
     String table_metadata_tmp_path = table_metadata_path + ".tmp";
     String statement = DB::getObjectDefinitionFromCreateQuery(create.clone());

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -230,23 +230,23 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
                             db_num_limit, db_count);
     }
 
-    auto global_db_disk = getContext()->getDatabaseDisk();
+    auto default_db_disk = getContext()->getDatabaseDisk();
 
     /// Will write file with database metadata, if needed.
     String database_name_escaped = escapeForFileName(database_name);
     fs::path metadata_dir_path("metadata");
     fs::path store_dir_path("store");
-    global_db_disk->createDirectories(metadata_dir_path);
+    default_db_disk->createDirectories(metadata_dir_path);
     fs::path metadata_file_tmp_path = metadata_dir_path / (database_name_escaped + ".sql.tmp");
     fs::path metadata_file_path = metadata_dir_path / (database_name_escaped + ".sql");
 
     fs::path metadata_path;
     if (!create.storage && create.attach)
     {
-        if (!global_db_disk->existsFile(metadata_file_path))
+        if (!default_db_disk->existsFile(metadata_file_path))
             throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE, "Database engine must be specified for ATTACH DATABASE query");
         /// Short syntax: try read database definition from file
-        auto ast = DatabaseOnDisk::parseQueryFromMetadata(nullptr, getContext(), global_db_disk, metadata_file_path);
+        auto ast = DatabaseOnDisk::parseQueryFromMetadata(nullptr, getContext(), default_db_disk, metadata_file_path);
         create = ast->as<ASTCreateQuery &>();
         if (create.table || !create.storage)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "Metadata file {} contains incorrect CREATE DATABASE query", metadata_file_path.string());
@@ -293,7 +293,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
 
         metadata_path = store_dir_path / DatabaseCatalog::getPathForUUID(create.uuid);
 
-        if (!create.attach && global_db_disk->existsDirectory(metadata_path) && !global_db_disk->isDirectoryEmpty(metadata_path))
+        if (!create.attach && default_db_disk->existsDirectory(metadata_path) && !default_db_disk->isDirectoryEmpty(metadata_path))
             throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Metadata directory {} already exists and is not empty", metadata_path.string());
     }
     else
@@ -327,7 +327,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
                         "Enable allow_experimental_database_materialized_postgresql to use it");
     }
 
-    bool need_write_metadata = !create.attach || !global_db_disk->existsFile(metadata_file_path);
+    bool need_write_metadata = !create.attach || !default_db_disk->existsFile(metadata_file_path);
     bool need_lock_uuid = internal || need_write_metadata;
     auto mode = getLoadingStrictnessLevel(create.attach, force_attach, has_force_restore_data_flag, /*secondary*/ false);
 
@@ -356,11 +356,11 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         String statement = statement_buf.str();
 
         /// Needed to make database creation retriable if it fails after the file is created
-        global_db_disk->removeFileIfExists(metadata_file_tmp_path);
+        default_db_disk->removeFileIfExists(metadata_file_tmp_path);
 
         /// Exclusive flag guarantees, that database is not created right now in another thread.
         writeMetadataFile(
-            global_db_disk,
+            default_db_disk,
             /*file_path=*/metadata_file_tmp_path,
             /*content=*/statement,
             /*fsync_metadata=*/getContext()->getSettingsRef()[Setting::fsync_metadata]);
@@ -393,7 +393,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         if (need_write_metadata)
         {
             /// Prevents from overwriting metadata of detached database
-            global_db_disk->moveFile(metadata_file_tmp_path, metadata_file_path);
+            default_db_disk->moveFile(metadata_file_tmp_path, metadata_file_path);
             renamed = true;
         }
     }
@@ -401,8 +401,8 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     {
         if (renamed)
         {
-            assert(global_db_disk->existsFile(metadata_file_path));
-            global_db_disk->removeFileIfExists(metadata_file_path);
+            assert(default_db_disk->existsFile(metadata_file_path));
+            default_db_disk->removeFileIfExists(metadata_file_path);
         }
         if (added)
             DatabaseCatalog::instance().detachDatabase(getContext(), database_name, false, false);

--- a/src/Interpreters/loadMetadata.cpp
+++ b/src/Interpreters/loadMetadata.cpp
@@ -110,11 +110,11 @@ static void loadDatabase(
     String database_attach_query;
     String database_metadata_file = database_path + ".sql";
 
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
-    if (db_disk->existsFile(fs::path(database_metadata_file)))
+    auto global_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
+    if (global_db_disk->existsFile(fs::path(database_metadata_file)))
     {
         /// There is .sql file with database creation statement.
-        database_attach_query = readMetadataFile(db_disk, database_metadata_file);
+        database_attach_query = readMetadataFile(global_db_disk, database_metadata_file);
     }
     else
     {
@@ -136,10 +136,10 @@ static void loadDatabase(
 
 static void checkUnsupportedVersion(ContextMutablePtr, const String & database_name)
 {
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
+    auto global_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
     /// Produce better exception message
     auto metadata_path = fs::path("metadata") / database_name;
-    if (db_disk->existsDirectory(metadata_path))
+    if (global_db_disk->existsDirectory(metadata_path))
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Data directory for {} database exists, but metadata file does not. "
                                                      "Probably you are trying to upgrade from version older than 20.7. "
                                                      "If so, you should upgrade through intermediate version.", database_name);
@@ -150,10 +150,8 @@ static void checkIncompleteOrdinaryToAtomicConversion(ContextPtr context, const 
     if (context->getConfigRef().has("allow_reserved_database_name_tmp_convert"))
         return;
 
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
-
     auto convert_flag_path = fs::path(context->getFlagsPath()) / "convert_ordinary_to_atomic";
-    if (!db_disk->existsFile(convert_flag_path))
+    if (!fs::exists(convert_flag_path))
         return;
 
     /// Flag exists. Let's check if we had an unsuccessful conversion attempt previously
@@ -167,20 +165,27 @@ static void checkIncompleteOrdinaryToAtomicConversion(ContextPtr context, const 
 
         String actual_name = db.first.substr(strlen(ORDINARY_TO_ATOMIC_PREFIX), last_dot - strlen(ORDINARY_TO_ATOMIC_PREFIX));
 
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Found a database with special name: {}. "
-                        "Most likely it indicates that conversion of database {} from Ordinary to Atomic "
-                        "was interrupted or failed in the middle. You can add <allow_reserved_database_name_tmp_convert> to config.xml "
-                        "or remove convert_ordinary_to_atomic file from flags/ directory, so the server will start forcefully. "
-                        "After starting the server, you can finish conversion manually by moving rest of the tables from {} to {} "
-                        "(using RENAME TABLE) and executing DROP DATABASE {} and RENAME DATABASE {} TO {}",
-                        backQuote(db.first), backQuote(actual_name), backQuote(actual_name), backQuote(db.first),
-                        backQuote(actual_name), backQuote(db.first), backQuote(actual_name));
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Found a database with special name: {}. "
+            "Most likely it indicates that conversion of database {} from Ordinary to Atomic "
+            "was interrupted or failed in the middle. You can add <allow_reserved_database_name_tmp_convert> to config.xml "
+            "or remove convert_ordinary_to_atomic file from flags/ directory, so the server will start forcefully. "
+            "After starting the server, you can finish conversion manually by moving rest of the tables from {} to {} "
+            "(using RENAME TABLE) and executing DROP DATABASE {} and RENAME DATABASE {} TO {}",
+            backQuote(db.first),
+            backQuote(actual_name),
+            backQuote(actual_name),
+            backQuote(db.first),
+            backQuote(actual_name),
+            backQuote(db.first),
+            backQuote(actual_name));
     }
 }
 
 LoadTaskPtrs loadMetadata(ContextMutablePtr context, const String & default_database_name, bool async_load_databases)
 {
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
+    auto global_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
 
     LoggerPtr log = getLogger("loadMetadata");
 
@@ -188,12 +193,12 @@ LoadTaskPtrs loadMetadata(ContextMutablePtr context, const String & default_data
     /// on difference of data parts while initializing tables.
     /// This file is immediately deleted i.e. "one-shot".
     auto force_restore_data_flag_file = fs::path(context->getFlagsPath()) / "force_restore_data";
-    bool has_force_restore_data_flag = db_disk->existsFile(force_restore_data_flag_file);
+    bool has_force_restore_data_flag = fs::exists(force_restore_data_flag_file);
     if (has_force_restore_data_flag)
     {
         try
         {
-            db_disk->removeFileIfExists(force_restore_data_flag_file);
+            fs::remove(force_restore_data_flag_file);
         }
         catch (...)
         {
@@ -209,13 +214,13 @@ LoadTaskPtrs loadMetadata(ContextMutablePtr context, const String & default_data
     /// Some databases don't have an .sql metadata file.
     std::map<String, String> orphan_directories_and_symlinks;
 
-    for (const auto it = db_disk->iterateDirectory(metadata_dir_path); it->isValid(); it->next())
+    for (const auto it = global_db_disk->iterateDirectory(metadata_dir_path); it->isValid(); it->next())
     {
         auto sub_path = fs::path(it->path());
         if (sub_path.filename().empty())
             sub_path = sub_path.parent_path();
 
-        if (db_disk->isSymlinkSupported() && db_disk->isSymlink(sub_path))
+        if (global_db_disk->isSymlinkSupported() && global_db_disk->isSymlink(sub_path))
         {
             String db_name = sub_path.filename().string();
             if (!isSystemOrInformationSchema(db_name))
@@ -223,7 +228,7 @@ LoadTaskPtrs loadMetadata(ContextMutablePtr context, const String & default_data
             continue;
         }
 
-        if (db_disk->existsDirectory(sub_path))
+        if (global_db_disk->existsDirectory(sub_path))
             continue;
 
         const auto current_file = sub_path.filename().string();
@@ -242,7 +247,7 @@ LoadTaskPtrs loadMetadata(ContextMutablePtr context, const String & default_data
             LOG_WARNING(log, "Removing temporary file {}", sub_path.string());
             try
             {
-                db_disk->removeFileIfExists(sub_path);
+                global_db_disk->removeFileIfExists(sub_path);
             }
             catch (...)
             {
@@ -313,20 +318,20 @@ static void loadSystemDatabaseImpl(ContextMutablePtr context, const String & dat
     if (DatabaseCatalog::instance().isDatabaseExist(database_name))
         return;
 
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
+    auto global_db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
 
     String database_name_escaped = escapeForFileName(database_name);
     auto metadata_dir_path = fs::path("metadata");
     auto database_dir_path = metadata_dir_path / database_name_escaped;
     auto metadata_file = metadata_dir_path / (database_name_escaped + ".sql");
     auto metadata_file_tmp = metadata_dir_path / (database_name_escaped + ".sql" + ".tmp");
-    db_disk->removeFileIfExists(metadata_file_tmp);
+    global_db_disk->removeFileIfExists(metadata_file_tmp);
     LOG_DEBUG(
         getLogger("loadSystemDatabase"),
         "metadata_file_path {}, existsFile {}",
         metadata_file,
-        db_disk->existsFile(fs::path(metadata_file)));
-    if (db_disk->existsFile(fs::path(metadata_file)))
+        global_db_disk->existsFile(fs::path(metadata_file)));
+    if (global_db_disk->existsFile(fs::path(metadata_file)))
     {
         /// 'has_force_restore_data_flag' is true, to not fail on loading query_log table, if it is corrupted.
         loadDatabase(context, database_name, database_dir_path, true);
@@ -521,14 +526,14 @@ void maybeConvertSystemDatabase(ContextMutablePtr context, LoadTaskPtrs & load_s
 
 void convertDatabasesEnginesIfNeed(const LoadTaskPtrs & load_metadata, ContextMutablePtr context)
 {
-    auto db_disk = Context::getGlobalContextInstance()->getDatabaseDisk();
-
     auto convert_flag_path = fs::path(context->getFlagsPath()) / "convert_ordinary_to_atomic";
-    if (!db_disk->existsFile(convert_flag_path))
+    if (!fs::exists(convert_flag_path))
         return;
 
-    LOG_INFO(getLogger("loadMetadata"), "Found convert_ordinary_to_atomic file in flags directory, "
-                                                 "will try to convert all Ordinary databases to Atomic");
+    LOG_INFO(
+        getLogger("loadMetadata"),
+        "Found convert_ordinary_to_atomic file in flags directory, "
+        "will try to convert all Ordinary databases to Atomic");
 
     // Wait for all table to be loaded and started
     waitLoad(TablesLoaderForegroundPoolId, load_metadata);
@@ -538,7 +543,7 @@ void convertDatabasesEnginesIfNeed(const LoadTaskPtrs & load_metadata, ContextMu
             maybeConvertOrdinaryDatabaseToAtomic(context, name);
 
     LOG_INFO(getLogger("loadMetadata"), "Conversion finished, removing convert_ordinary_to_atomic flag");
-    db_disk->removeFileIfExists(convert_flag_path);
+    fs::remove(convert_flag_path);
 }
 
 LoadTaskPtrs loadMetadataSystem(ContextMutablePtr context, bool async_load_system_database)

--- a/tests/integration/test_database_disk_setting/configs/database_disk.xml
+++ b/tests/integration/test_database_disk_setting/configs/database_disk.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <custom_local_disks_base_directory>/var/lib/clickhouse/disks/</custom_local_disks_base_directory>
+    <database_disk>
+        <disk>global_db_disk</disk>
+    </database_disk>
+    <storage_configuration>
+        <disks>
+            <global_db_disk>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disks/global_db_disk/</path>
+            </global_db_disk>
+            <db_disk>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disks/db_disk/</path>
+            </db_disk>
+            <s3>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/disks/disk_s3_plain/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </s3>
+        </disks>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_database_disk_setting/configs/disk_app_config.xml
+++ b/tests/integration/test_database_disk_setting/configs/disk_app_config.xml
@@ -1,0 +1,25 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <global_db_disk>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disks/global_db_disk/</path>
+            </global_db_disk>
+            <db_disk>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disks/db_disk/</path>
+            </db_disk>
+            <custom_db_disk>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disks/custom_db_disk/</path>
+            </custom_db_disk>
+            <s3>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/disks/disk_s3_plain/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+                <readonly>true</readonly>
+            </s3>
+        </disks>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_database_disk_setting/test.py
+++ b/tests/integration/test_database_disk_setting/test.py
@@ -141,41 +141,41 @@ def remove_file(node, disk_name: str, file_path: str):
         ["bash", "-c", f"{disk_cmd_prefix} 'remove {file_path}'"]
     )
 
-# Currently, 's3' doesn't support moveFile, so the DB with 's3' disk cannot be dropped.
-# def test_db_disk_setting_with_s3(start_cluster):
-#     db_name = f"db_test"
+@pytest.mark.skip(reason="'s3' disk doesn't support moveFile, so the DB with 's3' disk cannot be dropped.")
+def test_db_disk_setting_with_s3(start_cluster):
+    db_name = f"db_test"
     
-#     node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
     
-#     node1.query(f"CREATE DATABASE {db_name} ENGINE= Atomic SETTINGS disk='db_disk'")
-#     node1.query(f"CREATE TABLE {db_name}.test (x INT) ENGINE=MergeTree ORDER BY x")
+    node1.query(f"CREATE DATABASE {db_name} ENGINE= Atomic SETTINGS disk='db_disk'")
+    node1.query(f"CREATE TABLE {db_name}.test (x INT) ENGINE=MergeTree ORDER BY x")
     
-#     table_metadata_path = node1.query(
-#         f"SELECT metadata_path FROM system.tables WHERE database='{db_name}' AND table='test'"
-#     ).strip()
+    table_metadata_path = node1.query(
+        f"SELECT metadata_path FROM system.tables WHERE database='{db_name}' AND table='test'"
+    ).strip()
     
      
-#     print(f"table_metadata_path: {table_metadata_path}")
+    print(f"table_metadata_path: {table_metadata_path}")
     
-#     node1.stop_clickhouse()
+    node1.stop_clickhouse()
     
-#     # Update disk of the DB to 's3'
-#     replace_text_in_metadata(node1, "global_db_disk", f"metadata/{db_name}.sql", "db_disk", "s3")
+    # Update disk of the DB to 's3'
+    replace_text_in_metadata(node1, "global_db_disk", f"metadata/{db_name}.sql", "db_disk", "s3")
     
-#     # Copy the table metadata file into 's3' disk
-#     table_metadata_content = read_file(node1, "db_disk", table_metadata_path)
-#     print(f"table_metadata_content: {table_metadata_content}")
-#     write_to_file(node1, 's3', table_metadata_path, table_metadata_content)
+    # Copy the table metadata file into 's3' disk
+    table_metadata_content = read_file(node1, "db_disk", table_metadata_path)
+    print(f"table_metadata_content: {table_metadata_content}")
+    write_to_file(node1, 's3', table_metadata_path, table_metadata_content)
     
-#     # Remove metadata file on the DB disk
-#     remove_file(node1, "db_disk", table_metadata_path)
+    # Remove metadata file on the DB disk
+    remove_file(node1, "db_disk", table_metadata_path)
     
-#     node1.start_clickhouse()
+    node1.start_clickhouse()
     
-#     validate_db_path(node1, "s3", db_name, False)
-#     assert directory_exists(node1, "s3", table_metadata_path)
+    validate_db_path(node1, "s3", db_name, False)
+    assert directory_exists(node1, "s3", table_metadata_path)
     
-#     assert node1.query("SELECT count() FROM system.tables WHERE table='test'").strip() == "1"
+    assert node1.query("SELECT count() FROM system.tables WHERE table='test'").strip() == "1"
     
-#     node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
     

--- a/tests/integration/test_database_disk_setting/test.py
+++ b/tests/integration/test_database_disk_setting/test.py
@@ -1,0 +1,181 @@
+import os
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from pathlib import Path
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=[
+        "configs/database_disk.xml",
+    ],
+    with_remote_database_disk=False,
+    with_minio = True,
+    stay_alive=True,
+)
+
+disk_config_file_path =  "/tmp/disk_app_config.xml"
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        node1.copy_file_to_container(
+            os.path.join(SCRIPT_DIR, "configs/disk_app_config.xml"),
+            disk_config_file_path,
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def directory_exists(node, disk_name: str, dir_path: str):
+    path = Path(dir_path.rstrip("/"))
+    parent_dir = path.parent
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /tmp/disk_app_config.xml --save-logs --disk {disk_name} --query "
+    file_list = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"{disk_cmd_prefix} 'ls {parent_dir}'",
+        ]
+    )
+    return path.name in file_list
+
+def validate_table_metadata_path(node, disk_name : str, db : str, table: str):
+    table_metadata_path = node1.query(
+        f"SELECT metadata_path FROM system.tables WHERE database='{db}' AND table='{table}'"
+    ).strip()
+
+    assert directory_exists(node, disk_name, table_metadata_path)
+    if(disk_name != "global_db_disk"):
+        assert not directory_exists(node1, "global_db_disk", table_metadata_path)
+        
+def validate_db_path(node, disk_name : str, db : str, support_symlink: bool = True):
+    db_data_path = node.query(
+        f"SELECT metadata_path FROM system.databases WHERE database='{db}'"
+    ).strip()
+
+    assert directory_exists(node, disk_name, db_data_path)
+    if support_symlink:
+        assert directory_exists(node, disk_name, os.path.join("metadata", db))
+        assert directory_exists(node, disk_name, os.path.join( "data", db))
+        
+@pytest.mark.parametrize("engine", ["Atomic", "Ordinary"])
+@pytest.mark.parametrize("db_disk_name", ["db_disk", "global_db_disk", ""])
+def test_db_disk_setting(start_cluster, engine: str, db_disk_name: str):
+    db_name = f"db_{db_disk_name}_{engine.lower()}"
+    
+    node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    node1.query(f"DROP DATABASE IF EXISTS {db_name}_rename SYNC")
+    
+    disk_setting = f"disk='{db_disk_name}'"
+    if len(db_disk_name) == 0:
+        disk_setting = "disk=disk(type='local', path='/var/lib/clickhouse/disks/custom_db_disk/')"
+        db_disk_name = "custom_db_disk"
+
+    node1.query(
+        sql=f"CREATE DATABASE {db_name} ENGINE= {engine} SETTINGS {disk_setting}",
+        settings={"allow_deprecated_database_ordinary": 1},
+    )
+    node1.query(f"CREATE TABLE {db_name}.test (x INT) ENGINE=MergeTree ORDER BY x")
+
+    validate_db_path(node1, db_disk_name, db_name)
+    validate_table_metadata_path(node1, db_disk_name, db_name, 'test')
+    
+    # Ordinay DB doesn't support renaming
+    if(engine != "Ordinary"):
+        node1.query(f"RENAME DATABASE {db_name} TO {db_name}_rename")
+        validate_db_path(node1, db_disk_name, f"{db_name}_rename")
+        validate_table_metadata_path(node1, db_disk_name, f"{db_name}_rename", 'test')
+        
+        node1.query(f"RENAME DATABASE {db_name}_rename TO {db_name}")
+        validate_db_path(node1, db_disk_name, db_name)
+        validate_table_metadata_path(node1, db_disk_name, db_name, 'test')
+    
+    node1.query(f"RENAME TABLE {db_name}.test TO {db_name}.test_rename")
+    validate_db_path(node1, db_disk_name, db_name)
+    validate_table_metadata_path(node1, db_disk_name, db_name, 'test_rename')
+    
+
+    node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    node1.query(f"DROP DATABASE IF EXISTS {db_name}_rename SYNC")
+
+def replace_text_in_metadata(node, disk_name: str, metadata_path: str, old_value: str, new_value: str):
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C {disk_config_file_path} --disk {disk_name} --save-logs --query "
+
+    old_metadata = node.exec_in_container(
+        ["bash", "-c", f"{disk_cmd_prefix} 'read --path-from {metadata_path}'"]
+    )
+
+    new_metadata = old_metadata.replace(old_value, new_value)
+    write_to_file(node, disk_name, metadata_path, new_metadata)
+
+def read_file(node, disk_name: str, metadata_path: str):
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C {disk_config_file_path} --disk {disk_name} --save-logs --query "
+
+    return node.exec_in_container(
+        ["bash", "-c", f"{disk_cmd_prefix} 'read --path-from {metadata_path}'"]
+    )
+    
+def write_to_file(node, disk_name: str, file_path: str, content: str):
+    # Escape backticks to avoid command substitution
+    escaped_content = content.replace('"', r"\"").replace("`", r"\`")
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C {disk_config_file_path} --save-logs --disk {disk_name} --query "
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"""printf "%s" "{escaped_content}" | {disk_cmd_prefix} 'w --path-to {file_path}'""",
+        ]
+    )
+        
+def remove_file(node, disk_name: str, file_path: str):
+    # Escape backticks to avoid command substitution
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C {disk_config_file_path} --save-logs --disk {disk_name} --query "
+    node.exec_in_container(
+        ["bash", "-c", f"{disk_cmd_prefix} 'remove {file_path}'"]
+    )
+
+# Currently, 's3' doesn't support moveFile, so the DB with 's3' disk cannot be dropped.
+# def test_db_disk_setting_with_s3(start_cluster):
+#     db_name = f"db_test"
+    
+#     node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    
+#     node1.query(f"CREATE DATABASE {db_name} ENGINE= Atomic SETTINGS disk='db_disk'")
+#     node1.query(f"CREATE TABLE {db_name}.test (x INT) ENGINE=MergeTree ORDER BY x")
+    
+#     table_metadata_path = node1.query(
+#         f"SELECT metadata_path FROM system.tables WHERE database='{db_name}' AND table='test'"
+#     ).strip()
+    
+     
+#     print(f"table_metadata_path: {table_metadata_path}")
+    
+#     node1.stop_clickhouse()
+    
+#     # Update disk of the DB to 's3'
+#     replace_text_in_metadata(node1, "global_db_disk", f"metadata/{db_name}.sql", "db_disk", "s3")
+    
+#     # Copy the table metadata file into 's3' disk
+#     table_metadata_content = read_file(node1, "db_disk", table_metadata_path)
+#     print(f"table_metadata_content: {table_metadata_content}")
+#     write_to_file(node1, 's3', table_metadata_path, table_metadata_content)
+    
+#     # Remove metadata file on the DB disk
+#     remove_file(node1, "db_disk", table_metadata_path)
+    
+#     node1.start_clickhouse()
+    
+#     validate_db_path(node1, "s3", db_name, False)
+#     assert directory_exists(node1, "s3", table_metadata_path)
+    
+#     assert node1.query("SELECT count() FROM system.tables WHERE table='test'").strip() == "1"
+    
+#     node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `disk` setting for Atomic and Ordinary DB engines, specifying the disk to store table metadata files.

If `disk` is not specified, the configured database disk (`database_disk.disk`) is used by default.

Example usage:
```
CREATE DATABASE db ENGINE=Atomic SETTINGS disk=disk(type='local', path='/var/lib/clickhouse/disks/disk_db')
```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
