### PR TITLE
Speed up toFixedString when the source is exactly what's requested

### DIFF
--- a/src/Functions/toFixedString.h
+++ b/src/Functions/toFixedString.h
@@ -116,6 +116,9 @@ public:
         else if (const auto * column_fixed_string = checkAndGetColumn<ColumnFixedString>(column.get()))
         {
             const auto src_n = column_fixed_string->getN();
+            if (src_n == n)
+                return column_fixed_string->cloneResized(column_fixed_string->size());
+
             if (src_n > n)
             {
                 if constexpr (exception_mode == ConvertToFixedStringExceptionMode::Throw)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up toFixedString when the source is exactly what's requested

There are a bunch of performance tests doing `toFixedString(ClientIP6, 16)`, but ClientIP6 is already a FixedString(16). Add a shortcut to copy the whole source together.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
