### PR TITLE
Verify array offsets received over network

### DIFF
--- a/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.reference
+++ b/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.reference
@@ -1,0 +1,1 @@
+Arrays offsets are not monotonically increasing (starting at 0, value 2): (in file/uri (fd = 0)): While executing Native: data for INSERT was parsed from stdin. (INCORRECT_DATA

--- a/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.sh
+++ b/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Refs: https://github.com/ClickHouse/ClickHouse/issues/81199
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT 'create table array_deserialize_offsets (val Array(String)) engine=Memory()'
+
+{
+  # Native header
+  $CLICKHOUSE_LOCAL "select * from values('val Array(String)', (['foo','fooo']),(['bar','barr'])) format Native" | head -c20
+  # Array offsets (without header) that are decreasing (2, 1)
+  $CLICKHOUSE_LOCAL "select * from values('val UInt64', (2),(1)) format Native" | tail -c+14
+  # We do not even need array values, offsets should be checked before reading them
+} | $CLICKHOUSE_CLIENT 'insert into array_deserialize_offsets format Native' |& grep -o 'Arrays offsets are not monotonically increasing (starting at 0, value 2).*INCORRECT_DATA'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Verify array offsets received over network

Otherwise it can lead to:

    DB::Exception: Array size is too large: 18446744073709551615: while reading column col at /src/ch/clickhouse/.cmake/.server/store/bd6/bd64f151-1ade-459c-87ac-5d042bf14a55/

Fixes: https://github.com/ClickHouse/ClickHouse/issues/81199