### PR TITLE
clickhouse-test: fix invalid escape sequence '\{'

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -308,7 +308,7 @@ class SharedEngineReplacer:
                 # Replace table engines if echo enabled to match changed reference
                 if (
                     self.cloud or self.args.replace_log_memory_with_mergetree
-                ) and re.match("-- ?\{ ?echo.*", line):
+                ) and re.match("-- ?{ ?echo.*", line):
                     self.with_echo = True
 
                 if self.cloud and self.with_echo:


### PR DESCRIPTION
Before:

    $ ../tests/clickhouse-test 01610_client_editor
    /src/ch/clickhouse/.cmake/../tests/clickhouse-test:311: SyntaxWarning: invalid escape sequence '\{'
      ) and re.match("-- ?\{ ?echo.*", line):

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)