### PR TITLE
Make ProcfsMetricsProvider thread_local to keep files open between tasks

### DIFF
--- a/src/Common/ThreadProfileEvents.cpp
+++ b/src/Common/ThreadProfileEvents.cpp
@@ -124,8 +124,12 @@ TasksStatsCounters::TasksStatsCounters(const UInt64 tid, const MetricsProvider p
                 };
         break;
     case MetricsProvider::Procfs:
-        stats_getter = [metrics_provider = std::make_shared<ProcfsMetricsProvider>(tid)]()
+        /// Note that in the case of Procfs we are always reading the same files over an over
+        /// In order to avoid opening and closing them for every task we use a ThreadLocal variable so we'll keep
+        /// the files under this thread until the thread exits
+        stats_getter = [tid]()
                 {
+                    thread_local auto metrics_provider = std::make_shared<ProcfsMetricsProvider>(tid);
                     ::taskstats result{};
                     metrics_provider->getTaskStats(result);
                     return result;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make ProcfsMetricsProvider thread_local to keep files open between tasks

Another micro-optimization. When using Procfs to handle task stats counters we are opening (and closing) the thread-related files (`/proc/thread-self/...`) every time we create a task, which is not great as we reuse threads all the time. We can use a thread_local variable and leave the files open until the thread exits.

In perf before (look at the top 3):
```
+    0.96%     0.01%             4  ThreadPool       clickhouse  [.] DB::ProcfsMetricsProvider::ProcfsMetricsProvider(int)
+    0.63%     0.00%             1  ThreadPool       clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
+    0.60%     0.00%             2  ThreadPool       clickhouse  [.] DB::ProcfsMetricsProvider::~ProcfsMetricsProvider()
     0.42%     0.00%             1  QueryPipelineEx  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.31%     0.02%            11  ThreadPool       clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.20%     0.01%             5  QueryPipelineEx  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.17%     0.01%             8  ThreadPool       clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.17%     0.01%             9  ThreadPool       clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.14%     0.01%             5  QueryPipelineEx  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.09%     0.01%             4  QueryPipelineEx  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.06%     0.00%             0  MergeTreeIndex   clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.05%     0.00%             0  TCPHandler       clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.04%     0.00%             2  MergeTreeIndex   clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.02%     0.00%             0  TCPHandler       clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.02%     0.00%             0  QueryPullPipeEx  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.02%     0.00%             0  TCPHandler       clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.02%     0.00%             0  MergeTreeIndex   clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             1  MergeTreeIndex   clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             0  QueryPullPipeEx  clickhouse  [.] DB::ProcfsMetricsProvider::~ProcfsMetricsProvider()
     0.01%     0.00%             0  QueryPullPipeEx  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             0  QueryPullPipeEx  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.01%     0.01%             5  ThreadPool       clickhouse  [.] std::__1::__shared_ptr_emplace<DB::ProcfsMetricsProvider, std::__1::allocator<DB::ProcfsMetricsProvider> >::__on_zero_shared()
     0.01%     0.00%             0  QueryPipelineEx  clickhouse  [.] DB::ProcfsMetricsProvider::~ProcfsMetricsProvider()
     0.01%     0.00%             0  QueryPullPipeEx  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.00%     0.00%             0  TCPHandler       clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.00%     0.00%             0  QueryPullPipeEx  clickhouse  [.] std::__1::__shared_ptr_emplace<DB::ProcfsMetricsProvider, std::__1::allocator<DB::ProcfsMetricsProvider> >::__on_zero_shared_weak()
     0.00%     0.00%             0  ThreadPool       clickhouse  [.] std::__1::__shared_ptr_emplace<DB::ProcfsMetricsProvider, std::__1::allocator<DB::ProcfsMetricsProvider> >::__on_zero_shared_weak()
```

In perf after, both the constructor and destructor dissappear:
```

+    0.63%     0.01%             4  ThreadPool  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.42%     0.00%             1  QueryPipel  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.33%     0.02%             9  ThreadPool  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.24%     0.02%            10  QueryPipel  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.15%     0.00%             1  ThreadPool  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.15%     0.01%             2  ThreadPool  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.10%     0.00%             2  QueryPipel  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.08%     0.00%             1  QueryPipel  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.05%     0.00%             0  MergeTreeI  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.05%     0.00%             0  TCPHandler  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.04%     0.00%             0  QueryPullP  clickhouse  [.] DB::ProcfsMetricsProvider::getTaskStats(taskstats&) const
     0.04%     0.00%             1  MergeTreeI  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.02%     0.00%             0  QueryPullP  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.02%     0.00%             0  TCPHandler  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             1  TCPHandler  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadBlkIOStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             0  MergeTreeI  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             0  TCPHandler  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             0  QueryPullP  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadIOStat(taskstats&, char*, unsigned long) const
     0.01%     0.00%             0  MergeTreeI  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
     0.00%     0.00%             0  QueryPullP  clickhouse  [.] DB::ProcfsMetricsProvider::readParseAndSetThreadCPUStat(taskstats&, char*, unsigned long) const
```

References: https://github.com/ClickHouse/ClickHouse/issues/81043


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
