### PR TITLE
Fix "Unexpected relative path for a deduplicated part" during ATTACH to RMT

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -1024,6 +1024,7 @@ std::pair<std::vector<String>, bool> ReplicatedMergeTreeSinkImpl<async_insert>::
             /// transaction: renameTempPartAndAdd
             transaction.rollbackPartsToTemporaryState();
             part->is_temp = true;
+            part->setName(initial_part_name);
             part->renameTo(temporary_part_relative_path, false);
             /// Throw an exception to set the proper keeper error and force a retry (if possible)
             zkutil::KeeperMultiException::check(multi_code, ops, responses);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Unexpected relative path for a deduplicated part` during `ATTACH` to `ReplicatedMergeTree`

In case of the part has been already attached on another replica, ATTACH PART can be deduplicated, but, if the ZooKeeper connection got lost during committing this part the part name will be changed, and this LOGICAL_ERROR will be triggered, since part name was not reverted properly:

    2025.06.11 00:15:54.178911 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Test> CancellationChecker: Added to set. query: ALTER TABLE alter_table0 ATTACH PARTITION ID 'all';, timeout: 60000 milliseconds
    ...
    2025.06.11 00:15:54.698389 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Trace> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5): Renaming temporary part detached/attaching_all_119_119_0 to all_131_131_0 with tid (1, 1, 00000000-0000-0000-0000-000000000000).
    2025.06.11 00:15:54.698545 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Test> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5): preparePartForCommit: inserting all_131_131_0 (state PreActive) into data_parts_indexes
    2025.06.11 00:15:54.698614 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Test> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5): Renaming part to all_131_131_0
    2025.06.11 00:16:04.690465 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Debug> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5) (Replicated OutputStream): Insert of part all_131_131_0 failed when committing to keeper (Reason: Connection loss). Attempting to recover it
    2025.06.11 00:16:05.752429 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Debug> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5) (Replicated OutputStream): Insert of part all_131_131_0 was not committed to keeper. Will try again with a new block
    2025.06.11 00:16:05.752556 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Debug> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5): Undoing transaction. Rollbacking parts state to temporary and removing from working set: all_131_131_0.
    2025.06.11 00:16:05.752715 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Test> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5): removePartsFromWorkingSetImmediatelyAndSetTemporaryState: removing all_131_131_0 (state Temporary) from data_parts_indexes
    2025.06.11 00:16:06.009686 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Debug> EphemeralLockInZooKeeper: ZooKeeper node was already deleted: code=No node message=Transaction failed (No node): Op #0, path: /clickhouse/tables/02443_detach_attach_partition_test_dmbwb3yi/alter_table/block_numbers/all/block-0000000131
    2025.06.11 00:16:06.103465 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Debug> createEphemeralLockInZooKeeper: Deduplication path already exists: deduplication_path=/clickhouse/tables/02443_detach_attach_partition_test_dmbwb3yi/alter_table/blocks/all_BAF06B235AC38BECD211A85A22146D8E
    2025.06.11 00:16:06.135552 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Information> test_dmbwb3yi.alter_table0 (41c938f4-23fb-4a88-997b-670f2323ecd5) (Replicated OutputStream): Block with ID all_BAF06B235AC38BECD211A85A22146D8E already exists on other replicas as part all_134_134_0; ignoring it.
    2025.06.11 00:16:06.136041 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Fatal> : Logical error: 'Unexpected relative path for a deduplicated part: store/41c/41c938f4-23fb-4a88-997b-670f2323ecd5/detached/attaching_all_119_119_0/'.
    2025.06.11 00:16:06.735737 [ 41142 ] {d5d1af42-7c6a-4138-9b41-632c0039d34c} <Fatal> : Stack trace (when copying this message, always include the lines below):
    2025.06.11 00:18:14.280147 [ 3768 ] {BgSchPool::20821289-1ff0-4e83-80a3-809179edae98} <Debug> CancellationChecker: Cancelling the task because of the timeout: 60000 ms, query_id: d5d1af42-7c6a-4138-9b41-632c0039d34c
    2025.06.11 00:18:14.288155 [ 42970 ] {} <Fatal> BaseDaemon: (version 25.6.1.1, build id: 6B470FC13F44047ED1F573E1E367782418F67BC7, git hash: b0ba08da3d455ed8b8574a7dbaaa19cf575b8766) (from thread 41142) (query_id: d5d1af42-7c6a-4138-9b41-632c0039d34c) (query: ALTER TABLE alter_table0 ATTACH PARTITION ID 'all';) Received signal Aborted (6)

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81585&sha=23ccb5fd9ef8c9c266108ecf87cf1e30f16f55b2&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29