### PR TITLE
Improve shutdown speed of Kafka engine

### DIFF
--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -12,7 +12,6 @@ class ASTStorage;
 struct KafkaSettingsImpl;
 
 const auto KAFKA_RESCHEDULE_MS = 500;
-const auto KAFKA_CLEANUP_TIMEOUT_MS = 3000;
 // once per minute leave do reschedule (we can't lock threads in pool forever)
 const auto KAFKA_MAX_THREAD_WORK_DURATION_MS = 60000;
 // 10min

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -324,13 +324,6 @@ void StorageKafka::shutdown(bool)
         consumers.clear();
         LOG_TRACE(log, "Consumers closed. Took {} ms.", watch.elapsedMilliseconds());
     }
-
-    {
-        LOG_TRACE(log, "Waiting for final cleanup");
-        Stopwatch watch;
-        rd_kafka_wait_destroyed(KAFKA_CLEANUP_TIMEOUT_MS);
-        LOG_TRACE(log, "Final cleanup finished in {} ms (timeout {} ms).", watch.elapsedMilliseconds(), KAFKA_CLEANUP_TIMEOUT_MS);
-    }
 }
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve shutdown speed of Kafka engine (remove extra 3 seconds delay in case of multiple Kafka tables) 

Previously, due to rd_kafka_wait_destroyed() call, the storage will wait until all kafka threads will be terminated, but, this actually will never happen with multiple Kafka tables attached, and this will basically just wait for 3 seconds on each shutdown.

So let's simply remove this, since this is totally safe, since each producer will join it's own thread[s].

See also: https://github.com/confluentinc/librdkafka/wiki/Proper-termination-sequence/b182d62033a62365027ab080d0e85db619f37375
