### PR TITLE
Fix test_refreshable_mv/test.py::test_backup_inner_table flakiness

### DIFF
--- a/src/Backups/BackupUtils.cpp
+++ b/src/Backups/BackupUtils.cpp
@@ -126,8 +126,8 @@ bool isInnerTable(const QualifiedTableName & table_name)
 
 bool isInnerTable(const String & /* database_name */, const String & table_name)
 {
-    /// We skip inner tables of materialized views.
-    return table_name.starts_with(".inner.") || table_name.starts_with(".inner_id.");
+    /// We skip inner tables of materialized views. They're backed up by StorageMaterializedView.
+    return table_name.starts_with(".inner.") || table_name.starts_with(".inner_id.") || table_name.starts_with(".tmp.inner.") || table_name.starts_with(".tmp.inner_id.");
 }
 
 }

--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -424,8 +424,13 @@ def do_test_backup(to_table):
 
     assert node1.query(tables_exist_query) == "2\n"
     assert node2.query(tables_exist_query) == "2\n"
-    node1.query(f'SYSTEM SYNC REPLICA re.{target}')
-    node2.query(f'SYSTEM SYNC REPLICA re.{target}')
+    if not to_table:
+        # Inner tables are not backed up, wait for first refresh.
+        node1.query(f'SYSTEM WAIT VIEW re.{target}')
+        node2.query(f'SYSTEM WAIT VIEW re.{target}')
+    else:
+        node1.query(f'SYSTEM SYNC REPLICA re.{target}')
+        node2.query(f'SYSTEM SYNC REPLICA re.{target}')
     assert node1.query(f'SELECT * FROM re.{target}') == '1\n'
     assert node2.query(f'SELECT * FROM re.{target}') == '1\n'
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/80744

Yet another missing `SYSTEM WAIT VIEW`, probably (I didn't reproduce the failure).

(The `".tmp.inner"` part is a separate unrelated fix.)