### PR TITLE
[WIP] Add prefix bits option for quotas keyed by IP addresses

### DIFF
--- a/src/Access/Quota.cpp
+++ b/src/Access/Quota.cpp
@@ -51,6 +51,7 @@ void Quota::clearAllExceptDependencies()
 {
     all_limits.clear();
     key_type = QuotaKeyType::NONE;
+    // TODO: Check if we need to clear prefix bits here.
 }
 
 }

--- a/src/Access/Quota.h
+++ b/src/Access/Quota.h
@@ -41,7 +41,8 @@ struct Quota : public IAccessEntity
     /// Which roles or users should use this quota.
     RolesOrUsersSet to_roles;
 
-    int prefix_bits;
+    int ipv4_prefix_bits;
+    int ipv6_prefix_bits;
     
     bool equal(const IAccessEntity & other) const override;
     std::shared_ptr<IAccessEntity> clone() const override { return cloneImpl<Quota>(); }

--- a/src/Access/Quota.h
+++ b/src/Access/Quota.h
@@ -41,6 +41,8 @@ struct Quota : public IAccessEntity
     /// Which roles or users should use this quota.
     RolesOrUsersSet to_roles;
 
+    int prefix_bits;
+    
     bool equal(const IAccessEntity & other) const override;
     std::shared_ptr<IAccessEntity> clone() const override { return cloneImpl<Quota>(); }
     static constexpr const auto TYPE = AccessEntityType::QUOTA;

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -12,7 +12,11 @@
 #include <boost/smart_ptr/make_shared.hpp>
 #include <Poco/Net/IPAddress.h>
 #include <Poco/Net/SocketDefs.h>
+<<<<<<< Updated upstream
 
+=======
+#include <iostream>
+>>>>>>> Stashed changes
 
 namespace DB
 {
@@ -31,24 +35,40 @@ void QuotaCache::QuotaInfo::setQuota(const QuotaPtr & quota_, const UUID & quota
     rebuildAllIntervals();
 }
 
+<<<<<<< Updated upstream
 Poco::Net::IPAddress QuotaCache::QuotaInfo::getMaskedIP(Poco::Net::IPAddress & ipAddr) const 
+=======
+Poco::Net::IPAddress QuotaCache::QuotaInfo::getMaskedIP(Poco::Net::IPAddress ipAddr) const 
+>>>>>>> Stashed changes
 {
     Poco::Net::IPAddress mask;
     if (ipAddr.family() == Poco::Net::AddressFamily::IPv4) 
     {
+<<<<<<< Updated upstream
         mask = Poco::Net::IPAddress(quota->prefix_bits, Poco::Net::AddressFamily::IPv4);
         ipAddr.mask(mask);
     } else if (ipAddr.family() == Poco::Net::AddressFamily::IPv6) {
         // mask method is not currently supported for IPv6.
         mask = Poco::Net::IPAddress(quota->prefix_bits, Poco::Net::AddressFamily::IPv6);
+=======
+        mask = Poco::Net::IPAddress(quota->ipv4_prefix_bits, Poco::Net::AddressFamily::IPv4);
+        ipAddr.mask(mask);
+    } else if (ipAddr.family() == Poco::Net::AddressFamily::IPv6) {
+        
+        // mask method is not currently supported for IPv6.
+        mask = Poco::Net::IPAddress(quota->ipv6_prefix_bits, Poco::Net::AddressFamily::IPv6);
+>>>>>>> Stashed changes
         std::array<unsigned char, 16> masked_addr;
         const unsigned char* raw_ip = static_cast<const unsigned char*>(ipAddr.addr());
         const unsigned char* raw_mask = static_cast<const unsigned char*>(mask.addr());
 
-        for (int i = 0; i < 16; ++i) {
+        auto ipv6_bytes = 16;
+        for (int i = 0; i < ipv6_bytes; ++i)
+        {
             masked_addr[i] = raw_ip[i] & raw_mask[i];
         }
-        return Poco::Net::IPAddress(masked_addr.data(), 16);
+
+        return Poco::Net::IPAddress(masked_addr.data(), ipv6_bytes);
     }
     return ipAddr;
 }
@@ -57,6 +77,8 @@ Poco::Net::IPAddress QuotaCache::QuotaInfo::getMaskedIP(Poco::Net::IPAddress & i
 String QuotaCache::QuotaInfo::calculateKey(const EnabledQuota & enabled, bool throw_if_client_key_empty) const
 {
     const auto & params = enabled.params;
+    const auto & masked_ip = getMaskedIP(params.client_address);
+    std::cout << "Client Address is: " << params.client_address.toString() << std::endl;
     switch (quota->key_type)
     {
         case QuotaKeyType::NONE:
@@ -69,7 +91,7 @@ String QuotaCache::QuotaInfo::calculateKey(const EnabledQuota & enabled, bool th
         }
         case QuotaKeyType::IP_ADDRESS:
         {
-            return params.client_address.toString();
+            return masked_ip.toString();
         }
         case QuotaKeyType::FORWARDED_IP_ADDRESS:
         {
@@ -98,7 +120,7 @@ String QuotaCache::QuotaInfo::calculateKey(const EnabledQuota & enabled, bool th
         {
             if (!params.client_key.empty())
                 return params.client_key;
-            return params.client_address.toString();
+            return masked_ip.toString();
         }
         case QuotaKeyType::MAX: break;
     }

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -44,7 +44,7 @@ private:
         void setQuota(const QuotaPtr & quota_, const UUID & quota_id_);
 
         String calculateKey(const EnabledQuota & enabled_quota, bool throw_if_client_key_empty) const;
-        Poco::Net::IPAddress getMaskedIP(Poco::Net::IPAddress & ipAddr) const;
+        Poco::Net::IPAddress getMaskedIP(Poco::Net::IPAddress ipAddr) const;
         boost::shared_ptr<const Intervals> getOrBuildIntervals(const String & key);
         boost::shared_ptr<const Intervals> rebuildIntervals(const String & key, std::chrono::system_clock::time_point current_time);
         void rebuildAllIntervals();

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -2,6 +2,7 @@
 
 #include <Access/EnabledQuota.h>
 #include <base/scope_guard.h>
+#include <Poco/Net/IPAddress.h>
 #include <memory>
 #include <mutex>
 #include <map>
@@ -43,6 +44,7 @@ private:
         void setQuota(const QuotaPtr & quota_, const UUID & quota_id_);
 
         String calculateKey(const EnabledQuota & enabled_quota, bool throw_if_client_key_empty) const;
+        Poco::Net::IPAddress getMaskedIP(Poco::Net::IPAddress & ipAddr) const;
         boost::shared_ptr<const Intervals> getOrBuildIntervals(const String & key);
         boost::shared_ptr<const Intervals> rebuildIntervals(const String & key, std::chrono::system_clock::time_point current_time);
         void rebuildAllIntervals();

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -517,9 +517,11 @@ namespace
         quota->setName(quota_name);
 
         String quota_config = "quotas." + quota_name;
-        if (config.has(quota_config + ".keyed_by_ip"))
+        if (config.has(quota_config + ".keyed_by_ip")) {
             quota->key_type = QuotaKeyType::IP_ADDRESS;
-        else if (config.has(quota_config + ".keyed_by_forwarded_ip"))
+            String ip_config = quota_config + ".keyed_by_ip";
+            quota->prefix_bits = config.getInt(ip_config, 128);
+        } else if (config.has(quota_config + ".keyed_by_forwarded_ip"))
             quota->key_type = QuotaKeyType::FORWARDED_IP_ADDRESS;
         else if (config.has(quota_config + ".keyed"))
             quota->key_type = QuotaKeyType::CLIENT_KEY_OR_USER_NAME;

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -520,7 +520,10 @@ namespace
         if (config.has(quota_config + ".keyed_by_ip")) {
             quota->key_type = QuotaKeyType::IP_ADDRESS;
             String ip_config = quota_config + ".keyed_by_ip";
-            quota->prefix_bits = config.getInt(ip_config, 128);
+            String ipv4_config = ip_config + ".ipv4_prefix_bits";
+            String ipv6_config = ip_config + ".ipv6_prefix_bits";
+            quota->ipv4_prefix_bits = config.getInt(ipv4_config, 32);
+            quota->ipv6_prefix_bits = config.getInt(ipv6_config, 128);
         } else if (config.has(quota_config + ".keyed_by_forwarded_ip"))
             quota->key_type = QuotaKeyType::FORWARDED_IP_ADDRESS;
         else if (config.has(quota_config + ".keyed"))

--- a/tests/integration/test_quota/ip_prefix_bits.xml
+++ b/tests/integration/test_quota/ip_prefix_bits.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+   <quotas>
+        <ipQuota>
+            <keyed_by_ip>48</keyed_by_ip>  
+            <interval>
+                <randomize>true</randomize>
+                <duration>3600</duration>
+                <read_rows>4000</read_rows>
+                <result_rows>4000</result_rows>
+                <read_bytes>400000</read_bytes>
+                <result_bytes>400000</result_bytes>
+                <execution_time>60</execution_time>
+                <failed_sequential_authentications>3</failed_sequential_authentications>
+            </interval>
+            <interval2>
+                <duration>2629746</duration>
+                <execution_time>1800</execution_time>
+            </interval2>
+        </ipQuota>
+    </quotas>
+</clickhouse>

--- a/tests/integration/test_quota/no_prefix_bits.xml
+++ b/tests/integration/test_quota/no_prefix_bits.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+   <quotas>
+        <ipQuota>
+            <keyed_by_ip>
+            </keyed_by_ip>  
+            <interval>
+                <!-- Length of interval = 1 year -->
+                <duration>31556952</duration>
+
+                <!-- No limits. Just calculate resource usage for time interval. -->
+                <queries>0</queries>
+                <query_selects>0</query_selects>
+                <query_inserts>0</query_inserts>
+                <errors>0</errors>
+                <read_rows>0</read_rows>
+                <result_rows>0</result_rows>
+            </interval>
+        </ipQuota>
+    </quotas>
+</clickhouse>

--- a/tests/integration/test_quota/prefix_bits.xml
+++ b/tests/integration/test_quota/prefix_bits.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+   <quotas>
+        <ipQuota>
+            <keyed_by_ip>
+                <ipv4_prefix_bits>24</ipv4_prefix_bits>
+                <ipv6_prefix_bits>64</ipv6_prefix_bits>
+            </keyed_by_ip>  
+            <interval>
+                <!-- Length of interval = 1 year -->
+                <duration>31556952</duration>
+
+                <!-- No limits. Just calculate resource usage for time interval. -->
+                <queries>0</queries>
+                <query_selects>0</query_selects>
+                <query_inserts>0</query_inserts>
+                <errors>0</errors>
+                <read_rows>0</read_rows>
+                <result_rows>0</result_rows>
+            </interval>
+        </ipQuota>
+    </quotas>
+</clickhouse>

--- a/tests/integration/test_quota/test.py
+++ b/tests/integration/test_quota/test.py
@@ -1444,6 +1444,74 @@ def test_reload_users_xml_by_timer():
         [["myQuota", 31556952, 0, 1, 1, 1, 1, 1, "\\N", 1, "\\N", "\\N", "\\N", "1"]],
     )
 
+def test_prefix_bits():
+    """
+    Check that quota keyed by IP uses correct key with and without prefix bits.
+    """
+
+    # Test with no prefix (should match full IP)
+    copy_quota_xml("tracking.xml")
+    instance.query("SELECT * from test_table")
+    system_quota_usage(
+        [
+            [
+                "ipQuota",           # quota_name
+                "127.0.0.1",         # quota_key (full IP)
+                31556952,            # start_time 
+                1,                   # end_time 
+                "\\N",               # duration
+                1,                   # queries
+                "\\N",               # query_selects
+                0,                   # query_inserts
+                "\\N",               # max_query_inserts
+                0,                   # errors
+                "\\N",               # max_errors
+                50,               # result_rows
+                "\\N",               # max_result_rows
+                200,               # result_bytes
+                "\\N",               # max_result_bytes
+                50,               # read_rows
+                "\\N",               # max_read_rows
+                200,               # read_bytes
+                "\\N",               # max_read_bytes
+                "\\N",               # execution_time
+                "\\N",               # max_execution_time
+            ]
+        ]
+    )
+
+    # Test with IPv4 prefix /24 (should match by subnet)
+    # copy_quota_xml("prefix_bits.xml")
+    # instance.query("SELECT * from test_table")
+    # system_quota_usage(
+    #     [
+    #         [
+    #             "ipQuota",           # quota_name
+    #             "127.0.0.0",         # quota_key (subnet)
+    #             31556952,            # duration
+    #             "\\N",               # queries
+    #             "\\N",               # max_queries
+    #             "\\N",               # query_selects
+    #             "\\N",               # max_query_selects
+    #             "\\N",               # query_inserts
+    #             "\\N",               # max_query_inserts
+    #             "\\N",               # errors
+    #             "\\N",               # max_errors
+    #             "\\N",               # result_rows
+    #             "\\N",               # max_result_rows
+    #             "\\N",               # result_bytes
+    #             "\\N",               # max_result_bytes
+    #             "\\N",               # read_rows
+    #             "\\N",               # max_read_rows
+    #             "\\N",               # read_bytes
+    #             "\\N",               # max_read_bytes
+    #             "\\N",               # execution_time
+    #             "\\N",               # max_execution_time
+    #             "\\N",               # failed_sequential_authentications
+    #             "\\N",               # max_failed_sequential_authentications
+    #         ]
+    #     ]
+    # )
 
 def test_dcl_introspection():
     assert instance.query("SHOW QUOTAS") == "myQuota\n"


### PR DESCRIPTION
See #79858

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add prefix bits option

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

TBD

Hi I'm sharing my progress on this in the hopes that I can get some additional direction :) 

The issue asked for 2 options, ipv4_prefix_bits and ipv6_prefix_bits but I wanted to implement as a single option to simplify the code, there is an included test case demonstrating my idea. Is there a scenario where we'd want different prefixes for ipv4 and ipv6? 

My change is just changing the calculated key used - are there other areas of the code that I am missing? I'd like to double check since I am new to the code base.

Thanks!


