### PR TITLE
More robust `clickhouse stop`

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -1198,7 +1198,7 @@ namespace
         constexpr size_t num_kill_check_tries = 1000;
         constexpr size_t kill_check_delay_ms = 100;
         fmt::print("Will terminate forcefully (pid = {}).\n", pid);
-        if (sendSignalAndWaitForStop(pid_file, SIGKILL, num_kill_check_tries, kill_check_delay_ms, signal_name))
+        if (sendSignalAndWaitForStop(pid_file, SIGKILL, num_kill_check_tries, kill_check_delay_ms, "kill"))
             return 0;
 
         if (!isRunning(pid_file))

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -1093,26 +1093,6 @@ namespace
                 throw;
         }
 
-        if (!pid)
-        {
-            auto sh = ShellCommand::execute("pidof clickhouse-server");
-
-            if (tryReadIntText(pid, sh->out))
-            {
-                fmt::print("Found pid = {} in the list of running processes.\n", pid);
-            }
-            else if (!sh->out.eof())
-            {
-                fmt::print("The pidof command returned unusual output.\n");
-            }
-
-            WriteBufferFromFileDescriptor std_err(STDERR_FILENO);
-            copyData(sh->err, std_err);
-            std_err.finalize();
-
-            sh->tryWait();
-        }
-
         if (pid)
         {
             if (0 == kill(pid, 0))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now `clickhouse stop` will ignore if pid file does not exist only during polling, otherwise it hides errors. Now `clickhouse stop` will not kill random `clickhouse-server`s (remove `pidof`). Improve some logging