### PR TITLE
Try to fix flaky hms tests

### DIFF
--- a/tests/integration/test_database_hms/hms_extensions/Dockerfile
+++ b/tests/integration/test_database_hms/hms_extensions/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:8-jre-slim AS build
 
+RUN apt-get update && apt-get -o Acquire::Retries=5 install --fix-missing -y curl
+
 ENV HADOOP_VERSION=3.3.6
 ENV AWS_SDK_BUNDLE=1.12.753
 

--- a/tests/integration/test_database_hms/hms_extensions/Dockerfile
+++ b/tests/integration/test_database_hms/hms_extensions/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre-slim AS build
 
-RUN apt-get update && apt-get -y install curl
-
 ENV HADOOP_VERSION=3.3.6
 ENV AWS_SDK_BUNDLE=1.12.753
 


### PR DESCRIPTION
Sometimes there are failures due to curl installation like this:

https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/1f89305f2ab13c0484d3aafbbf315ae4fef5046f//integration_tests_asan_old_analyzer_2_6/integration_run_parallel0_0.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Try to fix flaky hms tests

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
