### PR TITLE
Update s3queue.md

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -14,6 +14,8 @@ import ScalePlanFeatureBadge from '@theme/badges/ScalePlanFeatureBadge'
 
 This engine provides integration with [Amazon S3](https://aws.amazon.com/s3/) ecosystem and allows streaming import. This engine is similar to the [Kafka](../../../engines/table-engines/integrations/kafka.md), [RabbitMQ](../../../engines/table-engines/integrations/rabbitmq.md) engines, but provides S3-specific features.
 
+It is important to understand this note from the [original PR for S3Queue implementation](https://github.com/ClickHouse/ClickHouse/pull/49086/files#diff-e1106769c9c8fbe48dd84f18310ef1a250f2c248800fde97586b3104e9cd6af8R183): when the `MATERIALIZED VIEW` joins the engine, the S3Queue Table Engine starts collecting data in the background.
+
 ## Create Table {#creating-a-table}
 
 ```sql


### PR DESCRIPTION
Adding a documentation note as included in the PR code about the MATERIALIZED VIEW being required to join the engine before the S3Queue Table Engine begins collecting data

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding a documentation note as included in the PR code about the MATERIALIZED VIEW being required to join the engine before the S3Queue Table Engine begins collecting data

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

