### PR TITLE
add profile events about server keep alive connections

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -982,16 +982,16 @@ The server successfully detected this situation and will download merged part fr
     M(HTTPConnectionsErrors, "Number of cases when creation of a client HTTP connection failed", ValueType::Number) \
     M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating client HTTP connections", ValueType::Microseconds) \
     \
-    M(HTTPServerConnectionsCreated, "Number of created server http connections", ValueType::Number) \
-    M(HTTPServerConnectionsReused, "Number of reused server http connections", ValueType::Number) \
-    M(HTTPServerConnectionsPreserved, "Number of preserved server http connections. Connection kept alive successfully", ValueType::Number) \
-    M(HTTPServerConnectionsExpired, "Number of expired server http connections.", ValueType::Number) \
-    M(HTTPServerConnectionsClosed, "Number of closed server http connections. Keep alive has not been negotiated", ValueType::Number) \
-    M(HTTPServerConnectionsReset, "Number of reset server http connections. Server closes connection", ValueType::Number) \
+    M(HTTPServerConnectionsCreated, "Number of created server HTTP connections", ValueType::Number) \
+    M(HTTPServerConnectionsReused, "Number of reused server HTTP connections", ValueType::Number) \
+    M(HTTPServerConnectionsPreserved, "Number of preserved server HTTP connections. Connection kept alive successfully", ValueType::Number) \
+    M(HTTPServerConnectionsExpired, "Number of expired server HTTP connections.", ValueType::Number) \
+    M(HTTPServerConnectionsClosed, "Number of closed server HTTP connections. Keep alive has not been negotiated", ValueType::Number) \
+    M(HTTPServerConnectionsReset, "Number of reset server HTTP connections. Server closes connection", ValueType::Number) \
     \
-    M(AddressesDiscovered, "Total count of new addresses in dns resolve results for HTTP connections", ValueType::Number) \
-    M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for HTTP connections", ValueType::Number) \
-    M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for HTTP connections", ValueType::Number) \
+    M(AddressesDiscovered, "Total count of new addresses in DNS resolve results for HTTP connections", ValueType::Number) \
+    M(AddressesExpired, "Total count of expired addresses which is no longer presented in DNS resolve results for HTTP connections", ValueType::Number) \
+    M(AddressesMarkedAsFailed, "Total count of addresses which have been marked as faulty due to connection errors for HTTP connections", ValueType::Number) \
     \
     M(ReadWriteBufferFromHTTPRequestsSent, "Number of HTTP requests sent by ReadWriteBufferFromHTTP", ValueType::Number) \
     M(ReadWriteBufferFromHTTPBytes, "Total size of payload bytes received and sent by ReadWriteBufferFromHTTP. Doesn't include HTTP headers.", ValueType::Bytes) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -974,17 +974,24 @@ The server successfully detected this situation and will download merged part fr
     M(DiskConnectionsErrors, "Number of cases when creation of a connection for disk is failed", ValueType::Number) \
     M(DiskConnectionsElapsedMicroseconds, "Total time spend on creating connections for disk", ValueType::Microseconds) \
     \
-    M(HTTPConnectionsCreated, "Number of created http connections", ValueType::Number) \
-    M(HTTPConnectionsReused, "Number of reused http connections", ValueType::Number) \
-    M(HTTPConnectionsReset, "Number of reset http connections", ValueType::Number) \
-    M(HTTPConnectionsPreserved, "Number of preserved http connections", ValueType::Number) \
-    M(HTTPConnectionsExpired, "Number of expired http connections", ValueType::Number) \
-    M(HTTPConnectionsErrors, "Number of cases when creation of a http connection failed", ValueType::Number) \
-    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating http connections", ValueType::Microseconds) \
+    M(HTTPConnectionsCreated, "Number of created clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsReused, "Number of reused clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsReset, "Number of reset clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsPreserved, "Number of preserved clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsExpired, "Number of expired clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsErrors, "Number of cases when creation of a clients HTTP connection failed", ValueType::Number) \
+    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating clients HTTP connections", ValueType::Microseconds) \
     \
-    M(AddressesDiscovered, "Total count of new addresses in dns resolve results for http connections", ValueType::Number) \
-    M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for http connections", ValueType::Number) \
-    M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for http connections", ValueType::Number) \
+    M(HTTPServerConnectionsCreated, "Number of created server http connections", ValueType::Number) \
+    M(HTTPServerConnectionsReused, "Number of reused server http connections", ValueType::Number) \
+    M(HTTPServerConnectionsPreserved, "Number of preserved server http connections. Connection kept alive successfully", ValueType::Number) \
+    M(HTTPServerConnectionsExpired, "Number of expired server http connections.", ValueType::Number) \
+    M(HTTPServerConnectionsClosed, "Number of closed server http connections. Keep alive has not been negotiated", ValueType::Number) \
+    M(HTTPServerConnectionsReset, "Number of reset server http connections. Server closes connection", ValueType::Number) \
+    \
+    M(AddressesDiscovered, "Total count of new addresses in dns resolve results for HTTP connections", ValueType::Number) \
+    M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for HTTP connections", ValueType::Number) \
+    M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for HTTP connections", ValueType::Number) \
     \
     M(ReadWriteBufferFromHTTPRequestsSent, "Number of HTTP requests sent by ReadWriteBufferFromHTTP", ValueType::Number) \
     M(ReadWriteBufferFromHTTPBytes, "Total size of payload bytes received and sent by ReadWriteBufferFromHTTP. Doesn't include HTTP headers.", ValueType::Bytes) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -974,13 +974,13 @@ The server successfully detected this situation and will download merged part fr
     M(DiskConnectionsErrors, "Number of cases when creation of a connection for disk is failed", ValueType::Number) \
     M(DiskConnectionsElapsedMicroseconds, "Total time spend on creating connections for disk", ValueType::Microseconds) \
     \
-    M(HTTPConnectionsCreated, "Number of created clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsReused, "Number of reused clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsReset, "Number of reset clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsPreserved, "Number of preserved clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsExpired, "Number of expired clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsErrors, "Number of cases when creation of a clients HTTP connection failed", ValueType::Number) \
-    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating clients HTTP connections", ValueType::Microseconds) \
+    M(HTTPConnectionsCreated, "Number of created client HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsReused, "Number of reused client HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsReset, "Number of reset client HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsPreserved, "Number of preserved client HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsExpired, "Number of expired client HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsErrors, "Number of cases when creation of a client HTTP connection failed", ValueType::Number) \
+    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating client HTTP connections", ValueType::Microseconds) \
     \
     M(HTTPServerConnectionsCreated, "Number of created server http connections", ValueType::Number) \
     M(HTTPServerConnectionsReused, "Number of reused server http connections", ValueType::Number) \

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -118,7 +118,7 @@ void HTTPServerConnection::run()
                         {
                             /// server decided to close connection
                             /// usually it is related to the cases:
-                            /// - the request or respond stream is not bounded or
+                            /// - the request or response stream is not bounded or
                             /// - not all data is read from them
                             ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
                         }

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -106,7 +106,7 @@ void HTTPServerConnection::run()
                         bool keep_alive = false;
                         if (!params->getKeepAlive() || !request.canKeepAlive())
                         {
-                            /// Either server is not configured to keep connetions alive or client did not ask it
+                            /// Either server is not configured to keep connections alive or client did not ask it
                             ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsClosed);
                         }
                         else if (session.getMaxKeepAliveRequests() == 0 || !session.canKeepAlive())

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -2,7 +2,20 @@
 #include <Server/TCPServer.h>
 
 #include <Poco/Net/NetException.h>
+#include <Common/ProfileEvents.h>
 #include <Common/logger_useful.h>
+
+
+namespace ProfileEvents
+{
+    extern const Event HTTPServerConnectionsCreated;
+    extern const Event HTTPServerConnectionsReused;
+    extern const Event HTTPServerConnectionsPreserved;
+    extern const Event HTTPServerConnectionsExpired;
+    extern const Event HTTPServerConnectionsClosed;
+    extern const Event HTTPServerConnectionsReset;
+}
+
 
 namespace DB
 {
@@ -25,8 +38,28 @@ void HTTPServerConnection::run()
     std::string server = params->getSoftwareVersion();
     Poco::Net::HTTPServerSession session(socket(), params);
 
-    while (!stopped && tcp_server.isOpen() && session.hasMoreRequests() && session.connected())
+    ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsCreated);
+
+    while (!stopped && tcp_server.isOpen() && session.connected())
     {
+        const bool is_first_request = params->getMaxKeepAliveRequests() == session.getMaxKeepAliveRequests();
+
+        if (!session.hasMoreRequests())
+        {
+            if (is_first_request)
+                // it is strange to have a connection being oppend but no request has been sent, account it as an error case
+                ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
+            else
+                ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsExpired);
+
+            return;
+        }
+        else
+        {
+            if (!is_first_request)
+                ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReused);
+        }
+
         try
         {
             std::lock_guard lock(mutex);
@@ -69,10 +102,38 @@ void HTTPServerConnection::run()
                             response.sendContinue();
 
                         handler->handleRequest(request, response, write_event);
-                        session.setKeepAlive(params->getKeepAlive() && response.getKeepAlive() && session.canKeepAlive());
+
+                        bool keep_alive = false;
+                        if (!params->getKeepAlive() || !request.canKeepAlive())
+                        {
+                            /// Either server is not configured to keep connetions alive or client did not ask it
+                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsClosed);
+                        }
+                        else if (session.getMaxKeepAliveRequests() == 0 || !session.canKeepAlive())
+                        {
+                            /// connection is expired by max request count
+                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsExpired);
+                        }
+                        else if (!response.getKeepAlive())
+                        {
+                            /// server decided to close connection
+                            /// usually it is related to the cases:
+                            /// - the request or respond stream is not bounded or
+                            /// - not all data is read from them
+                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
+                        }
+                        else
+                        {
+                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsPreserved);
+                            keep_alive = true;
+                        }
+
+                        session.setKeepAlive(keep_alive);
                     }
                     else
+                    {
                         sendErrorResponse(session, Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED);
+                    }
                 }
                 catch (Poco::Exception &)
                 {
@@ -134,6 +195,7 @@ void HTTPServerConnection::sendErrorResponse(Poco::Net::HTTPServerSession & sess
     response.setKeepAlive(false);
     response.send();
     session.setKeepAlive(false);
+    ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
 }
 
 }

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -47,7 +47,7 @@ void HTTPServerConnection::run()
         if (!session.hasMoreRequests())
         {
             if (is_first_request)
-                // it is strange to have a connection being oppend but no request has been sent, account it as an error case
+                // it is strange to have a connection being opened but no request has been sent, account it as an error case
                 ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
             else
                 ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsExpired);


### PR DESCRIPTION
Follow for the https://github.com/ClickHouse/ClickHouse/pull/81595

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add profile events about server keep alive connections

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
