### PR TITLE
Add query_id for background schedule pool

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -172,9 +172,14 @@ ThreadGroupPtr ThreadStatus::getThreadGroup() const
     return thread_group;
 }
 
+void ThreadStatus::setQueryId(const std::string & new_query_id)
+{
+    query_id = new_query_id;
+}
+
 const String & ThreadStatus::getQueryId() const
 {
-    return query_id_from_query_context;
+    return query_id;
 }
 
 ContextPtr ThreadStatus::getQueryContext() const

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -174,12 +174,13 @@ ThreadGroupPtr ThreadStatus::getThreadGroup() const
 
 void ThreadStatus::setQueryId(std::string && new_query_id)
 {
+    chassert(query_id.empty());
     query_id = std::move(new_query_id);
 }
 
-std::string ThreadStatus::clearQueryId()
+void ThreadStatus::clearQueryId()
 {
-    return std::exchange(query_id, {});
+    query_id.clear();
 }
 
 const String & ThreadStatus::getQueryId() const

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -172,9 +172,14 @@ ThreadGroupPtr ThreadStatus::getThreadGroup() const
     return thread_group;
 }
 
-void ThreadStatus::setQueryId(const std::string & new_query_id)
+void ThreadStatus::setQueryId(std::string && new_query_id)
 {
-    query_id = new_query_id;
+    query_id = std::move(new_query_id);
+}
+
+std::string ThreadStatus::clearQueryId()
+{
+    return std::exchange(query_id, {});
 }
 
 const String & ThreadStatus::getQueryId() const

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -172,13 +172,13 @@ ThreadGroupPtr ThreadStatus::getThreadGroup() const
     return thread_group;
 }
 
-void ThreadStatus::setQueryId(std::string && new_query_id)
+void ThreadStatus::setQueryId(std::string && new_query_id) noexcept
 {
     chassert(query_id.empty());
     query_id = std::move(new_query_id);
 }
 
-void ThreadStatus::clearQueryId()
+void ThreadStatus::clearQueryId() noexcept
 {
     query_id.clear();
 }

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -278,8 +278,8 @@ public:
 
     ThreadGroupPtr getThreadGroup() const;
 
-    void setQueryId(std::string && new_query_id);
-    void clearQueryId();
+    void setQueryId(std::string && new_query_id) noexcept;
+    void clearQueryId() noexcept;
     const String & getQueryId() const;
 
     ContextPtr getQueryContext() const;

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -237,7 +237,7 @@ private:
 
     bool performance_counters_finalized = false;
 
-    String query_id_from_query_context;
+    String query_id;
 
     struct TimePoint
     {
@@ -278,6 +278,7 @@ public:
 
     ThreadGroupPtr getThreadGroup() const;
 
+    void setQueryId(const std::string & new_query_id);
     const String & getQueryId() const;
 
     ContextPtr getQueryContext() const;

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -279,7 +279,7 @@ public:
     ThreadGroupPtr getThreadGroup() const;
 
     void setQueryId(std::string && new_query_id);
-    std::string clearQueryId();
+    void clearQueryId();
     const String & getQueryId() const;
 
     ContextPtr getQueryContext() const;

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -278,7 +278,8 @@ public:
 
     ThreadGroupPtr getThreadGroup() const;
 
-    void setQueryId(const std::string & new_query_id);
+    void setQueryId(std::string && new_query_id);
+    std::string clearQueryId();
     const String & getQueryId() const;
 
     ContextPtr getQueryContext() const;

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -108,14 +108,17 @@ void BackgroundSchedulePoolTaskInfo::execute()
         executing = true;
     }
 
+    /// Using this tmp query_id storage to prevent bad_alloc thrown under the try/catch.
+    std::string task_query_id = fmt::format("{}::{}", pool.thread_name, UUIDHelpers::generateV4());
+
     try
     {
         chassert(current_thread); /// Thread from global thread pool
-        current_thread->setQueryId(fmt::format("{}::{}", pool.thread_name, UUIDHelpers::generateV4()));
+        current_thread->setQueryId(std::move(task_query_id));
 
         function();
 
-        current_thread->setQueryId("");
+        task_query_id = current_thread->clearQueryId();
     }
     catch (...)
     {

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -118,7 +118,7 @@ void BackgroundSchedulePoolTaskInfo::execute()
 
         function();
 
-        task_query_id = current_thread->clearQueryId();
+        current_thread->clearQueryId();
     }
     catch (...)
     {

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -1,4 +1,9 @@
-#include "BackgroundSchedulePool.h"
+#include <Core/BackgroundSchedulePool.h>
+#include <Core/UUID.h>
+
+#include <IO/WriteHelpers.h>
+
+#include <Common/ThreadStatus.h>
 #include <Common/Exception.h>
 #include <Common/setThreadName.h>
 #include <Common/Stopwatch.h>
@@ -6,6 +11,7 @@
 #include <Common/UniqueLock.h>
 #include <Common/logger_useful.h>
 #include <Common/ThreadPool.h>
+
 #include <chrono>
 
 
@@ -104,7 +110,12 @@ void BackgroundSchedulePoolTaskInfo::execute()
 
     try
     {
+        chassert(current_thread); /// Thread from global thread pool
+        current_thread->setQueryId(fmt::format("{}::{}", pool.thread_name, UUIDHelpers::generateV4()));
+
         function();
+
+        current_thread->setQueryId("");
     }
     catch (...)
     {

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -316,7 +316,7 @@ void ThreadStatus::applyQuerySettings()
 
     DB::Exception::enable_job_stack_trace = settings[Setting::enable_job_stack_trace];
 
-    query_id_from_query_context = query_context_ptr->getCurrentQueryId();
+    query_id = query_context_ptr->getCurrentQueryId();
     initQueryProfiler();
 
     untracked_memory_limit = settings[Setting::max_untracked_memory];
@@ -384,7 +384,7 @@ void ThreadStatus::detachFromGroup()
 
     thread_group.reset();
 
-    query_id_from_query_context.clear();
+    query_id.clear();
     query_context.reset();
 
     local_data = {};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set query_id for each task in background schedule pool

QueryId: `BgSchPool::d1da346f-a5ea-4b7d-bdf9-590120c7fc1c`
