### PR TITLE
Add support for the `--database` argument in `clickhouse-local`

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -907,17 +907,16 @@ void LocalServer::processConfig()
     /// We load temporary database first, because projections need it.
     DatabaseCatalog::instance().initializeAndLoadTemporaryDatabase();
 
-    std::string default_database = server_settings[ServerSetting::default_database];
-    if (default_database.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "default_database cannot be empty");
+    std::string server_default_database = server_settings[ServerSetting::default_database];
+    if (!server_default_database.empty())
     {
-        DatabasePtr database = createClickHouseLocalDatabaseOverlay(default_database, global_context);
+        DatabasePtr database = createClickHouseLocalDatabaseOverlay(server_default_database, global_context);
         if (UUID uuid = database->getUUID(); uuid != UUIDHelpers::Nil)
             DatabaseCatalog::instance().addUUIDMapping(uuid);
-        DatabaseCatalog::instance().attachDatabase(default_database, database);
+        DatabaseCatalog::instance().attachDatabase(server_default_database, database);
     }
-    global_context->setCurrentDatabase(default_database);
 
+    global_context->setCurrentDatabase(server_default_database);
     if (getClientConfiguration().has("path"))
     {
         attachInformationSchema(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::INFORMATION_SCHEMA));
@@ -969,6 +968,11 @@ void LocalServer::processConfig()
         attachInformationSchema(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::INFORMATION_SCHEMA));
         attachInformationSchema(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::INFORMATION_SCHEMA_UPPERCASE));
     }
+
+    std::string default_database = getClientConfiguration().getString("database", server_default_database);
+    if (default_database.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "default_database cannot be empty");
+    global_context->setCurrentDatabase(default_database);
 
     server_display_name = getClientConfiguration().getString("display_name", "");
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -914,9 +914,9 @@ void LocalServer::processConfig()
         if (UUID uuid = database->getUUID(); uuid != UUIDHelpers::Nil)
             DatabaseCatalog::instance().addUUIDMapping(uuid);
         DatabaseCatalog::instance().attachDatabase(server_default_database, database);
+        global_context->setCurrentDatabase(server_default_database);
     }
 
-    global_context->setCurrentDatabase(server_default_database);
     if (getClientConfiguration().has("path"))
     {
         attachInformationSchema(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::INFORMATION_SCHEMA));

--- a/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.reference
+++ b/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.reference
@@ -1,2 +1,1 @@
 CREATE TEMPORARY TABLE `table`\n(\n    `key` String\n)\nENGINE = File(TSVWithNamesAndTypes, \'/dev/null\', auto)
-CREATE TEMPORARY TABLE `table`\n(\n    `key` String\n)\nENGINE = File(TSVWithNamesAndTypes, \'/dev/null\', auto)

--- a/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.sh
+++ b/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.sh
@@ -5,4 +5,3 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 $CLICKHOUSE_LOCAL --file /dev/null --structure "key String" --input-format TSVWithNamesAndTypes --interactive <<<'show create temporary table table'
-$CLICKHOUSE_LOCAL --database foo --file /dev/null --structure "key String" --input-format TSVWithNamesAndTypes --interactive <<<'show create temporary table table'

--- a/tests/queries/0_stateless/03533_clickhouse_local_database_argument.reference
+++ b/tests/queries/0_stateless/03533_clickhouse_local_database_argument.reference
@@ -1,0 +1,9 @@
+Hello, world
+Hello, world
+Hello, world
+Hello, world
+Hello, world
+Hello, world
+Hello from a file
+Hello from a file
+Hello from a file

--- a/tests/queries/0_stateless/03533_clickhouse_local_database_argument.sh
+++ b/tests/queries/0_stateless/03533_clickhouse_local_database_argument.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --query "
+CREATE DATABASE test;
+USE test;
+CREATE TABLE t (s String) ORDER BY ();
+INSERT INTO t VALUES ('Hello, world');
+SELECT * FROM t;
+"
+
+# We can switch to the previously created database using a command-line argument:
+
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --query "SELECT * FROM test.t;"
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --query "USE test; SELECT * FROM t;"
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --database default --query "USE test; SELECT * FROM t;"
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --database test --query "SELECT * FROM t;"
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --database system --query "USE test; SELECT * FROM t;"
+
+# Only default database is configured as a filesystem overlay:
+
+echo "Hello from a file" > "${CLICKHOUSE_TMP}/file.csv"
+
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --query "SELECT * FROM '${CLICKHOUSE_TMP}/file.csv'"
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --query "SELECT * FROM default.\`${CLICKHOUSE_TMP}/file.csv\`"
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --database test --query "SELECT * FROM default.\`${CLICKHOUSE_TMP}/file.csv\`"
+
+$CLICKHOUSE_LOCAL --path "${CLICKHOUSE_TMP}" --query "DROP DATABASE test;"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for the `--database` argument in `clickhouse-local`. You can switch to a previously created database. This closes #44115.
