### PR TITLE
Add the ability to run the `03525_sql_udf_names_in_system_query_log` test in parallel

### DIFF
--- a/tests/queries/0_stateless/03525_sql_udf_names_in_system_query_log.reference
+++ b/tests/queries/0_stateless/03525_sql_udf_names_in_system_query_log.reference
@@ -1,6 +1,6 @@
 8
-['test_sql_udf_single']
+['test_sql_udf_single_default']
 888
-['test_sql_udf_multiple_1','test_sql_udf_multiple_2','test_sql_udf_multiple_3']
+['test_sql_udf_multiple_1_default','test_sql_udf_multiple_2_default','test_sql_udf_multiple_3_default']
 888
-['test_sql_udf_duplicate']
+['test_sql_udf_duplicate_default']

--- a/tests/queries/0_stateless/03525_sql_udf_names_in_system_query_log.sh
+++ b/tests/queries/0_stateless/03525_sql_udf_names_in_system_query_log.sh
@@ -11,10 +11,9 @@ check_sql_udf_functions() {
 
     # In order for the test to run in parallel,
     # we add the name of the database to the function name, because it has a random value.
-    suffix=$(${CLICKHOUSE_CLIENT} -q "SELECT current_database()")
     funcs=""
     for func in ${@}; do
-        funcs+="${func}_${suffix} "
+        funcs+="${func}_${CLICKHOUSE_DATABASE} "
     done
 
     for func in ${funcs}; do

--- a/tests/queries/0_stateless/03525_sql_udf_names_in_system_query_log.sh
+++ b/tests/queries/0_stateless/03525_sql_udf_names_in_system_query_log.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -10,7 +9,15 @@ check_sql_udf_functions() {
         return
     fi
 
-    for func in "${@}"; do
+    # In order for the test to run in parallel,
+    # we add the name of the database to the function name, because it has a random value.
+    suffix=$(${CLICKHOUSE_CLIENT} -q "SELECT current_database()")
+    funcs=""
+    for func in ${@}; do
+        funcs+="${func}_${suffix} "
+    done
+
+    for func in ${funcs}; do
         $CLICKHOUSE_CLIENT -q "
             DROP FUNCTION IF EXISTS ${func};
             CREATE FUNCTION ${func} AS (input) -> input"
@@ -18,10 +25,10 @@ check_sql_udf_functions() {
 
     execute_sql_udf=""
     if [ "${#}" == "1" ]; then
-        execute_sql_udf="${1}(8)"
+        execute_sql_udf="${funcs}(8)"
     else
         joined_string=""
-        for func in "${@}"; do
+        for func in ${funcs}; do
             if [ -n "${joined_string}" ]; then
                 joined_string+=", "
             fi
@@ -38,7 +45,7 @@ check_sql_udf_functions() {
         SELECT arraySort(used_sql_user_defined_functions) FROM system.query_log
         WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND query_id = '${query_id}'"
 
-    for func in "${@}"; do
+    for func in ${funcs}; do
         $CLICKHOUSE_CLIENT -q "DROP FUNCTION IF EXISTS ${func}"
     done
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add the ability to run the `03525_sql_udf_names_in_system_query_log` test in parallel.