### PR TITLE
Fix clickhouse-keeper-dbg for non-standalone build

### DIFF
--- a/cmake/split_debug_symbols.cmake
+++ b/cmake/split_debug_symbols.cmake
@@ -38,23 +38,25 @@ endmacro()
 
 
 macro(clickhouse_make_empty_debug_info_for_nfpm)
-   set(oneValueArgs TARGET DESTINATION_DIR)
+   set(oneValueArgs TARGET BINARY DESTINATION_DIR)
    cmake_parse_arguments(EMPTY_DEBUG "" "${oneValueArgs}" "" ${ARGN})
 
    if (NOT DEFINED EMPTY_DEBUG_TARGET)
        message(FATAL_ERROR "A target name must be provided for stripping binary")
    endif()
-
+   if (NOT DEFINED EMPTY_DEBUG_BINARY)
+       message(FATAL_ERROR "A binary name must be provided for stripping binary")
+   endif()
    if (NOT DEFINED EMPTY_DEBUG_DESTINATION_DIR)
        message(FATAL_ERROR "Destination directory for empty debug must be provided")
    endif()
 
    add_custom_command(TARGET ${EMPTY_DEBUG_TARGET} POST_BUILD
        COMMAND mkdir -p "${EMPTY_DEBUG_DESTINATION_DIR}/lib/debug"
-       COMMAND touch "${EMPTY_DEBUG_DESTINATION_DIR}/lib/debug/${EMPTY_DEBUG_TARGET}.debug"
+       COMMAND touch "${EMPTY_DEBUG_DESTINATION_DIR}/lib/debug/${EMPTY_DEBUG_BINARY}.debug"
        COMMENT "Adding empty debug info for NFPM" VERBATIM
    )
 
    cmake_path(SET DEBUG_PATH NORMALIZE "${CMAKE_INSTALL_LIBDIR}/debug/${CMAKE_INSTALL_FULL_BINDIR}")
-   install(FILES "${EMPTY_DEBUG_DESTINATION_DIR}/lib/debug/${EMPTY_DEBUG_TARGET}.debug" DESTINATION ${DEBUG_PATH} COMPONENT clickhouse)
+   install(FILES "${EMPTY_DEBUG_DESTINATION_DIR}/lib/debug/${EMPTY_DEBUG_BINARY}.debug" DESTINATION ${DEBUG_PATH} COMPONENT clickhouse)
 endmacro()

--- a/packages/build
+++ b/packages/build
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 # Avoid dependency on locale
 LC_ALL=C

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -198,6 +198,7 @@ if (ENABLE_CLICKHOUSE_KEEPER)
     if (NOT BUILD_STANDALONE_KEEPER)
         add_custom_command (TARGET clickhouse POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink clickhouse clickhouse-keeper)
         install (FILES "${CMAKE_CURRENT_BINARY_DIR}/clickhouse-keeper" DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse)
+        clickhouse_make_empty_debug_info_for_nfpm(TARGET clickhouse BINARY clickhouse-keeper DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/../${SPLIT_DEBUG_SYMBOLS_DIR})
     endif()
 
     # otherwise we don't build keeper
@@ -230,7 +231,7 @@ endif ()
 if (SPLIT_DEBUG_SYMBOLS)
     clickhouse_split_debug_symbols(TARGET clickhouse DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/${SPLIT_DEBUG_SYMBOLS_DIR} BINARY_PATH clickhouse)
 else()
-    clickhouse_make_empty_debug_info_for_nfpm(TARGET clickhouse DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/${SPLIT_DEBUG_SYMBOLS_DIR})
+    clickhouse_make_empty_debug_info_for_nfpm(TARGET clickhouse BINARY clickhouse DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/${SPLIT_DEBUG_SYMBOLS_DIR})
     install (TARGETS clickhouse RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse)
 endif()
 


### PR DESCRIPTION
Previously the error was simply ignored [1], but that was not a big deal, since it wasn't release build (and this package does not contains anything more):

```
Run command: [cd /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/packages/ && OUTPUT_DIR=/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp BUILD_TYPE=tsan VERSION_STRING=25.5.1.1 DEB_ARCH=amd64 ./build --deb ]

Current version is 25.5.1.1
Building deb package for clickhouse-client.yaml
using deb packager...
created package: /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/clickhouse-client_25.5.1.1_amd64.deb
Building deb package for clickhouse-common-static-dbg.yaml
using deb packager...
created package: /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/clickhouse-common-static-dbg_25.5.1.1_amd64.deb
Building deb package for clickhouse-common-static.yaml
using deb packager...
created package: /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/clickhouse-common-static_25.5.1.1_amd64.deb
Building deb package for clickhouse-keeper-dbg.yaml
using deb packager...
matching "./root/usr/lib/debug/usr/bin/clickhouse-keeper.debug": file does not exist
Building deb package for clickhouse-keeper.yaml
using deb packager...
created package: /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/clickhouse-keeper_25.5.1.1_amd64.deb
Building deb package for clickhouse-server.yaml
using deb packager...
created package: /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/clickhouse-server_25.5.1.1_amd64.deb
ok
```

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79449&sha=latest&name_0=PR&name_1=Build+%28amd_tsan%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)