### PR TITLE
Retry reading replicated DDL stop flag from Kepeer in case of network errors

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2491,28 +2491,7 @@ try
         throw;
     }
 
-    bool found_stop_flag = false;
-
-    if (has_zookeeper && global_context->getMacros()->getMacroMap().contains("replica"))
-    {
-        ZooKeeperRetriesControl zk_retry(
-            "Read replicated DDL stop flag",
-            getLogger(log->name()), /// Pass log as LoggerPtr
-            ZooKeeperRetriesInfo(5, 1000, 2000, nullptr));
-
-         zk_retry.retryLoop([&]()
-            {
-                auto zookeeper = global_context->getZooKeeper();
-                String stop_flag_path = "/clickhouse/stop_replicated_ddl_queries/{replica}";
-                stop_flag_path = global_context->getMacros()->expand(stop_flag_path);
-                found_stop_flag = zookeeper->exists(stop_flag_path);
-            });
-    }
-
-    if (found_stop_flag)
-        LOG_INFO(log, "Found a stop flag for replicated DDL queries. They will be disabled");
-    else
-        DatabaseCatalog::instance().startReplicatedDDLQueries();
+    DatabaseCatalog::instance().startReplicatedDDLQueries();
 
     LOG_DEBUG(log, "Loaded metadata.");
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -24,6 +24,7 @@
 #include <base/getFQDNOrHostName.h>
 #include <base/safeExit.h>
 #include <base/Numa.h>
+#include <base/sleep.h>
 #include <Common/PoolId.h>
 #include <Common/MemoryTracker.h>
 #include <Common/MemoryWorker.h>
@@ -2495,18 +2496,31 @@ try
 
     if (has_zookeeper && global_context->getMacros()->getMacroMap().contains("replica"))
     {
-        try
+        for (int attempt = 1; ; ++attempt)
         {
-            auto zookeeper = global_context->getZooKeeper();
-            String stop_flag_path = "/clickhouse/stop_replicated_ddl_queries/{replica}";
-            stop_flag_path = global_context->getMacros()->expand(stop_flag_path);
-            found_stop_flag = zookeeper->exists(stop_flag_path);
-        }
-        catch (const Coordination::Exception & e)
-        {
-            if (e.code != Coordination::Error::ZCONNECTIONLOSS)
+            try
+            {
+                auto zookeeper = global_context->getZooKeeper();
+                String stop_flag_path = "/clickhouse/stop_replicated_ddl_queries/{replica}";
+                stop_flag_path = global_context->getMacros()->expand(stop_flag_path);
+                found_stop_flag = zookeeper->exists(stop_flag_path);
+                break;
+            }
+            catch (const Coordination::Exception & e)
+            {
+                tryLogCurrentException(log);
+                if (isHardwareError(e.code) && attempt <= 5)
+                {
+                    UInt64 retry_delay_milliseconds = 1000;
+                    LOG_DEBUG(log, "Retrying to read replicated DDL stop flag from Kepeer, attempt: {}, delay: {} ms",
+                        attempt, retry_delay_milliseconds);
+                    sleepForMilliseconds(retry_delay_milliseconds);
+                    continue;
+                }
+
+                LOG_ERROR(log, "Failed to read replicated DDL stop flag from Kepeer, after {} attempts", attempt);
                 throw;
-            tryLogCurrentException(log);
+            }
         }
     }
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2496,7 +2496,7 @@ try
     if (has_zookeeper && global_context->getMacros()->getMacroMap().contains("replica"))
     {
         ZooKeeperRetriesControl zk_retry(
-            "Retrying to read replicated DDL stop flag",
+            "Read replicated DDL stop flag",
             getLogger(log->name()), /// Pass log as LoggerPtr
             ZooKeeperRetriesInfo(5, 1000, 2000, nullptr));
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Retry reading of replicated DDL stop flag from Keeper at startup to make tests more robust when fault injection is enabled for Keeper.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
