### PR TITLE
Fix timestamp_ntz for unity catalog

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -676,7 +676,7 @@ DataTypePtr DeltaLakeMetadata::getSimpleTypeByName(const String & type_name)
         return DataTypeFactory::instance().get("Bool");
     if (type_name == "date")
         return std::make_shared<DataTypeDate32>();
-    if (type_name == "timestamp")
+    if (type_name == "timestamp" || type_name == "timestamp_ntz")
         return std::make_shared<DataTypeDateTime64>(6);
     if (type_name.starts_with("decimal(") && type_name.ends_with(')'))
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add missing support data type `timestamp_ntz` for unity catalog. Fixes #79535, Fixes #79875.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
