### PR TITLE
Fix flakiness of 01155_old_mutation_parts_to_do

### DIFF
--- a/src/Storages/MergeTree/Compaction/CompactionStatistics.h
+++ b/src/Storages/MergeTree/Compaction/CompactionStatistics.h
@@ -40,7 +40,7 @@ UInt64 getMaxSourcePartsSizeForMerge(
 /** Get maximum total size of parts to do mutation, at current moment of time.
   * It depends only on amount of free space in disk.
   */
-UInt64 getMaxSourcePartSizeForMutation(const MergeTreeData & data);
+UInt64 getMaxSourcePartSizeForMutation(const MergeTreeData & data, String * out_log_comment = nullptr);
 
 };
 

--- a/tests/queries/0_stateless/00991_system_parts_race_condition_long.sh
+++ b/tests/queries/0_stateless/00991_system_parts_race_condition_long.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
-# Tags: race
-
-# This test is disabled because it triggers internal assert in Thread Sanitizer.
-# Thread Sanitizer does not support for more than 64 mutexes to be locked in a single thread.
-# https://github.com/google/sanitizers/issues/950
+# Tags: race, no-parallel
+# no-parallel because we run many concurrent mutations, which may break other tests by delaying their
+# mutations for a long time.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01155_old_mutation_parts_to_do.sh
+++ b/tests/queries/0_stateless/01155_old_mutation_parts_to_do.sh
@@ -12,8 +12,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} -q "drop table if exists rmt;"
 
+# max_replicated_mutations_in_queue is to pause mutations until later in the test.
+# max_merge_selecting_sleep_ms is to be less affected by concurrent tests taking up mutation thread
+# pool slots and delaying our mutations.
 ${CLICKHOUSE_CLIENT} -q "create table rmt (n int, m int, s String) engine=ReplicatedMergeTree('/test/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/rmt', '1')
-order by n settings max_replicated_mutations_in_queue=0;"
+order by n settings max_replicated_mutations_in_queue=0, max_merge_selecting_sleep_ms=5000;"
 
 ${CLICKHOUSE_CLIENT} -q "insert into rmt values (1, 1, '2');"     # 0_0_0_0
 ${CLICKHOUSE_CLIENT} --mutations_sync=0 -q "alter table rmt update m = m*toInt8(s) where 1;"  # 0000000000

--- a/tests/queries/0_stateless/mergetree_mutations.lib
+++ b/tests/queries/0_stateless/mergetree_mutations.lib
@@ -9,7 +9,7 @@ function wait_for_mutation()
 
     for _ in {1..300}
     do
-        sleep 0.1
+        sleep 0.3
         if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT min(is_done) FROM system.mutations WHERE database='$database' AND table='$table' AND mutation_id='$mutation_id'") -eq 1 ]]; then
             return
         fi


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/75986

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=75694&sha=e7e472c8b6301606b166afd24c5453104d1514c6&name_0=PR&name_1=Stateless%20tests%20%28debug%2C%20s3%20storage%29

Mutation didn't start for >30 seconds because the thread pool was too busy with other mutations or merges, presumably from some other tests. The log has lots of mutations from `00991_system_parts_race_condition_long`, which just spams mutations in a loop. Looking at a random other failure of the same test, it also ran concurrently with `00991_system_parts_race_condition_long`:

https://s3.amazonaws.com/clickhouse-test-reports/0/a468200d1b718f1b8958cfe8d962e21ea891c715/stateless_tests__debug__s3_storage_.html

This PR makes `00991_system_parts_race_condition_long` `no-parallel` (and also has other changes that I made before figuring out what's going on - I guess these changes are net positive?).