### PR TITLE
rust: match toolchain with the CI/docker-images

### DIFF
--- a/rust/VENDOR.md
+++ b/rust/VENDOR.md
@@ -2,9 +2,4 @@ As we have multiple projects we use a workspace to manage them (it's way
 simpler and leads to less issues). In order to vendor all the dependencies we
 need to store both the registry and the packages themselves.
 
-Note that this includes the exact `std` dependencies for the rustc (required to
-build with sanitizers flags) version used in CI (currently nightly-2024-12-01),
-so you need to install `rustup component add rust-src` for the specific
-version.
-
 To re-generate just use `vendor.sh`

--- a/rust/vendor.sh
+++ b/rust/vendor.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# std is required for sanitizers builds
+# and we need to match toolchain version for std (to vendor proper dependencies)
+TOOLCHAIN=nightly-2024-12-01
+function cargo() { rustup run "$TOOLCHAIN" cargo "$@"; }
+function rustc() { rustup run "$TOOLCHAIN" rustc "$@"; }
+rustup component add --toolchain "$TOOLCHAIN" rust-src
+
 CH_TOP_DIR=$(git rev-parse --show-toplevel)
 
 cd "$CH_TOP_DIR/rust/workspace" || exit 1


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)