### PR TITLE
add new table function to get current access grants

### DIFF
--- a/src/TableFunctions/TableFunctionCurrentGrants.cpp
+++ b/src/TableFunctions/TableFunctionCurrentGrants.cpp
@@ -1,0 +1,109 @@
+#include <Access/AccessRights.h>
+#include <Access/ContextAccess.h>
+#include <Access/AccessControl.h>
+#include <Access/EnabledRolesInfo.h>
+#include <Access/Role.h>
+#include <Access/User.h>
+#include <Columns/ColumnString.h>
+#include <Columns/IColumn.h>
+#include <DataTypes/DataTypeString.h>
+#include <Interpreters/Context.h>
+#include <Poco/Net/IPAddress.h>
+#include <Storages/ColumnsDescription.h>
+#include <Storages/StorageValues.h>
+#include <TableFunctions/ITableFunction.h>
+#include <TableFunctions/TableFunctionFactory.h>
+#include <Parsers/IAST.h>
+#include "registerTableFunctions.h"
+
+
+namespace DB
+{
+
+namespace
+{
+
+class TableFunctionCurrentGrants : public ITableFunction
+{
+public:
+    static constexpr auto name = "currentGrants";
+    std::string getName() const override { return name; }
+
+private:
+    StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const String & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
+    ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
+    const char * getStorageTypeName() const override { return "Values"; }
+    void collectGrantBySource(const String & source_name, const AccessRights & access_rights) const;
+
+    mutable IColumn::MutablePtr grant_column;
+    mutable IColumn::MutablePtr source_column;
+};
+
+
+ColumnsDescription TableFunctionCurrentGrants::getActualTableStructure(ContextPtr /*context*/, bool /*is_insert_query*/) const
+{
+    return ColumnsDescription{
+        { "grant", std::make_shared<DataTypeString>() },
+        { "source", std::make_shared<DataTypeString>() }
+    };
+}
+
+void TableFunctionCurrentGrants::collectGrantBySource(const String & source_name, const AccessRights & access_rights) const
+{
+    for (const auto & element : access_rights.getElements())
+    {
+        for (const auto & type : element.access_flags.toAccessTypes())
+        {
+            AccessRightsElement single_grant{type};
+            single_grant.database = element.database;
+            single_grant.table = element.table;
+            single_grant.columns = element.columns;
+            single_grant.grant_option = element.grant_option;
+            grant_column->insert(single_grant.toString());
+            source_column->insert(source_name);
+        }
+    }
+}
+
+StoragePtr TableFunctionCurrentGrants::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const String & table_name, ColumnsDescription /*cached_columns*/, bool /*is_insert_query*/) const
+{
+    auto access = context->getAccess();
+    const auto & access_control = context->getAccessControl();
+
+    grant_column = ColumnString::create();
+    source_column = ColumnString::create();
+
+    // Grants from user
+    if (auto user = access->tryGetUser())
+        collectGrantBySource(user->getName(), user->access);
+
+    // Grants from roles
+    if (auto roles_info = access->getRolesInfo())
+    {
+        for (const auto & role_id : roles_info->enabled_roles)
+        {
+            auto role = access_control.tryRead<Role>(role_id);
+            if (role)
+                collectGrantBySource(role->getName(), role->access);
+        }
+    }
+
+    Block res_block{
+        { std::move(grant_column), std::make_shared<DataTypeString>(), "grant" },
+        { std::move(source_column), std::make_shared<DataTypeString>(), "source" }
+    };
+
+    auto res = std::make_shared<StorageValues>(StorageID(getDatabaseName(), table_name), getActualTableStructure(context, false), res_block);
+    res->startup();
+    return res;
+}
+
+}
+
+void registerTableFunctionCurrentGrants(TableFunctionFactory & factory)
+{
+    factory.registerFunction<TableFunctionCurrentGrants>({.documentation = {}, .allow_readonly = true});
+    factory.registerAlias("current_grants", "currentGrants", TableFunctionFactory::Case::Insensitive);
+}
+
+}

--- a/src/TableFunctions/registerTableFunctions.cpp
+++ b/src/TableFunctions/registerTableFunctions.cpp
@@ -42,6 +42,7 @@ void registerTableFunctions()
 
     registerTableFunctionView(factory);
     registerTableFunctionViewIfPermitted(factory);
+    registerTableFunctionCurrentGrants(factory);
 
 #if USE_MYSQL
     registerTableFunctionMySQL(factory);

--- a/src/TableFunctions/registerTableFunctions.h
+++ b/src/TableFunctions/registerTableFunctions.h
@@ -41,6 +41,8 @@ void registerTableFunctionJDBC(TableFunctionFactory & factory);
 void registerTableFunctionView(TableFunctionFactory & factory);
 void registerTableFunctionViewIfPermitted(TableFunctionFactory & factory);
 
+void registerTableFunctionCurrentGrants(TableFunctionFactory & factory);
+
 #if USE_MYSQL
 void registerTableFunctionMySQL(TableFunctionFactory & factory);
 #endif


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Access current access grants and their origin using `currentGrants()` table function

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Adds a new table function `currentGrants()` to query current access rights. With JWT users, it can be tedious to query for the privileges of that user as its user name is is a long and a hash. And because the user is ephemeral you have to go through multiple queries many time to determine what grants are enabled.

```
:) select * from currentGrants()

SELECT *
FROM currentGrants()

Query id: 6acb92e6-0559-4749-8733-2b6da8f2d0b9

    ┌─grant──────────────────────────────────────┬─source──┐
 1. │ GRANT CHECK ON *.*                         │ default │
 2. │ GRANT SHOW ON *.*                          │ default │
 3. │ GRANT SELECT ON *.*                        │ default │
 4. │ GRANT INSERT ON *.*                        │ default │
 5. │ GRANT ALTER ON *.*                         │ default │
 6. │ GRANT CREATE ON *.*                        │ default │
 7. │ GRANT DROP ON *.*                          │ default │
 8. │ GRANT UNDROP TABLE ON *.*                  │ default │
 9. │ GRANT TRUNCATE ON *.*                      │ default │
10. │ GRANT OPTIMIZE ON *.*                      │ default │
11. │ GRANT BACKUP ON *.*                        │ default │
12. │ GRANT KILL QUERY ON *.*                    │ default │
13. │ GRANT KILL TRANSACTION ON *.*              │ default │
14. │ GRANT MOVE PARTITION BETWEEN SHARDS ON *.* │ default │
15. │ GRANT SYSTEM ON *.*                        │ default │
16. │ GRANT dictGet ON *.*                       │ default │
17. │ GRANT displaySecretsInShowAndSelect ON *.* │ default │
18. │ GRANT INTROSPECTION ON *.*                 │ default │
19. │ GRANT SOURCES ON *.*                       │ default │
20. │ GRANT CLUSTER ON *.*                       │ default │
21. │ GRANT TABLE ENGINE ON *                    │ default │
22. │ GRANT SET DEFINER ON *                     │ default │
23. │ GRANT ALTER NAMED COLLECTION ON *          │ default │
24. │ GRANT CREATE NAMED COLLECTION ON *         │ default │
25. │ GRANT DROP NAMED COLLECTION ON *           │ default │
26. │ GRANT SHOW NAMED COLLECTIONS ON *          │ default │
27. │ GRANT NAMED COLLECTION ON *                │ default │
    └────────────────────────────────────────────┴─────────┘
```


