### PR TITLE
Docs: add note about using llvm-ar for MacOS debug build

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -47,6 +47,11 @@ cmake --build build
 # The resulting binary will be created at: build/programs/clickhouse
 ```
 
+:::note
+If you are running into `ld: archive member '/' not a mach-o file in ...` errors during linking, you may need
+to use llvm-ar by setting flag `-DCMAKE_AR=/opt/homebrew/opt/llvm/bin/llvm-ar`.
+:::
+
 ## Caveats {#caveats}
 
 If you intend to run `clickhouse-server`, make sure to increase the system's `maxfiles` variable.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Instructions work perfectly except for when I try to do a debug build. In this case I get the following error during linking:

```text
ld: archive member '/' not a mach-o file in '/Users/sstruw/Desktop/ClickHouse/cmake-build-debug/contrib/xxHash-cmake/libxxHash.a'
```

Setting `-DCMAKE_AR=/opt/homebrew/opt/llvm/bin/llvm-ar` solved the problem for me.


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
