### PR TITLE
fs cache small optimization

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -303,6 +303,7 @@
     M(FilesystemCacheDownloadQueueElements, "Filesystem cache elements in download queue") \
     M(FilesystemCacheDelayedCleanupElements, "Filesystem cache elements in background cleanup queue") \
     M(FilesystemCacheHoldFileSegments, "Filesystem cache file segment which are currently hold as unreleasable") \
+    M(FilesystemCacheKeys, "Number of keys in filesystem cache") \
     M(AsyncInsertCacheSize, "Number of async insert hash id in cache") \
     M(IcebergMetadataFilesCacheBytes, "Size of the iceberg metadata cache in bytes") \
     M(IcebergMetadataFilesCacheFiles, "Number of cached files in the iceberg metadata cache") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -598,6 +598,7 @@ The server successfully detected this situation and will download merged part fr
     \
     M(FilesystemCacheLoadMetadataMicroseconds, "Time spent loading filesystem cache metadata", ValueType::Microseconds) \
     M(FilesystemCacheEvictedBytes, "Number of bytes evicted from filesystem cache", ValueType::Bytes) \
+    M(FilesystemCacheCreatedKeyDirectories, "Number of created key directories", ValueType::Bytes) \
     M(FilesystemCacheEvictedFileSegments, "Number of file segments evicted from filesystem cache", ValueType::Number) \
     M(FilesystemCacheEvictedFileSegmentsDuringPriorityIncrease, "Number of file segments evicted from filesystem cache when increasing priority of file segments (Applies to SLRU cache policy)", ValueType::Number) \
     M(FilesystemCacheBackgroundDownloadQueuePush, "Number of file segments sent for background download in filesystem cache", ValueType::Number) \

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1010,12 +1010,6 @@ bool FileCache::tryReserve(
         return false;
     }
 
-    if (!file_segment.getKeyMetadata()->createBaseDirectory())
-    {
-        failure_reason = "not enough space on device";
-        return false;
-    }
-
     if (eviction_candidates.size() > 0)
     {
         cache_lock.unlock();
@@ -1091,6 +1085,13 @@ bool FileCache::tryReserve(
 
     if (main_priority->getSize(cache_lock) > (1ull << 63))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cache became inconsistent. There must be a bug");
+
+    cache_lock.unlock();
+    if (!file_segment.getKeyMetadata()->createBaseDirectory())
+    {
+        failure_reason = "not enough space on device";
+        return false;
+    }
 
     return true;
 }

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -575,7 +575,7 @@ bool FileSegment::reserve(
     /// Currently it is used only for temporary files through cache.
     if (is_unbound && is_file_segment_size_exceeded)
         /// Note: segment_range.right is inclusive.
-        segment_range.right = range().left + expected_downloaded_size + size_to_reserve - 1;
+        segment_range.right = range().left + current_downloaded_size + size_to_reserve - 1;
 
     /// if reserve_stat is not passed then use dummy stat and discard the result.
     FileCacheReserveStat dummy_stat;

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -535,7 +535,7 @@ bool FileSegment::reserve(
     if (!size_to_reserve)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Zero space reservation is not allowed");
 
-    size_t expected_downloaded_size;
+    size_t current_downloaded_size;
 
     bool is_file_segment_size_exceeded;
     {
@@ -544,9 +544,9 @@ bool FileSegment::reserve(
         assertNotDetachedUnlocked(lk);
         assertIsDownloaderUnlocked("reserve", lk);
 
-        expected_downloaded_size = getDownloadedSize();
+        current_downloaded_size = getDownloadedSize();
 
-        is_file_segment_size_exceeded = expected_downloaded_size + size_to_reserve > range().size();
+        is_file_segment_size_exceeded = current_downloaded_size + size_to_reserve > range().size();
         if (is_file_segment_size_exceeded && !is_unbound)
         {
             throw Exception(
@@ -555,7 +555,7 @@ bool FileSegment::reserve(
                 size_to_reserve, range().toString(), downloaded_size.load());
         }
 
-        chassert(reserved_size >= expected_downloaded_size);
+        chassert(reserved_size >= current_downloaded_size);
     }
 
     /**
@@ -564,7 +564,7 @@ bool FileSegment::reserve(
      * and the caller is going to continue;
      */
 
-    size_t already_reserved_size = reserved_size - expected_downloaded_size;
+    size_t already_reserved_size = reserved_size - current_downloaded_size;
 
     if (already_reserved_size >= size_to_reserve)
         return true;

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -20,7 +20,7 @@ namespace ProfileEvents
 {
     extern const Event FilesystemCacheLockKeyMicroseconds;
     extern const Event FilesystemCacheLockMetadataMicroseconds;
-    extern const Event FilesystemCacheCreatedBaseDirectories;
+    extern const Event FilesystemCacheCreatedKeyDirectories;
 }
 
 namespace DB
@@ -129,7 +129,7 @@ bool KeyMetadata::createBaseDirectory(bool throw_if_failed)
         {
             std::shared_lock lock(cache_metadata->key_prefix_directory_mutex);
             fs::create_directories(getPath());
-            ProfileEvents::increment(ProfileEvents::FilesystemCacheCreatedBaseDirectories);
+            ProfileEvents::increment(ProfileEvents::FilesystemCacheCreatedKeyDirectories);
         }
         catch (const fs::filesystem_error & e)
         {

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -2,6 +2,7 @@
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileSegment.h>
 #include <Interpreters/Context.h>
+#include "Common/ProfileEvents.h"
 #include <Common/logger_useful.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <filesystem>
@@ -19,6 +20,7 @@ namespace ProfileEvents
 {
     extern const Event FilesystemCacheLockKeyMicroseconds;
     extern const Event FilesystemCacheLockMetadataMicroseconds;
+    extern const Event FilesystemCacheCreatedBaseDirectories;
 }
 
 namespace DB
@@ -127,6 +129,7 @@ bool KeyMetadata::createBaseDirectory(bool throw_if_failed)
         {
             std::shared_lock lock(cache_metadata->key_prefix_directory_mutex);
             fs::create_directories(getPath());
+            ProfileEvents::increment(ProfileEvents::FilesystemCacheCreatedBaseDirectories);
         }
         catch (const fs::filesystem_error & e)
         {

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -12,6 +12,7 @@ namespace CurrentMetrics
 {
     extern const Metric FilesystemCacheDownloadQueueElements;
     extern const Metric FilesystemCacheDelayedCleanupElements;
+    extern const Metric FilesystemCacheKeys;
 }
 
 namespace ProfileEvents
@@ -285,6 +286,8 @@ KeyMetadataPtr CacheMetadata::getKeyMetadata(
 
         it = bucket.emplace(
             key, std::make_shared<KeyMetadata>(key, user, this, is_initial_load)).first;
+
+        CurrentMetrics::add(CurrentMetrics::FilesystemCacheKeys);
     }
 
     it->second->assertAccess(user.user_id);
@@ -392,6 +395,8 @@ CacheMetadata::removeEmptyKey(
 
     locked_key.markAsRemoved();
     auto next_it = bucket.erase(it);
+
+    CurrentMetrics::sub(CurrentMetrics::FilesystemCacheKeys);
 
     LOG_DEBUG(log, "Key {} is removed from metadata", key);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In filesystem with journal `mkdir` is written to the journal of filesystem which is persisted to disk. In case of slow disk this can take long time. Definitely make sense to move out from reserve lock scope.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
