### PR TITLE
ci: fix "Cannot parse input: expected '\n' before" in performance tests

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -165,6 +165,7 @@ class CHServer:
                 --profile-seconds 10 \
                 {test_file}",
             verbose=True,
+            strip=False,
         )
         duration = sw.duration
         if res != 0:

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -182,7 +182,7 @@ class Shell:
         return res.stdout.strip()
 
     @classmethod
-    def get_res_stdout_stderr(cls, command, verbose=True):
+    def get_res_stdout_stderr(cls, command, verbose=True, strip=True):
         if verbose:
             print(f"Run command [{command}]")
         res = subprocess.run(
@@ -192,7 +192,10 @@ class Shell:
             stderr=subprocess.PIPE,
             text=True,
         )
-        return res.returncode, res.stdout.strip(), res.stderr.strip()
+        if strip:
+            return res.returncode, res.stdout.strip(), res.stderr.strip()
+        else:
+            return res.returncode, res.stdout, res.stderr
 
     @classmethod
     def check(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Now non of `*-err.log`/`*-raw.tsv` contains empty trailing new line:

```
$ for i in *-err.log; do tail -1 $i | grep -zqP '\n' && echo $i; done | wc -l
0
$ for i in *-raw.tsv; do tail -1 $i | grep -zqP '\n' && echo $i; done | wc -l
0
```

This breaks the `compare.sh` that builds the report, since the result files may have overlapped lines - https://github.com/ClickHouse/ClickHouse/blob/1df1cc75408abbd5f5a1ea5fe222e99793b529f8/ci/jobs/scripts/perf/compare.sh#L422-L432

Fixes: https://github.com/ClickHouse/ClickHouse/issues/80588