### PR TITLE
tests: temporary disable 03522_storage_kafka_shutdown_smoke to suppress data-race in cJSON

### DIFF
--- a/tests/queries/0_stateless/03522_storage_kafka_shutdown_smoke.sql
+++ b/tests/queries/0_stateless/03522_storage_kafka_shutdown_smoke.sql
@@ -1,5 +1,6 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, disabled
 -- Tag no-fasttest -- requires Kafka
+-- Tag disabled -- data race in cJSON (librdkafka vs aws-c-common) - https://github.com/ClickHouse/ClickHouse/issues/80866
 
 -- Regression test for proper StorageKafka shutdown
 -- https://github.com/ClickHouse/ClickHouse/issues/80674

--- a/tests/tsan_ignorelist.txt
+++ b/tests/tsan_ignorelist.txt
@@ -11,13 +11,3 @@
 [thread]
 # https://github.com/ClickHouse/ClickHouse/issues/55629
 fun:rd_kafka_broker_set_nodename
-# cJSON is used in two libraries (at least) in ClickHouse:
-# - librdkafka
-# - aws-c-common
-#
-# Both libraries has it's own hooks, passed to cJSON_InitHooks, but they are
-# compatible, and eventually they simply call malloc()/free().
-# So let's suppress this warning until it will be fixed properly.
-#
-# See https://github.com/ClickHouse/ClickHouse/issues/80866 for more details.
-fun:cJSON_InitHooks


### PR DESCRIPTION
The problem is that 03522_storage_kafka_shutdown_smoke triggers data-race between librdkafka and aws-c-common. Note, that the problem was always there, it pops up because we added stateless test with librdkafka.

Let's temporary disable it to avoid this TSan error on CI, until we will fix it properly.

Refs: https://github.com/ClickHouse/ClickHouse/issues/80866

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)