### PR TITLE
Fix clang20 build

### DIFF
--- a/src/Storages/Kafka/KafkaConsumer2.h
+++ b/src/Storages/Kafka/KafkaConsumer2.h
@@ -126,7 +126,6 @@ private:
     StalledStatus stalled_status = StalledStatus::NO_MESSAGES_RETURNED;
 
     const std::atomic<bool> & stopped;
-    bool is_subscribed = false;
 
     // order is important, need to be destructed before consumer
     Messages messages;


### PR DESCRIPTION
clang 20 reports:

    clickhouse/src/Storages/Kafka/KafkaConsumer2.h:129:10: error: private field 'is_subscribed' is not used [-Werror,-Wunused-private-field]

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #81235