### PR TITLE
Fix flaky 00938_dataset_test

### DIFF
--- a/tests/queries/0_stateless/00938_dataset_test.sql
+++ b/tests/queries/0_stateless/00938_dataset_test.sql
@@ -13,7 +13,7 @@ DROP TABLE IF EXISTS model;
 create table model engine = Memory as select stochasticLinearRegressionState(0.03, 0.00001, 2, 'Momentum')(target, param1, param2) as state from defaults;
 
 select ans > -67.0 and ans < -66.9 from
-(with (select state + state + state from model) as model select evalMLMethod(model, predict1, predict2) as ans from defaults limit 1);
+(with (select state + state + state from model) as model select evalMLMethod(model, predict1, predict2) as ans from defaults order by all limit 1);
 
 DROP TABLE defaults;
 DROP TABLE model;


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=80251&sha=8f1d068132886f6f3d5778745e8260464a2b0d14&name_0=PR&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
