### PR TITLE
Update exponentialtimedecayedsum.md

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/exponentialtimedecayedsum.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/exponentialtimedecayedsum.md
@@ -23,7 +23,7 @@ exponentialTimeDecayedSum(x)(v, t)
 
 **Parameters**
 
-- `x` — Half-life period. [Integer](../../../sql-reference/data-types/int-uint.md), [Float](../../../sql-reference/data-types/float.md) or [Decimal](../../../sql-reference/data-types/decimal.md).
+- `x` — Time difference required for a value's weight to decay to 1/e. [Integer](../../../sql-reference/data-types/int-uint.md), [Float](../../../sql-reference/data-types/float.md) or [Decimal](../../../sql-reference/data-types/decimal.md).
 
 **Returned values**
 


### PR DESCRIPTION
```
DROP TABLE IF EXISTS test_data;
CREATE TABLE test_data (
    v Float32,
    t Int32
) ENGINE = Memory;
INSERT INTO test_data VALUES 
    (10, 0),
    (10, 1);
SELECT 
    round(decayed_sum, 1) AS rounded_sum
FROM (
    SELECT 
        exponentialTimeDecayedSum(1)(v, t) OVER (ORDER BY t ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS decayed_sum
    FROM test_data
);
```
The result is:
```
10
13.7
```
For the second line, we have: 13.7 = 10 + 10 × (1/e)^1.
So, `x` in `exponentialTimeDecayedSum(x)(v, t)` is not the half-life period, but the time constant for the weight to decay to 1/e.

### Changelog category (leave one):
- Documentation

