### PR TITLE
Forbid ATTACH AS [NOT] REPLICATED if table already exists

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1565,7 +1565,15 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 
         /// Set replicated or not replicated MergeTree engine in metadata and query
         if (create.attach_as_replicated.has_value())
+        {
+            if (database->isTableExist(create.getTable(), getContext()))
+                throw Exception(
+                    ErrorCodes::TABLE_ALREADY_EXISTS,
+                    "Table {}.{} already exists",
+                    backQuoteIfNeed(create.getDatabase()),
+                    backQuoteIfNeed(create.getTable()));
             convertMergeTreeTableIfPossible(create_query, database, create.attach_as_replicated.value());
+        }
 
         if (!create.is_dictionary && create_query.is_dictionary)
             throw Exception(ErrorCodes::INCORRECT_QUERY,

--- a/tests/queries/0_stateless/03169_attach_as_replicated.sh
+++ b/tests/queries/0_stateless/03169_attach_as_replicated.sh
@@ -21,6 +21,11 @@ ${CLICKHOUSE_CLIENT} -n -q "
 
 # Convert tables
 $CLICKHOUSE_CLIENT -n -q "
+    ATTACH TABLE mt AS REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+    ATTACH TABLE replacing AS REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+    ATTACH TABLE replacing_ver AS REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+    ATTACH TABLE collapsing_ver AS REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+
     DETACH TABLE mt;
     DETACH TABLE replacing;
     DETACH TABLE replacing_ver;
@@ -73,6 +78,11 @@ COLLAPSING_VER_ZK_PATH=$($CLICKHOUSE_CLIENT --query="SELECT zookeeper_path FROM 
 # Restored replica has no table_shared_id node in ZK
 # DROP REPLICA will log warning while deleting this node
 $CLICKHOUSE_CLIENT -n -q "
+    ATTACH TABLE mt AS NOT REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+    ATTACH TABLE replacing AS NOT REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+    ATTACH TABLE replacing_ver AS NOT REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+    ATTACH TABLE collapsing_ver AS NOT REPLICATED; -- { serverError TABLE_ALREADY_EXISTS }
+
     DETACH TABLE mt;
     DETACH TABLE replacing;
     DETACH TABLE replacing_ver;


### PR DESCRIPTION
Otherwise later on `ATTACH` you will get `INCORRECT_QUERY` error

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)