### PR TITLE
Add lazy manifest files reading

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -593,10 +593,13 @@ void IcebergMetadata::updateState(const ContextPtr & local_context, Poco::JSON::
 
 std::optional<Int32> IcebergMetadata::getSchemaVersionByFileIfOutdated(String data_path) const
 {
-    if (!schema_id_by_data_file_initialized)
     {
-        initializeSchemasFromManifestList(relevant_snapshot->manifest_list_entries);
-        schema_id_by_data_file_initialized = true;
+        std::lock_guard lock(schema_id_by_data_file_mutex);
+        if (!schema_id_by_data_file_initialized)
+        {
+            initializeSchemasFromManifestList(relevant_snapshot->manifest_list_entries);
+            schema_id_by_data_file_initialized = true;
+        }
     }
     auto schema_id_it = schema_id_by_data_file.find(data_path);
     if (schema_id_it == schema_id_by_data_file.end())

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -108,6 +108,7 @@ private:
 
     mutable bool schema_id_by_data_file_initialized{false};
     mutable std::unordered_map<String, Int32> schema_id_by_data_file;
+    mutable std::mutex schema_id_by_data_file_mutex;
 
 
     Int32 relevant_snapshot_schema_id;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -106,7 +106,7 @@ private:
     Int32 last_metadata_version;
     Int32 format_version;
 
-    mutable bool schema_id_by_data_file_initialized{false};
+    mutable std::atomic<bool> schema_id_by_data_file_initialized{false};
     mutable std::unordered_map<String, Int32> schema_id_by_data_file;
     mutable std::mutex schema_id_by_data_file_mutex;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -106,6 +106,7 @@ private:
     Int32 last_metadata_version;
     Int32 format_version;
 
+    mutable bool schema_id_by_data_file_initialized{false};
     mutable std::unordered_map<String, Int32> schema_id_by_data_file;
 
 
@@ -128,6 +129,10 @@ private:
     void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object);
 
     std::optional<Int32> getSchemaVersionByFileIfOutdated(String data_path) const;
+
+    void initializeSchemasFromManifestList(ManifestFileCacheKeys manifest_list_ptr) const;
+
+    void initializeSchemasFromManifestFile(Iceberg::ManifestFilePtr manifest_file_ptr) const;
 
     void initializeSchemasFromManifestFile(ManifestFileCacheKeys manifest_list_ptr) const;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -134,8 +134,6 @@ private:
 
     void initializeSchemasFromManifestFile(Iceberg::ManifestFilePtr manifest_file_ptr) const;
 
-    void initializeSchemasFromManifestFile(ManifestFileCacheKeys manifest_list_ptr) const;
-
     Iceberg::ManifestFilePtr getManifestFile(const String & filename, Int64 inherited_sequence_number) const;
 
     std::optional<String> getRelevantManifestList(const Poco::JSON::Object::Ptr & metadata);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Postpone reading of Iceberg manifest files until first reading query  

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
