### PR TITLE
fix nullable check in optimizeReadInOrder

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -429,7 +429,7 @@ SortingInputOrder buildInputOrderFromSortDescription(
         // ASC NULLS LAST ("in order") or DESC NULLS FIRST ("reverse")
         /// supported only this direction, other cases are represented as nulls_direction==-1
         /// Also actual for floating point values NaN.
-        const auto column_is_nullable = sorting_key.data_types[next_sort_key]->isNullable() || isFloat(*sorting_key.data_types[next_sort_key]);
+        const auto column_is_nullable = isNullableOrLowCardinalityNullable(sorting_key.data_types[next_sort_key])|| isFloat(*sorting_key.data_types[next_sort_key]);
         if (column_is_nullable && sort_column_description.nulls_direction == -1)
             break;
 

--- a/tests/queries/0_stateless/03513_read_in_order_nullable.reference
+++ b/tests/queries/0_stateless/03513_read_in_order_nullable.reference
@@ -62,3 +62,19 @@ nan
 nan
 0
 1
+--- table asc, query desc, last
+1
+0
+\N
+--- table asc, query desc, first
+\N
+1
+0
+--- table asc, query asc, last
+0
+1
+\N
+--- table asc, query asc, first
+\N
+0
+1

--- a/tests/queries/0_stateless/03513_read_in_order_nullable.sql
+++ b/tests/queries/0_stateless/03513_read_in_order_nullable.sql
@@ -52,3 +52,16 @@ SELECT '--- table desc, query asc, last';
 SELECT * FROM f1 ORDER BY c0 ASC NULLS LAST;
 SELECT '--- table desc, query asc, first';
 SELECT * FROM f1 ORDER BY c0 ASC NULLS FIRST;
+
+SET allow_suspicious_low_cardinality_types = 1;
+CREATE TABLE lct0 (c0 LowCardinality(Nullable(Int64))) ENGINE = MergeTree() ORDER BY c0 SETTINGS allow_nullable_key=1;
+INSERT INTO TABLE lct0 VALUES (0);
+INSERT INTO TABLE lct0 VALUES (NULL), (1);
+SELECT '--- table asc, query desc, last';
+SELECT * FROM lct0 ORDER BY c0 DESC NULLS LAST;
+SELECT '--- table asc, query desc, first';
+SELECT * FROM lct0 ORDER BY c0 DESC NULLS FIRST;
+SELECT '--- table asc, query asc, last';
+SELECT * FROM lct0 ORDER BY c0 ASC NULLS LAST;
+SELECT '--- table asc, query asc, first';
+SELECT * FROM lct0 ORDER BY c0 ASC NULLS FIRST;


### PR DESCRIPTION
In the previous fix(#80515) forgot about low cordinality types

Closes #81572

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix sorting order for LowCardinality(Nullable(...)) types
