### PR TITLE
Fix docs for backup/restore query

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -24,8 +24,7 @@ title: 'Backup and Restore'
     [EXCEPT TABLES ...] |
   TEMPORARY TABLE table_name [AS table_name_in_backup] |
   VIEW view_name [AS view_name_in_backup]
-  ALL TEMPORARY TABLES [EXCEPT ...] |
-  ALL [EXCEPT ...] } [,...]
+  ALL [EXCEPT {TABLES|DATABASES}...] } [,...]
   [ON CLUSTER 'cluster_name']
   TO|FROM File('<path>/<filename>') | Disk('<disk_name>', '<path>/') | S3('<S3 endpoint>/<path>', '<Access key ID>', '<Secret access key>')
   [SETTINGS base_backup = File('<path>/<filename>') | Disk(...) | S3('<S3 endpoint>/<path>', '<Access key ID>', '<Secret access key>')]

--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -23,7 +23,7 @@ title: 'Backup and Restore'
   DATABASE database_name [AS database_name_in_backup]
     [EXCEPT TABLES ...] |
   TEMPORARY TABLE table_name [AS table_name_in_backup] |
-  VIEW view_name [AS view_name_in_backup]
+  VIEW view_name [AS view_name_in_backup] |
   ALL [EXCEPT {TABLES|DATABASES}...] } [,...]
   [ON CLUSTER 'cluster_name']
   TO|FROM File('<path>/<filename>') | Disk('<disk_name>', '<path>/') | S3('<S3 endpoint>/<path>', '<Access key ID>', '<Secret access key>')


### PR DESCRIPTION
The `ALL TEMPORARY TABLES` clause were removed in PR https://github.com/ClickHouse/ClickHouse/pull/37358. <!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
