### PR TITLE
Expose memory used for index granulas in asynchronous metrics

### DIFF
--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -309,6 +309,8 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
 
         size_t total_primary_key_bytes_memory = 0;
         size_t total_primary_key_bytes_memory_allocated = 0;
+        size_t total_index_granularity_bytes_in_memory = 0;
+        size_t total_index_granularity_bytes_in_memory_allocated = 0;
 
         for (const auto & db : databases)
         {
@@ -355,6 +357,8 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     {
                         total_primary_key_bytes_memory += part->getIndexSizeInBytes();
                         total_primary_key_bytes_memory_allocated += part->getIndexSizeInAllocatedBytes();
+                        total_index_granularity_bytes_in_memory += part->getIndexGranularityBytes();
+                        total_index_granularity_bytes_in_memory_allocated += part->getIndexGranularityAllocatedBytes();
                     }
                 }
 
@@ -418,6 +422,8 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
 
         new_values["TotalPrimaryKeyBytesInMemory"] = { total_primary_key_bytes_memory, "The total amount of memory (in bytes) used by primary key values (only takes active parts into account)." };
         new_values["TotalPrimaryKeyBytesInMemoryAllocated"] = { total_primary_key_bytes_memory_allocated, "The total amount of memory (in bytes) reserved for primary key values (only takes active parts into account)." };
+        new_values["TotalIndexGranularityBytesInMemory"] = { total_index_granularity_bytes_in_memory, "The total amount of memory (in bytes) used by index granulas (only takes active parts into account)." };
+        new_values["TotalIndexGranularityBytesInMemoryAllocated"] = { total_index_granularity_bytes_in_memory_allocated, "The total amount of memory (in bytes) reserved for index granulas (only takes active parts into account)." };
     }
 
 #if USE_NURAFT


### PR DESCRIPTION
Expose two new metrics:
- `TotalIndexGranularityBytesInMemory`
- `TotalIndexGranularityBytesInMemoryAllocated`

This can be used over
`index_granularity_bytes_in_memory`/`index_granularity_bytes_in_memory_allocated` from system.parts to avoid querying it, since this can be pretty heavy.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)