### PR TITLE
Use FunctionArgumentDescriptors to check timezoneOf function

### DIFF
--- a/src/Functions/timezoneOf.cpp
+++ b/src/Functions/timezoneOf.cpp
@@ -65,7 +65,11 @@ public:
     }
 
 private:
-    static bool isDateTimeOrDateTime64(const IDataType & type) { return WhichDataType(type).isDateTimeOrDateTime64(); }
+    static bool isDateTimeOrDateTime64(const IDataType & type)
+    {
+        DataTypePtr type_no_nullable = removeNullable(DataTypePtr(&type, [](const IDataType *) {}));
+        return WhichDataType(*type_no_nullable).isDateTimeOrDateTime64();
+    }
 };
 
 }

--- a/src/Functions/timezoneOf.cpp
+++ b/src/Functions/timezoneOf.cpp
@@ -67,7 +67,8 @@ public:
 private:
     static bool isDateTimeOrDateTime64(const IDataType & type)
     {
-        DataTypePtr type_no_nullable = removeNullable(DataTypePtr(&type, [](const IDataType *) {}));
+        DataTypePtr type_no_nullable = removeNullable(type.getPtr());
+
         return WhichDataType(*type_no_nullable).isDateTimeOrDateTime64();
     }
 };

--- a/src/Functions/timezoneOf.cpp
+++ b/src/Functions/timezoneOf.cpp
@@ -1,5 +1,6 @@
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeDateTime.h>
@@ -8,12 +9,6 @@
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int BAD_ARGUMENTS;
-}
-
 
 namespace
 {
@@ -33,13 +28,15 @@ public:
 
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & types) const override
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & types) const override
     {
-        DataTypePtr type_no_nullable = removeNullable(types[0]);
+        FunctionArgumentDescriptors mandatory_args{
+            {"datetime", &isDateTimeOrDateTime64, nullptr, "DateTime or DateTime64"},
+        };
 
-        if (isDateTime(type_no_nullable) || isDateTime64(type_no_nullable))
-            return std::make_shared<DataTypeString>();
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad argument for function {}, should be DateTime or DateTime64", name);
+        validateFunctionArguments(*this, types, mandatory_args);
+
+        return std::make_shared<DataTypeString>();
     }
 
     DataTypePtr getReturnTypeForDefaultImplementationForDynamic() const override
@@ -66,6 +63,9 @@ public:
         return DataTypeString().createColumnConst(1,
             dynamic_cast<const TimezoneMixin &>(*type_no_nullable).getTimeZone().getTimeZone());
     }
+
+private:
+    static bool isDateTimeOrDateTime64(const IDataType & type) { return WhichDataType(type).isDateTimeOrDateTime64(); }
 };
 
 }

--- a/tests/queries/0_stateless/03525_timezoneof_illegal_type.sql
+++ b/tests/queries/0_stateless/03525_timezoneof_illegal_type.sql
@@ -1,0 +1,1 @@
+SELECT timeZoneOf(1) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use FunctionArgumentDescriptors for `timezoneOf`.

Related Issue: https://github.com/ClickHouse/ClickHouse/issues/67447

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
