### PR TITLE
Make NATS connection retries less noisy in the logs

### DIFF
--- a/src/Storages/NATS/NATSHandler.cpp
+++ b/src/Storages/NATS/NATSHandler.cpp
@@ -156,7 +156,6 @@ std::future<NATSConnectionPtr> NATSHandler::createConnection(const NATSConfigura
             }
             catch (...)
             {
-                tryLogCurrentException(log);
                 try
                 {
                     connect_promise->set_exception(std::current_exception());

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -249,6 +249,7 @@ void StorageNATS::initializeConsumersFunc()
     }
     catch (...)
     {
+        LOG_WARNING(log, "Cannot initialize consumers: {}", getCurrentExceptionMessage(false));
         initialize_consumers_task->scheduleAfter(RESCHEDULE_MS);
         return;
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make NATS connection retries less noisy in the logs

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
