### PR TITLE
Don't profile processors if the log table is disabled

### DIFF
--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -54,7 +54,8 @@ PipelineExecutor::PipelineExecutor(std::shared_ptr<Processors> & processors, Que
 {
     if (process_list_element)
     {
-        profile_processors = process_list_element->getContext()->getSettingsRef()[Setting::log_processors_profiles];
+        profile_processors = process_list_element->getContext()->getSettingsRef()[Setting::log_processors_profiles]
+            && process_list_element->getContext()->getProcessorsProfileLog();
         trace_processors = process_list_element->getContext()->getSettingsRef()[Setting::opentelemetry_trace_processors];
     }
     try


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't profile processors if the log table is disabled

Really minor / negligible stuff, but when I was profiling a query I noticed that we were hitting lines that I did not expect. `log_processors_profiles` is enabled by default but we don't need to profile if we are not going to store it.

```
+    9.64%     1.02%          5392  QueryPipelineEx  clickhouse  [.] DB::ExecutingGraph::updateNode...
```

```
        │      void stop()                        { stop_ns = nanoseconds(); is_running = false; }                                                                                        ◆
        │      void reset()                       { start_ns = 0; stop_ns = 0; is_running = false; }                                                                                      ▒
        │      void restart()                     { start(); }                                                                                                                            ▒
        │      UInt64 elapsed() const             { return elapsedNanoseconds(); }                                                                                                        ▒
        │      UInt64 elapsedNanoseconds() const  { return is_running ? nanoseconds() - start_ns : stop_ns - start_ns; }                                                                  ▒
      9 │        cmpb   $0x1,0x74(%r12)                                                                                                                                                   ▒
      8 │      ↓ jne    7b1                                                                                                                                                               ▒
        │      {                                                                                                                                                                          ▒
        │      processor.input_wait_elapsed_ns += processor.input_wait_watch.elapsedNanoseconds();                                                                                        ▒
      4 │        lea    0x60(%r12),%rdi                                                                                                                                                   ▒
     41 │      → call   Stopwatch::nanoseconds() const                                                                                                                                    ▒
      2 │      ↓ jmp    7b6                                                                                                                                                               ▒
        │      __on_zero_shared();                                                                                                                                                        ▒
        │ 787:   mov    (%rbx),%rax                                                                                                                                                       ▒
        │        mov    %rbx,%rdi                                                                                                                                                         ▒
        │      → call   *0x10(%rax)                                                                                                                                                       ▒
        │      __release_weak();                                                                                                                                                          ▒
        │        mov    %rbx,%rdi                                                                                                                                                         ▒
        │      → call   std::__1::__shared_weak_count::__release_weak()                                                                                                                   ▒
        │        mov    -0xe8(%rbp),%rax                                                                                                                                                  ▒
        │      if (profile_processors)                                                                                                                                                    ▒
        │        cmpb   $0x1,0x100(%rax)                                                                                                                                                  ▒
        │      ↑ je     726                                                                                                                                                               ▒
        │      ↓ jmp    850                                                                                                                                                               ▒
        │ 7b1:   mov    0x68(%r12),%rax                                                                                                                                                   ▒
      6 │ 7b6:   sub    0x60(%r12),%rax                                                                                                                                                   ▒
        │      processor.input_wait_elapsed_ns += processor.input_wait_watch.elapsedNanoseconds();                                                                                        ▒
      3 │        add    %rax,0x78(%r12)                                                                                                                                                   ▒
        │      return static_cast<bool>(__x) ? *__x != __v : true;                                                                                                                        ▒
     13 │ 7c0:   cmp    $0x1,%r13b                                                                                                                                                        ▒
     19 │        setne  %al                                                                                                                                                               ▒
     15 │        or     %al,%bl                                                                                                                                                           ▒
```

References https://github.com/ClickHouse/ClickHouse/issues/81043

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
