### PR TITLE
Better metrics on query failures (and fix one test flakiness)

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -706,6 +706,12 @@ void logQueryException(
     elem.event_time = timeInSeconds(time_now);
     elem.event_time_microseconds = timeInMicroseconds(time_now);
 
+    ProfileEvents::increment(ProfileEvents::FailedQuery);
+    if (!query_ast || query_ast->as<ASTSelectQuery>() || query_ast->as<ASTSelectWithUnionQuery>())
+        ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
+    else if (query_ast->as<ASTInsertQuery>())
+        ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
+
     QueryStatusInfoPtr info;
     if (process_list_elem)
     {
@@ -731,12 +737,6 @@ void logQueryException(
         if (auto query_log = context->getQueryLog())
             query_log->add(elem);
     }
-
-    ProfileEvents::increment(ProfileEvents::FailedQuery);
-    if (!query_ast || query_ast->as<ASTSelectQuery>() || query_ast->as<ASTSelectWithUnionQuery>())
-        ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
-    else if (query_ast->as<ASTInsertQuery>())
-        ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
 
     if (query_span)
     {

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -826,7 +826,7 @@ void logExceptionBeforeStart(
         ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
 
     QueryStatusInfoPtr info;
-    if (QueryStatusPtr process_list_elem = context->getProcessListElement())
+    if (QueryStatusPtr process_list_elem = context->getProcessListElementSafe())
     {
         info = std::make_shared<QueryStatusInfo>(process_list_elem->getInfo(true, settings[Setting::log_profile_events], false));
         addStatusInfoToQueryLogElement(elem, *info, ast, context, query_end_time);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -800,8 +800,6 @@ void logExceptionBeforeStart(
 
     elem.client_info = context->getClientInfo();
 
-    logQueryMetricLogFinish(context, false, elem.client_info.current_query_id, std::chrono::system_clock::now(), nullptr);
-
     elem.log_comment = settings[Setting::log_comment];
     if (elem.log_comment.size() > settings[Setting::max_query_size])
         elem.log_comment.resize(settings[Setting::max_query_size]);
@@ -820,6 +818,20 @@ void logExceptionBeforeStart(
 
     /// Update performance counters before logging to query_log
     CurrentThread::finalizePerformanceCounters();
+
+    ProfileEvents::increment(ProfileEvents::FailedQuery);
+    if (!ast || ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
+        ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
+    else if (ast->as<ASTInsertQuery>())
+        ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
+
+    QueryStatusInfoPtr info;
+    if (QueryStatusPtr process_list_elem = context->getProcessListElement())
+    {
+        info = std::make_shared<QueryStatusInfo>(process_list_elem->getInfo(true, settings[Setting::log_profile_events], false));
+        addStatusInfoToQueryLogElement(elem, *info, ast, context, query_end_time);
+    }
+    logQueryMetricLogFinish(context, /*internal=*/ false, elem.client_info.current_query_id, query_end_time, info);
 
     if (auto query_log = context->getQueryLog())
     {
@@ -867,20 +879,6 @@ void logExceptionBeforeStart(
         query_span->addAttribute("db.statement", elem.query);
         query_span->addAttribute("clickhouse.query_id", elem.client_info.current_query_id);
         query_span->finish(query_end_time);
-    }
-
-    ProfileEvents::increment(ProfileEvents::FailedQuery);
-
-    if (ast)
-    {
-        if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
-        {
-            ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
-        }
-        else if (ast->as<ASTInsertQuery>())
-        {
-            ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
-        }
     }
 }
 

--- a/tests/queries/0_stateless/01281_unsucceeded_insert_select_queries_counter.reference
+++ b/tests/queries/0_stateless/01281_unsucceeded_insert_select_queries_counter.reference
@@ -1,4 +1,4 @@
-1
-2
-1
-2
+INSERT INTO table_that_do_not_exists VALUES 	ExceptionBeforeStart	0	1
+INSERT INTO to_insert SELECT throwIf(?);	ExceptionWhileProcessing	0	1
+SELECT * FROM table_that_do_not_exists;	ExceptionBeforeStart	1	0
+SELECT throwIf(?);	ExceptionWhileProcessing	1	0

--- a/tests/queries/0_stateless/01281_unsucceeded_insert_select_queries_counter.sql
+++ b/tests/queries/0_stateless/01281_unsucceeded_insert_select_queries_counter.sql
@@ -1,6 +1,7 @@
 -- Tags: no-parallel, no-fasttest
 
-CREATE OR REPLACE TABLE to_insert (value UInt64) ENGINE = Memory();
+DROP TABLE IF EXISTS to_insert;
+CREATE TABLE to_insert (value UInt64) ENGINE = Memory();
 
 INSERT INTO table_that_do_not_exists VALUES (42); -- { serverError UNKNOWN_TABLE }
 INSERT INTO to_insert SELECT throwIf(1); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }

--- a/tests/queries/0_stateless/01281_unsucceeded_insert_select_queries_counter.sql
+++ b/tests/queries/0_stateless/01281_unsucceeded_insert_select_queries_counter.sql
@@ -1,68 +1,15 @@
 -- Tags: no-parallel, no-fasttest
 
-DROP TABLE IF EXISTS current_failed_query_metrics;
-DROP TABLE IF EXISTS to_insert;
+CREATE OR REPLACE TABLE to_insert (value UInt64) ENGINE = Memory();
 
-CREATE TABLE current_failed_query_metrics (event LowCardinality(String), value UInt64) ENGINE = Memory();
-
-
-INSERT INTO current_failed_query_metrics 
-SELECT event, value
-FROM system.events
-WHERE event in ('FailedQuery', 'FailedInsertQuery', 'FailedSelectQuery');
-
-CREATE TABLE to_insert (value UInt64) ENGINE = Memory();
-
--- Failed insert before execution
 INSERT INTO table_that_do_not_exists VALUES (42); -- { serverError UNKNOWN_TABLE }
-
-SELECT current_value - previous_value
-FROM (
-    SELECT event, value as current_value FROM system.events WHERE event like 'FailedInsertQuery'
-) AS previous
-ALL LEFT JOIN (
-    SELECT event, value as previous_value FROM current_failed_query_metrics
-) AS current
-on previous.event = current.event;
-
-
--- Failed insert in execution
 INSERT INTO to_insert SELECT throwIf(1); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
-
-SELECT current_value - previous_value
-FROM (
-    SELECT event, value as current_value FROM system.events WHERE event like 'FailedInsertQuery'
-) AS previous
-ALL LEFT JOIN (
-    SELECT event, value as previous_value FROM current_failed_query_metrics
-) AS current
-on previous.event = current.event;
-
-
--- Failed select before execution
 SELECT * FROM table_that_do_not_exists; -- { serverError UNKNOWN_TABLE }
-
-SELECT current_value - previous_value
-FROM (
-    SELECT event, value as current_value FROM system.events WHERE event like 'FailedSelectQuery'
-) AS previous
-ALL LEFT  JOIN (
-    SELECT event, value as previous_value FROM current_failed_query_metrics
-) AS current
-on previous.event = current.event;
-
--- Failed select in execution
 SELECT throwIf(1); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 
-SELECT current_value - previous_value
-FROM (
-    SELECT event, value as current_value FROM system.events WHERE event like 'FailedSelectQuery'
-) AS previous
-ALL LEFT JOIN (
-    SELECT event, value as previous_value FROM current_failed_query_metrics
-) AS current
-on previous.event = current.event;
+SYSTEM FLUSH LOGS query_log;
 
-
-DROP TABLE current_failed_query_metrics;
-DROP TABLE to_insert;
+SELECT normalizeQuery(query), type, ProfileEvents['FailedSelectQuery'], ProfileEvents['FailedInsertQuery']
+FROM system.query_log
+WHERE current_database = currentDatabase() AND query_kind IN ('Select', 'Insert') AND event_date >= yesterday() AND type != 'QueryStart'
+ORDER BY event_time_microseconds;

--- a/tests/queries/0_stateless/01600_log_queries_with_extensive_info.reference
+++ b/tests/queries/0_stateless/01600_log_queries_with_extensive_info.reference
@@ -6,7 +6,7 @@ create database test_log_queries	18329631544365042880	Create	['test_log_queries'
 create table test_log_queries.logtable(i int, j int, k int) engine MergeTree order by i	14473140110122260412	Create	['test_log_queries']	['test_log_queries.logtable']	[]
 insert into test_log_queries.logtable values 	10533878590475998223	Insert	['test_log_queries']	['test_log_queries.logtable']	[]
 select k from test_log_queries.logtable where i = 4	10551554599491277990	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.k']
-select k from test_log_queries.logtable where i > \'\'	10861140285495151963	Select	[]	[]	[]
+select k from test_log_queries.logtable where i > \'\'	10861140285495151963	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.k']
 select k from test_log_queries.logtable where i = 1	10551554599491277990	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.k']
 select * from test_log_queries.logtable where i = 1	2790142879136771124	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.j','test_log_queries.logtable.k']
 create table test_log_queries.logtable2 as test_log_queries.logtable	16326833375045356331	Create	['test_log_queries']	['test_log_queries.logtable','test_log_queries.logtable2']	[]

--- a/tests/queries/0_stateless/01600_log_queries_with_extensive_info.sh
+++ b/tests/queries/0_stateless/01600_log_queries_with_extensive_info.sh
@@ -14,8 +14,10 @@ ${CLICKHOUSE_CLIENT} -q "insert into test_log_queries.logtable values (1,2,3), (
 ${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i = 4" "--query_id=01600_log_queries_with_extensive_info_004"
 
 # exception query should also contain query_kind
-# NOTE: force analyzer since the behavior is different, InterpreterSelectQuery logs used database/tables **after** it starts reading, analyzer during analysis
-${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i > ''" "--query_id=01600_log_queries_with_extensive_info_004_err" --allow_experimental_analyzer=1 2> /dev/null || true
+# NOTE:
+# - force analyzer since the behavior is different, InterpreterSelectQuery logs used database/tables **after** it starts reading, analyzer during analysis
+# - disable parallel replicas, since it also uses different code path
+${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i > ''" "--query_id=01600_log_queries_with_extensive_info_004_err" --allow_experimental_analyzer=1 --enable_parallel_replicas=0 2> /dev/null || true
 
 ${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i = 1" "--query_id=01600_log_queries_with_extensive_info_005"
 ${CLICKHOUSE_CLIENT} -q "select * from test_log_queries.logtable where i = 1" "--query_id=01600_log_queries_with_extensive_info_006"

--- a/tests/queries/0_stateless/01600_log_queries_with_extensive_info.sh
+++ b/tests/queries/0_stateless/01600_log_queries_with_extensive_info.sh
@@ -14,7 +14,8 @@ ${CLICKHOUSE_CLIENT} -q "insert into test_log_queries.logtable values (1,2,3), (
 ${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i = 4" "--query_id=01600_log_queries_with_extensive_info_004"
 
 # exception query should also contain query_kind
-${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i > ''" "--query_id=01600_log_queries_with_extensive_info_004_err" 2> /dev/null || true
+# NOTE: force analyzer since the behavior is different, InterpreterSelectQuery logs used database/tables **after** it starts reading, analyzer during analysis
+${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i > ''" "--query_id=01600_log_queries_with_extensive_info_004_err" --allow_experimental_analyzer=1 2> /dev/null || true
 
 ${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i = 1" "--query_id=01600_log_queries_with_extensive_info_005"
 ${CLICKHOUSE_CLIENT} -q "select * from test_log_queries.logtable where i = 1" "--query_id=01600_log_queries_with_extensive_info_006"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Properly capture Failed{Select,Insert,}Query for ExceptionWhileProcessing
- Capture profile events for ExceptionBeforeStart
- Fix 01281_unsucceeded_insert_select_queries_counter (https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81547&sha=7758bdfecdc5723b967cf73377fc761a98680865&name_0=PR&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29)