### PR TITLE
Avoid failure in 03040_dynamic_type_alters_2_wide_merge_tree test

### DIFF
--- a/tests/queries/0_stateless/03040_dynamic_type_alters_2_wide_merge_tree.sql
+++ b/tests/queries/0_stateless/03040_dynamic_type_alters_2_wide_merge_tree.sql
@@ -18,6 +18,7 @@ insert into test select number, number, number from numbers(3, 3);
 insert into test select number, number, 'str_' || toString(number) from numbers(6, 3);
 insert into test select number, number, NULL from numbers(9, 3);
 insert into test select number, number, multiIf(number % 3 == 0, number, number % 3 == 1, 'str_' || toString(number), NULL) from numbers(12, 3);
+optimize table test final;
 select count(), dynamicType(d) from test group by dynamicType(d) order by count(), dynamicType(d);
 select x, y, d, d.String, d.UInt64, d.Date, d.`Tuple(a UInt64)`.a from test order by x;
 
@@ -28,6 +29,7 @@ select x, y, d1, d1.String, d1.UInt64, d1.Date, d1.`Tuple(a UInt64)`.a from test
 
 select 'insert nested dynamic';
 insert into test select number, number, [number % 2 ? number : 'str_' || toString(number)]::Array(Dynamic) from numbers(15, 3);
+optimize table test final;
 select count(), dynamicType(d1) from test group by dynamicType(d1) order by count(), dynamicType(d1);
 select x, y, d1, d1.String, d1.UInt64, d1.Date, d1.`Tuple(a UInt64)`.a, d1.`Array(Dynamic)`.UInt64, d1.`Array(Dynamic)`.String, d1.`Array(Dynamic)`.Date from test order by x;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid this issue https://github.com/ClickHouse/ClickHouse/issues/80423#issuecomment-2897590879 in the test. The root cause is really complex to fix and we can do it later if we want.
Closes https://github.com/ClickHouse/ClickHouse/issues/80423#issuecomment-2897590879

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
