### PR TITLE
Disable test `read_in_order_optimization_with_virtual_row` with parallel replicas

### DIFF
--- a/tests/queries/0_stateless/03031_read_in_order_optimization_with_virtual_row.sql
+++ b/tests/queries/0_stateless/03031_read_in_order_optimization_with_virtual_row.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel-replicas
+-- ^ because we are using query_log
 
 SET read_in_order_use_virtual_row = 1;
 SET use_query_condition_cache = 0;
@@ -51,7 +53,7 @@ FROM system.query_log
 WHERE current_database = currentDatabase()
 AND log_comment = 'preliminary merge, no filter'
 AND type = 'QueryFinish'
-ORDER BY query_start_time DESC 
+ORDER BY query_start_time DESC
 limit 1;
 
 SELECT '========';


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7e34b1f791e414d3395bf3cb9c7f6bb3e6e08b15&name_0=MasterCI&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29