### PR TITLE
Count consumed messages manually to avoid depending on previous committed offset in StorageKafka2

### DIFF
--- a/src/Storages/Kafka/KafkaConsumer2.cpp
+++ b/src/Storages/Kafka/KafkaConsumer2.cpp
@@ -115,7 +115,7 @@ void KafkaConsumer2::initializeQueues(const cppkafka::TopicPartitionList & topic
             consumer->get_partition_queue(topic_partition));
 }
 
-// it do the poll when needed
+// it does the poll when needed
 ReadBufferPtr KafkaConsumer2::consume(const TopicPartition & topic_partition, const std::optional<int64_t> & message_count)
 {
     resetIfStopped();

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -1032,6 +1032,7 @@ StorageKafka2::PolledBatchInfo StorageKafka2::pollConsumer(
 
     std::optional<std::string> exception_message;
     size_t total_rows = 0;
+    size_t intent_size = 0;
     size_t failed_poll_attempts = 0;
 
     auto on_error = [&](const MutableColumns & result_columns, const ColumnCheckpoints & checkpoints, Exception & e)
@@ -1087,6 +1088,7 @@ StorageKafka2::PolledBatchInfo StorageKafka2::pollConsumer(
         exception_message.reset();
         if (auto buf = consumer.consume(topic_partition, message_count))
         {
+            ++intent_size;
             ProfileEvents::increment(ProfileEvents::KafkaMessagesRead);
             new_rows = executor.execute(*buf);
         }
@@ -1198,6 +1200,7 @@ StorageKafka2::PolledBatchInfo StorageKafka2::pollConsumer(
         result_block.insert(column);
 
     batch_info.blocks.emplace_back(std::move(result_block));
+    batch_info.intent_size = intent_size;
     return batch_info;
 }
 
@@ -1402,7 +1405,7 @@ std::optional<size_t> StorageKafka2::streamFromConsumer(ConsumerAndAssignmentInf
     ++consumer_info.poll_count;
 
     auto * lock_info = consumer_info.findTopicPartitionLock(topic_partition);
-    auto [blocks, last_read_offset] = pollConsumer(
+    auto [blocks, intent_size, last_read_offset] = pollConsumer(
         *consumer_info.consumer, topic_partition, lock_info->intent_size, consumer_info.watch, kafka_context);
 
     if (blocks.empty())
@@ -1425,7 +1428,7 @@ std::optional<size_t> StorageKafka2::streamFromConsumer(ConsumerAndAssignmentInf
 
     // We can't cancel during copyData, as it's not aware of commits and other kafka-related stuff.
     // It will be cancelled on underlying layer (kafka buffer)
-    lock_info->intent_size = last_read_offset - lock_info->committed_offset.value_or(0);
+    lock_info->intent_size = intent_size;
     saveIntent(keeper_to_use, topic_partition, *lock_info->intent_size);
     std::atomic_size_t rows = 0;
     {

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -837,11 +837,13 @@ std::optional<StorageKafka2::LockedTopicPartitionInfo> StorageKafka2::createLock
 
         LOG_TRACE(
             log,
-            "Locked topic partition: {}:{} at offset {} with intent size {}",
+            "Locked topic partition: {}:{} at offset {} with intent size {}, offset present: {}, intent size present: {}",
             partition_to_lock.topic,
             partition_to_lock.partition_id,
             lock_info.committed_offset.value_or(0),
-            lock_info.intent_size.value_or(0));
+            lock_info.intent_size.value_or(0),
+            lock_info.committed_offset.has_value(),
+            lock_info.intent_size.has_value());
 
         return lock_info;
     }

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -983,6 +983,14 @@ void StorageKafka2::saveCommittedOffset(zkutil::ZooKeeper & keeper_to_use, const
 
 void StorageKafka2::saveIntent(zkutil::ZooKeeper & keeper_to_use, const TopicPartition & topic_partition, int64_t intent)
 {
+    if (intent <= 0)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Intent for topic-partition [{}:{}] must be greater than 0, but got {}",
+            topic_partition.topic,
+            topic_partition.partition_id,
+            intent);
+
     LOG_TEST(
         log,
         "Saving intent of {} for topic-partition [{}:{}] at offset {}",

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -55,6 +55,9 @@ using KafkaConsumer2Ptr = std::shared_ptr<KafkaConsumer2>;
 /// manipulating the queues of librdkafka. By pulling from multiple topic-partitions
 /// the order of messages are not guaranteed, therefore they would have different
 /// hashes for deduplication.
+///
+/// For the committed offsets we try to mimic the same behavior as Kafka does: if the last
+/// read offset is `n`, then we save the offset `n + 1`, same as Kafka does.
 class StorageKafka2 final : public IStorage, WithContext
 {
     using KafkaInterceptors = KafkaInterceptors<StorageKafka2>;
@@ -160,6 +163,7 @@ private:
     struct PolledBatchInfo
     {
         BlocksList blocks;
+        int64_t intent_size;
         int64_t last_offset;
     };
 

--- a/tests/integration/test_storage_kafka/test_intent_sizes.py
+++ b/tests/integration/test_storage_kafka/test_intent_sizes.py
@@ -1,0 +1,157 @@
+import logging
+
+from helpers.kafka.common_direct import *
+from helpers.kafka.common_direct import _VarintBytes
+import helpers.kafka.common as k
+
+
+# protoc --version
+# libprotoc 3.0.0
+# # to create kafka_pb2.py
+# protoc --python_out=. kafka.proto
+
+
+# TODO: add test for run-time offset update in CH, if we manually update it on Kafka side.
+# TODO: add test for SELECT LIMIT is working.
+
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/kafka.xml", "configs/named_collection.xml"],
+    user_configs=["configs/users.xml"],
+    with_kafka=True,
+    with_zookeeper=True,  # For Replicated Table
+    macros={
+        "kafka_broker": "kafka1",
+        "kafka_topic_old": k.KAFKA_TOPIC_OLD,
+        "kafka_group_name_old": k.KAFKA_CONSUMER_GROUP_OLD,
+        "kafka_topic_new": k.KAFKA_TOPIC_NEW,
+        "kafka_group_name_new": k.KAFKA_CONSUMER_GROUP_NEW,
+        "kafka_client_id": "instance",
+        "kafka_format_json_each_row": "JSONEachRow",
+    },
+    clickhouse_path_dir="clickhouse_path",
+)
+
+
+# Fixtures
+@pytest.fixture(scope="module")
+def kafka_cluster():
+    try:
+        cluster.start()
+        kafka_id = instance.cluster.kafka_docker_id
+        print(("kafka_id is {}".format(kafka_id)))
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def kafka_setup_teardown():
+    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
+    admin_client = k.get_admin_client(cluster)
+
+    def get_topics_to_delete():
+        return [t for t in admin_client.list_topics() if not t.startswith("_")]
+
+    topics = get_topics_to_delete()
+    logging.debug(f"Deleting topics: {topics}")
+    result = admin_client.delete_topics(topics)
+    for topic, error in result.topic_error_codes:
+        if error != 0:
+            logging.warning(f"Received error {error} while deleting topic {topic}")
+        else:
+            logging.info(f"Deleted topic {topic}")
+
+    retries = 0
+    topics = get_topics_to_delete()
+    while len(topics) != 0:
+        logging.info(f"Existing topics: {topics}")
+        if retries >= 5:
+            raise Exception(f"Failed to delete topics {topics}")
+        retries += 1
+        time.sleep(0.5)
+    yield  # run test
+
+
+def test_good_intent_size(kafka_cluster):
+    instance.rotate_logs()
+
+    topic_name = "topic_intent_size"
+
+    def produce_message(index):
+        k.kafka_produce(
+            kafka_cluster,
+            topic_name,
+            [f"message_{index}"]
+        )
+
+    produce_message(1)
+
+    create_kafka_query = k.generate_new_create_table_query("kafka", "a String", topic_list=topic_name, format="LineAsString", settings={"kafka_flush_interval_ms": 500})
+
+    with k.existing_kafka_topic(k.get_admin_client(kafka_cluster), topic_name):
+        instance.query(
+            f"""
+            CREATE TABLE test.dst (
+                a String,
+            )
+            ENGINE = MergeTree()
+            ORDER BY a;
+
+            {create_kafka_query};
+
+            CREATE MATERIALIZED VIEW test.kafka_mv TO test.dst AS
+            SELECT
+                a
+            FROM test.kafka;
+            """
+        )
+
+        def check_intent_size(num_messages, offset):
+            consumed_messages = instance.query_with_retry("SELECT * FROM test.dst", retry_count =30, sleep_time=1, check_callback=lambda x: len(TSV(x)) == num_messages)
+            logging.debug(f"Consumed messages: {consumed_messages}")
+            instance.wait_for_log_line(f"Saving intent of 1 for topic-partition \\[{topic_name}:0\\] at offset {offset}", look_behind_lines=500)
+
+        INVALID_KAFKA_OFFSET = -1001
+        check_intent_size(1, INVALID_KAFKA_OFFSET)
+
+        produce_message(2)
+        check_intent_size(2, 1)
+
+        result = instance.query("SELECT * FROM test.dst ORDER BY a")
+        assert TSV(result) == TSV("message_1\nmessage_2\n")
+
+        instance.query(
+            """
+            DROP TABLE test.kafka SYNC;
+            TRUNCATE TABLE test.dst SETTINGS alter_sync=1;
+            """)
+        instance.query(create_kafka_query)
+
+        # Check that intent size is also correct when we have no saved committed offset
+        produce_message(3)
+        check_intent_size(1, INVALID_KAFKA_OFFSET)
+        # Do an extra check to make sure wait_for_log_line in `check_intent_size` didn't caught the wrong line
+        assert instance.wait_for_log_line(f"Saving intent of 1 for topic-partition \\[{topic_name}:0\\] at offset {INVALID_KAFKA_OFFSET}", look_behind_lines=10000, repetitions=2)
+
+        # Check that intent size is correct with multiple messages
+        k.kafka_produce(
+            kafka_cluster,
+            topic_name,
+            [f"message_4", "message_5"]
+        )
+
+        consumed_messages = instance.query_with_retry("SELECT * FROM test.dst", retry_count = 30, sleep_time = 1, check_callback=lambda x: len(TSV(x)) == 3)
+        logging.debug(f"Consumed messages: {consumed_messages}")
+        instance.wait_for_log_line(f"Saving intent of 2 for topic-partition \\[{topic_name}:0\\] at offset 3", look_behind_lines=500)
+
+        result = instance.query("SELECT * FROM test.dst ORDER BY a")
+        assert TSV(result) == TSV("message_3\nmessage_4\nmessage_5")
+
+
+if __name__ == "__main__":
+    cluster.start()
+    input("Cluster created, press any key to destroy...")
+    cluster.shutdown()


### PR DESCRIPTION
Closes #71430
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Count consumed messages manually to avoid depending on previous committed offset in StorageKafka2.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

We had an off-by-one error when calculating the intent size. I also discovered that when we read the offset from kafka on table creation, the intent size was also wrongly calculated. As a result I changed to logic to manually count the consumed message to ensure intent size is correct.