### PR TITLE
Add 01825_type_json_10 to parallel replicas blacklist

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -568,6 +568,8 @@
     Failpoint
 02910_prefetch_unexpceted_exception
 
+    https://github.com/ClickHouse/ClickHouse/issues/80604 (Bad cast)
+01825_type_json_10
 
     investigate failed tests
 00148_monotonic_functions_and_index


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add 01825_type_json_10 to parallel replicas blacklist

References https://github.com/ClickHouse/ClickHouse/issues/80604

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
