### PR TITLE
Fix slow allocations when using MemoryTrackerBlockerInThread

### DIFF
--- a/src/Common/MemoryTrackerBlockerInThread.cpp
+++ b/src/Common/MemoryTrackerBlockerInThread.cpp
@@ -3,18 +3,12 @@
 #include <utility>
 
 // MemoryTrackerBlockerInThread
-thread_local uint64_t MemoryTrackerBlockerInThread::counter = 0;
-thread_local VariableContext MemoryTrackerBlockerInThread::level = VariableContext::Global;
+thread_local VariableContext MemoryTrackerBlockerInThread::level = VariableContext::Max;
 
 MemoryTrackerBlockerInThread::MemoryTrackerBlockerInThread(VariableContext level_)
-    : previous_level(level), previous_counter(counter)
+    : previous_level(level)
 {
-    ++counter;
     level = level_;
-}
-
-MemoryTrackerBlockerInThread::MemoryTrackerBlockerInThread() : MemoryTrackerBlockerInThread(VariableContext::User)
-{
 }
 
 MemoryTrackerBlockerInThread::~MemoryTrackerBlockerInThread()
@@ -22,27 +16,21 @@ MemoryTrackerBlockerInThread::~MemoryTrackerBlockerInThread()
     reset();
 }
 
-MemoryTrackerBlockerInThread::MemoryTrackerBlockerInThread(std::nullopt_t)
-    : previous_level(VariableContext::User), previous_counter(UINT64_MAX) {}
-
 MemoryTrackerBlockerInThread::MemoryTrackerBlockerInThread(MemoryTrackerBlockerInThread && rhs) noexcept
-    : previous_level(rhs.previous_level), previous_counter(std::exchange(rhs.previous_counter, UINT64_MAX)) {}
+    : previous_level(std::exchange(rhs.previous_level, std::nullopt)) {}
 
 MemoryTrackerBlockerInThread & MemoryTrackerBlockerInThread::operator=(MemoryTrackerBlockerInThread && rhs) noexcept
 {
     reset();
-    previous_level = rhs.previous_level;
-    previous_counter = std::exchange(rhs.previous_counter, UINT64_MAX);
+    previous_level = std::exchange(rhs.previous_level, std::nullopt);
     return *this;
 }
 
 void MemoryTrackerBlockerInThread::reset()
 {
-    if (previous_counter != UINT64_MAX)
+    if (previous_level.has_value())
     {
-        --counter;
-        level = previous_level;
-        chassert(counter == previous_counter);
-        previous_counter = UINT64_MAX;
+        level = previous_level.value();
+        previous_level.reset();
     }
 }

--- a/src/Common/MemoryTrackerBlockerInThread.h
+++ b/src/Common/MemoryTrackerBlockerInThread.h
@@ -21,37 +21,33 @@ class TraceCollector;
 struct MemoryTrackerBlockerInThread
 {
 private:
-    static thread_local uint64_t counter;
     static thread_local VariableContext level;
 
-    VariableContext previous_level;
-    uint64_t previous_counter; // if UINT64_MAX, this blocker is empty
-
-    /// level_ - block in level and above
-    explicit MemoryTrackerBlockerInThread(VariableContext level_);
-
-    /// Empty.
-    explicit MemoryTrackerBlockerInThread(std::nullopt_t);
-    MemoryTrackerBlockerInThread(MemoryTrackerBlockerInThread &&) noexcept;
-    MemoryTrackerBlockerInThread & operator=(MemoryTrackerBlockerInThread &&) noexcept;
-    void reset();
+    std::optional<VariableContext> previous_level;
 
 public:
-    explicit MemoryTrackerBlockerInThread();
+    /// level_ - block in level and above
+    explicit MemoryTrackerBlockerInThread(VariableContext level_ = VariableContext::User);
+
+    MemoryTrackerBlockerInThread(MemoryTrackerBlockerInThread &&) noexcept;
+    MemoryTrackerBlockerInThread & operator=(MemoryTrackerBlockerInThread &&) noexcept;
+
+    void reset();
+
     ~MemoryTrackerBlockerInThread();
 
     static bool isBlocked(VariableContext current_level)
     {
-        return counter > 0 && current_level >= level;
+        return current_level >= level;
     }
 
     static bool isBlockedAny()
     {
-        return counter > 0;
+        return level < VariableContext::Max;
     }
 
-    friend class MemoryTracker;
-    friend struct AllocationTrace;
-    friend class DB::PageCache;
-    friend class DB::TraceCollector;
+    static VariableContext getLevel()
+    {
+        return level;
+    }
 };

--- a/src/Common/MemoryTrackerSwitcher.h
+++ b/src/Common/MemoryTrackerSwitcher.h
@@ -17,6 +17,7 @@ struct MemoryTrackerSwitcher
         auto * thread_tracker = CurrentThread::getMemoryTracker();
 
         prev_untracked_memory = current_thread->untracked_memory;
+        prev_untracked_memory_blocker_level = current_thread->untracked_memory_blocker_level;
         prev_memory_tracker_parent = thread_tracker->getParent();
 
         current_thread->untracked_memory = 0;
@@ -36,11 +37,13 @@ struct MemoryTrackerSwitcher
         /// 'setParent' because it may flush untracked memory to the wrong parent.
         thread_tracker->setParent(prev_memory_tracker_parent);
         current_thread->untracked_memory = prev_untracked_memory;
+        current_thread->untracked_memory_blocker_level = prev_untracked_memory_blocker_level;
     }
 
 private:
     MemoryTracker * prev_memory_tracker_parent = nullptr;
     Int64 prev_untracked_memory = 0;
+    VariableContext prev_untracked_memory_blocker_level = VariableContext::Max;
 };
 
 }

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -5,6 +5,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
 #include <Common/memory.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
 #include <base/getPageSize.h>
 #include <base/errnoToString.h>
 #include <Interpreters/Context.h>
@@ -240,6 +241,7 @@ void ThreadStatus::flushUntrackedMemory()
     if (untracked_memory == 0)
         return;
 
+    MemoryTrackerBlockerInThread blocker(untracked_memory_blocker_level);
     memory_tracker.adjustWithUntrackedMemory(untracked_memory);
     untracked_memory = 0;
 }

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -208,6 +208,8 @@ public:
     MemoryTracker memory_tracker{VariableContext::Thread};
     /// Small amount of untracked memory (per thread atomic-less counter)
     Int64 untracked_memory = 0;
+    /// MemoryTrackerBlockerInThread state corresponding to untracked_memory.
+    VariableContext untracked_memory_blocker_level = VariableContext::Max;
     /// Each thread could new/delete memory in range of (-untracked_memory_limit, untracked_memory_limit) without access to common counters.
     Int64 untracked_memory_limit = 4 * 1024 * 1024;
 

--- a/src/Common/VariableContext.h
+++ b/src/Common/VariableContext.h
@@ -10,4 +10,6 @@ enum class VariableContext : uint8_t
     User,           /// Group of processes
     Process,        /// For example, a query or a merge
     Thread,         /// A thread of a process
+
+    Max, /// size of the enum, not a real level
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed performance regression in memory tracking.

See https://github.com/ClickHouse/ClickHouse/issues/81304

https://github.com/ClickHouse/ClickHouse/pull/77114 fixed incorrect interaction between `ThreadStatus::untracked_memory` and `MemoryTrackerBlockerInThread`, at the cost of calling MemoryTracker on each allocation when `MemoryTrackerBlockerInThread` is active (i.e. it just disabled the `untracked_memory` in that case). This turned out to be too slow.

This PR does the second-simplest thing: use `untracked_memory` for consecutive allocations with the same `MemoryTrackerBlockerInThread` state; flush `untracked_memory` to MemoryTracker when `MemoryTrackerBlockerInThread` state changes.

On the test from https://github.com/ClickHouse/ClickHouse/issues/81304 I'm getting 15% improvement from this PR, and no clear difference (<1%) between this PR and full revert of the `CurrentMemoryTracker.cpp` change (i.e. handling `MemoryTrackerBlockerInThread` incorrectly).