### PR TITLE
preserve connection when final empty chunk is left by client

### DIFF
--- a/base/poco/Net/include/Poco/Net/HTTPChunkedStream.h
+++ b/base/poco/Net/include/Poco/Net/HTTPChunkedStream.h
@@ -45,7 +45,7 @@ namespace Net
         ~HTTPChunkedStreamBuf();
         void close();
 
-        bool isComplete();
+        bool isComplete(bool read_from_device_to_check_eof = false);
 
     protected:
         int readFromDevice(char * buffer, std::streamsize length);
@@ -70,7 +70,7 @@ namespace Net
         ~HTTPChunkedIOS();
         HTTPChunkedStreamBuf * rdbuf();
 
-        bool isComplete() { return _buf.isComplete(); }
+        //bool isComplete() { return _buf.isComplete(); }
 
     protected:
         HTTPChunkedStreamBuf _buf;
@@ -83,6 +83,8 @@ namespace Net
     public:
         HTTPChunkedInputStream(HTTPSession & session);
         ~HTTPChunkedInputStream();
+
+        bool isComplete() { return _buf.isComplete(); }
     };
 
 
@@ -92,6 +94,8 @@ namespace Net
     public:
         HTTPChunkedOutputStream(HTTPSession & session);
         ~HTTPChunkedOutputStream();
+
+        bool isComplete() { return _buf.isComplete(/*read_from_device_to_check_eof*/ true); }
     };
 
 

--- a/base/poco/Net/include/Poco/Net/HTTPChunkedStream.h
+++ b/base/poco/Net/include/Poco/Net/HTTPChunkedStream.h
@@ -45,7 +45,7 @@ namespace Net
         ~HTTPChunkedStreamBuf();
         void close();
 
-        bool isComplete() const { return _chunk == std::char_traits<char>::eof(); }
+        bool isComplete();
 
     protected:
         int readFromDevice(char * buffer, std::streamsize length);
@@ -70,7 +70,7 @@ namespace Net
         ~HTTPChunkedIOS();
         HTTPChunkedStreamBuf * rdbuf();
 
-        bool isComplete() const { return _buf.isComplete(); }
+        bool isComplete() { return _buf.isComplete(); }
 
     protected:
         HTTPChunkedStreamBuf _buf;

--- a/base/poco/Net/include/Poco/Net/HTTPChunkedStream.h
+++ b/base/poco/Net/include/Poco/Net/HTTPChunkedStream.h
@@ -70,8 +70,6 @@ namespace Net
         ~HTTPChunkedIOS();
         HTTPChunkedStreamBuf * rdbuf();
 
-        //bool isComplete() { return _buf.isComplete(); }
-
     protected:
         HTTPChunkedStreamBuf _buf;
     };
@@ -84,7 +82,7 @@ namespace Net
         HTTPChunkedInputStream(HTTPSession & session);
         ~HTTPChunkedInputStream();
 
-        bool isComplete() { return _buf.isComplete(); }
+        bool isComplete() { return _buf.isComplete(/*read_from_device_to_check_eof*/ true); }
     };
 
 
@@ -95,7 +93,7 @@ namespace Net
         HTTPChunkedOutputStream(HTTPSession & session);
         ~HTTPChunkedOutputStream();
 
-        bool isComplete() { return _buf.isComplete(/*read_from_device_to_check_eof*/ true); }
+        bool isComplete() { return _buf.isComplete(); }
     };
 
 

--- a/base/poco/Net/src/HTTPChunkedStream.cpp
+++ b/base/poco/Net/src/HTTPChunkedStream.cpp
@@ -54,7 +54,7 @@ void HTTPChunkedStreamBuf::close()
 		sync();
 		_session.write("0\r\n\r\n", 5);
 
-        _chunk = std::char_traits<char>::eof();
+		_chunk = std::char_traits<char>::eof();
 	}
 }
 
@@ -140,10 +140,23 @@ int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 }
 
 
-bool HTTPChunkedStreamBuf::isComplete()
+bool HTTPChunkedStreamBuf::isComplete(bool read_from_device_to_check_eof)
 {
-    readFromDevice(nullptr, 0);
-    return _chunk == std::char_traits<char>::eof();
+	if (read_from_device_to_check_eof)
+	{
+		try
+		{
+			/// If the stream is closed without final last chunk
+			/// "Unexpected EOF" exception would be thrown
+			readFromDevice(nullptr, 0);
+		}
+		catch (Poco::Net::MessageException &)
+		{
+			return false;
+		}
+	}
+
+	return _chunk == std::char_traits<char>::eof();
 }
 
 

--- a/base/poco/Net/src/HTTPChunkedStream.cpp
+++ b/base/poco/Net/src/HTTPChunkedStream.cpp
@@ -90,7 +90,7 @@ unsigned int HTTPChunkedStreamBuf::parseChunkLen()
 	if (size_t pos = line.find(';'); pos != std::string::npos)
 		line.resize(pos);
 
-	unsigned chunkLen;
+	unsigned chunkLen = 0;
 	if (NumberParser::tryParseHex(line, chunkLen))
 		return chunkLen;
 	else
@@ -118,6 +118,9 @@ int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 
 	if (_chunk > 0)
 	{
+		if (length == 0)
+			return 0;
+
 		if (length > _chunk) length = _chunk;
 		int n = _session.read(buffer, length);
 		if (n > 0)
@@ -128,12 +131,19 @@ int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 		if (_chunk == 0) skipCRLF();
 		return n;
 	}
-	else 
+	else
 	{
 		skipCRLF();
 		_chunk = eof;
 		return 0;
 	}
+}
+
+
+bool HTTPChunkedStreamBuf::isComplete()
+{
+    readFromDevice(nullptr, 0);
+    return _chunk == std::char_traits<char>::eof();
 }
 
 


### PR DESCRIPTION
This changes are inspired by https://github.com/ClickHouse/ClickHouse/pull/81595
This only applies only to the client.
When the response is read, theoretically, the last empty chunk could be left in socket.
Before this changes such connection would be closed, because not data is read.
Here I add an attempt to check that only last empty chunk is left.
And if it is true, the connection is reused, otherwise it is closed. 

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
preserve connection when final empty chunk is left by client

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
