### PR TITLE
Add correct introduced_in info to base32 functions

### DIFF
--- a/src/Functions/base32Decode.cpp
+++ b/src/Functions/base32Decode.cpp
@@ -28,6 +28,7 @@ Decode a [Base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded string.
             {"empty_string", "SELECT base32Decode('')", ""},
             {"non_ascii", "SELECT hex(base32Decode('4W2HIXV4'))", "E5B4745EBC"},
         },
+        .introduced_in = {25, 5},
         .category = FunctionDocumentation::Category::String});
 }
 }

--- a/src/Functions/base32Encode.cpp
+++ b/src/Functions/base32Encode.cpp
@@ -26,6 +26,7 @@ Encode a string with [Base32](https://datatracker.ietf.org/doc/html/rfc4648) enc
             {"simple_encoding1", "SELECT base32Encode('a')", "ME======"},
             {"simple_encoding2", "SELECT base32Encode('Hello')", "JBSWY3DP"}
         },
+        .introduced_in = {25, 5},
         .category = FunctionDocumentation::Category::String});
 }
 }

--- a/src/Functions/tryBase32Decode.cpp
+++ b/src/Functions/tryBase32Decode.cpp
@@ -30,6 +30,7 @@ Decode a [Base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded string.
             {"empty_string", "SELECT tryBase32Decode('')", ""},
             {"non_base32_characters", "SELECT tryBase32Decode('12345')", ""},
         },
+        .introduced_in = {25, 5},
         .category = FunctionDocumentation::Category::String});
 }
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -131,8 +131,6 @@ atan
 atan2
 atanh
 bar
-base32Decode
-base32Encode
 base58Decode
 base58Encode
 basename
@@ -1002,7 +1000,6 @@ trimBoth
 trimLeft
 trimRight
 trunc
-tryBase32Decode
 tryBase58Decode
 tumble
 tumbleEnd


### PR DESCRIPTION
When adding base32 functions (#79809) I didn't correctly add the version information. They became available in 25.5.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
