### PR TITLE
Fix out of bounds read in `Npy` format

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -853,7 +853,7 @@ void FormatFactory::setContentType(const String & name, const String & content_t
     getOrCreateCreators(name).content_type = [=](const std::optional<FormatSettings> &){ return content_type; };
 }
 
-void FormatFactory::setContentType(const String & name, std::function<String(const std::optional<FormatSettings> &)> content_type)
+void FormatFactory::setContentType(const String & name, ContentTypeGetter content_type)
 {
     getOrCreateCreators(name).content_type = content_type;
 }

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -617,22 +617,9 @@ OutputFormatPtr FormatFactory::getOutputFormat(
     return format;
 }
 
-String FormatFactory::getContentType(
-    const String & name,
-    const ContextPtr & context,
-    const std::optional<FormatSettings> & _format_settings) const
+String FormatFactory::getContentType(const String & name, const std::optional<FormatSettings> & settings) const
 {
-    const auto & output_getter = getCreators(name).output_creator;
-    if (!output_getter)
-        throw Exception(ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_OUTPUT, "Format {} is not suitable for output", name);
-
-    auto format_settings = _format_settings ? *_format_settings : getFormatSettings(context);
-
-    Block empty_block;
-    WriteBufferFromOwnString empty_buffer;
-    auto format = output_getter(empty_buffer, empty_block, format_settings);
-
-    return format->getContentType();
+    return getCreators(name).content_type(settings);
 }
 
 SchemaReaderPtr FormatFactory::getSchemaReader(
@@ -859,6 +846,16 @@ void FormatFactory::markOutputFormatNotTTYFriendly(const String & name)
     if (!target)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "FormatFactory: Format {} is already marked as non-TTY-friendly", name);
     target = false;
+}
+
+void FormatFactory::setContentType(const String & name, const String & content_type)
+{
+    getOrCreateCreators(name).content_type = [=](const std::optional<FormatSettings> &){ return content_type; };
+}
+
+void FormatFactory::setContentType(const String & name, std::function<String(const std::optional<FormatSettings> &)> content_type)
+{
+    getOrCreateCreators(name).content_type = content_type;
 }
 
 bool FormatFactory::checkIfFormatSupportsSubsetOfColumns(const String & name, const ContextPtr & context, const std::optional<FormatSettings> & format_settings_) const

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -114,6 +114,9 @@ private:
     /// The checker should return true if format support append.
     using AppendSupportChecker = std::function<bool(const FormatSettings & settings)>;
 
+    /// Obtain HTTP content-type for the output format.
+    using ContentTypeGetter = std::function<String(const std::optional<FormatSettings> & settings)>;
+
     using SchemaReaderCreator = std::function<SchemaReaderPtr(ReadBuffer & in, const FormatSettings & settings)>;
     using ExternalSchemaReaderCreator = std::function<ExternalSchemaReaderPtr(const FormatSettings & settings)>;
 
@@ -140,8 +143,7 @@ private:
         bool supports_parallel_formatting{false};
         bool prefers_large_blocks{false};
         bool is_tty_friendly{true}; /// If false, client will ask before output in the terminal.
-        std::function<String(const std::optional<FormatSettings> &)> content_type
-            = [](const std::optional<FormatSettings> &){ return "text/plain; charset=UTF-8"; };
+        ContentTypeGetter content_type = [](const std::optional<FormatSettings> &){ return "text/plain; charset=UTF-8"; };
         NonTrivialPrefixAndSuffixChecker non_trivial_prefix_and_suffix_checker;
         AppendSupportChecker append_support_checker;
         AdditionalInfoForSchemaCacheGetter additional_info_for_schema_cache_getter;
@@ -239,7 +241,7 @@ public:
     void markOutputFormatNotTTYFriendly(const String & name);
 
     void setContentType(const String & name, const String & content_type);
-    void setContentType(const String & name, std::function<String(const std::optional<FormatSettings> &)> content_type);
+    void setContentType(const String & name, ContentTypeGetter content_type);
 
     void markFormatSupportsSubsetOfColumns(const String & name);
     void registerSubsetOfColumnsSupportChecker(const String & name, SubsetOfColumnsSupportChecker subset_of_columns_support_checker);

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -140,6 +140,8 @@ private:
         bool supports_parallel_formatting{false};
         bool prefers_large_blocks{false};
         bool is_tty_friendly{true}; /// If false, client will ask before output in the terminal.
+        std::function<String(const std::optional<FormatSettings> &)> content_type
+            = [](const std::optional<FormatSettings> &){ return "text/plain; charset=UTF-8"; };
         NonTrivialPrefixAndSuffixChecker non_trivial_prefix_and_suffix_checker;
         AppendSupportChecker append_support_checker;
         AdditionalInfoForSchemaCacheGetter additional_info_for_schema_cache_getter;
@@ -188,10 +190,8 @@ public:
         const ContextPtr & context,
         const std::optional<FormatSettings> & _format_settings = std::nullopt) const;
 
-    String getContentType(
-        const String & name,
-        const ContextPtr & context,
-        const std::optional<FormatSettings> & format_settings = std::nullopt) const;
+    /// Content-Type to set when sending HTTP response with this output format.
+    String getContentType(const String & name, const std::optional<FormatSettings> & settings) const;
 
     SchemaReaderPtr getSchemaReader(
         const String & name,
@@ -237,6 +237,9 @@ public:
     void markOutputFormatSupportsParallelFormatting(const String & name);
     void markOutputFormatPrefersLargeBlocks(const String & name);
     void markOutputFormatNotTTYFriendly(const String & name);
+
+    void setContentType(const String & name, const String & content_type);
+    void setContentType(const String & name, std::function<String(const std::optional<FormatSettings> &)> content_type);
 
     void markFormatSupportsSubsetOfColumns(const String & name);
     void registerSubsetOfColumnsSupportChecker(const String & name, SubsetOfColumnsSupportChecker subset_of_columns_support_checker);

--- a/src/Formats/NativeWriter.h
+++ b/src/Formats/NativeWriter.h
@@ -33,8 +33,6 @@ public:
     size_t write(const Block & block);
     void flush();
 
-    static String getContentType() { return "application/octet-stream"; }
-
     static void writeData(const ISerialization & serialization, const ColumnPtr & column, WriteBuffer & ostr, const std::optional<FormatSettings> & format_settings, UInt64 offset, UInt64 limit, UInt64 client_revision);
 
 private:

--- a/src/IO/WriteBufferFromHTTP.h
+++ b/src/IO/WriteBufferFromHTTP.h
@@ -19,6 +19,7 @@ namespace DB
 class WriteBufferFromHTTP : public WriteBufferFromOStream
 {
     friend class BuilderWriteBufferFromHTTP;
+
     explicit WriteBufferFromHTTP(const HTTPConnectionGroupType & connection_group,
                                  const Poco::URI & uri,
                                  const std::string & method = Poco::Net::HTTPRequest::HTTP_POST, // POST or PUT only
@@ -42,6 +43,7 @@ class WriteBufferFromHTTP : public WriteBufferFromOStream
 
 class BuilderWriteBufferFromHTTP
 {
+private:
     Poco::URI uri;
     HTTPConnectionGroupType connection_group;
     std::string method = Poco::Net::HTTPRequest::HTTP_POST; // POST or PUT only
@@ -54,7 +56,8 @@ class BuilderWriteBufferFromHTTP
 
 public:
     explicit BuilderWriteBufferFromHTTP(const Poco::URI & uri_) : uri(uri_)
-    {}
+    {
+    }
 
 /// NOLINTBEGIN(bugprone-macro-parentheses)
 #define setterMember(name, member) \

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1828,7 +1828,7 @@ void executeQuery(
                 if (output_format && output_format->supportsWritingException())
                 {
                     /// Force an update of the headers before we start writing
-                    result_details.content_type = output_format->getContentType();
+                    result_details.content_type = FormatFactory::instance().getContentType(format_name, output_format_settings);
                     result_details.format = format_name;
 
                     fiu_do_on(FailPoints::execute_query_calling_empty_set_result_func_on_exception,
@@ -1964,7 +1964,7 @@ void executeQuery(
                 output_format->onProgress(progress);
             });
 
-            result_details.content_type = output_format->getContentType();
+            result_details.content_type = FormatFactory::instance().getContentType(format_name, output_format_settings);
             result_details.format = format_name;
 
             pipeline.complete(output_format);

--- a/src/Processors/Formats/IOutputFormat.h
+++ b/src/Processors/Formats/IOutputFormat.h
@@ -54,9 +54,6 @@ public:
     /// Set initial progress values on initialization of the format, before it starts writing the data.
     void setProgress(Progress progress);
 
-    /// Content-Type to set when sending HTTP response.
-    virtual std::string getContentType() const { return "text/plain; charset=UTF-8"; }
-
     InputPort & getPort(PortKind kind) { return *std::next(inputs.begin(), kind); }
 
     /// Compatibility with old interface.

--- a/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
@@ -135,6 +135,7 @@ void registerOutputFormatArrow(FormatFactory & factory)
         });
     factory.markFormatHasNoAppendSupport("Arrow");
     factory.markOutputFormatNotTTYFriendly("Arrow");
+    factory.setContentType("Arrow", "application/octet-stream");
 
     factory.registerOutputFormat(
         "ArrowStream",
@@ -147,6 +148,7 @@ void registerOutputFormatArrow(FormatFactory & factory)
     factory.markFormatHasNoAppendSupport("ArrowStream");
     factory.markOutputFormatPrefersLargeBlocks("ArrowStream");
     factory.markOutputFormatNotTTYFriendly("ArrowStream");
+    factory.setContentType("ArrowStream", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/ArrowBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ArrowBlockOutputFormat.h
@@ -20,9 +20,7 @@ class ArrowBlockOutputFormat : public IOutputFormat
 public:
     ArrowBlockOutputFormat(WriteBuffer & out_, const Block & header_, bool stream_, const FormatSettings & format_settings_);
 
-    String getName() const override { return "ArrowBlockOutputFormat"; }
-
-    String getContentType() const override { return "application/octet-stream"; }
+    String getName() const override { return "Arrow"; }
 
 private:
     void consume(Chunk) override;

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -637,6 +637,7 @@ void registerOutputFormatAvro(FormatFactory & factory)
     });
     factory.markFormatHasNoAppendSupport("Avro");
     factory.markOutputFormatNotTTYFriendly("Avro");
+    factory.setContentType("Avro", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/BSONEachRowRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/BSONEachRowRowOutputFormat.cpp
@@ -546,6 +546,7 @@ void registerOutputFormatBSONEachRow(FormatFactory & factory)
         { return std::make_shared<BSONEachRowRowOutputFormat>(buf, sample, _format_settings); });
     factory.markOutputFormatSupportsParallelFormatting("BSONEachRow");
     factory.markOutputFormatNotTTYFriendly("BSONEachRow");
+    factory.setContentType("BSONEachRow", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/BinaryRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/BinaryRowOutputFormat.cpp
@@ -75,6 +75,9 @@ void registerOutputFormatRowBinary(FormatFactory & factory)
     factory.markOutputFormatNotTTYFriendly("RowBinary");
     factory.markOutputFormatNotTTYFriendly("RowBinaryWithNames");
     factory.markOutputFormatNotTTYFriendly("RowBinaryWithNamesAndTypes");
+    factory.setContentType("RowBinary", "application/octet-stream");
+    factory.setContentType("RowBinaryWithNames", "application/octet-stream");
+    factory.setContentType("RowBinaryWithNamesAndTypes", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/BinaryRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/BinaryRowOutputFormat.h
@@ -20,8 +20,6 @@ public:
 
     String getName() const override { return "BinaryRowOutputFormat"; }
 
-    String getContentType() const override { return "application/octet-stream"; }
-
 private:
     void writeField(const IColumn & column, const ISerialization & serialization, size_t row_num) override;
     void writePrefix() override;

--- a/src/Processors/Formats/Impl/CSVRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/CSVRowOutputFormat.cpp
@@ -85,6 +85,8 @@ void registerOutputFormatCSV(FormatFactory & factory)
             return std::make_shared<CSVRowOutputFormat>(buf, sample, with_names, with_types, format_settings);
         });
         factory.markOutputFormatSupportsParallelFormatting(format_name);
+        /// https://www.iana.org/assignments/media-types/text/csv
+        factory.setContentType(format_name, String("text/csv; charset=UTF-8; header=") + (with_names ? "present" : "absent"));
     };
 
     registerWithNamesAndTypes("CSV", register_func);

--- a/src/Processors/Formats/Impl/CSVRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/CSVRowOutputFormat.h
@@ -22,13 +22,7 @@ public:
       */
     CSVRowOutputFormat(WriteBuffer & out_, const Block & header_, bool with_names_, bool with_types, const FormatSettings & format_settings_);
 
-    String getName() const override { return "CSVRowOutputFormat"; }
-
-    /// https://www.iana.org/assignments/media-types/text/csv
-    String getContentType() const override
-    {
-        return String("text/csv; charset=UTF-8; header=") + (with_names ? "present" : "absent");
-    }
+    String getName() const override { return "CSV"; }
 
 private:
     void writeField(const IColumn & column, const ISerialization & serialization, size_t row_num) override;

--- a/src/Processors/Formats/Impl/CapnProtoRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/CapnProtoRowOutputFormat.cpp
@@ -62,6 +62,7 @@ void registerOutputFormatCapnProto(FormatFactory & factory)
                 format_settings);
     });
     factory.markOutputFormatNotTTYFriendly("CapnProto");
+    factory.setContentType("CapnProto", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONColumnsBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONColumnsBlockOutputFormat.cpp
@@ -51,6 +51,8 @@ void registerOutputFormatJSONColumns(FormatFactory & factory)
     {
         return std::make_shared<JSONColumnsBlockOutputFormat>(buf, sample, format_settings, format_settings.json.validate_utf8);
     });
+
+    factory.setContentType("JSONColumns", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONColumnsWithMetadataBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONColumnsWithMetadataBlockOutputFormat.cpp
@@ -112,6 +112,7 @@ void registerOutputFormatJSONColumnsWithMetadata(FormatFactory & factory)
     });
 
     factory.markFormatHasNoAppendSupport("JSONColumnsWithMetadata");
+    factory.setContentType("JSONColumnsWithMetadata", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONCompactColumnsBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactColumnsBlockOutputFormat.cpp
@@ -37,6 +37,7 @@ void registerOutputFormatJSONCompactColumns(FormatFactory & factory)
     {
         return std::make_shared<JSONCompactColumnsBlockOutputFormat>(buf, sample, format_settings);
     });
+    factory.setContentType("JSONCompactColumns", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONCompactEachRowWithProgressRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowWithProgressRowOutputFormat.cpp
@@ -117,6 +117,8 @@ void registerOutputFormatJSONCompactEachRowWithProgress(FormatFactory & factory)
         return std::make_shared<JSONCompactEachRowWithProgressRowOutputFormat>(buf, sample, settings, false, false);
     });
 
+    factory.setContentType("JSONCompactEachRowWithProgress", "application/json; charset=UTF-8");
+
     factory.registerOutputFormat("JSONCompactStringsEachRowWithProgress", [](
             WriteBuffer & buf,
             const Block & sample,
@@ -126,6 +128,8 @@ void registerOutputFormatJSONCompactEachRowWithProgress(FormatFactory & factory)
         settings.json.serialize_as_strings = true;
         return std::make_shared<JSONCompactEachRowWithProgressRowOutputFormat>(buf, sample, settings, false, false);
     });
+
+    factory.setContentType("JSONCompactStringsEachRowWithProgress", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONCompactRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactRowOutputFormat.cpp
@@ -76,6 +76,7 @@ void registerOutputFormatJSONCompact(FormatFactory & factory)
     });
 
     factory.markOutputFormatSupportsParallelFormatting("JSONCompact");
+    factory.setContentType("JSONCompact", "application/json; charset=UTF-8");
 
     factory.registerOutputFormat("JSONCompactStrings", [](
         WriteBuffer & buf,
@@ -86,6 +87,7 @@ void registerOutputFormatJSONCompact(FormatFactory & factory)
     });
 
     factory.markOutputFormatSupportsParallelFormatting("JSONCompactStrings");
+    factory.setContentType("JSONCompactStrings", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.cpp
@@ -112,6 +112,10 @@ void registerOutputFormatJSONEachRow(FormatFactory & factory)
             return std::make_shared<JSONEachRowRowOutputFormat>(buf, sample, settings, pretty_json);
         });
         factory.markOutputFormatSupportsParallelFormatting(format);
+        factory.setContentType(format, [](const std::optional<FormatSettings> & settings)
+        {
+            return settings && settings->json.array_of_rows ? "application/json; charset=UTF-8" : "application/x-ndjson; charset=UTF-8";
+        });
     };
 
     register_function("JSONEachRow", false, false);

--- a/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.h
@@ -25,12 +25,6 @@ public:
 
     String getName() const override { return "JSONEachRowRowOutputFormat"; }
 
-    /// Content-Type to set when sending HTTP response.
-    String getContentType() const override
-    {
-        return settings.json.array_of_rows ? "application/json; charset=UTF-8" : "application/x-ndjson; charset=UTF-8" ;
-    }
-
 protected:
     void writeField(const IColumn & column, const ISerialization & serialization, size_t row_num) override;
     void writeFieldDelimiter() override;

--- a/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
@@ -118,6 +118,7 @@ void registerOutputFormatJSONEachRowWithProgress(FormatFactory & factory)
         settings.json.serialize_as_strings = false;
         return std::make_shared<JSONEachRowWithProgressRowOutputFormat>(buf, sample, settings);
     });
+    factory.setContentType("JSONEachRowWithProgress", "application/json; charset=UTF-8");
 
     factory.registerOutputFormat("JSONStringsEachRowWithProgress", [](
             WriteBuffer & buf,
@@ -128,6 +129,7 @@ void registerOutputFormatJSONEachRowWithProgress(FormatFactory & factory)
         settings.json.serialize_as_strings = true;
         return std::make_shared<JSONEachRowWithProgressRowOutputFormat>(buf, sample, settings);
     });
+    factory.setContentType("JSONStringsEachRowWithProgress", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONObjectEachRowRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONObjectEachRowRowOutputFormat.cpp
@@ -89,6 +89,7 @@ void registerOutputFormatJSONObjectEachRow(FormatFactory & factory)
     });
     factory.markOutputFormatSupportsParallelFormatting("JSONObjectEachRow");
     factory.markFormatHasNoAppendSupport("JSONObjectEachRow");
+    factory.setContentType("JSONObjectEachRow", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONRowOutputFormat.cpp
@@ -158,6 +158,7 @@ void registerOutputFormatJSON(FormatFactory & factory)
 
     factory.markOutputFormatSupportsParallelFormatting("JSON");
     factory.markFormatHasNoAppendSupport("JSON");
+    factory.setContentType("JSON", "application/json; charset=UTF-8");
 
     factory.registerOutputFormat("JSONStrings", [](
         WriteBuffer & buf,
@@ -169,6 +170,7 @@ void registerOutputFormatJSON(FormatFactory & factory)
 
     factory.markOutputFormatSupportsParallelFormatting("JSONStrings");
     factory.markFormatHasNoAppendSupport("JSONStrings");
+    factory.setContentType("JSONStrings", "application/json; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/JSONRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONRowOutputFormat.h
@@ -24,8 +24,6 @@ public:
 
     String getName() const override { return "JSONRowOutputFormat"; }
 
-    String getContentType() const override { return "application/json; charset=UTF-8"; }
-
     void setRowsBeforeLimit(size_t rows_before_limit_) override
     {
         statistics.applied_limit = true;

--- a/src/Processors/Formats/Impl/MsgPackRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowOutputFormat.cpp
@@ -310,6 +310,7 @@ void registerOutputFormatMsgPack(FormatFactory & factory)
     });
     factory.markOutputFormatSupportsParallelFormatting("MsgPack");
     factory.markOutputFormatNotTTYFriendly("MsgPack");
+    factory.setContentType("MsgPack", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -146,6 +146,7 @@ void registerOutputFormatMySQLWire(FormatFactory & factory)
            const Block & sample,
            const FormatSettings & settings) { return std::make_shared<MySQLOutputFormat>(buf, sample, settings); });
     factory.markOutputFormatNotTTYFriendly("MySQLWire");
+    factory.setContentType("MySQLWire", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/NativeFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeFormat.cpp
@@ -83,11 +83,6 @@ public:
 
     String getName() const override { return "Native"; }
 
-    std::string getContentType() const override
-    {
-        return NativeWriter::getContentType();
-    }
-
 protected:
     void consume(Chunk chunk) override
     {
@@ -143,6 +138,7 @@ void registerOutputFormatNative(FormatFactory & factory)
         return std::make_shared<NativeOutputFormat>(buf, sample, settings, settings.client_protocol_version);
     });
     factory.markOutputFormatNotTTYFriendly("Native");
+    factory.setContentType("Native", "application/octet-stream");
 }
 
 

--- a/src/Processors/Formats/Impl/NpyOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/NpyOutputFormat.cpp
@@ -67,7 +67,7 @@ NpyOutputFormat::NpyOutputFormat(WriteBuffer & out_, const Block & header_) : IO
 {
     const auto & header = getPort(PortKind::Main).getHeader();
     auto data_types = header.getDataTypes();
-    if (data_types.size() > 1)
+    if (data_types.size() != 1)
         throw Exception(ErrorCodes::TOO_MANY_COLUMNS, "Expected single column for Npy output format, got {}", data_types.size());
     data_type = data_types[0];
 
@@ -265,6 +265,7 @@ void registerOutputFormatNpy(FormatFactory & factory)
     });
     factory.markFormatHasNoAppendSupport("Npy");
     factory.markOutputFormatNotTTYFriendly("Npy");
+    factory.setContentType("Npy", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/NpyOutputFormat.h
+++ b/src/Processors/Formats/Impl/NpyOutputFormat.h
@@ -20,8 +20,6 @@ public:
 
     String getName() const override { return "NpyOutputFormat"; }
 
-    String getContentType() const override { return "application/octet-stream"; }
-
 private:
     String shapeStr() const;
 

--- a/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
@@ -103,6 +103,7 @@ void registerOutputFormatODBCDriver2(FormatFactory & factory)
             return std::make_shared<ODBCDriver2BlockOutputFormat>(buf, sample, format_settings);
         });
     factory.markOutputFormatNotTTYFriendly("ODBCDriver2");
+    factory.setContentType("ODBCDriver2", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.h
@@ -22,12 +22,7 @@ class ODBCDriver2BlockOutputFormat final : public IOutputFormat
 public:
     ODBCDriver2BlockOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & format_settings_);
 
-    String getName() const override { return "ODBCDriver2BlockOutputFormat"; }
-
-    std::string getContentType() const override
-    {
-        return "application/octet-stream";
-    }
+    String getName() const override { return "ODBCDriver2"; }
 
 private:
     void consume(Chunk) override;

--- a/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
@@ -589,6 +589,7 @@ void registerOutputFormatORC(FormatFactory & factory)
     factory.markFormatHasNoAppendSupport("ORC");
     factory.markOutputFormatPrefersLargeBlocks("ORC");
     factory.markOutputFormatNotTTYFriendly("ORC");
+    factory.setContentType("ORC", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -137,12 +137,6 @@ public:
         started_suffix = true;
     }
 
-    String getContentType() const override
-    {
-        NullWriteBuffer buffer;
-        return internal_formatter_creator(buffer)->getContentType();
-    }
-
     bool supportsWritingException() const override
     {
         NullWriteBuffer buffer;

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -592,6 +592,7 @@ void registerOutputFormatParquet(FormatFactory & factory)
         });
     factory.markFormatHasNoAppendSupport("Parquet");
     factory.markOutputFormatNotTTYFriendly("Parquet");
+    factory.setContentType("Parquet", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -35,8 +35,6 @@ public:
 
     String getName() const override { return "ParquetBlockOutputFormat"; }
 
-    String getContentType() const override { return "application/octet-stream"; }
-
 private:
     struct MemoryToken
     {

--- a/src/Processors/Formats/Impl/PostgreSQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/PostgreSQLOutputFormat.cpp
@@ -73,6 +73,7 @@ void registerOutputFormatPostgreSQLWire(FormatFactory & factory)
            const Block & sample,
            const FormatSettings & settings) { return std::make_shared<PostgreSQLOutputFormat>(buf, sample, settings); });
     factory.markOutputFormatNotTTYFriendly("PostgreSQLWire");
+    factory.setContentType("PostgreSQLWire", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/PrometheusTextOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/PrometheusTextOutputFormat.cpp
@@ -352,6 +352,9 @@ void registerOutputFormatPrometheus(FormatFactory & factory)
     {
         return std::make_shared<PrometheusTextOutputFormat>(buf, sample, settings);
     });
+
+    /// https://github.com/prometheus/docs/blob/86386ed25bc8a5309492483ec7d18d0914043162/content/docs/instrumenting/exposition_formats.md
+    factory.setContentType(FORMAT_NAME, "text/plain; version=0.0.4; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/PrometheusTextOutputFormat.h
+++ b/src/Processors/Formats/Impl/PrometheusTextOutputFormat.h
@@ -22,9 +22,6 @@ public:
 
     String getName() const override { return "PrometheusTextOutputFormat"; }
 
-    /// https://github.com/prometheus/docs/blob/86386ed25bc8a5309492483ec7d18d0914043162/content/docs/instrumenting/exposition_formats.md
-    String getContentType() const override { return "text/plain; version=0.0.4; charset=UTF-8"; }
-
 protected:
 
     struct ColumnPositions

--- a/src/Processors/Formats/Impl/ProtobufListOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufListOutputFormat.cpp
@@ -63,6 +63,7 @@ void registerOutputFormatProtobufList(FormatFactory & factory)
                 settings.protobuf.google_protos_path);
         });
     factory.markOutputFormatNotTTYFriendly("ProtobufList");
+    factory.setContentType("ProtobufList", "application/octet-stream");
 }
 
 }

--- a/src/Processors/Formats/Impl/ProtobufListOutputFormat.h
+++ b/src/Processors/Formats/Impl/ProtobufListOutputFormat.h
@@ -31,9 +31,7 @@ public:
         bool defaults_for_nullable_google_wrappers_,
         const String & google_protos_path);
 
-    String getName() const override { return "ProtobufListOutputFormat"; }
-
-    String getContentType() const override { return "application/octet-stream"; }
+    String getName() const override { return "ProtobufList"; }
 
 private:
     void write(const Columns & columns, size_t row_num) override;

--- a/src/Processors/Formats/Impl/ProtobufRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowOutputFormat.cpp
@@ -69,6 +69,7 @@ void registerOutputFormatProtobuf(FormatFactory & factory)
                     settings, with_length_delimiter);
             });
         factory.markOutputFormatNotTTYFriendly(name);
+        factory.setContentType(name, "application/octet-stream");
     }
 }
 

--- a/src/Processors/Formats/Impl/ProtobufRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/ProtobufRowOutputFormat.h
@@ -36,8 +36,6 @@ public:
 
     String getName() const override { return "ProtobufRowOutputFormat"; }
 
-    std::string getContentType() const override { return "application/octet-stream"; }
-
 private:
     void write(const Columns & columns, size_t row_num) override;
     void writeField(const IColumn &, const ISerialization &, size_t) override {}

--- a/src/Processors/Formats/Impl/SQLInsertRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/SQLInsertRowOutputFormat.cpp
@@ -102,6 +102,8 @@ void registerOutputFormatSQLInsert(FormatFactory & factory)
     {
         return std::make_shared<SQLInsertRowOutputFormat>(buf, sample, settings);
     });
+
+    factory.setContentType("SQLInsert", "text/plain; charset=UTF-8");
 }
 
 

--- a/src/Processors/Formats/Impl/SQLInsertRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/SQLInsertRowOutputFormat.h
@@ -19,9 +19,6 @@ public:
 
     String getName() const override { return "SQLInsertRowOutputFormat"; }
 
-    /// https://www.iana.org/assignments/media-types/text/tab-separated-values
-    String getContentType() const override { return "text/tab-separated-values; charset=UTF-8"; }
-
 protected:
     void writeField(const IColumn & column, const ISerialization & serialization, size_t row_num) override;
     void writeFieldDelimiter() override;

--- a/src/Processors/Formats/Impl/TSKVRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowOutputFormat.cpp
@@ -46,6 +46,7 @@ void registerOutputFormatTSKV(FormatFactory & factory)
         return std::make_shared<TSKVRowOutputFormat>(buf, sample, settings);
     });
     factory.markOutputFormatSupportsParallelFormatting("TSKV");
+    factory.setContentType("TSKV", "text/tab-separated-values; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
@@ -93,6 +93,8 @@ void registerOutputFormatTabSeparated(FormatFactory & factory)
             });
 
             factory.markOutputFormatSupportsParallelFormatting(format_name);
+            /// https://www.iana.org/assignments/media-types/text/tab-separated-values
+            factory.setContentType(format_name, "text/tab-separated-values; charset=UTF-8");
         };
 
         registerWithNamesAndTypes(is_raw ? "TSVRaw" : "TSV", register_func);

--- a/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.h
@@ -28,9 +28,6 @@ public:
 
     String getName() const override { return "TabSeparatedRowOutputFormat"; }
 
-    /// https://www.iana.org/assignments/media-types/text/tab-separated-values
-    String getContentType() const override { return "text/tab-separated-values; charset=UTF-8"; }
-
 protected:
     void writeField(const IColumn & column, const ISerialization & serialization, size_t row_num) override;
     void writeFieldDelimiter() final;

--- a/src/Processors/Formats/Impl/XMLRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/XMLRowOutputFormat.cpp
@@ -261,6 +261,7 @@ void registerOutputFormatXML(FormatFactory & factory)
 
     factory.markOutputFormatSupportsParallelFormatting("XML");
     factory.markFormatHasNoAppendSupport("XML");
+    factory.setContentType("XML", "application/xml; charset=UTF-8");
 }
 
 }

--- a/src/Processors/Formats/Impl/XMLRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/XMLRowOutputFormat.h
@@ -54,8 +54,6 @@ private:
     }
     void onRowsReadBeforeUpdate() override { row_count = getRowsReadBefore(); }
 
-    String getContentType() const override { return "application/xml; charset=UTF-8"; }
-
     void writeExtremesElement(const char * title, const Columns & columns, size_t row_num);
     void writeRowsBeforeLimitAtLeast();
     void writeRowsBeforeAggregationAtLeast();

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -624,7 +624,7 @@ void StorageURLSink::initBuffers()
     if (write_buf)
         return;
 
-    std::string content_type = FormatFactory::instance().getContentType(format, context, format_settings);
+    std::string content_type = FormatFactory::instance().getContentType(format, format_settings);
     std::string content_encoding = toContentEncodingName(compression_method);
 
     auto poco_uri = Poco::URI(uri);

--- a/tests/queries/0_stateless/03534_npy_output_to_url.sql
+++ b/tests/queries/0_stateless/03534_npy_output_to_url.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (c0 Int) ENGINE = URL('http://localhost:80/', Npy);
+INSERT INTO TABLE t0 (c0) VALUES (1); -- { serverError POCO_EXCEPTION }
+DROP TABLE t0;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix out-of-bounds read in the `Npy` format happening when writing to a table with the `URL` engine. This closes #81356.