### PR TITLE
fix redis storage get by keys with empty rows

### DIFF
--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -207,7 +207,6 @@ StorageRedis::StorageRedis(
     const String & primary_key_)
     : IStorage(table_id_)
     , WithContext(context_->getGlobalContext())
-    , table_id(table_id_)
     , configuration(configuration_)
     , log(getLogger("StorageRedis"))
     , primary_key(primary_key_)
@@ -427,7 +426,7 @@ void StorageRedis::multiSet(const RedisArray & data) const
 
     auto ret = connection->client->execute<RedisSimpleString>(cmd_mget);
     if (ret != "OK")
-        throw Exception(ErrorCodes::INTERNAL_REDIS_ERROR, "Fail to write to redis table {}, for {}", table_id.getFullNameNotQuoted(), ret);
+        throw Exception(ErrorCodes::INTERNAL_REDIS_ERROR, "Fail to write to redis table {}, for {}", getStorageID().getFullNameNotQuoted(), ret);
 }
 
 RedisInteger StorageRedis::multiDelete(const RedisArray & keys) const
@@ -445,7 +444,7 @@ RedisInteger StorageRedis::multiDelete(const RedisArray & keys) const
             "Try to delete {} rows but actually deleted {} rows from redis table {}.",
             keys.size(),
             ret,
-            table_id.getFullNameNotQuoted());
+            getStorageID().getFullNameNotQuoted());
 
     return ret;
 }
@@ -491,7 +490,7 @@ void StorageRedis::truncate(const ASTPtr & query, const StorageMetadataPtr &, Co
     auto ret = connection->client->execute<RedisSimpleString>(cmd_flush_db);
 
     if (ret != "OK")
-        throw Exception(ErrorCodes::INTERNAL_REDIS_ERROR, "Fail to truncate redis table {}, for {}", table_id.getFullNameNotQuoted(), ret);
+        throw Exception(ErrorCodes::INTERNAL_REDIS_ERROR, "Fail to truncate redis table {}, for {}", getStorageID().getFullNameNotQuoted(), ret);
 }
 
 void StorageRedis::checkMutationIsPossible(const MutationCommands & commands, const Settings & /* settings */) const

--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -357,7 +357,7 @@ Chunk StorageRedis::getBySerializedKeys(const RedisArray & keys, PaddedPODArray<
 
     RedisArray values = multiGet(keys);
     if (values.isNull() || values.size() == 0)
-        return {};
+        return Chunk(std::move(columns), 0);
 
     if (null_map)
     {
@@ -405,6 +405,9 @@ std::pair<RedisIterator, RedisArray> StorageRedis::scan(RedisIterator iterator, 
 
 RedisArray StorageRedis::multiGet(const RedisArray & keys) const
 {
+    if (keys.isNull() || keys.size() == 0)
+        return{};
+
     auto connection = getRedisConnection(pool, configuration);
 
     RedisCommand cmd_mget("MGET");

--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -406,7 +406,7 @@ std::pair<RedisIterator, RedisArray> StorageRedis::scan(RedisIterator iterator, 
 RedisArray StorageRedis::multiGet(const RedisArray & keys) const
 {
     if (keys.isNull() || keys.size() == 0)
-        return{};
+        return {};
 
     auto connection = getRedisConnection(pool, configuration);
 

--- a/src/Storages/StorageRedis.h
+++ b/src/Storages/StorageRedis.h
@@ -71,7 +71,6 @@ public:
     Block getSampleBlock(const Names &) const override;
 
 private:
-    StorageID table_id;
     RedisConfiguration configuration;
 
     LoggerPtr log;

--- a/tests/integration/test_storage_redis/test.py
+++ b/tests/integration/test_storage_redis/test.py
@@ -414,7 +414,7 @@ def test_direct_join(started_cluster):
     # create table
     node.query(
         f"""
-            CREATE TABLE test_direct_join(k Int) Engine=Redis('{address}', 0, 'clickhouse') PRIMARY KEY (k);
+            CREATE TABLE test_direct_join(k Int) Engine=Redis('{address}', 1, 'clickhouse') PRIMARY KEY (k);
             CREATE TABLE test_mt (k Int) ENGINE = MergeTree() ORDER BY tuple();
             INSERT INTO TABLE test_direct_join VALUES (1);
             INSERT INTO TABLE test_mt VALUES (1);

--- a/tests/integration/test_storage_redis/test.py
+++ b/tests/integration/test_storage_redis/test.py
@@ -411,8 +411,6 @@ def test_direct_join(started_cluster):
     drop_table("test_direct_join")
     drop_table("test_mt")
 
-    node.query
-
     # create table
     node.query(
         f"""
@@ -422,7 +420,6 @@ def test_direct_join(started_cluster):
             INSERT INTO TABLE test_mt VALUES (1);
         """
     )
-
 
     response = TSV.toMat(node.query("SELECT * FROM test_direct_join JOIN test_mt ON "
                                     "test_direct_join.k = test_mt.k FORMAT TSV"))


### PR DESCRIPTION
DirectJoin is called with an empty block during the planning stage to transform the header.
Currently, in such a case, the redis client would throw, so a valid query cannot be executed.
Closes: #81659

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix StorageRedis join in some cases
