### PR TITLE
tests: fix SharedEngineReplacer for running multiple tests in parallel

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2054,37 +2054,40 @@ class TestCase:
                 # to avoid breaking CSV parser
                 result.description = result.description.replace("\0", "")
             else:
-                with SharedEngineReplacer(
-                    args,
-                    self.case_file,
-                    args.replace_replicated_with_shared,
-                    args.replace_non_replicated_with_shared,
-                    False,
-                    args.cloud,
-                ):
-                    with SharedEngineReplacer(
+                with (
+                    SharedEngineReplacer(
                         args,
-                        self.reference_file,
+                        self.case_file,
                         args.replace_replicated_with_shared,
                         args.replace_non_replicated_with_shared,
+                        False,
+                        args.cloud,
+                    ),
+                    SharedEngineReplacer(
+                        args,
+                        self.reference_file,
+                        # cloud_mode_engine=2 in cloud, expect all engines to be Shared*
+                        args.replace_replicated_with_shared or args.cloud,
+                        args.replace_non_replicated_with_shared or args.cloud,
                         True,
                         args.cloud,
-                    ):
-                        (
-                            proc,
-                            total_time,
-                        ) = self.run_single_test(server_logs_level, client_options)
+                    ),
+                ):
+                    (
+                        proc,
+                        total_time,
+                    ) = self.run_single_test(server_logs_level, client_options)
 
-                        result = self.process_result_impl(proc, total_time)
+                    result = self.process_result_impl(proc, total_time)
 
-                        result.check_if_need_retry(
-                            args,
-                            result.description,
-                            result.description,
-                            self.runs_count,
-                        )
-                        # to avoid breaking CSV parser
-                        result.description = result.description.replace("\0", "")
+                    result.check_if_need_retry(
+                        args,
+                        result.description,
+                        result.description,
+                        self.runs_count,
+                    )
+                    # to avoid breaking CSV parser
+                    result.description = result.description.replace("\0", "")
             if result.status == TestStatus.FAIL:
                 result.description = self.add_info_about_settings(result.description)
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -298,11 +298,10 @@ class SharedEngineReplacer:
             return
 
         shutil.copyfile(self.file_name, self.temp_file_path)
-        shutil.copymode(self.file_name, self.temp_file_path)
 
         with (
-            open(self.file_name, "w", newline="", encoding="utf-8") as modified,
-            open(self.temp_file_path, "r", newline="", encoding="utf-8") as source,
+            open(self.file_name, "r", newline="", encoding="utf-8") as source,
+            open(self.temp_file_path, "w", newline="", encoding="utf-8") as modified,
         ):
             for line in source:
                 # Replace table engines if echo enabled to match changed reference
@@ -369,7 +368,12 @@ class SharedEngineReplacer:
     def __exit__(self, exc_type, exc_value, exc_tb):
         if not self._need_to_replace_something():
             return
-        shutil.move(self.temp_file_path, self.file_name)
+        os.unlink(self.temp_file_path)
+
+    def get_path(self):
+        if not self._need_to_replace_something():
+            return self.file_name
+        return self.temp_file_path
 
 
 def get_temp_file_path():
@@ -2062,7 +2066,7 @@ class TestCase:
                         args.replace_non_replicated_with_shared,
                         False,
                         args.cloud,
-                    ),
+                    ) as test_replacer,
                     SharedEngineReplacer(
                         args,
                         self.reference_file,
@@ -2071,8 +2075,11 @@ class TestCase:
                         args.replace_non_replicated_with_shared or args.cloud,
                         True,
                         args.cloud,
-                    ),
+                    ) as reference_replacer,
                 ):
+                    self.case_file = test_replacer.get_path()
+                    self.reference_file = reference_replacer.get_path()
+
                     (
                         proc,
                         total_time,

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -297,7 +297,7 @@ class SharedEngineReplacer:
         if not self._need_to_replace_something():
             return
 
-        shutil.copyfile(self.file_name, self.temp_file_path)
+        shutil.copy2(self.file_name, self.temp_file_path)
 
         with (
             open(self.file_name, "r", newline="", encoding="utf-8") as source,

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -286,7 +286,7 @@ class SharedEngineReplacer:
     ):
         self.args = args
         self.file_name = file_name
-        self.temp_file_path = get_temp_file_path()
+        self.temp_file_path = "{0}.{2}{1}".format(*os.path.splitext(file_name), os.getpid())
         self.replace_replicated = replace_replicated
         self.replace_non_replicated = replace_non_replicated
         self.reference_file = reference_file
@@ -374,12 +374,6 @@ class SharedEngineReplacer:
         if not self._need_to_replace_something():
             return self.file_name
         return self.temp_file_path
-
-
-def get_temp_file_path():
-    return os.path.join(
-        tempfile._get_default_tempdir(), next(tempfile._get_candidate_names())
-    )
 
 
 def stringhash(s: str) -> int:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Previously SharedEngineReplacer rewrite the original files, which is bad
because you cannot do this in parallel, so instead this patch replaces
the temporary file instead and use it for tests later.