### PR TITLE
Stabilize 03338_http_compression_profile_events

### DIFF
--- a/tests/queries/0_stateless/03338_http_compression_profile_events.sh
+++ b/tests/queries/0_stateless/03338_http_compression_profile_events.sh
@@ -14,6 +14,21 @@ for option in "${options[@]}"; do
     ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query_id=$CLICKHOUSE_TEST_UNIQUE_NAME-$option&$option" -d @- <<< "SELECT 1 FORMAT RowBinary" > /dev/null
 done
 
+# HTTPHandler will finish http request before query_log entry about query finish will be created.
+# That is why here we need to wait for all queries to finish.
+for _ in {1..60}; do
+    finished_queries_count=$($CLICKHOUSE_CLIENT --query "
+        SELECT count() FROM system.query_log
+        WHERE current_database = '$CLICKHOUSE_DATABASE' AND query_id LIKE '$CLICKHOUSE_TEST_UNIQUE_NAME%' AND type != 'QueryStart'
+    ")
+
+    if [[ $finished_queries_count -ne "4" ]]; then
+        sleep 0.1
+    else
+        break
+    fi
+done
+
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d @- <<< "SYSTEM FLUSH LOGS system.query_log"
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d @- <<< "
     SELECT query, replace(query_id, '$CLICKHOUSE_TEST_UNIQUE_NAME-', ''), ProfileEvents['NetworkSendBytes'] > 0


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Wait for all running queries to create a finish event in `query_log`.
