### PR TITLE
rust: move vendoring instructions into a separate script

### DIFF
--- a/rust/VENDOR.md
+++ b/rust/VENDOR.md
@@ -1,39 +1,10 @@
-As we have multiple projects we use a workspace to manage them (it's way simpler and leads to less issues). In order
-to vendor all the dependencies we need to store both the registry and the packages themselves.
+As we have multiple projects we use a workspace to manage them (it's way
+simpler and leads to less issues). In order to vendor all the dependencies we
+need to store both the registry and the packages themselves.
 
-Note that this includes the exact `std` dependencies for the rustc version used in CI (currently nightly-2024-12-01),
-so you need to install `rustup component add rust-src` for the specific version.
+Note that this includes the exact `std` dependencies for the rustc (required to
+build with sanitizers flags) version used in CI (currently nightly-2024-12-01),
+so you need to install `rustup component add rust-src` for the specific
+version.
 
-* First step: (Re)-generate the Cargo.lock file (run under `workspace/`).
-
-```bash
-cargo generate-lockfile
-```
-
-* Generate the vendor dir:
-
-```bash
-export CH_TOP_DIR=$(git rev-parse --show-toplevel)
-export RUSTC_ROOT=$(rustc --print=sysroot)
-# Currently delta-lake is built outside the workspace (TODO)
-export DELTA_LAKE_DIR="$CH_TOP_DIR"/contrib/delta-kernel-rs
-
-# Clean the vendor repo
-rm -rf "$CH_TOP_DIR"/contrib/rust_vendor/*
-
-cd "$CH_TOP_DIR"/rust/workspace
-cargo vendor --no-delete --locked --versioned-dirs --manifest-path Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
-
-# Now handle delta-lake
-cd "$DELTA_LAKE_DIR"
-cargo vendor --no-delete --locked --versioned-dirs --manifest-path Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
-
-# Standard library deps
-cargo vendor --no-delete --locked --versioned-dirs --manifest-path "$RUSTC_ROOT"/lib/rustlib/src/rust/library/std/Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
-cargo vendor --no-delete --locked --versioned-dirs --manifest-path "$RUSTC_ROOT"/lib/rustlib/src/rust/library/test/Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
-
-cd "$CH_TOP_DIR"/rust/workspace
-```
-
-The `rustc --print=sysroot` part includes `std` dependencies, required to build with sanitizer flags. It must be kept
-in sync with the rustc version used in CI.
+To re-generate just use `vendor.sh`

--- a/rust/vendor.sh
+++ b/rust/vendor.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+CH_TOP_DIR=$(git rev-parse --show-toplevel)
+
+cd "$CH_TOP_DIR/rust/workspace" || exit 1
+# (Re)-generate the Cargo.lock file
+cargo generate-lockfile
+
+#
+# Generate the vendor dir:
+#
+
+# Clean the vendor repo
+rm -rf "${CH_TOP_DIR:?}"/contrib/rust_vendor/*
+
+cd "$CH_TOP_DIR"/rust/workspace || exit 1
+cargo vendor --no-delete --locked --versioned-dirs --manifest-path Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
+
+#
+# Handle extra dependencies that is now outside of workspace:
+#
+
+# delta-lake
+cd "$CH_TOP_DIR"/contrib/delta-kernel-rs || exit 1
+cargo vendor --no-delete --locked --versioned-dirs --manifest-path Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
+
+# Just in case
+cd "$CH_TOP_DIR"/rust/workspace
+
+# Standard library deps
+RUSTC_ROOT=$(rustc --print=sysroot)
+cargo vendor --no-delete --locked --versioned-dirs --manifest-path "$RUSTC_ROOT"/lib/rustlib/src/rust/library/std/Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
+cargo vendor --no-delete --locked --versioned-dirs --manifest-path "$RUSTC_ROOT"/lib/rustlib/src/rust/library/test/Cargo.toml "$CH_TOP_DIR"/contrib/rust_vendor
+
+echo "*"
+echo "* Do not forget to check contrib/corrosion-cmake/config.toml.in"
+echo "* You need to make sure that it contains everything that is printed under"
+echo "      'To use vendored sources, add this to your .cargo/config.toml for this project:'"
+echo "*"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)