### PR TITLE
fix WindowNode to ast window node conversion

### DIFF
--- a/src/Analyzer/ListNode.cpp
+++ b/src/Analyzer/ListNode.cpp
@@ -1,5 +1,4 @@
 #include <Analyzer/ListNode.h>
-#include "Parsers/ASTWindowDefinition.h"
 
 #include <Common/SipHash.h>
 
@@ -63,21 +62,7 @@ ASTPtr ListNode::toASTImpl(const ConvertToASTOptions & options) const
     expression_list_ast->children.resize(children_size);
 
     for (size_t i = 0; i < children_size; ++i)
-    {
-        auto children_ast = children[i]->toAST(options);
-
-        // Named window should be wrapped in ASTWindowListElement with name.
-        if (children_ast->as<ASTWindowDefinition>())
-        {
-            auto window_list_node = std::make_shared<ASTWindowListElement>();
-            window_list_node->name = children[i]->getAlias();
-            window_list_node->children.push_back(children_ast);
-            window_list_node->definition = window_list_node->children.back();
-            children_ast = window_list_node;
-        }
-
-        expression_list_ast->children[i] = children_ast;
-    }
+        expression_list_ast->children[i] = children[i]->toAST(options);
 
     return expression_list_ast;
 }

--- a/src/Analyzer/ListNode.cpp
+++ b/src/Analyzer/ListNode.cpp
@@ -69,7 +69,6 @@ ASTPtr ListNode::toASTImpl(const ConvertToASTOptions & options) const
         // Named window should be wrapped in ASTWindowListElement with name.
         if (children_ast->as<ASTWindowDefinition>())
         {
-            ASTList
             auto window_list_node = std::make_shared<ASTWindowListElement>();
             window_list_node->name = children[i]->getAlias();
             window_list_node->children.push_back(children_ast);

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2535,6 +2535,7 @@ ProjectionName QueryAnalyzer::resolveWindow(QueryTreeNodePtr & node, IdentifierR
         if (identifier_node)
         {
             node = parent_window_node->clone();
+            node->removeAlias();
             result_projection_name = parent_window_name;
         }
         else
@@ -5714,13 +5715,11 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
             window_node_typed.setParentWindowName({});
         }
 
-        auto window_name = window_node_typed.getAlias();
-        window_node_typed.removeAlias();
-        auto [_, inserted] = scope.window_name_to_window_node.emplace(window_name, window_node);
+        auto [_, inserted] = scope.window_name_to_window_node.emplace(window_node_typed.getAlias(), window_node);
         if (!inserted)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "Window '{}' is already defined. In scope {}",
-                window_name,
+                window_node_typed.getAlias(),
                 scope.scope_node->formatASTForErrorMessage());
     }
 

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -5714,11 +5714,13 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
             window_node_typed.setParentWindowName({});
         }
 
-        auto [_, inserted] = scope.window_name_to_window_node.emplace(window_node_typed.getAlias(), window_node);
+        auto window_name = window_node_typed.getAlias();
+        window_node_typed.removeAlias();
+        auto [_, inserted] = scope.window_name_to_window_node.emplace(window_name, window_node);
         if (!inserted)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "Window '{}' is already defined. In scope {}",
-                window_node_typed.getAlias(),
+                window_name,
                 scope.scope_node->formatASTForErrorMessage());
     }
 

--- a/src/Analyzer/WindowNode.cpp
+++ b/src/Analyzer/WindowNode.cpp
@@ -142,6 +142,15 @@ ASTPtr WindowNode::toASTImpl(const ConvertToASTOptions & options) const
         window_definition->frame_end_offset = window_definition->children.back();
     }
 
+    if (hasAlias())
+    {
+        auto window_list_element = std::make_shared<ASTWindowListElement>();
+        window_list_element->name = getAlias();
+        window_list_element->children.push_back(window_definition);
+        window_list_element->definition = window_list_element->children.back();
+        return window_list_element;
+    }
+
     return window_definition;
 }
 

--- a/src/Analyzer/WindowNode.cpp
+++ b/src/Analyzer/WindowNode.cpp
@@ -142,15 +142,7 @@ ASTPtr WindowNode::toASTImpl(const ConvertToASTOptions & options) const
         window_definition->frame_end_offset = window_definition->children.back();
     }
 
-    // If it has alias then it is named window and should be wrapped in list node.
-    if (!hasAlias())
-        return window_definition;
-
-    auto window_list_node = std::make_shared<ASTWindowListElement>();
-    window_list_node->name = getAlias();
-    window_list_node->children.push_back(window_definition);
-    window_list_node->definition = window_list_node->children.back();
-    return window_list_node;
+    return window_definition;
 }
 
 }

--- a/src/Analyzer/WindowNode.cpp
+++ b/src/Analyzer/WindowNode.cpp
@@ -142,7 +142,15 @@ ASTPtr WindowNode::toASTImpl(const ConvertToASTOptions & options) const
         window_definition->frame_end_offset = window_definition->children.back();
     }
 
-    return window_definition;
+    // If it has alias then it is named window and should be wrapped in list node.
+    if (!hasAlias())
+        return window_definition;
+
+    auto window_list_node = std::make_shared<ASTWindowListElement>();
+    window_list_node->name = getAlias();
+    window_list_node->children.push_back(window_definition);
+    window_list_node->definition = window_list_node->children.back();
+    return window_list_node;
 }
 
 }

--- a/tests/queries/0_stateless/03522_window_table_arg.reference
+++ b/tests/queries/0_stateless/03522_window_table_arg.reference
@@ -1,0 +1,5 @@
+1
+2
+3
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+  ReadFromStorage (SystemOne)

--- a/tests/queries/0_stateless/03522_window_table_arg.sql
+++ b/tests/queries/0_stateless/03522_window_table_arg.sql
@@ -1,3 +1,5 @@
+SET enable_analyzer=1;
+
 SELECT * FROM view(
     SELECT row_number() OVER w
     FROM numbers(3)

--- a/tests/queries/0_stateless/03522_window_table_arg.sql
+++ b/tests/queries/0_stateless/03522_window_table_arg.sql
@@ -1,0 +1,7 @@
+SELECT * FROM view(
+    SELECT row_number() OVER w
+    FROM numbers(3)
+    WINDOW w AS ()
+);
+
+SELECT * FROM viewExplain('EXPLAIN', '', (SELECT 1 WINDOW w0 AS ()));

--- a/tests/queries/0_stateless/03522_window_table_arg.sql
+++ b/tests/queries/0_stateless/03522_window_table_arg.sql
@@ -5,3 +5,10 @@ SELECT * FROM view(
 );
 
 SELECT * FROM viewExplain('EXPLAIN', '', (SELECT 1 WINDOW w0 AS ()));
+
+-- Fuzzed, fails, but shouldn't crash server
+SELECT
+    number
+FROM numbers(assumeNotNull(viewExplain('EXPLAIN', '', (
+    SELECT 1 WINDOW w0 AS () QUALIFY number
+)))) -- { serverError UNKNOWN_IDENTIFIER }


### PR DESCRIPTION
Named Windows are expected to be wrapped by ASTWindowListElement, but the current conversion puts the definition directly into the list. 
This breaks table function resolution if it takes a subquery as an argument and the subquery uses window functions.

Closes: #78461

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the logical error in the nested functions with named windows

