### PR TITLE
tests: fix flaky hms/glue/iceberg tests due to port overlaps

### DIFF
--- a/tests/integration/compose/docker_compose_glue_catalog.yml
+++ b/tests/integration/compose/docker_compose_glue_catalog.yml
@@ -23,8 +23,8 @@ services:
         aliases:
           - warehouse.minio
     ports:
-        - 9001:9001
-        - 9002:9000
+      - 9001
+      - 9000
     command: ["server", "/data", "--console-address", ":9001"]
   mc:
     depends_on:

--- a/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
@@ -45,8 +45,8 @@ services:
         aliases:
           - warehouse.minio
     ports:
-        - 9001:9001
-        - 9002:9000
+      - 9001
+      - 9000
     command: ["server", "/data", "--console-address", ":9001"]
 
   mc:

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -43,8 +43,8 @@ services:
         aliases:
           - warehouse.minio
     ports:
-        - 9001:9001
-        - 9002:9000
+      - 9001
+      - 9000
     command: ["server", "/data", "--console-address", ":9001"]
   mc:
     depends_on:

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -79,7 +79,7 @@ def load_catalog_impl(started_cluster):
             "type": "glue",
             "glue.endpoint": BASE_URL_LOCAL_HOST,
             "glue.region": "us-east-1",
-            "s3.endpoint": "http://localhost:9002",
+            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
             "s3.access-key-id": "minio",
             "s3.secret-access-key": "minio123",
         },
@@ -133,22 +133,6 @@ CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', 'minio123
 SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     """
     )
-
-
-def print_objects():
-    minio_client = Minio(
-        f"minio:9002",
-        access_key="minio",
-        secret_key="minio123",
-        secure=False,
-        http_client=urllib3.PoolManager(cert_reqs="CERT_NONE"),
-    )
-
-    objects = list(minio_client.list_objects("warehouse", "", recursive=True))
-    names = [x.object_name for x in objects]
-    names.sort()
-    for name in names:
-        print(f"Found object: {name}")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_database_hms/test.py
+++ b/tests/integration/test_database_hms/test.py
@@ -81,7 +81,7 @@ def load_catalog_impl(started_cluster):
         **{
             "uri": "thrift://0.0.0.0:9083",
             "type": "hive",
-            "s3.endpoint": f"http://localhost:9002",
+            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
             "s3.access-key-id": "minio",
             "s3.secret-access-key": "minio123",
         },
@@ -132,21 +132,6 @@ def create_clickhouse_iceberg_database(
     SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
         """
         )
-
-def print_objects():
-    minio_client = Minio(
-        f"localhost:9002",
-        access_key="minio",
-        secret_key="minio123",
-        secure=False,
-        http_client=urllib3.PoolManager(cert_reqs="CERT_NONE"),
-    )
-
-    objects = list(minio_client.list_objects("warehouse", "", recursive=True))
-    names = [x.object_name for x in objects]
-    names.sort()
-    for name in names:
-        print(f"Found object: {name}")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -85,7 +85,7 @@ def load_catalog_impl(started_cluster):
         **{
             "uri": BASE_URL_LOCAL_RAW,
             "type": "rest",
-            "s3.endpoint": f"http://localhost:9002",
+            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
             "s3.access-key-id": "minio",
             "s3.secret-access-key": "ClickHouse_Minio_P@ssw0rd",
         },
@@ -141,22 +141,6 @@ SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     show_result = node.query(f"SHOW DATABASE {name}")
     assert minio_secret_key not in show_result
     assert "HIDDEN" in show_result
-
-
-def print_objects():
-    minio_client = Minio(
-        f"localhost:9002",
-        access_key="minio",
-        secret_key=minio_secret_key,
-        secure=False,
-        http_client=urllib3.PoolManager(cert_reqs="CERT_NONE"),
-    )
-
-    objects = list(minio_client.list_objects("warehouse", "", recursive=True))
-    names = [x.object_name for x in objects]
-    names.sort()
-    for name in names:
-        print(f"Found object: {name}")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Error on CI:

```
Error response from daemon: driver failed programming external connectivity on endpoint roottestdatabaseglue-gw4-minio-1 (b83a8948c5086f61fdcef153729569e0afd6b799c0771a085f3e34d5eb44dc84): Bind for 0.0.0.0:9002 failed: port is already allocated
```

The problem is that MinIO host port is overlapped for Glue and Iceberg

**P.S. static ports is almost always a problem** (see also https://github.com/ClickHouse/ClickHouse/pull/53266)

Refs: https://github.com/ClickHouse/ClickHouse/issues/79719