### PR TITLE
Avoid using global context for internal InterpreterSelectQuery from Distributed storage

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -411,10 +411,11 @@ StorageDistributed::StorageDistributed(
     if (sharding_key_)
     {
         /// buildShardingKeyExpression() may create interpreters
-        auto local_context = Context::createCopy(getContext());
-        local_context->makeQueryContext();
+        /// And we cannot create temporary context here since expression may hold reference to the context
+        sharding_key_expr_context = Context::createCopy(getContext());
+        sharding_key_expr_context->makeQueryContext();
 
-        sharding_key_expr = buildShardingKeyExpression(sharding_key_, local_context, storage_metadata.getColumns().getAllPhysical(), false);
+        sharding_key_expr = buildShardingKeyExpression(sharding_key_, sharding_key_expr_context, storage_metadata.getColumns().getAllPhysical(), false);
         sharding_key_column_name = sharding_key_->getColumnName();
         sharding_key_is_deterministic = isExpressionActionsDeterministic(sharding_key_expr);
     }

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -247,6 +247,7 @@ private:
 
     bool has_sharding_key;
     bool sharding_key_is_deterministic = false;
+    ContextMutablePtr sharding_key_expr_context;
     ExpressionActionsPtr sharding_key_expr;
     String sharding_key_column_name;
 

--- a/tests/queries/0_stateless/03541_distributed_no_global_context.sql
+++ b/tests/queries/0_stateless/03541_distributed_no_global_context.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS dist_with_interpreter_for_sharding_key;
+CREATE TABLE dist_with_interpreter_for_sharding_key (key Int) ENGINE=Distributed(test_shard_localhost, system, one, 1 IN (SELECT 2));
+
+SELECT * FROM remote('127.0.0.{3|2}', numbers(2), number NOT IN (SELECT number FROM numbers(1))) FORMAT Null;
+
+-- found by fuzzer
+SELECT number FROM remote('127.0.0.{3|2}', numbers(2), number NOT IN (SELECT number FROM numbers(1) FINAL WHERE 1025 QUALIFY equals(number) = number)) WHERE (materialize(number IN (SELECT number FROM numbers(1) WHERE toNullable(1) = number GROUP BY 1, number = (toInt256(10) = number)), 10) = number) OR (number NOT IN (SELECT DISTINCT number FROM numbers(1) WHERE -1 QUALIFY (1 = number) = number)) OR (number = 1) OR (toInt128(toInt128(3)) <= number) WITH TOTALS HAVING 1; -- { serverError ILLEGAL_FINAL }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/81585