### PR TITLE
Fix memory accounting for Iceberg metadata files cache

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -597,7 +597,6 @@ DataLakeMetadataPtr IcebergMetadata::create(
 
     auto log = getLogger("IcebergMetadata");
 
-    Poco::JSON::Object::Ptr object = nullptr;
     IcebergMetadataFilesCachePtr cache_ptr = nullptr;
     if (local_context->getSettingsRef()[Setting::use_iceberg_metadata_files_cache])
         cache_ptr = local_context->getIcebergMetadataFilesCache();
@@ -613,16 +612,19 @@ DataLakeMetadataPtr IcebergMetadata::create(
 
         String json_str;
         readJSONObjectPossiblyInvalid(json_str, *buf);
-
-        Poco::JSON::Parser parser; /// For some reason base/base/JSON.h can not parse this json file
-        Poco::Dynamic::Var json = parser.parse(json_str);
-        return std::make_pair(json.extract<Poco::JSON::Object::Ptr>(), json_str.size());
+        return json_str;
     };
 
+    String metadata_json_str;
     if (cache_ptr)
-        object = cache_ptr->getOrSetTableMetadata(IcebergMetadataFilesCache::getKey(configuration_ptr, metadata_file_path), create_fn);
+        metadata_json_str = cache_ptr->getOrSetTableMetadata(IcebergMetadataFilesCache::getKey(configuration_ptr, metadata_file_path), create_fn);
     else
-        object = create_fn().first;
+        metadata_json_str = create_fn();
+
+    /// For some reason base/base/JSON.h can not parse this json file
+    Poco::JSON::Parser parser;
+    Poco::Dynamic::Var json = parser.parse(metadata_json_str);
+    Poco::JSON::Object::Ptr object = json.extract<Poco::JSON::Object::Ptr>();
 
     IcebergSchemaProcessor schema_processor;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix memory accounting for Iceberg metadata files cache

The problem is that the JSON object takes more bytes in memory, then a plain string (via side channels the overhead is around 10-20x, so if you have 500MiB of cache, in reality it can take ~10GiB of RAM)

So let's simply storing the std::string itself, yes this will be slightly less optimal, but I doubt that the difference will be significant.

As a long-term we can fix this by using some intrusive parser, or JSON parser that allows to pass the allocator (AFAICS both variants can be implemented with rapidjson), but for now, let's keep it simple to backport this change.

Refs: https://github.com/ClickHouse/ClickHouse/pull/77156