### PR TITLE
Add reason to task scheduling failures to ease debugging

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -480,12 +480,17 @@ std::string getExtraExceptionInfo(const std::exception & e)
     return msg;
 }
 
-std::string getCurrentExceptionMessage(bool with_stacktrace, bool check_embedded_stacktrace /*= false*/, bool with_extra_info /*= true*/)
+std::string getVersionInfo()
 {
-    return getCurrentExceptionMessageAndPattern(with_stacktrace, check_embedded_stacktrace, with_extra_info).text;
+    return fmt::format(" (version {}{})", VERSION_STRING, VERSION_OFFICIAL);
 }
 
-PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, bool check_embedded_stacktrace /*= false*/, bool with_extra_info /*= true*/)
+std::string getCurrentExceptionMessage(bool with_stacktrace, bool check_embedded_stacktrace /*= false*/, bool with_extra_info /*= true*/, bool with_version_info /*= true*/)
+{
+    return getCurrentExceptionMessageAndPattern(with_stacktrace, check_embedded_stacktrace, with_extra_info, with_version_info).text;
+}
+
+PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, bool check_embedded_stacktrace /*= false*/, bool with_extra_info /*= true*/, bool with_version_info /*= true*/)
 {
     WriteBufferFromOwnString stream;
     std::string_view message_format_string;
@@ -499,7 +504,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, b
     {
         stream << getExceptionMessage(e, with_stacktrace, check_embedded_stacktrace)
                << (with_extra_info ? getExtraExceptionInfo(e) : "")
-               << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
+               << (with_version_info ? getVersionInfo() : "");
         message_format_string = e.tryGetMessageFormatString();
         message_format_string_args = e.getMessageFormatStringArgs();
     }
@@ -511,7 +516,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, b
                 << ", " << e.displayText()
                 << (with_stacktrace ? ", Stack trace (when copying this message, always include the lines below):\n\n" + getExceptionStackTraceString(e) : "")
                 << (with_extra_info ? getExtraExceptionInfo(e) : "")
-                << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
+                << (with_version_info ? getVersionInfo() : "");
         }
         catch (...) {} // NOLINT(bugprone-empty-catch)
     }
@@ -528,7 +533,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, b
             stream << "std::exception. Code: " << ErrorCodes::STD_EXCEPTION << ", type: " << name << ", e.what() = " << e.what()
                 << (with_stacktrace ? ", Stack trace (when copying this message, always include the lines below):\n\n" + getExceptionStackTraceString(e) : "")
                 << (with_extra_info ? getExtraExceptionInfo(e) : "")
-                << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
+                << (with_version_info ? getVersionInfo() : "");
         }
         catch (...) {} // NOLINT(bugprone-empty-catch)
 
@@ -557,7 +562,8 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, b
             if (status)
                 name += " (demangling status: " + toString(status) + ")";
 
-            stream << "Unknown exception. Code: " << ErrorCodes::UNKNOWN_EXCEPTION << ", type: " << name << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
+            stream << "Unknown exception. Code: " << ErrorCodes::UNKNOWN_EXCEPTION << ", type: " << name
+                   << (with_version_info ? getVersionInfo() : "");
         }
         catch (...) {} // NOLINT(bugprone-empty-catch)
     }

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -308,11 +308,12 @@ void tryLogCurrentException(const AtomicLogger & logger, const std::string & sta
   * check_embedded_stacktrace - if DB::Exception has embedded stacktrace then
   *  only this stack trace will be printed.
   * with_extra_info - add information about the filesystem in case of "No space left on device" and similar.
+  * with_version_info - add ClickHouse version
   */
 std::string getCurrentExceptionMessage(bool with_stacktrace, bool check_embedded_stacktrace = false,
-                                       bool with_extra_info = true);
+                                       bool with_extra_info = true, bool with_version_info = true);
 PreformattedMessage getCurrentExceptionMessageAndPattern(bool with_stacktrace, bool check_embedded_stacktrace = false,
-                                       bool with_extra_info = true);
+                                       bool with_extra_info = true, bool with_version_info = true);
 
 /// Returns error code from ErrorCodes
 int getCurrentExceptionCode();

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -295,7 +295,7 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, Priority priority, std:
             auto pool = std::is_same_v<Thread, std::thread> ? "global" : "local";
             throw DB::Exception(
                 DB::ErrorCodes::CANNOT_SCHEDULE_TASK,
-                "Cannot schedule task (pool={}, threads={}, jobs={}): {}",
+                "Cannot schedule a task (pool={}, threads={}, jobs={}): {}",
                 pool,
                 threads.size(),
                 scheduled_jobs,


### PR DESCRIPTION
Ease debugging of `CANNOT_SCHEDULE_TASK` errors (e.g. https://github.com/ClickHouse/ClickHouse/issues/78092). We currently swallow the causing exception in the local/global nesting.

This error can happen on the well-defined code path when `thread_pool_queue_size` is reached ("no free thread"). But it can also happen, for example, when a thread cannot be created on OS-level. In our case, we ran into the mmap limit (`vm.max_map_count`). In both cases, we only see the following error:

> Cannot schedule a task: failed to start the thread (threads=11, jobs=11)

With this change, we see:
 
> Cannot schedule task (pool=local, threads=11, jobs=11): Cannot schedule task (pool=global, threads=1000, jobs=1000): no free thread (timeout=0)

> Cannot schedule task (pool=local, threads=0, jobs=0): Cannot schedule task (pool=global, threads=1023, jobs=1012): thread constructor failed: Resource temporarily unavailable

Still not very nice due to the nesting, but that's inherent to the design.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add reason to task scheduling failures on global/local thread pools to ease debugging

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
