### PR TITLE
tests: fix 02769_parallel_replicas_unavailable_shards

### DIFF
--- a/tests/queries/0_stateless/02769_parallel_replicas_unavailable_shards.sql
+++ b/tests/queries/0_stateless/02769_parallel_replicas_unavailable_shards.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel
+-- - no-parallel - due to usage of fail points
+
 DROP TABLE IF EXISTS test_parallel_replicas_unavailable_shards;
 CREATE TABLE test_parallel_replicas_unavailable_shards (n UInt64) ENGINE=MergeTree() ORDER BY tuple();
 INSERT INTO test_parallel_replicas_unavailable_shards SELECT * FROM numbers(10);
@@ -8,6 +11,7 @@ SET parallel_replicas_only_with_analyzer = 0;  -- necessary for CI run with disa
 
 -- with local plan for initiator, the query can be executed fast on initator, we can simply not come to the point where unavailable replica can be detected
 -- therefore disable local plan for now
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
 SELECT count() FROM test_parallel_replicas_unavailable_shards WHERE NOT ignore(*) SETTINGS log_comment = '02769_7b513191-5082-4073-8568-53b86a49da79', parallel_replicas_local_plan=0;
 
 SYSTEM FLUSH LOGS query_log;


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5f842ffb92aee26e3ca117f64bc2468dadcbf8a5&name_0=MasterCI&name_1=Stateless%20tests%20%28release%2C%20ParallelReplicas%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
