### PR TITLE
Fix highlighting of `PARTITION BY` in `INSERT` queries

### DIFF
--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -52,21 +52,20 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
 {
     frame.need_parens = false;
 
-    ostr << (settings.hilite ? hilite_keyword : "") << "INSERT INTO ";
+    ostr << (settings.hilite ? hilite_keyword : "") << "INSERT INTO" << (settings.hilite ? hilite_none : "") << " ";
     if (table_function)
     {
-        ostr << (settings.hilite ? hilite_keyword : "") << "FUNCTION ";
+        ostr << (settings.hilite ? hilite_keyword : "") << "FUNCTION" << (settings.hilite ? hilite_none : "") << " ";
         table_function->format(ostr, settings, state, frame);
         if (partition_by)
         {
-            ostr << " PARTITION BY ";
+            ostr << " " << (settings.hilite ? hilite_keyword : "") << "PARTITION BY" << (settings.hilite ? hilite_none : "") << " ";
             partition_by->format(ostr, settings, state, frame);
         }
     }
     else if (table_id)
     {
-        ostr << (settings.hilite ? hilite_none : "")
-                      << (!table_id.database_name.empty() ? backQuoteIfNeed(table_id.database_name) + "." : "") << backQuoteIfNeed(table_id.table_name);
+        ostr << (!table_id.database_name.empty() ? backQuoteIfNeed(table_id.database_name) + "." : "") << backQuoteIfNeed(table_id.table_name);
     }
     else
     {
@@ -90,21 +89,21 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
     if (infile)
     {
         ostr
-            << (settings.hilite ? hilite_keyword : "")
-            << " FROM INFILE "
+            << " " << (settings.hilite ? hilite_keyword : "")
+            << "FROM INFILE"
             << (settings.hilite ? hilite_none : "")
-            << quoteString(infile->as<ASTLiteral &>().value.safeGet<std::string>());
+            << " " << quoteString(infile->as<ASTLiteral &>().value.safeGet<std::string>());
         if (compression)
             ostr
-                << (settings.hilite ? hilite_keyword : "")
-                << " COMPRESSION "
+                << " " << (settings.hilite ? hilite_keyword : "")
+                << "COMPRESSION"
                 << (settings.hilite ? hilite_none : "")
-                << quoteString(compression->as<ASTLiteral &>().value.safeGet<std::string>());
+                << " " << quoteString(compression->as<ASTLiteral &>().value.safeGet<std::string>());
     }
 
     if (settings_ast)
     {
-        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SETTINGS " << (settings.hilite ? hilite_none : "");
+        ostr << (settings.hilite ? hilite_keyword : "") << settings.nl_or_ws << "SETTINGS" << (settings.hilite ? hilite_none : "") << " ";
         settings_ast->format(ostr, settings, state, frame);
     }
 
@@ -130,12 +129,12 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         if (!format.empty())
         {
             ostr << delim
-                          << (settings.hilite ? hilite_keyword : "") << "FORMAT " << (settings.hilite ? hilite_none : "") << format;
+                << (settings.hilite ? hilite_keyword : "") << "FORMAT" << (settings.hilite ? hilite_none : "") << format << " ";
         }
         else if (!infile)
         {
             ostr << delim
-                          << (settings.hilite ? hilite_keyword : "") << "VALUES" << (settings.hilite ? hilite_none : "");
+                << (settings.hilite ? hilite_keyword : "") << "VALUES" << (settings.hilite ? hilite_none : "");
         }
     }
 }
@@ -162,7 +161,7 @@ static void tryFindInputFunctionImpl(const ASTPtr & ast, ASTPtr & input_function
         if (table_function_ast->name == "input")
         {
             if (input_function)
-                throw Exception(ErrorCodes::INVALID_USAGE_OF_INPUT, "You can use 'input()' function only once per request.");
+                throw Exception(ErrorCodes::INVALID_USAGE_OF_INPUT, "You can use the `input` function only once in a query.");
             input_function = ast;
         }
     }

--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -129,7 +129,7 @@ void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         if (!format.empty())
         {
             ostr << delim
-                << (settings.hilite ? hilite_keyword : "") << "FORMAT" << (settings.hilite ? hilite_none : "") << format << " ";
+                << (settings.hilite ? hilite_keyword : "") << "FORMAT" << (settings.hilite ? hilite_none : "") << " " << format;
         }
         else if (!infile)
         {

--- a/tests/queries/0_stateless/03527_format_insert_partition.reference
+++ b/tests/queries/0_stateless/03527_format_insert_partition.reference
@@ -1,0 +1,3 @@
+[1mINSERT INTO[0m [1mFUNCTION[0m [0;33ms3([0m'https://a_path_to_s3/bucket_name/test.parquet', 'access_key', 'secret_key', 'Parquet'[0;33m)[0m [1mPARTITION BY[0m [0;33mrand([0m[0;33m)[0m[1;33m % [0m10 [1mSELECT[0m *[1m
+FROM[0m [0;36mTestTable[0m[1m
+LIMIT [0m10

--- a/tests/queries/0_stateless/03527_format_insert_partition.sh
+++ b/tests/queries/0_stateless/03527_format_insert_partition.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# The words "PARTITION BY" were not highlighted in previous versions.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_FORMAT --query "INSERT INTO FUNCTION
+   s3(
+       'https://a_path_to_s3/bucket_name/test.parquet',
+       'access_key',
+       'secret_key',
+       'Parquet'
+    ) PARTITION BY rand() % 10 SELECT
+    *
+FROM TestTable
+LIMIT 10;
+" --hilite


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix highlighting of `PARTITION BY` in `INSERT` queries. In previous versions, `PARTITION BY` was not highlighted as a keyword.