### PR TITLE
Fix incorrect parent_part_offset calculation in unordered MergeTree during merge

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -894,11 +894,14 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::executeImpl() const
         /// Record _part_offset mapping and remove unneeded column
         if (global_ctx->merged_part_offsets && global_ctx->parent_part == nullptr)
         {
-            chassert(block.has("_part_index"));
-            auto part_index_column = block.getByName("_part_index").column->convertToFullColumnIfSparse();
-            const auto & index_data = assert_cast<const ColumnUInt64 &>(*part_index_column).getData();
-            global_ctx->merged_part_offsets->insert(index_data.begin(), index_data.end());
-            block.erase("_part_index");
+            if (global_ctx->merged_part_offsets->isMappingEnabled())
+            {
+                chassert(block.has("_part_index"));
+                auto part_index_column = block.getByName("_part_index").column->convertToFullColumnIfSparse();
+                const auto & index_data = assert_cast<const ColumnUInt64 &>(*part_index_column).getData();
+                global_ctx->merged_part_offsets->insert(index_data.begin(), index_data.end());
+                block.erase("_part_index");
+            }
         }
 
         global_ctx->rows_written += block.rows();
@@ -1059,6 +1062,7 @@ MergeTask::VerticalMergeStage::createPipelineForReadingOneColumn(const String & 
 {
     /// Read from all parts
     std::vector<QueryPlanPtr> plans;
+    size_t part_starting_offset = 0;
     for (size_t part_num = 0; part_num < global_ctx->future_part->parts.size(); ++part_num)
     {
         auto plan_for_part = std::make_unique<QueryPlan>();
@@ -1067,7 +1071,7 @@ MergeTask::VerticalMergeStage::createPipelineForReadingOneColumn(const String & 
             *plan_for_part,
             *global_ctx->data,
             global_ctx->storage_snapshot,
-            RangesInDataPart(global_ctx->future_part->parts[part_num], part_num, 0),
+            RangesInDataPart(global_ctx->future_part->parts[part_num], part_num, part_starting_offset),
             global_ctx->alter_conversions[part_num],
             global_ctx->merged_part_offsets,
             Names{column_name},
@@ -1080,6 +1084,7 @@ MergeTask::VerticalMergeStage::createPipelineForReadingOneColumn(const String & 
             getLogger("VerticalMergeStage"));
 
         plans.emplace_back(std::move(plan_for_part));
+        part_starting_offset += global_ctx->future_part->parts[part_num]->rows_count;
     }
 
     QueryPlan merge_column_query_plan;
@@ -1364,7 +1369,7 @@ bool MergeTask::MergeProjectionsStage::executeProjections() const
 
     /// Release offset mapping when all projections with _part_offset has been merged.
     if (global_ctx->merged_part_offsets && !(*ctx->projections_iterator)->global_ctx->merged_part_offsets)
-        *global_ctx->merged_part_offsets = {};
+        global_ctx->merged_part_offsets->clear();
 
     if ((*ctx->projections_iterator)->execute())
         return true;
@@ -1792,18 +1797,28 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
     for (const auto * projection : global_ctx->projections_to_merge)
     {
         /// If projection needs part offset mapping, add _part_index column to build this mapping
-        if (projection->with_parent_part_offset && global_ctx->metadata_snapshot->hasSortingKey())
+        if (projection->with_parent_part_offset)
         {
-            chassert(global_ctx->merged_part_offsets == nullptr);
-            chassert(std::find(merging_column_names.begin(), merging_column_names.end(), "_part_index") == merging_column_names.end());
-            global_ctx->merged_part_offsets = std::make_shared<MergedPartOffsets>(global_ctx->future_part->parts.size());
-            merging_column_names.push_back("_part_index");
+            if (global_ctx->metadata_snapshot->hasSortingKey())
+            {
+                chassert(global_ctx->merged_part_offsets == nullptr);
+                chassert(std::find(merging_column_names.begin(), merging_column_names.end(), "_part_index") == merging_column_names.end());
+                global_ctx->merged_part_offsets
+                    = std::make_shared<MergedPartOffsets>(global_ctx->future_part->parts.size(), MergedPartOffsets::MappingMode::Enabled);
+                merging_column_names.push_back("_part_index");
+            }
+            else
+            {
+                global_ctx->merged_part_offsets
+                    = std::make_shared<MergedPartOffsets>(global_ctx->future_part->parts.size(), MergedPartOffsets::MappingMode::Disabled);
+            }
             break;
         }
     }
 
     /// Read from all parts
     std::vector<QueryPlanPtr> plans;
+    size_t part_starting_offset = 0;
     for (size_t i = 0; i < global_ctx->future_part->parts.size(); ++i)
     {
         if (global_ctx->future_part->parts[i]->getMarksCount() == 0)
@@ -1815,7 +1830,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
             *plan_for_part,
             *global_ctx->data,
             global_ctx->storage_snapshot,
-            RangesInDataPart(global_ctx->future_part->parts[i], i, 0),
+            RangesInDataPart(global_ctx->future_part->parts[i], i, part_starting_offset),
             global_ctx->alter_conversions[i],
             global_ctx->merged_part_offsets,
             merging_column_names,
@@ -1828,6 +1843,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
             ctx->log);
 
         plans.emplace_back(std::move(plan_for_part));
+        part_starting_offset += global_ctx->future_part->parts[i]->rows_count;
     }
 
     QueryPlan merge_parts_query_plan;

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -143,6 +143,7 @@ void MergeTreeReadPoolBase::fillPerPartInfos(const Settings & settings)
         read_task_info.data_part = part_with_ranges.data_part;
 
         const auto & data_part = read_task_info.data_part;
+        /// TODO(ab): Hold parent part in RangesInDataParts during projection analysis
         if (data_part->isProjectionPart())
         {
             read_task_info.parent_part = data_part->storage.getPartIfExists(
@@ -174,7 +175,8 @@ void MergeTreeReadPoolBase::fillPerPartInfos(const Settings & settings)
                 .withSubcolumns();
 
             auto columns_list = storage_snapshot->getColumnsByNames(options, column_names);
-            auto mutation_steps = read_task_info.alter_conversions->getMutationSteps(part_info, columns_list, storage_snapshot->metadata, getContext());
+            auto mutation_steps
+                = read_task_info.alter_conversions->getMutationSteps(part_info, columns_list, storage_snapshot->metadata, getContext());
             std::move(mutation_steps.begin(), mutation_steps.end(), std::back_inserter(read_task_info.mutation_steps));
         }
 

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -229,8 +229,16 @@ try
             result_column = result_column->convertToFullColumnIfSparse();
             auto & column = result_column->assumeMutableRef();
             auto & offset_data = assert_cast<ColumnUInt64 &>(column).getData();
-            for (auto & offset : offset_data)
-                offset = (*read_task_info->merged_part_offsets)[read_task_info->part_index_in_query, offset];
+            if (read_task_info->merged_part_offsets->isMappingEnabled())
+            {
+                for (auto & offset : offset_data)
+                    offset = (*read_task_info->merged_part_offsets)[read_task_info->part_index_in_query, offset];
+            }
+            else
+            {
+                for (auto & offset : offset_data)
+                    offset += read_task_info->part_starting_offset_in_query;
+            }
         }
         result_column->assumeMutableRef().shrinkToFit();
     }

--- a/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.reference
+++ b/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.reference
@@ -1,0 +1,33 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS test;
+CREATE TABLE test
+(
+    `a` Int32,
+    `b` Int32,
+    PROJECTION p
+    (
+        SELECT
+            a,
+            b,
+            _part_offset
+        ORDER BY b
+    )
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+-- Insert enough rows so that future projection materialization test will trigger level 1 merge
+INSERT INTO test SELECT number * 3, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(360000);
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
+1080000
+OPTIMIZE TABLE test FINAL;
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
+1080000
+ALTER TABLE test ADD PROJECTION p2 (SELECT a, b, _part_offset ORDER BY b);
+ALTER TABLE test MATERIALIZE PROJECTION p2 SETTINGS mutations_sync = 2;
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p2) r USING (a) SETTINGS enable_analyzer = 1;
+1080000
+DROP TABLE test;

--- a/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.sql
+++ b/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.sql
@@ -1,0 +1,35 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test
+(
+    `a` Int32,
+    `b` Int32,
+    PROJECTION p
+    (
+        SELECT
+            a,
+            b,
+            _part_offset
+        ORDER BY b
+    )
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+
+-- Insert enough rows so that future projection materialization test will trigger level 1 merge
+INSERT INTO test SELECT number * 3, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(360000);
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
+
+OPTIMIZE TABLE test FINAL;
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
+
+ALTER TABLE test ADD PROJECTION p2 (SELECT a, b, _part_offset ORDER BY b);
+ALTER TABLE test MATERIALIZE PROJECTION p2 SETTINGS mutations_sync = 2;
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p2) r USING (a) SETTINGS enable_analyzer = 1;
+
+DROP TABLE test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect `parent_part_offset` calculation in unordered MergeTree during merge. This addresses https://github.com/ClickHouse/ClickHouse/pull/78429#issuecomment-2925591105 . Mark as not for changelog, as this is part of ongoing work on projection index which is not landed yet.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
