### PR TITLE
Fix exception handling in TemporaryFile

### DIFF
--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -149,21 +149,23 @@ public:
     }
 
     ~TemporaryFileOnLocalDisk() override
-    try
     {
-        if (disk->existsFile(path_to_file))
+        try
         {
-            LOG_TRACE(getLogger("TemporaryFileOnLocalDisk"), "Removing temporary file '{}'", path_to_file);
-            disk->removeRecursive(path_to_file);
+            if (disk->existsFile(path_to_file))
+            {
+                LOG_TRACE(getLogger("TemporaryFileOnLocalDisk"), "Removing temporary file '{}'", path_to_file);
+                disk->removeRecursive(path_to_file);
+            }
+            else
+            {
+                LOG_WARNING(getLogger("TemporaryFileOnLocalDisk"), "Temporary path '{}' does not exist in '{}' on disk {}", path_to_file, disk->getPath(), disk->getName());
+            }
         }
-        else
+        catch (...)
         {
-            LOG_WARNING(getLogger("TemporaryFileOnLocalDisk"), "Temporary path '{}' does not exist in '{}' on disk {}", path_to_file, disk->getPath(), disk->getName());
+            tryLogCurrentException(__PRETTY_FUNCTION__);
         }
-    }
-    catch (...)
-    {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 
 private:


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a crash: if an exception is thrown in an attempt to remove a temporary file (they are used for spilling temporary data on disk) in the destructor, the program can terminate.

If you think you know how function-try blocks work in destructors, you are too self-confident.

1. https://pastila.nl/?015b6bdb/432c23e8fa96cfe9bbf898117e5f3d6a#g2fQIds43Bxck4yM5wPrnw==

2. https://pastila.nl/?0095551a/6ef219f9fb1faf106eb3108bcdfe0d42#2HaFqZhBFkg9TqWHeZMr0g==

3. https://pastila.nl/?04f050fb/bac91e21010c1903c63f7e01c8b53549#6CPluq/pDCErpSZwRR5UJw==

This crash was found by our crash reporting.