### PR TITLE
Fix erroneous code around StorageObjectStorageConfiguration

### DIFF
--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -65,14 +65,6 @@ void StorageAzureConfiguration::check(ContextPtr context) const
     Configuration::check(context);
 }
 
-StorageAzureConfiguration::StorageAzureConfiguration(const StorageAzureConfiguration & other)
-    : Configuration(other)
-{
-    blob_path = other.blob_path;
-    blobs_paths = other.blobs_paths;
-    connection_params = other.connection_params;
-}
-
 StorageObjectStorage::QuerySettings StorageAzureConfiguration::getQuerySettings(const ContextPtr & context) const
 {
     const auto & settings = context->getSettingsRef();

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -49,7 +49,6 @@ public:
         " - storage_account_url, container_name, blobpath, account_name, account_key, format, compression\n";
 
     StorageAzureConfiguration() = default;
-    StorageAzureConfiguration(const StorageAzureConfiguration & other);
 
     ObjectStorageType getType() const override { return type; }
     std::string getTypeName() const override { return type_name; }
@@ -69,7 +68,6 @@ public:
     StorageObjectStorage::QuerySettings getQuerySettings(const ContextPtr &) const override;
 
     void check(ContextPtr context) const override;
-    ConfigurationPtr clone() override { return std::make_shared<StorageAzureConfiguration>(*this); }
 
     ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override;
 

--- a/src/Storages/ObjectStorage/HDFS/Configuration.cpp
+++ b/src/Storages/ObjectStorage/HDFS/Configuration.cpp
@@ -41,14 +41,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-StorageHDFSConfiguration::StorageHDFSConfiguration(const StorageHDFSConfiguration & other)
-    : Configuration(other)
-{
-    url = other.url;
-    path = other.path;
-    paths = other.paths;
-}
-
 void StorageHDFSConfiguration::check(ContextPtr context) const
 {
     context->getRemoteHostFilter().checkURL(Poco::URI(url));

--- a/src/Storages/ObjectStorage/HDFS/Configuration.h
+++ b/src/Storages/ObjectStorage/HDFS/Configuration.h
@@ -33,7 +33,6 @@ public:
         " - uri, format, compression_method\n";
 
     StorageHDFSConfiguration() = default;
-    StorageHDFSConfiguration(const StorageHDFSConfiguration & other);
 
     ObjectStorageType getType() const override { return type; }
     std::string getTypeName() const override { return type_name; }
@@ -54,7 +53,6 @@ public:
     StorageObjectStorage::QuerySettings getQuerySettings(const ContextPtr &) const override;
 
     void check(ContextPtr context) const override;
-    ConfigurationPtr clone() override { return std::make_shared<StorageHDFSConfiguration>(*this); }
 
     ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override;
 

--- a/src/Storages/ObjectStorage/Local/Configuration.h
+++ b/src/Storages/ObjectStorage/Local/Configuration.h
@@ -55,8 +55,6 @@ public:
     String getDataSourceDescription() const override { return ""; }
     StorageObjectStorage::QuerySettings getQuerySettings(const ContextPtr &) const override;
 
-    ConfigurationPtr clone() override { return std::make_shared<StorageLocalConfiguration>(*this); }
-
     ObjectStoragePtr createObjectStorage(ContextPtr, bool readonly) override
     {
         return std::make_shared<LocalObjectStorage>(LocalObjectStorageSettings("/", readonly));

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -104,15 +104,6 @@ void StorageS3Configuration::validateNamespace(const String & name) const
     S3::URI::validateBucket(name, {});
 }
 
-StorageS3Configuration::StorageS3Configuration(const StorageS3Configuration & other)
-    : Configuration(other)
-{
-    url = other.url;
-    static_configuration = other.static_configuration;
-    headers_from_ast = other.headers_from_ast;
-    keys = other.keys;
-}
-
 StorageObjectStorage::QuerySettings StorageS3Configuration::getQuerySettings(const ContextPtr & context) const
 {
     const auto & settings = context->getSettingsRef();

--- a/src/Storages/ObjectStorage/S3/Configuration.h
+++ b/src/Storages/ObjectStorage/S3/Configuration.h
@@ -57,7 +57,6 @@ public:
         "All signatures supports optional headers (specified as `headers('name'='value', 'name2'='value2')`)";
 
     StorageS3Configuration() = default;
-    StorageS3Configuration(const StorageS3Configuration & other);
 
     ObjectStorageType getType() const override { return type; }
     std::string getTypeName() const override { return type_name; }
@@ -85,7 +84,6 @@ public:
 
     void check(ContextPtr context) const override;
     void validateNamespace(const String & name) const override;
-    ConfigurationPtr clone() override { return std::make_shared<StorageS3Configuration>(*this); }
     bool isStaticConfiguration() const override { return static_configuration; }
 
     ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override;

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -456,8 +456,9 @@ SinkToStoragePtr StorageObjectStorage::write(
     configuration->setPaths(paths);
 
     return std::make_shared<StorageObjectStorageSink>(
+        paths.back(),
         object_storage,
-        configuration->clone(),
+        configuration,
         format_settings,
         sample_block,
         local_context);
@@ -648,13 +649,6 @@ const StorageObjectStorageSettings & StorageObjectStorage::Configuration::getSet
 void StorageObjectStorage::Configuration::check(ContextPtr) const
 {
     FormatFactory::instance().checkFormatName(format);
-}
-
-StorageObjectStorage::Configuration::Configuration(const Configuration & other)
-{
-    format = other.format;
-    compression_method = other.compression_method;
-    structure = other.structure;
 }
 
 bool StorageObjectStorage::Configuration::withPartitionWildcard() const

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -171,7 +171,6 @@ class StorageObjectStorage::Configuration
 {
 public:
     Configuration() = default;
-    Configuration(const Configuration & other);
     virtual ~Configuration() = default;
 
     using Path = std::string;
@@ -224,7 +223,6 @@ public:
     virtual void validateNamespace(const String & /* name */) const {}
 
     virtual ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) = 0;
-    virtual ConfigurationPtr clone() = 0;
     virtual bool isStaticConfiguration() const { return true; }
 
     virtual bool isDataLakeConfiguration() const { return false; }
@@ -267,13 +265,13 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method iterate() is not implemented for configuration type {}", getTypeName());
     }
 
-    String format = "auto";
-    String compression_method = "auto";
-    String structure = "auto";
-
     virtual void update(ObjectStoragePtr object_storage, ContextPtr local_context);
 
     const StorageObjectStorageSettings & getSettingsRef() const;
+
+    String format = "auto";
+    String compression_method = "auto";
+    String structure = "auto";
 
 protected:
     virtual void fromNamedCollection(const NamedCollection & collection, ContextPtr context) = 0;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
@@ -22,17 +22,17 @@ namespace ErrorCodes
 }
 
 StorageObjectStorageSink::StorageObjectStorageSink(
+    const std::string & path_,
     ObjectStoragePtr object_storage,
     ConfigurationPtr configuration,
     const std::optional<FormatSettings> & format_settings_,
     const Block & sample_block_,
-    ContextPtr context,
-    const std::string & blob_path)
+    ContextPtr context)
     : SinkToStorage(sample_block_)
+    , path(path_)
     , sample_block(sample_block_)
 {
     const auto & settings = context->getSettingsRef();
-    const auto path = blob_path.empty() ? configuration->getPaths().back() : blob_path;
     const auto chosen_compression_method = chooseCompressionMethod(path, configuration->compression_method);
 
     auto buffer = object_storage->writeObject(
@@ -137,12 +137,12 @@ SinkPtr PartitionedStorageObjectStorageSink::createSinkForPartition(const String
     }
 
     return std::make_shared<StorageObjectStorageSink>(
+        partition_key,
         object_storage,
         configuration,
         format_settings,
         sample_block,
-        context,
-        partition_key
+        context
     );
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.h
@@ -12,12 +12,12 @@ public:
     using ConfigurationPtr = StorageObjectStorage::ConfigurationPtr;
 
     StorageObjectStorageSink(
+        const std::string & path_,
         ObjectStoragePtr object_storage,
         ConfigurationPtr configuration,
         const std::optional<FormatSettings> & format_settings_,
         const Block & sample_block_,
-        ContextPtr context,
-        const std::string & blob_path = "");
+        ContextPtr context);
 
     ~StorageObjectStorageSink() override;
 
@@ -28,6 +28,7 @@ public:
     void onFinish() override;
 
 private:
+    const String path;
     const Block sample_block;
     std::unique_ptr<WriteBuffer> write_buf;
     OutputFormatPtr writer;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -158,11 +158,8 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
         if (hasExactlyOneBracketsExpansion(path))
         {
             auto paths = expandSelectionGlob(configuration->getPath());
-
-            ConfigurationPtr copy_configuration = configuration->clone();
-            copy_configuration->setPaths(paths);
             iterator = std::make_unique<KeysIterator>(
-                object_storage, copy_configuration, virtual_columns, is_archive ? nullptr : read_keys,
+                paths, object_storage, virtual_columns, is_archive ? nullptr : read_keys,
                 query_settings.ignore_non_existent_file, skip_object_metadata, file_progress_callback);
         }
         else
@@ -181,12 +178,12 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
     }
     else
     {
-        ConfigurationPtr copy_configuration = configuration->clone();
+        Strings paths;
+
         auto filter_dag = VirtualColumnUtils::createPathAndFileFilterDAG(predicate, virtual_columns);
         if (filter_dag)
         {
             auto keys = configuration->getPaths();
-            std::vector<String> paths;
             paths.reserve(keys.size());
             for (const auto & key : keys)
                 paths.push_back(fs::path(configuration->getNamespace()) / key);
@@ -194,11 +191,15 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
             VirtualColumnUtils::buildSetsForDAG(*filter_dag, local_context);
             auto actions = std::make_shared<ExpressionActions>(std::move(*filter_dag));
             VirtualColumnUtils::filterByPathOrFile(keys, paths, actions, virtual_columns, local_context);
-            copy_configuration->setPaths(keys);
+            paths = keys;
+        }
+        else
+        {
+            paths = configuration->getPaths();
         }
 
         iterator = std::make_unique<KeysIterator>(
-            object_storage, copy_configuration, virtual_columns, is_archive ? nullptr : read_keys,
+            paths, object_storage, virtual_columns, is_archive ? nullptr : read_keys,
             query_settings.ignore_non_existent_file, /*skip_object_metadata=*/false, file_progress_callback);
     }
 
@@ -834,18 +835,17 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::GlobIterator::ne
 }
 
 StorageObjectStorageSource::KeysIterator::KeysIterator(
+    const Strings & keys_,
     ObjectStoragePtr object_storage_,
-    ConfigurationPtr configuration_,
     const NamesAndTypesList & virtual_columns_,
     ObjectInfos * read_keys_,
     bool ignore_non_existent_files_,
     bool skip_object_metadata_,
     std::function<void(FileProgress)> file_progress_callback_)
     : object_storage(object_storage_)
-    , configuration(configuration_)
     , virtual_columns(virtual_columns_)
     , file_progress_callback(file_progress_callback_)
-    , keys(configuration->getPaths())
+    , keys(keys_)
     , ignore_non_existent_files(ignore_non_existent_files_)
     , skip_object_metadata(skip_object_metadata_)
 {

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -219,8 +219,8 @@ class StorageObjectStorageSource::KeysIterator : public IObjectIterator
 {
 public:
     KeysIterator(
+        const Strings & keys_,
         ObjectStoragePtr object_storage_,
-        ConfigurationPtr configuration_,
         const NamesAndTypesList & virtual_columns_,
         ObjectInfos * read_keys_,
         bool ignore_non_existent_files_,
@@ -235,7 +235,6 @@ public:
 
 private:
     const ObjectStoragePtr object_storage;
-    const ConfigurationPtr configuration;
     const NamesAndTypesList virtual_columns;
     const std::function<void(FileProgress)> file_progress_callback;
     const std::vector<String> keys;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
There are the following reasons for this change:
1. `clone` method was used in several places completely unnecessarily (when creating `StorageObjectStorageSource::KeysIterator` it was not needed completely, in `StorageObjectStorageSink` its usage is not warranted as well).
2. `clone` method was based on copy constructor, which was never updated when someone added new fields to the class, making it work incorrectly (though it did not lead to any noticeable problem, because those fields were not used after `clone` had been called, but no guarantee that it would not have caused problems in the future).
3. We forgot to override `clone` method in `DataLakeConfuguration`, which inherits from `S3(Azure/etc)StorageConfiguration`, leading to `DataLakeConfiguration` always becoming its base class after `clone`, which again did not cause any noticeable problem, because of how little usage we made of this object after using `clone`, but it will change in the future.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
