### PR TITLE
tests: fix 02843_backup_use_same_s3_credentials_for_base_backup

### DIFF
--- a/tests/queries/0_stateless/02843_backup_use_same_s3_credentials_for_base_backup.sh
+++ b/tests/queries/0_stateless/02843_backup_use_same_s3_credentials_for_base_backup.sh
@@ -8,7 +8,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 client_opts=(
-  --send_logs_level 'error'
+    --allow_repeated_settings
+    --send_logs_level 'error'
 )
 
 


### PR DESCRIPTION
With clickhouse-test --no-random-settings --no-random-merge-tree-settings it fails

And it has not been found because it is disabled for fast-test, but it fails for azure [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c7630700168f18c68e2394f2ad77791cf12945f5&name_0=MasterCI&name_1=Stateless%20tests%20%28azure%2C%20arm_asan%2C%201%2F3%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
