### PR TITLE
Fix flaky kafka rebalance test

### DIFF
--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -956,8 +956,6 @@ void StorageKafka2::updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, cons
             ++i;
         }
     }
-
-    return;
 }
 
 void StorageKafka2::saveTopicPartitionInfo(zkutil::ZooKeeper & keeper_to_use, const std::filesystem::path & keeper_path_to_data, const String & data)

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -124,8 +124,7 @@ namespace
 {
 constexpr auto MAX_FAILED_POLL_ATTEMPTS = 10;
 constexpr auto TMP_LOCKS_REFRESH_POLLS = 15;
-constexpr auto TMP_LOCKS_QUOTA_STEP = 2;
-constexpr auto LOCKS_QUOTA_MIN = 1U;
+constexpr auto TMP_LOCKS_QUOTA_STEP = 2U;
 }
 
 StorageKafka2::StorageKafka2(
@@ -755,18 +754,18 @@ void StorageKafka2::dropReplica()
 }
 
 
-// We go through all the replicas, count the number of live replicas,
+// We go through all the topic partitions, count the number of live replicas,
 // and see which partitions are already locked by other replicas
-std::pair<StorageKafka2::TopicPartitionSet, UInt32> StorageKafka2::getLockedTopicPartitions(zkutil::ZooKeeper & keeper_to_use)
+std::pair<StorageKafka2::TopicPartitionSet, StorageKafka2::ActiveReplicasInfo> StorageKafka2::getLockedTopicPartitions(zkutil::ZooKeeper & keeper_to_use)
 {
     LOG_TRACE(log, "Starting to lookup replica's state");
-    auto replicas = keeper_to_use.getChildren(keeper_path + "/replicas");
-
     StorageKafka2::TopicPartitionSet locked_partitions;
     auto lock_nodes = keeper_to_use.getChildren(keeper_path + "/topic_partition_locks");
+    std::unordered_set<String> replicas_with_lock;
 
     for (const auto & lock_name : lock_nodes)
     {
+        replicas_with_lock.insert(keeper_to_use.get(keeper_path + "/topic_partition_locks/" + lock_name));
         auto base = lock_name.substr(0, lock_name.size() - 5); // drop ".lock"
         auto sep  = base.rfind('_');
         if (sep == String::npos)
@@ -794,10 +793,12 @@ std::pair<StorageKafka2::TopicPartitionSet, UInt32> StorageKafka2::getLockedTopi
         boost::algorithm::join(already_locked_partitions_str, ", ")
     );
 
-    return {locked_partitions, replicas.size()};
+    const auto replicas_count = keeper_to_use.getChildren(keeper_path + "/replicas").size();
+    const auto has_replica_without_locks = replicas_with_lock.size() < replicas_count;
+    return {locked_partitions, ActiveReplicasInfo{replicas_count, has_replica_without_locks}};
 }
 
-std::pair<StorageKafka2::TopicPartitions, UInt32> StorageKafka2::getAvailableTopicPartitions(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & all_topic_partitions)
+std::pair<StorageKafka2::TopicPartitions, StorageKafka2::ActiveReplicasInfo> StorageKafka2::getAvailableTopicPartitions(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & all_topic_partitions)
 {
     const auto get_locked_partitions_res = getLockedTopicPartitions(keeper_to_use);
     const auto & already_locked_partitions = get_locked_partitions_res.first;
@@ -860,28 +861,43 @@ std::optional<StorageKafka2::LockedTopicPartitionInfo> StorageKafka2::createLock
 
 // First we delete all current temporary locks,
 // then we create new locks from free partitions
-void StorageKafka2::updateTemporaryLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & tmp_locks, std::optional<size_t> & tmp_locks_quota)
+void StorageKafka2::updateTemporaryLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & tmp_locks, size_t & tmp_locks_quota)
 {
     LOG_TRACE(log, "Starting to update temporary locks");
+    tmp_locks.clear();
     auto available_topic_partitions_res = getAvailableTopicPartitions(keeper_to_use, topic_partitions);
+
+    if (available_topic_partitions_res.first.empty())
+    {
+        LOG_TRACE(log, "There are no available topic partitions to lock");
+        tmp_locks_quota = 0;
+        return;
+    }
+
     pcg64 generator(randomSeed());
     std::shuffle(available_topic_partitions_res.first.begin(), available_topic_partitions_res.first.end(), generator);
     const auto & available_topic_partitions = available_topic_partitions_res.first;
 
     /// tmp_locks_quota is increased by TMP_LOCKS_QUOTA_STEP
-    /// but always stays within [LOCKS_QUOTA_MIN, free_partitions - TMP_LOCKS_QUOTA_STEP].
-    if (!tmp_locks_quota.has_value())
-        tmp_locks_quota = LOCKS_QUOTA_MIN;
+    /// but always capped to the number of available topic partitions
+    if (tmp_locks_quota > 0 && available_topic_partitions_res.second.has_replica_without_locks)
+    {
+        LOG_TRACE(log, "There is at least one consumer without locks, won't lock any temporary locks");
+        tmp_locks_quota = 0;
+        return;
+    }
+    else if (tmp_locks_quota > 0 && tmp_locks_quota == available_topic_partitions.size())
+    {
+
+        LOG_TRACE(log, "Reducing temporary locks to give other replicas a chance to lock some partitions");
+        tmp_locks_quota--;
+    }
     else
     {
-        using quota_t = std::make_signed_t<size_t>;
-        quota_t q = static_cast<quota_t>(tmp_locks_quota.value());
-        quota_t fp = static_cast<quota_t>(available_topic_partitions.size());
-        tmp_locks_quota = static_cast<size_t>(std::clamp(q + TMP_LOCKS_QUOTA_STEP, static_cast<quota_t>(LOCKS_QUOTA_MIN), fp - TMP_LOCKS_QUOTA_STEP));
+        tmp_locks_quota = std::min(available_topic_partitions.size(), tmp_locks_quota + TMP_LOCKS_QUOTA_STEP);
     }
-    LOG_INFO(log, "The replica can take {} locks in the current round", tmp_locks_quota.value());
+    LOG_INFO(log, "The replica can take {} temporary locks in the current round", tmp_locks_quota);
 
-    tmp_locks.clear(); // to maintain order: looked at the old state, updated the state, committed the new state
     for (const auto & tp : available_topic_partitions)
     {
         if (tmp_locks.size() >= tmp_locks_quota)
@@ -895,33 +911,39 @@ void StorageKafka2::updateTemporaryLocks(zkutil::ZooKeeper & keeper_to_use, cons
 
 // If the number of locks on a replica is greater than it can hold, then we first release the partitions that we can no longer hold.
 // Otherwise, we try to lock free partitions one by one.
-bool StorageKafka2::updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & permanent_locks)
+void StorageKafka2::updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & permanent_locks)
 {
     LOG_TRACE(log, "Starting to update permanent locks");
     const auto available_topic_partitions_res = getAvailableTopicPartitions(keeper_to_use, topic_partitions);
     const auto & available_topic_partitions = available_topic_partitions_res.first;
-    const auto active_replica_count = available_topic_partitions_res.second;
-    size_t can_lock_partitions = std::max<size_t>(active_replica_count != 0 ?
-        topic_partitions.size() / static_cast<size_t>(active_replica_count) : LOCKS_QUOTA_MIN,
-        LOCKS_QUOTA_MIN);
+    const auto active_replica_count = available_topic_partitions_res.second.active_replica_count;
+    chassert(active_replica_count > 0 && "There should be at least one active replica, because we are active");
+    size_t can_lock_partitions = std::max<size_t>(topic_partitions.size() / static_cast<size_t>(active_replica_count), 1);
 
-    // tells us “the set of permanent assignments shifted”.
-    // We use this flag to trigger an immediate refresh of temporary locks
-    // so that no stale partitions linger when the “stable” assignment changes under us.
-    bool permanent_locks_changed = false;
+    LOG_TRACE(log, "The replica can have {} permanent locks after the current round", can_lock_partitions);
+
+    if (can_lock_partitions == permanent_locks.size())
+    {
+        LOG_TRACE(log, "The number of permanent locks is equal to the number of locks that can be taken, will not update them");
+        return;
+    }
+
     if (can_lock_partitions < permanent_locks.size())
     {
+        LOG_TRACE(log, "Will release the extra {} topic partition locks", permanent_locks.size() - can_lock_partitions);
         size_t need_to_unlock = permanent_locks.size() - can_lock_partitions;
         auto permanent_locks_it = permanent_locks.begin();
         for (size_t i = 0; i < need_to_unlock && permanent_locks_it != permanent_locks.end(); ++i)
         {
-            permanent_locks_changed = true;
+            LOG_TEST(log, "Releasing topic partition lock for [{}:{}] at offset",
+                permanent_locks_it->first.topic, permanent_locks_it->first.partition_id);
             permanent_locks_it = permanent_locks.erase(permanent_locks_it);
         }
     }
     else
     {
         size_t need_to_lock = can_lock_partitions - permanent_locks.size();
+        LOG_TRACE(log, "Will try to lock {} topic partitions", need_to_lock);
         auto tp_it = available_topic_partitions.begin();
         for (size_t i = 0; i < need_to_lock && tp_it != available_topic_partitions.end();)
         {
@@ -930,13 +952,12 @@ bool StorageKafka2::updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, cons
             auto maybe_lock = createLocksInfoIfFree(keeper_to_use, tp);
             if (!maybe_lock.has_value())
                 continue;
-            permanent_locks_changed = true;
             permanent_locks.emplace(TopicPartition(tp), std::move(*maybe_lock));
             ++i;
         }
     }
 
-    return permanent_locks_changed;
+    return;
 }
 
 void StorageKafka2::saveTopicPartitionInfo(zkutil::ZooKeeper & keeper_to_use, const std::filesystem::path & keeper_path_to_data, const String & data)
@@ -1269,12 +1290,9 @@ std::optional<StorageKafka2::StallReason> StorageKafka2::streamToViews(size_t id
                 return StallReason::NoMetadata;
             }
 
-            const auto permanent_locks_changed = updatePermanentLocks(*consumer_info.keeper, all_topic_partitions, consumer_info.permanent_locks);
-            if (permanent_locks_changed || consumer_info.poll_count >= TMP_LOCKS_REFRESH_POLLS)
-            {
-                updateTemporaryLocks(*consumer_info.keeper, all_topic_partitions, consumer_info.tmp_locks, consumer_info.tmp_locks_quota);
-                consumer_info.poll_count = 0;
-            }
+            updatePermanentLocks(*consumer_info.keeper, all_topic_partitions, consumer_info.permanent_locks);
+            updateTemporaryLocks(*consumer_info.keeper, all_topic_partitions, consumer_info.tmp_locks, consumer_info.tmp_locks_quota);
+            consumer_info.poll_count = 0;
 
             // Now we always have some assignment
             consumer_info.topic_partitions.clear();

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -139,7 +139,7 @@ private:
         TopicPartitionLocks tmp_locks{};
 
         // Quota, how many temporary locks can be taken in current round
-        std::optional<size_t> tmp_locks_quota = std::nullopt;
+        size_t tmp_locks_quota{};
 
         // Searches first in permanent_locks, then in tmp_locks.
         // Returns a pointer to the lock if found; otherwise, returns nullptr.
@@ -255,14 +255,18 @@ private:
     void createReplica();
     void dropReplica();
 
-    // The second number in the pair is the number of active replicas
-    std::pair<TopicPartitionSet, UInt32> getLockedTopicPartitions(zkutil::ZooKeeper & keeper_to_use);
-    std::pair<TopicPartitions, UInt32> getAvailableTopicPartitions(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & all_topic_partitions);
+    struct ActiveReplicasInfo
+    {
+        UInt64 active_replica_count{0};
+        bool has_replica_without_locks{false};
+    };
+    std::pair<TopicPartitionSet, ActiveReplicasInfo> getLockedTopicPartitions(zkutil::ZooKeeper & keeper_to_use);
+    std::pair<TopicPartitions, ActiveReplicasInfo>  getAvailableTopicPartitions(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & all_topic_partitions);
     std::optional<LockedTopicPartitionInfo> createLocksInfoIfFree(zkutil::ZooKeeper & keeper_to_use, const TopicPartition & partition_to_lock);
 
     // Takes lock over topic partitions and sets the committed offset in topic_partitions
-    void updateTemporaryLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & tmp_locks, std::optional<size_t> & tmp_locks_quota);
-    bool updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & permanent_locks);
+    void updateTemporaryLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & tmp_locks, size_t & tmp_locks_quota);
+    void updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & permanent_locks);
 
     // To save commit and intent nodes
     void saveTopicPartitionInfo(zkutil::ZooKeeper & keeper_to_use, const std::filesystem::path & keeper_path_to_data, const String & data);

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -122,10 +122,8 @@ private:
         KafkaConsumer2::OnlyTopicNameAndPartitionIdHash,
         KafkaConsumer2::OnlyTopicNameAndPartitionIdEquality>;
 
-    using TopicPartitionSet = std::unordered_set<
-        TopicPartition,
-        KafkaConsumer2::OnlyTopicNameAndPartitionIdHash,
-        KafkaConsumer2::OnlyTopicNameAndPartitionIdEquality>;
+    using TopicPartitionSet = std::
+        unordered_set<TopicPartition, KafkaConsumer2::OnlyTopicNameAndPartitionIdHash, KafkaConsumer2::OnlyTopicNameAndPartitionIdEquality>;
 
     struct ConsumerAndAssignmentInfo
     {
@@ -151,7 +149,11 @@ private:
             locks_it = tmp_locks.find(topic_partition);
             if (locks_it != tmp_locks.end())
                 return &locks_it->second;
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot find locks for topic partition {}:{}", topic_partition.topic, topic_partition.partition_id);
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Cannot find locks for topic partition {}:{}",
+                topic_partition.topic,
+                topic_partition.partition_id);
         }
     };
 
@@ -166,7 +168,10 @@ private:
     {
         BackgroundSchedulePoolTaskHolder holder;
         std::atomic<bool> stream_cancelled{false};
-        explicit TaskContext(BackgroundSchedulePoolTaskHolder && task_) : holder(std::move(task_)) { }
+        explicit TaskContext(BackgroundSchedulePoolTaskHolder && task_)
+            : holder(std::move(task_))
+        {
+        }
     };
 
     enum class AssignmentChange
@@ -261,12 +266,26 @@ private:
         bool has_replica_without_locks{false};
     };
     std::pair<TopicPartitionSet, ActiveReplicasInfo> getLockedTopicPartitions(zkutil::ZooKeeper & keeper_to_use);
-    std::pair<TopicPartitions, ActiveReplicasInfo>  getAvailableTopicPartitions(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & all_topic_partitions);
-    std::optional<LockedTopicPartitionInfo> createLocksInfoIfFree(zkutil::ZooKeeper & keeper_to_use, const TopicPartition & partition_to_lock);
 
-    // Takes lock over topic partitions and sets the committed offset in topic_partitions
-    void updateTemporaryLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & tmp_locks, size_t & tmp_locks_quota);
-    void updatePermanentLocks(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & topic_partitions, TopicPartitionLocks & permanent_locks);
+    std::pair<TopicPartitions, ActiveReplicasInfo>
+    getAvailableTopicPartitions(zkutil::ZooKeeper & keeper_to_use, const TopicPartitions & all_topic_partitions);
+
+    std::optional<LockedTopicPartitionInfo>
+    createLocksInfoIfFree(zkutil::ZooKeeper & keeper_to_use, const TopicPartition & partition_to_lock);
+
+    void lockTemporaryLocks(
+        zkutil::ZooKeeper & keeper_to_use,
+        const TopicPartitions & available_topic_partitions,
+        TopicPartitionLocks & tmp_locks,
+        size_t & tmp_locks_quota,
+        bool has_replica_without_locks);
+
+    void updatePermanentLocks(
+        zkutil::ZooKeeper & keeper_to_use,
+        const TopicPartitions & topic_partitions,
+        TopicPartitionLocks & permanent_locks,
+        size_t topic_partitions_count,
+        size_t active_replica_count);
 
     // To save commit and intent nodes
     void saveTopicPartitionInfo(zkutil::ZooKeeper & keeper_to_use, const std::filesystem::path & keeper_path_to_data, const String & data);

--- a/tests/integration/test_storage_kafka/test_batch_slow_6.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_6.py
@@ -201,7 +201,7 @@ def test_block_based_formats_2(kafka_cluster, create_query_generator):
     ],
 )
 def test_kafka_rebalance(kafka_cluster, create_query_generator, log_line):
-    NUMBER_OF_CONSURRENT_CONSUMERS = 11
+    NUMBER_OF_CONSURRENT_CONSUMERS = 5
 
     instance.query(
         """

--- a/tests/integration/test_storage_kafka/test_zookeeper_locks.py
+++ b/tests/integration/test_storage_kafka/test_zookeeper_locks.py
@@ -102,7 +102,7 @@ def test_zookeeper_partition_locks(kafka_cluster):
         for i in range(num_partitions):
             messages.append(json.dumps({"key": i, "value": i}))
         k.kafka_produce(kafka_cluster, topic_name, messages, retries=5)
-        
+
         base = f"{keeper_path}/topic_partition_locks"
         expected_locks = {f"zk_locks_topic_{pid}.lock" for pid in range(num_partitions)}
         with KeeperClient.from_cluster(kafka_cluster, keeper_node="zoo1") as zk:
@@ -180,7 +180,7 @@ def test_three_replicas_ten_partitions_rebalance(kafka_cluster):
                 time.sleep(interval)
             else:
                 pytest.fail(f"Timed out waiting for locks in ZK: got {children!r}, expected {expected_locks!r}")
-            
+
             counts = {replica: 0 for replica in replica_names}
             for lock in expected_locks:
                 owner = zk.get(f"{base}/{lock}")
@@ -191,5 +191,5 @@ def test_three_replicas_ten_partitions_rebalance(kafka_cluster):
             base_count = num_partitions // len(replica_names)
             values = sorted(counts.values())
             assert sum(values) == num_partitions
-            assert all(v in (base_count-1, base_count, base_count+1) for v in values)
+            assert all(v in (base_count-1, base_count, base_count+1) for v in values), f"Values: {values}"
             assert values[-1] - values[0] <= 2


### PR DESCRIPTION
In every second lock update replicas will release all topic partitions to let new replicas pick them up. Fixes #81263.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
