### PR TITLE
make sure that server does not send body on HTTP HEAD

### DIFF
--- a/src/IO/NullWriteBuffer.cpp
+++ b/src/IO/NullWriteBuffer.cpp
@@ -5,6 +5,13 @@ namespace DB
 
 NullWriteBuffer::NullWriteBuffer()
     : WriteBufferFromPointer(data, sizeof(data))
+    , write_event(ProfileEvents::end())
+{
+}
+
+NullWriteBuffer::NullWriteBuffer(const ProfileEvents::Event & write_event_)
+    : WriteBufferFromPointer(data, sizeof(data))
+    , write_event(write_event_)
 {
 }
 
@@ -15,7 +22,9 @@ NullWriteBuffer::~NullWriteBuffer()
 
 void NullWriteBuffer::nextImpl()
 {
-    // no op
+    // no op, only update counters
+    if (write_event != ProfileEvents::end())
+        ProfileEvents::increment(write_event, offset());
 }
 
 }

--- a/src/IO/NullWriteBuffer.h
+++ b/src/IO/NullWriteBuffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IO/WriteBuffer.h>
+#include <Common/ProfileEvents.h>
 
 namespace DB
 {
@@ -10,11 +11,13 @@ class NullWriteBuffer final : public WriteBufferFromPointer
 {
 public:
     NullWriteBuffer();
+    explicit NullWriteBuffer(const ProfileEvents::Event & write_event);
     ~NullWriteBuffer() override;
 
     void nextImpl() override;
 
 private:
+    ProfileEvents::Event write_event;
     char data[128];
 };
 

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -9,7 +9,7 @@
 #include <Poco/Net/HTTPFixedLengthStream.h>
 #include <Poco/Net/HTTPHeaderStream.h>
 #include <Poco/Net/HTTPStream.h>
-#include "IO/NullWriteBuffer.h"
+#include <IO/NullWriteBuffer.h>
 #include <sstream>
 
 

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -9,6 +9,7 @@
 #include <Poco/Net/HTTPFixedLengthStream.h>
 #include <Poco/Net/HTTPHeaderStream.h>
 #include <Poco/Net/HTTPStream.h>
+#include "IO/NullWriteBuffer.h"
 #include <sstream>
 
 
@@ -27,13 +28,31 @@ void HTTPServerResponse::sendContinue()
     hs << getVersion() << " 100 Continue\r\n\r\n";
 }
 
-std::shared_ptr<WriteBufferFromPocoSocket> HTTPServerResponse::send()
+std::shared_ptr<WriteBuffer> HTTPServerResponse::send()
 {
     poco_assert(!stream);
 
-    if ((request && request->getMethod() == HTTPRequest::HTTP_HEAD) || getStatus() < 200 || getStatus() == HTTPResponse::HTTP_NO_CONTENT
-        || getStatus() == HTTPResponse::HTTP_NOT_MODIFIED)
+    if (request && request->getMethod() == HTTPRequest::HTTP_HEAD)
     {
+        // HTTP_HEAD is a special case
+        // client usually reads nothing from socet after headers even when 'Contex-Lenght' is sent
+        // if server wrote a message to the connection with enabled 'Connection: Keep-Alive'
+        // the connection would be poisoned.
+        // Next request over that connection reads previously unreaded message as a HTTP status line
+
+        // Send header
+        Poco::Net::HTTPHeaderOutputStream hs(session);
+        write(hs);
+        // make sure that nothing is sent to the client if it was HTTP_HEAD request
+        stream = std::make_shared<NullWriteBuffer>(write_event);
+
+    }
+    else if (getStatus() < 200 || getStatus() == HTTPResponse::HTTP_NOT_MODIFIED || getStatus() == HTTPResponse::HTTP_NO_CONTENT)
+    {
+        // I really do not know why are we threting this cases as special one
+        // but if we do, then it is safer to close the connection at the end
+        setKeepAlive(false);
+
         // Send header
         Poco::Net::HTTPHeaderOutputStream hs(session);
         write(hs);
@@ -66,7 +85,7 @@ std::shared_ptr<WriteBufferFromPocoSocket> HTTPServerResponse::send()
     return stream;
 }
 
-std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBufferFromPocoSocket>> HTTPServerResponse::beginSend()
+std::pair<std::shared_ptr<WriteBuffer>, std::shared_ptr<WriteBuffer>> HTTPServerResponse::beginSend()
 {
     poco_assert(!stream);
     poco_assert(!header_stream);
@@ -90,7 +109,7 @@ std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBuffe
     // Send header
     auto str = header.str();
     header_stream = std::make_shared<AutoFinalizedWriteBuffer<WriteBufferFromPocoSocket>>(session.socket(), write_event, str.size());
-    header_stream->write(str);
+    header_stream->write(str.data(), str.size());
 
     if (getChunkedTransferEncoding())
         stream = std::make_shared<AutoFinalizedWriteBuffer<HTTPWriteBufferChunked>>(session.socket(), write_event);

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<WriteBuffer> HTTPServerResponse::send()
     if (request && request->getMethod() == HTTPRequest::HTTP_HEAD)
     {
         // HTTP_HEAD is a special case
-        // client usually reads nothing from socet after headers even when 'Contex-Lenght' is sent
+        // client usually reads nothing from socket after headers even when 'Contex-Lenght' is sent
         // if server wrote a message to the connection with enabled 'Connection: Keep-Alive'
         // the connection would be poisoned.
         // Next request over that connection reads previously unreaded message as a HTTP status line
@@ -49,7 +49,7 @@ std::shared_ptr<WriteBuffer> HTTPServerResponse::send()
     }
     else if (getStatus() < 200 || getStatus() == HTTPResponse::HTTP_NOT_MODIFIED || getStatus() == HTTPResponse::HTTP_NO_CONTENT)
     {
-        // I really do not know why are we threting this cases as special one
+        // I really do not know why do we consider this cases as special one
         // but if we do, then it is safer to close the connection at the end
         setKeepAlive(false);
 

--- a/src/Server/HTTP/HTTPServerResponse.h
+++ b/src/Server/HTTP/HTTPServerResponse.h
@@ -232,7 +232,7 @@ public:
     ///
     /// Must not be called after beginSend(), sendFile(), sendBuffer()
     /// or redirect() has been called.
-    std::shared_ptr<WriteBufferFromPocoSocket> send();
+    std::shared_ptr<WriteBuffer> send();
 
     /// Sends the response headers to the client
     /// but do not finish headers with \r\n,
@@ -240,7 +240,7 @@ public:
     ///
     /// Must not be called after send(), sendFile(), sendBuffer()
     /// or redirect() has been called.
-    std::pair<std::shared_ptr<WriteBufferFromPocoSocket>, std::shared_ptr<WriteBufferFromPocoSocket>> beginSend();
+    std::pair<std::shared_ptr<WriteBuffer>, std::shared_ptr<WriteBuffer>> beginSend();
 
     /// Override to correctly mark that the data send had been started for
     /// zero-copy response (i.e. replicated fetches).
@@ -288,8 +288,8 @@ private:
     Poco::Net::HTTPServerSession & session;
     HTTPServerRequest * request = nullptr;
     ProfileEvents::Event write_event;
-    std::shared_ptr<WriteBufferFromPocoSocket> stream;
-    std::shared_ptr<WriteBufferFromPocoSocket> header_stream;
+    std::shared_ptr<WriteBuffer> stream;
+    std::shared_ptr<WriteBuffer> header_stream;
     mutable bool send_started = false;
 };
 

--- a/tests/queries/0_stateless/03522_404_head_request.reference
+++ b/tests/queries/0_stateless/03522_404_head_request.reference
@@ -1,0 +1,6 @@
+HEAD does not have a message
+HTTP/1.1 404 Not Found
+Connection: Close
+
+GET has a message
+There is no handle /does_not_exist

--- a/tests/queries/0_stateless/03522_404_head_request.sh
+++ b/tests/queries/0_stateless/03522_404_head_request.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -eu
+
+# server does not send the message body at HTTP HEAD request
+# client closes connection just to save time
+
+URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/does_not_exist"
+
+echo HEAD does not have a message
+${CLICKHOUSE_CURL} -H 'Connection: close' -X HEAD "${URL}" -D - | grep -v 'Date:'
+
+echo GET has a message
+${CLICKHOUSE_CURL} -H 'Connection: close' -X GET "${URL}" -D - | grep 'There is no handle /does_not_exist'


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/80725

Servet should never send message body on HTTP HEAD request. Otherwise the connection is poisoned because client does not read a body, in case if keep alive, the next request fails in surprising way.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix and make sure that clickhouse server does not send body on HTTP HEAD request

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
