### PR TITLE
Fix more test_refreshable_mat_view_replicated::test_real_wait_refresh flakiness

### DIFF
--- a/tests/integration/test_refreshable_mat_view/test.py
+++ b/tests/integration/test_refreshable_mat_view/test.py
@@ -351,7 +351,7 @@ def get_rmv_info(
             check_callback=(
                 (lambda r: r.iloc[0]["status"] == wait_status)
                 if wait_status
-                else (lambda x: True)
+                else (lambda r: r.iloc[0]["status"] != "Scheduling")
             ),
             parse=True,
         ).to_dict("records")[0]

--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -493,7 +493,7 @@ def get_rmv_info(
             check_callback=(
                 (lambda r: r.iloc[0]["status"] == wait_status)
                 if wait_status
-                else (lambda x: True)
+                else (lambda r: r.iloc[0]["status"] != "Scheduling")
             ),
             parse=True,
         ).to_dict("records")[0]


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7f9166e14bb4ff7e72bbb14b8606a8591d1dbf7e&name_0=MasterCI&name_1=Integration%20tests%20%28release%2C%203%2F4%29

(`next_refresh_time` is not set when status is `Scheduling`.)