### PR TITLE
Fix LOGICAL_ERROR in case of Sparse column in INSERT block pushed to non-MT MV

### DIFF
--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -3,6 +3,7 @@
 
 #include <Access/Common/AccessType.h>
 #include <Access/Common/AccessFlags.h>
+#include <Processors/Transforms/RemovingSparseTransform.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/LiveView/StorageLiveView.h>
@@ -1168,6 +1169,9 @@ Chain InsertDependenciesBuilder::createSink(StorageIDPrivate view_id) const
     /// NOTE It'd better to do this check in serialization of nested structures (in place when this assumption is required),
     /// but currently we don't have methods for serialization of nested structures "as a whole".
     result.addSink(std::make_shared<NestedElementsValidationTransform>(header));
+
+    if (!inner_storage->supportsSparseSerialization())
+        result.addSink(std::make_shared<RemovingSparseTransform>(header));
 
     auto constraints = buildConstraints(inner_metadata, inner_storage);
     if (!constraints.empty())

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -32,7 +32,6 @@
 #include <Processors/Transforms/CheckConstraintsTransform.h>
 #include <Processors/Transforms/CountingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
-#include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
 #include <Processors/Transforms/SquashingTransform.h>
 #include <Processors/Transforms/PlanSquashingTransform.h>
@@ -420,12 +419,6 @@ QueryPipeline InterpreterInsertQuery::addInsertToSelectPipeline(ASTInsertQuery &
     pipeline.addSimpleTransform([&](const Block & in_header) -> ProcessorPtr
     {
         return std::make_shared<ExpressionTransform>(in_header, actions);
-    });
-
-    /// We need to convert Sparse columns to full if the destination storage doesn't support them.
-    pipeline.addSimpleTransform([&](const Block & in_header) -> ProcessorPtr
-    {
-        return std::make_shared<MaterializingTransform>(in_header, !table->supportsSparseSerialization());
     });
 
     pipeline.addSimpleTransform([&](const Block & in_header) -> ProcessorPtr

--- a/src/Processors/Transforms/RemovingSparseTransform.cpp
+++ b/src/Processors/Transforms/RemovingSparseTransform.cpp
@@ -1,0 +1,24 @@
+#include <Processors/Transforms/RemovingSparseTransform.h>
+#include <Columns/ColumnSparse.h>
+
+
+namespace DB
+{
+
+RemovingSparseTransform::RemovingSparseTransform(const Block & header)
+    : ISimpleTransform(header, materializeBlock(header), false)
+{
+}
+
+void RemovingSparseTransform::transform(Chunk & chunk)
+{
+    auto num_rows = chunk.getNumRows();
+    auto columns = chunk.detachColumns();
+
+    for (auto & col : columns)
+        col = recursiveRemoveSparse(col);
+
+    chunk.setColumns(std::move(columns), num_rows);
+}
+
+}

--- a/src/Processors/Transforms/RemovingSparseTransform.h
+++ b/src/Processors/Transforms/RemovingSparseTransform.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <Processors/ISimpleTransform.h>
+
+namespace DB
+{
+
+class RemovingSparseTransform : public ISimpleTransform
+{
+public:
+    explicit RemovingSparseTransform(const Block & header);
+
+    String getName() const override { return "RemovingSparseTransform"; }
+
+protected:
+    void transform(Chunk & chunk) override;
+};
+
+}

--- a/tests/queries/0_stateless/03530_insert_into_distributed_different_types_sparseness.reference
+++ b/tests/queries/0_stateless/03530_insert_into_distributed_different_types_sparseness.reference
@@ -1,0 +1,3 @@
+String, Sparse(size = 1, String(size = 1), UInt64(size = 0))
+100
+100

--- a/tests/queries/0_stateless/03530_insert_into_distributed_different_types_sparseness.sql
+++ b/tests/queries/0_stateless/03530_insert_into_distributed_different_types_sparseness.sql
@@ -1,0 +1,30 @@
+-- Ensure that sparse columns does not leads to any errors/warnings while pushing via Distributed
+
+drop table if exists sparse;
+drop table if exists intermediate;
+drop table if exists non_sparse;
+drop table if exists non_sparse_remote;
+drop table if exists mv_non_sparse;
+drop table if exists log;
+drop table if exists log_remote;
+drop table if exists mv_log;
+
+create table sparse (key String) engine=MergeTree order by () settings ratio_of_defaults_for_sparse_serialization=0.01;
+insert into sparse select ''::String from numbers(100);
+select dumpColumnStructure(*) from sparse limit 1;
+
+-- we need a table that supports sparse columns as intermediate, hence MergeTree
+create table intermediate (key String) engine=MergeTree order by ();
+
+create table non_sparse (key String) engine=MergeTree order by () settings ratio_of_defaults_for_sparse_serialization=1;
+create table non_sparse_remote as remote('127.1', currentDatabase(), non_sparse);
+create materialized view mv_non_sparse to non_sparse_remote as select * from intermediate;
+
+-- now ensure that insert into Log will not break anything
+create table log (key String) engine=Log;
+create table log_remote as remote('127.1', currentDatabase(), log);
+create materialized view mv_log to log as select * from intermediate;
+
+insert into intermediate select * from sparse;
+select count() from non_sparse;
+select count() from mv_log;

--- a/tests/queries/0_stateless/03531_insert_removing_sparse_transform.reference
+++ b/tests/queries/0_stateless/03531_insert_removing_sparse_transform.reference
@@ -1,0 +1,161 @@
+-- { echo }
+
+-- Log does not support sparse columns - RemovingSparseTransform added
+create table t_log (key Int) engine=Log;
+explain pipeline insert into t_log select * from system.one;
+digraph
+{
+  rankdir="LR";
+  { node [shape = rect]
+    n0[label="SourceFromSingleChunk_0"];
+    n1[label="ExpressionTransform_1"];
+    n2[label="ExpressionTransform_2"];
+    n3[label="CountingTransform_3"];
+    n4[label="PlanSquashingTransform_4"];
+    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
+    n6[label="ApplySquashingTransform_10"];
+    n7[label="ConvertingTransform_6"];
+    n8[label="NestedElementsValidationTransform_7"];
+    n9[label="RemovingSparseTransform_8"];
+    n10[label="LogSink_9"];
+    n11[label="EmptySink_11"];
+  }
+  n0 -> n1;
+  n1 -> n2;
+  n2 -> n3;
+  n3 -> n4;
+  n4 -> n5;
+  n5 -> n6;
+  n6 -> n7;
+  n7 -> n8;
+  n8 -> n9;
+  n9 -> n10;
+  n10 -> n11;
+}
+-- MergeTree support sparse columns - no RemovingSparseTransform
+create table t_mt (key Int) engine=MergeTree order by ();
+explain pipeline insert into t_mt select * from system.one;
+digraph
+{
+  rankdir="LR";
+  { node [shape = rect]
+    n0[label="SourceFromSingleChunk_0"];
+    n1[label="ExpressionTransform_1"];
+    n2[label="ExpressionTransform_2"];
+    n3[label="CountingTransform_3"];
+    n4[label="PlanSquashingTransform_4"];
+    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
+    n6[label="ApplySquashingTransform_9"];
+    n7[label="ConvertingTransform_6"];
+    n8[label="NestedElementsValidationTransform_7"];
+    n9[label="MergeTreeSink_8"];
+    n10[label="EmptySink_10"];
+  }
+  n0 -> n1;
+  n1 -> n2;
+  n2 -> n3;
+  n3 -> n4;
+  n4 -> n5;
+  n5 -> n6;
+  n6 -> n7;
+  n7 -> n8;
+  n8 -> n9;
+  n9 -> n10;
+}
+-- MergeTree pushes to Log, which does not support sparse columns - RemovingSparseTransform added
+create materialized view mv to t_log as select * from t_mt;
+explain pipeline insert into t_mt select * from system.one;
+digraph
+{
+  rankdir="LR";
+  { node [shape = rect]
+    n0[label="SourceFromSingleChunk_0"];
+    n1[label="ExpressionTransform_1"];
+    n2[label="ExpressionTransform_2"];
+    n3[label="CountingTransform_3"];
+    n4[label="PlanSquashingTransform_4"];
+    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
+    n6[label="ApplySquashingTransform_18"];
+    n7[label="ConvertingTransform_6"];
+    n8[label="NestedElementsValidationTransform_7"];
+    n9[label="MergeTreeSink_8"];
+    n10[label="Copy_16"];
+    n11[label="BeginingViewsTransform_9"];
+    n12[label="ExecutingInnerQueryFromView_12"];
+    n13[label="CountingTransform_11"];
+    n14[label="SquashingTransform_10"];
+    n15[label="NestedElementsValidationTransform_13"];
+    n16[label="RemovingSparseTransform_14"];
+    n17[label="LogSink_15"];
+    n18[label="FinalizingViewsTransform_17"];
+    n19[label="EmptySink_19"];
+  }
+  n0 -> n1;
+  n1 -> n2;
+  n2 -> n3;
+  n3 -> n4;
+  n4 -> n5;
+  n5 -> n6;
+  n6 -> n7;
+  n7 -> n8;
+  n8 -> n9;
+  n9 -> n10;
+  n10 -> n11;
+  n11 -> n12;
+  n12 -> n13;
+  n13 -> n14;
+  n14 -> n15;
+  n15 -> n16;
+  n16 -> n17;
+  n17 -> n18;
+  n18 -> n19;
+}
+drop table mv;
+-- Log does not support sparse columns - RemovingSparseTransform added
+create materialized view mv to t_mt as select * from t_log;
+explain pipeline insert into t_log select * from system.one;
+digraph
+{
+  rankdir="LR";
+  { node [shape = rect]
+    n0[label="SourceFromSingleChunk_0"];
+    n1[label="ExpressionTransform_1"];
+    n2[label="ExpressionTransform_2"];
+    n3[label="CountingTransform_3"];
+    n4[label="PlanSquashingTransform_4"];
+    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
+    n6[label="ApplySquashingTransform_18"];
+    n7[label="ConvertingTransform_6"];
+    n8[label="NestedElementsValidationTransform_7"];
+    n9[label="RemovingSparseTransform_8"];
+    n10[label="LogSink_9"];
+    n11[label="Copy_16"];
+    n12[label="BeginingViewsTransform_10"];
+    n13[label="ExecutingInnerQueryFromView_13"];
+    n14[label="CountingTransform_12"];
+    n15[label="SquashingTransform_11"];
+    n16[label="NestedElementsValidationTransform_14"];
+    n17[label="MergeTreeSink_15"];
+    n18[label="FinalizingViewsTransform_17"];
+    n19[label="EmptySink_19"];
+  }
+  n0 -> n1;
+  n1 -> n2;
+  n2 -> n3;
+  n3 -> n4;
+  n4 -> n5;
+  n5 -> n6;
+  n6 -> n7;
+  n7 -> n8;
+  n8 -> n9;
+  n9 -> n10;
+  n10 -> n11;
+  n11 -> n12;
+  n12 -> n13;
+  n13 -> n14;
+  n14 -> n15;
+  n15 -> n16;
+  n16 -> n17;
+  n17 -> n18;
+  n18 -> n19;
+}

--- a/tests/queries/0_stateless/03531_insert_removing_sparse_transform.sql
+++ b/tests/queries/0_stateless/03531_insert_removing_sparse_transform.sql
@@ -1,0 +1,30 @@
+-- Tags: no-debug, no-debug, no-asan, no-tsan, no-msan, no-ubsan, no-sanitize-coverage, no-parallel-replicas
+-- - debug build adds CheckTokenTransform
+-- - no-parallel-replicas - has --replace-log-memory-with-mergetree switch
+
+drop table if exists t_log;
+drop table if exists t_mt;
+drop table if exists mv;
+
+set max_threads=1;
+set max_insert_threads=1;
+set deduplicate_blocks_in_dependent_materialized_views=0;
+
+-- { echo }
+
+-- Log does not support sparse columns - RemovingSparseTransform added
+create table t_log (key Int) engine=Log;
+explain pipeline insert into t_log select * from system.one;
+
+-- MergeTree support sparse columns - no RemovingSparseTransform
+create table t_mt (key Int) engine=MergeTree order by ();
+explain pipeline insert into t_mt select * from system.one;
+
+-- MergeTree pushes to Log, which does not support sparse columns - RemovingSparseTransform added
+create materialized view mv to t_log as select * from t_mt;
+explain pipeline insert into t_mt select * from system.one;
+drop table mv;
+
+-- Log does not support sparse columns - RemovingSparseTransform added
+create materialized view mv to t_mt as select * from t_log;
+explain pipeline insert into t_log select * from system.one;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix LOGICAL_ERROR in case of Sparse column in INSERT block pushed to non-MT MV

Previously the following:

    create table sparse (key String) engine=MergeTree order by () settings ratio_of_defaults_for_sparse_serialization=0.01;
    insert into sparse select ''::String from numbers(100);
    create table intermediate (key String) engine=MergeTree order by ();
    create table log (key String) engine=Log;
    create table log_remote as remote('127.1', currentDatabase(), log);
    create materialized view mv_log to log as select * from intermediate;
    insert into intermediate select * from sparse;

Lead to:

    Code: 49. DB::Exception: Received from localhost:9000. DB::Exception: Bad cast from type DB::ColumnSparse to DB::ColumnString: while pushing to view test_y52fdreq.mv_log. (LOGICAL_ERROR)

The reason is that supportsSparseSerialization() is done only for the destination INSERT table, but not to all the tables that are pushed to via materialized views.

Introduce separate transform that will only remove sparseness, and apply it for each table, including tables that are pushed via MVs.
