### PR TITLE
Docs: explain that query condition cache only works when analyzer is on

### DIFF
--- a/docs/en/operations/query-condition-cache.md
+++ b/docs/en/operations/query-condition-cache.md
@@ -50,6 +50,10 @@ SETTINGS use_query_condition_cache = true;
 will store ranges of the table which do not satisfy the predicate.
 Subsequent executions of the same query, also with parameter `use_query_condition_cache = true`, will utilize the query condition cache to scan less data.
 
+:::note
+The query condition cache only works when [allow_experimental_analyzer](https://clickhouse.com/docs/operations/settings/settings#allow_experimental_analyzer) is set to true, which is the default value.
+:::
+
 ## Administration {#administration}
 
 The query condition cache is not retained between restarts of ClickHouse.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)