### PR TITLE
Allow `filesystem_caches` and `named_collections` in `clickhouse-local` configuration file

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -33,6 +33,8 @@
 #include <Common/quoteString.h>
 #include <Common/ThreadPool.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/NamedCollections/NamedCollectionsFactory.h>
+#include <Interpreters/Cache/FileCacheFactory.h>
 #include <Loggers/OwnFormattingChannel.h>
 #include <Loggers/OwnPatternFormatter.h>
 #include <IO/ReadBufferFromFile.h>
@@ -884,6 +886,9 @@ void LocalServer::processConfig()
     size_t compiled_expression_cache_max_elements = server_settings[ServerSetting::compiled_expression_cache_elements_size];
     CompiledExpressionCacheFactory::instance().init(compiled_expression_cache_max_size_in_bytes, compiled_expression_cache_max_elements);
 #endif
+
+    NamedCollectionFactory::instance().loadIfNot();
+    FileCacheFactory::instance().loadDefaultCaches(config());
 
     /// NOTE: it is important to apply any overrides before
     /// `setDefaultProfiles` calls since it will copy current context (i.e.

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1823,7 +1823,6 @@ try
 #endif
 
     NamedCollectionFactory::instance().loadIfNot();
-
     FileCacheFactory::instance().loadDefaultCaches(config());
 
     /// Initialize main config reloader.
@@ -2124,7 +2123,6 @@ try
             CertificateReloader::instance().tryReloadAll(*config);
 #endif
             NamedCollectionFactory::instance().reloadFromConfig(*config);
-
             FileCacheFactory::instance().updateSettingsFromConfig(*config);
 
             HTTPConnectionPools::instance().setLimits(

--- a/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.reference
+++ b/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.reference
@@ -1,5 +1,5 @@
 Row 1:
 ──────
 cache_name: cache
-path:       ./cache/
+path:       /cache/
 max_size:   1000000000 -- 1.00 billion

--- a/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.reference
+++ b/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.reference
@@ -1,0 +1,5 @@
+Row 1:
+──────
+cache_name: cache
+path:       ./cache/
+max_size:   1000000000 -- 1.00 billion

--- a/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.sh
+++ b/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Until recently, clickhouse-local supported only caches from the disk configuration,
+# but not the standalone filesystem_caches configuration.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CONFIG_FILE="${CLICKHOUSE_TMP}/config.yaml"
+
+> "${CONFIG_FILE}" echo "
+filesystem_caches:
+    cache:
+        path: '${CLICKHOUSE_TMP}/cache/'
+        max_size: '1G'
+"
+
+$CLICKHOUSE_LOCAL --config-file "${CONFIG_FILE}" --filesystem_cache_name cache --query "
+SELECT cache_name, path, max_size FROM system.filesystem_cache_settings FORMAT Vertical
+"
+
+rm "${CONFIG_FILE}"

--- a/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.sh
+++ b/tests/queries/0_stateless/03525_filesystem_caches_clickhouse_local.sh
@@ -16,7 +16,7 @@ filesystem_caches:
 "
 
 $CLICKHOUSE_LOCAL --config-file "${CONFIG_FILE}" --filesystem_cache_name cache --query "
-SELECT cache_name, path, max_size FROM system.filesystem_cache_settings FORMAT Vertical
+SELECT cache_name, extract(path, '/cache/$') AS path, max_size FROM system.filesystem_cache_settings FORMAT Vertical
 "
 
 rm "${CONFIG_FILE}"

--- a/tests/queries/0_stateless/03526_static_named_collections_clickhouse_local.reference
+++ b/tests/queries/0_stateless/03526_static_named_collections_clickhouse_local.reference
@@ -1,0 +1,1 @@
+test	{'hello':'[HIDDEN]'}	CONFIG	

--- a/tests/queries/0_stateless/03526_static_named_collections_clickhouse_local.sh
+++ b/tests/queries/0_stateless/03526_static_named_collections_clickhouse_local.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Until recently, clickhouse-local supported only SQL-based named collections configuration,
+# but not the static configuration of named collections in the config file.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CONFIG_FILE="${CLICKHOUSE_TMP}/config.yaml"
+
+> "${CONFIG_FILE}" echo "
+named_collections:
+    test:
+        hello: 'world'
+"
+
+$CLICKHOUSE_LOCAL --config-file "${CONFIG_FILE}" --filesystem_cache_name cache --query "
+SELECT * FROM system.named_collections
+"
+
+rm "${CONFIG_FILE}"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow `filesystem_caches` and `named_collections` in the `clickhouse-local` configuration file.