### PR TITLE
Fix: check is ttl finished before update it

### DIFF
--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -236,8 +236,14 @@ void TTLAggregationAlgorithm::finalizeAggregates(MutableColumns & result_columns
 
 void TTLAggregationAlgorithm::finalize(const MutableDataPartPtr & data_part) const
 {
-    data_part->ttl_infos.group_by_ttl[description.result_column] = new_ttl_info;
-    data_part->ttl_infos.updatePartMinMaxTTL(new_ttl_info.min, new_ttl_info.max);
+    if (new_ttl_info.ttl_finished)
+    {
+        data_part->ttl_infos.group_by_ttl[description.result_column] = new_ttl_info;
+        data_part->ttl_infos.updatePartMinMaxTTL(new_ttl_info.min, new_ttl_info.max);
+        return;
+    }
+    data_part->ttl_infos.group_by_ttl[description.result_column] = old_ttl_info;
+    data_part->ttl_infos.updatePartMinMaxTTL(old_ttl_info.min, old_ttl_info.max);
 }
 
 }

--- a/tests/integration/test_ttl_multilevel_group_by/test.py
+++ b/tests/integration/test_ttl_multilevel_group_by/test.py
@@ -1,0 +1,101 @@
+import time
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", with_minio=False)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def wait_until(condition_fn, timeout=10, interval=1, fail_message="Condition not met in time"):
+    """
+    Repeatedly calls condition_fn until it returns True or timeout is reached.
+    """
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        if condition_fn():
+            return
+        time.sleep(interval)
+    assert False, fail_message
+
+
+def test_two_stage_ttl_group_by(started_cluster):
+    node = cluster.instances["node"]
+
+    node.query("DROP TABLE IF EXISTS test_ttl_group_by")
+
+    # Create table with two TTL GROUP BY rules:
+    #   1. After 3 seconds, aggregate by user_id, item_id using SUM
+    #   2. After 7 seconds, aggregate by user_id using SUM
+    node.query("""
+    CREATE TABLE test_ttl_group_by (
+        event_date DateTime,
+        user_id Int32,
+        item_id Int32,
+        val Float32,
+        rolled_by_item_id DateTime DEFAULT event_date,
+        rolled_by_user_id DateTime DEFAULT event_date
+    ) ENGINE = MergeTree()
+        PRIMARY KEY (event_date, user_id, item_id)
+        TTL rolled_by_item_id + INTERVAL 4 SECOND
+            GROUP BY event_date, user_id, item_id
+            SET val = sum(val),
+                rolled_by_item_id = max(rolled_by_item_id) + INTERVAL 10 YEAR,
+        rolled_by_user_id + INTERVAL 7 SECOND
+            GROUP BY event_date, user_id
+            SET val = sum(val),
+                rolled_by_user_id = max(rolled_by_user_id) + INTERVAL 10 YEAR
+        SETTINGS merge_with_ttl_timeout = 0;
+    """)
+
+    # Insert 10 rows with current timestamp, evenly distributed across 2 user_ids and 3 items
+    node.query("""
+        INSERT INTO test_ttl_group_by
+        SELECT
+            now() AS event_date,  -- Указываем фиксированное время
+            number % 2 AS user_id,
+            user_id * 10 + (number % 3) AS item_id,
+            1 AS val,
+            event_date AS rolled_by_item_id,
+            event_date AS rolled_by_user_id
+        FROM numbers(10);
+    """)
+
+    def get_row_count():
+        return int(node.query("SELECT count() FROM test_ttl_group_by").strip())
+
+    # Step 1: Ensure all 10 rows were inserted
+    wait_until(lambda: get_row_count() == 10, timeout=3, fail_message="Initial insert failed")
+
+    # Step 2: Wait for the first TTL (2 seconds) to apply — should reduce to 6 rows (one per item_id)
+    wait_until(
+        lambda: get_row_count() == 6,
+        timeout=10,
+        fail_message="First TTL was not applied"
+    )
+
+    row_count_after_first_ttl = get_row_count()
+    assert row_count_after_first_ttl == 6, \
+        f"Expected = 6 rows after first TTL, got: {row_count_after_first_ttl}"
+
+    # Step 3: Wait for second TTL (7 seconds since insert) to apply — should reduce to 2 rows (one per user_id)
+    wait_until(lambda: get_row_count() == 2, timeout=10, fail_message="Second TTL was not applied")
+
+    row_count_after_second_ttl = get_row_count()
+    assert row_count_after_second_ttl == 2, \
+        f"Expected = 2 rows after second TTL, got: {row_count_after_second_ttl}"
+
+    row_after_second_ttl = node.query("SELECT user_id, val FROM test_ttl_group_by ORDER BY user_id FORMAT TSV")
+
+    rows = row_after_second_ttl.strip().splitlines()
+    for line in rows:
+        user_id_str, value_str = line.strip().split("\t")
+        assert int(value_str) == 5, "Invalid value after TTL aggregation"


### PR DESCRIPTION
### Changelog category:
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrent TTL recalculation in TTL GROUP BY when updating TTL

### Documentation entry for user-facing changes

- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

Currently, when the TTL date triggered in group_by_ttl_info, all TTLs are updated during a merge. However, if some TTLs have not yet been reached, they are not recalculated properly, causing them to be reset. This fix ensures that TTLs that have not yet been triggered are correctly preserved when date is updated.

The worker [checks](https://github.com/ClickHouse/ClickHouse/blob/965312e93d1b0ec3e1c50ec40e93cfd1304b2af1/src/Processors/TTL/TTLAggregationAlgorithm.cpp#L108) whether a TTL has expired. If it has expired and there is data to aggregate, new_ttl_info is [set](https://github.com/ClickHouse/ClickHouse/blob/965312e93d1b0ec3e1c50ec40e93cfd1304b2af1/src/Processors/TTL/TTLAggregationAlgorithm.cpp#L185). However, for TTLs that have not yet expired, new_ttl_info is correctly left unset. Later in [finalize](https://github.com/ClickHouse/ClickHouse/blob/965312e93d1b0ec3e1c50ec40e93cfd1304b2af1/src/Processors/Transforms/TTLTransform.cpp#L163), all TTLs are updated. However, since the non-expired TTLs were not recalculated, they sets to empty struct with TTLs of 0 (1970-01-01), meaning they will never expire

- Example use: A query or command.

### Simple example

simple_test_ttl_group_by must group by data in two levels. After group by ttl will trigger next time in 10 days.

```sql
CREATE TABLE simple_test_ttl_group_by (
    event_date DateTime,
    user_id Int32,
    item_id Int32,
    val Float32,
    rolled_by_item_id DateTime DEFAULT event_date,
    rolled_by_user_id DateTime DEFAULT event_date
) ENGINE = MergeTree()
      PRIMARY KEY (event_date, user_id, item_id)
      TTL rolled_by_item_id + INTERVAL 15 SECOND
          GROUP BY event_date, user_id, item_id
          SET val = sum(val),
          rolled_by_item_id = max(rolled_by_item_id) + INTERVAL 10 DAY,
      rolled_by_user_id + INTERVAL 1 MINUTE
          GROUP BY event_date, user_id
          SET val = sum(val),
              rolled_by_user_id = max(rolled_by_user_id) + INTERVAL 10 DAY
      SETTINGS merge_with_ttl_timeout = 30;


INSERT INTO simple_test_ttl_group_by
SELECT
    now() AS event_date,
    number % 2 AS user_id,
    user_id * 10 + (number % 3) AS item_id,
    number AS val,
    event_date AS rolled_by_item_id,
    event_date as rolled_by_user_id
FROM numbers(10);

SELECT * FROM simple_test_ttl_group_by;

SELECT * FROM system.parts WHERE  active = 1 and table = 'simple_test_ttl_group_by';
```

a. Run code

```   
    ┌──────────event_date─┬─user_id─┬─item_id─┬─val─┬───rolled_by_item_id─┬───rolled_by_user_id─┐
 1. │ 2025-02-18 13:51:49 │       0 │       0 │   0 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 2. │ 2025-02-18 13:51:49 │       0 │       0 │   6 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 3. │ 2025-02-18 13:51:49 │       0 │       1 │   4 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 4. │ 2025-02-18 13:51:49 │       0 │       2 │   2 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 5. │ 2025-02-18 13:51:49 │       0 │       2 │   8 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 6. │ 2025-02-18 13:51:49 │       1 │      10 │   3 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 7. │ 2025-02-18 13:51:49 │       1 │      10 │   9 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 8. │ 2025-02-18 13:51:49 │       1 │      11 │   1 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
 9. │ 2025-02-18 13:51:49 │       1 │      11 │   7 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
10. │ 2025-02-18 13:51:49 │       1 │      12 │   5 │ 2025-02-18 13:51:49 │ 2025-02-18 13:51:49 │
    └─────────────────────┴─────────┴─────────┴─────┴─────────────────────┴─────────────────────┘ 
```

and 

```
...
group_by_ttl_info.expression:          ['rolled_by_item_id + toIntervalSecond(15)','rolled_by_user_id + toIntervalMinute(1)']
group_by_ttl_info.min:                 ['2025-02-18 13:52:04','2025-02-18 13:52:49']
group_by_ttl_info.max:                 ['2025-02-18 13:52:04','2025-02-18 13:52:49']
...
```

b. Check data in 15 seconds

```
   ┌──────────event_date─┬─user_id─┬─item_id─┬─val─┬───rolled_by_item_id─┬───rolled_by_user_id─┐
1. │ 2025-02-18 13:51:49 │       0 │       0 │   6 │ 2025-02-28 13:51:49 │ 2025-02-18 13:51:49 │
2. │ 2025-02-18 13:51:49 │       0 │       1 │   4 │ 2025-02-28 13:51:49 │ 2025-02-18 13:51:49 │
3. │ 2025-02-18 13:51:49 │       0 │       2 │  10 │ 2025-02-28 13:51:49 │ 2025-02-18 13:51:49 │
4. │ 2025-02-18 13:51:49 │       1 │      10 │  12 │ 2025-02-28 13:51:49 │ 2025-02-18 13:51:49 │
5. │ 2025-02-18 13:51:49 │       1 │      11 │   8 │ 2025-02-28 13:51:49 │ 2025-02-18 13:51:49 │
6. │ 2025-02-18 13:51:49 │       1 │      12 │   5 │ 2025-02-28 13:51:49 │ 2025-02-18 13:51:49 │
   └─────────────────────┴─────────┴─────────┴─────┴─────────────────────┴─────────────────────┘
```

c. Run: `SELECT * FROM system.parts WHERE  active = 1 and table = 'simple_test_ttl_group_by';`

```
...
group_by_ttl_info.expression:          ['rolled_by_item_id + toIntervalSecond(15)','rolled_by_user_id + toIntervalMinute(1)']
group_by_ttl_info.min:                 ['2025-02-28 13:52:04','1970-01-01 03:00:00']
group_by_ttl_info.max:                 ['2025-02-28 13:52:04','1970-01-01 03:00:00']
...
```

So last ttl will never trigger.

Run code on build with fix:

a. Run code

```     
    ┌──────────event_date─┬─user_id─┬─item_id─┬─val─┬───rolled_by_item_id─┬───rolled_by_user_id─┐
 1. │ 2025-02-18 13:53:36 │       0 │       0 │   0 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 2. │ 2025-02-18 13:53:36 │       0 │       0 │   6 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 3. │ 2025-02-18 13:53:36 │       0 │       1 │   4 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 4. │ 2025-02-18 13:53:36 │       0 │       2 │   2 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 5. │ 2025-02-18 13:53:36 │       0 │       2 │   8 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 6. │ 2025-02-18 13:53:36 │       1 │      10 │   3 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 7. │ 2025-02-18 13:53:36 │       1 │      10 │   9 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 8. │ 2025-02-18 13:53:36 │       1 │      11 │   1 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
 9. │ 2025-02-18 13:53:36 │       1 │      11 │   7 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
10. │ 2025-02-18 13:53:36 │       1 │      12 │   5 │ 2025-02-18 13:53:36 │ 2025-02-18 13:53:36 │
    └─────────────────────┴─────────┴─────────┴─────┴─────────────────────┴─────────────────────┘      
```

and

```
...
group_by_ttl_info.expression:          ['rolled_by_item_id + toIntervalSecond(15)','rolled_by_user_id + toIntervalMinute(1)']
group_by_ttl_info.min:                 ['2025-02-18 13:53:51','2025-02-18 13:54:36']
group_by_ttl_info.max:                 ['2025-02-18 13:53:51','2025-02-18 13:54:36']
...
```

b. Check data in 15 seconds

```
   ┌──────────event_date─┬─user_id─┬─item_id─┬─val─┬───rolled_by_item_id─┬───rolled_by_user_id─┐
1. │ 2025-02-18 13:53:36 │       0 │       0 │   6 │ 2025-02-28 13:53:36 │ 2025-02-18 13:53:36 │
2. │ 2025-02-18 13:53:36 │       0 │       1 │   4 │ 2025-02-28 13:53:36 │ 2025-02-18 13:53:36 │
3. │ 2025-02-18 13:53:36 │       0 │       2 │  10 │ 2025-02-28 13:53:36 │ 2025-02-18 13:53:36 │
4. │ 2025-02-18 13:53:36 │       1 │      10 │  12 │ 2025-02-28 13:53:36 │ 2025-02-18 13:53:36 │
5. │ 2025-02-18 13:53:36 │       1 │      11 │   8 │ 2025-02-28 13:53:36 │ 2025-02-18 13:53:36 │
6. │ 2025-02-18 13:53:36 │       1 │      12 │   5 │ 2025-02-28 13:53:36 │ 2025-02-18 13:53:36 │
   └─────────────────────┴─────────┴─────────┴─────┴─────────────────────┴─────────────────────┘
```

and

``` 
...
group_by_ttl_info.expression:                ['rolled_by_item_id + toIntervalSecond(15)','rolled_by_user_id + toIntervalMinute(1)']
group_by_ttl_info.min:                       ['2025-02-28 13:53:51','2025-02-18 13:54:36']
group_by_ttl_info.max:                       ['2025-02-28 13:53:51','2025-02-18 13:54:36']
...
```

c. Check data in 1 minute

```
   ┌──────────event_date─┬─user_id─┬─item_id─┬─val─┬───rolled_by_item_id─┬───rolled_by_user_id─┐
1. │ 2025-02-18 13:53:36 │       0 │       0 │  20 │ 2025-02-28 13:53:36 │ 2025-02-28 13:53:36 │
2. │ 2025-02-18 13:53:36 │       1 │      10 │  25 │ 2025-02-28 13:53:36 │ 2025-02-28 13:53:36 │
   └─────────────────────┴─────────┴─────────┴─────┴─────────────────────┴─────────────────────┘
```

and

```
...
group_by_ttl_info.expression:                ['rolled_by_item_id + toIntervalSecond(15)','rolled_by_user_id + toIntervalMinute(1)']
group_by_ttl_info.min:                       ['2025-02-28 13:53:51','2025-02-28 13:54:36']
group_by_ttl_info.max:                       ['2025-02-28 13:53:51','2025-02-28 13:54:36']
...
```

So fix works.

### Example of multilevel ttl

Let's use the code of [multilevel ttl](https://kb.altinity.com/altinity-kb-queries-and-syntax/ttl/ttl-group-by-examples/#multilevel-ttl-group-by)

a. Run script before start merges.
b. Run: "SELECT * FROM system.parts WHERE  active = 1 and table = 'test_ttl_group_by';"

```
...
group_by_ttl_info.expression:     ['ts + toIntervalDay(1)','ts + toIntervalDay(30)','ts + toIntervalHour(1)']
group_by_ttl_info.min:                 ['2025-02-19 10:58:23','2025-03-20 10:58:23','2025-02-18 11:58:23']
group_by_ttl_info.max:                ['2025-02-19 11:00:02','2025-03-20 11:00:02','2025-02-18 12:00:02']
...
```
There are three TTL, part will trigger when starts merges.

c. Run merges

```
group_by_ttl_info.expression:     ['ts + toIntervalDay(1)','ts + toIntervalDay(30)','ts + toIntervalHour(1)']
group_by_ttl_info.min:                 ['2025-02-17 00:00:00','1970-01-01 03:00:00','2025-02-16 01:00:00']
group_by_ttl_info.max:                ['2025-02-19 11:00:02','1970-01-01 03:00:00','2025-02-18 12:00:02']
```

So, some data will never expire but `ts + toIntervalDay(30)` ttl.

Fix checks if ttl finished and in that case update it. Let's run code with fix.

a. Run script before start merges.
b. Run: "SELECT * FROM system.parts WHERE  active = 1 and table = 'test_ttl_group_by';"

```
...
group_by_ttl_info.expression:           ['ts + toIntervalDay(1)','ts + toIntervalDay(30)','ts + toIntervalHour(1)']
group_by_ttl_info.min:                       ['2025-02-17 12:10:51','2025-03-18 12:10:51','2025-02-16 13:10:51']
group_by_ttl_info.max:                      ['2025-02-17 12:12:30','2025-03-18 12:12:30','2025-02-16 13:12:30']
...
```

c. Run merges

```
group_by_ttl_info.expression:           ['ts + toIntervalDay(1)','ts + toIntervalDay(30)','ts + toIntervalHour(1)']
group_by_ttl_info.min:                       ['2025-02-17 12:10:51','2025-03-18 12:10:51','2025-02-16 13:00:00']
group_by_ttl_info.max:                      ['2025-02-19 12:12:29','2025-03-20 12:12:29','2025-02-18 13:12:29']
```

TTL was updated without reset.

