### PR TITLE
tests: fix test_cleanup_after_start flakiness

### DIFF
--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -29,6 +29,7 @@ def test_old_dirs_cleanup(start_cluster):
         CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
         ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table', 'node1')
         PARTITION BY date ORDER BY id
+        SETTINGS cleanup_delay_period=3600, max_cleanup_delay_period=3600
         """
     )
 


### PR DESCRIPTION
It is possible that the part will be already removed

```
2025.06.04 19:24:49.010431 [ 816 ] {BgSchPool::5233970e-0b5b-47a6-884a-bd1e03761745} <Information> default.test_table (52ea9ad8-2d08-445f-aefa-e065c8a44702): Created empty part 20200101_0_0_0 instead of lost part
...
2025.06.04 19:24:49.080410 [ 823 ] {BgSchPool::514fc616-faff-4af1-99b8-ccdf92cb6f87} <Debug> default.test_table (52ea9ad8-2d08-445f-aefa-e065c8a44702): Removing 1 parts from memory: Parts: [20200101_0_0_0]
```

```
2025-06-04 19:24:49.867000 [ 664 ] DEBUG : Command:[docker exec --privileged roottestcleanupafterstart-gw3-node1-1 bash -c ls /var/lib/clickhouse/store/52e/52ea9ad8-2d08-445f-aefa-e065c8a44702//] (cluster.py:121, run_and_check)
```

So the command in docker executed **after** server removed the part

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)