### PR TITLE
Extend exception message in CachedOnDiskReadBufferFromFile, add finished_download_time column to system.filesystem_cache'

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -1085,18 +1085,47 @@ bool CachedOnDiskReadBufferFromFile::nextImplStep()
         size_t cache_file_size = getFileSizeFromReadBuffer(*implementation_buffer);
         auto cache_file_path = getFileNameFromReadBuffer(*implementation_buffer);
 
+        std::string download_finished_time;
+        if (file_segment.isDownloaded())
+        {
+            WriteBufferFromString buf{download_finished_time};
+            writeDateTimeText(file_segment.getFinishedDownloadTime(), buf);
+        }
+        else
+            download_finished_time = "None";
+
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
-            "Having zero bytes, but range is not finished: file offset: {}, starting offset: {}, "
-            "reading until: {}, read type: {}, cache file size: {}, cache file path: {}, "
-            "cache file offset: {}, current file segment: {}",
+            "Having zero bytes, but range is not finished: "
+            "result: {}, "
+            "file offset: {}, "
+            "read bytes: {}, "
+            "initial read offset: {}, "
+            "nextimpl working buffer offset: {},"
+            "reading until: {}, "
+            "read type: {}, "
+            "working buffer size: {}, "
+            "internal buffer size: {}, "
+            "finished download time: {}, "
+            "cache file size: {}, "
+            "cache file path: {}, "
+            "cache file offset: {}, "
+            "remaining file segments: {}, "
+            "current file segment: {}",
+            result,
             file_offset_of_buffer_end,
+            size,
             first_offset,
+            nextimpl_working_buffer_offset,
             read_until_position,
             toString(read_type),
+            implementation_buffer->buffer().size(),
+            implementation_buffer->internalBuffer().size(),
+            download_finished_time,
             cache_file_size ? std::to_string(cache_file_size) : "None",
             cache_file_path,
             implementation_buffer->getFileOffsetOfBufferEnd(),
+            file_segments->size(),
             file_segment.getInfoForLog());
     }
 

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -194,6 +194,12 @@ bool FileSegment::isDownloaded() const
     return download_state == State::DOWNLOADED;
 }
 
+time_t FileSegment::getFinishedDownloadTime() const
+{
+    auto lk = lock();
+    return download_finished_time;
+}
+
 String FileSegment::getCallerId()
 {
     if (!CurrentThread::isInitialized() || CurrentThread::getQueryId().empty())
@@ -590,6 +596,7 @@ void FileSegment::setDownloadedUnlocked(const FileSegmentGuard::Lock &)
         return;
 
     download_state = State::DOWNLOADED;
+    download_finished_time = timeInSeconds(std::chrono::system_clock::now());
 
     if (cache_writer)
     {
@@ -1052,6 +1059,7 @@ FileSegment::Info FileSegment::getInfo(const FileSegmentPtr & file_segment)
         .state = file_segment->download_state,
         .size = file_segment->range().size(),
         .downloaded_size = file_segment->downloaded_size,
+        .download_finished_time = file_segment->download_finished_time,
         .cache_hits = file_segment->hits_count,
         .references = static_cast<uint64_t>(file_segment.use_count()),
         .is_unbound = file_segment->is_unbound,

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -131,6 +131,8 @@ public:
 
     bool isDownloaded() const;
 
+    time_t getFinishedDownloadTime() const;
+
     size_t getHitsCount() const { return hits_count; }
 
     size_t getRefCount() const { return ref_count; }
@@ -264,6 +266,7 @@ private:
 
     std::atomic<State> download_state;
     DownloaderId downloader_id; /// The one who prepares the download
+    time_t download_finished_time = 0;
 
     RemoteFileReaderPtr remote_file_reader;
     LocalCacheWriterPtr cache_writer;

--- a/src/Interpreters/Cache/FileSegmentInfo.h
+++ b/src/Interpreters/Cache/FileSegmentInfo.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Interpreters/Cache/FileCache_fwd.h>
 #include <Interpreters/Cache/FileCacheKey.h>
+#include <time.h>
 
 namespace DB
 {

--- a/src/Interpreters/Cache/FileSegmentInfo.h
+++ b/src/Interpreters/Cache/FileSegmentInfo.h
@@ -76,6 +76,7 @@ namespace DB
         FileSegmentState state;
         uint64_t size;
         uint64_t downloaded_size;
+        time_t download_finished_time;
         uint64_t cache_hits;
         uint64_t references;
         bool is_unbound;

--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeDateTime.h>
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileSegment.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
@@ -26,6 +27,7 @@ ColumnsDescription StorageSystemFilesystemCache::getColumnsDescription()
         {"file_segment_range_end", std::make_shared<DataTypeUInt64>(), "Offset corresponding to the (including) end of the file segment range"},
         {"size", std::make_shared<DataTypeUInt64>(), "Size of the file segment"},
         {"state", std::make_shared<DataTypeString>(), "File segment state (DOWNLOADED, DOWNLOADING, PARTIALLY_DOWNLOADED, ...)"},
+        {"finished_download_time", std::make_shared<DataTypeDateTime>(), "Time when file segment finished downloading."},
         {"cache_hits", std::make_shared<DataTypeUInt64>(), "Number of cache hits of corresponding file segment"},
         {"references", std::make_shared<DataTypeUInt64>(), "Number of references to corresponding file segment. Value 1 means that nobody uses it at the moment (the only existing reference is in cache storage itself)"},
         {"downloaded_size", std::make_shared<DataTypeUInt64>(), "Downloaded size of the file segment"},
@@ -69,6 +71,7 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
             res_columns[i++]->insert(file_segment.range_right);
             res_columns[i++]->insert(file_segment.size);
             res_columns[i++]->insert(FileSegment::stateToString(file_segment.state));
+            res_columns[i++]->insert(file_segment.download_finished_time);
             res_columns[i++]->insert(file_segment.cache_hits);
             res_columns[i++]->insert(file_segment.references);
             res_columns[i++]->insert(file_segment.downloaded_size);


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Extend exception message about "Having zero bytes, but read range is not finished...", add finished_download_time column to system.filesystem_cache'.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
