### PR TITLE
Fix possible crash while querying from system.tables

### DIFF
--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -390,16 +390,17 @@ protected:
                                 try
                                 {
                                     if (auto total_rows = table.second->totalRows(context))
-                                        res_columns[res_index++]->insert(*total_rows);
+                                        res_columns[res_index]->insert(*total_rows);
                                     else
-                                        res_columns[res_index++]->insertDefault();
+                                        res_columns[res_index]->insertDefault();
                                 }
                                 catch (const Exception &)
                                 {
                                     /// Even if the method throws, it should not prevent querying system.tables.
                                     tryLogCurrentException("StorageSystemTables");
-                                    res_columns[res_index++]->insertDefault();
+                                    res_columns[res_index]->insertDefault();
                                 }
+                                ++res_index;
                             }
                             // total_bytes
                             else if (src_index == 21 && columns_mask[src_index])
@@ -407,9 +408,9 @@ protected:
                                 try
                                 {
                                     if (auto total_bytes = table.second->totalBytes(context))
-                                        res_columns[res_index++]->insert(*total_bytes);
+                                        res_columns[res_index]->insert(*total_bytes);
                                     else
-                                        res_columns[res_index++]->insertDefault();
+                                        res_columns[res_index]->insertDefault();
                                 }
                                 catch (const Exception &)
                                 {
@@ -417,6 +418,7 @@ protected:
                                     tryLogCurrentException("StorageSystemTables");
                                     res_columns[res_index++]->insertDefault();
                                 }
+                                ++res_index;
                             }
                             /// Fill the rest columns with defaults
                             else if (columns_mask[src_index])
@@ -643,16 +645,17 @@ protected:
                     {
                         auto total_rows = table ? table->totalRows(context) : std::nullopt;
                         if (total_rows)
-                            res_columns[res_index++]->insert(*total_rows);
+                            res_columns[res_index]->insert(*total_rows);
                         else
-                            res_columns[res_index++]->insertDefault();
+                            res_columns[res_index]->insertDefault();
                     }
                     catch (const Exception &)
                     {
                         /// Even if the method throws, it should not prevent querying system.tables.
                         tryLogCurrentException("StorageSystemTables");
-                        res_columns[res_index++]->insertDefault();
+                        res_columns[res_index]->insertDefault();
                     }
+                    ++res_index;
                 }
 
                 if (columns_mask[src_index++])
@@ -661,16 +664,17 @@ protected:
                     {
                         auto total_bytes = table->totalBytes(context_copy);
                         if (total_bytes)
-                            res_columns[res_index++]->insert(*total_bytes);
+                            res_columns[res_index]->insert(*total_bytes);
                         else
-                            res_columns[res_index++]->insertDefault();
+                            res_columns[res_index]->insertDefault();
                     }
                     catch (const Exception &)
                     {
                         /// Even if the method throws, it should not prevent querying system.tables.
                         tryLogCurrentException("StorageSystemTables");
-                        res_columns[res_index++]->insertDefault();
+                        res_columns[res_index]->insertDefault();
                     }
+                    ++res_index;
                 }
 
                 if (columns_mask[src_index++])
@@ -679,16 +683,17 @@ protected:
                     {
                         auto total_bytes_uncompressed = table->totalBytesUncompressed(context_copy->getSettingsRef());
                         if (total_bytes_uncompressed)
-                            res_columns[res_index++]->insert(*total_bytes_uncompressed);
+                            res_columns[res_index]->insert(*total_bytes_uncompressed);
                         else
-                            res_columns[res_index++]->insertDefault();
+                            res_columns[res_index]->insertDefault();
                     }
                     catch (const Exception &)
                     {
                         /// Even if the method throws, it should not prevent querying system.tables.
                         tryLogCurrentException("StorageSystemTables");
-                        res_columns[res_index++]->insertDefault();
+                        res_columns[res_index]->insertDefault();
                     }
+                    ++res_index;
                 }
 
                 auto table_merge_tree = std::dynamic_pointer_cast<MergeTreeData>(table);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash while querying from system.tables (likely the case under memory pressure)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/75772