### PR TITLE
Add search algorithm section to EXPLAIN indexes = 1

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2677,6 +2677,18 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
             if (i)
                 format_settings.out << '/' << index_stats[i - 1].num_granules_after;
             format_settings.out << '\n';
+
+            auto search_algorithm_to_string = [](const MarkRanges::SearchAlgorithm search_algorithm) -> String {
+                switch (search_algorithm)
+                {
+                    case MarkRanges::SearchAlgorithm::BinarySearch: return "binary search";
+                    case MarkRanges::SearchAlgorithm::GenericExclusionSearch: return "generic exclusion search";
+                    default: return "";
+                }
+            };
+            const auto search_algorithm = search_algorithm_to_string(stat.search_algorithm);
+            if (!search_algorithm.empty())
+                format_settings.out << prefix << indent << indent << "Search algorithm: " << search_algorithm << "\n";
         }
     }
 }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -86,6 +86,7 @@ public:
         std::vector<std::string> used_keys = {};
         size_t num_parts_after;
         size_t num_granules_after;
+        MarkRanges::SearchAlgorithm search_algorithm = {MarkRanges::SearchAlgorithm::Unknown};
     };
 
     using IndexStats = std::vector<IndexStat>;

--- a/src/Storages/MergeTree/MarkRange.h
+++ b/src/Storages/MergeTree/MarkRange.h
@@ -32,6 +32,13 @@ struct MarkRange
 
 struct MarkRanges : public std::deque<MarkRange>
 {
+    enum class SearchAlgorithm : uint8_t
+    {
+        Unknown,
+        BinarySearch,
+        GenericExclusionSearch,
+    };
+
     using std::deque<MarkRange>::deque; /// NOLINT(modernize-type-traits)
 
     size_t getNumberOfMarks() const;
@@ -40,6 +47,8 @@ struct MarkRanges : public std::deque<MarkRange>
     void serialize(WriteBuffer & out) const;
     String describe() const;
     void deserialize(ReadBuffer & in);
+
+    SearchAlgorithm search_algorithm = {SearchAlgorithm::Unknown};
 };
 
 /** Get max range.end from ranges.

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -724,6 +724,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
         std::atomic<size_t> total_parts = 0;
         std::atomic<size_t> parts_dropped = 0;
         std::atomic<size_t> elapsed_us = 0;
+        std::atomic<MarkRanges::SearchAlgorithm> search_algorithm = MarkRanges::SearchAlgorithm::Unknown;
     };
 
     IndexStat pk_stat;
@@ -774,6 +775,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
                     settings,
                     log);
 
+                pk_stat.search_algorithm.store(ranges.ranges.search_algorithm, std::memory_order_relaxed);
                 pk_stat.granules_dropped.fetch_add(total_marks_count - ranges.ranges.getNumberOfMarks(), std::memory_order_relaxed);
                 if (ranges.ranges.empty())
                     pk_stat.parts_dropped.fetch_add(1, std::memory_order_relaxed);
@@ -915,7 +917,9 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
             .condition = std::move(description.condition),
             .used_keys = std::move(description.used_keys),
             .num_parts_after = sum_parts_pk.load(std::memory_order_relaxed),
-            .num_granules_after = sum_marks_pk.load(std::memory_order_relaxed)});
+            .num_granules_after = sum_marks_pk.load(std::memory_order_relaxed),
+            .search_algorithm = pk_stat.search_algorithm.load(std::memory_order_relaxed)
+        });
     }
 
     for (size_t idx = 0; idx < skip_indexes.useful_indices.size(); ++idx)
@@ -1477,6 +1481,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
             }
         }
 
+        res.search_algorithm = MarkRanges::SearchAlgorithm::GenericExclusionSearch;
         ProfileEvents::increment(ProfileEvents::IndexGenericExclusionSearchAlgorithm);
         LOG_TRACE(
             log,
@@ -1491,6 +1496,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
         /// we can use binary search algorithm to find the left and right endpoint key marks of such interval.
         /// The returned value is the minimum range of marks, containing all keys for which KeyCondition holds
 
+        res.search_algorithm = MarkRanges::SearchAlgorithm::BinarySearch;
         ProfileEvents::increment(ProfileEvents::IndexBinarySearchAlgorithm);
         LOG_TRACE(log, "Running binary search on index range for part {} ({} marks)", part_name, marks_count);
 

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
@@ -18,6 +18,7 @@ Expression ((Projection + Before ORDER BY))
             Condition: (id in [101, 101])
             Parts: 1/1
             Granules: 1/1
+            Search algorithm: binary search
       Expression ((Joined actions + (Rename joined columns + (Projection + Before ORDER BY))))
         ReadFromMergeTree (default.t2)
         Indexes:
@@ -37,6 +38,7 @@ Expression ((Project names + Projection))
             Condition: (id in [101, 101])
             Parts: 1/1
             Granules: 1/1
+            Search algorithm: binary search
       Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
         ReadFromMergeTree (default.t2)
         Indexes:

--- a/tests/queries/0_stateless/01786_explain_merge_tree.reference
+++ b/tests/queries/0_stateless/01786_explain_merge_tree.reference
@@ -17,6 +17,7 @@
           y
         Parts: 2/3
         Granules: 6/10
+        Search algorithm: generic exclusion search
       Skip
         Name: t_minmax
         Description: minmax GRANULARITY 2
@@ -107,6 +108,7 @@
         Condition: or((x in 2-element set), (plus(plus(x, y), 1) in (-Inf, 2]))
         Parts: 1/1
         Granules: 1/1
+        Search algorithm: generic exclusion search
     ReadFromMergeTree (default.test_index)
     Indexes:
       MinMax
@@ -126,6 +128,7 @@
           y
         Parts: 2/3
         Granules: 6/10
+        Search algorithm: generic exclusion search
       Skip
         Name: t_minmax
         Description: minmax GRANULARITY 2
@@ -218,3 +221,4 @@
         Condition: or((x in 2-element set), (plus(plus(x, y), 1) in (-Inf, 2]))
         Parts: 1/1
         Granules: 1/1
+        Search algorithm: generic exclusion search

--- a/tests/queries/0_stateless/02882_primary_key_index_in_function_different_types.reference
+++ b/tests/queries/0_stateless/02882_primary_key_index_in_function_different_types.reference
@@ -10,6 +10,7 @@ CreatingSets
           Condition: and((value in 1-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -22,6 +23,7 @@ CreatingSets
           Condition: and((value in 1-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -34,6 +36,7 @@ CreatingSets
           Condition: and((value in 5-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -46,6 +49,7 @@ CreatingSets
           Condition: and((value in 5-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -58,6 +62,7 @@ CreatingSets
           Condition: and((value in 1-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -70,6 +75,7 @@ CreatingSets
           Condition: and((value in 1-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -82,6 +88,7 @@ CreatingSets
           Condition: and((value in 5-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search
 CreatingSets
   Expression
     Expression
@@ -94,3 +101,4 @@ CreatingSets
           Condition: and((value in 5-element set), (id in (-Inf, 10]))
           Parts: 1/1
           Granules: 1/1
+          Search algorithm: generic exclusion search

--- a/tests/queries/0_stateless/02911_support_alias_column_in_indices.reference
+++ b/tests/queries/0_stateless/02911_support_alias_column_in_indices.reference
@@ -8,6 +8,7 @@ Expression ((Projection + Before ORDER BY))
         Condition: (plus(c, 1) in [11, +Inf))
         Parts: 1/2
         Granules: 1/2
+        Search algorithm: generic exclusion search
       Skip
         Name: i
         Description: minmax GRANULARITY 1
@@ -23,6 +24,7 @@ Expression ((Project names + Projection))
         Condition: (plus(c, 1) in [11, +Inf))
         Parts: 1/2
         Granules: 1/2
+        Search algorithm: generic exclusion search
       Skip
         Name: i
         Description: minmax GRANULARITY 1
@@ -38,6 +40,7 @@ Expression ((Projection + Before ORDER BY))
         Condition: (plus(plus(c, 1), 1) in [16, +Inf))
         Parts: 1/2
         Granules: 1/2
+        Search algorithm: generic exclusion search
       Skip
         Name: i
         Description: minmax GRANULARITY 1
@@ -53,6 +56,7 @@ Expression ((Project names + Projection))
         Condition: (plus(plus(c, 1), 1) in [16, +Inf))
         Parts: 1/2
         Granules: 1/2
+        Search algorithm: generic exclusion search
       Skip
         Name: i
         Description: minmax GRANULARITY 1

--- a/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.reference
+++ b/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.reference
@@ -19,6 +19,7 @@ Header: name String
             Condition: (name in [\'Alice\', \'Alice\'])
             Parts: 1/3
             Granules: 1/3
+            Search algorithm: generic exclusion search
       Filter (( + Change column names to column identifiers))
       Header: __table2.name String
         ReadFromMergeTree (default.users2)
@@ -30,6 +31,7 @@ Header: name String
             Condition: (name in [\'Alice\', \'Alice\'])
             Parts: 1/3
             Granules: 1/3
+            Search algorithm: generic exclusion search
 SELECT '--';
 --
 EXPLAIN header = 1, indexes = 1
@@ -51,6 +53,7 @@ Header: name String
             Condition: (name in [\'Alice\', \'Alice\'])
             Parts: 1/3
             Granules: 1/3
+            Search algorithm: generic exclusion search
       Filter (( + Change column names to column identifiers))
       Header: __table2.name String
         ReadFromMergeTree (default.users2)
@@ -62,6 +65,7 @@ Header: name String
             Condition: (name in [\'Alice\', \'Alice\'])
             Parts: 1/3
             Granules: 1/3
+            Search algorithm: generic exclusion search
 SELECT '--';
 --
 EXPLAIN header = 1, indexes = 1
@@ -83,6 +87,7 @@ Header: name String
             Condition: (name in [\'Alice\', \'Alice\'])
             Parts: 1/3
             Granules: 1/3
+            Search algorithm: generic exclusion search
       Filter (( + Change column names to column identifiers))
       Header: __table2.name String
         ReadFromMergeTree (default.users2)
@@ -94,3 +99,4 @@ Header: name String
             Condition: (name in [\'Alice\', \'Alice\'])
             Parts: 1/3
             Granules: 1/3
+            Search algorithm: generic exclusion search

--- a/tests/queries/0_stateless/03272_partition_pruning_monotonic_func_bug.reference
+++ b/tests/queries/0_stateless/03272_partition_pruning_monotonic_func_bug.reference
@@ -9,3 +9,4 @@ Expression
       Condition: and((dateTrunc(\'hour\', ts) in (-Inf, 1731592800]), (dateTrunc(\'hour\', ts) in [1731506400, +Inf)))
       Parts: 1/1
       Granules: 1/1
+      Search algorithm: binary search

--- a/tests/queries/0_stateless/03275_subcolumns_in_primary_key.reference
+++ b/tests/queries/0_stateless/03275_subcolumns_in_primary_key.reference
@@ -95,6 +95,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 0	((0,'str_0',[]))	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -107,6 +108,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -120,6 +122,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -135,6 +138,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 1
 0	((0,'str_0',[]))	Hello, World!
 2	((0,'str_2',[0,1]))	Hello, World!
@@ -258,6 +262,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 0	((0,'str_0',[]))	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -270,6 +275,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/1
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -283,6 +289,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -298,6 +305,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/1
 Granules: 1/8
+Search algorithm: binary search
 create table test (id UInt64, a Tuple(b Tuple(c UInt32, d String, e Array(UInt32))), data String) engine=MergeTree order by (a.b.c, a.b.d) settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_columns_to_activate=10, vertical_merge_algorithm_min_rows_to_activate=10000000000, index_granularity = 1;
 0	((0,'str_0',[]))	Hello, World!
 2	((0,'str_2',[0,1]))	Hello, World!
@@ -395,6 +403,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 0	((0,'str_0',[]))	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -407,6 +416,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -420,6 +430,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -435,6 +446,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 1
 0	((0,'str_0',[]))	Hello, World!
 2	((0,'str_2',[0,1]))	Hello, World!
@@ -558,6 +570,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 0	((0,'str_0',[]))	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -570,6 +583,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/1
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -583,6 +597,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -598,6 +613,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/1
 Granules: 1/8
+Search algorithm: binary search
 create table test (id UInt64, a Tuple(b Tuple(c UInt32, d String, e Array(UInt32))), data String) engine=MergeTree order by (a.b.c, a.b.d) settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_columns_to_activate=1, vertical_merge_algorithm_min_rows_to_activate=1, index_granularity = 1;
 0	((0,'str_0',[]))	Hello, World!
 2	((0,'str_2',[0,1]))	Hello, World!
@@ -695,6 +711,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 0	((0,'str_0',[]))	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -707,6 +724,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -720,6 +738,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -735,6 +754,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 1
 0	((0,'str_0',[]))	Hello, World!
 2	((0,'str_2',[0,1]))	Hello, World!
@@ -858,6 +878,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 0	((0,'str_0',[]))	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -870,6 +891,7 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/1
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -883,6 +905,7 @@ a.b.c
 Condition: (a.b.c in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -898,3 +921,4 @@ a.b.d
 Condition: and((a.b.d in [\'str_0\', \'str_0\']), (a.b.c in [0, 0]))
 Parts: 1/1
 Granules: 1/8
+Search algorithm: binary search

--- a/tests/queries/0_stateless/03277_json_subcolumns_in_primary_key.reference
+++ b/tests/queries/0_stateless/03277_json_subcolumns_in_primary_key.reference
@@ -95,6 +95,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -107,6 +108,7 @@ CAST(json.b, \'String\')
 Condition: and((CAST(json.b, \'String\') in [\'str_0\', \'str_0\']), (json.a in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -120,6 +122,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -134,6 +137,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 1
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 2	{"a":0,"b":"str_2","c":["0","1"]}	Hello, World!
@@ -232,6 +236,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -246,6 +251,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 create table test (id UInt64, json JSON(a UInt32), data String) engine=MergeTree order by (json.a, json.b::String) settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_columns_to_activate=10, vertical_merge_algorithm_min_rows_to_activate=1000000, index_granularity=1;
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 2	{"a":0,"b":"str_2","c":["0","1"]}	Hello, World!
@@ -343,6 +349,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -355,6 +362,7 @@ CAST(json.b, \'String\')
 Condition: and((CAST(json.b, \'String\') in [\'str_0\', \'str_0\']), (json.a in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -368,6 +376,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -382,6 +391,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 1
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 2	{"a":0,"b":"str_2","c":["0","1"]}	Hello, World!
@@ -480,6 +490,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -494,6 +505,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 create table test (id UInt64, json JSON(a UInt32), data String) engine=MergeTree order by (json.a, json.b::String) settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1, vertical_merge_algorithm_min_columns_to_activate=1, vertical_merge_algorithm_min_rows_to_activate=1, index_granularity=1;
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 2	{"a":0,"b":"str_2","c":["0","1"]}	Hello, World!
@@ -591,6 +603,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 Expression ((Project names + Projection))
 Expression
@@ -603,6 +616,7 @@ CAST(json.b, \'String\')
 Condition: and((CAST(json.b, \'String\') in [\'str_0\', \'str_0\']), (json.a in [0, 0]))
 Parts: 1/2
 Granules: 1/8
+Search algorithm: binary search
 2
 Expression ((Project names + Projection))
 AggregatingProjection
@@ -616,6 +630,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -630,6 +645,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/2
 Granules: 2/8
+Search algorithm: binary search
 1
 0	{"a":0,"b":"str_0","c":[]}	Hello, World!
 2	{"a":0,"b":"str_2","c":["0","1"]}	Hello, World!
@@ -728,6 +744,7 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search
 ReadFromPreparedSource (_minmax_count_projection)
 1
 Expression ((Project names + Projection))
@@ -742,3 +759,4 @@ json.a
 Condition: (json.a in [0, 0])
 Parts: 1/1
 Granules: 2/8
+Search algorithm: binary search

--- a/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
+++ b/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
@@ -35,6 +35,7 @@ Union
           Condition: (x in [42, 42])
           Parts: 1/1
           Granules: 1/123
+          Search algorithm: binary search
   Expression ((Project names + Projection))
   Actions: INPUT : 0 -> __table1.x UInt32 : 0
            INPUT : 1 -> __table1.y UInt32 : 1
@@ -82,6 +83,7 @@ Union
                 Condition: (x in [42, 42])
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
 ============ lambdas
 41	41
 41	41
@@ -129,6 +131,7 @@ Positions: 1
               Condition: (x in [42, 42])
               Parts: 1/1
               Granules: 1/123
+              Search algorithm: binary search
       Expression (Before GROUP BY)
       Actions: INPUT :: 0 -> __table1.y UInt32 : 0
       Positions: 0
@@ -172,6 +175,7 @@ Positions: 1
                     Condition: (x in [42, 42])
                     Parts: 1/1
                     Granules: 1/123
+                    Search algorithm: binary search
 Expression ((Project names + (Projection + )))
 Actions: INPUT : 0 -> sum(__table2.y) UInt64 : 0
          INPUT : 1 -> __table2.x UInt32 : 1
@@ -227,6 +231,7 @@ Positions: 1 0
                 Condition: (x in [42, 42])
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
       Filter (( + Change remote column names to local column names))
       Filter column: equals(__table1.x, 42_UInt8) (removed)
       Actions: INPUT : 0 -> __table1.x UInt32 : 0
@@ -274,6 +279,7 @@ CreatingSets (Create sets before main query execution)
                 Condition: (x in 1-element set)
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -288,6 +294,7 @@ CreatingSets (Create sets before main query execution)
                         Condition: (x in 1-element set)
                         Parts: 1/1
                         Granules: 1/123
+                        Search algorithm: binary search
 42
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -306,6 +313,7 @@ CreatingSets (Create sets before main query execution)
                       Condition: (x in 1-element set)
                       Parts: 1/1
                       Granules: 1/123
+                      Search algorithm: binary search
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
@@ -323,6 +331,7 @@ CreatingSets (Create sets before main query execution)
               Condition: (x in 1-element set)
               Parts: 1/1
               Granules: 1/123
+              Search algorithm: binary search
 84
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -341,6 +350,7 @@ CreatingSets (Create sets before main query execution)
                       Condition: (x in 1-element set)
                       Parts: 1/1
                       Granules: 1/123
+                      Search algorithm: binary search
             CreatingSets (Create sets before main query execution)
               Expression ((Project names + Projection))
                 Expression
@@ -352,6 +362,7 @@ CreatingSets (Create sets before main query execution)
                       Condition: (x in 1-element set)
                       Parts: 1/1
                       Granules: 1/123
+                      Search algorithm: binary search
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
@@ -370,6 +381,7 @@ CreatingSets (Create sets before main query execution)
                 Condition: (x in 1-element set)
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -384,6 +396,7 @@ CreatingSets (Create sets before main query execution)
                         Condition: (x in 1-element set)
                         Parts: 1/1
                         Granules: 1/123
+                        Search algorithm: binary search
 126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -399,6 +412,7 @@ CreatingSets (Create sets before main query execution)
                 Condition: (x in 1-element set)
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -413,6 +427,7 @@ CreatingSets (Create sets before main query execution)
                         Condition: (x in 1-element set)
                         Parts: 1/1
                         Granules: 1/123
+                        Search algorithm: binary search
               CreatingSets (Create sets before main query execution)
                 Expression ((Project names + Projection))
                   Expression
@@ -424,6 +439,7 @@ CreatingSets (Create sets before main query execution)
                         Condition: (x in 1-element set)
                         Parts: 1/1
                         Granules: 1/123
+                        Search algorithm: binary search
 126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -480,6 +496,7 @@ CreatingSets (Create sets before main query execution)
             Condition: (recordTimestamp in 0-element set)
             Parts: 0/1
             Granules: 0/1
+            Search algorithm: generic exclusion search
     Expression ((Project names + Projection))
       Filter (( + Change column names to column identifiers))
         ReadFromRemote (Read from remote replica)
@@ -494,6 +511,7 @@ CreatingSets (Create sets before main query execution)
                     Condition: (recordTimestamp in 0-element set)
                     Parts: 0/1
                     Granules: 0/1
+                    Search algorithm: generic exclusion search
 ============ #68030
 Union
   Expression ((Project names + Projection))
@@ -520,6 +538,7 @@ Union
           Condition: (n in [100, 100])
           Parts: 1/1
           Granules: 1/62
+          Search algorithm: binary search
   Expression ((Project names + Projection))
   Actions: INPUT : 0 -> __table1.n UInt64 : 0
            ALIAS __table1.n :: 0 -> n UInt64 : 1
@@ -557,3 +576,4 @@ Union
                 Condition: (n in [100, 100])
                 Parts: 1/1
                 Granules: 1/62
+                Search algorithm: binary search

--- a/tests/queries/0_stateless/03305_mergine_aggregated_filter_push_down.reference
+++ b/tests/queries/0_stateless/03305_mergine_aggregated_filter_push_down.reference
@@ -17,6 +17,7 @@ Expression ((Project names + (Projection + )))
                 Condition: (x in [42, 42])
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)
 select * from (select x, sum(y) from remote('127.0.0.{1,2}', currentDatabase(), tab) group by grouping sets ((x, z + 1), (x, z + 2))) where x = 42;
@@ -38,6 +39,7 @@ Expression ((Project names + (Projection + )))
                   Condition: (x in [42, 42])
                   Parts: 1/1
                   Granules: 1/123
+                  Search algorithm: binary search
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)
 select * from (select x, sum(y), z + 1 as q from remote('127.0.0.{1,2}', currentDatabase(), tab) group by grouping sets ((x, z + 1), (x, z + 2))) where q = 42;
@@ -76,6 +78,7 @@ Expression ((Project names + (Projection + )))
                 Condition: (x in [42, 42])
                 Parts: 1/1
                 Granules: 1/123
+                Search algorithm: binary search
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)
 select * from (select x, sum(y) from remote('127.0.0.{1,2}', currentDatabase(), tab) group by grouping sets ((x, z + 1), (x, z + 2))) where x = 42;

--- a/tests/queries/0_stateless/03464_projections_with_subcolumns.reference
+++ b/tests/queries/0_stateless/03464_projections_with_subcolumns.reference
@@ -8,6 +8,7 @@ Expression ((Project names + Projection))
         Condition: (json.a in [1, 1])
         Parts: 1/1
         Granules: 2/100
+        Search algorithm: binary search
 {"a":1,"b":"str","c":[{"d":"1"}]}
 Expression ((Project names + Projection))
   Filter
@@ -19,6 +20,7 @@ Expression ((Project names + Projection))
         Condition: (t.a in [1, 1])
         Parts: 1/1
         Granules: 2/100
+        Search algorithm: binary search
 (1,1)
 Expression ((Project names + Projection))
   Filter
@@ -30,6 +32,7 @@ Expression ((Project names + Projection))
         Condition: (json.c.:`Array(JSON)`.d.:`Int64` in [[1], [1]])
         Parts: 1/1
         Granules: 2/100
+        Search algorithm: binary search
 {"a":1,"b":"str","c":[{"d":"1"}]}
 Expression ((Project names + Projection))
   Filter
@@ -41,6 +44,7 @@ Expression ((Project names + Projection))
         Condition: (json.a in [1, 1])
         Parts: 1/1
         Granules: 3/200
+        Search algorithm: binary search
 {"a":1,"b":"str","c":[{"d":"1"}]}
 {"a":1,"b":"str","c":[{"d":"1"}]}
 Expression ((Project names + Projection))
@@ -53,6 +57,7 @@ Expression ((Project names + Projection))
         Condition: (t.a in [1, 1])
         Parts: 1/1
         Granules: 3/200
+        Search algorithm: binary search
 (1,1)
 (1,1)
 Expression ((Project names + Projection))
@@ -65,6 +70,7 @@ Expression ((Project names + Projection))
         Condition: (json.c.:`Array(JSON)`.d.:`Int64` in [[1], [1]])
         Parts: 1/1
         Granules: 3/200
+        Search algorithm: binary search
 {"a":1,"b":"str","c":[{"d":"1"}]}
 {"a":1,"b":"str","c":[{"d":"1"}]}
 ------------------------------------------------------------------
@@ -78,6 +84,7 @@ Expression ((Project names + Projection))
         Condition: (json.a in [1, 1])
         Parts: 1/1
         Granules: 2/100
+        Search algorithm: binary search
 {"a":1,"b":"str","c":[{"d":"1"}]}
 Expression ((Project names + Projection))
   Filter
@@ -89,6 +96,7 @@ Expression ((Project names + Projection))
         Condition: (t.a in [1, 1])
         Parts: 1/1
         Granules: 2/100
+        Search algorithm: binary search
 (1,1)
 Expression ((Project names + Projection))
   Filter
@@ -100,4 +108,5 @@ Expression ((Project names + Projection))
         Condition: (json.c.:`Array(JSON)`.d.:`Int64` in [[1], [1]])
         Parts: 1/1
         Granules: 2/100
+        Search algorithm: binary search
 {"a":1,"b":"str","c":[{"d":"1"}]}

--- a/tests/queries/0_stateless/03522_search_algorithm_in_explain.reference
+++ b/tests/queries/0_stateless/03522_search_algorithm_in_explain.reference
@@ -1,0 +1,25 @@
+-- Output when the key condition is the first of the compound key
+Expression ((Project names + Projection))
+  Expression
+    ReadFromMergeTree (default.t)
+    Indexes:
+      PrimaryKey
+        Keys: 
+          a
+        Condition: (a in [0, 0])
+        Parts: 1/1
+        Granules: 1/1
+        Search algorithm: binary search
+
+-- Output when the key condition is the second of the compound key
+Expression ((Project names + Projection))
+  Expression
+    ReadFromMergeTree (default.t)
+    Indexes:
+      PrimaryKey
+        Keys: 
+          b
+        Condition: (b in [0, 0])
+        Parts: 1/1
+        Granules: 1/1
+        Search algorithm: generic exclusion search

--- a/tests/queries/0_stateless/03522_search_algorithm_in_explain.reference
+++ b/tests/queries/0_stateless/03522_search_algorithm_in_explain.reference
@@ -1,25 +1,2 @@
--- Output when the key condition is the first of the compound key
-Expression ((Project names + Projection))
-  Expression
-    ReadFromMergeTree (default.t)
-    Indexes:
-      PrimaryKey
-        Keys: 
-          a
-        Condition: (a in [0, 0])
-        Parts: 1/1
-        Granules: 1/1
         Search algorithm: binary search
-
--- Output when the key condition is the second of the compound key
-Expression ((Project names + Projection))
-  Expression
-    ReadFromMergeTree (default.t)
-    Indexes:
-      PrimaryKey
-        Keys: 
-          b
-        Condition: (b in [0, 0])
-        Parts: 1/1
-        Granules: 1/1
         Search algorithm: generic exclusion search

--- a/tests/queries/0_stateless/03522_search_algorithm_in_explain.sh
+++ b/tests/queries/0_stateless/03522_search_algorithm_in_explain.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Tags: no-parallel-replicas
+# no-parallel-replicas: the ProfileEvents with the expected values are reported on the replicas the query runs in,
+# and the coordinator does not collect all ProfileEvents values.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -n -q "
+CREATE TABLE t (a UInt8, b UInt8) ORDER BY (a, b);
+INSERT INTO t VALUES (0,0);
+"
+
+$CLICKHOUSE_CLIENT -n -q "EXPLAIN indexes = 1 SELECT * FROM t WHERE a = 0;" | grep "Search algorithm: binary search"
+$CLICKHOUSE_CLIENT -n -q "EXPLAIN indexes = 1 SELECT * FROM t WHERE b = 0;" | grep "Search algorithm: generic exclusion search"

--- a/tests/queries/0_stateless/03522_search_algorithm_in_explain.sql
+++ b/tests/queries/0_stateless/03522_search_algorithm_in_explain.sql
@@ -1,9 +1,0 @@
-CREATE TABLE t (a UInt8, b UInt8) ORDER BY (a, b);
-INSERT INTO t VALUES (0,0);
-
-SELECT '-- Output when the key condition is the first of the compound key';
-EXPLAIN indexes = 1 SELECT * FROM t WHERE a = 0;
-
-SELECT '';
-SELECT '-- Output when the key condition is the second of the compound key';
-EXPLAIN indexes = 1 SELECT * FROM t WHERE b = 0;

--- a/tests/queries/0_stateless/03522_search_algorithm_in_explain.sql
+++ b/tests/queries/0_stateless/03522_search_algorithm_in_explain.sql
@@ -1,0 +1,9 @@
+CREATE TABLE t (a UInt8, b UInt8) ORDER BY (a, b);
+INSERT INTO t VALUES (0,0);
+
+SELECT '-- Output when the key condition is the first of the compound key';
+EXPLAIN indexes = 1 SELECT * FROM t WHERE a = 0;
+
+SELECT '';
+SELECT '-- Output when the key condition is the second of the compound key';
+EXPLAIN indexes = 1 SELECT * FROM t WHERE b = 0;


### PR DESCRIPTION
Add search algorithm to `EXPLAIN indexes = 1` output.

In https://github.com/ClickHouse/ClickHouse/pull/80597 it was added an optimization to ensure binary search is used. I realized we lacked observability on which search algorithm is used and I added two new profile events in https://github.com/ClickHouse/ClickHouse/pull/80679.

This improves the UX a little bit adding the search algorithm to EXPLAIN's output.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add search algorithm section to EXPLAIN output when using it with indexes = 1. If shows either "binary search" or "generic exclusion search"

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
