### PR TITLE
Hide settings under --verbose for clickhouse-benchmark and improve bash completion scripts

### DIFF
--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -154,8 +154,16 @@ function _clickhouse_quote()
 # Extract every option (everything that starts with "-") from the --help dialog.
 function _clickhouse_get_options()
 {
-    # By default --help will not print all settings, this is done only under --verbose
-    "$@" --help --verbose 2>&1 | LANG=c awk -F '[ ,=<>.]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 1, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
+    local extra_args=()
+
+    # By default client/local/benchmark --help will not print all settings, this is done only under --verbose
+    case "$1" in
+        *client*) extra_args+=(--verbose) ;;
+        *local*) extra_args+=(--verbose) ;;
+        *benchmark*) extra_args+=(--verbose) ;;
+    esac
+
+    "$@" --help "${extra_args[@]}" 2>&1 | LANG=c awk -F '[ ,=<>.]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 1, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
 }
 
 function _complete_for_clickhouse_generic_bin_impl()

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -622,9 +622,10 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
         if (env_quota_key != nullptr)
             env_quota_key_str.emplace(std::string(env_quota_key));
 
-        boost::program_options::options_description desc = createOptionsDescription("Allowed options", getTerminalWidth());
-        desc.add_options()
-            ("help",                                                            "produce help message")
+        boost::program_options::options_description options_description = createOptionsDescription("Allowed options", getTerminalWidth());
+        options_description.add_options()
+            ("help", "Print usage summary and exit; combine with --verbose to display all options")
+            ("verbose", "Increase output verbosity")
             ("query,q",       value<std::string>()->default_value(""),          "query to execute")
             ("concurrency,c", value<unsigned>()->default_value(1),              "number of parallel queries")
             ("delay,d",       value<double>()->default_value(1),                "delay between intermediate reports in seconds (set 0 to disable reports)")
@@ -652,10 +653,11 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
         ;
 
         Settings settings;
-        settings.addToProgramOptions(desc);
+        auto options_description_non_verbose = options_description;
+        settings.addToProgramOptions(options_description);
 
         boost::program_options::variables_map options;
-        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, options_description), options);
         boost::program_options::notify(options);
 
         clearPasswordFromCommandLine(argc, argv);
@@ -663,7 +665,10 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
         if (options.contains("help"))
         {
             std::cout << "Usage: " << argv[0] << " [options] < queries.txt\n";
-            std::cout << desc << "\n";
+            if (options.contains("verbose"))
+                std::cout << options_description << "\n";
+            else
+                std::cout << options_description_non_verbose << "\n";
             std::cout << "\nSee also: https://clickhouse.com/docs/operations/utilities/clickhouse-benchmark/\n";
             return 0;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)