### PR TITLE
Cache metadata json string in iceberg metadata

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -97,7 +97,7 @@ std::string normalizeUuid(const std::string & uuid)
     return result;
 }
 
-static Poco::JSON::Object::Ptr readJSON(
+Poco::JSON::Object::Ptr readJSON(
     const String & metadata_file_path,
     ObjectStoragePtr object_storage,
     StorageObjectStorage::ConfigurationPtr configuration_ptr,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -97,17 +97,32 @@ std::string normalizeUuid(const std::string & uuid)
     return result;
 }
 
-Poco::JSON::Object::Ptr
-readJSON(const String & metadata_file_path, ObjectStoragePtr object_storage, const ContextPtr & local_context, LoggerPtr log)
+static Poco::JSON::Object::Ptr readJSON(
+    const String & metadata_file_path,
+    ObjectStoragePtr object_storage,
+    StorageObjectStorage::ConfigurationPtr configuration_ptr,
+    IcebergMetadataFilesCachePtr cache_ptr,
+    const ContextPtr & local_context,
+    LoggerPtr log)
 {
-    ObjectInfo object_info(metadata_file_path);
-    auto buf = StorageObjectStorageSource::createReadBuffer(object_info, object_storage, local_context, log);
+    auto create_fn = [&]()
+    {
+        ObjectInfo object_info(metadata_file_path);
+        auto buf = StorageObjectStorageSource::createReadBuffer(object_info, object_storage, local_context, log);
 
-    String json_str;
-    readJSONObjectPossiblyInvalid(json_str, *buf);
+        String json_str;
+        readJSONObjectPossiblyInvalid(json_str, *buf);
+        return json_str;
+    };
+
+    String metadata_json_str;
+    if (cache_ptr)
+        metadata_json_str = cache_ptr->getOrSetTableMetadata(IcebergMetadataFilesCache::getKey(configuration_ptr, metadata_file_path), create_fn);
+    else
+        metadata_json_str = create_fn();
 
     Poco::JSON::Parser parser; /// For some reason base/base/JSON.h can not parse this json file
-    Poco::Dynamic::Var json = parser.parse(json_str);
+    Poco::Dynamic::Var json = parser.parse(metadata_json_str);
     return json.extract<Poco::JSON::Object::Ptr>();
 }
 
@@ -130,12 +145,11 @@ IcebergMetadata::IcebergMetadata(
     , log(getLogger("IcebergMetadata"))
     , manifest_cache(cache_ptr)
     , last_metadata_version(metadata_version_)
-    , last_metadata_object(metadata_object_)
     , format_version(format_version_)
     , relevant_snapshot_schema_id(-1)
-    , table_location(last_metadata_object->getValue<String>(f_location))
+    , table_location(metadata_object_->getValue<String>(f_location))
 {
-    updateState(context_, true);
+    updateState(context_, metadata_object_, true);
 }
 
 std::pair<Poco::JSON::Object::Ptr, Int32> parseTableSchemaV2Method(const Poco::JSON::Object::Ptr & metadata_object)
@@ -174,7 +188,7 @@ std::pair<Poco::JSON::Object::Ptr, Int32> parseTableSchemaV1Method(const Poco::J
 {
     if (!metadata_object->has(f_schema))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot parse Iceberg table schema: '{}' field is missing in metadata", f_schema);
-    Poco::JSON::Object::Ptr schema = metadata_object->getObject("schema");
+    Poco::JSON::Object::Ptr schema = metadata_object->getObject(f_schema);
     if (!metadata_object->has(f_schema_id))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot parse Iceberg table schema: '{}' field is missing in schema", f_schema_id);
     auto current_schema_id = schema->getValue<int>(f_schema_id);
@@ -182,16 +196,16 @@ std::pair<Poco::JSON::Object::Ptr, Int32> parseTableSchemaV1Method(const Poco::J
 }
 
 
-void IcebergMetadata::addTableSchemaById(Int32 schema_id)
+void IcebergMetadata::addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object)
 {
     if (schema_processor.hasClickhouseTableSchemaById(schema_id))
         return;
-    if (!last_metadata_object->has(f_schemas))
+    if (!metadata_object->has(f_schemas))
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS, "Cannot parse Iceberg table schema with id `{}`: 'schemas' field is missing in metadata", schema_id);
     }
-    auto schemas = last_metadata_object->get("schemas").extract<Poco::JSON::Array::Ptr>();
+    auto schemas = metadata_object->get(f_schemas).extract<Poco::JSON::Array::Ptr>();
     for (uint32_t i = 0; i != schemas->size(); ++i)
     {
         auto current_schema = schemas->getObject(i);
@@ -295,22 +309,23 @@ struct ShortMetadataFileInfo
  */
 static std::pair<Int32, String> getLatestMetadataFileAndVersion(
     const ObjectStoragePtr & object_storage,
-    const StorageObjectStorage::Configuration & configuration,
+    StorageObjectStorage::ConfigurationPtr configuration_ptr,
+    IcebergMetadataFilesCachePtr cache_ptr,
     const ContextPtr & local_context,
     const std::optional<String> & table_uuid)
 {
     auto log = getLogger("IcebergMetadataFileResolver");
     MostRecentMetadataFileSelectionWay selection_way
-        = configuration.getDataLakeSettings()[DataLakeStorageSetting::iceberg_recent_metadata_file_by_last_updated_ms_field].value
+        = configuration_ptr->getDataLakeSettings()[DataLakeStorageSetting::iceberg_recent_metadata_file_by_last_updated_ms_field].value
         ? MostRecentMetadataFileSelectionWay::BY_LAST_UPDATED_MS_FIELD
         : MostRecentMetadataFileSelectionWay::BY_METADATA_FILE_VERSION;
     bool need_all_metadata_files_parsing
         = (selection_way == MostRecentMetadataFileSelectionWay::BY_LAST_UPDATED_MS_FIELD) || table_uuid.has_value();
-    const auto metadata_files = listFiles(*object_storage, configuration, "metadata", ".metadata.json");
+    const auto metadata_files = listFiles(*object_storage, *configuration_ptr, "metadata", ".metadata.json");
     if (metadata_files.empty())
     {
         throw Exception(
-            ErrorCodes::FILE_DOESNT_EXIST, "The metadata file for Iceberg table with path {} doesn't exist", configuration.getPath());
+            ErrorCodes::FILE_DOESNT_EXIST, "The metadata file for Iceberg table with path {} doesn't exist", configuration_ptr->getPath());
     }
     std::vector<ShortMetadataFileInfo> metadata_files_with_versions;
     metadata_files_with_versions.reserve(metadata_files.size());
@@ -319,7 +334,7 @@ static std::pair<Int32, String> getLatestMetadataFileAndVersion(
         auto [version, metadata_file_path] = getMetadataFileAndVersion(path);
         if (need_all_metadata_files_parsing)
         {
-            auto metadata_file_object = readJSON(metadata_file_path, object_storage, local_context, log);
+            auto metadata_file_object = readJSON(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log);
             if (table_uuid.has_value())
             {
                 if (metadata_file_object->has(f_table_uuid))
@@ -374,11 +389,12 @@ static std::pair<Int32, String> getLatestMetadataFileAndVersion(
 
 static std::pair<Int32, String> getLatestOrExplicitMetadataFileAndVersion(
     const ObjectStoragePtr & object_storage,
-    const StorageObjectStorage::Configuration & configuration,
+    StorageObjectStorage::ConfigurationPtr configuration_ptr,
+    IcebergMetadataFilesCachePtr cache_ptr,
     const ContextPtr & local_context,
     Poco::Logger * log)
 {
-    const auto & data_lake_settings = configuration.getDataLakeSettings();
+    const auto & data_lake_settings = configuration_ptr->getDataLakeSettings();
     if (data_lake_settings[DataLakeStorageSetting::iceberg_metadata_file_path].changed)
     {
         auto explicit_metadata_path = data_lake_settings[DataLakeStorageSetting::iceberg_metadata_file_path].value;
@@ -392,7 +408,7 @@ static std::pair<Int32, String> getLatestOrExplicitMetadataFileAndVersion(
                 if (*it == "." || *it == "..")
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Relative paths are not allowed");
             }
-            auto prefix_storage_path = configuration.getPath();
+            auto prefix_storage_path = configuration_ptr->getPath();
             if (!explicit_metadata_path.starts_with(prefix_storage_path))
                 explicit_metadata_path = std::filesystem::path(prefix_storage_path) / explicit_metadata_path;
             return getMetadataFileAndVersion(explicit_metadata_path);
@@ -405,11 +421,11 @@ static std::pair<Int32, String> getLatestOrExplicitMetadataFileAndVersion(
     else if (data_lake_settings[DataLakeStorageSetting::iceberg_metadata_table_uuid].changed)
     {
         std::optional<String> table_uuid = data_lake_settings[DataLakeStorageSetting::iceberg_metadata_table_uuid].value;
-        return getLatestMetadataFileAndVersion(object_storage, configuration, local_context, table_uuid);
+        return getLatestMetadataFileAndVersion(object_storage, configuration_ptr, cache_ptr, local_context, table_uuid);
     }
     else if (data_lake_settings[DataLakeStorageSetting::iceberg_use_version_hint].value)
     {
-        auto prefix_storage_path = configuration.getPath();
+        auto prefix_storage_path = configuration_ptr->getPath();
         auto version_hint_path = std::filesystem::path(prefix_storage_path) / "metadata" / "version-hint.text";
         std::string metadata_file;
         StoredObject version_hint(version_hint_path);
@@ -428,7 +444,7 @@ static std::pair<Int32, String> getLatestOrExplicitMetadataFileAndVersion(
     }
     else
     {
-        return getLatestMetadataFileAndVersion(object_storage, configuration, local_context, std::nullopt);
+        return getLatestMetadataFileAndVersion(object_storage, configuration_ptr, cache_ptr, local_context, std::nullopt);
     }
 }
 
@@ -437,22 +453,22 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
     auto configuration_ptr = configuration.lock();
 
     const auto [metadata_version, metadata_file_path]
-        = getLatestOrExplicitMetadataFileAndVersion(object_storage, *configuration_ptr, local_context, log.get());
+        = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_ptr, manifest_cache, local_context, log.get());
 
     bool metadata_file_changed = false;
     if (last_metadata_version != metadata_version)
     {
         last_metadata_version = metadata_version;
-        last_metadata_object = ::DB::readJSON(metadata_file_path, object_storage, local_context, log);
         metadata_file_changed = true;
     }
 
-    chassert(format_version == last_metadata_object->getValue<int>(f_format_version));
+    auto metadata_object = readJSON(metadata_file_path, object_storage, configuration_ptr, manifest_cache, local_context, log);
+    chassert(format_version == metadata_object->getValue<int>(f_format_version));
 
     auto previous_snapshot_id = relevant_snapshot_id;
     auto previous_snapshot_schema_id = relevant_snapshot_schema_id;
 
-    updateState(local_context, metadata_file_changed);
+    updateState(local_context, metadata_object, metadata_file_changed);
 
     if (previous_snapshot_id != relevant_snapshot_id)
     {
@@ -462,16 +478,16 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
     return previous_snapshot_schema_id != relevant_snapshot_schema_id;
 }
 
-void IcebergMetadata::updateSnapshot()
+void IcebergMetadata::updateSnapshot(Poco::JSON::Object::Ptr metadata_object)
 {
     auto configuration_ptr = configuration.lock();
-    if (!last_metadata_object->has(f_snapshots))
+    if (!metadata_object->has(f_snapshots))
         throw Exception(
             ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
             "No snapshot set found in metadata for iceberg table `{}`, it is impossible to get manifest list by snapshot id `{}`",
             configuration_ptr->getPath(),
             relevant_snapshot_id);
-    auto snapshots = last_metadata_object->get(f_snapshots).extract<Poco::JSON::Array::Ptr>();
+    auto snapshots = metadata_object->get(f_snapshots).extract<Poco::JSON::Array::Ptr>();
     for (size_t i = 0; i < snapshots->size(); ++i)
     {
         const auto snapshot = snapshots->getObject(static_cast<UInt32>(i));
@@ -508,7 +524,7 @@ void IcebergMetadata::updateSnapshot()
                     relevant_snapshot_id,
                     configuration_ptr->getPath());
             relevant_snapshot_schema_id = snapshot->getValue<Int32>(f_schema_id);
-            addTableSchemaById(relevant_snapshot_schema_id);
+            addTableSchemaById(relevant_snapshot_schema_id, metadata_object);
             return;
         }
     }
@@ -519,7 +535,7 @@ void IcebergMetadata::updateSnapshot()
         configuration_ptr->getPath());
 }
 
-void IcebergMetadata::updateState(const ContextPtr & local_context, bool metadata_file_changed)
+void IcebergMetadata::updateState(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object, bool metadata_file_changed)
 {
     auto configuration_ptr = configuration.lock();
     std::optional<String> manifest_list_file;
@@ -537,9 +553,9 @@ void IcebergMetadata::updateState(const ContextPtr & local_context, bool metadat
     {
         Int64 closest_timestamp = 0;
         Int64 query_timestamp = local_context->getSettingsRef()[Setting::iceberg_timestamp_ms];
-        if (!last_metadata_object->has(f_snapshot_log))
+        if (!metadata_object->has(f_snapshot_log))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "No snapshot log found in metadata for iceberg table {} so it is impossible to get relevant snapshot id using timestamp", configuration_ptr->getPath());
-        auto snapshots = last_metadata_object->get(f_snapshot_log).extract<Poco::JSON::Array::Ptr>();
+        auto snapshots = metadata_object->get(f_snapshot_log).extract<Poco::JSON::Array::Ptr>();
         relevant_snapshot_id = -1;
         for (size_t i = 0; i < snapshots->size(); ++i)
         {
@@ -553,24 +569,24 @@ void IcebergMetadata::updateState(const ContextPtr & local_context, bool metadat
         }
         if (relevant_snapshot_id < 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "No snapshot found in snapshot log before requested timestamp for iceberg table {}", configuration_ptr->getPath());
-        updateSnapshot();
+        updateSnapshot(metadata_object);
     }
     else if (snapshot_id_changed)
     {
         relevant_snapshot_id = local_context->getSettingsRef()[Setting::iceberg_snapshot_id];
-        updateSnapshot();
+        updateSnapshot(metadata_object);
     }
     else if (metadata_file_changed)
     {
-        if (!last_metadata_object->has(f_current_snapshot_id))
+        if (!metadata_object->has(f_current_snapshot_id))
             relevant_snapshot_id = -1;
         else
-            relevant_snapshot_id = last_metadata_object->getValue<Int64>(f_current_snapshot_id);
+            relevant_snapshot_id = metadata_object->getValue<Int64>(f_current_snapshot_id);
         if (relevant_snapshot_id != -1)
         {
-            updateSnapshot();
+            updateSnapshot(metadata_object);
         }
-        relevant_snapshot_schema_id = parseTableSchema(last_metadata_object, schema_processor, log);
+        relevant_snapshot_schema_id = parseTableSchema(metadata_object, schema_processor, log);
     }
 }
 
@@ -604,28 +620,9 @@ DataLakeMetadataPtr IcebergMetadata::create(
     else
         LOG_TRACE(log, "Not using in-memory cache for iceberg metadata files, because the setting use_iceberg_metadata_files_cache is false.");
 
-    const auto [metadata_version, metadata_file_path] = getLatestOrExplicitMetadataFileAndVersion(object_storage, *configuration_ptr, local_context, log.get());
+    const auto [metadata_version, metadata_file_path] = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_ptr, cache_ptr, local_context, log.get());
 
-    auto create_fn = [&]()
-    {
-        ObjectInfo object_info(metadata_file_path); // NOLINT
-        auto buf = StorageObjectStorageSource::createReadBuffer(object_info, object_storage, local_context, log);
-
-        String json_str;
-        readJSONObjectPossiblyInvalid(json_str, *buf);
-        return json_str;
-    };
-
-    String metadata_json_str;
-    if (cache_ptr)
-        metadata_json_str = cache_ptr->getOrSetTableMetadata(IcebergMetadataFilesCache::getKey(configuration_ptr, metadata_file_path), create_fn);
-    else
-        metadata_json_str = create_fn();
-
-    /// For some reason base/base/JSON.h can not parse this json file
-    Poco::JSON::Parser parser;
-    Poco::Dynamic::Var json = parser.parse(metadata_json_str);
-    Poco::JSON::Object::Ptr object = json.extract<Poco::JSON::Object::Ptr>();
+    Poco::JSON::Object::Ptr object = readJSON(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log);
 
     IcebergSchemaProcessor schema_processor;
 
@@ -703,11 +700,11 @@ IcebergMetadata::IcebergHistory IcebergMetadata::getHistory() const
 {
     auto configuration_ptr = configuration.lock();
 
-    const auto [metadata_version, metadata_file_path] = getLatestOrExplicitMetadataFileAndVersion(object_storage, *configuration_ptr, getContext(), log.get());
+    const auto [metadata_version, metadata_file_path] = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_ptr, manifest_cache, getContext(), log.get());
 
     chassert(metadata_version == last_metadata_version);
 
-    auto metadata_object = readJSON(metadata_file_path, object_storage, getContext(), log);
+    auto metadata_object = readJSON(metadata_file_path, object_storage, configuration_ptr, manifest_cache, getContext(), log);
 
     chassert(format_version == metadata_object->getValue<int>(f_format_version));
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -97,7 +97,7 @@ std::string normalizeUuid(const std::string & uuid)
     return result;
 }
 
-Poco::JSON::Object::Ptr readJSON(
+Poco::JSON::Object::Ptr getMetadataJSONObject(
     const String & metadata_file_path,
     ObjectStoragePtr object_storage,
     StorageObjectStorage::ConfigurationPtr configuration_ptr,
@@ -111,7 +111,7 @@ Poco::JSON::Object::Ptr readJSON(
         auto buf = StorageObjectStorageSource::createReadBuffer(object_info, object_storage, local_context, log);
 
         String json_str;
-        readJSONObjectPossiblyInvalid(json_str, *buf);
+        getMetadataJSONObjectObjectPossiblyInvalid(json_str, *buf);
         return json_str;
     };
 
@@ -334,7 +334,7 @@ static std::pair<Int32, String> getLatestMetadataFileAndVersion(
         auto [version, metadata_file_path] = getMetadataFileAndVersion(path);
         if (need_all_metadata_files_parsing)
         {
-            auto metadata_file_object = readJSON(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log);
+            auto metadata_file_object = getMetadataJSONObject(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log);
             if (table_uuid.has_value())
             {
                 if (metadata_file_object->has(f_table_uuid))
@@ -462,7 +462,7 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
         metadata_file_changed = true;
     }
 
-    auto metadata_object = readJSON(metadata_file_path, object_storage, configuration_ptr, manifest_cache, local_context, log);
+    auto metadata_object = getMetadataJSONObject(metadata_file_path, object_storage, configuration_ptr, manifest_cache, local_context, log);
     chassert(format_version == metadata_object->getValue<int>(f_format_version));
 
     auto previous_snapshot_id = relevant_snapshot_id;
@@ -622,7 +622,7 @@ DataLakeMetadataPtr IcebergMetadata::create(
 
     const auto [metadata_version, metadata_file_path] = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_ptr, cache_ptr, local_context, log.get());
 
-    Poco::JSON::Object::Ptr object = readJSON(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log);
+    Poco::JSON::Object::Ptr object = getMetadataJSONObject(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log);
 
     IcebergSchemaProcessor schema_processor;
 
@@ -704,7 +704,7 @@ IcebergMetadata::IcebergHistory IcebergMetadata::getHistory() const
 
     chassert(metadata_version == last_metadata_version);
 
-    auto metadata_object = readJSON(metadata_file_path, object_storage, configuration_ptr, manifest_cache, getContext(), log);
+    auto metadata_object = getMetadataJSONObject(metadata_file_path, object_storage, configuration_ptr, manifest_cache, getContext(), log);
 
     chassert(format_version == metadata_object->getValue<int>(f_format_version));
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -111,7 +111,7 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
         auto buf = StorageObjectStorageSource::createReadBuffer(object_info, object_storage, local_context, log);
 
         String json_str;
-        getMetadataJSONObjectObjectPossiblyInvalid(json_str, *buf);
+        readJSONObjectPossiblyInvalid(json_str, *buf);
         return json_str;
     };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -107,7 +107,6 @@ private:
     std::tuple<Int64, Int32> getVersion() const { return std::make_tuple(relevant_snapshot_id, relevant_snapshot_schema_id); }
 
     Int32 last_metadata_version;
-    Poco::JSON::Object::Ptr last_metadata_object;
     Int32 format_version;
 
 
@@ -118,16 +117,16 @@ private:
 
     mutable std::optional<Strings> cached_unprunned_files_for_last_processed_snapshot;
 
-    void updateState(const ContextPtr & local_context, bool metadata_file_changed);
+    void updateState(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object, bool metadata_file_changed);
 
     Strings getDataFiles(const ActionsDAG * filter_dag) const;
 
-    void updateSnapshot();
+    void updateSnapshot(Poco::JSON::Object::Ptr metadata_object);
 
     Iceberg::ManifestListPtr getManifestList(const String & filename) const;
     mutable std::vector<Iceberg::ManifestFileEntry> positional_delete_files_for_current_query;
 
-    void addTableSchemaById(Int32 schema_id);
+    void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object);
 
     std::optional<Int32> getSchemaVersionByFileIfOutdated(String data_path) const;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -102,7 +102,7 @@ public:
     }
 
     template <typename LoadFunc>
-    const String & getOrSetTableMetadata(const String & data_path, LoadFunc && load_fn)
+    String getOrSetTableMetadata(const String & data_path, LoadFunc && load_fn)
     {
         auto load_fn_wrapper = [&]()
         {

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -2585,7 +2585,8 @@ def test_metadata_cache(started_cluster, storage_type):
         )
     )
 
-    assert 0 == int(
+    # cache hit = 1 because we read metadata object string from cache when we call update()
+    assert 1 == int(
         instance.query(
             f"SELECT ProfileEvents['IcebergMetadataFilesCacheHits'] FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
         )
@@ -2626,7 +2627,7 @@ def test_metadata_cache(started_cluster, storage_type):
         )
     )
 
-    assert 0 == int(
+    assert 1 == int(
         instance.query(
             f"SELECT ProfileEvents['IcebergMetadataFilesCacheHits'] FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
         )

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -2585,13 +2585,6 @@ def test_metadata_cache(started_cluster, storage_type):
         )
     )
 
-    # cache hit = 1 because we read metadata object string from cache when we call update()
-    assert 1 == int(
-        instance.query(
-            f"SELECT ProfileEvents['IcebergMetadataFilesCacheHits'] FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
-        )
-    )
-
     query_id = f"{TABLE_NAME}-{uuid.uuid4()}"
     instance.query(
         f"SELECT * FROM {table_expr}",
@@ -2624,12 +2617,6 @@ def test_metadata_cache(started_cluster, storage_type):
     assert 0 < int(
         instance.query(
             f"SELECT ProfileEvents['IcebergMetadataFilesCacheMisses'] FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
-        )
-    )
-
-    assert 1 == int(
-        instance.query(
-            f"SELECT ProfileEvents['IcebergMetadataFilesCacheHits'] FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
         )
     )
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

In this PR https://github.com/ClickHouse/ClickHouse/pull/80904
metadata json string is cached, but in Iceberg metadata, it still cache json object. This PR will fix it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
