### PR TITLE
Docs: fix formatting of arguments for bitSlice.cpp

### DIFF
--- a/src/Functions/bitSlice.cpp
+++ b/src/Functions/bitSlice.cpp
@@ -414,15 +414,15 @@ REGISTER_FUNCTION(BitSlice)
         {"s", "The String or Fixed String to slice. [`String`](../data-types/string.md)/[`FixedString(N)`](../data-types/fixedstring.md)."},
         {"offset", R"(
 The starting bit position (1-based indexing). [`(U)Int8/16/32/64`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float).
-- Positive values: count from the beginning of the string.
-- Negative values: count from the end of the string.
+  - Positive values: count from the beginning of the string.
+  - Negative values: count from the end of the string.
         )"},
         {"length", R"(
 Optional. The number of bits to extract. [`(U)Int8/16/32/64`](/sql-reference/data-types/int-uint)/[`Float32/64`](/sql-reference/data-types/float).
-- Positive values: extract `length` bits.
-- Negative values: extract from the offset to `(string_length - |length|)`.
-- Omitted: extract from offset to end of string.
-- If length is not a multiple of 8, the result is padded with zeros on the right.
+  - Positive values: extract `length` bits.
+  - Negative values: extract from the offset to `(string_length - |length|)`.
+  - Omitted: extract from offset to end of string.
+  - If length is not a multiple of 8, the result is padded with zeros on the right.
     )"}};
     FunctionDocumentation::ReturnedValue returned_value = "Returns a string containing the extracted bits, represented as a binary sequence. The result is always padded to byte boundaries (multiples of 8 bits). [`String`](../data-types/string.md)";
     FunctionDocumentation::Examples examples = {{"Usage example",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fixes formatting here which is not rendering as intended. There should be sub-bullet points.
![Screenshot 2025-06-03 at 23 24 41](https://github.com/user-attachments/assets/e3b2fbdc-938f-4940-9f3d-89a94a53d67b)


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
