### PR TITLE
notify integrations ecosystem team when a new type is added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
+* @ClickHouse/core
 
+# notify @ClickHouse/integrations-ecosystem when a new type is added
+src/Core/TypeId.h @ClickHouse/core @ClickHouse/integrations-ecosystem 


### PR DESCRIPTION
New data types in ClickHouse require corresponding updates in language clients for encoding/decoding support. Language client teams should be informed about new data types early in development to allow sufficient planning and implementation time. For instance, the `Time` type integration took 3 months (https://github.com/ClickHouse/ClickHouse/pull/75735), which is enough for language client extensions.

Currently, tests detect new data types in ClickHouse HEAD, but this notification occurs after merging, which is reactive. Early notification would proactively address this issue.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
