### PR TITLE
Docs: move documentation for comparison functions to source

### DIFF
--- a/docs/en/sql-reference/functions/comparison-functions.md
+++ b/docs/en/sql-reference/functions/comparison-functions.md
@@ -8,7 +8,13 @@ title: 'Comparison Functions'
 
 # Comparison Functions
 
-The comparison functions below return `0` or `1` with type [UInt8](/sql-reference/data-types/int-uint). Only values within the same group can be compared (e.g. `UInt16` and `UInt64`) but not across groups (e.g. `UInt16` and `DateTime`). Comparison of numbers and strings are possible, as is comparison of strings with dates and dates with times. For tuples and arrays, the comparison is lexicographic meaning that the comparison is made for each corresponding element of the left side and right side tuple/array. 
+## Comparison rules {#comparison-rules}
+
+The comparison functions below return `0` or `1` with type [UInt8](/sql-reference/data-types/int-uint). Only values within the same group can be 
+compared (e.g. `UInt16` and `UInt64`) but not across groups (e.g. `UInt16` and `DateTime`). 
+Comparison of numbers and strings are possible, as is comparison of strings with dates and dates with times. 
+For tuples and arrays, the comparison is lexicographic meaning that the comparison is made for each corresponding 
+element of the left side and right side tuple/array. 
 
 The following types can be compared:
 - numbers and decimals

--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -30,6 +30,11 @@ std::string FunctionDocumentation::argumentsAsString() const
     return res;
 }
 
+std::string FunctionDocumentation::syntaxAsString() const
+{
+    return boost::algorithm::trim_copy(syntax);
+}
+
 std::string FunctionDocumentation::returnedValueAsString() const
 {
     return boost::algorithm::trim_copy(returned_value);

--- a/src/Common/FunctionDocumentation.h
+++ b/src/Common/FunctionDocumentation.h
@@ -129,6 +129,7 @@ struct FunctionDocumentation
     IntroducedIn introduced_in {VERSION_UNKNOWN}; /// E.g. {25, 5}
     Category category;                            /// E.g. Category::DatesAndTimes
 
+    std::string syntaxAsString() const;
     std::string argumentsAsString() const;
     std::string returnedValueAsString() const;
     std::string examplesAsString() const;

--- a/src/Functions/equals.cpp
+++ b/src/Functions/equals.cpp
@@ -18,8 +18,8 @@ REGISTER_FUNCTION(Equals)
         -- a == b
     )";
     FunctionDocumentation::Arguments arguments_equals = {
-        {"a", "First value. Can be of any comparable type."},
-        {"b", "Second value. Must be of the same type as `a`."}
+        {"a", "First value.<sup>[*](#comparison-rules)</sup>"},
+        {"b", "Second value.<sup>[*](#comparison-rules)</sup>"}
     };
     FunctionDocumentation::ReturnedValue returned_value_equals = "Returns `1` if `a` is equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
     FunctionDocumentation::Examples examples_equals = {

--- a/src/Functions/equals.cpp
+++ b/src/Functions/equals.cpp
@@ -10,7 +10,37 @@ using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Equals)
 {
-    factory.registerFunction<FunctionEquals>();
+    // Documentation for equals
+    FunctionDocumentation::Description description_equals = "Compares two values for equality.";
+    FunctionDocumentation::Syntax syntax_equals = R"(
+        equals(a, b)
+        -- a = b
+        -- a == b
+    )";
+    FunctionDocumentation::Arguments arguments_equals = {
+        {"a", "First value. Can be of any comparable type."},
+        {"b", "Second value. Must be of the same type as `a`."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_equals = "Returns `1` if `a` is equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
+    FunctionDocumentation::Examples examples_equals = {
+        {"Usage example", "SELECT 1 = 1, 1 = 2;", R"(
+┌─equals(1, 1)─┬─equals(1, 2)─┐
+│            1 │            0 │
+└──────────────┴──────────────┘
+)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_equals = {1, 1};
+    FunctionDocumentation::Category category_equals = FunctionDocumentation::Category::Comparison;
+    FunctionDocumentation documentation_equals = {
+        description_equals,
+        syntax_equals,
+        arguments_equals,
+        returned_value_equals,
+        examples_equals,
+        introduced_in_equals,
+        category_equals
+    };
+    factory.registerFunction<FunctionEquals>(documentation_equals);
 }
 
 template <>

--- a/src/Functions/greater.cpp
+++ b/src/Functions/greater.cpp
@@ -11,7 +11,36 @@ extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Greater)
 {
-    factory.registerFunction<FunctionGreater>();
+    // Documentation for greater
+    FunctionDocumentation::Description description_greater = "Compares two values for greater-than relation.";
+    FunctionDocumentation::Syntax syntax_greater = R"(
+    greater(a, b)
+    -- a > b
+)";
+    FunctionDocumentation::Arguments arguments_greater = {
+        {"a", "First value. Can be of any comparable type."},
+        {"b", "Second value. Must be of the same type as `a`."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_greater = "Returns `1` if `a` is greater than `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
+    FunctionDocumentation::Examples examples_greater = {
+        {"Usage example", "SELECT 2 > 1, 1 > 2;", R"(
+┌─greater(2, 1)─┬─greater(1, 2)─┐
+│             1 │             0 │
+└───────────────┴───────────────┘
+)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_greater = {1, 1};
+    FunctionDocumentation::Category category_greater = FunctionDocumentation::Category::Comparison;
+    FunctionDocumentation documentation_greater = {
+        description_greater,
+        syntax_greater,
+        arguments_greater,
+        returned_value_greater,
+        examples_greater,
+        introduced_in_greater,
+        category_greater
+    };
+    factory.registerFunction<FunctionGreater>(documentation_greater);
 }
 
 template <>

--- a/src/Functions/greater.cpp
+++ b/src/Functions/greater.cpp
@@ -18,8 +18,8 @@ REGISTER_FUNCTION(Greater)
     -- a > b
 )";
     FunctionDocumentation::Arguments arguments_greater = {
-        {"a", "First value. Can be of any comparable type."},
-        {"b", "Second value. Must be of the same type as `a`."}
+        {"a", "First value.<sup>[*](#comparison-rules)</sup>"},
+        {"b", "Second value.<sup>[*](#comparison-rules)</sup>"}
     };
     FunctionDocumentation::ReturnedValue returned_value_greater = "Returns `1` if `a` is greater than `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
     FunctionDocumentation::Examples examples_greater = {

--- a/src/Functions/greaterOrEquals.cpp
+++ b/src/Functions/greaterOrEquals.cpp
@@ -20,8 +20,8 @@ REGISTER_FUNCTION(GreaterOrEquals)
     -- a >= b
 )";
     FunctionDocumentation::Arguments arguments_greaterOrEquals = {
-        {"a", "First value. Can be of any comparable type."},
-        {"b", "Second value. Must be of the same type as `a`."}
+        {"a", "First value.<sup>[*](#comparison-rules)</sup>"},
+        {"b", "Second value.<sup>[*](#comparison-rules)</sup>"}
     };
     FunctionDocumentation::ReturnedValue returned_value_greaterOrEquals = "Returns `1` if `a` is greater than or equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
     FunctionDocumentation::Examples examples_greaterOrEquals = {

--- a/src/Functions/greaterOrEquals.cpp
+++ b/src/Functions/greaterOrEquals.cpp
@@ -13,7 +13,36 @@ extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(GreaterOrEquals)
 {
-    factory.registerFunction<FunctionGreaterOrEquals>();
+    // Documentation for greaterOrEquals
+    FunctionDocumentation::Description description_greaterOrEquals = "Compares two values for greater-than-or-equal-to relation.";
+    FunctionDocumentation::Syntax syntax_greaterOrEquals = R"(
+    greaterOrEquals(a, b)
+    -- a >= b
+)";
+    FunctionDocumentation::Arguments arguments_greaterOrEquals = {
+        {"a", "First value. Can be of any comparable type."},
+        {"b", "Second value. Must be of the same type as `a`."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_greaterOrEquals = "Returns `1` if `a` is greater than or equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
+    FunctionDocumentation::Examples examples_greaterOrEquals = {
+        {"Usage example", "SELECT 2 >= 1, 2 >= 2, 1 >= 2;", R"(
+┌─greaterOrEquals(2, 1)─┬─greaterOrEquals(2, 2)─┬─greaterOrEquals(1, 2)─┐
+│                     1 │                     1 │                     0 │
+└───────────────────────┴───────────────────────┴───────────────────────┘
+)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_greaterOrEquals = {1, 1};
+    FunctionDocumentation::Category category_greaterOrEquals = FunctionDocumentation::Category::Comparison;
+    FunctionDocumentation documentation_greaterOrEquals = {
+        description_greaterOrEquals,
+        syntax_greaterOrEquals,
+        arguments_greaterOrEquals,
+        returned_value_greaterOrEquals,
+        examples_greaterOrEquals,
+        introduced_in_greaterOrEquals,
+        category_greaterOrEquals
+    };
+    factory.registerFunction<FunctionGreaterOrEquals>(documentation_greaterOrEquals);
 }
 
 template <>

--- a/src/Functions/less.cpp
+++ b/src/Functions/less.cpp
@@ -19,8 +19,8 @@ REGISTER_FUNCTION(Less)
     -- a < b
 )";
     FunctionDocumentation::Arguments arguments_less = {
-        {"a", "First value. Can be of any comparable type."},
-        {"b", "Second value. Must be of the same type as `a`."}
+        {"a", "First value.<sup>[*](#comparison-rules)</sup>"},
+        {"b", "Second value.<sup>[*](#comparison-rules)</sup>"}
     };
     FunctionDocumentation::ReturnedValue returned_value_less = "Returns `1` if `a` is less than `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
     FunctionDocumentation::Examples examples_less = {

--- a/src/Functions/less.cpp
+++ b/src/Functions/less.cpp
@@ -12,7 +12,36 @@ extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Less)
 {
-    factory.registerFunction<FunctionLess>();
+    // Documentation for less
+    FunctionDocumentation::Description description_less = "Compares two values for less-than relation.";
+    FunctionDocumentation::Syntax syntax_less = R"(
+    less(a, b)
+    -- a < b
+)";
+    FunctionDocumentation::Arguments arguments_less = {
+        {"a", "First value. Can be of any comparable type."},
+        {"b", "Second value. Must be of the same type as `a`."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_less = "Returns `1` if `a` is less than `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
+    FunctionDocumentation::Examples examples_less = {
+        {"Usage example", "SELECT 1 < 2, 2 < 1;", R"(
+┌─less(1, 2)─┬─less(2, 1)─┐
+│          1 │          0 │
+└────────────┴────────────┘
+)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_less = {1, 1};
+    FunctionDocumentation::Category category_less = FunctionDocumentation::Category::Comparison;
+    FunctionDocumentation documentation_less = {
+        description_less,
+        syntax_less,
+        arguments_less,
+        returned_value_less,
+        examples_less,
+        introduced_in_less,
+        category_less
+    };
+    factory.registerFunction<FunctionLess>(documentation_less);
 }
 
 template <>

--- a/src/Functions/lessOrEquals.cpp
+++ b/src/Functions/lessOrEquals.cpp
@@ -21,8 +21,8 @@ REGISTER_FUNCTION(LessOrEquals)
     -- a <= b
 )";
     FunctionDocumentation::Arguments arguments_lessOrEquals = {
-        {"a", "First value. Can be of any comparable type."},
-        {"b", "Second value. Must be of the same type as `a`."}
+        {"a", "First value.<sup>[*](#comparison-rules)</sup>"},
+        {"b", "Second value.<sup>[*](#comparison-rules)</sup>"}
     };
     FunctionDocumentation::ReturnedValue returned_value_lessOrEquals = "Returns `1` if `a` is less than or equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
     FunctionDocumentation::Examples examples_lessOrEquals = {

--- a/src/Functions/lessOrEquals.cpp
+++ b/src/Functions/lessOrEquals.cpp
@@ -14,7 +14,36 @@ extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(LessOrEquals)
 {
-    factory.registerFunction<FunctionLessOrEquals>();
+    // Documentation for lessOrEquals
+    FunctionDocumentation::Description description_lessOrEquals = "Compares two values for less-than-or-equal-to relation.";
+    FunctionDocumentation::Syntax syntax_lessOrEquals = R"(
+    lessOrEquals(a, b)
+    -- a <= b
+)";
+    FunctionDocumentation::Arguments arguments_lessOrEquals = {
+        {"a", "First value. Can be of any comparable type."},
+        {"b", "Second value. Must be of the same type as `a`."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_lessOrEquals = "Returns `1` if `a` is less than or equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
+    FunctionDocumentation::Examples examples_lessOrEquals = {
+        {"Usage example", "SELECT 1 <= 2, 2 <= 2, 3 <= 2;", R"(
+┌─lessOrEquals(1, 2)─┬─lessOrEquals(2, 2)─┬─lessOrEquals(3, 2)─┐
+│                  1 │                  1 │                  0 │
+└────────────────────┴────────────────────┴────────────────────┘
+)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_lessOrEquals = {1, 1};
+    FunctionDocumentation::Category category_lessOrEquals = FunctionDocumentation::Category::Comparison;
+    FunctionDocumentation documentation_lessOrEquals = {
+        description_lessOrEquals,
+        syntax_lessOrEquals,
+        arguments_lessOrEquals,
+        returned_value_lessOrEquals,
+        examples_lessOrEquals,
+        introduced_in_lessOrEquals,
+        category_lessOrEquals
+    };
+    factory.registerFunction<FunctionLessOrEquals>(documentation_lessOrEquals);
 }
 
 template <>

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -17,8 +17,8 @@ REGISTER_FUNCTION(NotEquals)
     -- a <> b
 )";
     FunctionDocumentation::Arguments arguments_notEquals = {
-        {"a", "First value. Can be of any comparable type."},
-        {"b", "Second value. Must be of the same type as `a`."}
+        {"a", "First value.<sup>[*](#comparison-rules)</sup>"},
+        {"b", "Second value.<sup>[*](#comparison-rules)</sup>"}
     };
     FunctionDocumentation::ReturnedValue returned_value_notEquals = "Returns `1` if `a` is not equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
     FunctionDocumentation::Examples examples_notEquals = {

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -9,7 +9,37 @@ using FunctionNotEquals = FunctionComparison<NotEqualsOp, NameNotEquals>;
 
 REGISTER_FUNCTION(NotEquals)
 {
-    factory.registerFunction<FunctionNotEquals>();
+    // Documentation for notEquals
+    FunctionDocumentation::Description description_notEquals = "Compares two values for inequality.";
+    FunctionDocumentation::Syntax syntax_notEquals = R"(
+    notEquals(a, b)
+    -- a != b
+    -- a <> b
+)";
+    FunctionDocumentation::Arguments arguments_notEquals = {
+        {"a", "First value. Can be of any comparable type."},
+        {"b", "Second value. Must be of the same type as `a`."}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_notEquals = "Returns `1` if `a` is not equal to `b`, otherwise `0`. [`UInt8`](/sql-reference/data-types/int-uint/)";
+    FunctionDocumentation::Examples examples_notEquals = {
+        {"Usage example", "SELECT 1 != 2, 1 != 1;", R"(
+┌─notEquals(1, 2)─┬─notEquals(1, 1)─┐
+│               1 │               0 │
+└─────────────────┴─────────────────┘
+)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_notEquals = {1, 1};
+    FunctionDocumentation::Category category_notEquals = FunctionDocumentation::Category::Comparison;
+    FunctionDocumentation documentation_notEquals = {
+        description_notEquals,
+        syntax_notEquals,
+        arguments_notEquals,
+        returned_value_notEquals,
+        examples_notEquals,
+        introduced_in_notEquals,
+        category_notEquals
+    };
+    factory.registerFunction<FunctionNotEquals>(documentation_notEquals);
 }
 
 template <>

--- a/src/Storages/System/StorageSystemFunctions.cpp
+++ b/src/Storages/System/StorageSystemFunctions.cpp
@@ -69,7 +69,7 @@ namespace
             {
                 auto documentation = factory.getDocumentation(name);
                 res_columns[6]->insert(documentation.description);
-                res_columns[7]->insert(documentation.syntax);
+                res_columns[7]->insert(documentation.syntaxAsString());
                 res_columns[8]->insert(documentation.argumentsAsString());
                 res_columns[9]->insert(documentation.returnedValueAsString());
                 res_columns[10]->insert(documentation.examplesAsString());

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -205,7 +205,6 @@ encodeURLComponent
 encodeURLFormComponent
 encodeXMLComponent
 endsWith
-equals
 erf
 erfc
 errorCodeToName
@@ -274,8 +273,6 @@ globalNullInIgnoreSet
 globalVariable
 greatCircleAngle
 greatCircleDistance
-greater
-greaterOrEquals
 greatest
 has
 hasColumnInTable
@@ -332,8 +329,6 @@ leftPad
 leftPadUTF8
 leftUTF8
 lengthUTF8
-less
-lessOrEquals
 lgamma
 like
 log
@@ -417,7 +412,6 @@ normalizeQueryKeepNames
 normalizedQueryHash
 normalizedQueryHashKeepNames
 not
-notEquals
 notILike
 notIn
 notInIgnoreSet

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -295,7 +295,6 @@ encodeURLFormComponent
 encodeXMLComponent
 endsWith
 endsWithUTF8
-equals
 erf
 erfc
 errorCodeToName
@@ -386,8 +385,6 @@ globalNullInIgnoreSet
 globalVariable
 greatCircleAngle
 greatCircleDistance
-greater
-greaterOrEquals
 greatest
 has
 hasColumnInTable
@@ -455,8 +452,6 @@ leftPad
 leftPadUTF8
 leftUTF8
 lengthUTF8
-less
-lessOrEquals
 lgamma
 like
 log
@@ -544,7 +539,6 @@ normalizeQueryKeepNames
 normalizedQueryHash
 normalizedQueryHashKeepNames
 not
-notEquals
 notILike
 notIn
 notInIgnoreSet


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Moves the documentation for comparison functions into the source code
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
