### PR TITLE
allow read-only mode for merge table function

### DIFF
--- a/src/TableFunctions/TableFunctionMerge.cpp
+++ b/src/TableFunctions/TableFunctionMerge.cpp
@@ -161,7 +161,16 @@ StoragePtr TableFunctionMerge::executeImpl(const ASTPtr & /*ast_function*/, Cont
 
 void registerTableFunctionMerge(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionMerge>();
+    factory.registerFunction<TableFunctionMerge>(
+        {
+            .documentation = {
+                .description = "Creates a temporary Merge table. The structure will be derived from underlying tables by using a union of their columns and by deriving common types.",
+                .examples = {{"merge", "SELECT * FROM merge(db, '^table_.*')", ""}},
+                .category = FunctionDocumentation::Category::TableFunction
+            },
+            .allow_readonly = true,
+        }
+    );
 }
 
 }

--- a/tests/integration/test_table_functions_access_rights/test.py
+++ b/tests/integration/test_table_functions_access_rights/test.py
@@ -40,12 +40,7 @@ def test_merge():
     assert instance.query(select_query) == "1\n2\n"
 
     instance.query("CREATE USER A")
-    assert (
-        "it's necessary to have the grant CREATE TEMPORARY TABLE ON *.*"
-        in instance.query_and_get_error(select_query, user="A")
-    )
 
-    instance.query("GRANT CREATE TEMPORARY TABLE ON *.* TO A")
     assert "no tables satisfied provided regexp" in instance.query_and_get_error(
         select_query, user="A"
     )

--- a/tests/queries/0_stateless/02414_all_new_table_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02414_all_new_table_functions_must_be_documented.reference
@@ -8,7 +8,6 @@ generateSeries
 generate_series
 input
 jdbc
-merge
 null
 numbers
 numbers_mt


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow read-only mode for the `merge` table function, so the `CREATE TEMPORARY TABLE` grant is not required for using it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
