### PR TITLE
Handle missing slash in metadata_path when printing system.tables

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8134,7 +8134,7 @@ bool MergeTreeData::canUseAdaptiveGranularity() const
 
 String MergeTreeData::getFullPathOnDisk(const DiskPtr & disk) const
 {
-    return disk->getPath() + relative_data_path;
+    return fs::path(disk->getPath()) / relative_data_path;
 }
 
 

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -7,6 +7,7 @@
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
+                <metadata_path>/var/lib/clickhouse/disks/custom_path</metadata_path>
             </s3>
             <unstable_s3>
                 <type>s3</type>

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import os
 import time
@@ -1064,3 +1065,21 @@ def test_s3_disk_heavy_write_check_mem(cluster, broken_s3, node_name):
     assert int(result) > 0.8 * memory
 
     check_no_objects_after_drop(cluster, node_name=node_name)
+
+
+@pytest.mark.parametrize("node_name", ["node"])
+def test_metadata_path_works_correctly(cluster, node_name):
+    node = cluster.instances[node_name]
+    table = "s3_test_metadata_path"
+    create_table(node, table)
+
+    response = node.query(f"SELECT data_paths FROM system.tables WHERE name='{table}'")
+    data_paths = ast.literal_eval(response)
+    assert len(data_paths) >= 1, list
+
+    # Verifies that trailing slash is added correctly: https://github.com/ClickHouse/ClickHouse/issues/80647
+    found = False
+    for path in data_paths:
+        found = found or "/custom_path/" in path
+    assert found, data_paths
+    node.query(f"DROP TABLE IF EXISTS {table}")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Handle missing slash in metadata_path when printing system.tables

This has been like this since ancient times, nothing changed recently (5+ years).
Closes https://github.com/ClickHouse/ClickHouse/issues/80647

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
