### PR TITLE
Add pattern tokenizer for the `tokens` function

### DIFF
--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -393,9 +393,10 @@ The default tokenizer uses non-alphanumeric ASCII characters as separators.
 **Arguments**
 
 - `value` — The input string. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
-- `tokenizer` — The tokenizer to use. Valid arguments are `default`, `ngram`, `string`, and `noop`. Optional, if not set explicitly, defaults to `default`. [const String](../data-types/string.md)
+- `tokenizer` — The tokenizer to use. Valid arguments are `default`, `ngram`, `string`, `pattern`, and `no_op`. Optional, if not set explicitly, defaults to `default`. [const String](../data-types/string.md)
 - `ngrams` — Only relevant if argument `tokenizer` is `ngram`: An optional parameter which defines the length of the ngrams. If not set explicitly, defaults to `3`. [UInt8](../data-types/int-uint.md).
 - `separators` — Only relevant if argument `tokenizer` is `string`: An optional parameter which defines the separator strings. If not set explicitly, defaults to `[' ']`. [Array(String)](../data-types/array.md).
+- `patterns` — Only relevant if argument `tokenizer` is `pattern`: An optional array parameter which defines the patterns. If not set explicitly or empty, defaults to ['\\w+']. [Array(String)](../data-types/array.md)..
 
 :::note
 In case of the `string` tokenizer: if the tokens do not form a [prefix code](https://en.wikipedia.org/wiki/Prefix_code), you likely want that the matching prefers longer separators first.
@@ -434,6 +435,20 @@ Result:
 ```text
 ┌─tokens──────────────────────────┐
 │ ['abc','bc ','c d',' de','def'] │
+└─────────────────────────────────┘
+```
+
+Using the pattern tokenizer with a pattern matches only ASCII alphabetic characters:
+
+```sql
+SELECT tokens('hello, world! test123,; text456\\', 'pattern', ['[a-zA-Z]+']) AS tokens;
+```
+
+Result:
+
+```text
+┌─tokens──────────────────────────┐
+│ ['hello','world','test','text'] │
 └─────────────────────────────────┘
 ```
 

--- a/src/Common/OptimizedRegularExpression.cpp
+++ b/src/Common/OptimizedRegularExpression.cpp
@@ -600,7 +600,11 @@ bool OptimizedRegularExpression::match(const char * subject, size_t subject_size
     if (is_trivial)
     {
         if (required_substring.empty())
+        {
+            match.offset = 0;
+            match.length = 0;
             return true;
+        }
 
         const UInt8 * pos;
         if (is_case_insensitive)
@@ -630,14 +634,13 @@ bool OptimizedRegularExpression::match(const char * subject, size_t subject_size
 
     std::string_view piece;
 
-    if (!re2::RE2::PartialMatch({subject, subject_size}, *re2, &piece))
+    if (!re2->Match({subject, subject_size}, 0, subject_size, re2::RE2::UNANCHORED, &piece, 1))
         return false;
 
     match.offset = piece.data() - subject;
     match.length = piece.length();
     return true;
 }
-
 
 unsigned OptimizedRegularExpression::match(const char * subject, size_t subject_size, MatchVec & matches, unsigned limit) const
 {

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -2,9 +2,10 @@
 
 #include <base/types.h>
 
+#include <Functions/Regexps.h>
 #include <Interpreters/BloomFilter.h>
 #include <Interpreters/GinFilter.h>
-
+#include <Common/OptimizedRegularExpression.h>
 
 namespace DB
 {
@@ -196,6 +197,22 @@ struct StringTokenExtractor final : public ITokenExtractorHelper<StringTokenExtr
 
 private:
     std::vector<String> separators;
+};
+
+struct PatternTokenExtractor final : public ITokenExtractorHelper<PatternTokenExtractor>
+{
+    explicit PatternTokenExtractor(const std::vector<String>& patterns);
+
+    static const char * getName() { return "pattern"; }
+    static const char * getExternalName() { return getName(); }
+
+    std::vector<String> getTokens(const char * data, size_t length) const override;
+
+    bool nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
+
+    bool nextInStringLike(const char * data, size_t length, size_t * __restrict pos, String & token) const override;
+private:
+    std::vector<OptimizedRegularExpression> regular_expressions;
 };
 
 /// Parser doing "no operation". Returns the entire input as a single token.

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -846,7 +846,7 @@ void ginIndexValidator(const IndexDescription & index, bool /*attach*/)
     if (!is_supported_tokenizer)
         throw Exception(
             ErrorCodes::INCORRECT_QUERY,
-            "Text index '{}' argument supports only 'default', 'ngram', and 'noop', but got {}",
+            "Text index '{}' argument supports only 'default', 'ngram', and 'no_op', but got {}",
             ARGUMENT_TOKENIZER,
             tokenizer.value());
 

--- a/tests/queries/0_stateless/03403_function_tokens.reference
+++ b/tests/queries/0_stateless/03403_function_tokens.reference
@@ -15,6 +15,19 @@ String tokenizer
 ['a','bc','d']
 ['a','bc','d']
 ['a','bc','d']
+Pattern tokenizer
+Unset or empty patterns behave as default tokenizer
+[]
+['abc','def']
+['abc','def']
+[]
+['h','e','l','l','o','w','o','r','l','d']
+['hello','world']
+['1','2','3','4','5','6']
+['123','456']
+['hello','world']
+['hello','world','123','456']
+['hello','world']
 No-op tokenizer
 ['']
 ['abc def']

--- a/tests/queries/0_stateless/03403_function_tokens.sql
+++ b/tests/queries/0_stateless/03403_function_tokens.sql
@@ -25,6 +25,12 @@ SELECT tokens('a', 'string', toInt8(-1)); -- { serverError ILLEGAL_TYPE_OF_ARGUM
 SELECT tokens('a', 'string', toFixedString('c', 1)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT tokens('a', 'string', materialize(['c'])); -- { serverError ILLEGAL_COLUMN }
 SELECT tokens('a', 'string', [1, 2]); -- { serverError BAD_GET }
+--    const Array (for "pattern")
+SELECT tokens('a', 'pattern', 'c'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT tokens('a', 'pattern', toInt8(-1)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT tokens('a', 'pattern', toFixedString('c', 1)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT tokens('a', 'pattern', materialize(['c'])); -- { serverError ILLEGAL_COLUMN }
+SELECT tokens('a', 'pattern', [1, 2]); -- { serverError BAD_GET }
 
 SELECT 'Default tokenizer';
 
@@ -47,6 +53,23 @@ SELECT tokens('  a  bc d', 'string', [' ']);
 SELECT tokens('()()a()bc()d', 'string', ['()']);
 SELECT tokens(',()a(),bc,(),d,', 'string', ['()', ',']);
 SELECT tokens('\\a\n\\bc\\d\n', 'string', ['\n', '\\']);
+
+SELECT 'Pattern tokenizer';
+
+SELECT 'Unset or empty patterns behave as default tokenizer';
+SELECT tokens('', 'pattern') AS tokenized;
+SELECT tokens('abc def', 'pattern') AS tokenized;
+SELECT tokens('abc def', 'pattern', []) AS tokenized;
+
+SELECT tokens('abc def', 'pattern', ['']) AS tokenized;
+SELECT tokens('hello world', 'pattern', ['\w']) AS tokenized;
+SELECT tokens('hello world', 'pattern', ['\w+']) AS tokenized;
+SELECT tokens('hello world 123 456', 'pattern', ['\d']) AS tokenized;
+SELECT tokens('hello world 123 456', 'pattern', ['\d+']) AS tokenized;
+
+SELECT tokens('hello world 123 456', 'pattern', ['[a-zA-Z]*']) AS tokenized;
+SELECT tokens('hello world 123 456', 'pattern', ['[a-zA-Z]*', '\d+']) AS tokenized;
+SELECT tokens('hello world 123 456', 'pattern', ['[a-zA-Z]*', 'hello']) AS tokenized;
 
 SELECT 'No-op tokenizer';
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The new pattern tokenizer accepts multiple patterns and returns a list of the tokens matched by all patterns. If a token (by its offset and length) is produced again by another pattern, it will be ignored.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
