### PR TITLE
Fix GH commit POST with large descriptions

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -146,7 +146,10 @@ class GH:
         :param repo:
         :return: True or False in case of error
         """
-        description = description.replace("'", "'\"'\"'")  # escape single quote
+        description_max_size = 80  # GH limits to 140, but 80 is reasonable
+        description = description[:description_max_size].replace(
+            "'", "'\"'\"'"
+        )  # escape single quote
         status = cls.convert_to_gh_status(status)
         repo = _Environment.get().REPOSITORY
         command = (
@@ -171,6 +174,10 @@ class GH:
         :param commit_sha: Commit in a foreign repo
         :return: True or False in case of error
         """
+        description_max_size = 80  # GH limits to 140, but 80 is reasonable
+        description = description[:description_max_size].replace(
+            "'", "'\"'\"'"
+        )  # escape single quote
         status = cls.convert_to_gh_status(status)
         command = (
             f"gh api -X POST -H 'Accept: application/vnd.github.v3+json' "


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix GH commit POST with large descriptions

Related: https://github.com/ClickHouse/ClickHouse/actions/runs/15393679073/job/43313171567?pr=81016

```
err:[gh: Validation failed: Description is too long (maximum is 140 characters) (Validation Failed)] after [0] attempts
2025-06-02T14:57:50.6148167Z ERROR: Failed to post commit status for the job
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
