### PR TITLE
Fix crash in `ConcurrentHashJoin` with empty `USING ()`

### DIFF
--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -576,7 +576,7 @@ bool TableJoin::sameStrictnessAndKind(JoinStrictness strictness_, JoinKind kind_
 
 bool TableJoin::oneDisjunct() const
 {
-    return clauses.size() == 1;
+    return clauses.size() == 1 && !clauses.front().isEmpty();
 }
 
 bool TableJoin::needStreamWithNonJoinedRows() const

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -121,6 +121,12 @@ public:
                 "Left keys: [{}] Right keys [{}] Condition columns: '{}', '{}'",
                  fmt::join(key_names_left, ", "), fmt::join(key_names_right, ", "), left_cond, right_cond);
         }
+
+        bool isEmpty() const
+        {
+            return key_names_left.empty() && key_names_right.empty() && !on_filter_condition_left && !on_filter_condition_right
+                && analyzer_left_filter_condition_column_name.empty() && analyzer_right_filter_condition_column_name.empty();
+        }
     };
 
     using Clauses = std::vector<JoinOnClause>;

--- a/tests/queries/0_stateless/03538_crash_in_parallel_hash_with_empty_using.sql
+++ b/tests/queries/0_stateless/03538_crash_in_parallel_hash_with_empty_using.sql
@@ -1,0 +1,15 @@
+SELECT
+    n,
+    myfield
+FROM
+(
+    SELECT toString(number) AS n
+    FROM system.numbers
+    LIMIT 1000
+) AS a
+ANY LEFT JOIN
+(
+    SELECT 1 AS myfield
+) AS b USING ()
+FORMAT Null
+SETTINGS allow_experimental_analyzer = false;

--- a/tests/queries/0_stateless/03538_crash_in_parallel_hash_with_empty_using.sql
+++ b/tests/queries/0_stateless/03538_crash_in_parallel_hash_with_empty_using.sql
@@ -1,3 +1,5 @@
+set  enable_parallel_replicas = 0;
+
 SELECT
     n,
     myfield

--- a/tests/queries/0_stateless/03538_crash_in_parallel_hash_with_empty_using.sql
+++ b/tests/queries/0_stateless/03538_crash_in_parallel_hash_with_empty_using.sql
@@ -13,3 +13,19 @@ ANY LEFT JOIN
 ) AS b USING ()
 FORMAT Null
 SETTINGS allow_experimental_analyzer = false;
+
+SELECT
+    n,
+    myfield
+FROM
+(
+    SELECT toString(number) AS n
+    FROM system.numbers
+    LIMIT 1000
+) AS a
+ANY LEFT JOIN
+(
+    SELECT 1 AS myfield
+) AS b USING ()
+FORMAT Null
+SETTINGS allow_experimental_analyzer = true; -- { serverError INVALID_JOIN_ON_EXPRESSION }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in `ConcurrentHashJoin` with empty `USING ()` and old analyzer enabled.


Closes: #81540