### PR TITLE
Avoid extra block conversion for Distributed INSERT

### DIFF
--- a/src/Storages/Distributed/DistributedAsyncInsertHelpers.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertHelpers.cpp
@@ -93,7 +93,7 @@ void writeRemoteConvert(
         return;
     }
 
-    if (!blocksHaveEqualStructure(distributed_header.block_header, remote.getHeader()))
+    if (!isCompatibleHeader(distributed_header.block_header, remote.getHeader()))
     {
         LOG_WARNING(log,
             "Structure does not match (remote: {}, local: {}), implicit conversion will be done",

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -93,7 +93,7 @@ namespace ErrorCodes
 
 static Block adoptBlock(const Block & header, const Block & block, LoggerPtr log)
 {
-    if (blocksHaveEqualStructure(header, block))
+    if (isCompatibleHeader(header, block))
         return block;
 
     LOG_WARNING(log,


### PR DESCRIPTION
Ignore column sparseness difference while comparing block for Distributed INSERT

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid extra block conversion for Distributed INSERT