### PR TITLE
Fix handling of enum globs of a single element in object storage table functions

### DIFF
--- a/src/Common/parseGlobs.cpp
+++ b/src/Common/parseGlobs.cpp
@@ -184,8 +184,7 @@ void expandSelectorGlobImpl(const std::string & path, std::vector<std::string> &
     std::string_view matched;
 
     /// enum_regexp does not match elements of one char, e.g. {a}.tsv
-    auto definitely_no_selector_globs = path.find_first_of("{}") == std::string::npos
-                                        && path.find_first_of("*?") == std::string::npos;
+    auto definitely_no_selector_globs = path.find_first_of("{}") == std::string::npos;
 
     /// No (more) selector globs found, quit
     if (!RE2::PartialMatch(path_view, Regexps::instance().enum_regex, &matched) && definitely_no_selector_globs)

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -699,7 +699,7 @@ def test_s3_enum_glob_should_not_list(started_cluster):
     for night in nights:
         path = f"shard_{night // 100}/night_{night % 100}/tale.csv"
         print(path)
-        query = "insert into table function s3('http://{}:{}/{}/{}', 'CSV', '{}') values {}".format(
+        query = "insert into table function s3('http://{}:{}/{}/{}', 'CSV', '{}') settings s3_truncate_on_insert=1 values {}".format(
             started_cluster.minio_ip,
             MINIO_INTERNAL_PORT,
             bucket,

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -693,11 +693,12 @@ def test_s3_enum_glob_should_not_list(started_cluster):
     jobs = []
 
     glob1 = [2, 3, 4, 5]
-    glob2 = [32, 48, 97, 11]
+    glob2 = [1, 32, 48, 97, 11]
     nights = [x * 100 + y for x in glob1 for y in glob2]
 
     for night in nights:
         path = f"shard_{night // 100}/night_{night % 100}/tale.csv"
+        print(path)
         query = "insert into table function s3('http://{}:{}/{}/{}', 'CSV', '{}') values {}".format(
             started_cluster.minio_ip,
             MINIO_INTERNAL_PORT,
@@ -711,6 +712,7 @@ def test_s3_enum_glob_should_not_list(started_cluster):
     for job in jobs:
         job.join()
 
+    # Enum of multiple elements
     query = "select count(), sum(column1), sum(column2), sum(column3) from s3('http://{}:{}/{}/shard_2/night_{{32,48,97,11}}/tale.csv', 'CSV', '{}')".format(
         started_cluster.minio_redirect_host,
         started_cluster.minio_redirect_port,
@@ -719,6 +721,26 @@ def test_s3_enum_glob_should_not_list(started_cluster):
     )
     query_id = f"validate_no_s3_list_requests{uuid.uuid4()}"
     assert run_query(instance, query, query_id=query_id).splitlines() == ["4\t4\t4\t4"]
+
+    # Enum of one element
+    query = "select count(), sum(column1), sum(column2), sum(column3) from s3('http://{}:{}/{}/shard_2/night_{{32}}/tale.csv', 'CSV', '{}')".format(
+        started_cluster.minio_redirect_host,
+        started_cluster.minio_redirect_port,
+        bucket,
+        table_format,
+    )
+    query_id = f"validate_no_s3_list_requests{uuid.uuid4()}"
+    assert run_query(instance, query, query_id=query_id).splitlines() == ["1\t1\t1\t1"]
+
+    # Enum of one element of one char
+    query = "select count(), sum(column1), sum(column2), sum(column3) from s3('http://{}:{}/{}/shard_2/night_{{1}}/tale.csv', 'CSV', '{}')".format(
+        started_cluster.minio_redirect_host,
+        started_cluster.minio_redirect_port,
+        bucket,
+        table_format,
+    )
+    query_id = f"validate_no_s3_list_requests{uuid.uuid4()}"
+    assert run_query(instance, query, query_id=query_id).splitlines() == ["1\t1\t1\t1"]
 
     instance.query("SYSTEM FLUSH LOGS")
     list_request_count = instance.query(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

Relates to https://github.com/ClickHouse/ClickHouse/pull/73518
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix handling of enum globs of a single element in object storage table functions. 


