### PR TITLE
Fix appendRemovalTIDToVersionMetadata for covered_parts in MergeTreeTransaction::addNewPartAndRemoveCovered

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -127,6 +127,8 @@ void MergeTreeTransaction::addNewPartAndRemoveCovered(const StoragePtr & storage
         {
             transaction_context.part_name = covered->name;
             covered->version.lockRemovalTID(tid, transaction_context);
+            if (covered->wasInvolvedInTransaction())
+                covered->appendRemovalTIDToVersionMetadata();
         }
     }
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix: `appendRemovalTIDToVersionMetadata` for covered_parts in `MergeTreeTransaction::addNewPartAndRemoveCovered `so that there is a removal_id in the transaction metadata file even when it is removed without a transaction.
Hence, when restarting, it can load the outdated parts successfully without triggering:
```
Logical error: \'Data part 202410_1_42_8 is Outdated and has creation TID (94, 40, 3ce64a6c-c10e-4c02-8891-47977f2b6a1a) and CSN 95, but does not have removal tid. It\'s a bug or a result of manual intervention.\'.
```

Closes #71136

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
