### PR TITLE
tests: increase timeout for RabbitMQ restarts

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2512,7 +2512,7 @@ class ClickHouseCluster:
             if monitor is not None:
                 monitor.start(self)
 
-    def reset_rabbitmq(self, timeout=120):
+    def reset_rabbitmq(self, timeout=240):
         self.stop_rabbitmq_app()
         run_rabbitmqctl(self.rabbitmq_docker_id, self.rabbitmq_cookie, "reset", timeout)
         self.start_rabbitmq_app()


### PR DESCRIPTION
Recently CI saw the case when it takes > 2 min:

    2025-06-11 22:46:39.235096+00:00 [notice] <0.45.0> Application mnesia exited with reason: stopped
    2025-06-11 22:46:39.246595+00:00 [debug] <0.45102.0> Feature flags: resetting loaded registry
    2025-06-11 22:48:48.891483+00:00 [debug] <0.45257.0> Feature flags: acquiring lock {feature_flags_state_change,<0.45257.0>}

Though not sure that this is a good idea, but for that case it would help, since other tests passed after this failure.

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81589&sha=0018ae04f8fd8066d4a2ced3bd1ef958b7a0e090&name_0=PR&name_1=Integration%20tests%20%28aarch64%2C%20distributed%20plan%2C%203%2F4%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)