### PR TITLE
fix logical error when we read a file that cannot infer schema

### DIFF
--- a/src/Formats/ReadSchemaUtils.cpp
+++ b/src/Formats/ReadSchemaUtils.cpp
@@ -240,6 +240,13 @@ try
 
             if (format_name)
             {
+                if (!FormatFactory::instance().checkIfFormatHasSchemaReader(*format_name))
+                {
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "{} file format doesn't support schema inference. You must specify the structure manually",
+                        *format_name);
+                }
                 SchemaReaderPtr schema_reader;
 
                 try


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
a stress test failed here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81673&sha=6d730d5698e5e9789f175d6c89900032516b1d1f&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29
read some file but cannot refer the schema
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
