### PR TITLE
cosmetics: simplify gin condition check

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1733,11 +1733,10 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
                 else
                 {
                     bool result = false;
-                    const auto * gin_filter_condition = dynamic_cast<const MergeTreeIndexConditionGin *>(&*condition);
-                    if (!gin_filter_condition)
-                        result = condition->mayBeTrueOnGranule(granule);
-                    else
+                    if (const auto * gin_filter_condition = dynamic_cast<const MergeTreeIndexConditionGin *>(&*condition))
                         result = cache_in_store.store ? gin_filter_condition->mayBeTrueOnGranuleInPart(granule, cache_in_store) : true;
+                    else
+                        result = condition->mayBeTrueOnGranule(granule);
 
                     if (!result)
                         continue;

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -249,18 +249,18 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
         throw Exception(ErrorCodes::LOGICAL_ERROR, "GinFilter index condition got a granule with the wrong type.");
 
     /// Check like in KeyCondition.
-    std::vector<BoolMask> rpn_stack;
+    std::vector<bool> rpn_stack;
     for (const auto & element : rpn)
     {
         if (element.function == RPNElement::FUNCTION_UNKNOWN)
         {
-            rpn_stack.emplace_back(true, true);
+            rpn_stack.emplace_back(true);
         }
         else if (element.function == RPNElement::FUNCTION_EQUALS
              || element.function == RPNElement::FUNCTION_NOT_EQUALS
              || element.function == RPNElement::FUNCTION_HAS)
         {
-            rpn_stack.emplace_back(granule->gin_filters[element.key_column].contains(*element.gin_filter, cache_store), true);
+            rpn_stack.emplace_back(granule->gin_filters[element.key_column].contains(*element.gin_filter, cache_store));
 
             if (element.function == RPNElement::FUNCTION_NOT_EQUALS)
                 rpn_stack.back() = !rpn_stack.back();
@@ -279,7 +279,7 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
                     result[row] = result[row] && granule->gin_filters[key_idx].contains(gin_filters[row], cache_store);
             }
 
-            rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
+            rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result));
             if (element.function == RPNElement::FUNCTION_NOT_IN)
                 rpn_stack.back() = !rpn_stack.back();
         }
@@ -292,7 +292,7 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
             for (size_t row = 0; row < gin_filters.size(); ++row)
                 result[row] = granule->gin_filters[element.key_column].contains(gin_filters[row], cache_store);
 
-            rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
+            rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result));
         }
         else if (element.function == RPNElement::FUNCTION_MATCH)
         {
@@ -306,11 +306,11 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
                 for (size_t row = 0; row < gin_filters.size(); ++row)
                     result[row] = granule->gin_filters[element.key_column].contains(gin_filters[row], cache_store);
 
-                rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
+                rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result));
             }
             else if (element.gin_filter)
             {
-                rpn_stack.emplace_back(granule->gin_filters[element.key_column].contains(*element.gin_filter, cache_store), true);
+                rpn_stack.emplace_back(granule->gin_filters[element.key_column].contains(*element.gin_filter, cache_store));
             }
 
         }
@@ -323,22 +323,22 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
             auto arg1 = rpn_stack.back();
             rpn_stack.pop_back();
             auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 & arg2;
+            rpn_stack.back() = arg1 && arg2;
         }
         else if (element.function == RPNElement::FUNCTION_OR)
         {
             auto arg1 = rpn_stack.back();
             rpn_stack.pop_back();
             auto arg2 = rpn_stack.back();
-            rpn_stack.back() = arg1 | arg2;
+            rpn_stack.back() = arg1 || arg2;
         }
         else if (element.function == RPNElement::ALWAYS_FALSE)
         {
-            rpn_stack.emplace_back(false, true);
+            rpn_stack.emplace_back(false);
         }
         else if (element.function == RPNElement::ALWAYS_TRUE)
         {
-            rpn_stack.emplace_back(true, false);
+            rpn_stack.emplace_back(true);
         }
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function type in GinFilterCondition::RPNElement");
@@ -347,7 +347,7 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
     if (rpn_stack.size() != 1)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected stack size in GinFilterCondition::mayBeTrueOnGranule");
 
-    return rpn_stack[0].can_be_true;
+    return rpn_stack[0];
 }
 
 bool MergeTreeIndexConditionGin::traverseAtomAST(const RPNBuilderTreeNode & node, RPNElement & out)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The condition that checks if we could use `gin_filter_condition` was unnecessarily difficult to read. The condition was as follows:
```cpp
const auto gin_filter_condition = /* dynamic casting */
if (gin_filter_condition == nullptr)
   // casting failed, use default impl
else
   // use gin_filter_condition specific impl
```
With this change:
```cpp

if (const auto gin_filter_condition = /* dynamic casting */)
   // casting succedded, use gin_filter_condition specific impl
else
   // use default impl
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
