### PR TITLE
Fix 03518_key_condition_binary_search disabling it for ParallelReplicas

### DIFF
--- a/tests/queries/0_stateless/03518_key_condition_binary_search.sh
+++ b/tests/queries/0_stateless/03518_key_condition_binary_search.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Tags: no-parallel-replicas
+# no-parallel-replicas: the ProfileEvents with the expected values are reported on the replicas the query runs in,
+# and the coordinator does not collect all ProfileEvents values.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Fix 03518_key_condition_binary_search disabling it for ParallelReplicas

Even though https://github.com/ClickHouse/ClickHouse/pull/80679 improved the test to avoid relying on log traces (which made the test fail sometimes in [parallel_replicas](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=80688&sha=3792965aac98d03140721e6781f9ba6d2beeae1c&name_0=PR&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29) because there was 1 trace per each of the 3 replicas) it didn't fully work for parallel replicas.

In master, there is [one execution](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5773f767d0f648bfbdc79a323589bd799471cf82&name_0=MasterCI&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29) where we can see that the ProfileEvents of the query for the coordinator has empty `IndexBinarySearchAlgorithm` and `IndexGenericExclusionSearchAlgorithm`. If the coordinator collected all results for all queries of all replicas, we could relax the checks to make them "at least" the expected amount. Since that's not the case, the simplest solution is to disable running this for parallel replicas.

```sql
SELECT
    query_id,
    ProfileEvents['IndexBinarySearchAlgorithm'],
    ProfileEvents['IndexGenericExclusionSearchAlgorithm']
FROM file('query_log_master_error.tsv.zst')
WHERE (query_id = 'test_bowpahzh_generic') AND (type > 1)

Query id: 90b0844b-f9e1-49f2-afa9-b33b68e99c90

   ┌─query_id──────────────┬─arrayElement⋯Algorithm')─┬─arrayElement⋯Algorithm')─┐
1. │ test_bowpahzh_generic │                        0 │                        0 │
   └───────────────────────┴──────────────────────────┴──────────────────────────┘
```

We could also collect all ProfileEvents ourselves and implement the "at least" approach, but I prefer to have a deterministic job that matches exactly the expected amount for every other case.

```sql
SELECT sum(ProfileEvents['IndexGenericExclusionSearchAlgorithm'])
FROM file('query_log_master_error.tsv.zst')
WHERE (initial_query_id = 'test_bowpahzh_generic') AND (type > 1)

Query id: 435c5faf-7f92-4a0b-9003-39b762532511

   ┌─sum(arrayEle⋯lgorithm'))─┐
1. │                        3 │
   └──────────────────────────┘
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
