### PR TITLE
ci: disable bash tracing by default for clickhouse-test and enable only on CI

### DIFF
--- a/ci/jobs/functional_stateful_tests.py
+++ b/ci/jobs/functional_stateful_tests.py
@@ -36,7 +36,7 @@ def run_test(
 ):
     test_output_file = f"{temp_dir}/test_result.txt"
 
-    test_command = f"clickhouse-test --jobs 2 --testname --shard --zookeeper --check-zookeeper-session --no-stateless \
+    test_command = f"clickhouse-test --jobs 2 --testname --shard --zookeeper --check-zookeeper-session --no-stateless --trace \
         --hung-check \
         --capture-client-stacktrace --queries ./tests/queries -- '{test}' \
         | ts '%Y-%m-%d %H:%M:%S' | tee -a \"{test_output_file}\""

--- a/ci/jobs/functional_stateless_tests.py
+++ b/ci/jobs/functional_stateless_tests.py
@@ -40,7 +40,7 @@ def run_stateless_test(
     nproc = int(Utils.cpu_count() / 2)
     if batch_num and batch_total:
         aux = f"--run-by-hash-total {batch_total} --run-by-hash-num {batch_num-1}"
-    statless_test_command = f"clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --hung-check \
+    statless_test_command = f"clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --hung-check --trace \
                 --capture-client-stacktrace --queries /repo/tests/queries --test-runs 1 --hung-check \
                 {'--no-parallel' if no_parallel else ''}  {'--no-sequential' if no_sequiential else ''} \
                 --jobs {nproc} --report-coverage --report-logs-stats {aux} \

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -45,7 +45,7 @@ class ClickHouseProc:
         self.proc = None
         self.pid = 0
         nproc = int(Utils.cpu_count() / 2)
-        self.fast_test_command = f"clickhouse-test --hung-check --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --zookeeper --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc} -- '{{TEST}}' | ts '%Y-%m-%d %H:%M:%S' \
+        self.fast_test_command = f"clickhouse-test --hung-check --trace --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --zookeeper --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc} -- '{{TEST}}' | ts '%Y-%m-%d %H:%M:%S' \
         | tee -a \"{self.test_output_file}\""
         # TODO: store info in case of failure
         self.info = ""

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1922,7 +1922,8 @@ class TestCase:
         pattern = "{test} > {stdout} 2> {stderr}"
 
         tests_env = os.environ.copy()
-        tests_env["CLICKHOUSE_BASH_TRACING_FILE"] = args.debug_log_file
+        if args.trace:
+            tests_env["CLICKHOUSE_BASH_TRACING_FILE"] = args.debug_log_file
 
         if self.ext == ".sql" and args.cloud:
             # Get at least some logs, because we don't have access to system.text_log and pods...
@@ -3874,6 +3875,7 @@ def parse_args():
         action="store_true",
         help="Capture stacktraces from clickhouse-client/local on errors",
     )
+    parser.add_argument("--trace", action="store_true", help="Capture various tracing info")
 
     return parser.parse_args()
 

--- a/tests/docker_scripts/stateful_runner.sh
+++ b/tests/docker_scripts/stateful_runner.sh
@@ -238,6 +238,7 @@ function run_tests()
         --check-zookeeper-session
         --no-stateless
         --hung-check
+        --trace
         --capture-client-stacktrace
         --queries "/repo/tests/queries"
         "${ADDITIONAL_OPTIONS[@]}"

--- a/tests/docker_scripts/stateless_runner.sh
+++ b/tests/docker_scripts/stateless_runner.sh
@@ -363,6 +363,7 @@ function run_tests()
         --check-zookeeper-session
         --hung-check
         --capture-client-stacktrace
+        --trace
         --queries "/repo/tests/queries"
         --test-runs "$NUM_TRIES"
         "${ADDITIONAL_OPTIONS[@]}"

--- a/tests/queries/shell_config.sh
+++ b/tests/queries/shell_config.sh
@@ -215,7 +215,7 @@ function run_with_error()
 }
 
 # BASH_XTRACEFD is supported only since 4.1
-if [[ -n $CLICKHOUSE_BASH_TRACING_FILE ]] && [[ ${BASH_VERSINFO[0]} -gt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 1) ]]; then
+if [[ -v CLICKHOUSE_BASH_TRACING_FILE ]] && [[ ${BASH_VERSINFO[0]} -gt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 1) ]]; then
     exec 3>"$CLICKHOUSE_BASH_TRACING_FILE"
     # It will be also nice to have stderr in the tracing output, but:
     # - exec 2>&3


### PR DESCRIPTION
It can be annoying to see it only if the reference did not match, since in this case you will have lots of command tracing output, but all you care about is the diff.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
