### PR TITLE
Do not reset network throttlers on inactivity

### DIFF
--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -416,7 +416,7 @@ ProcessListEntry::~ProcessListEntry()
 
     parent.have_space.notify_all();
 
-    /// If there are no more queries for the user, then we will reset memory tracker and network throttler.
+    /// If there are no more queries for the user, then we will reset memory tracker.
     if (user_process_list.queries.empty())
         user_process_list.resetTrackers();
 

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -420,9 +420,7 @@ ProcessListEntry::~ProcessListEntry()
     if (user_process_list.queries.empty())
         user_process_list.resetTrackers();
 
-    /// Reset throttler, similarly (see above).
-    if (parent.processes.empty())
-        parent.total_network_throttler.reset();
+    /// NOTE: Do not reset parent.total_network_throttler, it MUST account for periods of inactivity for correct work. Also creating multiple parent throttlers is wrong.
 }
 
 

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -420,7 +420,7 @@ ProcessListEntry::~ProcessListEntry()
     if (user_process_list.queries.empty())
         user_process_list.resetTrackers();
 
-    /// NOTE: Do not reset parent.total_network_throttler, it MUST account for periods of inactivity for correct work. Also creating multiple parent throttlers is wrong.
+    /// NOTE: Do not reset parent.total_network_throttler, it MUST account for periods of inactivity for correct work.
 }
 
 

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -322,13 +322,12 @@ struct ProcessListForUser
     /// Clears MemoryTracker for the user.
     /// Sometimes it is important to reset the MemoryTracker, because it may accumulate skew
     ///  due to the fact that there are cases when memory can be allocated while processing the query, but released later.
-    /// Clears network bandwidth Throttler, so it will not count periods of inactivity.
     void resetTrackers()
     {
         /// TODO: should we drop user_temp_data_on_disk here?
         user_memory_tracker.reset();
-        if (user_throttler)
-            user_throttler.reset();
+
+        /// NOTE: we should not reset user_throttler here because TokenBucket throttling MUST account periods of inactivity for correct work
     }
 };
 


### PR DESCRIPTION
This behaviour was probably necessary before we changed the throttling algorithm to a Token Bucket Filter. Now, it creates a problem. After a reset, the Throttler instance is recreated with a replenished number of tokens (full bucket = 1 second * max_speed), which allows it to exceed the limit any number of times if recreated multiple times a second.

I've found it just by reading the code, so there is no reproducing case. 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The total and per-user network throttlers are never reset, which ensures that `max_network_bandwidth_for_all_users` and `max_network_bandwidth_for_all_users` limits are never exceeded.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
