### PR TITLE
add more debug when http message parsing fails

### DIFF
--- a/base/poco/Net/src/HTTPResponse.cpp
+++ b/base/poco/Net/src/HTTPResponse.cpp
@@ -108,7 +108,7 @@ HTTPResponse::HTTPResponse():
 {
 }
 
-	
+
 HTTPResponse::HTTPResponse(HTTPStatus status, const std::string& reason):
 	_status(status),
 	_reason(reason)
@@ -116,7 +116,7 @@ HTTPResponse::HTTPResponse(HTTPStatus status, const std::string& reason):
 }
 
 
-	
+
 HTTPResponse::HTTPResponse(const std::string& version, HTTPStatus status, const std::string& reason):
 	HTTPMessage(version),
 	_status(status),
@@ -124,7 +124,7 @@ HTTPResponse::HTTPResponse(const std::string& version, HTTPStatus status, const 
 {
 }
 
-	
+
 HTTPResponse::HTTPResponse(HTTPStatus status):
 	_status(status),
 	_reason(getReasonForStatus(status))
@@ -155,8 +155,8 @@ void HTTPResponse::setStatus(const std::string& status)
 {
 	setStatus((HTTPStatus) NumberParser::parse(status));
 }
-	
-	
+
+
 void HTTPResponse::setReason(const std::string& reason)
 {
 	_reason = reason;
@@ -169,7 +169,7 @@ void HTTPResponse::setStatusAndReason(HTTPStatus status, const std::string& reas
 	_reason = reason;
 }
 
-	
+
 void HTTPResponse::setStatusAndReason(HTTPStatus status)
 {
 	setStatusAndReason(status, getReasonForStatus(status));
@@ -181,7 +181,7 @@ void HTTPResponse::setDate(const Poco::Timestamp& dateTime)
 	set(DATE, DateTimeFormatter::format(dateTime, DateTimeFormat::HTTP_FORMAT));
 }
 
-	
+
 Poco::Timestamp HTTPResponse::getDate() const
 {
 	const std::string& dateTime = get(DATE);
@@ -240,7 +240,7 @@ void HTTPResponse::read(std::istream& istr)
 	std::string version;
 	std::string status;
 	std::string reason;
-	
+
 	int ch =  istr.get();
 	if (istr.bad()) throw NetException("Error reading HTTP response header");
 	if (ch == eof) throw NoMessageException();
@@ -260,9 +260,17 @@ void HTTPResponse::read(std::istream& istr)
 	HTTPMessage::read(istr);
 	ch = istr.get();
 	while (ch != '\n' && ch != eof) { ch = istr.get(); }
-	setVersion(version);
-	setStatus(status);
-	setReason(reason);
+
+	try
+	{
+		setVersion(version);
+		setStatus(status);
+		setReason(reason);
+	}
+	catch (SyntaxException & e)
+	{
+		throw SyntaxException(e.message(), ", while reading HTTP response: version='" + version + "', status='" + status + "', reason='" + reason + "'");
+	}
 }
 
 
@@ -282,7 +290,7 @@ const std::string& HTTPResponse::getReasonForStatus(HTTPStatus status)
 		return HTTP_REASON_CREATED;
 	case HTTP_ACCEPTED:
 		return HTTP_REASON_ACCEPTED;
-	case HTTP_NONAUTHORITATIVE:	
+	case HTTP_NONAUTHORITATIVE:
 		return HTTP_REASON_NONAUTHORITATIVE;
 	case HTTP_NO_CONTENT:
 		return HTTP_REASON_NO_CONTENT;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add more debug info when http message header parsing fails

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
