### PR TITLE
Add a note about set table engine in cloud in set.md

### DIFF
--- a/docs/en/engines/table-engines/special/set.md
+++ b/docs/en/engines/table-engines/special/set.md
@@ -9,6 +9,10 @@ title: 'Set Table Engine'
 
 # Set Table Engine
 
+:::note
+In ClickHouse Cloud, if your service was created with a version earlier than 25.4, you will need to set the compatibility to at least 25.4 using  `SET compatibility=25.4`.
+:::
+
 A data set that is always in RAM. It is intended for use on the right side of the `IN` operator (see the section "IN operators").
 
 You can use `INSERT` to insert data in the table. New elements will be added to the data set, while duplicates will be ignored.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a note about set table engine in cloud 

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)