### PR TITLE
Specify `CARGO_HOME` for `delta-kernel-rs`

### DIFF
--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -147,7 +147,7 @@ set(RUST_VENDOR_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rust_vendor")
 
 # We now prepare a custom config.toml with all the flags and add it to cargo via flags
 configure_file("config.toml.in" "config.toml" @ONLY)
-set (RUST_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/config.toml" CACHE INTERNAL "Rust config")
+set(RUST_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/config.toml" CACHE INTERNAL "Rust config")
 set(RUST_CFLAGS ${RUST_CFLAGS} CACHE INTERNAL "Rust config")
 set(RUST_CXXFLAGS ${RUST_CXXFLAGS} CACHE INTERNAL "Rust config")
 set(RUSTFLAGS "${RUSTFLAGS}" CACHE INTERNAL "Rust config")

--- a/contrib/delta-kernel-rs-cmake/CMakeLists.txt
+++ b/contrib/delta-kernel-rs-cmake/CMakeLists.txt
@@ -59,6 +59,7 @@ file(COPY ${ClickHouse_SOURCE_DIR}/contrib/openssl/include/ DESTINATION ${DELTA_
 set(DELTA_KERNEL_TARGET_PATH ${DELTA_KERNEL_RS_BINARY_DIR}/include)
 
 corrosion_set_env_vars(delta_kernel_ffi
+        "CARGO_HOME=${CMAKE_BINARY_DIR}/contrib/corrosion-cmake/"
         "CARGO_TARGET_DIR=${DELTA_KERNEL_TARGET_PATH}"
         "OPENSSL_LIBS=ssl:crypto"
         "OPENSSL_STATIC=1"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `delta-kernel-rs` requiring network access during build. Closes https://github.com/ClickHouse/ClickHouse/issues/80609


cc @Algunenano @azat 
