### PR TITLE
Always allow DDL for inner users.

### DIFF
--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -1,4 +1,5 @@
 #include <Storages/StorageInMemoryMetadata.h>
+#include "Access/ContextAccess.h"
 
 #include <Access/AccessControl.h>
 #include <Access/User.h>
@@ -159,6 +160,7 @@ ContextMutablePtr StorageInMemoryMetadata::getSQLSecurityOverriddenContext(Conte
     auto changed_settings = context->getSettingsRef().changes();
     new_context->clampToSettingsConstraints(changed_settings, SettingSource::QUERY);
     new_context->applySettingsChanges(changed_settings);
+    new_context->setSetting("allow_ddl", 1);
 
     return new_context;
 }

--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -1,5 +1,4 @@
 #include <Storages/StorageInMemoryMetadata.h>
-#include "Access/ContextAccess.h"
 
 #include <Access/AccessControl.h>
 #include <Access/User.h>

--- a/tests/integration/test_refreshable_mv/configs/users.xml
+++ b/tests/integration/test_refreshable_mv/configs/users.xml
@@ -3,6 +3,7 @@
         <default>
             <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
             <allow_experimental_alter_materialized_view_structure>1</allow_experimental_alter_materialized_view_structure>
+            <allow_ddl>1</allow_ddl>
         </default>
     </profiles>
     <users>

--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -51,17 +51,17 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 @pytest.fixture
 def cleanup():
     yield
 
     for node in nodes + [reading_node]:
-        node.query(
-            "drop database if exists re sync;"
-            "drop table if exists system.a;")
+        node.query("drop database if exists re sync;" "drop table if exists system.a;")
 
     global test_idx
     test_idx += 1
+
 
 def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
     for node in nodes:
@@ -177,7 +177,9 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
     )
 
     # Locate coordination znodes.
-    znode_exists_query = lambda uuid: f"select count() from system.zookeeper where path = '/clickhouse/tables/{uuid}' and name = 'shard1'"
+    znode_exists_query = (
+        lambda uuid: f"select count() from system.zookeeper where path = '/clickhouse/tables/{uuid}' and name = 'shard1'"
+    )
     tables = []
     for row in node1.query(
         "select table, uuid from system.tables where database = 're'"
@@ -188,7 +190,7 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
             continue
         coordinated = not name.endswith("uncoordinated")
         tables.append((name, uuid, coordinated))
-        znode_exists = nodes[randint(0, 1)].query(znode_exists_query(uuid)) == '1\n'
+        znode_exists = nodes[randint(0, 1)].query(znode_exists_query(uuid)) == "1\n"
         assert coordinated == znode_exists
     assert sorted([name for (name, _, _) in tables]) == [
         "a",
@@ -205,7 +207,7 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
         nodes[randint(0, 1)].query(f"drop table re.{name}{' sync' if sync else ''}")
         # TODO: After https://github.com/ClickHouse/ClickHouse/issues/61065 is done (for MVs, not ReplicatedMergeTree), check the parent znode instead.
         if sync:
-            assert_eq_with_retry(nodes[randint(0, 1)], znode_exists_query(uuid), '0\n')
+            assert_eq_with_retry(nodes[randint(0, 1)], znode_exists_query(uuid), "0\n")
 
     # A little stress test dropping MV while it's refreshing, hoping to hit various cases where the
     # drop happens while creating/exchanging/dropping the inner table.
@@ -227,6 +229,7 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
     for node in nodes:
         assert node.query("show tables from re") == ""
 
+
 def test_refreshable_mv_in_system_db(started_cluster, cleanup):
     node1.query(
         "create materialized view system.a refresh every 1 second (x Int64) engine Memory as select number+1 as x from numbers(2);"
@@ -236,6 +239,7 @@ def test_refreshable_mv_in_system_db(started_cluster, cleanup):
     node1.restart_clickhouse()
     node1.query("system refresh view system.a")
     assert node1.query("select count(), sum(x) from system.a") == "2\t3\n"
+
 
 def test_refreshable_mv_in_read_only_node(started_cluster, cleanup):
     # writable node
@@ -249,15 +253,10 @@ def test_refreshable_mv_in_read_only_node(started_cluster, cleanup):
     )
 
     # disable view sync on writable node, see if there's RefreshTask on read_only node
-    node1.query(
-        "system stop view sync"
-    )
+    node1.query("system stop view sync")
 
     # clear text_log ensure all logs are related to this test
-    reading_node.query(
-        "system flush logs;"
-        "truncate table system.text_log;"
-    )
+    reading_node.query("system flush logs;" "truncate table system.text_log;")
 
     # this MV will be replicated to read_only node
     node1.query(
@@ -272,8 +271,18 @@ def test_refreshable_mv_in_read_only_node(started_cluster, cleanup):
 
     # check if there's RefreshTask on read_only node
     reading_node.query("system flush logs")
-    assert reading_node.query("select count() from system.text_log where message like '%QUERY_IS_PROHIBITED%'") == "0\n"
-    assert reading_node.query("select count() from system.view_refreshes where exception != ''") == "0\n"
+    assert (
+        reading_node.query(
+            "select count() from system.text_log where message like '%QUERY_IS_PROHIBITED%'"
+        )
+        == "0\n"
+    )
+    assert (
+        reading_node.query(
+            "select count() from system.view_refreshes where exception != ''"
+        )
+        == "0\n"
+    )
 
     # start sync and chek refresh task works well on node1
     node1.query("system start view sync")
@@ -288,6 +297,62 @@ def test_refreshable_mv_in_read_only_node(started_cluster, cleanup):
         "select count() from system.view_refreshes where exception = '' and last_refresh_replica = '1'",
         "1\n",
     )
+
+
+def test_refreshable_mv_in_read_only_node_no_ddl(started_cluster, cleanup):
+    node1.query(
+        f"create database re engine = Replicated('/test/re_{test_idx}', 'shard1', '{{replica}}');"
+    )
+
+    reading_node.query(
+        f"create database re engine = Replicated('/test/re_{test_idx}', 'shard1', '{{replica}}');"
+    )
+
+    reading_node.replace_in_config(
+        "/etc/clickhouse-server/users.d/users.xml", "<allow_ddl>1", "<allow_ddl>0"
+    )
+    reading_node.query("SYSTEM RELOAD CONFIG")
+
+    assert "DDL queries are prohibited" in reading_node.query_and_get_error(
+        "create table foo (x Int64) engine = Null;"
+    )
+
+    node1.query(
+        "create table re.foo (x Int64) engine = ReplicatedMergeTree order by x;"
+    )
+
+    node1.query("system stop view sync")
+
+    # this MV will be replicated to read_only node
+    node1.query(
+        "create materialized view re.a refresh every 1 second (x Int64) engine ReplicatedMergeTree order by x as select number*10 as x from numbers(2)",
+    )
+
+    reading_node.query("system refresh view re.a")
+
+    # slepp 3 seconds to make sure the view is refreshed
+    reading_node.query("select sleep(3)")
+
+    # check if there's RefreshTask on read_only node
+    assert (
+        reading_node.query(
+            "select count() from system.view_refreshes where exception != ''"
+        )
+        == "0\n"
+    )
+
+    assert_eq_with_retry(
+        reading_node,
+        "select * from re.a order by x",
+        "0\n10\n",
+    )
+
+    # for cleanup
+    reading_node.replace_in_config(
+        "/etc/clickhouse-server/users.d/users.xml", "<allow_ddl>0", "<allow_ddl>1"
+    )
+    reading_node.query("SYSTEM RELOAD CONFIG")
+
 
 def test_refresh_vs_shutdown_smoke(started_cluster, cleanup):
     for node in nodes:
@@ -338,6 +403,7 @@ def test_refresh_vs_shutdown_smoke(started_cluster, cleanup):
 
     node1.start_clickhouse()
 
+
 def test_pause(started_cluster, cleanup):
     for node in nodes:
         node.query(
@@ -345,24 +411,24 @@ def test_pause(started_cluster, cleanup):
         )
     node1.query(
         "create table re.src (x Int64) engine ReplicatedMergeTree order by x;"
-        "insert into re.src values (1);")
+        "insert into re.src values (1);"
+    )
     node2.query(
         "system sync database replica re;"
         "system sync replica re.src;"
         "create materialized view re.a refresh every 1 second (x Int64) engine ReplicatedMergeTree order by x as select x from re.src;"
-        "system wait view re.a")
+        "system wait view re.a"
+    )
     assert node2.query("select * from re.a") == "1\n"
     node2.query("system stop replicated view re.a")
-    node1.restart_clickhouse() # just to guarantee that it notices the new znode
+    node1.restart_clickhouse()  # just to guarantee that it notices the new znode
     try:
         node2.query("system wait view re.a")
     except QueryRuntimeException as ex:
         # If the node1.restart_clickhouse() interrupted a refresh, the error message (with substring
         # "cancelled") is written to keeper, then thrown by "system wait view". That's normal.
         assert "cancelled" in str(ex)
-    node2.query(
-        "truncate table re.src;"
-        "insert into re.src values (2);")
+    node2.query("truncate table re.src;" "insert into re.src values (2);")
     time.sleep(3)
     assert node1.query("select * from re.a") == "1\n"
     node1.query("system start replicated view re.a")
@@ -376,16 +442,17 @@ def test_pause(started_cluster, cleanup):
     for node in nodes:
         node.query("drop database re sync")
 
+
 backup_id_counter = 0
+
 
 def new_backup_destination():
     global backup_id_counter
     backup_id_counter += 1
     backup_name = f"backup{backup_id_counter}"
 
-    return (
-        f"S3('http://minio1:9001/root/data/backups/{backup_name}', 'minio', 'ClickHouse_Minio_P@ssw0rd')"
-    )
+    return f"S3('http://minio1:9001/root/data/backups/{backup_name}', 'minio', 'ClickHouse_Minio_P@ssw0rd')"
+
 
 def do_test_backup(to_table):
     for node in nodes:
@@ -393,19 +460,23 @@ def do_test_backup(to_table):
             "create database re engine = Replicated('/test/re', 'shard1', '{replica}');"
         )
 
-    target = 'rmv'
+    target = "rmv"
     if to_table:
-        node1.query("create table re.tgt (x Int64) engine ReplicatedMergeTree order by x")
-        target = 'tgt'
+        node1.query(
+            "create table re.tgt (x Int64) engine ReplicatedMergeTree order by x"
+        )
+        target = "tgt"
 
     node1.query(
         "create table re.src (x Int64) engine ReplicatedMergeTree order by x;"
-        "insert into re.src values (1);")
+        "insert into re.src values (1);"
+    )
     node2.query(
         "system sync database replica re;"
         "system sync replica re.src;"
         f"create materialized view re.rmv refresh every 1 second {'TO re.tgt' if to_table else '(x Int64) engine ReplicatedMergeTree order by x'} as select x from re.src;"
-        "system wait view re.rmv")
+        "system wait view re.rmv"
+    )
     assert node2.query(f"select * from re.{target}") == "1\n"
 
     backup_destination = new_backup_destination()
@@ -417,7 +488,8 @@ def do_test_backup(to_table):
     for node in nodes:
         node.query(
             "drop database re sync;"
-            "drop database if exists re_broken_replicated_tables sync;")
+            "drop database if exists re_broken_replicated_tables sync;"
+        )
     assert node1.query(tables_exist_query) == "0\n"
 
     node1.query(f"RESTORE ALL ON CLUSTER 'default' FROM {backup_destination};")
@@ -426,13 +498,13 @@ def do_test_backup(to_table):
     assert node2.query(tables_exist_query) == "2\n"
     if not to_table:
         # Inner tables are not backed up, wait for first refresh.
-        node1.query(f'SYSTEM WAIT VIEW re.{target}')
-        node2.query(f'SYSTEM WAIT VIEW re.{target}')
+        node1.query(f"SYSTEM WAIT VIEW re.{target}")
+        node2.query(f"SYSTEM WAIT VIEW re.{target}")
     else:
-        node1.query(f'SYSTEM SYNC REPLICA re.{target}')
-        node2.query(f'SYSTEM SYNC REPLICA re.{target}')
-    assert node1.query(f'SELECT * FROM re.{target}') == '1\n'
-    assert node2.query(f'SELECT * FROM re.{target}') == '1\n'
+        node1.query(f"SYSTEM SYNC REPLICA re.{target}")
+        node2.query(f"SYSTEM SYNC REPLICA re.{target}")
+    assert node1.query(f"SELECT * FROM re.{target}") == "1\n"
+    assert node2.query(f"SELECT * FROM re.{target}") == "1\n"
 
     node1.query("insert into re.src values (2)")
     assert_eq_with_retry(
@@ -441,27 +513,40 @@ def do_test_backup(to_table):
         "1\n2\n",
     )
 
+
 def test_backup_outer_table(started_cluster, cleanup):
     do_test_backup(True)
 
+
 def test_backup_inner_table(started_cluster, cleanup):
     do_test_backup(False)
+
 
 def test_adding_replica(started_cluster, cleanup):
     node1.query(
         "create database re engine = Replicated('/test/re', 'shard1', 'r1');"
         "create materialized view re.a refresh every 1 second (x Int64) engine ReplicatedMergeTree order by x as select number*10 as x from numbers(2);"
-        "system wait view re.a")
+        "system wait view re.a"
+    )
     assert node1.query("select * from re.a order by all") == "0\n10\n"
-    assert node1.query("select last_refresh_replica from system.view_refreshes") == "1\n"
+    assert (
+        node1.query("select last_refresh_replica from system.view_refreshes") == "1\n"
+    )
 
     r = node2.query(
         "create database re engine = Replicated('/test/re', 'shard1', 'r2');"
-        "system sync database replica re")
+        "system sync database replica re"
+    )
     assert node2.query("select * from re.a order by all") == "0\n10\n"
 
     node1.query("system stop view re.a")
-    node2.query_with_retry("select last_refresh_replica from system.view_refreshes", check_callback=lambda x: x == "2\n", sleep_time=1, retry_count=20)
+    node2.query_with_retry(
+        "select last_refresh_replica from system.view_refreshes",
+        check_callback=lambda x: x == "2\n",
+        sleep_time=1,
+        retry_count=20,
+    )
+
 
 def test_replicated_db_startup_race(started_cluster, cleanup):
     for node in nodes:
@@ -469,16 +554,26 @@ def test_replicated_db_startup_race(started_cluster, cleanup):
             f"create database re engine = Replicated('/test/re_{test_idx}', 'shard1', '{{replica}}');"
         )
     node1.query(
-            "create materialized view re.a refresh every 1 second (x Int64) engine ReplicatedMergeTree order by x as select number*10 as x from numbers(2);\
+        "create materialized view re.a refresh every 1 second (x Int64) engine ReplicatedMergeTree order by x as select number*10 as x from numbers(2);\
             system wait view re.a"
-        )
+    )
 
     # Drop a database before it's loaded.
     # We stall DatabaseReplicated::startupDatabaseAsync task and expect the server to become responsive without waiting for it.
-    node1.replace_in_config("/etc/clickhouse-server/config.d/config.xml", "<database_replicated_startup_pause>false</database_replicated_startup_pause>", "<database_replicated_startup_pause>true</database_replicated_startup_pause>")
+    node1.replace_in_config(
+        "/etc/clickhouse-server/config.d/config.xml",
+        "<database_replicated_startup_pause>false</database_replicated_startup_pause>",
+        "<database_replicated_startup_pause>true</database_replicated_startup_pause>",
+    )
     node1.restart_clickhouse()
-    node1.replace_in_config("/etc/clickhouse-server/config.d/config.xml", "<database_replicated_startup_pause>true</database_replicated_startup_pause>", "<database_replicated_startup_pause>false</database_replicated_startup_pause>")
-    drop_query_handle = node1.get_query_request("drop database re sync") # this will get stuck until we unpause loading
+    node1.replace_in_config(
+        "/etc/clickhouse-server/config.d/config.xml",
+        "<database_replicated_startup_pause>true</database_replicated_startup_pause>",
+        "<database_replicated_startup_pause>false</database_replicated_startup_pause>",
+    )
+    drop_query_handle = node1.get_query_request(
+        "drop database re sync"
+    )  # this will get stuck until we unpause loading
     time.sleep(2)
     node1.query("system disable failpoint database_replicated_startup_pause")
     _, err = drop_query_handle.get_answer_and_error()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If a replica has `allow_ddl=false`, some of the inner queries for RMV can fail.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
