### PR TITLE
Split Keeper replication out of `ReplicatedAccessStorage` for shared use

### DIFF
--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -477,7 +477,7 @@ AccessEntityPtr DiskAccessStorage::readImpl(const UUID & id, bool throw_if_not_e
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return nullptr;
     }
@@ -496,7 +496,7 @@ std::optional<std::pair<String, AccessEntityType>> DiskAccessStorage::readNameWi
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return std::nullopt;
     }
@@ -531,7 +531,7 @@ bool DiskAccessStorage::insertNoLock(const UUID & id, const AccessEntityPtr & ne
     {
         if (throw_if_exists)
         {
-            throwNameCollisionCannotInsert(type, name);
+            throwNameCollisionCannotInsert(type, name, getStorageName());
         }
         else
         {
@@ -548,7 +548,7 @@ bool DiskAccessStorage::insertNoLock(const UUID & id, const AccessEntityPtr & ne
         if (throw_if_exists)
         {
             const auto & existing_entry = it_by_id->second;
-            throwIDCollisionCannotInsert(id, type, name, existing_entry.type, existing_entry.name);
+            throwIDCollisionCannotInsert(id, type, name, existing_entry.type, existing_entry.name, getStorageName());
         }
         else
         {
@@ -622,7 +622,7 @@ bool DiskAccessStorage::removeNoLock(const UUID & id, bool throw_if_not_exists, 
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return false;
     }
@@ -663,7 +663,7 @@ bool DiskAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & update_
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return false;
     }
@@ -692,7 +692,7 @@ bool DiskAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & update_
     if (name_changed)
     {
         if (entries_by_name.contains(new_name))
-            throwNameCollisionCannotRename(type, old_name, new_name);
+            throwNameCollisionCannotRename(type, old_name, new_name, getStorageName());
         if (write_on_disk)
             scheduleWriteLists(type);
     }

--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -92,7 +92,7 @@ UUID IAccessStorage::getID(AccessEntityType type, const String & name) const
     auto id = findImpl(type, name);
     if (id)
         return *id;
-    throwNotFound(type, name);
+    throwNotFound(type, name, storage_name);
 }
 
 
@@ -576,7 +576,7 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
     }
 
     if (throw_if_user_not_exists)
-        throwNotFound(AccessEntityType::USER, credentials.getUserName());
+        throwNotFound(AccessEntityType::USER, credentials.getUserName(), storage_name);
     else
         return std::nullopt;
 }
@@ -748,17 +748,15 @@ LoggerPtr IAccessStorage::getLogger() const
     return log;
 }
 
-
-void IAccessStorage::throwNotFound(const UUID & id) const
+void IAccessStorage::throwNotFound(const UUID & id, const String & storage_name)
 {
-    throw Exception(ErrorCodes::ACCESS_ENTITY_NOT_FOUND, "{} not found in {}", outputID(id), getStorageName());
+    throw Exception(ErrorCodes::ACCESS_ENTITY_NOT_FOUND, "{} not found in {}", outputID(id), backQuote(storage_name));
 }
 
-
-void IAccessStorage::throwNotFound(AccessEntityType type, const String & name) const
+void IAccessStorage::throwNotFound(AccessEntityType type, const String & name, const String & storage_name)
 {
     int error_code = AccessEntityTypeInfo::get(type).not_found_error_code;
-    throw Exception(error_code, "There is no {} in {}", formatEntityTypeWithName(type, name), getStorageName());
+    throw Exception(error_code, "There is no {} in {}", formatEntityTypeWithName(type, name), backQuote(storage_name));
 }
 
 
@@ -768,26 +766,23 @@ void IAccessStorage::throwBadCast(const UUID & id, AccessEntityType type, const 
         formatEntityTypeWithName(type, name), toString(required_type));
 }
 
-
-void IAccessStorage::throwIDCollisionCannotInsert(const UUID & id, AccessEntityType type, const String & name, AccessEntityType existing_type, const String & existing_name) const
+void IAccessStorage::throwIDCollisionCannotInsert(
+    const UUID & id, AccessEntityType type, const String & name, AccessEntityType existing_type, const String & existing_name, const String & storage_name)
 {
-    throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "{}: "
-        "cannot insert because the {} is already used by {} in {}", formatEntityTypeWithName(type, name),
-        outputID(id), formatEntityTypeWithName(existing_type, existing_name), getStorageName());
+    throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "{}: cannot insert because the {} is already used by {} in {}", formatEntityTypeWithName(type, name),
+        outputID(id), formatEntityTypeWithName(existing_type, existing_name), backQuote(storage_name));
 }
 
-
-void IAccessStorage::throwNameCollisionCannotInsert(AccessEntityType type, const String & name) const
+void IAccessStorage::throwNameCollisionCannotInsert(AccessEntityType type, const String & name, const String & storage_name)
 {
     throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "{}: cannot insert because {} already exists in {}",
-                    formatEntityTypeWithName(type, name), formatEntityTypeWithName(type, name), getStorageName());
+                    formatEntityTypeWithName(type, name), formatEntityTypeWithName(type, name), backQuote(storage_name));
 }
 
-
-void IAccessStorage::throwNameCollisionCannotRename(AccessEntityType type, const String & old_name, const String & new_name) const
+void IAccessStorage::throwNameCollisionCannotRename(AccessEntityType type, const String & old_name, const String & new_name, const String & storage_name)
 {
     throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "{}: cannot rename to {} because {} already exists in {}",
-        formatEntityTypeWithName(type, old_name), backQuote(new_name), formatEntityTypeWithName(type, new_name), getStorageName());
+        formatEntityTypeWithName(type, old_name), backQuote(new_name), formatEntityTypeWithName(type, new_name), backQuote(storage_name));
 }
 
 

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -217,6 +217,14 @@ public:
     virtual void backup(BackupEntriesCollector & backup_entries_collector, const String & data_path_in_backup, AccessEntityType type) const;
     virtual void restoreFromBackup(RestorerFromBackup & restorer, const String & data_path_in_backup);
 
+    // Static versions for use in non-member functions (ZookeeperReplicator)
+    [[noreturn]] static void throwIDCollisionCannotInsert(
+        const UUID & id, AccessEntityType type, const String & name, AccessEntityType existing_type, const String & existing_name, const String & storage_name);
+    [[noreturn]] static void throwNameCollisionCannotInsert(AccessEntityType type, const String & name, const String & storage_name);
+    [[noreturn]] static void throwNameCollisionCannotRename(AccessEntityType type, const String & old_name, const String & new_name, const String & storage_name);
+    [[noreturn]] static void throwNotFound(const UUID & id, const String & storage_name);
+    [[noreturn]] static void throwNotFound(AccessEntityType type, const String & name, const String & storage_name);
+
 protected:
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const = 0;
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
@@ -247,13 +255,7 @@ protected:
     static String formatEntityTypeWithName(AccessEntityType type, const String & name) { return AccessEntityTypeInfo::get(type).formatEntityNameWithType(name); }
     static void clearConflictsInEntitiesList(std::vector<std::pair<UUID, AccessEntityPtr>> & entities, LoggerPtr log_);
     virtual bool acquireReplicatedRestore(RestorerFromBackup &) const { return false; }
-    [[noreturn]] void throwNotFound(const UUID & id) const;
-    [[noreturn]] void throwNotFound(AccessEntityType type, const String & name) const;
     [[noreturn]] static void throwBadCast(const UUID & id, AccessEntityType type, const String & name, AccessEntityType required_type);
-    [[noreturn]] void throwIDCollisionCannotInsert(
-    const UUID & id, AccessEntityType type, const String & name, AccessEntityType existing_type, const String & existing_name) const;
-    [[noreturn]] void throwNameCollisionCannotInsert(AccessEntityType type, const String & name) const;
-    [[noreturn]] void throwNameCollisionCannotRename(AccessEntityType type, const String & old_name, const String & new_name) const;
     [[noreturn]] void throwReadonlyCannotInsert(AccessEntityType type, const String & name) const;
     [[noreturn]] void throwReadonlyCannotUpdate(AccessEntityType type, const String & name) const;
     [[noreturn]] void throwReadonlyCannotRemove(AccessEntityType type, const String & name) const;
@@ -303,7 +305,7 @@ std::shared_ptr<const EntityClassT> IAccessStorage::read(const String & name, bo
     if (auto id = find<EntityClassT>(name))
         return read<EntityClassT>(*id, throw_if_not_exists);
     if (throw_if_not_exists)
-        throwNotFound(EntityClassT::TYPE, name);
+        throwNotFound(EntityClassT::TYPE, name, storage_name);
     else
         return nullptr;
 }

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -485,7 +485,7 @@ std::optional<AuthResult> LDAPAccessStorage::authenticateImpl(
         // We treat this situation as if there is no such user because we don't want to block
         // other storages following this LDAPAccessStorage from trying to authenticate on their own.
         if (throw_if_user_not_exists)
-            throwNotFound(AccessEntityType::USER, credentials.getUserName());
+            throwNotFound(AccessEntityType::USER, credentials.getUserName(), getStorageName());
         else
             return {};
     }

--- a/src/Access/MemoryAccessStorage.cpp
+++ b/src/Access/MemoryAccessStorage.cpp
@@ -52,7 +52,7 @@ AccessEntityPtr MemoryAccessStorage::readImpl(const UUID & id, bool throw_if_not
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return nullptr;
     }
@@ -85,7 +85,7 @@ bool MemoryAccessStorage::insertNoLock(const UUID & id, const AccessEntityPtr & 
     {
         if (throw_if_exists)
         {
-            throwNameCollisionCannotInsert(type, name);
+            throwNameCollisionCannotInsert(type, name, getStorageName());
         }
         else
         {
@@ -102,7 +102,7 @@ bool MemoryAccessStorage::insertNoLock(const UUID & id, const AccessEntityPtr & 
         const auto & existing_entry = it_by_id->second;
         if (throw_if_exists)
         {
-            throwIDCollisionCannotInsert(id, type, name, existing_entry.entity->getType(), existing_entry.entity->getName());
+            throwIDCollisionCannotInsert(id, type, name, existing_entry.entity->getType(), existing_entry.entity->getName(), getStorageName());
         }
         else
         {
@@ -164,7 +164,7 @@ bool MemoryAccessStorage::removeNoLock(const UUID & id, bool throw_if_not_exists
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return false;
     }
@@ -197,7 +197,7 @@ bool MemoryAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & updat
     if (it == entries_by_id.end())
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return false;
     }
@@ -219,7 +219,7 @@ bool MemoryAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & updat
         auto & entries_by_name = entries_by_name_and_type[static_cast<size_t>(old_entity->getType())];
         auto it2 = entries_by_name.find(new_entity->getName());
         if (it2 != entries_by_name.end())
-            throwNameCollisionCannotRename(old_entity->getType(), old_entity->getName(), new_entity->getName());
+            throwNameCollisionCannotRename(old_entity->getType(), old_entity->getName(), new_entity->getName(), getStorageName());
 
         entries_by_name.erase(old_entity->getName());
         entries_by_name[new_entity->getName()] = &entry;

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -192,7 +192,7 @@ StoragePtr MultipleAccessStorage::getStorage(const UUID & id)
     auto storage = findStorage(id);
     if (storage)
         return storage;
-    throwNotFound(id);
+    throwNotFound(id, getStorageName());
 }
 
 
@@ -292,7 +292,7 @@ AccessEntityPtr MultipleAccessStorage::readImpl(const UUID & id, bool throw_if_n
         return storage->read(id, throw_if_not_exists);
 
     if (throw_if_not_exists)
-        throwNotFound(id);
+        throwNotFound(id, getStorageName());
     else
         return nullptr;
 }
@@ -304,7 +304,7 @@ std::optional<std::pair<String, AccessEntityType>> MultipleAccessStorage::readNa
         return storage->readNameWithType(id, throw_if_not_exists);
 
     if (throw_if_not_exists)
-        throwNotFound(id);
+        throwNotFound(id, getStorageName());
     else
         return std::nullopt;
 }
@@ -393,7 +393,7 @@ bool MultipleAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists
         return storage->remove(id, throw_if_not_exists);
 
     if (throw_if_not_exists)
-        throwNotFound(id);
+        throwNotFound(id, getStorageName());
     else
         return false;
 }
@@ -405,7 +405,7 @@ bool MultipleAccessStorage::updateImpl(const UUID & id, const UpdateFunc & updat
     if (!storage_for_updating)
     {
         if (throw_if_not_exists)
-            throwNotFound(id);
+            throwNotFound(id, getStorageName());
         else
             return false;
     }
@@ -461,7 +461,7 @@ MultipleAccessStorage::authenticateImpl(const Credentials & credentials, const P
     }
 
     if (throw_if_user_not_exists)
-        throwNotFound(AccessEntityType::USER, credentials.getUserName());
+        throwNotFound(AccessEntityType::USER, credentials.getUserName(), getStorageName());
     else
         return std::nullopt;
 }

--- a/src/Access/ReplicatedAccessStorage.cpp
+++ b/src/Access/ReplicatedAccessStorage.cpp
@@ -21,15 +21,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int NO_ZOOKEEPER;
-}
-
-static UUID parseUUID(const String & text)
-{
-    UUID uuid = UUIDHelpers::Nil;
-    auto buffer = ReadBufferFromMemory(text.data(), text.length());
-    readUUIDText(uuid, buffer);
-    return uuid;
 }
 
 ReplicatedAccessStorage::ReplicatedAccessStorage(
@@ -39,24 +30,12 @@ ReplicatedAccessStorage::ReplicatedAccessStorage(
     AccessChangesNotifier & changes_notifier_,
     bool allow_backup_)
     : IAccessStorage(storage_name_)
-    , zookeeper_path(zookeeper_path_)
-    , get_zookeeper(get_zookeeper_)
-    , watched_queue(std::make_shared<ConcurrentBoundedQueue<UUID>>(std::numeric_limits<size_t>::max()))
     , memory_storage(storage_name_, changes_notifier_, false)
-    , changes_notifier(changes_notifier_)
+    , replicator(storage_name_, zookeeper_path_, get_zookeeper_, changes_notifier_, memory_storage)
     , backup_allowed(allow_backup_)
 {
-    if (zookeeper_path.empty())
+    if (zookeeper_path_.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path must be non-empty");
-
-    if (zookeeper_path.back() == '/')
-        zookeeper_path.resize(zookeeper_path.size() - 1);
-
-    /// If zookeeper chroot prefix is used, path should start with '/', because chroot concatenates without it.
-    if (zookeeper_path.front() != '/')
-        zookeeper_path = "/" + zookeeper_path;
-
-    initZooKeeperWithRetries(/* max_retries= */ 2);
 }
 
 ReplicatedAccessStorage::~ReplicatedAccessStorage()
@@ -73,25 +52,7 @@ ReplicatedAccessStorage::~ReplicatedAccessStorage()
 
 void ReplicatedAccessStorage::shutdown()
 {
-    stopWatchingThread();
-}
-
-void ReplicatedAccessStorage::startWatchingThread()
-{
-    bool prev_watching_flag = watching.exchange(true);
-    if (!prev_watching_flag)
-        watching_thread = std::make_unique<ThreadFromGlobalPool>(&ReplicatedAccessStorage::runWatchingThread, this);
-}
-
-void ReplicatedAccessStorage::stopWatchingThread()
-{
-    bool prev_watching_flag = watching.exchange(false);
-    if (prev_watching_flag)
-    {
-        watched_queue->finish();
-        if (watching_thread && watching_thread->joinable())
-            watching_thread->join();
-    }
+    replicator.shutdown();
 }
 
 template <typename Func>
@@ -116,567 +77,42 @@ static void retryOnZooKeeperUserError(size_t attempts, Func && function)
 
 bool ReplicatedAccessStorage::insertImpl(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id)
 {
-    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(new_entity->getType());
-    const String & name = new_entity->getName();
-    LOG_DEBUG(getLogger(), "Inserting entity of type {} named {} with id {}", type_info.name, name, toString(id));
-
-    auto zookeeper = getZooKeeper();
-    bool ok = false;
-    retryOnZooKeeperUserError(10, [&]{ ok = insertZooKeeper(zookeeper, id, new_entity, replace_if_exists, throw_if_exists, conflicting_id); });
-
-    if (!ok)
-        return false;
-
-    refreshEntity(zookeeper, id);
-    return true;
-}
-
-
-bool ReplicatedAccessStorage::insertZooKeeper(
-    const zkutil::ZooKeeperPtr & zookeeper,
-    const UUID & id,
-    const AccessEntityPtr & new_entity,
-    bool replace_if_exists,
-    bool throw_if_exists,
-    UUID * conflicting_id)
-{
-    const String & name = new_entity->getName();
-    const AccessEntityType type = new_entity->getType();
-    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(type);
-
-    const String entity_uuid = toString(id);
-    /// The entity data will be stored here, this ensures all entities have unique ids
-    const String entity_path = zookeeper_path + "/uuid/" + entity_uuid;
-    /// Then we create a znode with the entity name, inside the znode of each entity type
-    /// This ensure all entities of the same type have a unique name
-    const String name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(name);
-
-    Coordination::Requests ops;
-    const String new_entity_definition = serializeAccessEntity(*new_entity);
-    ops.emplace_back(zkutil::makeCreateRequest(entity_path, new_entity_definition, zkutil::CreateMode::Persistent));
-    /// The content of the "name" znode is the uuid of the entity owning that name
-    ops.emplace_back(zkutil::makeCreateRequest(name_path, entity_uuid, zkutil::CreateMode::Persistent));
-
-    Coordination::Responses responses;
-    const Coordination::Error res = zookeeper->tryMulti(ops, responses);
-
-    if (res == Coordination::Error::ZNODEEXISTS)
-    {
-        if (!replace_if_exists)
-        {
-            if (responses[0]->error == Coordination::Error::ZNODEEXISTS)
-            {
-                /// Couldn't insert the new entity because there is an existing entity with such UUID.
-                if (throw_if_exists)
-                {
-                    /// To fail with a nice error message, we need info about what already exists.
-                    /// This itself can fail if the conflicting uuid disappears in the meantime.
-                    /// If that happens, then retryOnZooKeeperUserError() will just retry the operation from the start.
-                    String existing_entity_definition = zookeeper->get(entity_path);
-
-                    AccessEntityPtr existing_entity = deserializeAccessEntity(existing_entity_definition, entity_path);
-                    AccessEntityType existing_type = existing_entity->getType();
-                    String existing_name = existing_entity->getName();
-                    throwIDCollisionCannotInsert(id, type, name, existing_type, existing_name);
-                }
-                else
-                {
-                    if (conflicting_id)
-                        *conflicting_id = id;
-                    return false;
-                }
-            }
-            else if (responses[1]->error == Coordination::Error::ZNODEEXISTS)
-            {
-                /// Couldn't insert the new entity because there is an existing entity with the same name.
-                if (throw_if_exists)
-                {
-                    throwNameCollisionCannotInsert(type, name);
-                }
-                else
-                {
-                    if (conflicting_id)
-                    {
-                        /// Get UUID of the existing entry with the same name.
-                        /// This itself can fail if the conflicting name disappears in the meantime.
-                        /// If that happens, then retryOnZooKeeperUserError() will just retry the operation from the start.
-                        *conflicting_id = parseUUID(zookeeper->get(name_path));
-                    }
-                    return false;
-                }
-            }
-            else
-            {
-                zkutil::KeeperMultiException::check(res, ops, responses);
-            }
-        }
-
-        assert(replace_if_exists);
-        Coordination::Requests replace_ops;
-        if (responses[0]->error == Coordination::Error::ZNODEEXISTS)
-        {
-            /// The UUID is already associated with some existing entity, we will get rid of the conflicting entity first.
-            /// This itself could fail if the conflicting entity disappears in the meantime.
-            /// If that happens, then we'll just retry from the start.
-            Coordination::Stat stat;
-            String existing_entity_definition = zookeeper->get(entity_path, &stat);
-            auto existing_entity = deserializeAccessEntity(existing_entity_definition, entity_path);
-            const String & existing_entity_name = existing_entity->getName();
-            const AccessEntityType existing_entity_type = existing_entity->getType();
-            const AccessEntityTypeInfo existing_entity_type_info = AccessEntityTypeInfo::get(existing_entity_type);
-            const String existing_name_path = zookeeper_path + "/" + existing_entity_type_info.unique_char + "/" + escapeForFileName(existing_entity_name);
-
-            if (existing_name_path != name_path)
-                replace_ops.emplace_back(zkutil::makeRemoveRequest(existing_name_path, -1));
-
-            replace_ops.emplace_back(zkutil::makeSetRequest(entity_path, new_entity_definition, stat.version));
-        }
-        else
-        {
-            replace_ops.emplace_back(zkutil::makeCreateRequest(entity_path, new_entity_definition, zkutil::CreateMode::Persistent));
-        }
-
-        if (responses[1]->error == Coordination::Error::ZNODEEXISTS)
-        {
-            /// The name is already associated with some existing entity, we will get rid of the conflicting entity first.
-            /// This itself could fail if the conflicting entity disappears in the meantime.
-            /// If that happens, then we'll just retry from the start.
-            Coordination::Stat stat;
-            String existing_entity_uuid = zookeeper->get(name_path, &stat);
-            const String existing_entity_path = zookeeper_path + "/uuid/" + existing_entity_uuid;
-
-            if (existing_entity_path != entity_path)
-                replace_ops.emplace_back(zkutil::makeRemoveRequest(existing_entity_path, -1));
-
-            replace_ops.emplace_back(zkutil::makeSetRequest(name_path, entity_uuid, stat.version));
-        }
-        else
-        {
-            replace_ops.emplace_back(zkutil::makeCreateRequest(name_path, entity_uuid, zkutil::CreateMode::Persistent));
-        }
-
-        /// If this fails, then we'll just retry from the start.
-        zookeeper->multi(replace_ops);
-
-        /// Everything's fine, the new entity has been inserted instead of an existing entity.
-        return true;
-    }
-
-    /// If this fails, then we'll just retry from the start.
-    zkutil::KeeperMultiException::check(res, ops, responses);
-
-    /// Everything's fine, the new entity has been inserted.
-    return true;
+    return replicator.insertEntity(id, new_entity, replace_if_exists, throw_if_exists, conflicting_id);
 }
 
 bool ReplicatedAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
 {
-    LOG_DEBUG(getLogger(), "Removing entity {}", toString(id));
-
-    auto zookeeper = getZooKeeper();
-    bool ok = false;
-    retryOnZooKeeperUserError(10, [&] { ok = removeZooKeeper(zookeeper, id, throw_if_not_exists); });
-
-    if (!ok)
-        return false;
-
-    std::lock_guard lock{mutex};
-    removeEntityNoLock(id);
-    return true;
+    return replicator.removeEntity(id, throw_if_not_exists);
 }
-
-
-bool ReplicatedAccessStorage::removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, bool throw_if_not_exists)
-{
-    const String entity_uuid = toString(id);
-    const String entity_path = zookeeper_path + "/uuid/" + entity_uuid;
-
-    String entity_definition;
-    Coordination::Stat entity_stat;
-    const bool uuid_exists = zookeeper->tryGet(entity_path, entity_definition, &entity_stat);
-    if (!uuid_exists)
-    {
-        /// Couldn't remove, there is no such entity.
-        if (throw_if_not_exists)
-            throwNotFound(id);
-        else
-            return false;
-    }
-
-    const AccessEntityPtr entity = deserializeAccessEntity(entity_definition, entity_path);
-    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(entity->getType());
-    const String & name = entity->getName();
-
-    const String entity_name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(name);
-
-    Coordination::Requests ops;
-    ops.emplace_back(zkutil::makeRemoveRequest(entity_path, entity_stat.version));
-    ops.emplace_back(zkutil::makeRemoveRequest(entity_name_path, -1));
-
-    /// If this fails, then we'll just retry from the start.
-    zookeeper->multi(ops);
-
-    /// Everything's fine, the entity has been removed.
-    return true;
-}
-
 
 bool ReplicatedAccessStorage::updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists)
 {
-    LOG_DEBUG(getLogger(), "Updating entity {}", toString(id));
-
-    auto zookeeper = getZooKeeper();
-    bool ok = false;
-    retryOnZooKeeperUserError(10, [&] { ok = updateZooKeeper(zookeeper, id, update_func, throw_if_not_exists); });
-
-    if (!ok)
-        return false;
-
-    refreshEntity(zookeeper, id);
-    return true;
-}
-
-
-bool ReplicatedAccessStorage::updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists)
-{
-    const String entity_uuid = toString(id);
-    const String entity_path = zookeeper_path + "/uuid/" + entity_uuid;
-
-    String old_entity_definition;
-    Coordination::Stat stat;
-    const bool uuid_exists = zookeeper->tryGet(entity_path, old_entity_definition, &stat);
-    if (!uuid_exists)
-    {
-        if (throw_if_not_exists)
-            throwNotFound(id);
-        else
-            return false;
-    }
-
-    const AccessEntityPtr old_entity = deserializeAccessEntity(old_entity_definition, entity_path);
-    const AccessEntityPtr new_entity = update_func(old_entity, id);
-
-    if (!new_entity->isTypeOf(old_entity->getType()))
-        throwBadCast(id, new_entity->getType(), new_entity->getName(), old_entity->getType());
-
-    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(new_entity->getType());
-
-    Coordination::Requests ops;
-    const String new_entity_definition = serializeAccessEntity(*new_entity);
-    ops.emplace_back(zkutil::makeSetRequest(entity_path, new_entity_definition, stat.version));
-
-    const String & old_name = old_entity->getName();
-    const String & new_name = new_entity->getName();
-    if (new_name != old_name)
-    {
-        auto old_name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(old_name);
-        auto new_name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(new_name);
-        ops.emplace_back(zkutil::makeRemoveRequest(old_name_path, -1));
-        ops.emplace_back(zkutil::makeCreateRequest(new_name_path, entity_uuid, zkutil::CreateMode::Persistent));
-    }
-
-    Coordination::Responses responses;
-    const Coordination::Error res = zookeeper->tryMulti(ops, responses);
-    if (res == Coordination::Error::ZNODEEXISTS)
-    {
-        throwNameCollisionCannotRename(new_entity->getType(), old_name, new_name);
-    }
-    else if (res == Coordination::Error::ZNONODE)
-    {
-        throwNotFound(id);
-    }
-    else
-    {
-        /// If this fails, then we'll just retry from the start.
-        zkutil::KeeperMultiException::check(res, ops, responses);
-
-        /// Everything's fine, the entity has been updated.
-        return true;
-    }
-}
-
-
-void ReplicatedAccessStorage::runWatchingThread()
-{
-    LOG_DEBUG(getLogger(), "Started watching thread");
-    setThreadName("ReplACLWatch");
-
-    while (watching)
-    {
-        bool refreshed = false;
-        try
-        {
-            initZooKeeperIfNeeded();
-            refreshed = refresh();
-        }
-        catch (...)
-        {
-            tryLogCurrentException(getLogger(), "Will try to restart watching thread after error");
-            resetAfterError();
-            sleepForSeconds(5);
-            continue;
-        }
-
-        if (refreshed)
-        {
-            try
-            {
-                changes_notifier.sendNotifications();
-            }
-            catch (...)
-            {
-                tryLogCurrentException(getLogger(), "Error while sending notifications");
-            }
-        }
-    }
-}
-
-void ReplicatedAccessStorage::resetAfterError()
-{
-    /// Make watching thread reinitialize ZooKeeper and reread everything.
-    std::lock_guard lock{cached_zookeeper_mutex};
-    cached_zookeeper = nullptr;
-}
-
-void ReplicatedAccessStorage::initZooKeeperWithRetries(size_t max_retries)
-{
-    for (size_t attempt = 0; attempt < max_retries; ++attempt)
-    {
-        try
-        {
-            initZooKeeperIfNeeded();
-            break; /// If we're here the initialization has been successful.
-        }
-        catch (const Exception & e)
-        {
-            bool need_another_attempt = false;
-
-            if (const auto * coordination_exception = dynamic_cast<const Coordination::Exception *>(&e);
-                coordination_exception && Coordination::isHardwareError(coordination_exception->code))
-            {
-                /// In case of a network error we'll try to initialize again.
-                LOG_ERROR(getLogger(), "Initialization failed. Error: {}", e.message());
-                need_another_attempt = (attempt + 1 < max_retries);
-            }
-
-            if (!need_another_attempt)
-                throw;
-        }
-    }
-}
-
-void ReplicatedAccessStorage::initZooKeeperIfNeeded()
-{
-    getZooKeeper();
-}
-
-zkutil::ZooKeeperPtr ReplicatedAccessStorage::getZooKeeper()
-{
-    std::lock_guard lock{cached_zookeeper_mutex};
-    return getZooKeeperNoLock();
-}
-
-zkutil::ZooKeeperPtr ReplicatedAccessStorage::getZooKeeperNoLock()
-{
-    if (!cached_zookeeper || cached_zookeeper->expired())
-    {
-        auto zookeeper = get_zookeeper();
-        if (!zookeeper)
-            throw Exception(ErrorCodes::NO_ZOOKEEPER, "Can't have Replicated access without ZooKeeper");
-
-        /// It's possible that we connected to different [Zoo]Keeper instance
-        /// so we may read a bit stale state.
-        zookeeper->sync(zookeeper_path);
-
-        createRootNodes(zookeeper);
-        refreshEntities(zookeeper, /* all= */ true);
-        cached_zookeeper = zookeeper;
-    }
-    return cached_zookeeper;
+    return replicator.updateEntity(id, update_func, throw_if_not_exists);
 }
 
 void ReplicatedAccessStorage::reload(ReloadMode reload_mode)
 {
-    if (reload_mode != ReloadMode::ALL)
-        return;
-
-    /// Reinitialize ZooKeeper and reread everything.
-    std::lock_guard lock{cached_zookeeper_mutex};
-    cached_zookeeper = nullptr;
-    getZooKeeperNoLock();
+    replicator.reload(reload_mode == ReloadMode::ALL);
 }
-
-void ReplicatedAccessStorage::createRootNodes(const zkutil::ZooKeeperPtr & zookeeper)
-{
-    zookeeper->createAncestors(zookeeper_path);
-    zookeeper->createIfNotExists(zookeeper_path, "");
-    zookeeper->createIfNotExists(zookeeper_path + "/uuid", "");
-    for (const auto type : collections::range(AccessEntityType::MAX))
-    {
-        /// Create a znode for each type of AccessEntity
-        const auto type_info = AccessEntityTypeInfo::get(type);
-        zookeeper->createIfNotExists(zookeeper_path + "/" + type_info.unique_char, "");
-    }
-}
-
-bool ReplicatedAccessStorage::refresh()
-{
-    UUID id;
-    if (!watched_queue->tryPop(id, /* timeout_ms: */ 10000))
-        return false;
-
-    auto zookeeper = getZooKeeper();
-
-    if (id == UUIDHelpers::Nil)
-        refreshEntities(zookeeper, /* all= */ false);
-    else
-        refreshEntity(zookeeper, id);
-
-    return true;
-}
-
-
-void ReplicatedAccessStorage::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper, bool all)
-{
-    LOG_DEBUG(getLogger(), "Refreshing entities list");
-
-    if (all)
-    {
-        /// It doesn't make sense to keep the queue because we will reread everything in this function.
-        watched_queue->clear();
-    }
-
-    const String zookeeper_uuids_path = zookeeper_path + "/uuid";
-    auto watch_entities_list = [my_watched_queue = watched_queue](const Coordination::WatchResponse &)
-    {
-        [[maybe_unused]] bool push_result = my_watched_queue->push(UUIDHelpers::Nil);
-    };
-    Coordination::Stat stat;
-    const auto entity_uuid_strs = zookeeper->getChildrenWatch(zookeeper_uuids_path, &stat, watch_entities_list);
-
-    std::vector<UUID> entity_uuids;
-    entity_uuids.reserve(entity_uuid_strs.size());
-    for (const String & entity_uuid_str : entity_uuid_strs)
-        entity_uuids.emplace_back(parseUUID(entity_uuid_str));
-
-    std::lock_guard lock{mutex};
-
-    if (all)
-    {
-        /// all=true means we read & parse all access entities from ZooKeeper.
-        std::vector<std::pair<UUID, AccessEntityPtr>> entities;
-        for (const auto & uuid : entity_uuids)
-        {
-            if (auto entity = tryReadEntityFromZooKeeper(zookeeper, uuid))
-                entities.emplace_back(uuid, entity);
-        }
-        memory_storage.setAll(entities);
-    }
-    else
-    {
-        /// all=false means we read & parse only new access entities from ZooKeeper.
-        memory_storage.removeAllExcept(entity_uuids);
-        for (const auto & uuid : entity_uuids)
-        {
-            if (!memory_storage.exists(uuid))
-                refreshEntityNoLock(zookeeper, uuid);
-        }
-    }
-
-    LOG_DEBUG(getLogger(), "Refreshing entities list finished");
-}
-
-
-void ReplicatedAccessStorage::refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
-{
-    LOG_DEBUG(getLogger(), "Refreshing entity {}", toString(id));
-
-    auto entity = tryReadEntityFromZooKeeper(zookeeper, id);
-
-    std::lock_guard lock{mutex};
-
-    if (entity)
-        setEntityNoLock(id, entity);
-    else
-        removeEntityNoLock(id);
-}
-
-void ReplicatedAccessStorage::refreshEntityNoLock(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
-{
-    LOG_DEBUG(getLogger(), "Refreshing entity {}", toString(id));
-
-    auto entity = tryReadEntityFromZooKeeper(zookeeper, id);
-    if (entity)
-        setEntityNoLock(id, entity);
-    else
-        removeEntityNoLock(id);
-}
-
-AccessEntityPtr ReplicatedAccessStorage::tryReadEntityFromZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) const
-{
-    const auto watch_entity = [my_watched_queue = watched_queue, id](const Coordination::WatchResponse & response)
-    {
-        if (response.type == Coordination::Event::CHANGED)
-            [[maybe_unused]] bool push_result = my_watched_queue->push(id);
-    };
-
-    Coordination::Stat entity_stat;
-    const String entity_path = zookeeper_path + "/uuid/" + toString(id);
-    String entity_definition;
-    bool exists = zookeeper->tryGetWatch(entity_path, entity_definition, &entity_stat, watch_entity);
-    if (!exists)
-        return nullptr;
-
-    try
-    {
-        return deserializeAccessEntity(entity_definition, entity_path);
-    }
-    catch (...)
-    {
-        tryLogCurrentException(getLogger(), "Error while reading the definition of " + toString(id));
-        return nullptr;
-    }
-}
-
-void ReplicatedAccessStorage::setEntityNoLock(const UUID & id, const AccessEntityPtr & entity)
-{
-    LOG_DEBUG(getLogger(), "Setting id {} to entity named {}", toString(id), entity->getName());
-    memory_storage.insert(id, entity, /* replace_if_exists= */ true, /* throw_if_exists= */ false);
-}
-
-
-void ReplicatedAccessStorage::removeEntityNoLock(const UUID & id)
-{
-    LOG_DEBUG(getLogger(), "Removing entity with id {}", toString(id));
-    memory_storage.remove(id, /* throw_if_not_exists= */ false); // NOLINT
-}
-
 
 std::optional<UUID> ReplicatedAccessStorage::findImpl(AccessEntityType type, const String & name) const
 {
-    std::lock_guard lock{mutex};
-    return memory_storage.find(type, name);
+    return replicator.findEntity(type, name);
 }
-
 
 std::vector<UUID> ReplicatedAccessStorage::findAllImpl(AccessEntityType type) const
 {
-    std::lock_guard lock{mutex};
-    return memory_storage.findAll(type);
+    return replicator.findAllEntities(type);
 }
-
 
 bool ReplicatedAccessStorage::exists(const UUID & id) const
 {
-    std::lock_guard lock{mutex};
-    return memory_storage.exists(id);
+    return replicator.exists(id);
 }
-
 
 AccessEntityPtr ReplicatedAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
-    std::lock_guard lock{mutex};
-    return memory_storage.read(id, throw_if_not_exists);
+    return replicator.readEntity(id, throw_if_not_exists);
 }
 
 }

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -1,14 +1,8 @@
 #pragma once
 
-#include <atomic>
-
-#include <Common/ThreadPool_fwd.h>
-#include <Common/ZooKeeper/Common.h>
-#include <Common/ZooKeeper/ZooKeeper.h>
-#include <Common/ConcurrentBoundedQueue.h>
-
+#include <Access/IAccessStorage.h>
 #include <Access/MemoryAccessStorage.h>
-
+#include <Access/ZooKeeperReplicator.h>
 
 namespace DB
 {
@@ -28,10 +22,10 @@ public:
     const char * getStorageType() const override { return STORAGE_TYPE; }
 
     bool isReplicated() const override { return true; }
-    String getReplicationID() const override { return zookeeper_path; }
+    String getReplicationID() const override { return replicator.getReplicationID(); }
 
-    void startPeriodicReloading() override { startWatchingThread(); }
-    void stopPeriodicReloading() override { stopWatchingThread(); }
+    void startPeriodicReloading() override { replicator.startWatchingThread(); }
+    void stopPeriodicReloading() override { replicator.stopWatchingThread(); }
     void reload(ReloadMode reload_mode) override;
 
     bool exists(const UUID & id) const override;
@@ -39,52 +33,16 @@ public:
     bool isBackupAllowed() const override { return backup_allowed; }
 
 private:
-    String zookeeper_path;
-    const zkutil::GetZooKeeper get_zookeeper;
-
-    zkutil::ZooKeeperPtr cached_zookeeper TSA_GUARDED_BY(cached_zookeeper_mutex);
-    std::mutex cached_zookeeper_mutex;
-
-    std::atomic<bool> watching = false;
-    std::unique_ptr<ThreadFromGlobalPool> watching_thread;
-    std::shared_ptr<ConcurrentBoundedQueue<UUID>> watched_queue;
-
     bool insertImpl(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id) override;
     bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
-
-    bool insertZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id);
-    bool removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, bool throw_if_not_exists);
-    bool updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists);
-
-    void initZooKeeperWithRetries(size_t max_retries);
-    void initZooKeeperIfNeeded();
-    zkutil::ZooKeeperPtr getZooKeeper();
-    zkutil::ZooKeeperPtr getZooKeeperNoLock() TSA_REQUIRES(cached_zookeeper_mutex);
-    void createRootNodes(const zkutil::ZooKeeperPtr & zookeeper);
-
-    void startWatchingThread();
-    void stopWatchingThread();
-
-    void runWatchingThread();
-    void resetAfterError();
-
-    bool refresh();
-    void refreshEntities(const zkutil::ZooKeeperPtr & zookeeper, bool all);
-    void refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id);
-    void refreshEntityNoLock(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) TSA_REQUIRES(mutex);
-
-    AccessEntityPtr tryReadEntityFromZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) const;
-    void setEntityNoLock(const UUID & id, const AccessEntityPtr & entity) TSA_REQUIRES(mutex);
-    void removeEntityNoLock(const UUID & id) TSA_REQUIRES(mutex);
 
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
 
-    mutable std::mutex mutex;
-    MemoryAccessStorage memory_storage TSA_GUARDED_BY(mutex);
-    AccessChangesNotifier & changes_notifier;
+    MemoryAccessStorage memory_storage;
+    ZooKeeperReplicator replicator;
     const bool backup_allowed = false;
 };
 }

--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -1,0 +1,674 @@
+#include <Access/ZooKeeperReplicator.h>
+
+#include <Access/AccessEntityIO.h>
+#include <Access/AccessChangesNotifier.h>
+#include <Common/setThreadName.h>
+#include <Common/ZooKeeper/KeeperException.h>
+#include <Common/escapeForFileName.h>
+#include <Common/logger_useful.h>
+#include <Common/ThreadPool.h>
+#include <Interpreters/Context.h>
+#include <IO/ReadHelpers.h>
+#include <base/range.h>
+#include <base/sleep.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int NO_ZOOKEEPER;
+    extern const int LOGICAL_ERROR;
+}
+
+static UUID parseUUID(const String & text)
+{
+    UUID uuid = UUIDHelpers::Nil;
+    auto buffer = ReadBufferFromMemory(text.data(), text.length());
+    readUUIDText(uuid, buffer);
+    return uuid;
+}
+
+static String formatEntityNameWithType(AccessEntityType type, const String & name)
+{
+    return AccessEntityTypeInfo::get(type).formatEntityNameWithType(name);
+}
+
+ZooKeeperReplicator::ZooKeeperReplicator(
+    const String & storage_name_,
+    const String & zookeeper_path_,
+    zkutil::GetZooKeeper get_zookeeper_,
+    AccessChangesNotifier & changes_notifier_,
+    MemoryAccessStorage & memory_storage_)
+    : storage_name(storage_name_)
+    , zookeeper_path(zookeeper_path_)
+    , get_zookeeper(get_zookeeper_)
+    , watched_queue(std::make_shared<ConcurrentBoundedQueue<UUID>>(std::numeric_limits<size_t>::max()))
+    , memory_storage(memory_storage_)
+    , changes_notifier(changes_notifier_)
+{
+    if (zookeeper_path.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path must be non-empty");
+
+    if (zookeeper_path.back() == '/')
+        zookeeper_path.resize(zookeeper_path.size() - 1);
+
+    /// If zookeeper chroot prefix is used, path should start with '/', because chroot concatenates without it.
+    if (zookeeper_path.front() != '/')
+        zookeeper_path = "/" + zookeeper_path;
+
+    initZooKeeperWithRetries(/* max_retries= */ 2);
+}
+
+ZooKeeperReplicator::~ZooKeeperReplicator()
+{
+    try
+    {
+        shutdown();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
+void ZooKeeperReplicator::shutdown()
+{
+    stopWatchingThread();
+}
+
+void ZooKeeperReplicator::startWatchingThread()
+{
+    bool prev_watching_flag = watching.exchange(true);
+    if (!prev_watching_flag)
+        watching_thread = std::make_unique<ThreadFromGlobalPool>(&ZooKeeperReplicator::runWatchingThread, this);
+}
+
+void ZooKeeperReplicator::stopWatchingThread()
+{
+    bool prev_watching_flag = watching.exchange(false);
+    if (prev_watching_flag)
+    {
+        watched_queue->finish();
+        if (watching_thread && watching_thread->joinable())
+            watching_thread->join();
+    }
+}
+
+template <typename Func>
+static void retryOnZooKeeperUserError(size_t attempts, Func && function)
+{
+    while (attempts > 0)
+    {
+        try
+        {
+            function();
+            return;
+        }
+        catch (zkutil::KeeperException & keeper_exception)
+        {
+            if (Coordination::isUserError(keeper_exception.code) && attempts > 1)
+                attempts -= 1;
+            else
+                throw;
+        }
+    }
+}
+
+bool ZooKeeperReplicator::insertEntity(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id)
+{
+    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(new_entity->getType());
+    const String & name = new_entity->getName();
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Inserting entity of type {} named {} with id {}", type_info.name, name, toString(id));
+
+    auto zookeeper = getZooKeeper();
+    bool ok = false;
+    retryOnZooKeeperUserError(10, [&]{ ok = insertZooKeeper(zookeeper, id, new_entity, replace_if_exists, throw_if_exists, conflicting_id); });
+
+    if (!ok)
+        return false;
+
+    refreshEntity(zookeeper, id);
+    return true;
+}
+
+bool ZooKeeperReplicator::insertZooKeeper(
+    const zkutil::ZooKeeperPtr & zookeeper,
+    const UUID & id,
+    const AccessEntityPtr & new_entity,
+    bool replace_if_exists,
+    bool throw_if_exists,
+    UUID * conflicting_id)
+{
+    const String & name = new_entity->getName();
+    const AccessEntityType type = new_entity->getType();
+    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(type);
+
+    const String entity_uuid = toString(id);
+    /// The entity data will be stored here, this ensures all entities have unique ids
+    const String entity_path = zookeeper_path + "/uuid/" + entity_uuid;
+    /// Then we create a znode with the entity name, inside the znode of each entity type
+    /// This ensure all entities of the same type have a unique name
+    const String name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(name);
+
+    Coordination::Requests ops;
+    const String new_entity_definition = serializeAccessEntity(*new_entity);
+    ops.emplace_back(zkutil::makeCreateRequest(entity_path, new_entity_definition, zkutil::CreateMode::Persistent));
+    /// The content of the "name" znode is the uuid of the entity owning that name
+    ops.emplace_back(zkutil::makeCreateRequest(name_path, entity_uuid, zkutil::CreateMode::Persistent));
+
+    Coordination::Responses responses;
+    const Coordination::Error res = zookeeper->tryMulti(ops, responses);
+
+    if (res == Coordination::Error::ZNODEEXISTS)
+    {
+        if (!replace_if_exists)
+        {
+            if (responses[0]->error == Coordination::Error::ZNODEEXISTS)
+            {
+                /// Couldn't insert the new entity because there is an existing entity with such UUID.
+                if (throw_if_exists)
+                {
+                    /// To fail with a nice error message, we need info about what already exists.
+                    /// This itself can fail if the conflicting uuid disappears in the meantime.
+                    /// If that happens, then retryOnZooKeeperUserError() will just retry the operation from the start.
+                    String existing_entity_definition = zookeeper->get(entity_path);
+
+                    AccessEntityPtr existing_entity = deserializeAccessEntity(existing_entity_definition, entity_path);
+                    AccessEntityType existing_type = existing_entity->getType();
+                    String existing_name = existing_entity->getName();
+                    IAccessStorage::throwIDCollisionCannotInsert(id, type, name, existing_type, existing_name, storage_name);
+                }
+                else
+                {
+                    if (conflicting_id)
+                        *conflicting_id = id;
+                    return false;
+                }
+            }
+            else if (responses[1]->error == Coordination::Error::ZNODEEXISTS)
+            {
+                /// Couldn't insert the new entity because there is an existing entity with the same name.
+                if (throw_if_exists)
+                {
+                    IAccessStorage::throwNameCollisionCannotInsert(type, name, storage_name);
+                }
+                else
+                {
+                    if (conflicting_id)
+                    {
+                        /// Get UUID of the existing entry with the same name.
+                        /// This itself can fail if the conflicting name disappears in the meantime.
+                        /// If that happens, then retryOnZooKeeperUserError() will just retry the operation from the start.
+                        *conflicting_id = parseUUID(zookeeper->get(name_path));
+                    }
+                    return false;
+                }
+            }
+            else
+            {
+                zkutil::KeeperMultiException::check(res, ops, responses);
+            }
+        }
+
+        assert(replace_if_exists);
+        Coordination::Requests replace_ops;
+        if (responses[0]->error == Coordination::Error::ZNODEEXISTS)
+        {
+            /// The UUID is already associated with some existing entity, we will get rid of the conflicting entity first.
+            /// This itself could fail if the conflicting entity disappears in the meantime.
+            /// If that happens, then we'll just retry from the start.
+            Coordination::Stat stat;
+            String existing_entity_definition = zookeeper->get(entity_path, &stat);
+            auto existing_entity = deserializeAccessEntity(existing_entity_definition, entity_path);
+            const String & existing_entity_name = existing_entity->getName();
+            const AccessEntityType existing_entity_type = existing_entity->getType();
+            const AccessEntityTypeInfo existing_entity_type_info = AccessEntityTypeInfo::get(existing_entity_type);
+            const String existing_name_path = zookeeper_path + "/" + existing_entity_type_info.unique_char + "/" + escapeForFileName(existing_entity_name);
+
+            LOG_DEBUG(&Poco::Logger::get(storage_name), "Removing existing entity with name {} and path {}", existing_entity_name, existing_name_path);
+            if (existing_name_path != name_path)
+                replace_ops.emplace_back(zkutil::makeRemoveRequest(existing_name_path, -1));
+
+            replace_ops.emplace_back(zkutil::makeSetRequest(entity_path, new_entity_definition, stat.version));
+        }
+        else
+        {
+            replace_ops.emplace_back(zkutil::makeCreateRequest(entity_path, new_entity_definition, zkutil::CreateMode::Persistent));
+        }
+
+        if (responses[1]->error == Coordination::Error::ZNODEEXISTS)
+        {
+            /// The name is already associated with some existing entity, we will get rid of the conflicting entity first.
+            /// This itself could fail if the conflicting entity disappears in the meantime.
+            /// If that happens, then we'll just retry from the start.
+            Coordination::Stat stat;
+            String existing_entity_uuid = zookeeper->get(name_path, &stat);
+            const String existing_entity_path = zookeeper_path + "/uuid/" + existing_entity_uuid;
+
+            LOG_DEBUG(&Poco::Logger::get(storage_name), "Removing existing entity with uuid {} and path {}", existing_entity_uuid, existing_entity_path);
+            if (existing_entity_path != entity_path)
+                replace_ops.emplace_back(zkutil::makeRemoveRequest(existing_entity_path, -1));
+
+            replace_ops.emplace_back(zkutil::makeSetRequest(name_path, entity_uuid, stat.version));
+        }
+        else
+        {
+            replace_ops.emplace_back(zkutil::makeCreateRequest(name_path, entity_uuid, zkutil::CreateMode::Persistent));
+        }
+
+        /// If this fails, then we'll just retry from the start.
+        zookeeper->multi(replace_ops);
+
+        /// Everything's fine, the new entity has been inserted instead of an existing entity.
+        return true;
+    }
+
+    /// If this fails, then we'll just retry from the start.
+    zkutil::KeeperMultiException::check(res, ops, responses);
+
+    /// Everything's fine, the new entity has been inserted.
+    return true;
+}
+
+bool ZooKeeperReplicator::removeEntity(const UUID & id, bool throw_if_not_exists)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Removing entity {}", toString(id));
+
+    auto zookeeper = getZooKeeper();
+    bool ok = false;
+    retryOnZooKeeperUserError(10, [&] { ok = removeZooKeeper(zookeeper, id, throw_if_not_exists); });
+
+    if (!ok)
+        return false;
+
+    std::lock_guard lock{mutex};
+    removeEntityNoLock(id);
+    return true;
+}
+
+bool ZooKeeperReplicator::removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, bool throw_if_not_exists)
+{
+    const String entity_uuid = toString(id);
+    const String entity_path = zookeeper_path + "/uuid/" + entity_uuid;
+
+    String entity_definition;
+    Coordination::Stat entity_stat;
+    const bool uuid_exists = zookeeper->tryGet(entity_path, entity_definition, &entity_stat);
+    if (!uuid_exists)
+    {
+        /// Couldn't remove, there is no such entity.
+        if (throw_if_not_exists)
+            IAccessStorage::throwNotFound(id, storage_name);
+        else
+            return false;
+    }
+
+    const AccessEntityPtr entity = deserializeAccessEntity(entity_definition, entity_path);
+    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(entity->getType());
+    const String & name = entity->getName();
+
+    const String entity_name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(name);
+
+    Coordination::Requests ops;
+    ops.emplace_back(zkutil::makeRemoveRequest(entity_path, entity_stat.version));
+    ops.emplace_back(zkutil::makeRemoveRequest(entity_name_path, -1));
+
+    /// If this fails, then we'll just retry from the start.
+    zookeeper->multi(ops);
+
+    /// Everything's fine, the entity has been removed.
+    return true;
+}
+
+bool ZooKeeperReplicator::updateEntity(const UUID & id, const IAccessStorage::UpdateFunc & update_func, bool throw_if_not_exists)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Updating entity {}", toString(id));
+
+    auto zookeeper = getZooKeeper();
+    bool ok = false;
+    retryOnZooKeeperUserError(10, [&] { ok = updateZooKeeper(zookeeper, id, update_func, throw_if_not_exists); });
+
+    if (!ok)
+        return false;
+
+    refreshEntity(zookeeper, id);
+    return true;
+}
+
+bool ZooKeeperReplicator::updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const IAccessStorage::UpdateFunc & update_func, bool throw_if_not_exists)
+{
+    const String entity_uuid = toString(id);
+    const String entity_path = zookeeper_path + "/uuid/" + entity_uuid;
+
+    String old_entity_definition;
+    Coordination::Stat stat;
+    const bool uuid_exists = zookeeper->tryGet(entity_path, old_entity_definition, &stat);
+    if (!uuid_exists)
+    {
+        if (throw_if_not_exists)
+            IAccessStorage::throwNotFound(id, storage_name);
+        else
+            return false;
+    }
+
+    const AccessEntityPtr old_entity = deserializeAccessEntity(old_entity_definition, entity_path);
+    const AccessEntityPtr new_entity = update_func(old_entity, id);
+
+    if (!new_entity->isTypeOf(old_entity->getType()))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "{}: {} expected to be of type {}",
+            toString(id), formatEntityNameWithType(new_entity->getType(), new_entity->getName()), toString(old_entity->getType()));
+
+    const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(new_entity->getType());
+
+    Coordination::Requests ops;
+    const String new_entity_definition = serializeAccessEntity(*new_entity);
+    ops.emplace_back(zkutil::makeSetRequest(entity_path, new_entity_definition, stat.version));
+
+    const String & old_name = old_entity->getName();
+    const String & new_name = new_entity->getName();
+    if (new_name != old_name)
+    {
+        auto old_name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(old_name);
+        auto new_name_path = zookeeper_path + "/" + type_info.unique_char + "/" + escapeForFileName(new_name);
+        ops.emplace_back(zkutil::makeRemoveRequest(old_name_path, -1));
+        ops.emplace_back(zkutil::makeCreateRequest(new_name_path, entity_uuid, zkutil::CreateMode::Persistent));
+    }
+
+    Coordination::Responses responses;
+    const Coordination::Error res = zookeeper->tryMulti(ops, responses);
+    if (res == Coordination::Error::ZNODEEXISTS)
+    {
+        IAccessStorage::throwNameCollisionCannotRename(new_entity->getType(), old_name, new_name, storage_name);
+    }
+    else if (res == Coordination::Error::ZNONODE)
+    {
+        IAccessStorage::throwNotFound(id, storage_name);
+    }
+    else
+    {
+        /// If this fails, then we'll just retry from the start.
+        zkutil::KeeperMultiException::check(res, ops, responses);
+
+        /// Everything's fine, the entity has been updated.
+        return true;
+    }
+}
+
+void ZooKeeperReplicator::runWatchingThread()
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Started watching thread");
+    setThreadName("ZooACLWatch");
+
+    while (watching)
+    {
+        bool refreshed = false;
+        try
+        {
+            initZooKeeperIfNeeded();
+            refreshed = refresh();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(&Poco::Logger::get(storage_name), "Will try to restart watching thread after error");
+            resetAfterError();
+            sleepForSeconds(5);
+            continue;
+        }
+
+        if (refreshed)
+        {
+            try
+            {
+                changes_notifier.sendNotifications();
+            }
+            catch (...)
+            {
+                tryLogCurrentException(&Poco::Logger::get(storage_name), "Error while sending notifications");
+            }
+        }
+    }
+}
+
+void ZooKeeperReplicator::resetAfterError()
+{
+    /// Make watching thread reinitialize ZooKeeper and reread everything.
+    std::lock_guard lock{cached_zookeeper_mutex};
+    cached_zookeeper = nullptr;
+}
+
+void ZooKeeperReplicator::initZooKeeperWithRetries(size_t max_retries)
+{
+    for (size_t attempt = 0; attempt < max_retries; ++attempt)
+    {
+        try
+        {
+            initZooKeeperIfNeeded();
+            break; /// If we're here the initialization has been successful.
+        }
+        catch (const Exception & e)
+        {
+            bool need_another_attempt = false;
+
+            if (const auto * coordination_exception = dynamic_cast<const Coordination::Exception *>(&e);
+                coordination_exception && Coordination::isHardwareError(coordination_exception->code))
+            {
+                /// In case of a network error we'll try to initialize again.
+                LOG_ERROR(&Poco::Logger::get(storage_name), "Initialization failed. Error: {}", e.message());
+                need_another_attempt = (attempt + 1 < max_retries);
+            }
+
+            if (!need_another_attempt)
+                throw;
+        }
+    }
+}
+
+void ZooKeeperReplicator::initZooKeeperIfNeeded()
+{
+    getZooKeeper();
+}
+
+zkutil::ZooKeeperPtr ZooKeeperReplicator::getZooKeeper()
+{
+    std::lock_guard lock{cached_zookeeper_mutex};
+    return getZooKeeperNoLock();
+}
+
+zkutil::ZooKeeperPtr ZooKeeperReplicator::getZooKeeperNoLock()
+{
+    if (!cached_zookeeper || cached_zookeeper->expired())
+    {
+        auto zookeeper = get_zookeeper();
+        if (!zookeeper)
+            throw Exception(ErrorCodes::NO_ZOOKEEPER, "Can't have Replicated access without ZooKeeper");
+
+        /// It's possible that we connected to different [Zoo]Keeper instance
+        /// so we may read a bit stale state.
+        zookeeper->sync(zookeeper_path);
+
+        createRootNodes(zookeeper);
+        refreshEntities(zookeeper, /* all= */ true);
+        cached_zookeeper = zookeeper;
+    }
+    return cached_zookeeper;
+}
+
+void ZooKeeperReplicator::reload(bool force_reload_all)
+{
+    if (!force_reload_all)
+        return;
+
+    /// Reinitialize ZooKeeper and reread everything.
+    std::lock_guard lock{cached_zookeeper_mutex};
+    cached_zookeeper = nullptr;
+    getZooKeeperNoLock();
+}
+
+void ZooKeeperReplicator::createRootNodes(const zkutil::ZooKeeperPtr & zookeeper)
+{
+    zookeeper->createAncestors(zookeeper_path);
+    zookeeper->createIfNotExists(zookeeper_path, "");
+    zookeeper->createIfNotExists(zookeeper_path + "/uuid", "");
+    for (const auto type : collections::range(AccessEntityType::MAX))
+    {
+        /// Create a znode for each type of AccessEntity
+        const auto type_info = AccessEntityTypeInfo::get(type);
+        zookeeper->createIfNotExists(zookeeper_path + "/" + type_info.unique_char, "");
+    }
+}
+
+bool ZooKeeperReplicator::refresh()
+{
+    UUID id;
+    if (!watched_queue->tryPop(id, /* timeout_ms: */ 10000))
+        return false;
+
+    auto zookeeper = getZooKeeper();
+
+    if (id == UUIDHelpers::Nil)
+        refreshEntities(zookeeper, /* all= */ false);
+    else
+        refreshEntity(zookeeper, id);
+
+    return true;
+}
+
+void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper, bool all)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entities list");
+
+    if (all)
+    {
+        /// It doesn't make sense to keep the queue because we will reread everything in this function.
+        watched_queue->clear();
+    }
+
+    const String zookeeper_uuids_path = zookeeper_path + "/uuid";
+    auto watch_entities_list = [my_watched_queue = watched_queue](const Coordination::WatchResponse &)
+    {
+        [[maybe_unused]] bool push_result = my_watched_queue->push(UUIDHelpers::Nil);
+    };
+    Coordination::Stat stat;
+    const auto entity_uuid_strs = zookeeper->getChildrenWatch(zookeeper_uuids_path, &stat, watch_entities_list);
+
+    std::vector<UUID> entity_uuids;
+    entity_uuids.reserve(entity_uuid_strs.size());
+    for (const String & entity_uuid_str : entity_uuid_strs)
+        entity_uuids.emplace_back(parseUUID(entity_uuid_str));
+
+    std::lock_guard lock{mutex};
+
+    if (all)
+    {
+        /// all=true means we read & parse all access entities from ZooKeeper.
+        std::vector<std::pair<UUID, AccessEntityPtr>> entities;
+        for (const auto & uuid : entity_uuids)
+        {
+            if (auto entity = tryReadEntityFromZooKeeper(zookeeper, uuid))
+                entities.emplace_back(uuid, entity);
+        }
+        memory_storage.setAll(entities);
+    }
+    else
+    {
+        /// all=false means we read & parse only new access entities from ZooKeeper.
+        memory_storage.removeAllExcept(entity_uuids);
+        for (const auto & uuid : entity_uuids)
+        {
+            if (!memory_storage.exists(uuid))
+                refreshEntityNoLock(zookeeper, uuid);
+        }
+    }
+
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entities list finished");
+}
+
+void ZooKeeperReplicator::refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entity {}", toString(id));
+
+    auto entity = tryReadEntityFromZooKeeper(zookeeper, id);
+
+    std::lock_guard lock{mutex};
+
+    if (entity)
+        setEntityNoLock(id, entity);
+    else
+        removeEntityNoLock(id);
+}
+
+void ZooKeeperReplicator::refreshEntityNoLock(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entity {}", toString(id));
+
+    auto entity = tryReadEntityFromZooKeeper(zookeeper, id);
+    if (entity)
+        setEntityNoLock(id, entity);
+    else
+        removeEntityNoLock(id);
+}
+
+AccessEntityPtr ZooKeeperReplicator::tryReadEntityFromZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) const
+{
+    const auto watch_entity = [my_watched_queue = watched_queue, id](const Coordination::WatchResponse & response)
+    {
+        if (response.type == Coordination::Event::CHANGED)
+            [[maybe_unused]] bool push_result = my_watched_queue->push(id);
+    };
+
+    Coordination::Stat entity_stat;
+    const String entity_path = zookeeper_path + "/uuid/" + toString(id);
+    String entity_definition;
+    bool exists = zookeeper->tryGetWatch(entity_path, entity_definition, &entity_stat, watch_entity);
+    if (!exists)
+        return nullptr;
+
+    try
+    {
+        return deserializeAccessEntity(entity_definition, entity_path);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(&Poco::Logger::get(storage_name), "Error while reading the definition of " + toString(id));
+        return nullptr;
+    }
+}
+
+void ZooKeeperReplicator::setEntityNoLock(const UUID & id, const AccessEntityPtr & entity)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Setting id {} to entity named {}", toString(id), entity->getName());
+    memory_storage.insert(id, entity, /* replace_if_exists= */ true, /* throw_if_exists= */ false);
+}
+
+void ZooKeeperReplicator::removeEntityNoLock(const UUID & id)
+{
+    LOG_DEBUG(&Poco::Logger::get(storage_name), "Removing entity with id {}", toString(id));
+    memory_storage.remove(id, /* throw_if_not_exists= */ false);
+}
+
+std::optional<UUID> ZooKeeperReplicator::findEntity(AccessEntityType type, const String & name) const
+{
+    std::lock_guard lock{mutex};
+    return memory_storage.find(type, name);
+}
+
+std::vector<UUID> ZooKeeperReplicator::findAllEntities(AccessEntityType type) const
+{
+    std::lock_guard lock{mutex};
+    return memory_storage.findAll(type);
+}
+
+bool ZooKeeperReplicator::exists(const UUID & id) const
+{
+    std::lock_guard lock{mutex};
+    return memory_storage.exists(id);
+}
+
+AccessEntityPtr ZooKeeperReplicator::readEntity(const UUID & id, bool throw_if_not_exists) const
+{
+    std::lock_guard lock{mutex};
+    return memory_storage.read(id, throw_if_not_exists);
+}
+
+}

--- a/src/Access/ZooKeeperReplicator.h
+++ b/src/Access/ZooKeeperReplicator.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <mutex>
+
+#include <base/defines.h>
+#include <Common/ThreadPool_fwd.h>
+#include <Common/ZooKeeper/Common.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
+#include <Common/ConcurrentBoundedQueue.h>
+#include <Access/IAccessStorage.h>
+#include <Access/MemoryAccessStorage.h>
+
+namespace DB
+{
+class AccessChangesNotifier;
+
+/// Class that handles replication of access entities using ZooKeeper.
+/// This can be used by different access storage implementations to provide replication.
+class ZooKeeperReplicator
+{
+public:
+    ZooKeeperReplicator(
+        const String & storage_name_,
+        const String & zookeeper_path_,
+        zkutil::GetZooKeeper get_zookeeper_,
+        AccessChangesNotifier & changes_notifier_,
+        MemoryAccessStorage & memory_storage_);
+
+    ~ZooKeeperReplicator();
+
+    void shutdown();
+
+    /// Start and stop the thread watching for ZooKeeper changes
+    void startWatchingThread();
+    void stopWatchingThread();
+    void runWatchingThread();
+    void resetAfterError();
+
+    /// Reload entities from ZooKeeper
+    void reload(bool force_reload_all);
+
+    /// ZooKeeper operations for entities
+    bool insertEntity(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id);
+    bool removeEntity(const UUID & id, bool throw_if_not_exists);
+    bool updateEntity(const UUID & id, const IAccessStorage::UpdateFunc & update_func, bool throw_if_not_exists);
+    std::optional<UUID> findEntity(AccessEntityType type, const String & name) const;
+    std::vector<UUID> findAllEntities(AccessEntityType type) const;
+    AccessEntityPtr readEntity(const UUID & id, bool throw_if_not_exists) const;
+
+    /// Check if entity exists in ZooKeeper
+    bool exists(const UUID & id) const;
+
+    /// Get ZooKeeper replication ID
+    String getReplicationID() const { return zookeeper_path; }
+
+    /// Get current ZooKeeper connection
+    zkutil::ZooKeeperPtr getZooKeeper();
+
+private:
+    String storage_name;
+    String zookeeper_path;
+    const zkutil::GetZooKeeper get_zookeeper;
+
+    zkutil::ZooKeeperPtr cached_zookeeper TSA_GUARDED_BY(cached_zookeeper_mutex);
+    std::mutex cached_zookeeper_mutex;
+
+    std::atomic<bool> watching = false;
+    std::unique_ptr<ThreadFromGlobalPool> watching_thread;
+    std::shared_ptr<ConcurrentBoundedQueue<UUID>> watched_queue;
+
+    MemoryAccessStorage & memory_storage TSA_GUARDED_BY(mutex);
+    AccessChangesNotifier & changes_notifier;
+
+    bool insertZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id);
+    bool removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, bool throw_if_not_exists);
+    bool updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const IAccessStorage::UpdateFunc & update_func, bool throw_if_not_exists);
+
+    void initZooKeeperWithRetries(size_t max_retries);
+    void initZooKeeperIfNeeded();
+    zkutil::ZooKeeperPtr getZooKeeperNoLock() TSA_REQUIRES(cached_zookeeper_mutex);
+    void createRootNodes(const zkutil::ZooKeeperPtr & zookeeper);
+
+    bool refresh();
+    void refreshEntities(const zkutil::ZooKeeperPtr & zookeeper, bool all);
+    void refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id);
+    void refreshEntityNoLock(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) TSA_REQUIRES(mutex);
+
+    AccessEntityPtr tryReadEntityFromZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) const;
+    void setEntityNoLock(const UUID & id, const AccessEntityPtr & entity)  TSA_REQUIRES(mutex);
+    void removeEntityNoLock(const UUID & id) TSA_REQUIRES(mutex);
+
+    mutable std::mutex mutex;
+};
+
+}

--- a/tests/integration/test_replicated_users/test.py
+++ b/tests/integration/test_replicated_users/test.py
@@ -65,7 +65,7 @@ def get_entity_id(entity):
 def test_create_replicated(started_cluster, entity):
     node1.query(f"CREATE {entity.keyword} {entity.name} {entity.options}")
     assert (
-        f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in replicated"
+        f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in `replicated`"
         in node2.query_and_get_error_with_retry(
             f"CREATE {entity.keyword} {entity.name} {entity.options}"
         )
@@ -82,7 +82,7 @@ def test_create_and_delete_replicated(started_cluster, entity):
 @pytest.mark.parametrize("entity", entities, ids=get_entity_id)
 def test_create_replicated_on_cluster(started_cluster, entity):
     assert (
-        f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in replicated"
+        f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in `replicated`"
         in node1.query_and_get_error(
             f"CREATE {entity.keyword} {entity.name} ON CLUSTER default {entity.options}"
         )
@@ -112,7 +112,7 @@ def test_create_replicated_on_cluster_ignore(started_cluster, entity):
         f"CREATE {entity.keyword} {entity.name} ON CLUSTER default {entity.options}"
     )
     assert (
-        f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in replicated"
+        f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in `replicated`"
         in node2.query_and_get_error_with_retry(
             f"CREATE {entity.keyword} {entity.name} {entity.options}"
         )


### PR DESCRIPTION
A slight refactor for `ReplicatedAccessStorage`. This decouples the replication logic into a separate `ZooKeeperReplicator` class so that we can share it between other AccessStorages.

Also updates the error messaging to include the Access Storage which throws the exception, to identify more clearly the source. Needed when multiple storages can use keeper replication. 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
