### PR TITLE
Ignore weird errors from catalogs when listing tables

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -479,7 +479,7 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getLightweightTablesIterator(
         if (filter_by_table_name && !filter_by_table_name(table_name))
             continue;
 
-        /// NOTE: There are one million of different ways how we can recieve
+        /// NOTE: There are one million of different ways how we can receive
         /// weird response from different catalogs. tryGetTableImpl will not
         /// throw only in case of expected errors, but sometimes we can receive
         /// completely unexpected results for some objects which can be stored

--- a/src/Databases/DataLake/DatabaseDataLake.h
+++ b/src/Databases/DataLake/DatabaseDataLake.h
@@ -75,7 +75,8 @@ private:
 
     std::string getStorageEndpointForTable(const DataLake::TableMetadata & table_metadata) const;
 
-
+    /// Can return nullptr in case of *expected* issues with response from catalog. Sometimes
+    /// catalogs can produce completely unexpected responses. In such cases this function may throw.
     StoragePtr tryGetTableImpl(const String & name, ContextPtr context, bool lightweight) const;
 };
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now ClickHouse will ignore errors and unexpected responses from data lake catalogs in `SHOW TABLES` query. Fixes #79725.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
