### PR TITLE
rust: Move tuikit fork into ClickHouse org

### DIFF
--- a/contrib/corrosion-cmake/config.toml.in
+++ b/contrib/corrosion-cmake/config.toml.in
@@ -11,8 +11,8 @@ lto = true
 registry = 'sparse+https://index.crates.io/'
 replace-with = 'vendored-sources'
 
-[source."git+https://github.com/azat-rust/tuikit.git?rev=e1994c0e03ff02c49cf1471f0cc3cbf185ce0104"]
-git = "https://github.com/azat-rust/tuikit.git"
+[source."git+https://github.com/ClickHouse/tuikit.git?rev=e1994c0e03ff02c49cf1471f0cc3cbf185ce0104"]
+git = "https://github.com/ClickHouse/tuikit.git"
 rev = "e1994c0e03ff02c49cf1471f0cc3cbf185ce0104"
 replace-with = "vendored-sources"
 

--- a/rust/workspace/Cargo.lock
+++ b/rust/workspace/Cargo.lock
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "tuikit"
 version = "0.5.0"
-source = "git+https://github.com/azat-rust/tuikit.git?rev=e1994c0e03ff02c49cf1471f0cc3cbf185ce0104#e1994c0e03ff02c49cf1471f0cc3cbf185ce0104"
+source = "git+https://github.com/ClickHouse/tuikit.git?rev=e1994c0e03ff02c49cf1471f0cc3cbf185ce0104#e1994c0e03ff02c49cf1471f0cc3cbf185ce0104"
 dependencies = [
  "bitflags 1.3.2",
  "lazy_static",

--- a/rust/workspace/Cargo.toml
+++ b/rust/workspace/Cargo.toml
@@ -8,4 +8,4 @@ resolver = "2"
 
 [patch.crates-io]
 # Ref: https://github.com/lotabout/tuikit/pull/51
-tuikit = { git = "https://github.com/azat-rust/tuikit.git", rev = "e1994c0e03ff02c49cf1471f0cc3cbf185ce0104" }
+tuikit = { git = "https://github.com/ClickHouse/tuikit.git", rev = "e1994c0e03ff02c49cf1471f0cc3cbf185ce0104" }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

P.S. no need to update https://github.com/ClickHouse/rust_vendor, since I simply transfer the repository into ClickHouse org