### PR TITLE
Fix std::out_of_range in system.clusters for Replicated database w/o replicas

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -356,6 +356,9 @@ ClusterPtr DatabaseReplicated::getClusterImpl(bool all_groups) const
         shards.back().push_back(DatabaseReplicaInfo{std::move(hostname), std::move(shard), std::move(replica)});
     }
 
+    if (shards.empty())
+        throw Exception(ErrorCodes::ALL_CONNECTION_TRIES_FAILED, "No active replicas");
+
     UInt16 default_port;
     if (cluster_auth_info.cluster_secure_connection)
         default_port = getContext()->getTCPPortSecure().value_or(DBMS_DEFAULT_SECURE_PORT);


### PR DESCRIPTION
Example:

    2025.06.13 00:30:09.740996 [ 4632 ] {84895dee-a302-45ae-a1e8-6a26e2ad7fed} <Trace> DatabaseReplicated (test_zhl78ujr): Got a list of hosts after 1 iterations. All hosts: [s1|r1], filtered: [s1|r1], ids: [DROPPED]
    2025.06.13 00:30:09.885031 [ 4632 ] {84895dee-a302-45ae-a1e8-6a26e2ad7fed} <Fatal> : Logical error: 'std::exception. Code: 1001, type: std::out_of_range, e.what() = vector, Stack trace (when copying this message, always include the lines below):

    0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:0: std::logic_error::logic_error(char const*) @ 0x0000000036ffeadc
    1. std::out_of_range::out_of_range[abi:ne190107](char const*) @ 0x000000000d3b5c34
    2. std::__throw_out_of_range[abi:ne190107](char const*) @ 0x000000000d3b5bc4
    3. ./contrib/llvm-project/libcxx/include/vector:1001: ? @ 0x0000000024b1b078
    4. ./contrib/llvm-project/libcxx/include/vector:1450: DB::Cluster::addShard(DB::Settings const&, std::vector<DB::Cluster::Address, std::allocator<DB::Cluster::Address>>, bool, unsigned int, String, unsigned int, DB::Cluster::ShardInfoInsertPathForInternalReplication, bool) @ 0x0000000024b0db70
    5. ./ci/tmp/build/./src/Interpreters/Cluster.cpp:626: DB::Cluster::Cluster(DB::Settings const&, std::vector<std::vector<DB::DatabaseReplicaInfo, std::allocator<DB::DatabaseReplicaInfo>>, std::allocator<std::vector<DB::DatabaseReplicaInfo, std::allocator<DB::DatabaseReplicaInfo>>>> const&, DB::ClusterConnectionParameters const&) @ 0x0000000024b0ff48
    6. ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:41: DB::DatabaseReplicated::getClusterImpl(bool) const @ 0x0000000023306c7c
    7. ./ci/tmp/build/./src/Databases/DatabaseReplicated.cpp:221: DB::DatabaseReplicated::tryGetCluster() const @ 0x0000000023303880
    8. ./ci/tmp/build/./src/Storages/System/StorageSystemClusters.cpp:62: DB::StorageSystemClusters::fillData(std::vector<COW<DB::IColumn>::mutable_ptr<DB::IColumn>, std::allocator<COW<DB::IColumn>::mutable_ptr<DB::IColumn>>>&, std::shared_ptr<DB::Context const>, DB::ActionsDAG::Node const*, std::vector<char8_t, std::allocator<char8_t>>) const @ 0x000000001dca5608

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)