### PR TITLE
tests: avoid possible "Bind for 0.0.0.0:2181 failed: port is already allocated" in kafka tests

### DIFF
--- a/tests/integration/compose/docker_compose_kafka.yml
+++ b/tests/integration/compose/docker_compose_kafka.yml
@@ -3,7 +3,7 @@ services:
     image: zookeeper:3.4.9
     hostname: kafka_zookeeper
     ports:
-      - 2181:2181
+      - 2181
     environment:
       ZOO_MY_ID: 1
       ZOO_PORT: 2181


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=25.4&sha=c269cee9261fc783af88ce4f50535665f345c167&name_0=ReleaseBranchCI&name_1=Integration%20tests%20%28asan%2C%20old%20analyzer%2C%204%2F6%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)