### PR TITLE
Bug fix + changes in `extractKeyValuePairs` parsing logic

### DIFF
--- a/docs/en/sql-reference/functions/tuple-map-functions.md
+++ b/docs/en/sql-reference/functions/tuple-map-functions.md
@@ -124,7 +124,7 @@ Keys and values can be quoted.
 **Syntax**
 
 ```sql
-extractKeyValuePairs(data[, key_value_delimiter[, pair_delimiter[, quoting_character]]])
+extractKeyValuePairs(data[, key_value_delimiter[, pair_delimiter[, quoting_character[, unexpected_quoting_character_strategy]]])
 ```
 
 Alias:
@@ -137,6 +137,7 @@ Alias:
 - `key_value_delimiter` - Single character delimiting keys and values. Defaults to `:`. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
 - `pair_delimiters` - Set of character delimiting pairs. Defaults to ` `, `,` and `;`. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
 - `quoting_character` - Single character used as quoting character. Defaults to `"`. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
+- `unexpected_quoting_character_strategy` - Strategy to handle quoting characters in unexpected places during `read_key` and `read_value` phase. Possible values: "invalid", "accept" and "promote". Invalid will discard key/value and transition back to `WAITING_KEY` state. Accept will treat it as a normal character. Promote will transition to `READ_QUOTED_{KEY/VALUE}` state and start from next character.
 
 **Returned values**
 
@@ -170,6 +171,74 @@ Result:
 ┌─kv───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ {'name':'neymar','age':'31','team':'psg','nationality':'brazil','last_key':'last_value'}                                 │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+unexpected_quoting_character_strategy examples:
+
+unexpected_quoting_character_strategy=invalid
+
+```sql
+SELECT extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'INVALID') as kv;
+```
+
+```text
+┌─kv────────────────┐
+│ {'abc':'5'}  │
+└───────────────────┘
+```
+
+```sql
+SELECT extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'INVALID') as kv;
+```
+
+```text
+┌─kv──┐
+│ {}  │
+└─────┘
+```
+
+unexpected_quoting_character_strategy=accept
+
+```sql
+SELECT extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'ACCEPT') as kv;
+```
+
+```text
+┌─kv────────────────┐
+│ {'name"abc':'5'}  │
+└───────────────────┘
+```
+
+```sql
+SELECT extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'ACCEPT') as kv;
+```
+
+```text
+┌─kv─────────────────┐
+│ {'name"abc"':'5'}  │
+└────────────────────┘
+```
+
+unexpected_quoting_character_strategy=promote
+
+```sql
+SELECT extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'PROMOTE') as kv;
+```
+
+```text
+┌─kv──┐
+│ {}  │
+└─────┘
+```
+
+```sql
+SELECT extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'PROMOTE') as kv;
+```
+
+```text
+┌─kv───────────┐
+│ {'abc':'5'}  │
+└──────────────┘
 ```
 
 Escape sequences without escape sequences support:

--- a/src/Functions/extractKeyValuePairs.cpp
+++ b/src/Functions/extractKeyValuePairs.cpp
@@ -176,7 +176,7 @@ REGISTER_FUNCTION(ExtractKeyValuePairs)
             - `key_value_delimiter` - Character to be used as delimiter between the key and the value. Defaults to `:`. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
             - `pair_delimiters` - Set of character to be used as delimiters between pairs. Defaults to `\space`, `,` and `;`. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
             - `quoting_character` - Character to be used as quoting character. Defaults to `"`. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
-            - `unexpected_quoting_character_strategy` - Strategy to handle quoting characters in unexpected places during `read_key` and `read_value` phase. Possible values: "invalid", "accept" and "promote". Invalid will discard key/value and transition back to `WAITING_KEY` state. Accept will treat it as a normal character. Promote will transition to `READ_QUOTED_{KEY/VALUE}` state and start from next character.
+            - `unexpected_quoting_character_strategy` - Strategy to handle quoting characters in unexpected places during `read_key` and `read_value` phase. Possible values: `invalid`, `accept` and `promote`. Invalid will discard key/value and transition back to `WAITING_KEY` state. Accept will treat it as a normal character. Promote will transition to `READ_QUOTED_{KEY/VALUE}` state and start from next character. The default value is `INVALID`
 
             **Returned values**
             - The extracted key-value pairs in a Map(String, String).

--- a/src/Functions/keyvaluepair/ArgumentExtractor.cpp
+++ b/src/Functions/keyvaluepair/ArgumentExtractor.cpp
@@ -71,7 +71,7 @@ ArgumentExtractor::ParsedArguments ArgumentExtractor::extract(ColumnsWithTypeAnd
             data_column,
             key_value_delimiter,
             pair_delimiters,
-            quoting_character,
+            quoting_character
         };
     }
 

--- a/src/Functions/keyvaluepair/ArgumentExtractor.cpp
+++ b/src/Functions/keyvaluepair/ArgumentExtractor.cpp
@@ -31,7 +31,7 @@ ArgumentExtractor::ParsedArguments ArgumentExtractor::extract(const ColumnsWithT
 
 ArgumentExtractor::ParsedArguments ArgumentExtractor::extract(ColumnsWithTypeAndNameList arguments)
 {
-    static constexpr auto MAX_NUMBER_OF_ARGUMENTS = 4u;
+    static constexpr auto MAX_NUMBER_OF_ARGUMENTS = 5u;
 
     if (arguments.empty() || arguments.size() > MAX_NUMBER_OF_ARGUMENTS)
     {
@@ -65,11 +65,24 @@ ArgumentExtractor::ParsedArguments ArgumentExtractor::extract(ColumnsWithTypeAnd
 
     auto quoting_character = extractSingleCharacter(popFrontAndGet(arguments), "quoting_character");
 
+    if (arguments.empty())
+    {
+        return ParsedArguments {
+            data_column,
+            key_value_delimiter,
+            pair_delimiters,
+            quoting_character,
+        };
+    }
+
+    auto unexpected_quoting_character_strategy = extractStringColumn(popFrontAndGet(arguments), "unexpected_quoting_character_strategy");
+
     return ParsedArguments {
         data_column,
         key_value_delimiter,
         pair_delimiters,
         quoting_character,
+        unexpected_quoting_character_strategy
     };
 }
 

--- a/src/Functions/keyvaluepair/ArgumentExtractor.h
+++ b/src/Functions/keyvaluepair/ArgumentExtractor.h
@@ -30,6 +30,7 @@ public:
         CharArgument key_value_delimiter = {};
         VectorArgument pair_delimiters = {};
         CharArgument quoting_character = {};
+        ColumnPtr unexpected_quoting_character_strategy = nullptr;
     };
 
 

--- a/src/Functions/keyvaluepair/impl/CHKeyValuePairExtractor.h
+++ b/src/Functions/keyvaluepair/impl/CHKeyValuePairExtractor.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Columns/ColumnMap.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 
@@ -67,6 +66,16 @@ protected:
     }
 
 private:
+    void incrementRowOffset(uint64_t & row_offset)
+    {
+        row_offset++;
+
+        if (row_offset > max_number_of_pairs)
+        {
+            throw Exception(ErrorCodes::LIMIT_EXCEEDED, "Number of pairs produced exceeded the limit of {}", max_number_of_pairs);
+        }
+    }
+
     NextState processState(std::string_view file, State state, auto & pair_writer, uint64_t & row_offset)
     {
         switch (state)
@@ -101,28 +110,23 @@ private:
             }
             case State::FLUSH_PAIR:
             {
-                return flushPair(file, pair_writer, row_offset);
+                incrementRowOffset(row_offset);
+                return state_handler.flushPair(file, pair_writer);
+            }
+            case State::FLUSH_PAIR_AFTER_QUOTED_VALUE:
+            {
+                incrementRowOffset(row_offset);
+                return state_handler.flushPairAfterQuotedValue(file, pair_writer);
+            }
+            case State::WAITING_PAIR_DELIMITER:
+            {
+                return state_handler.waitPairDelimiter(file);
             }
             case State::END:
             {
                 return {0, state};
             }
         }
-    }
-
-    NextState flushPair(const std::string_view & file, auto & pair_writer, uint64_t & row_offset)
-    {
-        row_offset++;
-
-        if (row_offset > max_number_of_pairs)
-        {
-            throw Exception(ErrorCodes::LIMIT_EXCEEDED, "Number of pairs produced exceeded the limit of {}", max_number_of_pairs);
-        }
-
-        pair_writer.commitKey();
-        pair_writer.commitValue();
-
-        return {0, file.empty() ? State::END : State::WAITING_KEY};
     }
 
     void reset(auto & pair_writer)

--- a/src/Functions/keyvaluepair/impl/Configuration.cpp
+++ b/src/Functions/keyvaluepair/impl/Configuration.cpp
@@ -1,5 +1,4 @@
 #include <Functions/keyvaluepair/impl/Configuration.h>
-#include "Poco/String.h"
 
 #include <Common/Exception.h>
 
@@ -13,29 +12,6 @@ namespace ErrorCodes
 
 namespace extractKV
 {
-
-static Configuration::UnexpectedQuotingCharacterStrategy unexpectedQuotingCharacterStrategyFromString(
-    const std::string & unexpected_quoting_character_strategy)
-{
-    const auto unexpected_quoting_character_strategy_lower = Poco::toLower(unexpected_quoting_character_strategy);
-
-    if (unexpected_quoting_character_strategy_lower == "accept")
-    {
-        return Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT;
-    }
-
-    if (unexpected_quoting_character_strategy_lower == "invalid")
-    {
-        return Configuration::UnexpectedQuotingCharacterStrategy::INVALID;
-    }
-
-    if (unexpected_quoting_character_strategy_lower == "promote")
-    {
-        return Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE;
-    }
-
-    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid unexpected_quoting_character_strategy argument: {}", unexpected_quoting_character_strategy);
-}
 
 Configuration::Configuration(
     char key_value_delimiter_,
@@ -53,7 +29,7 @@ Configuration ConfigurationFactory::createWithoutEscaping(
     char key_value_delimiter,
     char quoting_character,
     std::vector<char> pair_delimiters,
-    const std::string & unexpected_quoting_character_strategy)
+    Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy)
 {
     validate(key_value_delimiter, quoting_character, pair_delimiters);
 
@@ -61,7 +37,7 @@ Configuration ConfigurationFactory::createWithoutEscaping(
         key_value_delimiter,
         quoting_character,
         pair_delimiters,
-        unexpectedQuotingCharacterStrategyFromString(unexpected_quoting_character_strategy));
+        unexpected_quoting_character_strategy);
 }
 
 Configuration ConfigurationFactory::createWithEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters)
@@ -82,7 +58,7 @@ Configuration ConfigurationFactory::createWithEscaping(char key_value_delimiter,
         key_value_delimiter,
         quoting_character,
         pair_delimiters,
-        "accept");
+        Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT);
 }
 
 void ConfigurationFactory::validate(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters)

--- a/src/Functions/keyvaluepair/impl/Configuration.cpp
+++ b/src/Functions/keyvaluepair/impl/Configuration.cpp
@@ -40,7 +40,11 @@ Configuration ConfigurationFactory::createWithoutEscaping(
         unexpected_quoting_character_strategy);
 }
 
-Configuration ConfigurationFactory::createWithEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters)
+Configuration ConfigurationFactory::createWithEscaping(
+    char key_value_delimiter,
+    char quoting_character,
+    std::vector<char> pair_delimiters,
+    Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy)
 {
     static constexpr char ESCAPE_CHARACTER = '\\';
 
@@ -58,7 +62,7 @@ Configuration ConfigurationFactory::createWithEscaping(char key_value_delimiter,
         key_value_delimiter,
         quoting_character,
         pair_delimiters,
-        Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT);
+        unexpected_quoting_character_strategy);
 }
 
 void ConfigurationFactory::validate(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters)

--- a/src/Functions/keyvaluepair/impl/Configuration.h
+++ b/src/Functions/keyvaluepair/impl/Configuration.h
@@ -40,7 +40,7 @@ private:
 struct ConfigurationFactory
 {
 public:
-    static Configuration createWithoutEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters, const std::string & unexpected_quoting_character_strategy);
+    static Configuration createWithoutEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy);
 
     static Configuration createWithEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters);
 

--- a/src/Functions/keyvaluepair/impl/Configuration.h
+++ b/src/Functions/keyvaluepair/impl/Configuration.h
@@ -42,7 +42,7 @@ struct ConfigurationFactory
 public:
     static Configuration createWithoutEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy);
 
-    static Configuration createWithEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters);
+    static Configuration createWithEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy);
 
 private:
     static void validate(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters);

--- a/src/Functions/keyvaluepair/impl/Configuration.h
+++ b/src/Functions/keyvaluepair/impl/Configuration.h
@@ -10,18 +10,28 @@ struct ConfigurationFactory;
 
 class Configuration
 {
+public:
+    enum class UnexpectedQuotingCharacterStrategy
+    {
+        INVALID,
+        ACCEPT,
+        PROMOTE
+    };
+
+    const char key_value_delimiter;
+    const char quoting_character;
+    const std::vector<char> pair_delimiters;
+    const UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy;
+
+private:
     friend struct ConfigurationFactory;
 
     Configuration(
         char key_value_delimiter_,
         char quoting_character_,
-        std::vector<char> pair_delimiters_
+        std::vector<char> pair_delimiters_,
+        UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy_
     );
-
-public:
-    const char key_value_delimiter;
-    const char quoting_character;
-    const std::vector<char> pair_delimiters;
 };
 
 /*
@@ -30,7 +40,7 @@ public:
 struct ConfigurationFactory
 {
 public:
-    static Configuration createWithoutEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters);
+    static Configuration createWithoutEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters, const std::string & unexpected_quoting_character_strategy);
 
     static Configuration createWithEscaping(char key_value_delimiter, char quoting_character, std::vector<char> pair_delimiters);
 

--- a/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.cpp
+++ b/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.cpp
@@ -30,7 +30,7 @@ KeyValuePairExtractorBuilder & KeyValuePairExtractorBuilder::withMaxNumberOfPair
 }
 
 KeyValuePairExtractorBuilder & KeyValuePairExtractorBuilder::withUnexpectedQuotingCharacterStrategy(
-    const std::string & unexpected_quoting_character_strategy_)
+    extractKV::Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy_)
 {
     unexpected_quoting_character_strategy = unexpected_quoting_character_strategy_;
     return *this;

--- a/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.cpp
+++ b/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.cpp
@@ -29,4 +29,11 @@ KeyValuePairExtractorBuilder & KeyValuePairExtractorBuilder::withMaxNumberOfPair
     return *this;
 }
 
+KeyValuePairExtractorBuilder & KeyValuePairExtractorBuilder::withUnexpectedQuotingCharacterStrategy(
+    const std::string & unexpected_quoting_character_strategy_)
+{
+    unexpected_quoting_character_strategy = unexpected_quoting_character_strategy_;
+    return *this;
+}
+
 }

--- a/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h
+++ b/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h
@@ -33,7 +33,7 @@ public:
 
     auto buildWithEscaping() const
     {
-        auto configuration = extractKV::ConfigurationFactory::createWithEscaping(key_value_delimiter, quoting_character, item_delimiters);
+        auto configuration = extractKV::ConfigurationFactory::createWithEscaping(key_value_delimiter, quoting_character, item_delimiters, unexpected_quoting_character_strategy);
 
         return KeyValuePairExtractorInlineEscaping(configuration, max_number_of_pairs);
     }
@@ -50,7 +50,9 @@ private:
     char quoting_character = '"';
     std::vector<char> item_delimiters = {' ', ',', ';'};
     uint64_t max_number_of_pairs = std::numeric_limits<uint64_t>::max();
-    extractKV::Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy = extractKV::Configuration::UnexpectedQuotingCharacterStrategy::INVALID;
+
+    /// The ideal default behavior should be `UnexpectedQuotingCharacterStrategy::INVALID`, but to make it backwards compatible, we are leaving it as `PROMOTE`
+    extractKV::Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy = extractKV::Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE;
 };
 
 }

--- a/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h
+++ b/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h
@@ -22,7 +22,7 @@ public:
 
     KeyValuePairExtractorBuilder & withMaxNumberOfPairs(uint64_t max_number_of_pairs_);
 
-    KeyValuePairExtractorBuilder & withUnexpectedQuotingCharacterStrategy(const std::string & unexpected_quoting_character_strategy_);
+    KeyValuePairExtractorBuilder & withUnexpectedQuotingCharacterStrategy(extractKV::Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy_);
 
     auto buildWithoutEscaping() const
     {
@@ -50,7 +50,7 @@ private:
     char quoting_character = '"';
     std::vector<char> item_delimiters = {' ', ',', ';'};
     uint64_t max_number_of_pairs = std::numeric_limits<uint64_t>::max();
-    std::string unexpected_quoting_character_strategy = "invalid";
+    extractKV::Configuration::UnexpectedQuotingCharacterStrategy unexpected_quoting_character_strategy = extractKV::Configuration::UnexpectedQuotingCharacterStrategy::INVALID;
 };
 
 }

--- a/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h
+++ b/src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h
@@ -22,9 +22,11 @@ public:
 
     KeyValuePairExtractorBuilder & withMaxNumberOfPairs(uint64_t max_number_of_pairs_);
 
+    KeyValuePairExtractorBuilder & withUnexpectedQuotingCharacterStrategy(const std::string & unexpected_quoting_character_strategy_);
+
     auto buildWithoutEscaping() const
     {
-        auto configuration = extractKV::ConfigurationFactory::createWithoutEscaping(key_value_delimiter, quoting_character, item_delimiters);
+        auto configuration = extractKV::ConfigurationFactory::createWithoutEscaping(key_value_delimiter, quoting_character, item_delimiters, unexpected_quoting_character_strategy);
 
         return KeyValuePairExtractorNoEscaping(configuration, max_number_of_pairs);
     }
@@ -38,7 +40,7 @@ public:
 
     auto buildWithReferenceMap() const
     {
-        auto configuration = extractKV::ConfigurationFactory::createWithoutEscaping(key_value_delimiter, quoting_character, item_delimiters);
+        auto configuration = extractKV::ConfigurationFactory::createWithoutEscaping(key_value_delimiter, quoting_character, item_delimiters, unexpected_quoting_character_strategy);
 
         return KeyValuePairExtractorReferenceMap(configuration, max_number_of_pairs);
     }
@@ -48,6 +50,7 @@ private:
     char quoting_character = '"';
     std::vector<char> item_delimiters = {' ', ',', ';'};
     uint64_t max_number_of_pairs = std::numeric_limits<uint64_t>::max();
+    std::string unexpected_quoting_character_strategy = "invalid";
 };
 
 }

--- a/src/Functions/keyvaluepair/impl/NeedleFactory.h
+++ b/src/Functions/keyvaluepair/impl/NeedleFactory.h
@@ -22,7 +22,7 @@ class NeedleFactory
 public:
     SearchSymbols getWaitKeyNeedles(const Configuration & extractor_configuration)
     {
-        const auto & [key_value_delimiter, quoting_character, pair_delimiters]
+        const auto & [key_value_delimiter, quoting_character, pair_delimiters, _]
             = extractor_configuration;
 
         std::vector<char> needles;
@@ -41,13 +41,17 @@ public:
 
     SearchSymbols getReadKeyNeedles(const Configuration & extractor_configuration)
     {
-        const auto & [key_value_delimiter, quoting_character, pair_delimiters]
+        const auto & [key_value_delimiter, quoting_character, pair_delimiters, unexpected_quoting_character_strategy]
             = extractor_configuration;
 
         std::vector<char> needles;
 
         needles.push_back(key_value_delimiter);
-        needles.push_back(quoting_character);
+
+        if (unexpected_quoting_character_strategy != Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT)
+        {
+            needles.push_back(quoting_character);
+        }
 
         std::copy(pair_delimiters.begin(), pair_delimiters.end(), std::back_inserter(needles));
 
@@ -61,12 +65,15 @@ public:
 
     SearchSymbols getReadValueNeedles(const Configuration & extractor_configuration)
     {
-        const auto & [key_value_delimiter, quoting_character, pair_delimiters]
+        const auto & [key_value_delimiter, quoting_character, pair_delimiters, unexpected_quoting_character_strategy]
             = extractor_configuration;
 
         std::vector<char> needles;
 
-        needles.push_back(quoting_character);
+        if (unexpected_quoting_character_strategy != Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT)
+        {
+            needles.push_back(quoting_character);
+        }
 
         std::copy(pair_delimiters.begin(), pair_delimiters.end(), std::back_inserter(needles));
 

--- a/src/Functions/keyvaluepair/impl/NeedleFactory.h
+++ b/src/Functions/keyvaluepair/impl/NeedleFactory.h
@@ -20,7 +20,7 @@ template <bool WITH_ESCAPING>
 class NeedleFactory
 {
 public:
-    SearchSymbols getWaitNeedles(const Configuration & extractor_configuration)
+    SearchSymbols getWaitKeyNeedles(const Configuration & extractor_configuration)
     {
         const auto & [key_value_delimiter, quoting_character, pair_delimiters]
             = extractor_configuration;
@@ -90,6 +90,17 @@ public:
         {
             needles.push_back('\\');
         }
+
+        return SearchSymbols {std::string{needles.data(), needles.size()}};
+    }
+
+    SearchSymbols getWaitPairDelimiterNeedles(const Configuration & extractor_configuration)
+    {
+        const auto & pair_delimiters = extractor_configuration.pair_delimiters;
+
+        std::vector<char> needles;
+
+        std::copy(pair_delimiters.begin(), pair_delimiters.end(), std::back_inserter(needles));
 
         return SearchSymbols {std::string{needles.data(), needles.size()}};
     }

--- a/src/Functions/keyvaluepair/impl/StateHandler.h
+++ b/src/Functions/keyvaluepair/impl/StateHandler.h
@@ -30,6 +30,11 @@ public:
         READING_QUOTED_VALUE,
         // In this state, both key and value have already been collected and should be flushed. Might jump to WAITING_KEY or END.
         FLUSH_PAIR,
+        // The `READING_QUOTED_VALUE` will assert the closing quoting character is found and then flush the pair. In this case, we should not
+        // move from `FLUSH_PAIR` directly to `WAITING_FOR_KEY` because a pair delimiter has not been found. Might jump to WAITING_FOR_PAIR_DELIMITER or END
+        FLUSH_PAIR_AFTER_QUOTED_VALUE,
+        // Might jump to WAITING_KEY or END.
+        WAITING_PAIR_DELIMITER,
         END
     };
 

--- a/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
+++ b/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
@@ -115,19 +115,17 @@ public:
             }
             else if (isQuotingCharacter(*p))
             {
-                if (configuration.unexpected_quoting_character_strategy == Configuration::UnexpectedQuotingCharacterStrategy::INVALID)
+                switch (configuration.unexpected_quoting_character_strategy)
                 {
-                    return {next_pos, State::WAITING_KEY};
+                    case Configuration::UnexpectedQuotingCharacterStrategy::INVALID:
+                        return {next_pos, State::WAITING_KEY};
+                    case Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE:
+                        return {next_pos, State::READING_QUOTED_KEY};
+                    case Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT:
+                        // The quoting character should not be added to the search symbols list in case strategy = Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT
+                        // See `NeedleFactory`
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to handle unexpected quoting character. This is a bug");
                 }
-
-                if (configuration.unexpected_quoting_character_strategy == Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE)
-                {
-                    return {next_pos, State::READING_QUOTED_KEY};
-                }
-
-                // The quoting character should not be added to the search symbols list in case strategy = Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT
-                // See `NeedleFactory`
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to handle unexpected quoting character. This is a bug");
             }
 
             pos = next_pos;
@@ -265,19 +263,17 @@ public:
             }
             else if (isQuotingCharacter(*p))
             {
-                if (configuration.unexpected_quoting_character_strategy == Configuration::UnexpectedQuotingCharacterStrategy::INVALID)
+                switch (configuration.unexpected_quoting_character_strategy)
                 {
-                    return {next_pos, State::WAITING_KEY};
+                    case Configuration::UnexpectedQuotingCharacterStrategy::INVALID:
+                        return {next_pos, State::WAITING_KEY};
+                    case Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE:
+                        return {next_pos, State::READING_QUOTED_VALUE};
+                    case Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT:
+                        // The quoting character should not be added to the search symbols list in case strategy = Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT
+                        // See `NeedleFactory`
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to handle unexpected quoting character. This is a bug");
                 }
-
-                if (configuration.unexpected_quoting_character_strategy == Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE)
-                {
-                    return {next_pos, State::READING_QUOTED_VALUE};
-                }
-
-                // The quoting character should not be added to the search symbols list in case strategy = Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT
-                // See `NeedleFactory`
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to handle unexpected quoting character. This is a bug");
             }
 
             pos = next_pos;

--- a/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
+++ b/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
@@ -120,8 +120,9 @@ public:
                     return {next_pos, State::READING_QUOTED_KEY};
                 }
 
-                // todo arthur
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected quoting character found in key. This should not happen.");
+                // The quoting character should not be added to the search symbols list in case strategy = Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT
+                // See `NeedleFactory`
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to handle unexpected quoting character. This is a bug");
             }
 
             pos = next_pos;
@@ -269,8 +270,9 @@ public:
                     return {next_pos, State::READING_QUOTED_VALUE};
                 }
 
-                // todo arthur
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected quoting character found in value. This should not happen.");
+                // The quoting character should not be added to the search symbols list in case strategy = Configuration::UnexpectedQuotingCharacterStrategy::ACCEPT
+                // See `NeedleFactory`
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to handle unexpected quoting character. This is a bug");
             }
 
             pos = next_pos;

--- a/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
+++ b/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
@@ -19,6 +19,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 namespace extractKV
 {
 

--- a/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
+++ b/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
@@ -103,13 +103,9 @@ public:
 
                 return {next_pos, State::WAITING_VALUE};
             }
-            else if (isPairDelimiter(*p))
+            else if (isPairDelimiter(*p) || isQuotingCharacter(*p))
             {
                 return {next_pos, State::WAITING_KEY};
-            }
-            else if (isQuotingCharacter(*p))
-            {
-                return {next_pos, State::READING_QUOTED_KEY};
             }
 
             pos = next_pos;

--- a/src/Functions/keyvaluepair/tests/gtest_inline_escaping_key_state_handler.cpp
+++ b/src/Functions/keyvaluepair/tests/gtest_inline_escaping_key_state_handler.cpp
@@ -63,7 +63,7 @@ TEST(extractKVPairInlineEscapingKeyStateHandler, Wait)
 {
     auto pair_delimiters = std::vector<char>{',', ' '};
 
-    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters);
+    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE);
 
     StateHandlerImpl<true> handler(configuration);
 
@@ -79,7 +79,7 @@ TEST(extractKVPairInlineEscapingKeyStateHandler, Read)
 {
     auto pair_delimiters = std::vector<char>{',', ' '};
 
-    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters);
+    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE);
 
     StateHandlerImpl<true> handler(configuration);
 
@@ -103,7 +103,7 @@ TEST(extractKVPairInlineEscapingKeyStateHandler, ReadEnclosed)
 {
     auto pair_delimiters = std::vector<char>{',', ' '};
 
-    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters);
+    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE);
 
     StateHandlerImpl<true> handler(configuration);
 

--- a/src/Functions/keyvaluepair/tests/gtest_inline_escaping_value_state_handler.cpp
+++ b/src/Functions/keyvaluepair/tests/gtest_inline_escaping_value_state_handler.cpp
@@ -27,7 +27,7 @@ TEST(extractKVPairInlineEscapingValueStateHandler, Wait)
 {
     auto pair_delimiters = std::vector<char> {','};
 
-    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters);
+    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE);
     StateHandlerImpl<true> handler(configuration);
 
     test_wait(handler, " los$ yours3lf", 0u, State::READING_VALUE);

--- a/src/Functions/keyvaluepair/tests/gtest_no_escaping_key_state_handler.cpp
+++ b/src/Functions/keyvaluepair/tests/gtest_no_escaping_key_state_handler.cpp
@@ -63,7 +63,7 @@ TEST(extractKVPairNoEscapingKeyStateHandler, Wait)
 {
     auto pair_delimiters = std::vector<char>{',', ' ', '$'};
 
-    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters);
+    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE);
 
     NoEscapingStateHandler handler(configuration);
 
@@ -82,7 +82,7 @@ TEST(extractKVPairNoEscapingKeyStateHandler, Read)
 {
     auto pair_delimiters = std::vector<char>{',', ' '};
 
-    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters);
+    auto configuration = ConfigurationFactory::createWithEscaping(':', '"', pair_delimiters, Configuration::UnexpectedQuotingCharacterStrategy::PROMOTE);
 
     NoEscapingStateHandler handler(configuration);
 

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
@@ -381,7 +381,7 @@ WITH
 SELECT
     x;
 {'age':'31','name':'neymar','nationality':'brazil','team':'psg'}
--- Quoting character must be escaped, otherwise key will be discarded
+-- Quoting character must be escaped, otherwise key will be discarded. Consider using `unexpected_quoting_character_strategy`
 WITH
     extractKeyValuePairs('key:"#123"junk", second_key:0') as s_map,
     CAST(
@@ -393,6 +393,154 @@ WITH
 SELECT
     x;
 {'key':'#123','second_key':'0'}
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting characters shall become part of the key
+WITH
+    extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'name"abc"':'5'}
+-- unexpected_quoting_character_strategy=invalid, empty return
+WITH
+    extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{}
+-- unexpected_quoting_character_strategy=promote, abc=5
+WITH
+    extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'abc':'5'}
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting character shall become part of the key
+WITH
+    extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'name"abc':'5'}
+-- unexpected_quoting_character_strategy=invalid, start reading key from abc
+WITH
+    extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'abc':'5'}
+-- unexpected_quoting_character_strategy=promote, start reading abc as quoted key but fails to find closing quoting character
+WITH
+    extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{}
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting characters shall become part of the value
+WITH
+    extractKeyValuePairs('key:val"abc', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'key':'val"abc'}
+-- unexpected_quoting_character_strategy=invalid, empty return
+WITH
+    extractKeyValuePairs('key:val"abc', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{}
+-- unexpected_quoting_character_strategy=promote, empty
+WITH
+    extractKeyValuePairs('key:val"abc', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{}
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting characters shall become part of the value
+WITH
+    extractKeyValuePairs('key:val"abc"', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'key':'val"abc"'}
+-- unexpected_quoting_character_strategy=invalid, empty
+WITH
+    extractKeyValuePairs('key:val"abc"', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{}
+-- unexpected_quoting_character_strategy=promote, start reading abc as quoted key but fails to find closing quoting character
+WITH
+    extractKeyValuePairs('key:val"abc"', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'key':'abc'}
 -- after parsing a quoted value, the next key should only start after a pair delimiter
 WITH
     extractKeyValuePairs('key:"quoted_value"junk,second_key:0') as s_map,

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
@@ -393,3 +393,15 @@ WITH
 SELECT
     x;
 {'key':'#123','second_key':'0'}
+-- after parsing a quoted value, the next key should only start after a pair delimiter
+WITH
+    extractKeyValuePairs('key:"quoted_value"junk,second_key:0') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'key':'quoted_value','second_key':'0'}

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.reference
@@ -347,7 +347,7 @@ SELECT
 {'argument1':'1','argument2':'2','char':'=','char2':'=','formula':'1+2=3','result':'3','string':'foo=bar'}
 -- https://github.com/ClickHouse/ClickHouse/issues/56357
 WITH
-    extractKeyValuePairs('{"a":"1", "b":"2"}') as s_map,
+    extractKeyValuePairs('{"a":"1", "b":"2"}', ':', '{, }') as s_map,
     CAST(
         arrayMap(
             (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
@@ -381,3 +381,15 @@ WITH
 SELECT
     x;
 {'age':'31','name':'neymar','nationality':'brazil','team':'psg'}
+-- Quoting character must be escaped, otherwise key will be discarded
+WITH
+    extractKeyValuePairs('key:"#123"junk", second_key:0') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+{'key':'#123','second_key':'0'}

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
@@ -483,7 +483,7 @@ SELECT
 
 -- https://github.com/ClickHouse/ClickHouse/issues/56357
 WITH
-    extractKeyValuePairs('{"a":"1", "b":"2"}') as s_map,
+    extractKeyValuePairs('{"a":"1", "b":"2"}', ':', '{, }') as s_map,
     CAST(
         arrayMap(
             (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
@@ -514,5 +514,17 @@ WITH
                 ),
             'Map(String,String)'
         ) AS x
+SELECT
+    x;
+
+-- Quoting character must be escaped, otherwise key will be discarded
+WITH
+    extractKeyValuePairs('key:"#123"junk", second_key:0') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
 SELECT
     x;

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
@@ -528,3 +528,14 @@ WITH
     ) AS x
 SELECT
     x;
+-- after parsing a quoted value, the next key should only start after a pair delimiter
+WITH
+    extractKeyValuePairs('key:"quoted_value"junk,second_key:0') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;

--- a/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
+++ b/tests/queries/0_stateless/02499_extract_key_value_pairs_multiple_input.sql
@@ -404,7 +404,7 @@ SELECT
 
 -- should fail because one extra argument / non existent has been provided
 WITH
-    extractKeyValuePairs('a', ':', ',', '"', '') AS s_map,
+    extractKeyValuePairs('a', ':', ',', '"', 'accept', '') AS s_map,
     CAST(
             arrayMap(
                     (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
@@ -517,7 +517,7 @@ WITH
 SELECT
     x;
 
--- Quoting character must be escaped, otherwise key will be discarded
+-- Quoting character must be escaped, otherwise key will be discarded. Consider using `unexpected_quoting_character_strategy`
 WITH
     extractKeyValuePairs('key:"#123"junk", second_key:0') as s_map,
     CAST(
@@ -528,6 +528,155 @@ WITH
     ) AS x
 SELECT
     x;
+
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting characters shall become part of the key
+WITH
+    extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=invalid, empty return
+WITH
+    extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=promote, abc=5
+WITH
+    extractKeyValuePairs('name"abc":5', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting character shall become part of the key
+WITH
+    extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=invalid, start reading key from abc
+WITH
+    extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=promote, start reading abc as quoted key but fails to find closing quoting character
+WITH
+    extractKeyValuePairs('name"abc:5', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting characters shall become part of the value
+WITH
+    extractKeyValuePairs('key:val"abc', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=invalid, empty return
+WITH
+    extractKeyValuePairs('key:val"abc', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=promote, empty
+WITH
+    extractKeyValuePairs('key:val"abc', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- test unexpected_quoting_character_strategy
+-- unexpected_quoting_character_strategy=accept, the quoting characters shall become part of the value
+WITH
+    extractKeyValuePairs('key:val"abc"', ':', ' ,;', '\"', 'accept') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=invalid, empty
+WITH
+    extractKeyValuePairs('key:val"abc"', ':', ' ,;', '\"', 'invalid') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
+-- unexpected_quoting_character_strategy=promote, start reading abc as quoted key but fails to find closing quoting character
+WITH
+    extractKeyValuePairs('key:val"abc"', ':', ' ,;', '\"', 'promote') as s_map,
+    CAST(
+        arrayMap(
+            (x) -> (x, s_map[x]), arraySort(mapKeys(s_map))
+        ),
+        'Map(String,String)'
+    ) AS x
+SELECT
+    x;
+
 -- after parsing a quoted value, the next key should only start after a pair delimiter
 WITH
     extractKeyValuePairs('key:"quoted_value"junk,second_key:0') as s_map,

--- a/tests/queries/0_stateless/03228_url_engine_response_headers.sql
+++ b/tests/queries/0_stateless/03228_url_engine_response_headers.sql
@@ -3,5 +3,5 @@ FROM url('http://127.0.0.1:8123/?query=select+1&user=default', LineAsString, 's 
 
 SELECT
     *,
-    mapFromString(_headers['X-ClickHouse-Summary'])['read_rows']
+    mapFromString(_headers['X-ClickHouse-Summary'], ':', '{,')['read_rows']
 FROM url('http://127.0.0.1:8123/?query=select+1&user=default', LineAsString, 's String');


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Changes in this PR:
1. Introduce a new argument `unexpected_quoting_character_strategy` to the `extractKeyValuePairs` function that controls what happens when a `quoting_character` is unexpectedly found when reading a non quoted key or value. The value can be one of: `invalid`, `accept` or `promote`. Invalid will discard the key and go back to waiting key state. Accept will treat it as part of the key. Promote will discard previous character and start parsing as a quoted key. I believe the default behavior (and maybe the only behavior) should be `INVALID`, but in 2023 on https://github.com/ClickHouse/ClickHouse/pull/56423 it was implemented the `PROMOTE` logic. So, to make it kind of backwards compatible, I created this setting.
2. After parsing a quoted value, only parse the next key if a pair delimiter is found

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
