### PR TITLE
Add _disk_name virtual column to MergeTree engine tables

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -974,6 +974,7 @@ ClickHouse versions 22.3 through 22.7 use a different cache configuration, see [
 - `_partition_value` — Values (a tuple) of a `partition by` expression.
 - `_sample_factor` — Sample factor (from the query).
 - `_block_number` — Block number of the row, it is persisted on merges when `allow_experimental_block_number_column` is set to true.
+- `_disk_name` — Disk name used for the storage.
 
 ## Column Statistics {#column-statistics}
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -603,6 +603,7 @@ VirtualColumnsDescription MergeTreeData::createVirtuals(const StorageInMemoryMet
     desc.addEphemeral("_sample_factor", std::make_shared<DataTypeFloat64>(), "Sample factor (from the query)");
     desc.addEphemeral("_part_offset", std::make_shared<DataTypeUInt64>(), "Number of row in the part");
     desc.addEphemeral("_part_data_version", std::make_shared<DataTypeUInt64>(), "Data version of part (either min block number or mutation version)");
+    desc.addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name");
 
     if (metadata.hasPartitionKey())
     {
@@ -627,6 +628,7 @@ VirtualColumnsDescription MergeTreeData::createProjectionVirtuals(const StorageI
     desc.addEphemeral("_part_uuid", std::make_shared<DataTypeUUID>(), "Unique part identifier (if enabled MergeTree setting assign_part_uuids)");
     desc.addEphemeral("_partition_id", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of partition");
     desc.addEphemeral("_part_data_version", std::make_shared<DataTypeUInt64>(), "Data version of part (either min block number or mutation version)");
+    desc.addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name");
 
     if (metadata.hasPartitionKey())
     {
@@ -1362,7 +1364,7 @@ void MergeTreeData::MergingParams::check(const MergeTreeSettings & settings, con
     /// TODO Checks for Graphite mode.
 }
 
-const Names MergeTreeData::virtuals_useful_for_filter = {"_part", "_partition_id", "_part_uuid", "_partition_value", "_part_data_version"};
+const Names MergeTreeData::virtuals_useful_for_filter = {"_part", "_partition_id", "_part_uuid", "_partition_value", "_part_data_version", "_disk_name"};
 
 Block MergeTreeData::getHeaderWithVirtualsForFilter(const StorageMetadataPtr & metadata) const
 {

--- a/src/Storages/MergeTree/MergeTreeVirtualColumns.cpp
+++ b/src/Storages/MergeTree/MergeTreeVirtualColumns.cpp
@@ -55,6 +55,9 @@ Field getFieldForConstVirtualColumn(const String & column_name, const IMergeTree
     if (column_name == "_partition_value")
         return Tuple(part.partition.value.begin(), part.partition.value.end());
 
+    if (column_name == "_disk_name")
+        return part.getDataPartStorage().getDiskName();
+
     throw Exception(ErrorCodes::NO_SUCH_COLUMN_IN_TABLE, "Unexpected const virtual column: {}", column_name);
 }
 

--- a/tests/integration/test_disk_name_virtual_column/configs/config.xml
+++ b/tests/integration/test_disk_name_virtual_column/configs/config.xml
@@ -23,15 +23,27 @@
             </disk_local3>
         </disks>
         <policies>
-            <default>
+            <disk_local1>
                 <volumes>
                     <main>
                         <disk>disk_local1</disk>
+                    </main>
+                </volumes>
+            </disk_local1>
+            <disk_local2>
+                <volumes>
+                    <main>
                         <disk>disk_local2</disk>
+                    </main>
+                </volumes>
+            </disk_local2>
+            <disk_local3>
+                <volumes>
+                    <main>
                         <disk>disk_local3</disk>
                     </main>
                 </volumes>
-            </default>
+            </disk_local3>
         </policies>
     </storage_configuration>
 

--- a/tests/integration/test_disk_name_virtual_column/configs/config.xml
+++ b/tests/integration/test_disk_name_virtual_column/configs/config.xml
@@ -1,0 +1,45 @@
+<clickhouse>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+    </logger>
+
+    <storage_configuration>
+        <disks>
+            <disk_local1>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disk1/</path>
+            </disk_local1>
+            <disk_local2>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disk2/</path>
+            </disk_local2>
+            <disk_local3>
+                <type>local</type>
+                <path>/var/lib/clickhouse/disk3/</path>
+            </disk_local3>
+        </disks>
+        <policies>
+            <default>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                        <disk>disk_local1</disk>
+                        <disk>disk_local2</disk>
+                        <disk>disk_local3</disk>
+                    </main>
+                </volumes>
+            </default>
+        </policies>
+    </storage_configuration>
+
+    <tcp_port>9000</tcp_port>
+    <listen_host>127.0.0.1</listen_host>
+
+    <max_concurrent_queries>500</max_concurrent_queries>
+    <path>./clickhouse/</path>
+    <users_config>users.xml</users_config>
+</clickhouse>

--- a/tests/integration/test_disk_name_virtual_column/configs/config.xml
+++ b/tests/integration/test_disk_name_virtual_column/configs/config.xml
@@ -26,7 +26,6 @@
             <default>
                 <volumes>
                     <main>
-                        <disk>default</disk>
                         <disk>disk_local1</disk>
                         <disk>disk_local2</disk>
                         <disk>disk_local3</disk>
@@ -35,9 +34,6 @@
             </default>
         </policies>
     </storage_configuration>
-
-    <tcp_port>9000</tcp_port>
-    <listen_host>127.0.0.1</listen_host>
 
     <max_concurrent_queries>500</max_concurrent_queries>
     <path>./clickhouse/</path>

--- a/tests/integration/test_disk_name_virtual_column/configs/users.xml
+++ b/tests/integration/test_disk_name_virtual_column/configs/users.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</clickhouse>

--- a/tests/integration/test_disk_name_virtual_column/test.py
+++ b/tests/integration/test_disk_name_virtual_column/test.py
@@ -1,10 +1,8 @@
 import pytest
 
-from helpers.cluster import ClickHouseCluster, is_arm
-from helpers.test_tools import TSV
+from helpers.cluster import ClickHouseCluster
 
 disk_types = {
-    "default": "Local",
     "disk_local1": "Local",
     "disk_local2": "Local",
     "disk_local3": "Local",
@@ -30,46 +28,6 @@ def cluster():
         cluster.shutdown()
 
 
-def test_disk_name_virtual_column_basic(cluster):
-    node = cluster.instances["node"]
-    
-    # Create a table with storage policy
-    node.query("""
-        CREATE TABLE test_disk_name (
-            id UInt32,
-            value String
-        ) ENGINE = MergeTree()
-        ORDER BY id
-        SETTINGS storage_policy = 'default'
-    """)
-    
-    try:
-        # Insert some data
-        node.query("INSERT INTO test_disk_name VALUES (1, 'test1'), (2, 'test2')")
-        
-        # Verify data is on default disk
-        result = node.query("SELECT id, value, _disk_name FROM test_disk_name ORDER BY id")
-        assert result == "1\ttest1\tdefault\n2\ttest2\tdefault\n"
-        
-        # Move data to local disk 1
-        node.query("ALTER TABLE test_disk_name MOVE PARTITION tuple() TO DISK 'disk_local1'")
-        
-        # Verify data is now on local disk 1
-        result = node.query("SELECT id, value, _disk_name FROM test_disk_name ORDER BY id")
-        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local1\n"
-        
-        # Test filtering by _disk_name
-        result = node.query("SELECT id, value FROM test_disk_name WHERE _disk_name = 'disk_local1' ORDER BY id")
-        assert result == "1\ttest1\n2\ttest2\n"
-        
-        # Test filtering with non-matching disk name
-        result = node.query("SELECT id, value FROM test_disk_name WHERE _disk_name = 'default' ORDER BY id")
-        assert result == ""
-        
-    finally:
-        node.query("DROP TABLE IF EXISTS test_disk_name")
-
-
 def test_disk_name_virtual_column_multiple_disks(cluster):
     node = cluster.instances["node"]
     
@@ -87,73 +45,25 @@ def test_disk_name_virtual_column_multiple_disks(cluster):
     try:
         # Insert data in multiple parts
         node.query("INSERT INTO test_disk_name_multi VALUES (1, 'test1'), (2, 'test2')")
-        node.query("INSERT INTO test_disk_name_multi VALUES (3, 'test3'), (4, 'test4')")
         
         # Move first part to local disk 1
-        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 1 TO DISK 'disk_local1'")
+        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 1 TO DISK 'disk_local2'")
         
         # Move second part to local disk 2
-        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 3 TO DISK 'disk_local2'")
+        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 2 TO DISK 'disk_local3'")
         
         # Verify data is distributed across disks
         result = node.query("SELECT id, value, _disk_name FROM test_disk_name_multi ORDER BY id")
-        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local1\n3\ttest3\tdisk_local2\n4\ttest4\tdisk_local2\n"
+        assert result == "1\ttest1\tdisk_local2\n2\ttest2\tdisk_local3\n"
         
-        # Test filtering by _disk_name for local disk 1
         result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local1' ORDER BY id")
-        assert result == "1\ttest1\n2\ttest2\n"
-        
-        # Test filtering by _disk_name for local disk 2
-        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local2' ORDER BY id")
-        assert result == "3\ttest3\n4\ttest4\n"
-        
-        # Test filtering with non-matching disk name
-        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local3' ORDER BY id")
         assert result == ""
+        
+        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local2' ORDER BY id")
+        assert result == "1\ttest1\n"
+        
+        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local3' ORDER BY id")
+        assert result == "2\ttest2\n"
         
     finally:
         node.query("DROP TABLE IF EXISTS test_disk_name_multi")
-
-
-def test_disk_name_virtual_column_all_disks(cluster):
-    node = cluster.instances["node"]
-    
-    # Create a table with storage policy
-    node.query("""
-        CREATE TABLE test_disk_name_all (
-            id UInt32,
-            value String
-        ) ENGINE = MergeTree()
-        ORDER BY id
-        PARTITION by id
-        SETTINGS storage_policy = 'default'
-    """)
-    
-    try:
-        # Insert data in multiple parts
-        node.query("INSERT INTO test_disk_name_all VALUES (1, 'test1')")
-        node.query("INSERT INTO test_disk_name_all VALUES (2, 'test2')")
-        node.query("INSERT INTO test_disk_name_all VALUES (3, 'test3')")
-        node.query("INSERT INTO test_disk_name_all VALUES (4, 'test4')")
-        
-        # Move data to different local disks
-        node.query("ALTER TABLE test_disk_name_all MOVE PARTITION 1 TO DISK 'disk_local1'")
-        node.query("ALTER TABLE test_disk_name_all MOVE PARTITION 2 TO DISK 'disk_local2'")
-        node.query("ALTER TABLE test_disk_name_all MOVE PARTITION 3 TO DISK 'disk_local3'")
-        # Leave partition 4 on default disk
-        
-        # Verify data is distributed across all disks
-        result = node.query("SELECT id, value, _disk_name FROM test_disk_name_all ORDER BY id")
-        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local2\n3\ttest3\tdisk_local3\n4\ttest4\tdefault\n"
-        
-        # Test filtering for each disk
-        for disk in ['default', 'disk_local1', 'disk_local2', 'disk_local3']:
-            result = node.query(f"SELECT id, value FROM test_disk_name_all WHERE _disk_name = '{disk}' ORDER BY id")
-            if disk == 'default':
-                assert result == "4\ttest4\n"
-            else:
-                disk_num = disk[-1]  # Get the number from disk name
-                assert result == f"{disk_num}\ttest{disk_num}\n"
-        
-    finally:
-        node.query("DROP TABLE IF EXISTS test_disk_name_all")

--- a/tests/integration/test_disk_name_virtual_column/test.py
+++ b/tests/integration/test_disk_name_virtual_column/test.py
@@ -30,40 +30,42 @@ def cluster():
 
 def test_disk_name_virtual_column_multiple_disks(cluster):
     node = cluster.instances["node"]
-    
-    # Create a table with storage policy
-    node.query("""
-        CREATE TABLE test_disk_name_multi (
+
+    create_query_statement = """
+        CREATE TABLE test_disk_name_multi{disk_number} (
             id UInt32,
             value String
         ) ENGINE = MergeTree()
         ORDER BY id
         PARTITION by id
-        SETTINGS storage_policy = 'default'
-    """)
-    
+        SETTINGS storage_policy = 'disk_local{disk_number}'
+    """
+
+    # Create one table for each storage policy
+    node.query(create_query_statement.format(disk_number="1"))
+    node.query(create_query_statement.format(disk_number="2"))
+    node.query(create_query_statement.format(disk_number="3"))
+
     try:
-        # Insert data in multiple parts
-        node.query("INSERT INTO test_disk_name_multi VALUES (1, 'test1'), (2, 'test2')")
-        
-        # Move first part to local disk 1
-        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 1 TO DISK 'disk_local2'")
-        
-        # Move second part to local disk 2
-        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 2 TO DISK 'disk_local3'")
-        
-        # Verify data is distributed across disks
-        result = node.query("SELECT id, value, _disk_name FROM test_disk_name_multi ORDER BY id")
-        assert result == "1\ttest1\tdisk_local2\n2\ttest2\tdisk_local3\n"
-        
-        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local1' ORDER BY id")
-        assert result == ""
-        
-        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local2' ORDER BY id")
+        # Insert data into each table
+        node.query("INSERT INTO test_disk_name_multi1 VALUES (1, 'test1')")
+        node.query("INSERT INTO test_disk_name_multi2 VALUES (2, 'test2')")
+        node.query("INSERT INTO test_disk_name_multi3 VALUES (3, 'test3')")
+
+        # Verify data is distributed across tables and disks
+        result = node.query("SELECT id, value, _disk_name FROM merge('default', '^test_disk_name_multi') ORDER BY id")
+        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local2\n3\ttest3\tdisk_local3\n"
+
+        result = node.query("SELECT id, value FROM test_disk_name_multi1 WHERE _disk_name = 'disk_local1' ORDER BY id")
         assert result == "1\ttest1\n"
-        
-        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local3' ORDER BY id")
+
+        result = node.query("SELECT id, value FROM test_disk_name_multi2 WHERE _disk_name = 'disk_local2' ORDER BY id")
         assert result == "2\ttest2\n"
-        
+
+        result = node.query("SELECT id, value FROM test_disk_name_multi3 WHERE _disk_name = 'disk_local3' ORDER BY id")
+        assert result == "3\ttest3\n"
+
     finally:
-        node.query("DROP TABLE IF EXISTS test_disk_name_multi")
+        node.query("DROP TABLE IF EXISTS test_disk_name_multi1")
+        node.query("DROP TABLE IF EXISTS test_disk_name_multi2")
+        node.query("DROP TABLE IF EXISTS test_disk_name_multi3")

--- a/tests/integration/test_disk_name_virtual_column/test.py
+++ b/tests/integration/test_disk_name_virtual_column/test.py
@@ -1,0 +1,159 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.test_tools import TSV
+
+disk_types = {
+    "default": "Local",
+    "disk_local1": "Local",
+    "disk_local2": "Local",
+    "disk_local3": "Local",
+}
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node",
+            main_configs=(
+                ["configs/config.xml"]
+            ),
+            with_minio=False,
+            with_remote_database_disk=False,
+        )
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_disk_name_virtual_column_basic(cluster):
+    node = cluster.instances["node"]
+    
+    # Create a table with storage policy
+    node.query("""
+        CREATE TABLE test_disk_name (
+            id UInt32,
+            value String
+        ) ENGINE = MergeTree()
+        ORDER BY id
+        SETTINGS storage_policy = 'default'
+    """)
+    
+    try:
+        # Insert some data
+        node.query("INSERT INTO test_disk_name VALUES (1, 'test1'), (2, 'test2')")
+        
+        # Verify data is on default disk
+        result = node.query("SELECT id, value, _disk_name FROM test_disk_name ORDER BY id")
+        assert result == "1\ttest1\tdefault\n2\ttest2\tdefault\n"
+        
+        # Move data to local disk 1
+        node.query("ALTER TABLE test_disk_name MOVE PARTITION tuple() TO DISK 'disk_local1'")
+        
+        # Verify data is now on local disk 1
+        result = node.query("SELECT id, value, _disk_name FROM test_disk_name ORDER BY id")
+        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local1\n"
+        
+        # Test filtering by _disk_name
+        result = node.query("SELECT id, value FROM test_disk_name WHERE _disk_name = 'disk_local1' ORDER BY id")
+        assert result == "1\ttest1\n2\ttest2\n"
+        
+        # Test filtering with non-matching disk name
+        result = node.query("SELECT id, value FROM test_disk_name WHERE _disk_name = 'default' ORDER BY id")
+        assert result == ""
+        
+    finally:
+        node.query("DROP TABLE IF EXISTS test_disk_name")
+
+
+def test_disk_name_virtual_column_multiple_disks(cluster):
+    node = cluster.instances["node"]
+    
+    # Create a table with storage policy
+    node.query("""
+        CREATE TABLE test_disk_name_multi (
+            id UInt32,
+            value String
+        ) ENGINE = MergeTree()
+        ORDER BY id
+        PARTITION by id
+        SETTINGS storage_policy = 'default'
+    """)
+    
+    try:
+        # Insert data in multiple parts
+        node.query("INSERT INTO test_disk_name_multi VALUES (1, 'test1'), (2, 'test2')")
+        node.query("INSERT INTO test_disk_name_multi VALUES (3, 'test3'), (4, 'test4')")
+        
+        # Move first part to local disk 1
+        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 1 TO DISK 'disk_local1'")
+        
+        # Move second part to local disk 2
+        node.query("ALTER TABLE test_disk_name_multi MOVE PARTITION 3 TO DISK 'disk_local2'")
+        
+        # Verify data is distributed across disks
+        result = node.query("SELECT id, value, _disk_name FROM test_disk_name_multi ORDER BY id")
+        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local1\n3\ttest3\tdisk_local2\n4\ttest4\tdisk_local2\n"
+        
+        # Test filtering by _disk_name for local disk 1
+        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local1' ORDER BY id")
+        assert result == "1\ttest1\n2\ttest2\n"
+        
+        # Test filtering by _disk_name for local disk 2
+        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local2' ORDER BY id")
+        assert result == "3\ttest3\n4\ttest4\n"
+        
+        # Test filtering with non-matching disk name
+        result = node.query("SELECT id, value FROM test_disk_name_multi WHERE _disk_name = 'disk_local3' ORDER BY id")
+        assert result == ""
+        
+    finally:
+        node.query("DROP TABLE IF EXISTS test_disk_name_multi")
+
+
+def test_disk_name_virtual_column_all_disks(cluster):
+    node = cluster.instances["node"]
+    
+    # Create a table with storage policy
+    node.query("""
+        CREATE TABLE test_disk_name_all (
+            id UInt32,
+            value String
+        ) ENGINE = MergeTree()
+        ORDER BY id
+        PARTITION by id
+        SETTINGS storage_policy = 'default'
+    """)
+    
+    try:
+        # Insert data in multiple parts
+        node.query("INSERT INTO test_disk_name_all VALUES (1, 'test1')")
+        node.query("INSERT INTO test_disk_name_all VALUES (2, 'test2')")
+        node.query("INSERT INTO test_disk_name_all VALUES (3, 'test3')")
+        node.query("INSERT INTO test_disk_name_all VALUES (4, 'test4')")
+        
+        # Move data to different local disks
+        node.query("ALTER TABLE test_disk_name_all MOVE PARTITION 1 TO DISK 'disk_local1'")
+        node.query("ALTER TABLE test_disk_name_all MOVE PARTITION 2 TO DISK 'disk_local2'")
+        node.query("ALTER TABLE test_disk_name_all MOVE PARTITION 3 TO DISK 'disk_local3'")
+        # Leave partition 4 on default disk
+        
+        # Verify data is distributed across all disks
+        result = node.query("SELECT id, value, _disk_name FROM test_disk_name_all ORDER BY id")
+        assert result == "1\ttest1\tdisk_local1\n2\ttest2\tdisk_local2\n3\ttest3\tdisk_local3\n4\ttest4\tdefault\n"
+        
+        # Test filtering for each disk
+        for disk in ['default', 'disk_local1', 'disk_local2', 'disk_local3']:
+            result = node.query(f"SELECT id, value FROM test_disk_name_all WHERE _disk_name = '{disk}' ORDER BY id")
+            if disk == 'default':
+                assert result == "4\ttest4\n"
+            else:
+                disk_num = disk[-1]  # Get the number from disk name
+                assert result == f"{disk_num}\ttest{disk_num}\n"
+        
+    finally:
+        node.query("DROP TABLE IF EXISTS test_disk_name_all")

--- a/tests/queries/0_stateless/02890_describe_table_options.reference
+++ b/tests/queries/0_stateless/02890_describe_table_options.reference
@@ -37,6 +37,7 @@ _partition_id	LowCardinality(String)			Name of partition			1
 _sample_factor	Float64			Sample factor (from the query)			1
 _part_offset	UInt64			Number of row in the part			1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			1
+_disk_name	LowCardinality(String)			Disk name			1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			1
 _block_number	UInt64			Persisted original number of block that was assigned at insert	Delta, LZ4		1
 _block_offset	UInt64			Persisted original number of row in block that was assigned at insert	Delta, LZ4		1
@@ -52,6 +53,7 @@ _partition_id	LowCardinality(String)			Name of partition			1
 _sample_factor	Float64			Sample factor (from the query)			1
 _part_offset	UInt64			Number of row in the part			1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			1
+_disk_name	LowCardinality(String)			Disk name			1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			1
 _block_number	UInt64			Persisted original number of block that was assigned at insert	Delta, LZ4		1
 _block_offset	UInt64			Persisted original number of row in block that was assigned at insert	Delta, LZ4		1
@@ -71,6 +73,7 @@ _partition_id	LowCardinality(String)			Name of partition			0	1
 _sample_factor	Float64			Sample factor (from the query)			0	1
 _part_offset	UInt64			Number of row in the part			0	1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			0	1
+_disk_name	LowCardinality(String)			Disk name			0	1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			0	1
 _block_number	UInt64			Persisted original number of block that was assigned at insert	Delta, LZ4		0	1
 _block_offset	UInt64			Persisted original number of row in block that was assigned at insert	Delta, LZ4		0	1
@@ -89,6 +92,7 @@ _partition_id	LowCardinality(String)			Name of partition			0	1
 _sample_factor	Float64			Sample factor (from the query)			0	1
 _part_offset	UInt64			Number of row in the part			0	1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			0	1
+_disk_name	LowCardinality(String)			Disk name			0	1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			0	1
 _block_number	UInt64			Persisted original number of block that was assigned at insert	Delta, LZ4		0	1
 _block_offset	UInt64			Persisted original number of row in block that was assigned at insert	Delta, LZ4		0	1
@@ -135,6 +139,7 @@ _partition_id	LowCardinality(String)	1
 _sample_factor	Float64	1
 _part_offset	UInt64	1
 _part_data_version	UInt64	1
+_disk_name	LowCardinality(String)	1
 _row_exists	UInt8	1
 _block_number	UInt64	1
 _block_offset	UInt64	1
@@ -150,6 +155,7 @@ _partition_id	LowCardinality(String)	1
 _sample_factor	Float64	1
 _part_offset	UInt64	1
 _part_data_version	UInt64	1
+_disk_name	LowCardinality(String)	1
 _row_exists	UInt8	1
 _block_number	UInt64	1
 _block_offset	UInt64	1
@@ -169,6 +175,7 @@ _partition_id	LowCardinality(String)	0	1
 _sample_factor	Float64	0	1
 _part_offset	UInt64	0	1
 _part_data_version	UInt64	0	1
+_disk_name	LowCardinality(String)	0	1
 _row_exists	UInt8	0	1
 _block_number	UInt64	0	1
 _block_offset	UInt64	0	1
@@ -187,6 +194,7 @@ _partition_id	LowCardinality(String)	0	1
 _sample_factor	Float64	0	1
 _part_offset	UInt64	0	1
 _part_data_version	UInt64	0	1
+_disk_name	LowCardinality(String)	0	1
 _row_exists	UInt8	0	1
 _block_number	UInt64	0	1
 _block_offset	UInt64	0	1


### PR DESCRIPTION
Q: new to this repo, where is a relevant place for tests?

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow filtering parts selected for query by the disk they reside on

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

If you wish to scope a query to only parts that are on a local disk and ignore parts on remote storage, or only query parts on remote storage and ignore parts on local.

- Example use: A query or command.
`SELECT DISTINCT _disk_name FROM events;`
`SELECT * FROM events WHERE _disk_name = 'ssd'`
