### PR TITLE
Remove verbose logging

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -716,7 +716,6 @@ public:
                 }
             }
         }
-        LOG_DEBUG(log, "Loaded or scheduled for load {} objects", loaded_or_scheduled_count);
     }
 
 private:

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -676,7 +676,6 @@ public:
             }
         }
 
-        size_t loaded_or_scheduled_count = 0;
         /// Iterate through all the objects again and either start loading or just set `next_update_time`.
         {
             std::lock_guard lock{mutex};
@@ -701,13 +700,11 @@ public:
 
                         /// Object was modified or it was failed to reload last time, so it should be reloaded.
                         startLoading(info);
-                        ++loaded_or_scheduled_count;
                     }
                     else if (info.failed())
                     {
                         /// Object was never loaded successfully and should be reloaded.
                         startLoading(info);
-                        ++loaded_or_scheduled_count;
                     }
                     else
                     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
