### PR TITLE
Fixes #60989: add metrics for mark cache evicted bytes, marks and files

### DIFF
--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -64,9 +64,9 @@ public:
         size_t max_count,
         double size_ratio)
     {
-        auto on_remove_function = [this](const MappedPtr & mapped_ptr)
+        auto on_remove_entry_function = [this](const MappedPtr & mapped_ptr)
         {
-            onValueRemoval(mapped_ptr);
+            onEntryRemoval(mapped_ptr);
         };
 
         if (cache_policy_name.empty())
@@ -78,12 +78,12 @@ public:
         if (cache_policy_name == "LRU")
         {
             using LRUPolicy = LRUCachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
-            cache_policy = std::make_unique<LRUPolicy>(size_in_bytes_metric, count_metric, max_size_in_bytes, max_count, on_remove_function);
+            cache_policy = std::make_unique<LRUPolicy>(size_in_bytes_metric, count_metric, max_size_in_bytes, max_count, on_remove_entry_function);
         }
         else if (cache_policy_name == "SLRU")
         {
             using SLRUPolicy = SLRUCachePolicy<TKey, TMapped, HashFunction, WeightFunction>;
-            cache_policy = std::make_unique<SLRUPolicy>(size_in_bytes_metric, count_metric, max_size_in_bytes, max_count, size_ratio, on_remove_function);
+            cache_policy = std::make_unique<SLRUPolicy>(size_in_bytes_metric, count_metric, max_size_in_bytes, max_count, size_ratio, on_remove_entry_function);
         }
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown cache policy name: {}", cache_policy_name);
@@ -338,9 +338,9 @@ private:
 
     InsertTokenById insert_tokens TSA_GUARDED_BY(mutex);
 
-    /// This is called when a cell is being evicted from the cache.
-    /// Override this method if you want to handle individual value removals from cache
-    virtual void onValueRemoval(const MappedPtr &) { }
+    /// This is called when an entry is being evicted from the cache.
+    /// Override this method if you want to handle individual entry removals from cache
+    virtual void onEntryRemoval(const MappedPtr &) { }
 };
 
 

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -64,9 +64,9 @@ public:
         size_t max_count,
         double size_ratio)
     {
-        auto on_remove_function = [this](const MappedPtr & mappedPtr)
+        auto on_remove_function = [this](const MappedPtr & mapped_ptr)
         {
-            onValueRemoval(mappedPtr);
+            onValueRemoval(mapped_ptr);
         };
 
         if (cache_policy_name.empty())
@@ -340,7 +340,7 @@ private:
 
     /// This is called when a cell is being evicted from the cache.
     /// Override this method if you want to handle individual value removals from cache
-    virtual void onValueRemoval(const MappedPtr & /*mapped*/) { }
+    virtual void onValueRemoval(const MappedPtr &) { }
 };
 
 

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -67,7 +67,6 @@ public:
     {
         auto on_eviction_function = [this](const EvictionStats & stats)
         {
-            onRemoveOverflowWeightLoss(stats.total_weight_loss); // Backward compatibility
             onEviction(stats); // New callback with full stats
         };
 
@@ -344,10 +343,6 @@ private:
     friend struct InsertTokenHolder;
 
     InsertTokenById insert_tokens TSA_GUARDED_BY(mutex);
-
-    /// Override this method if you want to track how much weight was lost in removeOverflow method.
-    /// Keep existing method for backward compatibility, prefer OnEviction() for new implementations.
-    virtual void onRemoveOverflowWeightLoss(size_t /*weight_loss*/) {}
 
     /// Override this method if you want to track eviction metrics in removeOverflow method.
     /// To add more metrics, add them to EvictionStats struct.

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -65,7 +65,7 @@ public:
         size_t max_count,
         double size_ratio)
     {
-        auto on_eviction_function = [&](size_t weight_loss, std::vector<MappedPtr>& evicted_values)
+        auto on_eviction_function = [&](size_t weight_loss, std::vector<MappedPtr> & evicted_values)
         {
             EvictionDetails details{weight_loss, std::move(evicted_values)};
             onEviction(details);
@@ -346,7 +346,7 @@ private:
 
     /// Override this method if you want to track eviction metrics in removeOverflow method.
     /// To add more metrics, add them to EvictionDetails struct.
-    virtual void onEviction(const EvictionDetails&) {}
+    virtual void onEviction(const EvictionDetails &) {}
 };
 
 

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -65,7 +65,8 @@ public:
         size_t max_count,
         double size_ratio)
     {
-        auto on_eviction_function = [&](size_t weight_loss, std::vector<MappedPtr>& evicted_values) {
+        auto on_eviction_function = [&](size_t weight_loss, std::vector<MappedPtr>& evicted_values)
+        {
             EvictionDetails details{weight_loss, std::move(evicted_values)};
             onEviction(details);
         };

--- a/src/Common/CacheBase.h
+++ b/src/Common/CacheBase.h
@@ -64,9 +64,9 @@ public:
         size_t max_count,
         double size_ratio)
     {
-        auto on_remove_entry_function = [this](const MappedPtr & mapped_ptr)
+        auto on_remove_entry_function = [this](size_t weight_loss, const MappedPtr & mapped_ptr)
         {
-            onEntryRemoval(mapped_ptr);
+            onEntryRemoval(weight_loss, mapped_ptr);
         };
 
         if (cache_policy_name.empty())
@@ -340,7 +340,7 @@ private:
 
     /// This is called when an entry is being evicted from the cache.
     /// Override this method if you want to handle individual entry removals from cache
-    virtual void onEntryRemoval(const MappedPtr &) { }
+    virtual void onEntryRemoval(size_t /*weight_loss*/, const MappedPtr &) { }
 };
 
 

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -26,7 +26,7 @@ public:
     using Key = TKey;
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
-    using OnRemoveFunction = std::function<void(const MappedPtr &)>;  // For per-item callback
+    using OnRemoveEntryFunction = std::function<void(const MappedPtr &)>;  /// For per-item callback
 
     struct KeyMapped
     {

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -26,25 +26,13 @@ public:
     using Key = TKey;
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
-    using OnRemoveFunction = std::function<size_t(const MappedPtr &)>;  // For per-item callback
+    using OnRemoveFunction = std::function<void(const MappedPtr &)>;  // For per-item callback
 
     struct KeyMapped
     {
         Key key;
         MappedPtr mapped;
     };
-
-    struct EvictionStats
-    {
-        /// Used to count total weight loss (e.g., in bytes) during eviction
-        size_t total_weight_loss;
-        /// Used to count cached entities (eg: marks totalling over MarksInCompressedFile in MarkCache)
-        size_t total_evicted_value_entities_num;
-        /// Used to count number of evicted keys (eg: files in MarkCache)
-        size_t total_evicted_keys_num;
-    };
-
-    using OnEvictionFunction = std::function<void(const EvictionStats &)>;  // Receives aggregate stats
 
     explicit ICachePolicy(CachePolicyUserQuotaPtr user_quotas_) : user_quotas(std::move(user_quotas_)) {}
     virtual ~ICachePolicy() = default;

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -26,12 +26,18 @@ public:
     using Key = TKey;
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
-    using OnWeightLossFunction = std::function<void(size_t)>;
+    using OnEvictionFunction = std::function<void(size_t, std::vector<MappedPtr>&)>;
 
     struct KeyMapped
     {
         Key key;
         MappedPtr mapped;
+    };
+
+    struct EvictionDetails
+    {
+        size_t total_weight_loss;
+        std::vector<MappedPtr> evicted_values; // vector to store evicted values on account of overflow
     };
 
     explicit ICachePolicy(CachePolicyUserQuotaPtr user_quotas_) : user_quotas(std::move(user_quotas_)) {}

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -26,7 +26,7 @@ public:
     using Key = TKey;
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
-    using OnEvictionFunction = std::function<void(size_t, std::vector<MappedPtr>&)>;
+    using OnRemoveFunction = std::function<size_t(const MappedPtr &)>;  // For per-item callback
 
     struct KeyMapped
     {
@@ -34,11 +34,14 @@ public:
         MappedPtr mapped;
     };
 
-    struct EvictionDetails
+    struct EvictionStats
     {
         size_t total_weight_loss;
-        std::vector<MappedPtr> evicted_values; // vector to store evicted values on account of overflow
+        size_t total_evicted_marks_num;
+        size_t total_evicted_files_num;
     };
+
+    using OnEvictionFunction = std::function<void(const EvictionStats &)>;  // Receives aggregate stats
 
     explicit ICachePolicy(CachePolicyUserQuotaPtr user_quotas_) : user_quotas(std::move(user_quotas_)) {}
     virtual ~ICachePolicy() = default;

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -36,9 +36,12 @@ public:
 
     struct EvictionStats
     {
+        /// Used to count total weight loss (e.g., in bytes) during eviction
         size_t total_weight_loss;
-        size_t total_evicted_marks_num;
-        size_t total_evicted_files_num;
+        /// Used to count cached entities (eg: marks totalling over MarksInCompressedFile in MarkCache)
+        size_t total_evicted_value_entities_num;
+        /// Used to count number of evicted keys (eg: files in MarkCache)
+        size_t total_evicted_keys_num;
     };
 
     using OnEvictionFunction = std::function<void(const EvictionStats &)>;  // Receives aggregate stats

--- a/src/Common/ICachePolicy.h
+++ b/src/Common/ICachePolicy.h
@@ -26,7 +26,7 @@ public:
     using Key = TKey;
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
-    using OnRemoveEntryFunction = std::function<void(const MappedPtr &)>;  /// For per-item callback
+    using OnRemoveEntryFunction = std::function<void(size_t, const MappedPtr &)>;  /// For per-item callback
 
     struct KeyMapped
     {

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -243,7 +243,7 @@ private:
 
             current_size_in_bytes -= cell.size;
             current_weight_lost += cell.size;
-            on_remove_entry_function(cell.value);
+            on_remove_entry_function(cell.size, cell.value);
 
             cells.erase(it);
             queue.pop_front();

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -21,7 +21,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnWeightLossFunction;
+    using typename Base::OnEvictionFunction;
 
     /** Initialize LRUCachePolicy with max_size_in_bytes and max_count.
      *  max_size_in_bytes == 0 means the cache accepts no entries.
@@ -32,13 +32,13 @@ public:
         CurrentMetrics::Metric count_metric_,
         size_t max_size_in_bytes_,
         size_t max_count_,
-        OnWeightLossFunction on_weight_loss_function_)
+        OnEvictionFunction on_eviction_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
         , max_size_in_bytes(max_size_in_bytes_)
         , max_count(max_count_)
         , current_size_in_bytes_metric(size_in_bytes_metric_)
         , count_metric(count_metric_)
-        , on_weight_loss_function(on_weight_loss_function_)
+        , on_eviction_function(on_eviction_function_)
     {
     }
 
@@ -221,7 +221,7 @@ private:
     CurrentMetrics::Metric count_metric;
 
     WeightFunction weight_function;
-    OnWeightLossFunction on_weight_loss_function;
+    OnEvictionFunction on_eviction_function;
 
     void removeOverflow()
     {
@@ -230,6 +230,7 @@ private:
 
         size_t current_weight_lost = 0;
         size_t queue_size = cells.size();
+        std::vector<MappedPtr> evicted_values; // vector to store evicted values on account of overflow
 
         while ((current_size_in_bytes > max_size_in_bytes || (max_count != 0 && queue_size > max_count)) && (queue_size > 0))
         {
@@ -243,13 +244,14 @@ private:
 
             current_size_in_bytes -= cell.size;
             current_weight_lost += cell.size;
+            evicted_values.push_back(cell.value); // Store the evicted value
 
             cells.erase(it);
             queue.pop_front();
             --queue_size;
         }
 
-        on_weight_loss_function(current_weight_lost);
+        on_eviction_function(current_weight_lost, evicted_values);
 
         if (current_size_in_bytes > (1ull << 63))
             std::terminate(); // Queue became inconsistent

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -21,7 +21,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnRemoveFunction;
+    using typename Base::OnRemoveEntryFunction;
 
     /** Initialize LRUCachePolicy with max_size_in_bytes and max_count.
      *  max_size_in_bytes == 0 means the cache accepts no entries.
@@ -32,13 +32,13 @@ public:
         CurrentMetrics::Metric count_metric_,
         size_t max_size_in_bytes_,
         size_t max_count_,
-        OnRemoveFunction on_remove_function_)
+        OnRemoveEntryFunction on_remove_entry_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
         , max_size_in_bytes(max_size_in_bytes_)
         , max_count(max_count_)
         , current_size_in_bytes_metric(size_in_bytes_metric_)
         , count_metric(count_metric_)
-        , on_remove_function(on_remove_function_)
+        , on_remove_entry_function(on_remove_entry_function_)
     {
     }
 
@@ -221,7 +221,7 @@ private:
     CurrentMetrics::Metric count_metric;
 
     WeightFunction weight_function;
-    OnRemoveFunction on_remove_function;
+    OnRemoveEntryFunction on_remove_entry_function;
 
     void removeOverflow()
     {
@@ -243,7 +243,7 @@ private:
 
             current_size_in_bytes -= cell.size;
             current_weight_lost += cell.size;
-            on_remove_function(cell.value);
+            on_remove_entry_function(cell.value);
 
             cells.erase(it);
             queue.pop_front();

--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -250,8 +250,8 @@ private:
             current_size_in_bytes -= cell.size;
             current_weight_lost += cell.size;
             /// Get item-specific count from callback (e.g., number of marks)
-            eviction_stats.total_evicted_marks_num += on_remove_function(cell.value);
-            ++eviction_stats.total_evicted_files_num;
+            eviction_stats.total_evicted_value_entities_num += on_remove_function(cell.value);
+            ++eviction_stats.total_evicted_keys_num;
 
             cells.erase(it);
             queue.pop_front();
@@ -259,7 +259,7 @@ private:
         }
 
         /// Call eviction callback with accumulated stats
-        if (eviction_stats.total_evicted_files_num > 0)
+        if (eviction_stats.total_evicted_keys_num > 0)
             on_eviction_function(eviction_stats);
 
         if (current_size_in_bytes > (1ull << 63))

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -145,9 +145,10 @@ bool PageCache::contains(const PageCacheKey & key, bool inject_eviction) const
     return shard.contains(key_hash);
 }
 
-void PageCache::Shard::onEviction(const EvictionStats& stats)
+void PageCache::Shard::onValueRemoval(const MappedPtr & mappedPtr)
 {
-    ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, stats.total_weight_loss);
+    auto page_cache_cell = std::static_pointer_cast<PageCacheCell>(mappedPtr);
+    ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, PageCacheWeightFunction()(*page_cache_cell));
 }
 
 void PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -145,7 +145,7 @@ bool PageCache::contains(const PageCacheKey & key, bool inject_eviction) const
     return shard.contains(key_hash);
 }
 
-void PageCache::Shard::onValueRemoval(const MappedPtr & mapped_ptr)
+void PageCache::Shard::onEntryRemoval(const MappedPtr & mapped_ptr)
 {
     auto page_cache_cell = std::static_pointer_cast<PageCacheCell>(mapped_ptr);
     ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, PageCacheWeightFunction()(*page_cache_cell));

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -145,9 +145,9 @@ bool PageCache::contains(const PageCacheKey & key, bool inject_eviction) const
     return shard.contains(key_hash);
 }
 
-void PageCache::Shard::onValueRemoval(const MappedPtr & mappedPtr)
+void PageCache::Shard::onValueRemoval(const MappedPtr & mapped_ptr)
 {
-    auto page_cache_cell = std::static_pointer_cast<PageCacheCell>(mappedPtr);
+    auto page_cache_cell = std::static_pointer_cast<PageCacheCell>(mapped_ptr);
     ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, PageCacheWeightFunction()(*page_cache_cell));
 }
 

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -145,9 +145,9 @@ bool PageCache::contains(const PageCacheKey & key, bool inject_eviction) const
     return shard.contains(key_hash);
 }
 
-void PageCache::Shard::onRemoveOverflowWeightLoss(size_t weight_loss)
+void PageCache::Shard::onEviction(const EvictionStats& stats)
 {
-    ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, weight_loss);
+    ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, stats.total_weight_loss);
 }
 
 void PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -145,10 +145,10 @@ bool PageCache::contains(const PageCacheKey & key, bool inject_eviction) const
     return shard.contains(key_hash);
 }
 
-void PageCache::Shard::onEntryRemoval(const MappedPtr & mapped_ptr)
+void PageCache::Shard::onEntryRemoval(const size_t weight_loss, const MappedPtr & mapped_ptr)
 {
-    auto page_cache_cell = std::static_pointer_cast<PageCacheCell>(mapped_ptr);
-    ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, PageCacheWeightFunction()(*page_cache_cell));
+    ProfileEvents::increment(ProfileEvents::PageCacheWeightLost, weight_loss);
+    UNUSED(mapped_ptr);
 }
 
 void PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -98,7 +98,7 @@ private:
     public:
         using Base::Base;
 
-        void onEntryRemoval(const MappedPtr & mapped_ptr) override;
+        void onEntryRemoval(size_t weight_loss, const MappedPtr & mapped_ptr) override;
     };
 
 public:

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -98,7 +98,7 @@ private:
     public:
         using Base::Base;
 
-        void onRemoveOverflowWeightLoss(size_t /*weight_loss*/) override;
+        void onEviction(const EvictionStats & /*stats*/) override;
     };
 
 public:

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -98,7 +98,7 @@ private:
     public:
         using Base::Base;
 
-        void onValueRemoval(const MappedPtr & mappedPtr) override;
+        void onValueRemoval(const MappedPtr & mapped_ptr) override;
     };
 
 public:

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -98,7 +98,7 @@ private:
     public:
         using Base::Base;
 
-        void onEviction(const EvictionStats & /*stats*/) override;
+        void onValueRemoval(const MappedPtr & mappedPtr) override;
     };
 
 public:

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -98,7 +98,7 @@ private:
     public:
         using Base::Base;
 
-        void onValueRemoval(const MappedPtr & mapped_ptr) override;
+        void onEntryRemoval(const MappedPtr & mapped_ptr) override;
     };
 
 public:

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -274,6 +274,7 @@
     M(LoadedMarksFiles, "Number of mark files loaded.", ValueType::Number) \
     M(LoadedMarksCount, "Number of marks loaded (total across columns).", ValueType::Number) \
     M(LoadedMarksMemoryBytes, "Size of in-memory representations of loaded marks.", ValueType::Bytes) \
+    M(MarkCacheEvictedBytes, "Number of bytes evicted from the mark cache.", ValueType::Bytes) \
     M(LoadedPrimaryIndexFiles, "Number of primary index files loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexRows, "Number of rows of primary key loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexBytes, "Number of rows of primary key loaded.", ValueType::Bytes) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -276,6 +276,7 @@
     M(LoadedMarksMemoryBytes, "Size of in-memory representations of loaded marks.", ValueType::Bytes) \
     M(MarkCacheEvictedBytes, "Number of bytes evicted from the mark cache.", ValueType::Bytes) \
     M(MarkCacheEvictedMarks, "Number of marks evicted from the mark cache.", ValueType::Number) \
+    M(MarkCacheEvictedFiles, "Number of mark files evicted from the mark cache.", ValueType::Number) \
     M(LoadedPrimaryIndexFiles, "Number of primary index files loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexRows, "Number of rows of primary key loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexBytes, "Number of rows of primary key loaded.", ValueType::Bytes) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -275,6 +275,7 @@
     M(LoadedMarksCount, "Number of marks loaded (total across columns).", ValueType::Number) \
     M(LoadedMarksMemoryBytes, "Size of in-memory representations of loaded marks.", ValueType::Bytes) \
     M(MarkCacheEvictedBytes, "Number of bytes evicted from the mark cache.", ValueType::Bytes) \
+    M(MarkCacheEvictedMarks, "Number of marks evicted from the mark cache.", ValueType::Number) \
     M(LoadedPrimaryIndexFiles, "Number of primary index files loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexRows, "Number of rows of primary key loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexBytes, "Number of rows of primary key loaded.", ValueType::Bytes) \

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -327,7 +327,7 @@ private:
             {
                 current_weight_lost += cell.size;
                 if (!is_protected)
-                    on_remove_entry_function(cell.value);
+                    on_remove_entry_function(cell.size, cell.value);
 
                 cells.erase(it);
                 queue.pop_front();

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -326,8 +326,10 @@ private:
             else
             {
                 current_weight_lost += cell.size;
-                if (!is_protected)
-                    on_remove_entry_function(cell.size, cell.value);
+
+                /// We cannot have protected cells in non-protected queue
+                chassert(!is_protected);
+                on_remove_entry_function(cell.size, cell.value);
 
                 cells.erase(it);
                 queue.pop_front();

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -23,9 +23,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnEvictionFunction;
     using typename Base::OnRemoveFunction;
-    using typename Base::EvictionStats;
 
     /** Initialize SLRUCachePolicy with max_size_in_bytes and max_protected_size.
       * max_protected_size shows how many of the most frequently used entries will not be evicted after a sequential scan.
@@ -38,7 +36,6 @@ public:
         size_t max_size_in_bytes_,
         size_t max_count_,
         double size_ratio_,
-        OnEvictionFunction on_eviction_function_,
         OnRemoveFunction on_remove_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
         , max_size_in_bytes(max_size_in_bytes_)
@@ -47,7 +44,6 @@ public:
         , size_ratio(size_ratio_)
         , current_size_in_bytes_metric(size_in_bytes_metric_)
         , count_metric(count_metric_)
-        , on_eviction_function(on_eviction_function_)
         , on_remove_function(on_remove_function_)
     {
     }
@@ -274,7 +270,6 @@ private:
     CurrentMetrics::Metric count_metric;
 
     WeightFunction weight_function;
-    OnEvictionFunction on_eviction_function;
     OnRemoveFunction on_remove_function;
 
     static size_t calculateMaxProtectedSize(size_t max_size_in_bytes, double size_ratio)
@@ -288,7 +283,6 @@ private:
         const size_t old_size = cells.size();
 
         size_t current_weight_lost = 0;
-        EvictionStats eviction_stats{0, 0, 0};
         size_t queue_size = queue.size();
 
         std::function<bool()> need_remove;
@@ -332,22 +326,14 @@ private:
             else
             {
                 current_weight_lost += cell.size;
-                eviction_stats.total_weight_loss += cell.size;
-                // Get item-specific count from callback (e.g., number of marks)
-                eviction_stats.total_evicted_value_entities_num += on_remove_function(cell.value);
-                ++eviction_stats.total_evicted_keys_num;
+                if (!is_protected)
+                    on_remove_function(cell.value);
 
                 cells.erase(it);
                 queue.pop_front();
             }
 
             --queue_size;
-        }
-
-        // Call eviction callback only for actual evictions from probationary queue
-        if (!is_protected && eviction_stats.total_evicted_keys_num > 0)
-        {
-            on_eviction_function(eviction_stats);
         }
 
         if (current_size_in_bytes > (1ull << 63))

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -334,8 +334,8 @@ private:
                 current_weight_lost += cell.size;
                 eviction_stats.total_weight_loss += cell.size;
                 // Get item-specific count from callback (e.g., number of marks)
-                eviction_stats.total_evicted_marks_num += on_remove_function(cell.value);
-                ++eviction_stats.total_evicted_files_num;
+                eviction_stats.total_evicted_value_entities_num += on_remove_function(cell.value);
+                ++eviction_stats.total_evicted_keys_num;
 
                 cells.erase(it);
                 queue.pop_front();
@@ -345,7 +345,7 @@ private:
         }
 
         // Call eviction callback only for actual evictions from probationary queue
-        if (!is_protected && eviction_stats.total_evicted_files_num > 0)
+        if (!is_protected && eviction_stats.total_evicted_keys_num > 0)
         {
             on_eviction_function(eviction_stats);
         }

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -23,7 +23,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnRemoveFunction;
+    using typename Base::OnRemoveEntryFunction;
 
     /** Initialize SLRUCachePolicy with max_size_in_bytes and max_protected_size.
       * max_protected_size shows how many of the most frequently used entries will not be evicted after a sequential scan.
@@ -36,7 +36,7 @@ public:
         size_t max_size_in_bytes_,
         size_t max_count_,
         double size_ratio_,
-        OnRemoveFunction on_remove_function_)
+        OnRemoveEntryFunction on_remove_entry_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
         , max_size_in_bytes(max_size_in_bytes_)
         , max_protected_size(calculateMaxProtectedSize(max_size_in_bytes_, size_ratio_))
@@ -44,7 +44,7 @@ public:
         , size_ratio(size_ratio_)
         , current_size_in_bytes_metric(size_in_bytes_metric_)
         , count_metric(count_metric_)
-        , on_remove_function(on_remove_function_)
+        , on_remove_entry_function(on_remove_entry_function_)
     {
     }
 
@@ -270,7 +270,7 @@ private:
     CurrentMetrics::Metric count_metric;
 
     WeightFunction weight_function;
-    OnRemoveFunction on_remove_function;
+    OnRemoveEntryFunction on_remove_entry_function;
 
     static size_t calculateMaxProtectedSize(size_t max_size_in_bytes, double size_ratio)
     {
@@ -327,7 +327,7 @@ private:
             {
                 current_weight_lost += cell.size;
                 if (!is_protected)
-                    on_remove_function(cell.value);
+                    on_remove_entry_function(cell.value);
 
                 cells.erase(it);
                 queue.pop_front();

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -93,7 +93,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnRemoveFunction;
+    using typename Base::OnRemoveEntryFunction;
 
     explicit TTLCachePolicy(CurrentMetrics::Metric size_in_bytes_metric_, CurrentMetrics::Metric count_metric_, CachePolicyUserQuotaPtr quotas_)
         : Base(std::move(quotas_))
@@ -288,7 +288,7 @@ private:
 
     WeightFunction weight_function;
     IsStaleFunction is_stale_function;
-    /// TODO support OnRemoveFunction callback
+    /// TODO support OnRemoveEntryFunction callback
 
     void clearImpl()
     {

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -93,9 +93,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnEvictionFunction;
     using typename Base::OnRemoveFunction;
-    using typename Base::EvictionStats;
 
     explicit TTLCachePolicy(CurrentMetrics::Metric size_in_bytes_metric_, CurrentMetrics::Metric count_metric_, CachePolicyUserQuotaPtr quotas_)
         : Base(std::move(quotas_))
@@ -290,7 +288,7 @@ private:
 
     WeightFunction weight_function;
     IsStaleFunction is_stale_function;
-    /// TODO support OnEvictionFunction callback
+    /// TODO support OnRemoveFunction callback
 
     void clearImpl()
     {

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -93,7 +93,7 @@ public:
     using Base = ICachePolicy<Key, Mapped, HashFunction, WeightFunction>;
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
-    using typename Base::OnWeightLossFunction;
+    using typename Base::OnEvictionFunction;
 
     explicit TTLCachePolicy(CurrentMetrics::Metric size_in_bytes_metric_, CurrentMetrics::Metric count_metric_, CachePolicyUserQuotaPtr quotas_)
         : Base(std::move(quotas_))
@@ -288,7 +288,7 @@ private:
 
     WeightFunction weight_function;
     IsStaleFunction is_stale_function;
-    /// TODO support OnWeightLossFunction callback
+    /// TODO support OnEvictionFunction callback
 
     void clearImpl()
     {
@@ -300,6 +300,7 @@ private:
 
         size_in_bytes = 0;
     }
+
 };
 
 }

--- a/src/Common/TTLCachePolicy.h
+++ b/src/Common/TTLCachePolicy.h
@@ -94,6 +94,8 @@ public:
     using typename Base::MappedPtr;
     using typename Base::KeyMapped;
     using typename Base::OnEvictionFunction;
+    using typename Base::OnRemoveFunction;
+    using typename Base::EvictionStats;
 
     explicit TTLCachePolicy(CurrentMetrics::Metric size_in_bytes_metric_, CurrentMetrics::Metric count_metric_, CachePolicyUserQuotaPtr quotas_)
         : Base(std::move(quotas_))

--- a/src/Formats/MarkInCompressedFile.h
+++ b/src/Formats/MarkInCompressedFile.h
@@ -50,6 +50,8 @@ public:
 
     size_t approximateMemoryUsage() const;
 
+    size_t getNumberOfMarks() const { return num_marks; }
+
 private:
     /** Throughout this class:
      *   * "x" stands for offset_in_compressed_file,

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -61,8 +61,8 @@ public:
     }
 
 private:
-    /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mapped_ptr) override
+    /// Called for each individual entry being evicted from cache
+    void onEntryRemoval(const MappedPtr & mapped_ptr) override
     {
         auto uncompressed_cache_cell = std::static_pointer_cast<UncompressedCacheCell>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, UncompressedSizeWeightFunction()(*uncompressed_cache_cell));

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -62,10 +62,10 @@ public:
 
 private:
     /// Called for each individual entry being evicted from cache
-    void onEntryRemoval(const MappedPtr & mapped_ptr) override
+    void onEntryRemoval(const size_t weight_loss, const MappedPtr & mapped_ptr) override
     {
-        auto uncompressed_cache_cell = std::static_pointer_cast<UncompressedCacheCell>(mapped_ptr);
-        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, UncompressedSizeWeightFunction()(*uncompressed_cache_cell));
+        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, weight_loss);
+        UNUSED(mapped_ptr);
     }
 };
 

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -61,9 +61,10 @@ public:
     }
 
 private:
-    void onRemoveOverflowWeightLoss(size_t weight_loss) override
+    /// Called when cache eviction occurs
+    void onEviction(const EvictionStats& stats) override
     {
-        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, weight_loss);
+        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, stats.total_weight_loss);
     }
 };
 

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -61,10 +61,11 @@ public:
     }
 
 private:
-    /// Called when cache eviction occurs
-    void onEviction(const EvictionStats& stats) override
+    /// Called for each individual cell being evicted from cache
+    void onValueRemoval(const MappedPtr & mappedPtr) override
     {
-        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, stats.total_weight_loss);
+        auto uncompressed_cache_cell = std::static_pointer_cast<UncompressedCacheCell>(mappedPtr);
+        ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, UncompressedSizeWeightFunction()(*uncompressed_cache_cell));
     }
 };
 

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -62,9 +62,9 @@ public:
 
 private:
     /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mappedPtr) override
+    void onValueRemoval(const MappedPtr & mapped_ptr) override
     {
-        auto uncompressed_cache_cell = std::static_pointer_cast<UncompressedCacheCell>(mappedPtr);
+        auto uncompressed_cache_cell = std::static_pointer_cast<UncompressedCacheCell>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::UncompressedCacheWeightLost, UncompressedSizeWeightFunction()(*uncompressed_cache_cell));
     }
 };

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -61,12 +61,12 @@ public:
 
 private:
     /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mappedPtr) override
+    void onValueRemoval(const MappedPtr & mapped_ptr) override
     {
         /// File is the key of MarkCache, each removal means eviction of 1 file from the cache.
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles);
 
-        auto marks_in_compressed_file = std::static_pointer_cast<MarksInCompressedFile>(mappedPtr);
+        auto marks_in_compressed_file = std::static_pointer_cast<MarksInCompressedFile>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, MarksWeightFunction()(*marks_in_compressed_file));
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks, marks_in_compressed_file->getNumberOfMarks());
     }

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -61,13 +61,13 @@ public:
 
 private:
     /// Called when the cache is full, and we evict some cells as per the cache policy.
-    void onEviction(const EvictionDetails& details) override
+    void onEviction(const EvictionDetails & details) override
     {
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, details.total_weight_loss);
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks,
             /// Sum up the total number of marks across all evicted cache entries
             std::accumulate(details.evicted_values.begin(), details.evicted_values.end(), 0ULL,
-            [](size_t const sum, const MappedPtr& ptr)
+            [](size_t sum, const MappedPtr & ptr)
             {
                 return sum + std::static_pointer_cast<MarksInCompressedFile>(ptr)->getNumberOfMarks();
             }));

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -60,14 +60,14 @@ public:
     }
 
 private:
-    /// Called for each individual cell being evicted from cache
-    void onEntryRemoval(const MappedPtr & mapped_ptr) override
+    /// Called for each individual entry being evicted from cache
+    void onEntryRemoval(const size_t weight_loss, const MappedPtr & mapped_ptr) override
     {
         /// File is the key of MarkCache, each removal means eviction of 1 file from the cache.
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles);
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, weight_loss);
 
         auto marks_in_compressed_file = std::static_pointer_cast<MarksInCompressedFile>(mapped_ptr);
-        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, MarksWeightFunction()(*marks_in_compressed_file));
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks, marks_in_compressed_file->getNumberOfMarks());
     }
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -14,6 +14,7 @@ namespace ProfileEvents
     extern const Event MarkCacheMisses;
     extern const Event MarkCacheEvictedBytes;
     extern const Event MarkCacheEvictedMarks;
+    extern const Event MarkCacheEvictedFiles;
 }
 
 namespace DB
@@ -70,6 +71,8 @@ private:
             {
                 return sum + std::static_pointer_cast<MarksInCompressedFile>(ptr)->getNumberOfMarks();
             }));
+        /// number of files evicted from the cache is same as number of evicted values as both are tied together as a cell in the cache
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles, details.evicted_values.size());
     }
 };
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -13,6 +13,7 @@ namespace ProfileEvents
     extern const Event MarkCacheHits;
     extern const Event MarkCacheMisses;
     extern const Event MarkCacheEvictedBytes;
+    extern const Event MarkCacheEvictedMarks;
 }
 
 namespace DB
@@ -58,10 +59,17 @@ public:
     }
 
 private:
-
-    void onRemoveOverflowWeightLoss(size_t weight_loss) override
+    /// Called when the cache is full, and we evict some cells as per the cache policy.
+    void onEviction(const EvictionDetails& details) override
     {
-        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, weight_loss);
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, details.total_weight_loss);
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks,
+            /// Sum up the total number of marks across all evicted cache entries
+            std::accumulate(details.evicted_values.begin(), details.evicted_values.end(), 0ULL,
+            [](size_t const sum, const MappedPtr& ptr)
+            {
+                return sum + std::static_pointer_cast<MarksInCompressedFile>(ptr)->getNumberOfMarks();
+            }));
     }
 };
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -61,7 +61,7 @@ public:
 
 private:
     /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mapped_ptr) override
+    void onEntryRemoval(const MappedPtr & mapped_ptr) override
     {
         /// File is the key of MarkCache, each removal means eviction of 1 file from the cache.
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles);

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -12,6 +12,7 @@ namespace ProfileEvents
 {
     extern const Event MarkCacheHits;
     extern const Event MarkCacheMisses;
+    extern const Event MarkCacheEvictedBytes;
 }
 
 namespace DB
@@ -41,7 +42,7 @@ private:
 public:
     MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 
-    /// Calculate key from path to file and offset.
+    /// Calculate key from path to file.
     static UInt128 hash(const String & path_to_file);
 
     template <typename LoadFunc>
@@ -54,6 +55,13 @@ public:
             ProfileEvents::increment(ProfileEvents::MarkCacheHits);
 
         return result.first;
+    }
+
+private:
+
+    void onRemoveOverflowWeightLoss(size_t weight_loss) override
+    {
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, weight_loss);
     }
 };
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -72,8 +72,8 @@ private:
     void onEviction(const EvictionStats& stats) override
     {
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, stats.total_weight_loss);
-        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks, stats.total_evicted_marks_num);
-        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles, stats.total_evicted_files_num);
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks, stats.total_evicted_value_entities_num);
+        ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles, stats.total_evicted_keys_num);
     }
 };
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -67,7 +67,7 @@ private:
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedFiles);
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedBytes, weight_loss);
 
-        auto marks_in_compressed_file = std::static_pointer_cast<MarksInCompressedFile>(mapped_ptr);
+        const auto * marks_in_compressed_file = static_cast<const MarksInCompressedFile *>(mapped_ptr.get());
         ProfileEvents::increment(ProfileEvents::MarkCacheEvictedMarks, marks_in_compressed_file->getNumberOfMarks());
     }
 

--- a/src/Storages/MergeTree/VectorSimilarityIndexCache.h
+++ b/src/Storages/MergeTree/VectorSimilarityIndexCache.h
@@ -90,10 +90,10 @@ public:
 
 private:
     /// Called for each individual entry being evicted from cache
-    void onEntryRemoval(const MappedPtr & mapped_ptr) override
+    void onEntryRemoval(const size_t weight_loss, const MappedPtr & mapped_ptr) override
     {
-        auto vector_similarity_index_cache_cell = std::static_pointer_cast<VectorSimilarityIndexCacheCell>(mapped_ptr);
-        ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, VectorSimilarityIndexCacheWeightFunction()(*vector_similarity_index_cache_cell));
+        ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, weight_loss);
+        UNUSED(mapped_ptr);
     }
 };
 

--- a/src/Storages/MergeTree/VectorSimilarityIndexCache.h
+++ b/src/Storages/MergeTree/VectorSimilarityIndexCache.h
@@ -89,10 +89,11 @@ public:
     }
 
 private:
-    /// Called when cache eviction occurs
-    void onEviction(const EvictionStats& stats) override
+    /// Called for each individual cell being evicted from cache
+    void onValueRemoval(const MappedPtr & mappedPtr) override
     {
-        ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, stats.total_weight_loss);
+        auto vector_similarity_index_cache_cell = std::static_pointer_cast<VectorSimilarityIndexCacheCell>(mappedPtr);
+        ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, VectorSimilarityIndexCacheWeightFunction()(*vector_similarity_index_cache_cell));
     }
 };
 

--- a/src/Storages/MergeTree/VectorSimilarityIndexCache.h
+++ b/src/Storages/MergeTree/VectorSimilarityIndexCache.h
@@ -89,8 +89,8 @@ public:
     }
 
 private:
-    /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mapped_ptr) override
+    /// Called for each individual entry being evicted from cache
+    void onEntryRemoval(const MappedPtr & mapped_ptr) override
     {
         auto vector_similarity_index_cache_cell = std::static_pointer_cast<VectorSimilarityIndexCacheCell>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, VectorSimilarityIndexCacheWeightFunction()(*vector_similarity_index_cache_cell));

--- a/src/Storages/MergeTree/VectorSimilarityIndexCache.h
+++ b/src/Storages/MergeTree/VectorSimilarityIndexCache.h
@@ -90,9 +90,9 @@ public:
 
 private:
     /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mappedPtr) override
+    void onValueRemoval(const MappedPtr & mapped_ptr) override
     {
-        auto vector_similarity_index_cache_cell = std::static_pointer_cast<VectorSimilarityIndexCacheCell>(mappedPtr);
+        auto vector_similarity_index_cache_cell = std::static_pointer_cast<VectorSimilarityIndexCacheCell>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, VectorSimilarityIndexCacheWeightFunction()(*vector_similarity_index_cache_cell));
     }
 };

--- a/src/Storages/MergeTree/VectorSimilarityIndexCache.h
+++ b/src/Storages/MergeTree/VectorSimilarityIndexCache.h
@@ -89,9 +89,10 @@ public:
     }
 
 private:
-    void onRemoveOverflowWeightLoss(size_t weight_loss) override
+    /// Called when cache eviction occurs
+    void onEviction(const EvictionStats& stats) override
     {
-        ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, weight_loss);
+        ProfileEvents::increment(ProfileEvents::VectorSimilarityIndexCacheWeightLost, stats.total_weight_loss);
     }
 };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -150,10 +150,10 @@ public:
 
 private:
     /// Called for each individual entry being evicted from cache
-    void onEntryRemoval(const MappedPtr & mapped_ptr) override
+    void onEntryRemoval(const size_t weight_loss, const MappedPtr & mapped_ptr) override
     {
-        auto iceberg_metadata_files_cache_cell = std::static_pointer_cast<IcebergMetadataFilesCacheCell>(mapped_ptr);
-        ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, IcebergMetadataFilesCacheWeightFunction()(*iceberg_metadata_files_cache_cell));
+        ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, weight_loss);
+        UNUSED(mapped_ptr);
     }
 };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -149,8 +149,8 @@ public:
     }
 
 private:
-    /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mapped_ptr) override
+    /// Called for each individual entry being evicted from cache
+    void onEntryRemoval(const MappedPtr & mapped_ptr) override
     {
         auto iceberg_metadata_files_cache_cell = std::static_pointer_cast<IcebergMetadataFilesCacheCell>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, IcebergMetadataFilesCacheWeightFunction()(*iceberg_metadata_files_cache_cell));

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -149,9 +149,10 @@ public:
     }
 
 private:
-    void onRemoveOverflowWeightLoss(size_t weight_loss) override
+    /// Called when cache eviction occurs
+    void onEviction(const EvictionStats& stats) override
     {
-        ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, weight_loss);
+        ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, stats.total_weight_loss);
     }
 };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -149,10 +149,11 @@ public:
     }
 
 private:
-    /// Called when cache eviction occurs
-    void onEviction(const EvictionStats& stats) override
+    /// Called for each individual cell being evicted from cache
+    void onValueRemoval(const MappedPtr & mappedPtr) override
     {
-        ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, stats.total_weight_loss);
+        auto iceberg_metadata_files_cache_cell = std::static_pointer_cast<IcebergMetadataFilesCacheCell>(mappedPtr);
+        ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, IcebergMetadataFilesCacheWeightFunction()(*iceberg_metadata_files_cache_cell));
     }
 };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -150,9 +150,9 @@ public:
 
 private:
     /// Called for each individual cell being evicted from cache
-    void onValueRemoval(const MappedPtr & mappedPtr) override
+    void onValueRemoval(const MappedPtr & mapped_ptr) override
     {
-        auto iceberg_metadata_files_cache_cell = std::static_pointer_cast<IcebergMetadataFilesCacheCell>(mappedPtr);
+        auto iceberg_metadata_files_cache_cell = std::static_pointer_cast<IcebergMetadataFilesCacheCell>(mapped_ptr);
         ProfileEvents::increment(ProfileEvents::IcebergMetadataFilesCacheWeightLost, IcebergMetadataFilesCacheWeightFunction()(*iceberg_metadata_files_cache_cell));
     }
 };

--- a/tests/integration/test_mark_cache_profile_events/configs/mark_cache_config.xml
+++ b/tests/integration/test_mark_cache_profile_events/configs/mark_cache_config.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+
+    <mark_cache_size>124</mark_cache_size>
+    <merge_tree>
+        <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
+    </merge_tree>
+
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </query_log>
+
+</clickhouse>

--- a/tests/integration/test_mark_cache_profile_events/test.py
+++ b/tests/integration/test_mark_cache_profile_events/test.py
@@ -1,0 +1,291 @@
+import os
+import time
+import pytest
+import logging
+from helpers.cluster import ClickHouseCluster
+
+# Setup logging
+logger = logging.getLogger(__name__)
+
+cluster = ClickHouseCluster(__file__)
+# Use a smaller mark cache to force evictions more reliably
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/mark_cache_config.xml"],
+    stay_alive=True,
+)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def get_current_cache_metrics():
+    """Get current cache metrics from system.events to establish baseline"""
+    result = node.query("""
+                        SELECT event, value
+                        FROM system.events
+                        WHERE event IN ('MarkCacheEvictedBytes', 'MarkCacheEvictedMarks', 'MarkCacheEvictedFiles')
+                        ORDER BY event
+                        """).strip()
+
+    metrics = {}
+    if result:
+        for line in result.splitlines():
+            event, value = line.split('\t')
+            metrics[event] = int(value)
+
+    logger.info(f"Current cache metrics: {metrics}")
+    return metrics
+
+def wait_for_cache_eviction(initial_metrics, timeout=30):
+    """Wait for cache eviction to occur by monitoring metrics change"""
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        current_metrics = get_current_cache_metrics()
+
+        # Check if any eviction metric has increased
+        eviction_occurred = False
+        for metric in ['MarkCacheEvictedBytes', 'MarkCacheEvictedMarks', 'MarkCacheEvictedFiles']:
+            initial_value = initial_metrics.get(metric, 0)
+            current_value = current_metrics.get(metric, 0)
+            if current_value > initial_value:
+                eviction_occurred = True
+                logger.info(f"Eviction detected: {metric} increased from {initial_value} to {current_value}")
+                break
+
+        if eviction_occurred:
+            return current_metrics
+
+        time.sleep(0.5)
+
+    raise TimeoutError(f"Cache eviction not detected within {timeout} seconds")
+
+@pytest.fixture()
+def setup_cache_test_environment():
+    """Setup environment with controlled cache size and data that will force evictions"""
+    table_name = "mark_cache_eviction_test"
+    logger.info(f"Setting up test environment with table: {table_name}")
+
+    try:
+        # Clean up any existing table
+        node.query(f"DROP TABLE IF EXISTS {table_name}")
+
+        # Set a small mark cache size to force evictions
+        # This ensures our test is deterministic
+        node.query("SYSTEM DROP MARK CACHE")
+
+        # Create table with specific settings to control mark file size
+        node.query(f"""
+            CREATE TABLE {table_name} (
+                id UInt64, 
+                data String,
+                padding String
+            )
+            ENGINE = MergeTree()
+            ORDER BY id
+            SETTINGS 
+                index_granularity = 1024,  -- Smaller granularity = more marks
+                index_granularity_bytes = 0  -- Disable adaptive granularity
+        """)
+
+        # Insert data in multiple parts to create multiple mark files
+        # Each insert creates a separate part with its own mark file
+        batch_size = 5000
+        num_batches = 20
+
+        logger.info(f"Inserting {num_batches} batches of {batch_size} rows each")
+        for batch in range(num_batches):
+            offset = batch * batch_size
+            node.query(f"""
+                INSERT INTO {table_name}
+                SELECT 
+                    number + {offset} as id,
+                    'data_' || toString(number) as data,
+                    repeat('x', 100) as padding  -- Add padding to increase mark file size
+                FROM numbers({batch_size})
+            """)
+
+        # Optimize to ensure we have the expected number of parts
+        # But don't merge everything into one part
+        node.query(f"OPTIMIZE TABLE {table_name}")
+
+        # Verify table structure
+        parts_info = node.query(f"""
+            SELECT count() as part_count, sum(rows) as total_rows 
+            FROM system.parts 
+            WHERE table = '{table_name}' AND active
+        """).strip().split('\t')
+
+        logger.info(f"Created table with {parts_info[0]} parts and {parts_info[1]} total rows")
+
+        yield table_name
+
+    finally:
+        logger.info(f"Cleaning up table: {table_name}")
+        try:
+            node.query(f"DROP TABLE IF EXISTS {table_name}")
+        except Exception as e:
+            logger.warning(f"Error during cleanup: {e}")
+
+def test_mark_cache_eviction_functionality(start_cluster, setup_cache_test_environment):
+    """
+    Test that mark cache eviction metrics are properly tracked when cache overflows.
+
+    This test:
+    1. Records baseline metrics
+    2. Performs operations that will fill and overflow the mark cache
+    3. Verifies that eviction metrics are incremented appropriately
+    """
+    table_name = setup_cache_test_environment
+
+    # Get baseline metrics before starting the test
+    initial_metrics = get_current_cache_metrics()
+    logger.info(f"Starting test with baseline metrics: {initial_metrics}")
+
+    # Clear the mark cache to start fresh
+    node.query("SYSTEM DROP MARK CACHE")
+
+    # Perform queries that will load many mark files into cache
+    # Query different ranges to load different parts and their mark files
+    logger.info("Executing queries to fill mark cache...")
+
+    # First, do some queries to populate the cache
+    for i in range(0, 50000, 2500):  # Query every 2500 records
+        end_range = i + 2500
+        result = node.query(f"""
+            SELECT count(*), avg(length(data)) 
+            FROM {table_name} 
+            WHERE id BETWEEN {i} AND {end_range}
+        """)
+        logger.debug(f"Query range {i}-{end_range}: {result.strip()}")
+
+    # Now do more intensive queries that should trigger evictions
+    logger.info("Executing queries to trigger cache evictions...")
+
+    # Perform random access patterns to force cache pressure
+    import random
+    ranges = [(i, i + 1000) for i in range(0, 90000, 3000)]
+    random.shuffle(ranges)  # Random access pattern increases cache pressure
+
+    for start, end in ranges:
+        node.query(f"""
+            SELECT count(*), sum(length(padding))
+            FROM {table_name} 
+            WHERE id BETWEEN {start} AND {end}
+        """)
+
+    # Wait for evictions to be reflected in metrics
+    logger.info("Waiting for cache evictions to be recorded...")
+    try:
+        final_metrics = wait_for_cache_eviction(initial_metrics, timeout=30)
+    except TimeoutError:
+        # If no eviction detected, try one more aggressive approach
+        logger.warning("No eviction detected, trying more aggressive cache pressure...")
+
+        # Force more cache pressure by querying with PREWHERE (loads more marks)
+        for i in range(0, 100000, 1000):
+            node.query(f"""
+                SELECT count() 
+                FROM {table_name} 
+                PREWHERE id % 100 = 0 
+                WHERE id >= {i} AND id < {i + 1000}
+            """)
+
+        final_metrics = wait_for_cache_eviction(initial_metrics, timeout=15)
+
+    # Verify that eviction metrics have increased
+    expected_metrics = ['MarkCacheEvictedBytes', 'MarkCacheEvictedMarks', 'MarkCacheEvictedFiles']
+
+    for metric in expected_metrics:
+        initial_value = initial_metrics.get(metric, 0)
+        final_value = final_metrics.get(metric, 0)
+
+        assert final_value > initial_value, \
+            f"{metric} should have increased: initial={initial_value}, final={final_value}"
+
+        logger.info(f"✓ {metric}: {initial_value} → {final_value} (delta: {final_value - initial_value})")
+
+    # Verify logical relationships between metrics
+    bytes_evicted = final_metrics.get('MarkCacheEvictedBytes', 0) - initial_metrics.get('MarkCacheEvictedBytes', 0)
+    marks_evicted = final_metrics.get('MarkCacheEvictedMarks', 0) - initial_metrics.get('MarkCacheEvictedMarks', 0)
+    files_evicted = final_metrics.get('MarkCacheEvictedFiles', 0) - initial_metrics.get('MarkCacheEvictedFiles', 0)
+
+    # Sanity checks for metric relationships
+    assert bytes_evicted > 0, "Should have evicted some bytes"
+    assert marks_evicted > 0, "Should have evicted some marks"
+    assert files_evicted > 0, "Should have evicted some files"
+
+    # Marks should be >= files (each file contains at least 1 mark)
+    assert marks_evicted >= files_evicted, \
+        f"Marks evicted ({marks_evicted}) should be >= files evicted ({files_evicted})"
+
+    logger.info(f"✓ Test passed - Cache eviction metrics working correctly")
+
+def test_mark_cache_query_log_integration(start_cluster, setup_cache_test_environment):
+    """
+    Test that eviction metrics appear in query logs when evictions occur during queries
+    """
+    table_name = setup_cache_test_environment
+
+    # Enable query log
+    node.query("SYSTEM FLUSH LOGS")
+
+    # Clear cache and perform operation that should trigger evictions
+    node.query("SYSTEM DROP MARK CACHE")
+
+    # Get initial metrics
+    initial_metrics = get_current_cache_metrics()
+
+    # Perform a query that should trigger cache evictions
+    node.query(f"""
+        SELECT count(*), avg(length(data)), sum(length(padding))
+        FROM {table_name}
+        WHERE id % 17 = 0  -- Sparse access pattern to stress cache
+    """)
+
+    # More cache pressure
+    for i in range(10):
+        node.query(f"""
+            SELECT count() FROM {table_name} 
+            WHERE id >= {i * 10000} AND id < {(i + 1) * 10000}
+            AND data LIKE '%{i}%'
+        """)
+
+    # Wait for metrics to update
+    time.sleep(2)
+    node.query("SYSTEM FLUSH LOGS")
+
+    # Check if eviction metrics appear in query log
+    eviction_queries = node.query("""
+                                  SELECT
+                                      query,
+                                      ProfileEvents['MarkCacheEvictedBytes'] as bytes,
+                                      ProfileEvents['MarkCacheEvictedMarks'] as marks,
+                                      ProfileEvents['MarkCacheEvictedFiles'] as files
+                                  FROM system.query_log
+                                  WHERE
+                                      type = 'QueryFinish'
+                                    AND (
+                                      ProfileEvents['MarkCacheEvictedBytes'] > 0 OR
+                                      ProfileEvents['MarkCacheEvictedMarks'] > 0 OR
+                                      ProfileEvents['MarkCacheEvictedFiles'] > 0
+                                      )
+                                    AND query NOT LIKE 'SYSTEM%'
+                                  ORDER BY event_time_microseconds DESC
+                                      LIMIT 5
+                                  """).strip()
+
+    logger.info(f"Queries with eviction metrics:\n{eviction_queries}")
+
+    # We should have at least some queries with eviction metrics
+    # (This might be empty if evictions didn't occur during these specific queries,
+    #  which is why we also test system.events separately)
+    if eviction_queries:
+        logger.info("✓ Found eviction metrics in query log")
+    else:
+        logger.info("ℹ No eviction metrics in query log (evictions may have occurred between queries)")


### PR DESCRIPTION
**Resolves** #60989

This PR adds detailed visibility into the behavior of the Mark Cache by introducing new `ProfileEvents` for tracking evictions. Specifically, it tracks:

- `MarkCacheEvictedBytes`  
- `MarkCacheEvictedMarks`  
- `MarkCacheEvictedFiles`

### Motivation

Previously, eviction tracking in the cache relied on a single callback invocation of `onRemoveOverflowWeightLoss()`:

```cpp
/// Override this method if you want to track how much weight was lost in removeOverflow method.
virtual void onRemoveOverflowWeightLoss(size_t /*weight_loss*/) {}
```
This callback only provided the total weight evicted (in bytes), aggregated in the cache policy implementation (`LRUCachePolicy.h`  or `SLRUCachePolicy.h`) and relayed back to the cache implementation class (`MarckCache.h`) after all evictions. It lacked contextual information about individual entries being removed.

### Changes Introduced
This patch replaces the `onRemoveOverflowWeightLoss()` callback with a more expressive method: `onEntryRemoval()`. The new method provides both the evicted entry and its weight at the time of removal:

```cpp
/// Called when an entry is evicted from the cache.
/// Override this to track individual entry removals.
virtual void onEntryRemoval(size_t weight_loss, const MappedPtr & entry) {}
```
This allows for more fine-grained eviction metrics currently implemented in `MarkCache.h.` 

The cache policy ( `LRUCachePolicy.h `or `SLRUCachePolicy.h`) is responsible for computing the weight of the entry. By passing this value to the callback, we avoid redundant computation within the cache implementation classes.

### Affected Components
All cache implementations have been updated to override the new `onEntryRemoval` callback:

- MarkCache  (`MarkCache.h`)
- PageCache  (`PageCache.h`, `PageCache.cpp`)
- UncompressedCache  (`UncompressedCache.h`)
- VectorSimilarityIndexCache  (`VectorSimilarityIndexCache.h`)
- IcebergMetadataFilesCache ( `IcebergMetadataFilesCache.h`)

This groundwork enables future improvements in observability and diagnostics for all these caches.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added metrics `MarkCacheEvictedBytes`, `MarkCacheEvictedMarks`, `MarkCacheEvictedFiles` for tracking evictions from the mark cache. (issue #60989)

### Documentation entry for user-facing changes

The [documentation page](https://clickhouse.com/docs/operations/system-tables/events) is done in a way that does not require update.
