### PR TITLE
tests: fix 01596_setting_limit_offset flakiness with async INSERTs

### DIFF
--- a/tests/queries/0_stateless/01596_setting_limit_offset.sql
+++ b/tests/queries/0_stateless/01596_setting_limit_offset.sql
@@ -6,30 +6,30 @@ OPTIMIZE TABLE test FINAL;
 
 -- Only set limit
 SET limit = 5;
-SELECT * FROM test; -- 5 rows
-SELECT * FROM test OFFSET 20; -- 5 rows
-SELECT * FROM (SELECT i FROM test LIMIT 10 OFFSET 50) TMP; -- 5 rows
-SELECT * FROM test LIMIT 4 OFFSET 192; -- 4 rows
-SELECT * FROM test LIMIT 10 OFFSET 195; -- 5 rows
-SELECT * FROM test LIMIT 2*2 OFFSET 192;
+SELECT * FROM test ORDER BY i; -- 5 rows
+SELECT * FROM test ORDER BY i OFFSET 20; -- 5 rows
+SELECT * FROM (SELECT i FROM test ORDER BY i LIMIT 10 OFFSET 50) TMP ORDER BY i; -- 5 rows
+SELECT * FROM test ORDER BY i LIMIT 4 OFFSET 192; -- 4 rows
+SELECT * FROM test ORDER BY i LIMIT 10 OFFSET 195; -- 5 rows
+SELECT * FROM test ORDER BY i LIMIT 2*2 OFFSET 192;
 
 -- Only set offset
 SET limit = 0;
 SET offset = 195;
-SELECT * FROM test; -- 5 rows
-SELECT * FROM test OFFSET 20; -- no result
-SELECT * FROM test LIMIT 100; -- no result
+SELECT * FROM test ORDER BY i; -- 5 rows
+SELECT * FROM test ORDER BY i OFFSET 20; -- no result
+SELECT * FROM test ORDER BY i LIMIT 100; -- no result
 SET offset = 10;
-SELECT * FROM test LIMIT 20 OFFSET 100; -- 10 rows
-SELECT * FROM test LIMIT 11 OFFSET 100; -- 1 rows
-SELECT * FROM test LIMIT 20 OFFSET 10*10;
-SELECT * FROM test LIMIT 4*5 OFFSET 10*10;
+SELECT * FROM test ORDER BY i LIMIT 20 OFFSET 100; -- 10 rows
+SELECT * FROM test ORDER BY i LIMIT 11 OFFSET 100; -- 1 rows
+SELECT * FROM test ORDER BY i LIMIT 20 OFFSET 10*10;
+SELECT * FROM test ORDER BY i LIMIT 4*5 OFFSET 10*10;
 
 -- offset and limit together
 SET limit = 10;
-SELECT * FROM test LIMIT 50 OFFSET 50; -- 10 rows
-SELECT * FROM test LIMIT 50 OFFSET 190; -- 0 rows
-SELECT * FROM test LIMIT 50 OFFSET 185; -- 5 rows
-SELECT * FROM test LIMIT 18 OFFSET 5; -- 8 rows
+SELECT * FROM test ORDER BY i LIMIT 50 OFFSET 50; -- 10 rows
+SELECT * FROM test ORDER BY i LIMIT 50 OFFSET 190; -- 0 rows
+SELECT * FROM test ORDER BY i LIMIT 50 OFFSET 185; -- 5 rows
+SELECT * FROM test ORDER BY i LIMIT 18 OFFSET 5; -- 8 rows
 
 DROP TABLE test;


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81758&sha=c171246303871059dbe882490a744ddd5ae4fb53&name_0=PR&name_1=Stateless%20tests%20%28debug%2C%20AsyncInsert%2C%20s3%20storage%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
