### PR TITLE
Fix markReplicasActive in DDLWorker and DatabaseReplicatedDDLWorker

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.h
+++ b/src/Databases/DatabaseReplicatedWorker.h
@@ -46,7 +46,7 @@ private:
     void initializeReplication() override;
 
     void createReplicaDirs(const ZooKeeperPtr &, const NameSet &) override { }
-    void markReplicasActive(bool) override { }
+    void markReplicasActive(bool reinitialized) override;
 
     void initializeLogPointer(const String & processed_entry_name);
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -74,6 +74,7 @@ namespace ErrorCodes
     extern const int MEMORY_LIMIT_EXCEEDED;
     extern const int NOT_IMPLEMENTED;
     extern const int TOO_MANY_SIMULTANEOUS_QUERIES;
+    extern const int NO_ZOOKEEPER;
 }
 
 constexpr const char * TASK_PROCESSED_OUT_REASON = "Task has been already processed";
@@ -168,9 +169,11 @@ DDLWorker::~DDLWorker()
 }
 
 
-ZooKeeperPtr DDLWorker::tryGetZooKeeper() const
+ZooKeeperPtr DDLWorker::getZooKeeper() const
 {
     std::lock_guard lock(zookeeper_mutex);
+    if (!current_zookeeper)
+        throw Exception(ErrorCodes::NO_ZOOKEEPER, "Unable to get zookeeper");
     return current_zookeeper;
 }
 
@@ -275,7 +278,7 @@ static void filterAndSortQueueNodes(Strings & all_nodes)
 void DDLWorker::scheduleTasks(bool reinitialized)
 {
     LOG_DEBUG(log, "Scheduling tasks");
-    auto zookeeper = tryGetZooKeeper();
+    auto zookeeper = getZooKeeper();
 
     /// Main thread of DDLWorker was restarted, probably due to lost connection with ZooKeeper.
     /// We have some unfinished tasks.
@@ -1082,7 +1085,7 @@ String DDLWorker::enqueueQueryAttempt(DDLLogEntry & entry)
     if (entry.hosts.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty host list in a distributed DDL task");
 
-    auto zookeeper = getAndSetZooKeeper();
+    auto zookeeper = context->getZooKeeper();
 
     String query_path_prefix = fs::path(queue_dir) / "query-";
     zookeeper->createAncestors(query_path_prefix);
@@ -1160,19 +1163,30 @@ bool DDLWorker::initializeMainThread()
 
 void DDLWorker::runMainThread()
 {
-    auto reset_state = [&]()
+    auto mark_reinitializing = [&]()
     {
+        LOG_INFO(log, "Marking reinitializing");
         initialized = false;
         /// It will wait for all threads in pool to finish and will not rethrow exceptions (if any).
         /// We create new thread pool to forget previous exceptions.
         if (1 < pool_size)
-            worker_pool = std::make_unique<ThreadPool>(CurrentMetrics::DDLWorkerThreads, CurrentMetrics::DDLWorkerThreadsActive, CurrentMetrics::DDLWorkerThreadsScheduled, pool_size);
+            worker_pool = std::make_unique<ThreadPool>(
+                CurrentMetrics::DDLWorkerThreads,
+                CurrentMetrics::DDLWorkerThreadsActive,
+                CurrentMetrics::DDLWorkerThreadsScheduled,
+                pool_size);
+    };
+
+    auto reset_state = [&]()
+    {
+        mark_reinitializing();
         /// Clear other in-memory state, like server just started.
         current_tasks.clear();
         last_skipped_entry_name.reset();
         max_id = 0;
         LOG_INFO(log, "Cleaned DDLWorker state");
     };
+
 
     setThreadName("DDLWorker");
     LOG_DEBUG(log, "Starting DDLWorker thread");
@@ -1212,10 +1226,7 @@ void DDLWorker::runMainThread()
             subsequent_errors_count = 0;
             if (Coordination::isHardwareError(e.code))
             {
-                initialized = false;
-                /// Wait for pending async tasks
-                if (1 < pool_size)
-                    worker_pool = std::make_unique<ThreadPool>(CurrentMetrics::DDLWorkerThreads, CurrentMetrics::DDLWorkerThreadsActive, CurrentMetrics::DDLWorkerThreadsScheduled, pool_size);
+                mark_reinitializing();
                 LOG_INFO(log, "Lost ZooKeeper connection, will try to connect again: {}", getCurrentExceptionMessage(true));
             }
             else
@@ -1260,7 +1271,7 @@ void DDLWorker::runMainThread()
 
 void DDLWorker::initializeReplication()
 {
-    auto zookeeper = getAndSetZooKeeper();
+    auto zookeeper = getZooKeeper();
 
     zookeeper->createAncestors(fs::path(replicas_dir) / "");
 
@@ -1284,7 +1295,7 @@ void DDLWorker::createReplicaDirs(const ZooKeeperPtr & zookeeper, const NameSet 
 
 void DDLWorker::markReplicasActive(bool reinitialized)
 {
-    auto zookeeper = getAndSetZooKeeper();
+    auto zookeeper = getZooKeeper();
 
     if (reinitialized)
     {
@@ -1299,6 +1310,27 @@ void DDLWorker::markReplicasActive(bool reinitialized)
 
         active_node_holders.clear();
     }
+
+    for (auto it = active_node_holders.begin(); it != active_node_holders.end();)
+    {
+        auto & zk = it->second.first;
+        if (zk->expired())
+        {
+            const auto & host_id = it->first;
+            String active_path = fs::path(replicas_dir) / host_id / "active";
+            LOG_DEBUG(log, "Zookeeper of active_path {} expired, removing the holder", active_path);
+
+            auto & active_node_holder = it->second.second;
+            if (active_node_holder)
+                active_node_holder->setAlreadyRemoved();
+            it = active_node_holders.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
 
     const auto maybe_secure_port = context->getTCPPortSecure();
     const auto port = context->getTCPPort();
@@ -1336,11 +1368,11 @@ void DDLWorker::markReplicasActive(bool reinitialized)
         }
 
         String active_path = fs::path(replicas_dir) / host_id / "active";
-        if (zookeeper->exists(active_path))
-            continue;
-
         String active_id = toString(ServerUUID::get());
+
         LOG_TRACE(log, "Trying to mark a replica active: active_path={}, active_id={}", active_path, active_id);
+
+        zookeeper->deleteEphemeralNodeIfContentMatches(active_path, active_id);
 
         zookeeper->create(active_path, active_id, zkutil::CreateMode::Ephemeral);
         auto active_node_holder_zookeeper = zookeeper;
@@ -1371,7 +1403,7 @@ void DDLWorker::runCleanupThread()
             }
 
             /// ZooKeeper connection is recovered by main thread. We will wait for it on cleanup_event.
-            auto zookeeper = tryGetZooKeeper();
+            auto zookeeper = getZooKeeper();
             if (zookeeper->expired())
                 continue;
 

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -90,8 +90,9 @@ public:
 
 
     /// Returns cached ZooKeeper session (possibly expired).
-    ZooKeeperPtr tryGetZooKeeper() const;
+    ZooKeeperPtr getZooKeeper() const;
     /// If necessary, creates a new session and caches it.
+    /// Should be called in `initializeMainThread` only, so if it is expired, `runMainThread` will reinitialized the state.
     ZooKeeperPtr getAndSetZooKeeper();
 
 protected:

--- a/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
+++ b/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
@@ -238,7 +238,7 @@ void StorageSystemDDLWorkerQueue::fillData(MutableColumns & res_columns, Context
 {
     auto& ddl_worker = context->getDDLWorker();
     fs::path ddl_zookeeper_path = ddl_worker.getQueueDir();
-    zkutil::ZooKeeperPtr zookeeper = ddl_worker.getAndSetZooKeeper();
+    zkutil::ZooKeeperPtr zookeeper = context->getZooKeeper();
     Strings ddl_task_paths = zookeeper->getChildren(ddl_zookeeper_path);
 
 

--- a/tests/integration/test_row_policy/configs/config.d/remote_servers.xml
+++ b/tests/integration/test_row_policy/configs/config.d/remote_servers.xml
@@ -14,19 +14,19 @@
                 </replica>
             </shard>
         </test_local_cluster>
-        <test_cluster_two_shards_localhost>
+        <test_cluster_two_shards_same_node>
              <shard>
                  <replica>
-                     <host>localhost</host>
+                     <host>node</host>
                      <port>9000</port>
                  </replica>
              </shard>
              <shard>
                  <replica>
-                     <host>localhost</host>
+                     <host>node</host>
                      <port>9000</port>
                  </replica>
              </shard>
-        </test_cluster_two_shards_localhost>
+        </test_cluster_two_shards_same_node>
     </remote_servers>
 </clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix markReplicasActive in DDLWorker and DatabaseReplicatedDDLWorker

When creating ephemeral nodes to indicate the replica is active, we hold the `ZooKeeperPtr` and `EphemeralNodeHolderPtr`. When the zookeeper expires, we expect the `DDLWorker::runMainThread` to throw an exception due to the expired keeper and re-mark the replica active in `markReplicaActive` (with `reinitialized=true`). However, the zookeeper may be recreated in other places. And `DDLWorker::runMainThread` does not encounter any error. So it doesn't remark the replica active. Hence, the active path in Keeper is removed, but the replica doesn't recreate the active path.
This PR checks if the holding keeper has expired to clear the corresponding `EphemeralNodeHolderPtr` in `markReplicaActive` even if  `reinitialized` is `false`. So that the active is recreated properly.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
