### PR TITLE
Better accounting of in-memory cache for Iceberg metadata (v2)

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/AvroForIcebergDeserializer.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/AvroForIcebergDeserializer.cpp
@@ -18,10 +18,9 @@ using namespace DB;
 
 AvroForIcebergDeserializer::AvroForIcebergDeserializer(
     std::unique_ptr<ReadBufferFromFileBase> buffer_,
-    const std::string & manifest_file_path_,
     const DB::FormatSettings & format_settings)
     : buffer(std::move(buffer_))
-    , manifest_file_path(manifest_file_path_)
+    , manifest_file_path(buffer->getFileName())
 {
     auto manifest_file_reader
         = std::make_unique<avro::DataFileReaderBase>(std::make_unique<AvroInputStreamReadBufferAdapter>(*buffer));

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/AvroForIcebergDeserializer.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/AvroForIcebergDeserializer.h
@@ -37,7 +37,6 @@ public:
 
     AvroForIcebergDeserializer(
         std::unique_ptr<DB::ReadBufferFromFileBase> buffer_,
-        const std::string & manifest_file_path_,
         const DB::FormatSettings & format_settings);
 
     size_t rows() const;
@@ -50,6 +49,8 @@ public:
     DB::Field getValueFromRowByName(size_t row_num, const std::string & path, std::optional<DB::TypeIndex> expected_type = std::nullopt) const;
 
     std::optional<std::string> tryGetAvroMetadataValue(std::string metadata_key) const;
+
+    String getMetadataFileName() const { return buffer->getFileName(); }
 };
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -72,10 +72,11 @@ private:
     static size_t getMemorySizeOfManifestCacheKeys(const ManifestFileCacheKeys & manifest_file_cache_keys)
     {
          size_t total_size = 0;
-         for (const auto & entry: manifest_file_cache_keys)
+         for (const auto & entry : manifest_file_cache_keys)
          {
              total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_path.capacity();
          }
+         total_size += sizeof(ManifestFileCacheKey) * (manifest_file_cache_keys.capacity() - manifest_file_cache_keys.size());
          return total_size;
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better accounting of in-memory cache for Iceberg metadata (v2)

Previous patch (#80904), was not enough, since there are lots of other places, so here is a second attempt.
