### PR TITLE
wip: support unions of secondary index

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -266,6 +266,8 @@
     M(LoadedDataPartsMicroseconds, "Microseconds spent by MergeTree tables for loading data parts during initialization.", ValueType::Microseconds) \
     M(FilteringMarksWithPrimaryKeyMicroseconds, "Time spent filtering parts by PK.", ValueType::Microseconds) \
     M(FilteringMarksWithSecondaryKeysMicroseconds, "Time spent filtering parts by skip indexes.", ValueType::Microseconds) \
+    M(FilteringMarksWithMergedSecondaryKeysMicroseconds, "Time spent filtering parts by merged skip indexes.", ValueType::Microseconds) \
+    M(AnalyzeConditionsForUnionIndexesMicroseconds, "Time spent analyzing conditions for union indexes.", ValueType::Microseconds) \
     \
     M(WaitMarksLoadMicroseconds, "Time spent loading marks", ValueType::Microseconds) \
     M(BackgroundLoadingMarksTasks, "Number of background tasks for loading marks", ValueType::Number) \

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -86,6 +86,17 @@ public:
         std::vector<std::string> used_keys = {};
         size_t num_parts_after;
         size_t num_granules_after;
+        
+        /// For union indexes, store information about individual indexes
+        struct UnionIndexInfo
+        {
+            std::string index_name;
+            size_t num_parts_after;
+            size_t num_granules_after;
+            size_t num_parts_total;
+            size_t num_granules_total;
+        };
+        std::vector<UnionIndexInfo> union_index_infos;
     };
 
     using IndexStats = std::vector<IndexStat>;

--- a/src/Storages/MergeTree/MergeTreeIndexUnionCondition.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexUnionCondition.cpp
@@ -1,0 +1,136 @@
+#include <Storages/MergeTree/MergeTreeIndexUnionCondition.h>
+#include <Common/Exception.h>
+#include <fmt/format.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+void MergeTreeIndexUnionCondition::addIndex(const MergeTreeIndexPtr & index)
+{
+    if (index->getGranularity() != granularity)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, 
+            "Index {} has different granularity ({}) than expected ({})", 
+            index->index.name, index->getGranularity(), granularity);
+
+    indices_with_conditions.push_back({index, nullptr});
+}
+
+void MergeTreeIndexUnionCondition::setCondition(size_t index_pos, MergeTreeIndexConditionPtr condition)
+{
+    if (index_pos >= indices_with_conditions.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, 
+            "Index position {} is out of range ({})", 
+            index_pos, indices_with_conditions.size());
+    
+    indices_with_conditions[index_pos].condition = condition;
+}
+
+bool MergeTreeIndexUnionCondition::alwaysUnknownOrTrue() const
+{
+    // Union condition is unknown/true only if ALL indexes are unknown/true
+    // If at least one index can be useful, the union can be useful
+    for (const auto & index_with_condition : indices_with_conditions)
+    {
+        if (index_with_condition.condition && !index_with_condition.condition->alwaysUnknownOrTrue())
+            return false;
+    }
+    return true;
+}
+
+bool MergeTreeIndexUnionCondition::mayBeTrueOnGranule(const MergeTreeIndexGranules & granules) const
+{
+    // Call the version with empty part name for backward compatibility
+    return mayBeTrueOnGranule(granules, "");
+}
+
+bool MergeTreeIndexUnionCondition::mayBeTrueOnGranule(const MergeTreeIndexGranules & granules, const String & part_name) const
+{
+    if (granules.size() != indices_with_conditions.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, 
+            "Number of granules ({}) doesn't match number of indexes ({})", 
+            granules.size(), indices_with_conditions.size());
+
+    // Initialize statistics if needed
+    if (collect_statistics && index_contributions.empty())
+    {
+        index_contributions.resize(indices_with_conditions.size());
+        for (size_t i = 0; i < indices_with_conditions.size(); ++i)
+        {
+            index_contributions[i].index_name = indices_with_conditions[i].index->index.name;
+        }
+    }
+
+    // Union logic: return true if ANY index says the granule may contain matching data
+    bool any_passed = false;
+    for (size_t i = 0; i < indices_with_conditions.size(); ++i)
+    {
+        const auto & index_with_condition = indices_with_conditions[i];
+        if (!index_with_condition.condition)
+            continue;
+
+        bool passed = index_with_condition.condition->mayBeTrueOnGranule(granules[i]);
+        
+        if (collect_statistics)
+        {
+            index_contributions[i].granules_total++;
+            if (passed)
+            {
+                index_contributions[i].granules_passed++;
+                if (!part_name.empty())
+                    index_contributions[i].parts_with_matches.insert(part_name);
+                any_passed = true;
+            }
+        }
+        else if (passed)
+        {
+            // Early return if not collecting statistics
+            return true;
+        }
+    }
+
+    // All indexes say the granule doesn't contain matching data
+    return any_passed;
+}
+
+String MergeTreeIndexUnionCondition::getDescription() const
+{
+    std::vector<String> index_names;
+    for (const auto & index_with_condition : indices_with_conditions)
+    {
+        index_names.push_back(index_with_condition.index->index.name);
+    }
+    
+    // Manual join since fmt::join might not be available
+    String joined_names;
+    for (size_t i = 0; i < index_names.size(); ++i)
+    {
+        if (i > 0)
+            joined_names += ", ";
+        joined_names += index_names[i];
+    }
+    
+    return fmt::format("Union of ({})", joined_names);
+}
+
+std::vector<String> MergeTreeIndexUnionCondition::getIndexNames() const
+{
+    std::vector<String> names;
+    names.reserve(indices_with_conditions.size());
+    for (const auto & index_with_condition : indices_with_conditions)
+    {
+        names.push_back(index_with_condition.index->index.name);
+    }
+    return names;
+}
+
+std::vector<MergeTreeIndexUnionCondition::IndexContribution> MergeTreeIndexUnionCondition::getIndexContributions() const
+{
+    return index_contributions;
+}
+
+} 

--- a/src/Storages/MergeTree/MergeTreeIndexUnionCondition.h
+++ b/src/Storages/MergeTree/MergeTreeIndexUnionCondition.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <memory>
+#include <unordered_set>
+
+namespace DB
+{
+
+/// MergeTreeIndexUnionCondition implements OR logic between multiple data skipping indexes.
+/// If any of the indexes indicates that a granule may contain matching data, the granule is kept.
+class MergeTreeIndexUnionCondition : public IMergeTreeIndexMergedCondition
+{
+public:
+    explicit MergeTreeIndexUnionCondition(size_t granularity_)
+        : IMergeTreeIndexMergedCondition(granularity_)
+    {
+    }
+
+    void addIndex(const MergeTreeIndexPtr & index) override;
+    void setCondition(size_t index_pos, MergeTreeIndexConditionPtr condition);
+    bool alwaysUnknownOrTrue() const override;
+    bool mayBeTrueOnGranule(const MergeTreeIndexGranules & granules) const override;
+    bool mayBeTrueOnGranule(const MergeTreeIndexGranules & granules, const String & part_name) const;
+    
+    /// Get a description of this union condition
+    String getDescription() const;
+    
+    /// Get the names of all indexes in this union
+    std::vector<String> getIndexNames() const;
+    
+    /// Get detailed statistics about which indexes contributed to filtering
+    struct IndexContribution
+    {
+        String index_name;
+        size_t granules_total = 0;
+        size_t granules_passed = 0;
+        std::unordered_set<String> parts_with_matches;  // Track which parts had matches
+    };
+    std::vector<IndexContribution> getIndexContributions() const;
+    
+    /// Enable statistics collection (disabled by default for performance)
+    void enableStatistics() { collect_statistics = true; }
+
+private:
+    struct IndexWithCondition
+    {
+        MergeTreeIndexPtr index;
+        MergeTreeIndexConditionPtr condition;
+    };
+
+    std::vector<IndexWithCondition> indices_with_conditions;
+    
+    /// Statistics collection
+    bool collect_statistics = false;
+    mutable std::vector<IndexContribution> index_contributions;
+};
+
+} 

--- a/tests/queries/0_stateless/03300_union_data_skipping_indexes_comprehensive.reference
+++ b/tests/queries/0_stateless/03300_union_data_skipping_indexes_comprehensive.reference
@@ -1,0 +1,191 @@
+Test 1: bloom_str OR num
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_indexes)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 4/4
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax)
+            Parts: 2/4
+            Granules: 2/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/4, Granules: 1/10)
+              - idx_minmax (Parts: 1/4, Granules: 1/10)
+2000
+Test 2: bloom_str OR num OR str
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_indexes)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 4/4
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax, idx_set)
+            Parts: 3/4
+            Granules: 3/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/4, Granules: 1/10)
+              - idx_minmax (Parts: 1/4, Granules: 1/10)
+              - idx_set (Parts: 1/4, Granules: 1/10)
+3000
+Test 3: All indexes with OR
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_indexes)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 4/4
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax, idx_set, idx_arr_set)
+            Parts: 4/4
+            Granules: 10/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/4, Granules: 1/10)
+              - idx_minmax (Parts: 1/4, Granules: 1/10)
+              - idx_set (Parts: 1/4, Granules: 1/10)
+              - idx_arr_set (Parts: 1/4, Granules: 7/10)
+10000
+Test 4: Complex nested conditions
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_indexes)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 4/4
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax, idx_set)
+            Parts: 3/4
+            Granules: 3/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/4, Granules: 1/10)
+              - idx_minmax (Parts: 1/4, Granules: 1/10)
+              - idx_set (Parts: 1/4, Granules: 1/10)
+1999
+Test 5: Highly selective query
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_indexes)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 4/4
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax)
+            Parts: 2/4
+            Granules: 2/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/4, Granules: 1/10)
+              - idx_minmax (Parts: 1/4, Granules: 1/10)
+1100
+Test 6: UnionIndex with multiple parts
+Number of parts:	5
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_parts)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          Partition
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          PrimaryKey
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax)
+            Parts: 2/5
+            Granules: 4/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/5, Granules: 2/10)
+              - idx_minmax (Parts: 1/5, Granules: 2/10)
+4000
+Test 7: Three parts match
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_parts)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          Partition
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          PrimaryKey
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax, idx_set)
+            Parts: 3/5
+            Granules: 6/10
+            Indexes in union:
+              - idx_bloom (Parts: 1/5, Granules: 2/10)
+              - idx_minmax (Parts: 1/5, Granules: 2/10)
+              - idx_set (Parts: 1/5, Granules: 2/10)
+6000
+Test 8: No parts match
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_union_parts)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          Partition
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          PrimaryKey
+            Condition: true
+            Parts: 5/5
+            Granules: 10/10
+          Skip
+            Name: UnionIndex
+            Description: Union of (idx_bloom, idx_minmax, idx_set)
+            Parts: 0/5
+            Granules: 0/10
+            Indexes in union:
+              - idx_bloom (Parts: 0/5, Granules: 0/10)
+              - idx_minmax (Parts: 0/5, Granules: 0/10)
+              - idx_set (Parts: 0/5, Granules: 0/10)
+0

--- a/tests/queries/0_stateless/03300_union_data_skipping_indexes_comprehensive.sql
+++ b/tests/queries/0_stateless/03300_union_data_skipping_indexes_comprehensive.sql
@@ -1,0 +1,108 @@
+-- Tags: no-parallel
+-- Test comprehensive UnionIndex functionality with multiple index types
+
+DROP TABLE IF EXISTS test_union_indexes;
+
+-- Create table with multiple index types
+CREATE TABLE test_union_indexes
+(
+    id UInt64,
+    str String,
+    num UInt32,
+    arr Array(UInt32),
+    bloom_str String,
+    INDEX idx_bloom bloom_str TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_minmax num TYPE minmax GRANULARITY 1,
+    INDEX idx_set str TYPE set(100) GRANULARITY 1,
+    INDEX idx_arr_set arr TYPE set(100) GRANULARITY 1
+)
+ENGINE = MergeTree()
+ORDER BY id
+SETTINGS index_granularity = 1000;
+
+-- Insert data with specific patterns to test filtering
+-- Rows 0-999: bloom_str='value_1', num=1, str='a', arr=[1]
+INSERT INTO test_union_indexes SELECT number, 'a', 1, [1], 'value_1' FROM numbers(1000);
+-- Rows 1000-1999: bloom_str='value_2', num=2, str='b', arr=[2]
+INSERT INTO test_union_indexes SELECT number, 'b', 2, [2], 'value_2' FROM numbers(1000, 1000);
+-- Rows 2000-2999: bloom_str='value_3', num=3, str='c', arr=[3]
+INSERT INTO test_union_indexes SELECT number, 'c', 3, [3], 'value_3' FROM numbers(2000, 1000);
+-- Rows 3000-9999: bloom_str='value_other', num=99, str='z', arr=[99]
+INSERT INTO test_union_indexes SELECT number, 'z', 99, [99], 'value_other' FROM numbers(3000, 7000);
+
+-- Test 1: Simple OR with two different index types (bloom filter and minmax)
+SELECT 'Test 1: bloom_str OR num';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR num = 2;
+SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR num = 2;
+
+-- Test 2: OR with three different index types
+SELECT 'Test 2: bloom_str OR num OR str';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR num = 2 OR str = 'c';
+SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR num = 2 OR str = 'c';
+
+-- Test 3: OR with all four index types
+SELECT 'Test 3: All indexes with OR';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR num = 2 OR str = 'c' OR has(arr, 99);
+SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR num = 2 OR str = 'c' OR has(arr, 99);
+
+-- Test 4: Complex nested AND/OR conditions
+SELECT 'Test 4: Complex nested conditions';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_indexes WHERE (bloom_str = 'value_1' AND id < 500) OR (num = 2 AND id > 1500) OR str = 'c';
+SELECT count() FROM test_union_indexes WHERE (bloom_str = 'value_1' AND id < 500) OR (num = 2 AND id > 1500) OR str = 'c';
+
+-- Test 5: Query that filters out most granules (only 1 out of 10 granules match)
+SELECT 'Test 5: Highly selective query';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR (num = 2 AND id < 1100);
+SELECT count() FROM test_union_indexes WHERE bloom_str = 'value_1' OR (num = 2 AND id < 1100);
+
+DROP TABLE test_union_indexes;
+
+-- Test with multiple parts using partitions
+DROP TABLE IF EXISTS test_union_parts;
+
+CREATE TABLE test_union_parts
+(
+    id UInt64,
+    part_key UInt32,
+    str String,
+    num UInt32,
+    bloom_str String,
+    INDEX idx_bloom bloom_str TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_minmax num TYPE minmax GRANULARITY 1,
+    INDEX idx_set str TYPE set(100) GRANULARITY 1
+)
+ENGINE = MergeTree()
+PARTITION BY part_key
+ORDER BY id
+SETTINGS index_granularity = 1000;
+
+-- Create 5 partitions with different data patterns
+-- Partition 0: bloom_str='part0', num=0, str='a' (rows 0-1999)
+INSERT INTO test_union_parts SELECT number, 0, 'a', 0, 'part0' FROM numbers(2000);
+-- Partition 1: bloom_str='part1', num=1, str='b' (rows 2000-3999)
+INSERT INTO test_union_parts SELECT number, 1, 'b', 1, 'part1' FROM numbers(2000, 2000);
+-- Partition 2: bloom_str='part2', num=2, str='c' (rows 4000-5999)
+INSERT INTO test_union_parts SELECT number, 2, 'c', 2, 'part2' FROM numbers(4000, 2000);
+-- Partition 3: bloom_str='other', num=99, str='z' (rows 6000-7999)
+INSERT INTO test_union_parts SELECT number, 3, 'z', 99, 'other' FROM numbers(6000, 2000);
+-- Partition 4: bloom_str='other', num=99, str='z' (rows 8000-9999)
+INSERT INTO test_union_parts SELECT number, 4, 'z', 99, 'other' FROM numbers(8000, 2000);
+
+SELECT 'Test 6: UnionIndex with multiple parts';
+SELECT 'Number of parts:', count() FROM system.parts WHERE database = currentDatabase() AND table = 'test_union_parts' AND active;
+
+-- This should filter to only 2 out of 5 parts
+EXPLAIN indexes = 1 SELECT count() FROM test_union_parts WHERE bloom_str = 'part0' OR num = 1;
+SELECT count() FROM test_union_parts WHERE bloom_str = 'part0' OR num = 1;
+
+-- This should filter to only 3 out of 5 parts
+SELECT 'Test 7: Three parts match';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_parts WHERE bloom_str = 'part0' OR num = 1 OR str = 'c';
+SELECT count() FROM test_union_parts WHERE bloom_str = 'part0' OR num = 1 OR str = 'c';
+
+-- Test with no matching parts
+SELECT 'Test 8: No parts match';
+EXPLAIN indexes = 1 SELECT count() FROM test_union_parts WHERE bloom_str = 'nonexistent' OR num = 100 OR str = 'nonexistent';
+SELECT count() FROM test_union_parts WHERE bloom_str = 'nonexistent' OR num = 100 OR str = 'nonexistent';
+
+DROP TABLE test_union_parts; 

--- a/tests/queries/0_stateless/03300_union_data_skipping_indexes_nested_conditions.reference
+++ b/tests/queries/0_stateless/03300_union_data_skipping_indexes_nested_conditions.reference
@@ -1,0 +1,12 @@
+Test 1: (category=A AND id<500) OR (category=B AND id>1500)
+999
+Test 2: Complex three-way nested
+2500
+Test 3: Deeply nested conditions
+9499
+Test 4: Mix of positive and negative conditions
+8000
+Test 5: Highly selective nested condition
+299
+Test 6: No matches
+0

--- a/tests/queries/0_stateless/03300_union_data_skipping_indexes_nested_conditions.sql
+++ b/tests/queries/0_stateless/03300_union_data_skipping_indexes_nested_conditions.sql
@@ -1,0 +1,73 @@
+-- Tags: no-parallel
+-- Test UnionIndex with complex nested AND/OR conditions
+
+DROP TABLE IF EXISTS test_nested_conditions;
+
+CREATE TABLE test_nested_conditions
+(
+    id UInt64,
+    category String,
+    value UInt32,
+    tag String,
+    flag UInt8,
+    INDEX idx_category category TYPE set(100) GRANULARITY 1,
+    INDEX idx_value value TYPE minmax GRANULARITY 1,
+    INDEX idx_tag tag TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_flag flag TYPE set(10) GRANULARITY 1
+)
+ENGINE = MergeTree()
+ORDER BY id
+SETTINGS index_granularity = 1000;
+
+-- Insert data with specific patterns
+-- Rows 0-999: category='A', value=10, tag='tag1', flag=1
+INSERT INTO test_nested_conditions SELECT number, 'A', 10, 'tag1', 1 FROM numbers(1000);
+-- Rows 1000-1999: category='B', value=20, tag='tag2', flag=0
+INSERT INTO test_nested_conditions SELECT number, 'B', 20, 'tag2', 0 FROM numbers(1000, 1000);
+-- Rows 2000-2999: category='C', value=30, tag='tag3', flag=1
+INSERT INTO test_nested_conditions SELECT number, 'C', 30, 'tag3', 1 FROM numbers(2000, 1000);
+-- Rows 3000-3999: category='D', value=40, tag='tag4', flag=0
+INSERT INTO test_nested_conditions SELECT number, 'D', 40, 'tag4', 0 FROM numbers(3000, 1000);
+-- Rows 4000-9999: category='E', value=50, tag='tag5', flag=1
+INSERT INTO test_nested_conditions SELECT number, 'E', 50, 'tag5', 1 FROM numbers(4000, 6000);
+
+-- Test 1: Simple nested condition (A AND id<500) OR (B AND id>1500)
+SELECT 'Test 1: (category=A AND id<500) OR (category=B AND id>1500)';
+SELECT count() FROM test_nested_conditions WHERE (category = 'A' AND id < 500) OR (category = 'B' AND id > 1500);
+
+-- Test 2: Three-way nested OR with AND conditions
+SELECT 'Test 2: Complex three-way nested';
+SELECT count() FROM test_nested_conditions WHERE 
+    (category = 'A' AND value = 10 AND flag = 1) OR 
+    (tag = 'tag2' AND value = 20 AND id < 1500) OR 
+    (category = 'C' AND flag = 1);
+
+-- Test 3: Deeply nested conditions
+SELECT 'Test 3: Deeply nested conditions';
+SELECT count() FROM test_nested_conditions WHERE 
+    ((category = 'A' OR category = 'B') AND value < 25) OR 
+    ((tag = 'tag3' OR tag = 'tag4') AND id > 2500) OR 
+    (flag = 1 AND value = 50);
+
+-- Test 4: Mix of positive and negative conditions
+SELECT 'Test 4: Mix of positive and negative conditions';
+SELECT count() FROM test_nested_conditions WHERE 
+    (category = 'A' AND value != 20) OR 
+    (tag = 'tag2' AND flag != 1) OR 
+    (value > 40 AND category != 'D');
+
+-- Test 5: Condition that filters out most data (highly selective)
+SELECT 'Test 5: Highly selective nested condition';
+SELECT count() FROM test_nested_conditions WHERE 
+    (category = 'A' AND id < 100) OR 
+    (tag = 'tag3' AND id > 2900) OR 
+    (value = 40 AND flag = 0 AND id < 3100);
+
+-- Test 6: All conditions false (no matches)
+SELECT 'Test 6: No matches';
+SELECT count() FROM test_nested_conditions WHERE 
+    (category = 'Z' AND value = 100) OR 
+    (tag = 'nonexistent' AND flag = 2) OR 
+    (value > 100 AND id < 0);
+
+DROP TABLE test_nested_conditions; 

--- a/tests/queries/0_stateless/03300_union_data_skipping_indexes_parts_stats.reference
+++ b/tests/queries/0_stateless/03300_union_data_skipping_indexes_parts_stats.reference
@@ -1,0 +1,8 @@
+Parts statistics test
+Total parts:	9
+Test 1: OR across all indexes
+3000
+Test 2: OR with two indexes
+2000
+Test 3: Single index
+1000

--- a/tests/queries/0_stateless/03300_union_data_skipping_indexes_parts_stats.sql
+++ b/tests/queries/0_stateless/03300_union_data_skipping_indexes_parts_stats.sql
@@ -1,0 +1,63 @@
+-- Tags: no-parallel
+-- Test UnionIndex parts statistics reporting
+
+DROP TABLE IF EXISTS test_union_stats;
+
+CREATE TABLE test_union_stats
+(
+    id UInt64,
+    part_key UInt32,
+    a UInt32,
+    b UInt32,
+    c UInt32,
+    INDEX idx_a a TYPE minmax GRANULARITY 1,
+    INDEX idx_b b TYPE minmax GRANULARITY 1,
+    INDEX idx_c c TYPE set(100) GRANULARITY 1
+)
+ENGINE = MergeTree()
+PARTITION BY part_key
+ORDER BY id
+SETTINGS index_granularity = 1000;
+
+-- Create 6 partitions with specific patterns:
+-- Partition 0: a=1 matches (1 granule)
+INSERT INTO test_union_stats SELECT number, 0, 1, 0, 0 FROM numbers(1000);
+INSERT INTO test_union_stats SELECT number, 0, 0, 0, 0 FROM numbers(1000, 9000);
+
+-- Partition 1: b=1 matches (1 granule)
+INSERT INTO test_union_stats SELECT number, 1, 0, 1, 0 FROM numbers(10000, 1000);
+INSERT INTO test_union_stats SELECT number, 1, 0, 0, 0 FROM numbers(11000, 9000);
+
+-- Partition 2: c=1 matches (1 granule)
+INSERT INTO test_union_stats SELECT number, 2, 0, 0, 1 FROM numbers(20000, 1000);
+INSERT INTO test_union_stats SELECT number, 2, 0, 0, 0 FROM numbers(21000, 9000);
+
+-- Partition 3: no matches
+INSERT INTO test_union_stats SELECT number, 3, 0, 0, 0 FROM numbers(30000, 10000);
+
+-- Partition 4: no matches
+INSERT INTO test_union_stats SELECT number, 4, 0, 0, 0 FROM numbers(40000, 10000);
+
+-- Partition 5: no matches
+INSERT INTO test_union_stats SELECT number, 5, 0, 0, 0 FROM numbers(50000, 10000);
+
+SELECT 'Parts statistics test';
+SELECT 'Total parts:', count() FROM system.parts WHERE database = currentDatabase() AND table = 'test_union_stats' AND active;
+
+-- Test 1: UnionIndex should show Parts: 3/6 (only partitions 0,1,2 have matches)
+-- Each individual index should show Parts: 1/6 (only one partition matches per index)
+SELECT 'Test 1: OR across all indexes';
+-- EXPLAIN indexes = 1 will show the UnionIndex with parts statistics
+SELECT count() FROM test_union_stats WHERE a = 1 OR b = 1 OR c = 1;
+
+-- Test 2: UnionIndex should show Parts: 2/6 (only partitions 0,1 have matches)
+SELECT 'Test 2: OR with two indexes';
+-- EXPLAIN indexes = 1 will show the UnionIndex with parts statistics
+SELECT count() FROM test_union_stats WHERE a = 1 OR b = 1;
+
+-- Test 3: Single index (no UnionIndex)
+SELECT 'Test 3: Single index';
+-- EXPLAIN indexes = 1 will show single index statistics
+SELECT count() FROM test_union_stats WHERE a = 1;
+
+DROP TABLE test_union_stats; 


### PR DESCRIPTION
re: https://github.com/ClickHouse/ClickHouse/issues/8168

I took a stab at some code to implement this, but am definitely in over my head. It appears to work if you uncomment the 1836-1837 in ReadFromMergeTree and comment out the rest of that else block, but right now it falls flat if you try something like `WHERE id1='1' OR id1='2' OR id2='2'` (which is what that else block is trying to do right now, but it segfaults). Figured I'd put up the draft code to see if a) is this approach completely insane, and b) any tips on how to solve the broken case, or just tips in general (I am new to C++). 

What I _think_ I need here is to create a fake action node that is just the `or(equals(id1, '1'), equals(id1, '2')` which then would let the *IndexCondition be able to takeover since it would cover only a single column. Also I did not consider compound indexes here at all for the initial draft, beyond knowing they could/should be included.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Automatically use multiple secondary data skipping indexes with OR conditions

### Documentation entry for user-facing changes

not yet, it's still not working

- [ ] Documentation is written (mandatory for new features)


```sql
CREATE TABLE default.events
(
    `id1` String,
    `id2` String,
    `timestamp` DateTime,
    `id3` String,
    INDEX idx_id1_bf id1 TYPE bloom_filter(0.01) GRANULARITY 1,
    INDEX idx_id2_bf id2 TYPE bloom_filter(0.01) GRANULARITY 1,
    INDEX idx_id3 id3 TYPE bloom_filter(0.01) GRANULARITY 1
)
ENGINE = MergeTree
PARTITION BY toStartOfMinute(timestamp)
ORDER BY timestamp
SETTINGS index_granularity = 8192

SELECT
    _part,
    *
FROM events

Query id: 9c2677fc-06e5-4b70-84ff-0732f741d241

   ┌─_part────────────┬─id1─┬─id2─┬───────────timestamp─┬─id3─┐
1. │ 1748219940_1_1_0 │ a   │ 1   │ 2025-05-25 19:39:00 │     │
2. │ 1748219940_1_1_0 │ b   │ 1   │ 2025-05-25 19:39:00 │     │
3. │ 1748220600_3_3_0 │ e   │ 3   │ 2025-05-25 19:50:30 │     │
4. │ 1748224440_4_4_0 │ g   │ h   │ 2025-05-25 20:54:47 │ k   │
5. │ 1748220240_2_2_0 │ c   │ 2   │ 2025-05-25 19:44:00 │     │
6. │ 1748220240_2_2_0 │ b   │ 2   │ 2025-05-25 19:44:00 │     │
   └──────────────────┴─────┴─────┴─────────────────────┴─────┘

6 rows in set. Elapsed: 0.004 sec.

Tanners-MacBook-Pro.local :) explain indexes=1 SELECT * FROM events where id1='a' or id2='3'

EXPLAIN indexes = 1
SELECT *
FROM events
WHERE (id1 = 'a') OR (id2 = '3')

Query id: 3e05bc83-c5f4-4ab2-b0a1-174c25d8c2e2

    ┌─explain────────────────────────────────────────────────┐
 1. │ Expression ((Project names + Projection))              │
 2. │   Expression                                           │
 3. │     ReadFromMergeTree (default.events)                 │
 4. │     Indexes:                                           │
 5. │       MinMax                                           │
 6. │         Condition: true                                │
 7. │         Parts: 4/4                                     │
 8. │         Granules: 4/4                                  │
 9. │       Partition                                        │
10. │         Condition: true                                │
11. │         Parts: 4/4                                     │
12. │         Granules: 4/4                                  │
13. │       PrimaryKey                                       │
14. │         Condition: true                                │
15. │         Parts: 4/4                                     │
16. │         Granules: 4/4                                  │
17. │       Skip                                             │
18. │         Name: UnionIndex                               │
19. │         Description: Union of (idx_id2_bf, idx_id1_bf) │
20. │         Parts: 2/4                                     │
21. │         Granules: 2/4                                  │
22. │         Indexes in union:                              │
23. │           - idx_id2_bf (Parts: 1/4, Granules: 1/4)     │
24. │           - idx_id1_bf (Parts: 1/4, Granules: 1/4)     │
    └────────────────────────────────────────────────────────┘
```