### PR TITLE
`clickhouse`/`ch` aliases will invoke clickhouse-client if connection parameters are specified

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -283,6 +283,22 @@ int main(int argc_, char ** argv_)
         }
     }
 
+    /// If host/port arguments are passed to clickhouse/ch shortcuts,
+    /// interpret it as clickhouse-client invocation for usability.
+    if (main_func == printHelp && argv.size() >= 2)
+    {
+        for (size_t i = 1, num_args = argv.size(); i < num_args; ++i)
+        {
+            if ((i + 1 < num_args && argv[i] == std::string_view("--host")) || startsWith(argv[i], "--host=")
+                || (i + 1 < num_args && argv[i] == std::string_view("--port")) || startsWith(argv[i], "--port=")
+                || startsWith(argv[i], "-h"))
+            {
+                main_func = mainEntryClickHouseClient;
+                break;
+            }
+        }
+    }
+
     /// Interpret binary without argument or with arguments starts with dash
     /// ('-') as clickhouse-local for better usability:
     ///
@@ -295,6 +311,7 @@ int main(int argc_, char ** argv_)
     ///
     std::error_code ec;
     if (main_func == printHelp && !argv.empty()
+        && (argv.size() < 2 || argv[1] != std::string_view("--help"))
         && (argv.size() == 1 || argv[1][0] == '-' || std::string_view(argv[1]).contains(' ')
             || std::filesystem::is_regular_file(std::filesystem::path{argv[1]}, ec)))
     {

--- a/tests/queries/0_stateless/03536_ch_as_client_and_local.reference
+++ b/tests/queries/0_stateless/03536_ch_as_client_and_local.reference
@@ -1,0 +1,7 @@
+Use one of the following commands:
+Use one of the following commands:
+Use one of the following commands:
+Overlay
+Overlay
+Atomic
+Atomic

--- a/tests/queries/0_stateless/03536_ch_as_client_and_local.sh
+++ b/tests/queries/0_stateless/03536_ch_as_client_and_local.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CLICKHOUSE_BINARY_CH=${CLICKHOUSE_BINARY/clickhouse/ch}
+
+# Invocation with unknown tool name prints help:
+${CLICKHOUSE_BINARY} test 2>&1 | grep -F 'Use one of the following commands'
+
+# Invocation with --help works the same:
+${CLICKHOUSE_BINARY} --help 2>&1 | grep -F 'Use one of the following commands'
+${CLICKHOUSE_BINARY_CH} --help 2>&1 | grep -F 'Use one of the following commands'
+
+# This is recognized as clickhouse-local:
+${CLICKHOUSE_BINARY} --query "SELECT engine FROM system.databases WHERE name = currentDatabase()"
+${CLICKHOUSE_BINARY_CH} --query "SELECT engine FROM system.databases WHERE name = currentDatabase()"
+
+# This is recognized as clickhouse-client:
+${CLICKHOUSE_BINARY} --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT_TCP} --query "SELECT engine FROM system.databases WHERE name = currentDatabase()"
+${CLICKHOUSE_BINARY_CH} --query "SELECT engine FROM system.databases WHERE name = currentDatabase()" -h${CLICKHOUSE_HOST} --port=${CLICKHOUSE_PORT_TCP}


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`clickhouse`/`ch` aliases will invoke `clickhouse-client` instead of `clickhouse-local` if `--host` or `--port` are specified. Continuation of #79422. Closes #65252.

Note: I decided not to include `--user` and `--password`, because you can create users inside `clickhouse-local`. I decided to also not include `--secure`, because it is rarely used without `host` or `port`.
