### PR TITLE
Add IF EXISTS modifier to SYSTEM SYNC REPLICA

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -432,11 +432,12 @@ SYSTEM START PULLING REPLICATION LOG [ON CLUSTER cluster_name] [[db.]replicated_
 Wait until a `ReplicatedMergeTree` table will be synced with other replicas in a cluster, but no more than `receive_timeout` seconds.
 
 ```sql
-SYSTEM SYNC REPLICA [ON CLUSTER cluster_name] [db.]replicated_merge_tree_family_table_name [STRICT | LIGHTWEIGHT [FROM 'srcReplica1'[, 'srcReplica2'[, ...]]] | PULL]
+SYSTEM SYNC REPLICA [ON CLUSTER cluster_name] [db.]replicated_merge_tree_family_table_name [IF EXISTS] [STRICT | LIGHTWEIGHT [FROM 'srcReplica1'[, 'srcReplica2'[, ...]]] | PULL]
 ```
 
 After running this statement the `[db.]replicated_merge_tree_family_table_name` fetches commands from the common replicated log into its own replication queue, and then the query waits till the replica processes all of the fetched commands. The following modifiers are supported:
 
+ - With `IF EXISTS` (available since 25.6) the query won't throw an error if the table does not exists. This is useful when adding a new replica to a cluster, when it's already part of the cluster configuration but it is still in the process of creating and synchronizing the table.
  - If a `STRICT` modifier was specified then the query waits for the replication queue to become empty. The `STRICT` version may never succeed if new entries constantly appear in the replication queue.
  - If a `LIGHTWEIGHT` modifier was specified then the query waits only for `GET_PART`, `ATTACH_PART`, `DROP_RANGE`, `REPLACE_RANGE` and `DROP_PART` entries to be processed.
    Additionally, the LIGHTWEIGHT modifier supports an optional FROM 'srcReplicas' clause, where 'srcReplicas' is a comma-separated list of source replica names. This extension allows for more targeted synchronization by focusing only on replication tasks originating from the specified source replicas.

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -123,7 +123,6 @@ namespace ErrorCodes
     extern const int TABLE_WAS_NOT_DROPPED;
     extern const int ABORTED;
     extern const int SUPPORT_IS_DISABLED;
-    extern const int UNKNOWN_TABLE;
     extern const int TOO_DEEP_RECURSION;
 }
 
@@ -1271,7 +1270,7 @@ void InterpreterSystemQuery::syncReplica(ASTSystemQuery & query)
     getContext()->checkAccess(AccessType::SYSTEM_SYNC_REPLICA, table_id);
     StoragePtr table;
 
-    if (query.if_exists.has_value() && query.if_exists.value())
+    if (query.if_exists)
     {
         table = DatabaseCatalog::instance().tryGetTable(table_id, getContext());
         if (!table)

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -116,7 +116,7 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         chassert(table);
         table->format(ostr, settings, state, frame);
 
-        if (if_exists && if_exists.value())
+        if (if_exists)
             print_keyword(" IF EXISTS");
 
         return ostr;

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -115,6 +115,10 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
 
         chassert(table);
         table->format(ostr, settings, state, frame);
+
+        if (if_exists && if_exists.value())
+            print_keyword(" IF EXISTS");
+
         return ostr;
     };
 

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -129,7 +129,7 @@ public:
 
     ASTPtr database;
     ASTPtr table;
-    std::optional<bool> if_exists;
+    bool if_exists = false;
     ASTPtr query_settings;
 
     String getDatabase() const;

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -129,6 +129,7 @@ public:
 
     ASTPtr database;
     ASTPtr table;
+    std::optional<bool> if_exists;
     ASTPtr query_settings;
 
     String getDatabase() const;

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -296,6 +296,9 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 return false;
             if (res->type == Type::SYNC_REPLICA)
             {
+                if (ParserKeyword{Keyword::IF_EXISTS}.ignore(pos, expected))
+                    res->if_exists = true;
+
                 if (ParserKeyword{Keyword::STRICT}.ignore(pos, expected))
                     res->sync_replica_mode = SyncReplicaMode::STRICT;
                 else if (ParserKeyword{Keyword::LIGHTWEIGHT}.ignore(pos, expected))

--- a/tests/integration/test_sync_replica_on_cluster/configs/remote_servers.xml
+++ b/tests/integration/test_sync_replica_on_cluster/configs/remote_servers.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_sync_replica_on_cluster/test.py
+++ b/tests/integration/test_sync_replica_on_cluster/test.py
@@ -1,0 +1,118 @@
+import os
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV, assert_eq_with_retry
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    macros={"replica": "node1"},
+    with_zookeeper=True,
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+    macros={"replica": "node2"},
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield
+    finally:
+        cluster.shutdown()
+
+
+def test_sync_replica_on_cluster():
+    table = "tbl_test_sync_replica_on_cluster"
+    node1.query(f"DROP TABLE IF EXISTS {table} ON CLUSTER 'cluster' SYNC")
+    node1.query(
+        f"""
+        CREATE TABLE {table} ON CLUSTER 'cluster' (id Int64, str String)
+        ENGINE=ReplicatedMergeTree('/clickhouse/tables/{table}/', '{{replica}}')
+        ORDER BY id
+        """
+    )
+
+    # Does not throw
+    node2.query(f"SYSTEM SYNC REPLICA ON CLUSTER 'cluster' {table}")
+
+    node2.query("INSERT INTO tbl_test_sync_replica_on_cluster VALUES (2, 'str2')")
+    node1.query(f"SYSTEM SYNC REPLICA ON CLUSTER 'cluster' {table}")
+    count = node1.query(f"SELECT count() FROM {table}")
+    assert count == "1\n"
+
+    node1.query(f"DROP TABLE IF EXISTS {table} ON CLUSTER 'cluster' SYNC")
+
+
+def test_sync_replica_not_replicated():
+    table = "test_sync_replica_not_replicated"
+
+    node1.query(f"DROP TABLE IF EXISTS {table} ON CLUSTER 'cluster' SYNC")
+    node1.query(
+        f"""
+        CREATE TABLE {table} ON CLUSTER 'cluster' (id Int64, str String)
+        ENGINE=MergeTree()
+        ORDER BY id
+        """
+    )
+
+    output, error = node1.query_and_get_answer_with_error(
+        f"SYSTEM SYNC REPLICA {table}"
+    )
+    assert "is not replicated" in error
+
+    output, error = node2.query_and_get_answer_with_error(
+        f"SYSTEM SYNC REPLICA {table}"
+    )
+    assert "is not replicated" in error
+
+    node1.query(f"DROP TABLE IF EXISTS {table} ON CLUSTER 'cluster' SYNC")
+
+
+def test_sync_replica_if_not_exists():
+    table = "test_sync_replica_if_not_exists"
+
+    node1.query(f"DROP TABLE IF EXISTS {table} ON CLUSTER 'cluster' SYNC")
+    output, error = node1.query_and_get_answer_with_error(
+        f"SYSTEM SYNC REPLICA {table} IF EXISTS"
+    )
+    assert error == ""
+
+    # Table exists only in node1
+    node1.query(
+        f"""
+        CREATE TABLE {table} (id Int64, str String)
+        ENGINE=ReplicatedMergeTree('/clickhouse/tables/{table}/', '{{replica}}')
+        ORDER BY id
+        """
+    )
+    output, error = node1.query_and_get_answer_with_error(
+        f"SYSTEM SYNC REPLICA ON CLUSTER cluster {table} IF EXISTS"
+    )
+    assert error == ""
+
+    query_id = str(uuid.uuid4())
+    output, error = node2.query_and_get_answer_with_error(
+        f"SYSTEM SYNC REPLICA ON CLUSTER cluster {table} IF EXISTS", query_id=query_id
+    )
+    assert error == ""
+
+    # Node 1 should have received the sync request even if the table didn't exist in node2
+    node1.query("SYSTEM FLUSH LOGS system.query_log")
+    output = node1.query(
+        f"SELECT count() FROM system.query_log where initial_query_id = '{query_id}'"
+    )
+    assert output == "2\n"
+
+    node1.query(f"DROP TABLE IF EXISTS {table} ON CLUSTER 'cluster' SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add IF EXISTS modifier to SYSTEM SYNC REPLICA

This is useful when adding a new replica to a cluster, as there is a period of time during which the replica it's already part of the cluster configuration but it is still in the process of creating and synchronizing tables.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
