### PR TITLE
Adjust compatibility values for max_merge_delayed_streams_for_parallel_write

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -789,7 +789,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"max_postpone_time_for_failed_replicated_tasks_ms", 0, 5ULL * 60 * 1000, "Added new setting to enable postponing tasks in the replication queue."},
             {"default_compression_codec", "", "", "New setting"},
             {"refresh_parts_interval", 0, 0, "A new setting"},
-            {"max_merge_delayed_streams_for_parallel_write", 1000, 40, "New setting"},
+            {"max_merge_delayed_streams_for_parallel_write", 40, 40, "New setting"},
             {"allow_summing_columns_in_partition_or_order_key", true, false, "New setting to allow summing of partition or sorting key columns"},
             /// Release closed. Please use 25.5
         });


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adjust compatibility values for max_merge_delayed_streams_for_parallel_write

The problem is that the previous value was lead to excessive memory usage (#77922), and now if you wll use compatibility=25.3 you will have the same.

So let's simply ignore that fact that it was 1000 at some point in time.

Note, that query-level setting
(`max_insert_delayed_streams_for_parallel_write`) was never adjusted for compatibility, since it has default of `0` (which means auto).
