### PR TITLE
Forbid INSERT/SELECT queries w/ global context

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5579,19 +5579,16 @@ void Context::setGoogleProtosPath(const String & path)
 
 std::pair<Context::SampleBlockCache *, std::unique_lock<std::mutex>> Context::getSampleBlockCache() const
 {
-    chassert(hasQueryContext());
     return std::make_pair(&getQueryContext()->sample_block_cache, std::unique_lock(getQueryContext()->sample_block_cache_mutex));
 }
 
 std::pair<Context::StorageMetadataCache *, std::unique_lock<std::mutex>> Context::getStorageMetadataCache() const
 {
-    chassert(hasQueryContext());
     return std::make_pair(&getQueryContext()->storage_metadata_cache, std::unique_lock(getQueryContext()->storage_metadata_cache_mutex));
 }
 
 std::pair<Context::StorageSnapshotCache *, std::unique_lock<std::mutex>> Context::getStorageSnapshotCache() const
 {
-    chassert(hasQueryContext());
     return std::make_pair(&getQueryContext()->storage_snapshot_cache, std::unique_lock(getQueryContext()->storage_snapshot_cache_mutex));
 }
 

--- a/src/Interpreters/IInterpreter.cpp
+++ b/src/Interpreters/IInterpreter.cpp
@@ -7,6 +7,7 @@
 
 namespace DB
 {
+
 namespace Setting
 {
     extern const SettingsBool throw_on_unsupported_query_inside_transaction;
@@ -15,8 +16,14 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int LOGICAL_ERROR;
 }
 
+IInterpreter::IInterpreter(const ContextPtr & context)
+{
+    if (context->isGlobalContext())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Query execution with global context is a bug");
+}
 
 void IInterpreter::extendQueryLogElem(
     QueryLogElement & elem, const ASTPtr & ast, ContextPtr context, const String & query_database, const String & query_table) const

--- a/src/Interpreters/IInterpreter.h
+++ b/src/Interpreters/IInterpreter.h
@@ -15,6 +15,9 @@ struct QueryLogElement;
 class IInterpreter
 {
 public:
+    IInterpreter() = default;
+    explicit IInterpreter(const ContextPtr & context);
+
     /** For queries that return a result (SELECT and similar), sets in BlockIO a stream from which you can read this result.
       * For queries that receive data (INSERT), sets a thread in BlockIO where you can write data.
       * For queries that do not require data and return nothing, BlockIO will be empty.

--- a/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
+++ b/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
@@ -50,7 +50,11 @@ IInterpreterUnionOrSelectQuery::IInterpreterUnionOrSelectQuery(const ASTPtr & qu
 
 IInterpreterUnionOrSelectQuery::IInterpreterUnionOrSelectQuery(
     const ASTPtr & query_ptr_, const ContextMutablePtr & context_, const SelectQueryOptions & options_)
-    : query_ptr(query_ptr_), context(context_), options(options_), max_streams(context->getSettingsRef()[Setting::max_threads])
+    : IInterpreter(context_)
+    , query_ptr(query_ptr_)
+    , context(context_)
+    , options(options_)
+    , max_streams(context->getSettingsRef()[Setting::max_threads])
 {
     /// FIXME All code here will work with the old analyzer, however for views over Distributed tables
     /// it's possible that new analyzer will be enabled in ::getQueryProcessingStage method

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -93,7 +93,8 @@ namespace ErrorCodes
 
 InterpreterInsertQuery::InterpreterInsertQuery(
     const ASTPtr & query_ptr_, ContextPtr context_, bool allow_materialized_, bool no_squash_, bool no_destination_, bool async_insert_)
-    : WithContext(context_)
+    : IInterpreter(context_)
+    , WithContext(context_)
     , query_ptr(query_ptr_)
     , allow_materialized(allow_materialized_)
     , no_squash(no_squash_)

--- a/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
@@ -176,7 +176,8 @@ InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(
     const ContextPtr & context_,
     const SelectQueryOptions & select_query_options_,
     const Names & column_names)
-    : query(normalizeAndValidateQuery(query_, column_names))
+    : IInterpreter(context_)
+    , query(normalizeAndValidateQuery(query_, column_names))
     , context(buildContext(context_, select_query_options_))
     , select_query_options(select_query_options_)
     , query_tree(buildQueryTreeAndRunPasses(query, select_query_options, context, nullptr /*storage*/))
@@ -190,7 +191,8 @@ InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(
     const StoragePtr & storage_,
     const SelectQueryOptions & select_query_options_,
     const Names & column_names)
-    : query(normalizeAndValidateQuery(query_, column_names))
+    : IInterpreter(context_)
+    , query(normalizeAndValidateQuery(query_, column_names))
     , context(buildContext(context_, select_query_options_))
     , select_query_options(select_query_options_)
     , query_tree(buildQueryTreeAndRunPasses(query, select_query_options, context, storage_))

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -489,7 +489,9 @@ static StoragePtr create(const StorageFactory::Arguments & args)
     }
 
     ASTs & engine_args = args.engine_args;
-    auto context = args.getContext();
+    /// Some internals may creates InterpreterSelectQuery, and it is prohibited with global context, so let's make a copy.
+    /// Note, that we should not use args.local_context, since it may tune some settings, i.e. max_ast_depth, and on restart this table may not be attached anymore.
+    auto context = Context::createCopy(args.getContext());
     size_t arg_num = 0;
     size_t arg_cnt = engine_args.size();
 


### PR DESCRIPTION
Using global context may lead to caching things that was not supposed to
be cached from the global context.

Note, at first I tried to check for hasQueryContext(), but there are
some very implicit queries, like:

    Interpreters/IInterpreter.cpp:25: DB::IInterpreter::IInterpreter() @ 0x00000000123fde29
    Interpreters/IInterpreterUnionOrSelectQuery.cpp:53: DB::IInterpreterUnionOrSelectQuery::IInterpreterUnionOrSelectQuery() @ 0x0000000012452d67
    Interpreters/InterpreterSelectQuery.cpp:514: DB::InterpreterSelectQuery::InterpreterSelectQuery() @ 0x0000000012480819
    Interpreters/InterpreterSelectQuery.cpp:493: DB::InterpreterSelectQuery::InterpreterSelectQuery() @ 0x000000001248063b
    Interpreters/InterpreterSelectQuery.cpp:334: DB::InterpreterSelectQuery::InterpreterSelectQuery() @ 0x00000000124867e7
    Storages/ProjectionsDescription.cpp:373: DB::ProjectionDescription::getMinMaxCountProjection() @ 0x000000001374cebc
    Storages/MergeTree/registerStorageMergeTree.cpp:697: DB::create() @ 0x00000000140bfd24

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)