### PR TITLE
support max_waiting_queries in workload

### DIFF
--- a/docs/en/operations/workload-scheduling.md
+++ b/docs/en/operations/workload-scheduling.md
@@ -285,9 +285,9 @@ CREATE WORKLOAD all SETTINGS max_concurrent_queries = 100, max_queries_per_secon
 
 Workload setting `max_concurrent_queries` limits the number of concurrent queries that could run simultaneously for a given workload. This is analog of query [`max_concurrent_queries_for_all_users`](/operations/settings/settings#max_concurrent_queries_for_all_users) and server [max_concurrent_queries](/operations/server-configuration-parameters/settings#max_concurrent_queries) settings. Async insert queries and some specific queries like KILL are not counted towards the limit.
 
-Workload settings `max_queries_per_second` and `max_burst_queries` limits number of queries for the workload with a token bucket throttler. It guarantees that during any time interval `T` no more than `max_queries_per_second * T + max_burst_queries` new queries will start execution.
+Workload settings `max_queries_per_second` and `max_burst_queries` limit number of queries for the workload with a token bucket throttler. It guarantees that during any time interval `T` no more than `max_queries_per_second * T + max_burst_queries` new queries will start execution.
 
-Workload settings `max_waiting_queries` limits number of waiting queries for the workload. When the limit is reached, the server returns an error `SERVER_OVERLOADED`
+Workload setting `max_waiting_queries` limits number of waiting queries for the workload. When the limit is reached, the server returns an error `SERVER_OVERLOADED`
 
 :::note
 Blocked queries will wait indefinitely and not appear in `SHOW PROCESSLIST` until all constraints are satisfied.

--- a/docs/en/operations/workload-scheduling.md
+++ b/docs/en/operations/workload-scheduling.md
@@ -287,6 +287,8 @@ Workload setting `max_concurrent_queries` limits the number of concurrent querie
 
 Workload settings `max_queries_per_second` and `max_burst_queries` limits number of queries for the workload with a token bucket throttler. It guarantees that during any time interval `T` no more than `max_queries_per_second * T + max_burst_queries` new queries will start execution.
 
+Workload settings `max_waiting_queries` limits number of waiting queries for the workload. When the limit is reached, the server returns an error `SERVER_OVERLOADED`
+
 :::note
 Blocked queries will wait indefinitely and not appear in `SHOW PROCESSLIST` until all constraints are satisfied.
 :::

--- a/docs/en/operations/workload-scheduling.md
+++ b/docs/en/operations/workload-scheduling.md
@@ -287,7 +287,7 @@ Workload setting `max_concurrent_queries` limits the number of concurrent querie
 
 Workload settings `max_queries_per_second` and `max_burst_queries` limit number of queries for the workload with a token bucket throttler. It guarantees that during any time interval `T` no more than `max_queries_per_second * T + max_burst_queries` new queries will start execution.
 
-Workload setting `max_waiting_queries` limits number of waiting queries for the workload. When the limit is reached, the server returns an error `SERVER_OVERLOADED`
+Workload setting `max_waiting_queries` limits number of waiting queries for the workload. When the limit is reached, the server returns an error `SERVER_OVERLOADED`.
 
 :::note
 Blocked queries will wait indefinitely and not appear in `SHOW PROCESSLIST` until all constraints are satisfied.

--- a/src/Common/Scheduler/ISchedulerNode.h
+++ b/src/Common/Scheduler/ISchedulerNode.h
@@ -29,7 +29,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int INVALID_SCHEDULER_NODE;
-    extern const int SERVER_OVERLOADED;
 }
 
 class ISchedulerNode;

--- a/src/Common/Scheduler/ISchedulerNode.h
+++ b/src/Common/Scheduler/ISchedulerNode.h
@@ -48,6 +48,7 @@ struct SchedulerNodeInfo
 {
     double weight = 1.0; /// Weight of this node among it's siblings
     Priority priority; /// Priority of this node among it's siblings (lower value means higher priority)
+    Int64 queue_size = std::numeric_limits<Int64>::max(); /// Size of a workload queue
 
     /// Arbitrary data accessed/stored by parent
     union {
@@ -67,6 +68,7 @@ struct SchedulerNodeInfo
     {
         setWeight(config.getDouble(config_prefix + ".weight", weight));
         setPriority(config.getInt64(config_prefix + ".priority", priority));
+        setQueueSize(config.getInt64(config_prefix + ".queue_size", queue_size));
     }
 
     void setWeight(double value)
@@ -77,6 +79,16 @@ struct SchedulerNodeInfo
                 "Zero, negative and non-finite node weights are not allowed: {}",
                 value);
         weight = value;
+    }
+
+    void setQueueSize(Int64 value)
+    {
+        if (value <= 0)
+            throw Exception(
+                ErrorCodes::INVALID_SCHEDULER_NODE,
+                "Zero, negative and non-finite node queue_size are not allowed: {}",
+                value);
+        queue_size = value;
     }
 
     void setPriority(Int64 value)

--- a/src/Common/Scheduler/ISchedulerNode.h
+++ b/src/Common/Scheduler/ISchedulerNode.h
@@ -86,7 +86,7 @@ struct SchedulerNodeInfo
         if (value <= 0)
             throw Exception(
                 ErrorCodes::INVALID_SCHEDULER_NODE,
-                "Zero, negative and non-finite node queue_size are not allowed: {}",
+                "Workload setting `max_waiting_queries` value must be positive, got: {}",
                 value);
         queue_size = value;
     }

--- a/src/Common/Scheduler/ISchedulerNode.h
+++ b/src/Common/Scheduler/ISchedulerNode.h
@@ -29,6 +29,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int INVALID_SCHEDULER_NODE;
+    extern const int SERVER_OVERLOADED;
 }
 
 class ISchedulerNode;

--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -61,7 +61,7 @@ public:
         if (is_not_usable)
             throw Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue is about to be destructed");
 
-        if (requests.size() > static_cast<size_t>(info.queue_size))
+        if (requests.size() >= static_cast<size_t>(info.queue_size))
             throw Exception(ErrorCodes::SERVER_OVERLOADED, "Queue limit has been reached: {} of {}", requests.size(), info.queue_size);
         queue_cost += request->cost;
         bool was_empty = requests.empty();

--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -61,8 +61,8 @@ public:
         if (is_not_usable)
             throw Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue is about to be destructed");
 
-        if (requests.size() > queue_size)
-            throw Exception(ErrorCodes::SERVER_OVERLOADED, PreformattedMessage::create("Queue limit has been reached: {} of {}", requests.size(), queue_size));
+        if (requests.size() > static_cast<size_t>(queue_size))
+            throw Exception(ErrorCodes::SERVER_OVERLOADED, "Queue limit has been reached: {} of {}", requests.size(), queue_size);
         queue_cost += request->cost;
         bool was_empty = requests.empty();
         requests.push_back(*request);

--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -62,7 +62,7 @@ public:
             throw Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue is about to be destructed");
 
         if (requests.size() >= static_cast<size_t>(info.queue_size))
-            throw Exception(ErrorCodes::SERVER_OVERLOADED, "Queue limit has been reached: {} of {}", requests.size(), info.queue_size);
+            throw Exception(ErrorCodes::SERVER_OVERLOADED, "Workload limit `max_waiting_queries` has been reached: {} of {}", requests.size(), info.queue_size);
         queue_cost += request->cost;
         bool was_empty = requests.empty();
         requests.push_back(*request);

--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -18,6 +18,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int INVALID_SCHEDULER_NODE;
+    extern const int SERVER_OVERLOADED;
 }
 
 /*

--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -30,8 +30,9 @@ public:
         : ISchedulerQueue(event_queue_, config, config_prefix)
     {}
 
-    FifoQueue(EventQueue * event_queue_, const SchedulerNodeInfo & info_)
+    FifoQueue(EventQueue * event_queue_, const SchedulerNodeInfo & info_, Int64 queue_size_)
         : ISchedulerQueue(event_queue_, info_)
+        , queue_size(queue_size_)
     {}
 
     ~FifoQueue() override
@@ -59,6 +60,9 @@ public:
         std::lock_guard lock(mutex);
         if (is_not_usable)
             throw Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue is about to be destructed");
+
+        if (requests.size() > queue_size)
+            throw Exception(ErrorCodes::SERVER_OVERLOADED, PreformattedMessage::create("Queue limit has been reached: {} of {}", requests.size(), queue_size));
         queue_cost += request->cost;
         bool was_empty = requests.empty();
         requests.push_back(*request);
@@ -164,6 +168,7 @@ private:
     Int64 queue_cost = 0;
     boost::intrusive::list<ResourceRequest> requests;
     bool is_not_usable = false;
+    Int64 queue_size;
 };
 
 }

--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -31,9 +31,8 @@ public:
         : ISchedulerQueue(event_queue_, config, config_prefix)
     {}
 
-    FifoQueue(EventQueue * event_queue_, const SchedulerNodeInfo & info_, Int64 queue_size_)
+    FifoQueue(EventQueue * event_queue_, const SchedulerNodeInfo & info_)
         : ISchedulerQueue(event_queue_, info_)
-        , queue_size(queue_size_)
     {}
 
     ~FifoQueue() override
@@ -62,8 +61,8 @@ public:
         if (is_not_usable)
             throw Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue is about to be destructed");
 
-        if (requests.size() > static_cast<size_t>(queue_size))
-            throw Exception(ErrorCodes::SERVER_OVERLOADED, "Queue limit has been reached: {} of {}", requests.size(), queue_size);
+        if (requests.size() > static_cast<size_t>(info.queue_size))
+            throw Exception(ErrorCodes::SERVER_OVERLOADED, "Queue limit has been reached: {} of {}", requests.size(), info.queue_size);
         queue_cost += request->cost;
         bool was_empty = requests.empty();
         requests.push_back(*request);
@@ -169,7 +168,6 @@ private:
     Int64 queue_cost = 0;
     boost::intrusive::list<ResourceRequest> requests;
     bool is_not_usable = false;
-    Int64 queue_size;
 };
 
 }

--- a/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
+++ b/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
@@ -264,9 +264,9 @@ private:
         }
 
         // Should be called after constructor, before any other methods
-        [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_, const WorkloadSettings& settings)
+        [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_, const WorkloadSettings& settings_)
         {
-            settings = settings;
+            settings = settings_;
             createQueue(event_queue_);
             return queue;
         }

--- a/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
+++ b/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
@@ -298,7 +298,9 @@ private:
     private:
         void createQueue(EventQueue * event_queue_)
         {
-            queue = std::make_shared<FifoQueue>(event_queue_, SchedulerNodeInfo{}, settings.getQueueSize());
+            SchedulerNodeInfo node_info{};
+            node_info.queue_size = settings.getQueueSize();
+            queue = std::make_shared<FifoQueue>(event_queue_, node_info);
             queue->basename = "fifo";
         }
 

--- a/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
+++ b/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
@@ -264,7 +264,7 @@ private:
         }
 
         // Should be called after constructor, before any other methods
-        [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_, const WorkloadSettings& settings_)
+        [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_, const WorkloadSettings & settings_)
         {
             settings = settings_;
             createQueue(event_queue_);

--- a/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
+++ b/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
@@ -253,6 +253,7 @@ private:
     {
         SchedulerNodePtr queue; /// FifoQueue node is used if there are no children
         ChildrenBranch branch; /// Used if there is at least one child
+        WorkloadSettings settings;
 
         SchedulerNodePtr getRoot()
         {
@@ -263,8 +264,9 @@ private:
         }
 
         // Should be called after constructor, before any other methods
-        [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_)
+        [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_, const WorkloadSettings& settings)
         {
+            settings = settings;
             createQueue(event_queue_);
             return queue;
         }
@@ -296,7 +298,7 @@ private:
     private:
         void createQueue(EventQueue * event_queue_)
         {
-            queue = std::make_shared<FifoQueue>(event_queue_, SchedulerNodeInfo{});
+            queue = std::make_shared<FifoQueue>(event_queue_, SchedulerNodeInfo{}, settings.getQueueSize());
             queue->basename = "fifo";
         }
 
@@ -323,7 +325,7 @@ private:
         [[nodiscard]] SchedulerNodePtr initialize(EventQueue * event_queue_, const WorkloadSettings & settings_)
         {
             settings = settings_;
-            SchedulerNodePtr node = branch.initialize(event_queue_);
+            SchedulerNodePtr node = branch.initialize(event_queue_, settings);
             if (settings.hasSemaphore())
             {
                 semaphore = std::make_shared<SemaphoreConstraint>(event_queue_, SchedulerNodeInfo{}, settings.getSemaphoreMaxRequests(), settings.getSemaphoreMaxCost());

--- a/src/Common/Scheduler/WorkloadSettings.cpp
+++ b/src/Common/Scheduler/WorkloadSettings.cpp
@@ -68,6 +68,10 @@ Int64 WorkloadSettings::getSemaphoreMaxCost() const
     }
 }
 
+Int64 WorkloadSettings::getQueueSize() const {
+    return max_waiting_queries;
+}
+
 void WorkloadSettings::initFromChanges(CostUnit unit_, const ASTCreateWorkloadQuery::SettingsChanges & changes, const String & resource_name, bool throw_on_unknown_setting)
 {
     // Set resource unit
@@ -85,6 +89,7 @@ void WorkloadSettings::initFromChanges(CostUnit unit_, const ASTCreateWorkloadQu
         std::optional<Int64> max_concurrent_threads;
         std::optional<Float64> max_concurrent_threads_ratio_to_cores;
         std::optional<Int64> max_concurrent_queries;
+        std::optional<Int64> max_waiting_queries;
 
         static Float64 getNotNegativeFloat64(const String & name, const Field & field)
         {
@@ -158,6 +163,8 @@ void WorkloadSettings::initFromChanges(CostUnit unit_, const ASTCreateWorkloadQu
                 max_concurrent_threads_ratio_to_cores = getNotNegativeFloat64(name, value);
             else if (name == "max_concurrent_queries")
                 max_concurrent_queries = getNotNegativeInt64(name, value);
+            else if (name == "max_waiting_queries")
+                max_waiting_queries = getNotNegativeInt64(name, value);
             else if (throw_on_unknown_setting)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown workload setting '{}'", name);
         }
@@ -236,6 +243,9 @@ void WorkloadSettings::initFromChanges(CostUnit unit_, const ASTCreateWorkloadQu
 
     // Concurrent queries limit
     max_concurrent_queries = get_value(specific.max_concurrent_queries, regular.max_concurrent_queries, max_concurrent_queries, unlimited);
+
+    // Concurrent query queue size limit
+    max_waiting_queries = get_value(specific.max_waiting_queries, regular.max_waiting_queries, max_waiting_queries, unlimited);
 }
 
 }

--- a/src/Common/Scheduler/WorkloadSettings.h
+++ b/src/Common/Scheduler/WorkloadSettings.h
@@ -42,6 +42,9 @@ struct WorkloadSettings
     /// Limits total number of queries
     Int64 max_concurrent_queries = unlimited;
 
+    /// Limits total number of waiting queries
+    Int64 max_waiting_queries = unlimited;
+
     /// Settings that are applied depend on cost unit
     CostUnit unit = CostUnit::IOByte;
 
@@ -54,6 +57,9 @@ struct WorkloadSettings
     bool hasSemaphore() const;
     Int64 getSemaphoreMaxRequests() const;
     Int64 getSemaphoreMaxCost() const;
+
+    // Queue
+    Int64 getQueueSize() const;
 
     // Should be called after default constructor
     void initFromChanges(CostUnit unit_, const ASTCreateWorkloadQuery::SettingsChanges & changes, const String & resource_name = {}, bool throw_on_unknown_setting = true);

--- a/tests/integration/test_scheduler_query/test.py
+++ b/tests/integration/test_scheduler_query/test.py
@@ -229,7 +229,7 @@ def test_under_max_waiting_queries_limit() -> None:
         """
     )
 
-    pool_all = QueryPool(6, "all")
+    pool_all = QueryPool(7, "all")
 
     pool_all.start()
     ensure_total_concurrency(1)

--- a/tests/integration/test_scheduler_query/test.py
+++ b/tests/integration/test_scheduler_query/test.py
@@ -117,7 +117,7 @@ class QueryPool:
                         f"select count(*) from numbers_mt(100000000) settings "
                         f"workload='{self.workload}', max_threads=2"
                     )
-                except ex:
+                except Exception as ex:
                     self.error = str(ex)
 
         for _ in range(self.num_queries):
@@ -203,7 +203,7 @@ def test_max_waiting_queries() -> None:
     node.query(
         f"""
         create resource query (query);
-        create workload all settings max_concurrent_queries=1 max_waiting_queries=1;
+        create workload all settings max_concurrent_queries=1, max_waiting_queries=1;
         """
     )
 

--- a/tests/integration/test_scheduler_query/test.py
+++ b/tests/integration/test_scheduler_query/test.py
@@ -218,7 +218,7 @@ def test_max_waiting_queries_reached() -> None:
     ensure_total_concurrency(1)
     ensure_workload_concurrency("all", 1)
     pool_all.stop()
-    assert "Queue limit has been reached" in pool_all.last_error
+    assert "Workload limit `max_waiting_queries` has been reached: 1 of 1" in pool_all.last_error
 
 
 def test_under_max_waiting_queries_limit() -> None:


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/78697

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The workload setting `max_waiting_queries` is now supported. It can be used to limit the size of the query queue. If the limit is reached, all subsequent queries will be terminated with the `SERVER_OVERLOADED` error.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
