### PR TITLE
Remove Snyk support file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file
-exclude:
-  global:
-    - tests/**


### PR DESCRIPTION
ClickHouse tried an eval version of Snyk long time ago (2022) but then didn't follow-up. Removing a leftover from the trial.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)