### PR TITLE
Docs: autogenerated docs formatting improvement

### DIFF
--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -27,14 +27,13 @@ std::string FunctionDocumentation::examplesAsString() const
     std::string res;
     for (const auto & [name, query, result] : examples)
     {
-        res += name + ":\n\n";
-        res += "```sql\n";
+        res += "**" + name + "**" + "\n\n";
+        res += "```sql title=""Query""\n";
         res += query + "\n";
         res += "```\n\n";
-        res += "Result:\n\n";
-        res += "```text\n";
+        res += "```response title=""Response""\n";
         res += result + "\n";
-        res += "```\n";
+        res += "```";
     }
     return res;
 }

--- a/src/Functions/modulo.cpp
+++ b/src/Functions/modulo.cpp
@@ -201,8 +201,8 @@ Calculates the remainder when dividing `x` by `y`. Similar to function
 `modulo` except that `positiveModulo` always return non-negative number.
     )";
     FunctionDocumentation::Syntax syntax = "positiveModulo(x, y)";
-    FunctionDocumentation::Argument argument1 = {"x", "The dividend"};
-    FunctionDocumentation::Argument argument2 = {"y", "The divisor (modulus)"};
+    FunctionDocumentation::Argument argument1 = {"x", "The dividend. [`(U)Int*`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float)."};
+    FunctionDocumentation::Argument argument2 = {"y", "The divisor (modulus). [`(U)Int*`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float)."};
     FunctionDocumentation::Arguments arguments = {argument1, argument2};
     FunctionDocumentation::ReturnedValue returned_value = R"(
 Returns the difference between `x` and the nearest integer not greater than

--- a/src/Functions/moduloOrNull.cpp
+++ b/src/Functions/moduloOrNull.cpp
@@ -21,15 +21,25 @@ using FunctionPositiveModuloOrNll = BinaryArithmeticOverloadResolver<PositiveMod
 
 REGISTER_FUNCTION(PositiveModuloOrNull)
 {
-    factory.registerFunction<FunctionPositiveModuloOrNll>(FunctionDocumentation
-        {
-            .description = R"(
+    FunctionDocumentation::Description description = R"(
 Calculates the remainder when dividing `a` by `b`. Similar to function `positiveModulo` except that `positiveModuloOrNull` will return NULL
 if the right argument is 0.
-        )",
-            .examples{{"positiveModuloOrNull", "SELECT positiveModuloOrNull(1, 0);", ""}},
-            .category = FunctionDocumentation::Category::Arithmetic},
-        FunctionFactory::Case::Insensitive);
+    )";
+    FunctionDocumentation::Syntax syntax = "positiveModulo(x, y)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "The dividend. [`(U)Int*`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float)."},
+        {"x", "The divisor (modulus). [`(U)Int*`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float)."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = R"(
+Returns the difference between `x` and the nearest integer not greater than
+`x` divisible by `y`, `null` when the divisor is zero.
+    )";
+    FunctionDocumentation::Examples examples = {{"positiveModulo", "SELECT positiveModulo(-1, 10)", "9"}};
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 11};
+    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, categories};
+
+    factory.registerFunction<FunctionPositiveModuloOrNll>(documentation, FunctionFactory::Case::Insensitive);
 
     factory.registerAlias("positive_modulo_or_null", "positiveModuloOrNull", FunctionFactory::Case::Insensitive);
     factory.registerAlias("pmodOrNull", "positiveModuloOrNull", FunctionFactory::Case::Insensitive);

--- a/src/Functions/moduloOrZero.cpp
+++ b/src/Functions/moduloOrZero.cpp
@@ -48,8 +48,8 @@ Like modulo but returns zero when the divisor is zero, as opposed to an
 exception with the modulo function.
     )";
     FunctionDocumentation::Syntax syntax = "moduloOrZero(a, b)";
-    FunctionDocumentation::Argument argument1 = {"a", "The dividend"};
-    FunctionDocumentation::Argument argument2 = {"b", "The divisor (modulus)"};
+    FunctionDocumentation::Argument argument1 = {"a", "The dividend. [`(U)Int*`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float)."};
+    FunctionDocumentation::Argument argument2 = {"b", "The divisor (modulus). [`(U)Int*`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float)."};
     FunctionDocumentation::Arguments arguments = {argument1, argument2};
     FunctionDocumentation::ReturnedValue returned_value = "The remainder of a % b, or `0` when the divisor is `0`.";
     FunctionDocumentation::Examples examples = {{"", "SELECT moduloOrZero(5, 0)", "0"}};
@@ -57,7 +57,7 @@ exception with the modulo function.
     FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, categories};
 
-    factory.registerFunction<FunctionModuloOrZero>();
+    factory.registerFunction<FunctionModuloOrZero>(documentation);
 }
 
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -361,7 +361,6 @@ minSampleSizeContinuous
 minSampleSizeConversion
 moduloLegacy
 moduloOrNull
-moduloOrZero
 monthName
 multiFuzzyMatchAllIndices
 multiFuzzyMatchAny

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -484,7 +484,6 @@ minSampleSizeContinuous
 minSampleSizeConversion
 moduloLegacy
 moduloOrNull
-moduloOrZero
 monthName
 mortonDecode
 mortonEncode
@@ -620,7 +619,6 @@ position
 positionCaseInsensitive
 positionCaseInsensitiveUTF8
 positionUTF8
-positiveModuloOrNull
 pow
 printf
 proportionsZTest


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Changes the formatting of the returned string for examples.

Fills out missing documentation for `moduloOrNull`

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
