### PR TITLE
Don't process quota values if the user is not limited

### DIFF
--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -518,8 +518,7 @@ std::shared_ptr<const EnabledQuota> ContextAccess::getQuota() const
         }
         else
         {
-            static const auto unlimited_quota = EnabledQuota::getUnlimitedQuota();
-            return unlimited_quota;
+            return nullptr;
         }
     }
 

--- a/src/Access/EnabledQuota.cpp
+++ b/src/Access/EnabledQuota.cpp
@@ -247,6 +247,8 @@ void EnabledQuota::used(QuotaType quota_type, QuotaValue value, bool check_excee
 
 void EnabledQuota::used(const std::pair<QuotaType, QuotaValue> & usage1, bool check_exceeded) const
 {
+    if (empty)
+        return;
     auto loaded = intervals.load();
     auto current_time = std::chrono::system_clock::now();
     Impl::used(getUserName(), *loaded, usage1.first, usage1.second, current_time, check_exceeded);
@@ -255,6 +257,8 @@ void EnabledQuota::used(const std::pair<QuotaType, QuotaValue> & usage1, bool ch
 
 void EnabledQuota::used(const std::pair<QuotaType, QuotaValue> & usage1, const std::pair<QuotaType, QuotaValue> & usage2, bool check_exceeded) const
 {
+    if (empty)
+        return;
     auto loaded = intervals.load();
     auto current_time = std::chrono::system_clock::now();
     Impl::used(getUserName(), *loaded, usage1.first, usage1.second, current_time, check_exceeded);
@@ -264,6 +268,8 @@ void EnabledQuota::used(const std::pair<QuotaType, QuotaValue> & usage1, const s
 
 void EnabledQuota::used(const std::pair<QuotaType, QuotaValue> & usage1, const std::pair<QuotaType, QuotaValue> & usage2, const std::pair<QuotaType, QuotaValue> & usage3, bool check_exceeded) const
 {
+    if (empty)
+        return;
     auto loaded = intervals.load();
     auto current_time = std::chrono::system_clock::now();
     Impl::used(getUserName(), *loaded, usage1.first, usage1.second, current_time, check_exceeded);
@@ -274,6 +280,8 @@ void EnabledQuota::used(const std::pair<QuotaType, QuotaValue> & usage1, const s
 
 void EnabledQuota::used(const std::vector<std::pair<QuotaType, QuotaValue>> & usages, bool check_exceeded) const
 {
+    if (empty)
+        return;
     auto loaded = intervals.load();
     auto current_time = std::chrono::system_clock::now();
     for (const auto & usage : usages)
@@ -283,6 +291,8 @@ void EnabledQuota::used(const std::vector<std::pair<QuotaType, QuotaValue>> & us
 
 void EnabledQuota::checkExceeded() const
 {
+    if (empty)
+        return;
     auto loaded = intervals.load();
     Impl::checkExceeded(getUserName(), *loaded, std::chrono::system_clock::now());
 }
@@ -290,6 +300,8 @@ void EnabledQuota::checkExceeded() const
 
 void EnabledQuota::checkExceeded(QuotaType quota_type) const
 {
+    if (empty)
+        return;
     auto loaded = intervals.load();
     Impl::checkExceeded(getUserName(), *loaded, quota_type, std::chrono::system_clock::now());
 }
@@ -306,17 +318,4 @@ std::optional<QuotaUsage> EnabledQuota::getUsage() const
     auto loaded = intervals.load();
     return loaded->getUsage(std::chrono::system_clock::now());
 }
-
-
-std::shared_ptr<const EnabledQuota> EnabledQuota::getUnlimitedQuota()
-{
-    static const std::shared_ptr<const EnabledQuota> res = []
-    {
-        auto unlimited_quota = std::shared_ptr<EnabledQuota>(new EnabledQuota);
-        unlimited_quota->intervals = boost::make_shared<Intervals>();
-        return unlimited_quota;
-    }();
-    return res;
-}
-
 }

--- a/src/Access/EnabledQuota.h
+++ b/src/Access/EnabledQuota.h
@@ -57,8 +57,7 @@ public:
     /// Returns the information about quota consumption.
     std::optional<QuotaUsage> getUsage() const;
 
-    /// Returns an instance of EnabledQuota which is never exceeded.
-    static std::shared_ptr<const EnabledQuota> getUnlimitedQuota();
+    bool isEmpty() const { return empty; }
 
 private:
     friend class QuotaCache;
@@ -98,6 +97,7 @@ private:
 
     const Params params;
     boost::atomic_shared_ptr<const Intervals> intervals; /// atomically changed by QuotaUsageManager
+    std::atomic<bool> empty = false; /// Use a separate flag to avoid loading intervals, which is way more expensive than an atomic bool
 };
 
 }

--- a/src/Access/EnabledQuota.h
+++ b/src/Access/EnabledQuota.h
@@ -57,7 +57,6 @@ public:
     /// Returns the information about quota consumption.
     std::optional<QuotaUsage> getUsage() const;
 
-    bool isEmpty() const { return empty; }
 
 private:
     friend class QuotaCache;

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -290,9 +290,15 @@ void QuotaCache::chooseQuotaToConsumeFor(EnabledQuota & enabled, bool throw_if_c
     }
 
     if (!intervals)
-        intervals = boost::make_shared<Intervals>(); /// No quota == no limits.
-
-    enabled.intervals.store(intervals);
+    {
+        enabled.empty = true;
+        enabled.intervals = boost::make_shared<Intervals>(); /// No quota == no limits.
+    }
+    else
+    {
+        enabled.intervals.store(intervals);
+        enabled.empty = false;
+    }
 }
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't process quota values if the user is not limited

References https://github.com/ClickHouse/ClickHouse/issues/81043

```
$ clickhouse benchmark --port 49000 --query "SELECT COUNT(*) FROM hits WHERE AdvEngineID <> 0;" -i 4000
```
* Before (includes #80125): localhost:49000, queries: 4000, QPS: 266.071, RPS: 16900711501.102, MiB/s: 1602.376, result RPS: **266.071**, result MiB/s: 0.002.
* After (includes #80125): localhost:49000, queries: 4000, QPS: 280.379, RPS: 17809579819.300, MiB/s: 1688.547, result RPS: **280.379**, result MiB/s: 0.002.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
