### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ The following versions of ClickHouse server are currently supported with securit
 | 25.3 | ✔️ |
 | 25.2 | ❌ |
 | 25.1 | ❌ |
-| 24.12 | ❌ |
+| 24.12 | ✔️ |
 | 24.11 | ❌ |
 | 24.10 | ❌ |
 | 24.9 | ❌ |


### PR DESCRIPTION
ClickHouse private build for 24.12 still receive updates/backport for security fixes as many customers are still on 24.12. Thus we're making exception here and also backport them to 24.12 public until all customers roll off 24.12 in cloud.
