### PR TITLE
validate mergetree setting merge_max_block_size

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -106,7 +106,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool enable_block_offset_column;
     extern const MergeTreeSettingsUInt64 enable_vertical_merge_algorithm;
     extern const MergeTreeSettingsUInt64 merge_max_block_size_bytes;
-    extern const MergeTreeSettingsUInt64 merge_max_block_size;
+    extern const MergeTreeSettingsNonZeroUInt64 merge_max_block_size;
     extern const MergeTreeSettingsUInt64 min_merge_bytes_to_use_direct_io;
     extern const MergeTreeSettingsFloat ratio_of_defaults_for_sparse_serialization;
     extern const MergeTreeSettingsUInt64 vertical_merge_algorithm_min_bytes_to_activate;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2063,6 +2063,13 @@ void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool allow
             index_granularity.value);
     }
 
+    if (merge_max_block_size < 1)
+    {
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "merge_max_block_size: value should be greater than 0.");
+    }
+
     // The min_index_granularity_bytes value is 1024 b and index_granularity_bytes is 10 mb by default.
     // If index_granularity_bytes is not disabled i.e > 0 b, then always ensure that it's greater than
     // min_index_granularity_bytes. This is mainly a safeguard against accidents whereby a really low

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -267,7 +267,7 @@ namespace ErrorCodes
     )", 0) \
     \
     /** Merge settings. */ \
-    DECLARE(UInt64, merge_max_block_size, 8192, R"(
+    DECLARE(NonZeroUInt64, merge_max_block_size, 8192, R"(
     The number of rows that are read from the merged parts into memory.
 
     Possible values:
@@ -2061,13 +2061,6 @@ void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool allow
             ErrorCodes::BAD_ARGUMENTS,
             "index_granularity: value {} makes no sense",
             index_granularity.value);
-    }
-
-    if (merge_max_block_size <= 0)
-    {
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "merge_max_block_size: value should be greater than 0.");
     }
 
     // The min_index_granularity_bytes value is 1024 b and index_granularity_bytes is 10 mb by default.

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2063,7 +2063,7 @@ void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool allow
             index_granularity.value);
     }
 
-    if (merge_max_block_size < 1)
+    if (merge_max_block_size <= 0)
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,

--- a/tests/queries/0_stateless/03538_validate_setting_merge_max_block_size.sql
+++ b/tests/queries/0_stateless/03538_validate_setting_merge_max_block_size.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS validate_setting_merge_max_block_size;
+
+CREATE TABLE validate_setting_merge_max_block_size (x Int64) ENGINE = MergeTree() ORDER BY tuple() SETTINGS merge_max_block_size = 0; -- {serverError BAD_ARGUMENTS}
+CREATE TABLE validate_setting_merge_max_block_size (x Int64) ENGINE = MergeTree() ORDER BY tuple() SETTINGS merge_max_block_size = 1;
+ALTER TABLE validate_setting_merge_max_block_size MODIFY SETTING merge_max_block_size = 0; -- {serverError BAD_ARGUMENTS}
+
+DROP TABLE validate_setting_merge_max_block_size;


### PR DESCRIPTION
Add validation to ensure that `merge_max_block_size` is > 0.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add validation for mergetree setting `merge_max_block_size` to ensure that it's non zero.

Closes: https://github.com/ClickHouse/ClickHouse/issues/81586

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
