### PR TITLE
fix typo in collapsingmergetree.md

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
@@ -278,7 +278,7 @@ SELECT * FROM UAct FINAL
 └─────────────────────┴───────────┴──────────┴──────┘
 ```
 :::note
-This way of selecting the data is less inefficient and is not recommended for use with large amounts of scanned data (millions of rows).
+This way of selecting the data is less efficient and is not recommended for use with large amounts of scanned data (millions of rows).
 :::
 
 ### Example of Another Approach {#example-of-another-approach}


### PR DESCRIPTION
This should write "less efficient" not "less inefficient"


### Changelog category:
- Documentation (changelog entry is not required)
