### PR TITLE
Fix dereferencing an empty optional in `executeInsertSelectWithParallelReplicas`

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -1036,7 +1036,8 @@ std::optional<QueryPipeline> executeInsertSelectWithParallelReplicas(
     }
     connection_pools.resize(max_replicas_to_use);
 
-    LOG_DEBUG(logger, "Local replica got replica number {}", local_replica_index.value());
+    if (local_replica_index)
+        LOG_DEBUG(logger, "Local replica got replica number {}", local_replica_index.value());
 
     String formatted_query;
     {
@@ -1068,7 +1069,7 @@ std::optional<QueryPipeline> executeInsertSelectWithParallelReplicas(
 
     for (size_t i = 0; i < connection_pools.size(); ++i)
     {
-        if (skip_local_replica && i == *local_replica_index)
+        if (skip_local_replica && (local_replica_index && i == *local_replica_index))
             continue;
 
         IConnections::ReplicaInfo replica_info{

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -1019,6 +1019,7 @@ std::optional<QueryPipeline> executeInsertSelectWithParallelReplicas(
         chassert(local_pipeline);
 
         local_replica_index = findLocalReplicaIndexAndUpdatePools(connection_pools, max_replicas_to_use, cluster);
+        chassert(local_replica_index.has_value());
 
         /// while building local pipeline
         /// - the coordinator is created
@@ -1033,11 +1034,10 @@ std::optional<QueryPipeline> executeInsertSelectWithParallelReplicas(
             std::swap(connection_pools[local_replica_index.value()], connection_pools[snapshot_replica_num.value()]);
             local_replica_index = snapshot_replica_num;
         }
+
+        LOG_DEBUG(logger, "Local replica got replica number {}", local_replica_index.value());
     }
     connection_pools.resize(max_replicas_to_use);
-
-    if (local_replica_index)
-        LOG_DEBUG(logger, "Local replica got replica number {}", local_replica_index.value());
 
     String formatted_query;
     {
@@ -1056,7 +1056,6 @@ std::optional<QueryPipeline> executeInsertSelectWithParallelReplicas(
         formatted_query = buf.str();
     }
 
-    const bool skip_local_replica = local_pipeline.has_value();
     QueryPipeline pipeline;
     if (local_pipeline)
     {
@@ -1069,7 +1068,7 @@ std::optional<QueryPipeline> executeInsertSelectWithParallelReplicas(
 
     for (size_t i = 0; i < connection_pools.size(); ++i)
     {
-        if (skip_local_replica && (local_replica_index && i == *local_replica_index))
+        if (local_replica_index && i == *local_replica_index)
             continue;
 
         IConnections::ReplicaInfo replica_info{


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


`local_replica_index` is not set if either `parallel_replicas_local_plan` or `parallel_replicas_insert_select_local_pipeline` is `false`.

Queries still finish successfully despite the exception (because it is swallowed in the logger). And, when we later dereference it for comparison, we access a local stack region, so there shouldn't be any segfaults or something similar. So I don't mark it as a bug fix and don't intend to backport.

Follow-up for: #78041