### PR TITLE
Make 02790_async_queries_in_query_log stable

### DIFF
--- a/tests/queries/0_stateless/02790_async_queries_in_query_log.reference
+++ b/tests/queries/0_stateless/02790_async_queries_in_query_log.reference
@@ -118,7 +118,7 @@ written_rows:   0
 written_bytes:  0
 result_rows:    0
 result_bytes:   0
-query:          INSERT INTO default.async_insert_landing (id) SETTINGS wait_for_async_insert = 1, async_insert = 1 FORMAT Values
+query:          INSERT INTO default.async_insert_landing (id) SETTINGS wait_for_async_insert = 1, async_insert = 1, materialized_views_ignore_errors = 1 FORMAT Values
 query_kind:     AsyncInsertFlush
 databases:      ['default']
 tables:         ['default.async_insert_landing','default.async_insert_target']
@@ -128,20 +128,20 @@ exception_code: 0
 
 Row 2:
 ──────
-type:           Exc*****onWhileProcessing
+type:           QueryFinish
 read_rows:      3
 read_bytes:     12
 written_rows:   3
 written_bytes:  12
-result_rows:    0
-result_bytes:   0
-query:          INSERT INTO default.async_insert_landing (id) SETTINGS wait_for_async_insert = 1, async_insert = 1 FORMAT Values
+result_rows:    3
+result_bytes:   12
+query:          INSERT INTO default.async_insert_landing (id) SETTINGS wait_for_async_insert = 1, async_insert = 1, materialized_views_ignore_errors = 1 FORMAT Values
 query_kind:     AsyncInsertFlush
 databases:      ['default']
 tables:         ['default.async_insert_landing','default.async_insert_target']
 columns:        ['default.async_insert_landing.id']
 views:          ['default.async_insert_mv']
-exception_code: 395
+exception_code: 0
 
 system.query_views_log
 Row 1:

--- a/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
+++ b/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
@@ -87,5 +87,6 @@ print_flush_query_logs ${query_id}
 
 
 query_id="$(random_str 10)"
-${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1 values (42), (12), (13)" 2>/dev/null || true
+# Use materialized_views_ignore_errors to guarantee it lands in the landing table, making the test stable
+${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1, materialized_views_ignore_errors=1 values (42), (12), (13)" 2>/dev/null || true
 print_flush_query_logs ${query_id}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make 02790_async_queries_in_query_log stable

Apparently there were some hacks before that made us ignore errors in some corner cases (like the first MV) and materialized_views_ignore_errors was not working fully as expected. https://github.com/ClickHouse/ClickHouse/pull/77309 fixed that and now things work as expected, which also means that the only way to guarantee the data will land in the landing for sure is to use materialized_views_ignore_errors=1. If you don't use the setting, then data might or might not land which made the test flaky.

Closes https://github.com/ClickHouse/ClickHouse/issues/80813

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
