### PR TITLE
handle Nulls and NaNs in ExtremesTransform

### DIFF
--- a/src/Processors/Transforms/ExtremesTransform.cpp
+++ b/src/Processors/Transforms/ExtremesTransform.cpp
@@ -1,6 +1,7 @@
 #include <Processors/Transforms/ExtremesTransform.h>
 #include <Columns/IColumn.h>
 #include <Core/Field.h>
+#include <Common/NaNUtils.h>
 
 namespace DB
 {
@@ -105,9 +106,17 @@ void ExtremesTransform::transform(DB::Chunk & chunk)
 
             columns[i]->getExtremes(cur_min_value, cur_max_value);
 
-            if (cur_min_value < min_value)
+            // getExtremes implementations for Nullable and floating point are ignoring Nulls, so do the same here
+            auto isNullORNaN = [] (const Field & value)
+            {
+                if (value.isNull())
+                    return true;
+                Float64 rawVal;
+                return value.tryGet<Float64>(rawVal) && isNaN(rawVal);
+            };
+            if (isNullORNaN(min_value) || (!isNullORNaN(cur_min_value) && cur_min_value < min_value))
                 min_value = cur_min_value;
-            if (cur_max_value > max_value)
+            if (isNullORNaN(max_value) || (!isNullORNaN(cur_max_value) && cur_max_value < max_value))
                 max_value = cur_max_value;
 
             MutableColumnPtr new_extremes = extremes_columns[i]->cloneEmpty();

--- a/src/Processors/Transforms/ExtremesTransform.cpp
+++ b/src/Processors/Transforms/ExtremesTransform.cpp
@@ -116,7 +116,7 @@ void ExtremesTransform::transform(DB::Chunk & chunk)
             };
             if (isNullORNaN(min_value) || (!isNullORNaN(cur_min_value) && cur_min_value < min_value))
                 min_value = cur_min_value;
-            if (isNullORNaN(max_value) || (!isNullORNaN(cur_max_value) && cur_max_value < max_value))
+            if (isNullORNaN(max_value) || (!isNullORNaN(cur_max_value) && cur_max_value > max_value))
                 max_value = cur_max_value;
 
             MutableColumnPtr new_extremes = extremes_columns[i]->cloneEmpty();

--- a/tests/queries/0_stateless/03524_nullable_extremes.reference
+++ b/tests/queries/0_stateless/03524_nullable_extremes.reference
@@ -1,0 +1,28 @@
+--- int, single part
+1
+2
+\N
+
+1
+2
+--- int, multi part
+1
+2
+\N
+
+1
+2
+--- float, single part
+1
+2
+nan
+
+1
+2
+--- float, multi part
+1
+2
+nan
+
+1
+2

--- a/tests/queries/0_stateless/03524_nullable_extremes.sql
+++ b/tests/queries/0_stateless/03524_nullable_extremes.sql
@@ -1,0 +1,19 @@
+SELECT '--- int, single part';
+CREATE TABLE single_int (k Int64, c Nullable(Int64)) Engine=MergeTree ORDER BY k;
+INSERT INTO single_int VALUES (1, 1), (2, 2), (3, NULL);
+SELECT c FROM single_int ORDER BY ALL SETTINGS extremes=1;
+
+SELECT '--- int, multi part';
+CREATE TABLE multi_int (k Int64, c Nullable(Int64)) Engine=MergeTree ORDER BY k PARTITION BY k;
+INSERT INTO multi_int VALUES (1, 1), (2, 2), (3, NULL);
+SELECT c FROM multi_int ORDER BY ALL SETTINGS extremes=1;
+
+SELECT '--- float, single part';
+CREATE TABLE single_float (k Int64, c Float64) Engine=MergeTree ORDER BY c;
+INSERT INTO single_float VALUES (1, 1), (2, 2), (3, 0/0);
+SELECT c FROM single_float ORDER BY ALL SETTINGS extremes=1;
+
+SELECT '--- float, multi part';
+CREATE TABLE multi_float (k Int64, c Float64) Engine=MergeTree ORDER BY k PARTITION BY k;
+INSERT INTO multi_float VALUES (1, 1), (2, 2), (3, 0/0);
+SELECT c FROM multi_float ORDER BY ALL SETTINGS extremes=1;


### PR DESCRIPTION
ExtremesTransform compares Fields by type first, so null or nan values once yielded as extreme from the block would be a result, because Types::Null is lower than every other.
Closes #80938

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix extremes for nullable and floating-point columns


