### PR TITLE
Avoid timeouts in 03207_json_read_subcolumns_2_compact_merge_tree test

### DIFF
--- a/tests/queries/0_stateless/03207_json_read_subcolumns_2_compact_merge_tree.sql.j2
+++ b/tests/queries/0_stateless/03207_json_read_subcolumns_2_compact_merge_tree.sql.j2
@@ -1,5 +1,5 @@
 -- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
--- Random settings limits: index_granularity=(1000, None), index_granularity_bytes=(100000, None)
+-- Random settings limits: index_granularity=(1000, None); index_granularity_bytes=(100000, None)
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;

--- a/tests/queries/0_stateless/03207_json_read_subcolumns_2_compact_merge_tree.sql.j2
+++ b/tests/queries/0_stateless/03207_json_read_subcolumns_2_compact_merge_tree.sql.j2
@@ -1,5 +1,5 @@
 -- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
--- Random settings limits: index_granularity=(1000, None)
+-- Random settings limits: index_granularity=(1000, None), index_granularity_bytes=(100000, None)
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/80342

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
