### PR TITLE
Fix possible deadlock during shutting down Kafka2

### DIFF
--- a/src/Storages/Kafka/KafkaConsumer2.h
+++ b/src/Storages/Kafka/KafkaConsumer2.h
@@ -111,6 +111,8 @@ public:
 
     void subscribeIfNotSubscribedYet();
 
+    ConsumerPtr && moveConsumer() { return std::move(consumer); }
+
 private:
     using Messages = std::vector<cppkafka::Message>;
     CurrentMetrics::Increment metric_increment{CurrentMetrics::KafkaConsumers};

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -328,7 +328,7 @@ void StorageKafka::shutdown(bool)
 void StorageKafka::cleanConsumers()
 {
     /// We need to clear the cppkafka::Consumer separately from KafkaConsumer, since cppkafka::Consumer holds a weak_ptr to the KafkaConsumer (for logging callback)
-    /// So if we will remove cppkafka::Consumer from KafkaConsumer destructor, then due to librdkafka will call the logging again from destructor, it will lead to a deadlock
+    /// So if we will remove cppkafka::Consumer from KafkaConsumer destructor, then if librdkafka will call the logging from destructor, it will lead to a deadlock.
     std::vector<ConsumerPtr> consumers_to_close;
 
     {

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -73,6 +73,7 @@ public:
 
     void startup() override;
     void shutdown(bool is_drop) override;
+    void cleanConsumers();
 
     void drop() override;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible deadlock during shutting down Kafka2

There is likely the same problem as has been fixed by #80795,
`cppkafka::Consumer` can hold the `shared_ptr` copy of the
`KafkaConsumer2`, and if during destroying `librdkafka` will log
something, then we will have a deadlock, with a stacktrace similar to
this one:

<details>

<summary>stack trace</summary>

    * thread #28, name = 'rdk:b/dummy_htt'
        frame 5: 0x00007ffff7e222a3 libc.so.6`___pthread_join(threadid=<unavailable>, thread_return=<unavailable>) + 19 at pthread_join.c:24
        frame 6: 0x000055556d0a2012 ch`rd_kafka_thrd_join(thr=<unavailable>, res=0x00007fffe59f4354) + 18 at tinycthread.c:692
        frame 7: 0x000055556cfb1c01 ch`rd_kafka_destroy_app(rk=0x00007fffe6ccc000, flags=<unavailable>) + 609 at rdkafka.c:1143
        frame 8: 0x000055556cf9826a ch`cppkafka::Consumer::~Consumer() [inlined] std::__1::unique_ptr<rd_kafka_s, cppkafka::KafkaHandleBase::HandleDeleter>::reset[abi:ne190107](this=0x00007fffe6cb11d8, __p=0x0000000000000000) + 330 at unique_ptr.h:292
        frame 9: 0x000055556cf98247 ch`cppkafka::Consumer::~Consumer() [inlined] std::__1::unique_ptr<rd_kafka_s, cppkafka::KafkaHandleBase::HandleDeleter>::~unique_ptr[abi:ne190107](this=0x00007fffe6cb11d8) at unique_ptr.h:261
        frame 10: 0x000055556cf98247 ch`cppkafka::Consumer::~Consumer() [inlined] cppkafka::KafkaHandleBase::~KafkaHandleBase(this=0x00007fffe6cb1018) + 14 at kafka_handle_base.h:66
        frame 11: 0x000055556cf98239 ch`cppkafka::Consumer::~Consumer(this=0x00007fffe6cb1018) + 281 at consumer.cpp:99
        frame 12: 0x0000555566718c70 ch`DB::KafkaConsumer::~KafkaConsumer() [inlined] std::__1::__shared_count::__release_shared[abi:ne190107](this=0x00007fffe6cb1000) + 1008 at shared_ptr.h:156
        frame 13: 0x0000555566718c67 ch`DB::KafkaConsumer::~KafkaConsumer() [inlined] std::__1::__shared_weak_count::__release_shared[abi:ne190107](this=0x00007fffe6cb1000) at shared_ptr.h:185
        frame 14: 0x0000555566718c67 ch`DB::KafkaConsumer::~KafkaConsumer() [inlined] std::__1::shared_ptr<cppkafka::Consumer>::~shared_ptr[abi:ne190107](this=0x00007ffff4cf7ff0) at shared_ptr.h:668
        frame 15: 0x0000555566718c67 ch`DB::KafkaConsumer::~KafkaConsumer(this=0x00007ffff4cf7f98) + 999 at KafkaConsumer.cpp:175
        ...
        frame #19: 0x00005555667968f2 ch`void void DB::()::updateGlobalConfiguration<DB::StorageKafka>()::'lambda'()::operator()() const + 1105 at KafkaConfigLoader.cpp:409
        ...
        frame 27: 0x000055556cf96779 ch`cppkafka::log_callback_proxy(h=<unavailable>, level=3, facility="ERROR", message="[thrd:localhost:9092/bootstrap]: 1/1 brokers are down") + 89 at configuration.cpp:85
        frame 28: 0x000055556cfb0be2 ch`rd_kafka_log0 [inlined] rd_kafka_log_buf(conf=0x00007fffe6ccc138, rk=0x00007fffe6ccc000, level=3, ctx=0, fac="ERROR", buf="[thrd:localhost:9092/bootstrap]: 1/1 brokers are down") + 546 at rdkafka.c:276
        frame 29: 0x000055556cfb0b02 ch`rd_kafka_log0(conf=0x00007fffe6ccc138, rk=0x00007fffe6ccc000, extra=0x0000000000000000, level=3, ctx=0, fac="ERROR", fmt="%i/%i brokers are down") + 322 at rdkafka.c:320
        frame 30: 0x000055556cf9d6aa ch`rd_kafka_broker_set_state(rkb=0x00007fffe6cbf800, state=1) + 298 at rdkafka_broker.c:348
        frame 31: 0x000055556cf9dbf6 ch`rd_kafka_broker_fail(rkb=0x00007fffe6cbf800, level=3, err=RD_KAFKA_RESP_ERR__TRANSPORT, fmt=<unavailable>) + 374 at rdkafka_broker.c:623
        frame 32: 0x000055556cfa1246 ch`rd_kafka_broker_connect_done(rkb=<unavailable>, errstr=<unavailable>) + 70 at rdkafka_broker.c:2641
        frame 33: 0x000055556d096efb ch`rd_kafka_transport_io_serve [inlined] rd_kafka_transport_connect_done(rktrans=0x00007ffff279c000, errstr="Connect to ipv4#127.0.0.1:9092 failed: Connection refused") + 731 at rdkafka_transport.c:381
        frame 34: 0x000055556d096eeb ch`rd_kafka_transport_io_serve [inlined] rd_kafka_transport_io_event(rktrans=0x00007ffff279c000, events=<unavailable>, socket_errstr=0x0000000000000000) + 153 at rdkafka_transport.c:691
        frame 35: 0x000055556d096e52 ch`rd_kafka_transport_io_serve(rktrans=0x00007ffff279c000, rkq=0x00007fffe7131240, timeout_ms=<unavailable>) + 562 at rdkafka_transport.c:1007
        frame 36: 0x000055556cfab0ef ch`rd_kafka_broker_ops_io_serve(rkb=0x00007fffe6cbf800, abs_timeout=373906299505) + 367 at rdkafka_broker.c:3670
        frame 37: 0x000055556cfa8d6c ch`rd_kafka_broker_serve [inlined] rd_kafka_broker_consumer_serve(rkb=0x00007fffe6cbf800, abs_timeout=373906299505) + 297 at rdkafka_broker.c:4373
        frame 38: 0x000055556cfa8c43 ch`rd_kafka_broker_serve(rkb=0x00007fffe6cbf800, timeout_ms=<unavailable>) + 4675 at rdkafka_broker.c:4515
        frame 39: 0x000055556cfa4120 ch`rd_kafka_broker_thread_main(arg=0x00007fffe6cbf800) + 320 at rdkafka_broker.c:4663
        frame 40: 0x000055556d0a1fd9 ch`_thrd_wrapper_function(aArg=<unavailable>) + 25 at tinycthread.c:576
        frame 41: 0x00007ffff7e20708 libc.so.6`start_thread(arg=<unavailable>) + 455209 at pthread_create.c:448
        frame 42: 0x00007ffff7ea4aac libc.so.6`__clone3 + 44 at clone3.S:78

      thread #26, name = 'rdk:m/dummy_htt', stop reason = signal SIGSTOP
        frame 5: 0x00007ffff7e222a3 libc.so.6`___pthread_join(threadid=<unavailable>, thread_return=<unavailable>) + 19 at pthread_join.c:24
        frame 6: 0x000055556d0a1f52 clickhouse`rd_kafka_thrd_join(thr=<unavailable>, res=0x00007fffe61e9fd4) + 18 at tinycthread.c:692
        frame 7: 0x000055556cfb439b clickhouse`rd_kafka_destroy_internal(rk=0x00007fffe6245000) + 1083 at rdkafka.c:1306
        frame 8: 0x000055556cfb3e34 clickhouse`rd_kafka_thread_main(arg=0x00007fffe6245000) + 788 at rdkafka.c:2182
        frame 9: 0x000055556d0a1f19 clickhouse`_thrd_wrapper_function(aArg=<unavailable>) + 25 at tinycthread.c:576
        frame 10: 0x00007ffff7e20708 libc.so.6`start_thread(arg=<unavailable>) + 455209 at pthread_create.c:448
        frame 11: 0x00007ffff7ea4aac libc.so.6`__clone3 + 44 at clone3.S:78

</details>

Fixes: https://github.com/ClickHouse/ClickHouse/issues/68360