### PR TITLE
rust: make sure that correct C++ std library will be used

### DIFF
--- a/contrib/chdig-cmake/CMakeLists.txt
+++ b/contrib/chdig-cmake/CMakeLists.txt
@@ -19,14 +19,6 @@ endif()
 clickhouse_import_crate(MANIFEST_PATH ../chdig/Cargo.toml ALL_FEATURES CRATE_TYPES bin)
 clickhouse_config_crate_flags(chdig)
 
-# See [1] for more details, but basically:
-# - we need to explicitly set CXXSTDLIB to avoid using of libstdc++
-# - link with the library explicitly to add search path (-L)
-#
-#   [1]: https://github.com/rust-lang/cc-rs/blob/7666d4f4f36d3bcacce9ab72fc6538fcc0ea1716/src/lib.rs#L762-L775
-corrosion_set_env_vars(chdig "CXXSTDLIB=cxx")
-corrosion_link_libraries(chdig cxx)
-
 corrosion_link_libraries(chdig unwind)
 
 # Add dummy libraries to satisfy dependencies for libc crate.

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -177,4 +177,12 @@ function(clickhouse_config_crate_flags target_name)
     if (NOT "${RUST_CARGO_BUILD_STD}" STREQUAL "")
         corrosion_set_cargo_flags(${target_name} "${RUST_CARGO_BUILD_STD}")
     endif()
+
+    # See [1] for more details, but basically:
+    # - we need to explicitly set CXXSTDLIB to avoid using of libstdc++
+    # - link with the library explicitly to add search path (-L)
+    #
+    #   [1]: https://github.com/rust-lang/cc-rs/blob/7666d4f4f36d3bcacce9ab72fc6538fcc0ea1716/src/lib.rs#L762-L775
+    corrosion_set_env_vars(${target_name} "CXXSTDLIB=cxx")
+    corrosion_link_libraries(${target_name} cxx)
 endfunction()


### PR DESCRIPTION
Before skim uses libstdc++:

    $ grep -F -r rustc-link-lib=stdc cargo/
    cargo/build/workspace_eda9b/x86_64-unknown-linux-gnu/release/build/link-cplusplus-41bb5f8b9484a20d/output:cargo:rustc-link-lib=stdc++

But this is minor, since it was not a problem due to skim was only a library so ClickHouse was not linked with stdc++ eventually

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc @Algunenano @thevar1able 