### PR TITLE
Ignore "Available disk space for logs at server startup is too low" for non-regular files used for logs

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -790,7 +790,7 @@ void sanityChecks(Server & server)
 
     try
     {
-        if (!logs_path.empty())
+        if (!logs_path.empty() && fs::is_regular_file(logs_path))
         {
             auto logs_parent = fs::path(logs_path).parent_path();
             if (!enoughSpaceInDirectory(logs_parent, 1ull << 30))


### PR DESCRIPTION
Typical examples are:
- /dev/null
- /dev/stdout
- /dev/stderr

Note, that we don't need to check that the file exists, since logger initialized earlier.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)