### PR TITLE
Remove ThreadStatus from the client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -345,7 +345,6 @@ void Client::initialize(Poco::Util::Application & self)
 int Client::main(const std::vector<std::string> & /*args*/)
 try
 {
-    auto & thread_status = MainThreadStatus::getInstance();
     setupSignalHandler();
 
     output_stream << std::fixed << std::setprecision(3);
@@ -360,14 +359,6 @@ try
     initTTYBuffer(
         toProgressOption(config().getString("progress", "default")), toProgressOption(config().getString("progress-table", "default")));
     initKeystrokeInterceptor();
-
-    {
-        // All that just to set DB::CurrentThread::get().getGlobalContext()
-        // which is required for client timezone (pushed from server) to work.
-        auto thread_group = std::make_shared<ThreadGroup>();
-        const_cast<ContextWeakPtr &>(thread_group->global_context) = global_context;
-        thread_status.attachToGroup(thread_group, false);
-    }
 
     /// Includes delayed_interactive.
     if (is_interactive)

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -345,6 +345,9 @@ void Client::initialize(Poco::Util::Application & self)
 int Client::main(const std::vector<std::string> & /*args*/)
 try
 {
+    /// For memory tracking
+    MainThreadStatus::getInstance();
+
     setupSignalHandler();
 
     output_stream << std::fixed << std::setprecision(3);

--- a/src/Common/DateLUT.cpp
+++ b/src/Common/DateLUT.cpp
@@ -24,11 +24,6 @@ namespace Setting
 namespace
 {
 
-std::string extractTimezoneFromContext(DB::ContextPtr query_context)
-{
-    return query_context->getSettingsRef()[DB::Setting::session_timezone].value;
-}
-
 Poco::DigestEngine::Digest calcSHA1(const std::string & path)
 {
     std::ifstream stream(path);
@@ -160,31 +155,27 @@ const DateLUTImpl & DateLUT::instance()
 {
     const auto & date_lut = getInstance();
 
+    std::string timezone_from_context;
     if (DB::CurrentThread::isInitialized())
     {
-        std::string timezone_from_context;
         const DB::ContextPtr query_context = DB::CurrentThread::get().getQueryContext();
-
         if (query_context)
-        {
-            timezone_from_context = extractTimezoneFromContext(query_context);
+            timezone_from_context = query_context->getSettingsRef()[DB::Setting::session_timezone];
+    }
 
-            if (!timezone_from_context.empty())
-                return date_lut.getImplementation(timezone_from_context);
-        }
-
+    if (timezone_from_context.empty())
+    {
         /// On the server side, timezone is passed in query_context,
         /// but on CH-client side we have no query context,
         /// and each time we modify client's global context
-        const DB::ContextPtr global_context = DB::CurrentThread::get().getGlobalContext();
+        const DB::ContextPtr global_context = DB::Context::getGlobalContextInstance();
         if (global_context)
-        {
-            timezone_from_context = extractTimezoneFromContext(global_context);
-
-            if (!timezone_from_context.empty())
-                return date_lut.getImplementation(timezone_from_context);
-        }
+            timezone_from_context = global_context->getSettingsRef()[DB::Setting::session_timezone];
     }
+
+    if (!timezone_from_context.empty())
+        return date_lut.getImplementation(timezone_from_context);
+
     return serverTimezoneInstance();
 }
 


### PR DESCRIPTION
It seems that it was required only for DateLUT, to obtain global context via ThreadStatus, but we can do better, simply use Context::getGlobalContextInstance() instead.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)