### PR TITLE
Make ConfigManager add test configs atomically

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2211,6 +2211,16 @@ class ClickHouseCluster:
                 ],
             )
 
+    def move_file_in_container(self, container_id, old_path, new_path):
+        self.exec_in_container(
+            container_id,
+            [
+                "bash",
+                "-c",
+                "mv {} {}".format(old_path, new_path),
+            ],
+        )
+
     def remove_file_from_container(self, container_id, path):
         self.exec_in_container(
             container_id,
@@ -4413,6 +4423,9 @@ class ClickHouseInstance:
         return self.cluster.copy_file_to_container(
             self.docker_id, local_path, dest_path
         )
+
+    def move_file_in_container(self, old_path, new_path):
+        return self.cluster.move_file_in_container(self.docker_id, old_path, new_path)
 
     def remove_file_from_container(self, path):
         return self.cluster.remove_file_from_container(self.docker_id, path)

--- a/tests/integration/helpers/config_manager.py
+++ b/tests/integration/helpers/config_manager.py
@@ -48,7 +48,11 @@ class ConfigManager:
             dest_path = os.path.join(
                 "/etc/clickhouse-server", dest_dir, os.path.basename(local_path)
             )
-            node.copy_file_to_container(src_path, dest_path)
+            # Function copy_file_to_container() is not atomic, so to add a configuration file atomically
+            # first we create a temporary file and then we rename it.
+            temp_dest_path = dest_path + ".temp"
+            node.copy_file_to_container(src_path, temp_dest_path)
+            node.move_file_in_container(temp_dest_path, dest_path)
         if reload_config:
             for node in nodes_to_add_config:
                 node.query("SYSTEM RELOAD CONFIG")


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Integration tests: Make `ConfigManager` add test configs atomically.

This PR will fix failures in tests `test_backup_restore_on_cluster/test_cancel_backup.py` ([see](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=19904278ec305afd694a47aae316b2ccd57d5ad8&name_0=MasterCI&name_1=Integration%20tests%20%28release%2C%204%2F4%29)) like the following:
```
CANNOT_LOAD_CONFIG	Poco::Exception. Code: 1000, e.code() = 0, Exception: Failed to merge config with \'/etc/clickhouse-server/config.d/faster_zk_disconnect_detect.xml\': SAXParseException: No element found in \'/etc/clickhouse-server/config.d/faster_zk_disconnect_detect.xml\', line 1 column 0
```

