### PR TITLE
Fix possible crash during shutting down background pools

### DIFF
--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -23,27 +23,29 @@ class TaskNotification;
 class BackgroundSchedulePoolTaskInfo;
 class BackgroundSchedulePoolTaskHolder;
 
+class BackgroundSchedulePool;
+using BackgroundSchedulePoolPtr = std::shared_ptr<BackgroundSchedulePool>;
+using BackgroundSchedulePoolWeakPtr = std::weak_ptr<BackgroundSchedulePool>;
+
 
 /** Executes functions scheduled at a specific point in time.
   * Basically all tasks are added in a queue and precessed by worker threads.
   *
-  * The most important difference between this and BackgroundProcessingPool
+  * The most important difference between this and MergeTreeBackgroundExecutor
   *  is that we have the guarantee that the same function is not executed from many workers in the same time.
   *
   * The usage scenario: instead starting a separate thread for each task,
   *  register a task in BackgroundSchedulePool and when you need to run the task,
   *  call schedule or scheduleAfter(duration) method.
   */
-class BackgroundSchedulePool
+class BackgroundSchedulePool : public std::enable_shared_from_this<BackgroundSchedulePool>, private boost::noncopyable
 {
 public:
     friend class BackgroundSchedulePoolTaskInfo;
 
     using TaskInfo = BackgroundSchedulePoolTaskInfo;
-    using TaskInfoPtr = std::shared_ptr<TaskInfo>;
     using TaskFunc = std::function<void()>;
     using TaskHolder = BackgroundSchedulePoolTaskHolder;
-    using DelayedTasks = std::multimap<Poco::Timestamp, TaskInfoPtr>;
 
     TaskHolder createTask(const std::string & log_name, const TaskFunc & function);
 
@@ -51,14 +53,19 @@ public:
     /// be error prone. We support only increasing number of threads at runtime.
     void increaseThreadsCount(size_t new_threads_count);
 
-    /// thread_name_ cannot be longer then 13 bytes (2 bytes is reserved for "/D" suffix for delayExecutionThreadFunction())
-    BackgroundSchedulePool(size_t size_, CurrentMetrics::Metric tasks_metric_, CurrentMetrics::Metric size_metric_, const char *thread_name_);
+    static BackgroundSchedulePoolPtr create(size_t size, CurrentMetrics::Metric tasks_metric, CurrentMetrics::Metric size_metric, const char * thread_name);
+
     ~BackgroundSchedulePool();
 
 private:
+    using TaskInfoPtr = std::shared_ptr<TaskInfo>;
+    using DelayedTasks = std::multimap<Poco::Timestamp, TaskInfoPtr>;
     /// BackgroundSchedulePool schedules a task on its own task queue, there's no need to construct/restore tracing context on this level.
     /// This is also how ThreadPool class treats the tracing context. See ThreadPool for more information.
     using Threads = std::vector<ThreadFromGlobalPoolNoTracingContextPropagation>;
+
+    /// @param thread_name_ cannot be longer then 13 bytes (2 bytes is reserved for "/D" suffix for delayExecutionThreadFunction())
+    BackgroundSchedulePool(size_t size_, CurrentMetrics::Metric tasks_metric_, CurrentMetrics::Metric size_metric_, const char * thread_name_);
 
     void threadFunction();
     void delayExecutionThreadFunction();
@@ -97,8 +104,6 @@ private:
 class BackgroundSchedulePoolTaskInfo : public std::enable_shared_from_this<BackgroundSchedulePoolTaskInfo>, private boost::noncopyable
 {
 public:
-    BackgroundSchedulePoolTaskInfo(BackgroundSchedulePool & pool_, const std::string & log_name_, const BackgroundSchedulePool::TaskFunc & function_);
-
     /// Schedule for execution as soon as possible (if not already scheduled).
     /// If the task was already scheduled with delay, the delay will be ignored.
     bool schedule();
@@ -110,9 +115,9 @@ public:
     bool scheduleAfter(size_t milliseconds, bool overwrite = true, bool only_if_scheduled = false);
 
     /// Further attempts to schedule become no-op. Will wait till the end of the current execution of the task.
-    void deactivate();
+    bool deactivate();
 
-    void activate();
+    bool activate();
 
     /// Atomically activate task and schedule it for execution.
     bool activateAndSchedule();
@@ -128,11 +133,13 @@ private:
     friend class TaskNotification;
     friend class BackgroundSchedulePool;
 
-    void execute();
+    BackgroundSchedulePoolTaskInfo(BackgroundSchedulePoolWeakPtr pool_, const std::string & log_name_, const BackgroundSchedulePool::TaskFunc & function_);
 
-    void scheduleImpl(std::lock_guard<std::mutex> & schedule_mutex_lock) TSA_REQUIRES(schedule_mutex);
+    void execute(BackgroundSchedulePool & pool);
 
-    BackgroundSchedulePool & pool;
+    bool scheduleImpl(std::lock_guard<std::mutex> & schedule_mutex_lock);
+
+    BackgroundSchedulePoolWeakPtr pool_ref;
     std::string log_name;
     BackgroundSchedulePool::TaskFunc function;
 

--- a/src/Core/tests/gtest_BackgroundSchedulePool.cpp
+++ b/src/Core/tests/gtest_BackgroundSchedulePool.cpp
@@ -1,0 +1,98 @@
+#include <Core/BackgroundSchedulePool.h>
+#include <Core/BackgroundSchedulePoolTaskHolder.h>
+#include <gtest/gtest.h>
+#include <condition_variable>
+#include <mutex>
+
+using namespace DB;
+
+TEST(BackgroundSchedulePool, Schedule)
+{
+    auto pool = BackgroundSchedulePool::create(4, CurrentMetrics::end(), CurrentMetrics::end(), "tests");
+
+    std::atomic<size_t> counter;
+    std::mutex mutex;
+    std::condition_variable condvar;
+
+    static const size_t ITERATIONS = 10;
+    BackgroundSchedulePoolTaskHolder task;
+    task = pool->createTask("test", [&]
+    {
+        ++counter;
+        if (counter < ITERATIONS)
+            ASSERT_EQ(task->schedule(), true);
+        else
+            condvar.notify_one();
+    });
+    ASSERT_EQ(task->activateAndSchedule(), true);
+
+    std::unique_lock lock(mutex);
+    condvar.wait(lock, [&] { return counter == ITERATIONS; });
+
+    ASSERT_EQ(counter, ITERATIONS);
+}
+
+TEST(BackgroundSchedulePool, ScheduleAfter)
+{
+    auto pool = BackgroundSchedulePool::create(4, CurrentMetrics::end(), CurrentMetrics::end(), "tests");
+
+    std::atomic<size_t> counter;
+    std::mutex mutex;
+    std::condition_variable condvar;
+
+    static const size_t ITERATIONS = 10;
+    BackgroundSchedulePoolTaskHolder task;
+    task = pool->createTask("test", [&]
+    {
+        ++counter;
+        if (counter < ITERATIONS)
+            ASSERT_EQ(task->scheduleAfter(1), true);
+        else
+            condvar.notify_one();
+    });
+    ASSERT_EQ(task->activateAndSchedule(), true);
+
+    std::unique_lock lock(mutex);
+    condvar.wait(lock, [&] { return counter == ITERATIONS; });
+
+    ASSERT_EQ(counter, ITERATIONS);
+}
+
+/// Previously leads to UB
+TEST(BackgroundSchedulePool, ActivateAfterTerminitePool)
+{
+    BackgroundSchedulePoolTaskHolder task;
+    BackgroundSchedulePoolTaskHolder delayed_task;
+
+    {
+        auto pool = BackgroundSchedulePool::create(4, CurrentMetrics::end(), CurrentMetrics::end(), "tests");
+
+        task = pool->createTask("test", [&] {});
+        delayed_task = pool->createTask("delayed_test", [&] {});
+    }
+
+    ASSERT_EQ(task->activateAndSchedule(), false);
+
+    ASSERT_EQ(delayed_task->activate(), true); /// does not requires pool
+    ASSERT_EQ(delayed_task->scheduleAfter(1), false);
+}
+
+/// Previously leads to UB
+TEST(BackgroundSchedulePool, ScheduleAfterTerminitePool)
+{
+    BackgroundSchedulePoolTaskHolder task;
+    BackgroundSchedulePoolTaskHolder delayed_task;
+
+    {
+        auto pool = BackgroundSchedulePool::create(4, CurrentMetrics::end(), CurrentMetrics::end(), "tests");
+
+        task = pool->createTask("test", [&] {});
+        delayed_task = pool->createTask("delayed_test", [&] {});
+
+        ASSERT_EQ(task->activate(), true);
+        ASSERT_EQ(delayed_task->activate(), true);
+    }
+
+    ASSERT_EQ(task->schedule(), false);
+    ASSERT_EQ(delayed_task->scheduleAfter(1), false);
+}

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -469,13 +469,13 @@ struct ContextSharedPart : boost::noncopyable
     InterserverIOHandler interserver_io_handler;                /// Handler for interserver communication.
 
     OnceFlag buffer_flush_schedule_pool_initialized;
-    mutable std::unique_ptr<BackgroundSchedulePool> buffer_flush_schedule_pool; /// A thread pool that can do background flush for Buffer tables.
+    mutable BackgroundSchedulePoolPtr buffer_flush_schedule_pool; /// A thread pool that can do background flush for Buffer tables.
     OnceFlag schedule_pool_initialized;
-    mutable std::unique_ptr<BackgroundSchedulePool> schedule_pool;    /// A thread pool that can run different jobs in background (used in replicated tables)
+    mutable BackgroundSchedulePoolPtr schedule_pool;    /// A thread pool that can run different jobs in background (used in replicated tables)
     OnceFlag distributed_schedule_pool_initialized;
-    mutable std::unique_ptr<BackgroundSchedulePool> distributed_schedule_pool; /// A thread pool that can run different jobs in background (used for distributed sends)
+    mutable BackgroundSchedulePoolPtr distributed_schedule_pool; /// A thread pool that can run different jobs in background (used for distributed sends)
     OnceFlag message_broker_schedule_pool_initialized;
-    mutable std::unique_ptr<BackgroundSchedulePool> message_broker_schedule_pool; /// A thread pool that can run different jobs in background (used for message brokers, like RabbitMQ and Kafka)
+    mutable BackgroundSchedulePoolPtr message_broker_schedule_pool; /// A thread pool that can run different jobs in background (used for message brokers, like RabbitMQ and Kafka)
 
     mutable OnceFlag readers_initialized;
     mutable std::unique_ptr<IAsynchronousReader> asynchronous_remote_fs_reader;
@@ -800,10 +800,10 @@ struct ContextSharedPart : boost::noncopyable
         std::unique_ptr<ExternalUserDefinedExecutableFunctionsLoader> delete_external_user_defined_executable_functions_loader;
         std::unique_ptr<IUserDefinedSQLObjectsStorage> delete_user_defined_sql_objects_storage;
         std::unique_ptr<IWorkloadEntityStorage> delete_workload_entity_storage;
-        std::unique_ptr<BackgroundSchedulePool> delete_buffer_flush_schedule_pool;
-        std::unique_ptr<BackgroundSchedulePool> delete_schedule_pool;
-        std::unique_ptr<BackgroundSchedulePool> delete_distributed_schedule_pool;
-        std::unique_ptr<BackgroundSchedulePool> delete_message_broker_schedule_pool;
+        BackgroundSchedulePoolPtr delete_buffer_flush_schedule_pool;
+        BackgroundSchedulePoolPtr delete_schedule_pool;
+        BackgroundSchedulePoolPtr delete_distributed_schedule_pool;
+        BackgroundSchedulePoolPtr delete_message_broker_schedule_pool;
         std::unique_ptr<DDLWorker> delete_ddl_worker;
         std::unique_ptr<AccessControl> delete_access_control;
 
@@ -3853,7 +3853,7 @@ ThreadPool & Context::getBuildVectorSimilarityIndexThreadPool() const
 BackgroundSchedulePool & Context::getBufferFlushSchedulePool() const
 {
     callOnce(shared->buffer_flush_schedule_pool_initialized, [&] {
-        shared->buffer_flush_schedule_pool = std::make_unique<BackgroundSchedulePool>(
+        shared->buffer_flush_schedule_pool = BackgroundSchedulePool::create(
             shared->server_settings[ServerSetting::background_buffer_flush_schedule_pool_size],
             CurrentMetrics::BackgroundBufferFlushSchedulePoolTask,
             CurrentMetrics::BackgroundBufferFlushSchedulePoolSize,
@@ -3897,7 +3897,7 @@ BackgroundTaskSchedulingSettings Context::getBackgroundMoveTaskSchedulingSetting
 BackgroundSchedulePool & Context::getSchedulePool() const
 {
     callOnce(shared->schedule_pool_initialized, [&] {
-        shared->schedule_pool = std::make_unique<BackgroundSchedulePool>(
+        shared->schedule_pool = BackgroundSchedulePool::create(
             shared->server_settings[ServerSetting::background_schedule_pool_size],
             CurrentMetrics::BackgroundSchedulePoolTask,
             CurrentMetrics::BackgroundSchedulePoolSize,
@@ -3910,7 +3910,7 @@ BackgroundSchedulePool & Context::getSchedulePool() const
 BackgroundSchedulePool & Context::getDistributedSchedulePool() const
 {
     callOnce(shared->distributed_schedule_pool_initialized, [&] {
-        shared->distributed_schedule_pool = std::make_unique<BackgroundSchedulePool>(
+        shared->distributed_schedule_pool = BackgroundSchedulePool::create(
             shared->server_settings[ServerSetting::background_distributed_schedule_pool_size],
             CurrentMetrics::BackgroundDistributedSchedulePoolTask,
             CurrentMetrics::BackgroundDistributedSchedulePoolSize,
@@ -3923,7 +3923,7 @@ BackgroundSchedulePool & Context::getDistributedSchedulePool() const
 BackgroundSchedulePool & Context::getMessageBrokerSchedulePool() const
 {
     callOnce(shared->message_broker_schedule_pool_initialized, [&] {
-        shared->message_broker_schedule_pool = std::make_unique<BackgroundSchedulePool>(
+        shared->message_broker_schedule_pool = BackgroundSchedulePool::create(
             shared->server_settings[ServerSetting::background_message_broker_schedule_pool_size],
             CurrentMetrics::BackgroundMessageBrokerSchedulePoolTask,
             CurrentMetrics::BackgroundMessageBrokerSchedulePoolSize,

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -1,4 +1,6 @@
 <clickhouse>
+    <local_disk_check_period_ms>1000</local_disk_check_period_ms>
+
     <storage_configuration>
         <disks>
             <s3_disk>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash during shutting down background pools (`background_.*pool_size`)

There are multiple issues in the BackgroundSchedulePool, due to
BackgroundSchedulePoolTaskInfo holds raw reference to the pool, which is
wrong for multiple reasons, and there is no way to fix it properly
because we do not track all tasks in the BackgroundSchedulePool (even
inactive), and eventually this may lead to crash (during server
shutdown of background pools).

There were multiple attempts to fix it:

- #80069

  - It introduces deadlock [1]
  - And a UB due to usuing foreach and erase inside
  - But the main reason is that it does not fix all the issues, i.e.
    active() after the pool has been destroyed still leads to UB

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/PRs/81398/c07d7ee6eb7c3d1d0c65649ea4b57f881571599c//stress_test_amd_debug/gdb.log

- previous version of this patch set

  - Introduces lock order inversion [2] and [3], since I tried the
    apprach that #80069 was been using - clean all jobs in the
    destructor of the pool

  - But, when it came to the test I found out that while
    clickhouse-server may use this pool correctly it is hard to do so
    without knowing how to, so after this I converted the
    raw reference of the BackgroundSchedulePool in
    BackgroundSchedulePoolTaskInfo to weak_ptr, to avoid any UBs

  [2]: https://s3.amazonaws.com/clickhouse-test-reports/PRs/81473/a0f20c2ad7efc19d698ceb0281e0a122ebef457e//stress_test_amd_tsan/stderr.log
  [3]: https://s3.amazonaws.com/clickhouse-test-reports/PRs/81473/6404951bfb5156b00a4aa5302d1c0ca8272a2c56//stress_test_amd_tsan/stderr.log

Also I've encapsulated the BackgroundSchedulePool and
BackgroundSchedulePoolTaskInfo more, to avoid any misuse.

Fixes: #80066 (cc @serxa @VicoWu)