### PR TITLE
More explicitly drain the leftover bytes in buffer for the POST request in HTTPHander

### DIFF
--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -56,11 +56,15 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
     /// and retry with exactly the same (incomplete) set of rows.
     /// That's why we have to check body size if it's provided.
     if (getChunkedTransferEncoding())
+    {
         stream = std::make_unique<HTTPChunkedReadBuffer>(std::move(in), HTTP_MAX_CHUNK_SIZE);
+        is_stream_bounded = true;
+    }
     else if (hasContentLength())
     {
         size_t content_length = getContentLength();
         stream = std::make_unique<LimitReadBuffer>(std::move(in), LimitReadBuffer::Settings{.read_no_less = content_length, .read_no_more = content_length, .expect_eof = true});
+        is_stream_bounded = true;
     }
     else if (getMethod() != HTTPRequest::HTTP_GET && getMethod() != HTTPRequest::HTTP_HEAD && getMethod() != HTTPRequest::HTTP_DELETE)
     {
@@ -70,8 +74,11 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
                 "and no chunked/multipart encoding, it may be impossible to distinguish graceful EOF from abnormal connection loss");
     }
     else
+    {
         /// We have to distinguish empty buffer and nullptr.
         stream = std::make_unique<EmptyReadBuffer>();
+        is_stream_bounded = true;
+    }
 }
 
 bool HTTPServerRequest::checkPeerConnected() const

--- a/src/Server/HTTP/HTTPServerRequest.h
+++ b/src/Server/HTTP/HTTPServerRequest.h
@@ -36,6 +36,10 @@ public:
 
     bool isSecure() const { return secure; }
 
+    /// Whether getStream() knows where this request ends (from Content-Length or chunked encoding).
+    /// If true, it's safe to drain the stream to eof before reusing the connection.
+    bool isStreamBounded() const { return is_stream_bounded; }
+
     /// Returns the client's address.
     const Poco::Net::SocketAddress & clientAddress() const { return client_address; }
 
@@ -66,6 +70,7 @@ private:
     Poco::Net::SocketAddress server_address;
 
     bool secure;
+    bool is_stream_bounded = false;
 
     void readRequest(ReadBuffer & in);
 };

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -622,13 +622,16 @@ void HTTPHandler::processQuery(
     {
         String remaining;
         readStringUntilEOF(remaining, *in_post_maybe_compressed);
-        auto hex_string = hexString(remaining.data(), remaining.size());
+        if (!remaining.empty())
+        {
+            auto hex_string = hexString(remaining.data(), remaining.size());
 #if defined(DEBUG_OR_SANITIZER_BUILD)
-        throw Exception(ErrorCodes::LOGICAL_ERROR,
-            "There is still some data in the buffer: {}", hex_string);
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "There is still some data in the buffer: {}", hex_string);
 #else
-        LOG_WARNING(log, "There is still some data in the buffer: {}", hex_string);
+            LOG_WARNING(log, "There is still some data in the buffer: {}", hex_string);
 #endif
+        }
     }
 }
 

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -617,6 +617,19 @@ void HTTPHandler::processQuery(
         {},
         handle_exception_in_output_format,
         query_finish_callback);
+
+    if (request.isStreamBounded())
+    {
+        String remaining;
+        readStringUntilEOF(remaining, *in_post_maybe_compressed);
+        auto hex_string = hexString(remaining.data(), remaining.size());
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "There is still some data in the buffer: {}", hex_string);
+#else
+        LOG_WARNING(log, "There is still some data in the buffer: {}", hex_string);
+#endif
+    }
 }
 
 bool HTTPHandler::trySendExceptionToClient(

--- a/tests/integration/test_http_chunked_encoding_tail_delay/test.py
+++ b/tests/integration/test_http_chunked_encoding_tail_delay/test.py
@@ -1,0 +1,63 @@
+import pytest
+import time, http.client
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "instance",
+    main_configs=[],
+)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def make_arrow_stream_data():
+    # Produce a valid ~300 KB ArrowStream payload.
+    # Made using `select 0x123456789abcdef0 as x from numbers(37000) settings output_format_arrow_compression_method='none' format ArrowStream`,
+    # then finding all the parts of the hex dump that are not "f0debc9a78563412" (0x123456789abcdef0 in little endian).
+    header = "ffffffff700000001000000000000a000c000600050008000a000000000104000c000000080008000000040008000000040000000100000014000000100014000800000007000c00000010001000000000000002100000001800000004000000000000000100000078000600080004000600000040000000ffffffff8800000014000000000000000c0016000600050008000c000c0000000003040018000000408404000000000000000a0018000c00040008000a0000003c00000010000000889000000000000000000000020000000000000000000000000000000000000000000000000000004084040000000000000000000100000088900000000000000000000000000000"
+    footer = "ffffffff00000000"
+    num_values = 37000
+
+    return bytes.fromhex(header) + b"xxxxxxxx" * num_values + bytes.fromhex(footer)
+
+def yield_then_sleep(data):
+    yield data
+    # Make the HTTP client wait after the data chunk but before sending the final "0\r\n\r\n" bytes.
+    time.sleep(1)
+
+# This used to break because the server didn't drain the final empty chunk from HTTP chunked encoded
+# data, then tried to parse the next request from the same connection and misinterpreted the
+# leftover empty chunk as part of next request's headers. Repro conditions:
+#  * ArrowStream format has size in header, and our parser stops reading exactly after consuming all
+#    payload bytes, without checking for eof after that. So the final empty chunk (end-of-data
+#    indicator) doesn't get read by IInputFormat.
+#  * Payload needs to be bigger than DBMS_DEFAULT_MAX_QUERY_SIZE (262144 bytes). Otherwise
+#    executeQuery accidentally reads it while buffering the query.
+def test_http_delay(started_cluster):
+    node.query("create table t (x Int64) engine Memory")
+
+    conn = http.client.HTTPConnection(node.ip_address, 8123)
+    data = make_arrow_stream_data()
+    conn.request('POST', '/?query=insert%20into%20t%20format%20ArrowStream', body=yield_then_sleep(data), headers={'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive'}, encode_chunked=True)
+    resp = conn.getresponse()
+    #print(f"POST response headers: {resp.headers}")
+    assert resp.status == 200
+    assert resp.getheader('Connection').lower() == 'keep-alive'
+    body = resp.read()
+    assert body == b""
+
+    conn.request('GET', '/?query=select%2042')
+    resp = conn.getresponse()
+    assert resp.status == 200
+    assert resp.read() == b"42\n"
+
+    node.query("drop table t")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed rare HTTP errors (`Invalid HTTP version string: /?query=I`) after INSERT using ArrowStream format, HTTP chunked encoding, and connection keep-alive.

Like https://github.com/ClickHouse/ClickHouse/pull/81461 , but with a simpler test and more reliable drain condition.