### PR TITLE
Fix read Redis and KeeperMap by keys

### DIFF
--- a/src/Storages/KVStorageUtils.cpp
+++ b/src/Storages/KVStorageUtils.cpp
@@ -3,9 +3,7 @@
 #include <Columns/ColumnSet.h>
 #include <Columns/ColumnConst.h>
 
-#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 
@@ -14,7 +12,6 @@
 #include <Interpreters/evaluateConstantExpression.h>
 
 #include <Functions/IFunction.h>
-
 
 namespace DB
 {
@@ -26,106 +23,8 @@ namespace ErrorCodes
 
 namespace
 {
-// returns keys may be filter by condition
-bool traverseASTFilter(
-    const std::string & primary_key, const DataTypePtr & primary_key_type, const ASTPtr & elem, const PreparedSetsPtr & prepared_sets, const ContextPtr & context, FieldVectorPtr & res)
-{
-    const auto * function = elem->as<ASTFunction>();
-    if (!function)
-        return false;
 
-    if (function->name == "and")
-    {
-        // one child has the key filter condition is ok
-        for (const auto & child : function->arguments->children)
-            if (traverseASTFilter(primary_key, primary_key_type, child, prepared_sets, context, res))
-                return true;
-        return false;
-    }
-    if (function->name == "or")
-    {
-        // make sure every child has the key filter condition
-        for (const auto & child : function->arguments->children)
-            if (!traverseASTFilter(primary_key, primary_key_type, child, prepared_sets, context, res))
-                return false;
-        return true;
-    }
-    if (function->name == "equals" || function->name == "in")
-    {
-        const auto & args = function->arguments->as<ASTExpressionList &>();
-        const ASTIdentifier * ident;
-        std::shared_ptr<IAST> value;
-
-        if (args.children.size() != 2)
-            return false;
-
-        if (function->name == "in")
-        {
-            if (!prepared_sets)
-                return false;
-
-            ident = args.children.at(0)->as<ASTIdentifier>();
-            if (!ident)
-                return false;
-
-            if (ident->name() != primary_key)
-                return false;
-            value = args.children.at(1);
-
-            PreparedSets::Hash set_key = value->getTreeHash(/*ignore_aliases=*/true);
-            FutureSetPtr future_set;
-
-            if ((value->as<ASTSubquery>() || value->as<ASTIdentifier>()))
-                future_set = prepared_sets->findSubquery(set_key);
-            else
-                future_set = prepared_sets->findTuple(set_key, {primary_key_type});
-
-            if (!future_set)
-                return false;
-
-            future_set->buildOrderedSetInplace(context);
-
-            auto set = future_set->get();
-            if (!set)
-                return false;
-
-            if (!set->hasExplicitSetElements())
-                return false;
-
-            set->checkColumnsNumber(1);
-            const auto & set_column = *set->getSetElements()[0];
-
-            if (set_column.getDataType() != primary_key_type->getTypeId())
-                return false;
-
-            for (size_t row = 0; row < set_column.size(); ++row)
-                res->push_back(set_column[row]);
-            return true;
-        }
-
-        if ((ident = args.children.at(0)->as<ASTIdentifier>()))
-            value = args.children.at(1);
-        else if ((ident = args.children.at(1)->as<ASTIdentifier>()))
-            value = args.children.at(0);
-        else
-            return false;
-
-        if (ident->name() != primary_key)
-            return false;
-
-        const auto node = evaluateConstantExpressionAsLiteral(value, context);
-        /// function->name == "equals"
-        if (const auto * literal = node->as<ASTLiteral>())
-        {
-            auto converted_field = convertFieldToType(literal->value, *primary_key_type);
-            if (!converted_field.isNull())
-                res->push_back(converted_field);
-            return true;
-        }
-    }
-    return false;
-}
-
+// returns keys may be filtered by condition
 bool traverseDAGFilter(
     const std::string & primary_key, const DataTypePtr & primary_key_type, const ActionsDAG::Node * elem, const ContextPtr & context, FieldVectorPtr & res)
 {
@@ -236,18 +135,6 @@ std::pair<FieldVectorPtr, bool> getFilterKeys(
 
     FieldVectorPtr res = std::make_shared<FieldVector>();
     auto matched_keys = traverseDAGFilter(primary_key, primary_key_type, predicate, context, res);
-    return std::make_pair(res, !matched_keys);
-}
-
-std::pair<FieldVectorPtr, bool> getFilterKeys(
-    const String & primary_key, const DataTypePtr & primary_key_type, const SelectQueryInfo & query_info, const ContextPtr & context)
-{
-    const auto & select = query_info.query->as<ASTSelectQuery &>();
-    if (!select.where())
-        return {{}, true};
-
-    FieldVectorPtr res = std::make_shared<FieldVector>();
-    auto matched_keys = traverseASTFilter(primary_key, primary_key_type, select.where(), query_info.prepared_sets, context, res);
     return std::make_pair(res, !matched_keys);
 }
 

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -670,7 +670,8 @@ void ReadFromEmbeddedRocksDB::applyFilters(ActionDAGNodes added_filter_nodes)
     std::tie(keys, all_scan) = getFilterKeys(storage.primary_key, primary_key_data_type, filter_actions_dag, context);
 }
 
-void ReadFromEmbeddedRocksDB::describeActions(FormatSettings & format_settings) const {
+void ReadFromEmbeddedRocksDB::describeActions(FormatSettings & format_settings) const
+{
     std::string prefix(format_settings.offset, format_settings.indent_char);
     if (!all_scan)
     {

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -563,7 +563,12 @@ void StorageEmbeddedRocksDB::initDB()
 class ReadFromEmbeddedRocksDB : public SourceStepWithFilter
 {
 public:
-    std::string getName() const override { return "ReadFromEmbeddedRocksDB"; }
+    std::string getName() const override
+    {
+        if (!keys || keys->empty())
+            return "ReadFromEmbeddedRocksDB (FullScan)";
+        return "ReadFromEmbeddedRocksDB (GetKeys)";
+    }
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
 

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -6,6 +6,8 @@
 
 #include <Storages/StorageFactory.h>
 #include <Storages/KVStorageUtils.h>
+#include <Storages/AlterCommands.h>
+#include <Storages/RocksDB/RocksDBSettings.h>
 
 #include <Parsers/ASTCreateQuery.h>
 
@@ -29,9 +31,9 @@
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
 #include <Common/Exception.h>
+#include <Common/JSONBuilder.h>
 #include <Core/Settings.h>
-#include <Storages/AlterCommands.h>
-#include <Storages/RocksDB/RocksDBSettings.h>
+
 #include <IO/SharedThreadPools.h>
 #include <Disks/DiskLocal.h>
 #include <base/sort.h>
@@ -563,14 +565,11 @@ void StorageEmbeddedRocksDB::initDB()
 class ReadFromEmbeddedRocksDB : public SourceStepWithFilter
 {
 public:
-    std::string getName() const override
-    {
-        if (!keys || keys->empty())
-            return "ReadFromEmbeddedRocksDB (FullScan)";
-        return "ReadFromEmbeddedRocksDB (GetKeys)";
-    }
+    std::string getName() const override { return "ReadFromEmbeddedRocksDB"; }
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
+    void describeActions(FormatSettings & format_settings) const override;
+    void describeActions(JSONBuilder::JSONMap & map) const override;
 
     ReadFromEmbeddedRocksDB(
         const Names & column_names_,
@@ -669,6 +668,28 @@ void ReadFromEmbeddedRocksDB::applyFilters(ActionDAGNodes added_filter_nodes)
     const auto & sample_block = getOutputHeader();
     auto primary_key_data_type = sample_block.getByName(storage.primary_key).type;
     std::tie(keys, all_scan) = getFilterKeys(storage.primary_key, primary_key_data_type, filter_actions_dag, context);
+}
+
+void ReadFromEmbeddedRocksDB::describeActions(FormatSettings & format_settings) const {
+    std::string prefix(format_settings.offset, format_settings.indent_char);
+    if (!all_scan)
+    {
+        format_settings.out << prefix << "ReadType: GetKeys\n";
+        format_settings.out << prefix << "Keys: " << keys->size() << '\n';
+    }
+    else
+        format_settings.out << prefix << "ReadType: FullScan\n";
+}
+
+void ReadFromEmbeddedRocksDB::describeActions(JSONBuilder::JSONMap & map) const
+{
+    if (!all_scan)
+    {
+        map.add("Read Type", "GetKeys");
+        map.add("Keys", keys->size());
+    }
+    else
+        map.add("Read Type", "FullScan");
 }
 
 SinkToStoragePtr StorageEmbeddedRocksDB::write(

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -190,6 +190,7 @@ struct SelectQueryInfo
     InputOrderInfoPtr input_order_info;
 
     /// Prepared sets are used for indices by storage engine.
+    /// New analyzer stores prepared sets in planner_context and hashes computed of QueryTree instead of AST.
     /// Example: x IN (1, 2, 3)
     PreparedSetsPtr prepared_sets;
 

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -23,12 +23,12 @@
 #include <Compression/CompressedReadBufferFromFile.h>
 
 #include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
 
 #include <Processors/ISource.h>
+#include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/Sources/NullSource.h>
 #include <Processors/Sinks/SinkToStorage.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 
@@ -284,13 +284,8 @@ class StorageKeeperMapSource : public ISource, WithContext
 
     bool with_version_column = false;
 
-    static Block getHeader(Block header, bool with_version_column)
+    static Block getHeader(Block header)
     {
-        if (with_version_column)
-            header.insert(
-                    {DataTypeInt32{}.createColumn(),
-                    std::make_shared<DataTypeInt32>(), std::string{version_column_name}});
-
         return header;
     }
 
@@ -304,7 +299,7 @@ public:
         KeyContainerIter end_,
         bool with_version_column_,
         ContextPtr context_)
-        : ISource(getHeader(header, with_version_column_))
+        : ISource(getHeader(header))
         , WithContext(std::move(context_))
         , storage(storage_)
         , max_block_size(max_block_size_)
@@ -601,25 +596,60 @@ StorageKeeperMap::StorageKeeperMap(
         zk_root_path);
 }
 
+class ReadFromKeeperMap : public SourceStepWithFilter
+{
+public:
+    std::string getName() const override { return "ReadFromKeeperMap"; }
+    void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
+    void applyFilters(ActionDAGNodes added_filter_nodes) override;
 
-Pipe StorageKeeperMap::read(
-    const Names & column_names,
-    const StorageSnapshotPtr & storage_snapshot,
-    SelectQueryInfo & query_info,
-    ContextPtr context_,
-    QueryProcessingStage::Enum /*processed_stage*/,
-    size_t max_block_size,
-    size_t num_streams)
+    ReadFromKeeperMap(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        const ContextPtr & context_,
+        Block sample_block,
+        const StorageKeeperMap & storage_,
+        size_t max_block_size_,
+        size_t num_streams_,
+        bool with_version_column_)
+        : SourceStepWithFilter(std::move(sample_block), column_names_, query_info_, storage_snapshot_, context_)
+        , storage(storage_)
+        , max_block_size(max_block_size_)
+        , num_streams(num_streams_)
+        , with_version_column(with_version_column_)
+    {
+    }
+
+private:
+    const StorageKeeperMap & storage;
+
+    size_t max_block_size;
+    size_t num_streams;
+    bool with_version_column;
+
+    FieldVectorPtr keys;
+    bool all_scan = false;
+
+    template<typename KeyContainerPtr>
+    void initializePipelineImpl(QueryPipelineBuilder & pipeline, KeyContainerPtr key_container);
+
+    Strings getAllKeys() const;
+};
+
+void StorageKeeperMap::read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context_,
+        QueryProcessingStage::Enum /*processed_stage*/,
+        size_t max_block_size,
+        size_t num_streams)
 {
     checkTable<true>(context_);
     storage_snapshot->check(column_names);
-
-    FieldVectorPtr filtered_keys;
-    bool all_scan;
-
     Block sample_block = storage_snapshot->metadata->getSampleBlock();
-    auto primary_key_type = sample_block.getByName(primary_key).type;
-    std::tie(filtered_keys, all_scan) = getFilterKeys(primary_key, primary_key_type, query_info, context_);
 
     bool with_version_column = false;
     for (const auto & column : column_names)
@@ -631,56 +661,87 @@ Pipe StorageKeeperMap::read(
         }
     }
 
-    const auto process_keys = [&]<typename KeyContainerPtr>(KeyContainerPtr keys) -> Pipe
-    {
-        if (keys->empty())
-            return {};
+    if (with_version_column)
+        sample_block.insert({DataTypeInt32{}.createColumn(),
+                    std::make_shared<DataTypeInt32>(), std::string{version_column_name}});
 
-        ::sort(keys->begin(), keys->end());
-        keys->erase(std::unique(keys->begin(), keys->end()), keys->end());
+    auto reading = std::make_unique<ReadFromKeeperMap>(
+        column_names, query_info, storage_snapshot, context_, std::move(sample_block), *this, max_block_size, num_streams, with_version_column);
 
-        Pipes pipes;
+    query_plan.addStep(std::move(reading));
+}
 
-        size_t num_keys = keys->size();
-        size_t num_threads = std::min<size_t>(num_streams, keys->size());
-
-        chassert(num_keys <= std::numeric_limits<uint32_t>::max());
-        chassert(num_threads <= std::numeric_limits<uint32_t>::max());
-
-        for (size_t thread_idx = 0; thread_idx < num_threads; ++thread_idx)
-        {
-            size_t begin = num_keys * thread_idx / num_threads;
-            size_t end = num_keys * (thread_idx + 1) / num_threads;
-
-            using KeyContainer = typename KeyContainerPtr::element_type;
-            pipes.emplace_back(std::make_shared<StorageKeeperMapSource<KeyContainer>>(
-                *this, sample_block, max_block_size, keys, keys->begin() + begin, keys->begin() + end, with_version_column, context_));
-        }
-        return Pipe::unitePipes(std::move(pipes));
-    };
-
+void ReadFromKeeperMap::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+{
     if (all_scan)
-    {
-        const auto & settings = context_->getSettingsRef();
-        ZooKeeperRetriesControl zk_retry{
-            getName(),
-            getLogger(getName()),
-            ZooKeeperRetriesInfo{
-                settings[Setting::keeper_max_retries],
-                settings[Setting::keeper_retry_initial_backoff_ms],
-                settings[Setting::keeper_retry_max_backoff_ms],
-                context_->getProcessListElement()}};
+        initializePipelineImpl(pipeline, std::make_shared<Strings>(getAllKeys()));
+    else
+        initializePipelineImpl(pipeline, std::move(keys));
+}
 
-        std::vector<std::string> children;
-        zk_retry.retryLoop([&]
-        {
-            auto client = getClient();
-            children = client->getChildren(zk_data_path);
-        });
-        return process_keys(std::make_shared<std::vector<std::string>>(std::move(children)));
+void ReadFromKeeperMap::applyFilters(ActionDAGNodes added_filter_nodes)
+{
+    SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
+
+    const auto & sample_block = getOutputHeader();
+    auto primary_key_data_type = sample_block.getByName(storage.primary_key).type;
+    std::tie(keys, all_scan) = getFilterKeys(storage.primary_key, primary_key_data_type, filter_actions_dag, context);
+}
+
+template<typename KeyContainerPtr>
+void ReadFromKeeperMap::initializePipelineImpl(QueryPipelineBuilder & pipeline, KeyContainerPtr key_container)
+{
+    const auto & sample_block = getOutputHeader();
+
+    if (key_container->empty())
+    {
+        pipeline.init(Pipe(std::make_shared<NullSource>(sample_block)));
+        return;
     }
 
-    return process_keys(std::move(filtered_keys));
+    ::sort(key_container->begin(), key_container->end());
+    key_container->erase(std::unique(key_container->begin(), key_container->end()), key_container->end());
+
+    Pipes pipes;
+
+    size_t num_keys = key_container->size();
+    size_t num_threads = std::min<size_t>(num_streams, key_container->size());
+
+    chassert(num_keys <= std::numeric_limits<uint32_t>::max());
+    chassert(num_threads <= std::numeric_limits<uint32_t>::max());
+
+    for (size_t thread_idx = 0; thread_idx < num_threads; ++thread_idx)
+    {
+        size_t begin = num_keys * thread_idx / num_threads;
+        size_t end = num_keys * (thread_idx + 1) / num_threads;
+
+        using KeyContainer = typename KeyContainerPtr::element_type;
+        pipes.emplace_back(std::make_shared<StorageKeeperMapSource<KeyContainer>>(
+            storage, sample_block, max_block_size, key_container, key_container->begin() + begin, key_container->begin() + end, with_version_column, context));
+    }
+    pipeline.init(Pipe::unitePipes(std::move(pipes)));
+}
+
+Strings ReadFromKeeperMap::getAllKeys() const
+{
+    const auto & settings = context->getSettingsRef();
+    ZooKeeperRetriesControl zk_retry{
+        getName(),
+        getLogger(getName()),
+        ZooKeeperRetriesInfo{
+            settings[Setting::keeper_max_retries],
+            settings[Setting::keeper_retry_initial_backoff_ms],
+            settings[Setting::keeper_retry_max_backoff_ms],
+            context->getProcessListElement()}};
+
+    Strings children;
+    zk_retry.retryLoop([&]
+    {
+        auto client = storage.getClient();
+        children = client->getChildren(storage.zk_data_path);
+    });
+
+    return children;
 }
 
 SinkToStoragePtr StorageKeeperMap::write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr local_context, bool /*async_insert*/)

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -747,7 +747,8 @@ Strings ReadFromKeeperMap::getAllKeys() const
     return children;
 }
 
-void ReadFromKeeperMap::describeActions(FormatSettings & format_settings) const {
+void ReadFromKeeperMap::describeActions(FormatSettings & format_settings) const
+{
     std::string prefix(format_settings.offset, format_settings.indent_char);
     if (!all_scan)
     {

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -599,7 +599,12 @@ StorageKeeperMap::StorageKeeperMap(
 class ReadFromKeeperMap : public SourceStepWithFilter
 {
 public:
-    std::string getName() const override { return "ReadFromKeeperMap"; }
+    std::string getName() const override
+    {
+        if (!keys || keys->empty())
+            return "ReadFromKeeperMap (FullScan)";
+        return "ReadFromKeeperMap (GetKeys)";
+    }
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
 
@@ -676,7 +681,7 @@ void ReadFromKeeperMap::initializePipeline(QueryPipelineBuilder & pipeline, cons
     if (all_scan)
         initializePipelineImpl(pipeline, std::make_shared<Strings>(getAllKeys()));
     else
-        initializePipelineImpl(pipeline, std::move(keys));
+        initializePipelineImpl(pipeline, keys);
 }
 
 void ReadFromKeeperMap::applyFilters(ActionDAGNodes added_filter_nodes)

--- a/src/Storages/StorageKeeperMap.h
+++ b/src/Storages/StorageKeeperMap.h
@@ -26,6 +26,7 @@ namespace ErrorCodes
 // KV store using (Zoo|CH)Keeper
 class StorageKeeperMap final : public IStorage, public IKeyValueEntity, WithContext
 {
+    friend class ReadFromKeeperMap;
 public:
     StorageKeeperMap(
         ContextPtr context_,
@@ -36,12 +37,13 @@ public:
         const std::string & root_path_,
         UInt64 keys_limit_);
 
-    Pipe read(
+    void read(
+        QueryPlan & query_plan,
         const Names & column_names,
         const StorageSnapshotPtr & storage_snapshot,
         SelectQueryInfo & query_info,
-        ContextPtr context,
-        QueryProcessingStage::Enum processed_stage,
+        ContextPtr context_,
+        QueryProcessingStage::Enum /*processed_stage*/,
         size_t max_block_size,
         size_t num_streams) override;
 

--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -221,7 +221,12 @@ StorageRedis::StorageRedis(
 class ReadFromRedis : public SourceStepWithFilter
 {
 public:
-    std::string getName() const override { return "ReadFromRedis"; }
+    std::string getName() const override
+    {
+        if (!keys || keys->empty())
+            return "ReadFromRedis (FullScan)";
+        return "ReadFromRedis (GetKeys)";
+    }
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
 

--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -8,7 +8,10 @@
 #include <Parsers/ASTLiteral.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/Sinks/SinkToStorage.h>
+#include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/ISource.h>
+#include <Processors/Sources/NullSource.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 
@@ -215,53 +218,109 @@ StorageRedis::StorageRedis(
     setInMemoryMetadata(storage_metadata);
 }
 
-Pipe StorageRedis::read(
-    const Names & column_names,
-    const StorageSnapshotPtr & storage_snapshot,
-    SelectQueryInfo & query_info,
-    ContextPtr context_,
-    QueryProcessingStage::Enum /*processed_stage*/,
-    size_t max_block_size,
-    size_t num_streams)
+class ReadFromRedis : public SourceStepWithFilter
 {
-    storage_snapshot->check(column_names);
+public:
+    std::string getName() const override { return "ReadFromRedis"; }
+    void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
+    void applyFilters(ActionDAGNodes added_filter_nodes) override;
+
+    ReadFromRedis(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        const ContextPtr & context_,
+        Block sample_block,
+        StorageRedis & storage_,
+        size_t max_block_size_,
+        size_t num_streams_)
+        : SourceStepWithFilter(std::move(sample_block), column_names_, query_info_, storage_snapshot_, context_)
+        , storage(storage_)
+        , max_block_size(max_block_size_)
+        , num_streams(num_streams_)
+    {
+    }
+
+private:
+    StorageRedis & storage;
+
+    size_t max_block_size;
+    size_t num_streams;
 
     FieldVectorPtr keys;
     bool all_scan = false;
+};
 
-    Block header = storage_snapshot->metadata->getSampleBlock();
-    auto primary_key_data_type = header.getByName(primary_key).type;
+void StorageRedis::read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context_,
+        QueryProcessingStage::Enum /*processed_stage*/,
+        size_t max_block_size,
+        size_t num_streams)
+{
+    storage_snapshot->check(column_names);
+    Block sample_block = storage_snapshot->metadata->getSampleBlock();
 
-    std::tie(keys, all_scan) = getFilterKeys(primary_key, primary_key_data_type, query_info, context_);
+    auto reading = std::make_unique<ReadFromRedis>(
+        column_names, query_info, storage_snapshot, context_, std::move(sample_block), *this, max_block_size, num_streams);
+
+    query_plan.addStep(std::move(reading));
+}
+
+void ReadFromRedis::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+{
+    const auto & sample_block = getOutputHeader();
 
     if (all_scan)
     {
-        return Pipe(std::make_shared<RedisDataSource>(*this, header, max_block_size));
+        auto source = std::make_shared<RedisDataSource>(storage, sample_block, max_block_size);
+        source->setStorageLimits(query_info.storage_limits);
+        pipeline.init(Pipe(std::move(source)));
     }
-
-    if (keys->empty())
-        return {};
-
-    Pipes pipes;
-
-    ::sort(keys->begin(), keys->end());
-    keys->erase(std::unique(keys->begin(), keys->end()), keys->end());
-
-    size_t num_keys = keys->size();
-    size_t num_threads = std::min<size_t>(num_streams, keys->size());
-
-    num_threads = std::min<size_t>(num_threads, configuration.pool_size);
-    assert(num_keys <= std::numeric_limits<uint32_t>::max());
-
-    for (size_t thread_idx = 0; thread_idx < num_threads; ++thread_idx)
+    else
     {
-        size_t begin = num_keys * thread_idx / num_threads;
-        size_t end = num_keys * (thread_idx + 1) / num_threads;
+        if (keys->empty())
+        {
+            pipeline.init(Pipe(std::make_shared<NullSource>(sample_block)));
+            return;
+        }
 
-        pipes.emplace_back(
-            std::make_shared<RedisDataSource>(*this, header, keys, keys->begin() + begin, keys->begin() + end, max_block_size));
+        ::sort(keys->begin(), keys->end());
+        keys->erase(std::unique(keys->begin(), keys->end()), keys->end());
+
+        Pipes pipes;
+
+        size_t num_keys = keys->size();
+        size_t num_threads = std::min<size_t>(num_streams, keys->size());
+        num_threads = std::min<size_t>(num_threads, storage.configuration.pool_size);
+
+        assert(num_keys <= std::numeric_limits<uint32_t>::max());
+        assert(num_threads <= std::numeric_limits<uint32_t>::max());
+
+        for (size_t thread_idx = 0; thread_idx < num_threads; ++thread_idx)
+        {
+            size_t begin = num_keys * thread_idx / num_threads;
+            size_t end = num_keys * (thread_idx + 1) / num_threads;
+
+            auto source = std::make_shared<RedisDataSource>(
+                    storage, sample_block, keys, keys->begin() + begin, keys->begin() + end, max_block_size);
+            source->setStorageLimits(query_info.storage_limits);
+            pipes.emplace_back(std::move(source));
+        }
+        pipeline.init(Pipe::unitePipes(std::move(pipes)));
     }
-    return Pipe::unitePipes(std::move(pipes));
+}
+
+void ReadFromRedis::applyFilters(ActionDAGNodes added_filter_nodes)
+{
+    SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
+
+    const auto & sample_block = getOutputHeader();
+    auto primary_key_data_type = sample_block.getByName(storage.primary_key).type;
+    std::tie(keys, all_scan) = getFilterKeys(storage.primary_key, primary_key_data_type, filter_actions_dag, context);
 }
 
 namespace

--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -326,7 +326,8 @@ void ReadFromRedis::applyFilters(ActionDAGNodes added_filter_nodes)
     std::tie(keys, all_scan) = getFilterKeys(storage.primary_key, primary_key_data_type, filter_actions_dag, context);
 }
 
-void ReadFromRedis::describeActions(FormatSettings & format_settings) const {
+void ReadFromRedis::describeActions(FormatSettings & format_settings) const
+{
     std::string prefix(format_settings.offset, format_settings.indent_char);
     if (!all_scan)
     {

--- a/src/Storages/StorageRedis.h
+++ b/src/Storages/StorageRedis.h
@@ -14,6 +14,7 @@ namespace DB
  */
 class StorageRedis : public IStorage, public IKeyValueEntity, WithContext
 {
+    friend class ReadFromRedis;
 public:
     StorageRedis(
         const StorageID & table_id_,
@@ -24,12 +25,13 @@ public:
 
     std::string getName() const override { return "Redis"; }
 
-    Pipe read(
+    void read(
+        QueryPlan & query_plan,
         const Names & column_names,
         const StorageSnapshotPtr & storage_snapshot,
         SelectQueryInfo & query_info,
         ContextPtr context_,
-        QueryProcessingStage::Enum processed_stage,
+        QueryProcessingStage::Enum /*processed_stage*/,
         size_t max_block_size,
         size_t num_streams) override;
 

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
@@ -1,7 +1,10 @@
-    (ReadFromEmbeddedRocksDB (FullScan))
+    ReadFromEmbeddedRocksDB
+    ReadType: FullScan
 1
 "rows_read":1,
-    (ReadFromEmbeddedRocksDB (GetKeys))
+    ReadFromEmbeddedRocksDB
+    ReadType: GetKeys
+    Keys: 1
 2
 "rows_read":2,
 1

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
@@ -1,5 +1,7 @@
+    (ReadFromEmbeddedRocksDB (FullScan))
 1
 "rows_read":1,
+    (ReadFromEmbeddedRocksDB (GetKeys))
 2
 "rows_read":2,
 1

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
@@ -10,11 +10,11 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS rocksdb_with_filter;"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE rocksdb_with_filter (key String, value String) ENGINE=EmbeddedRocksDB PRIMARY KEY key;"
 $CLICKHOUSE_CLIENT --query="INSERT INTO rocksdb_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
-$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM rocksdb_with_filter LIMIT 1" | grep "ReadFromEmbeddedRocksDB"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM rocksdb_with_filter LIMIT 1" | grep -A 2 "ReadFromEmbeddedRocksDB"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM rocksdb_with_filter WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM rocksdb_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
-$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM rocksdb_with_filter WHERE key = '5000'" | grep "ReadFromEmbeddedRocksDB"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM rocksdb_with_filter WHERE key = '5000'" | grep -A 3 "ReadFromEmbeddedRocksDB"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM rocksdb_with_filter WHERE key = '5000' OR key = '6000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM rocksdb_with_filter WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
@@ -10,8 +10,11 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS rocksdb_with_filter;"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE rocksdb_with_filter (key String, value String) ENGINE=EmbeddedRocksDB PRIMARY KEY key;"
 $CLICKHOUSE_CLIENT --query="INSERT INTO rocksdb_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
+$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM rocksdb_with_filter LIMIT 1" | grep "ReadFromEmbeddedRocksDB"
+
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM rocksdb_with_filter WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM rocksdb_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM rocksdb_with_filter WHERE key = '5000'" | grep "ReadFromEmbeddedRocksDB"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM rocksdb_with_filter WHERE key = '5000' OR key = '6000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM rocksdb_with_filter WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
@@ -1,5 +1,7 @@
+    (ReadFromKeeperMap (FullScan))
 1
 "rows_read":1,
+    (ReadFromKeeperMap (GetKeys))
 2
 "rows_read":2,
 1
@@ -8,6 +10,7 @@
 "rows_read":2,
 1
 "rows_read":1,
+    (ReadFromKeeperMap (GetKeys))
 2
 "rows_read":2,
 1

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
@@ -1,7 +1,10 @@
-    (ReadFromKeeperMap (FullScan))
+    ReadFromKeeperMap
+    ReadType: FullScan
 1
 "rows_read":1,
-    (ReadFromKeeperMap (GetKeys))
+    ReadFromKeeperMap
+    ReadType: GetKeys
+    Keys: 1
 2
 "rows_read":2,
 1
@@ -10,7 +13,9 @@
 "rows_read":2,
 1
 "rows_read":1,
-    (ReadFromKeeperMap (GetKeys))
+    ReadFromKeeperMap
+    ReadType: GetKeys
+    Keys: 1
 2
 "rows_read":2,
 1

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
@@ -1,0 +1,16 @@
+1
+"rows_read":1,
+2
+"rows_read":2,
+1
+"rows_read":1,
+2
+"rows_read":2,
+1
+"rows_read":1,
+2
+"rows_read":2,
+1
+"rows_read":1,
+2
+"rows_read":2,

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
@@ -8,41 +8,41 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS keeper_map_with_filter;"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, value String) ENGINE=KeeperMap(concat(currentDatabase(), '_simple')) PRIMARY KEY key;"
-$CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
+$CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10) n;"
 
 $CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter LIMIT 1" | grep -A 2 "ReadFromKeeperMap"
 
-$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5000'"
-$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
-$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter WHERE key = '5000'" | grep -A 3 "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5'"
+$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter WHERE key = '5'" | grep -A 3 "ReadFromKeeperMap"
 
-$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5000' OR key = '6000'"
-$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5' OR key = '6'"
+$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5' OR key = '6' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
 
-$CLICKHOUSE_CLIENT "--param_key=5000" --query "SELECT count() FROM keeper_map_with_filter WHERE key = {key:String}"
-$CLICKHOUSE_CLIENT "--param_key=5000" --query "SELECT value FROM keeper_map_with_filter WHERE key = {key:String} FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT "--param_key=5" --query "SELECT count() FROM keeper_map_with_filter WHERE key = {key:String}"
+$CLICKHOUSE_CLIENT "--param_key=5" --query "SELECT value FROM keeper_map_with_filter WHERE key = {key:String} FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
 
-$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key IN ('5000', '6000')"
-$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key IN ('5000', '6000') FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key IN ('5', '6')"
+$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key IN ('5', '6') FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE keeper_map_with_filter;"
 
 # Same test, but with complex key
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS keeper_map_with_filter_and_complex_key;"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter_and_complex_key (key String, value String) ENGINE=KeeperMap(concat(currentDatabase(), '_complex')) PRIMARY KEY hex(toFloat32(key));"
-$CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter_and_complex_key (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
+$CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter_and_complex_key (*) SELECT n.number, n.number*10 FROM numbers(10) n;"
 
-$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'"
-$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
-$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'" | grep -A 3 "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5'"
+$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5'" | grep -A 3 "ReadFromKeeperMap"
 
-$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' OR key = '6000'"
-$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5' OR key = '6'"
+$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5' OR key = '6' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
 
-$CLICKHOUSE_CLIENT "--param_key=5000" --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = {key:String}"
-$CLICKHOUSE_CLIENT "--param_key=5000" --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = {key:String} FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT "--param_key=5" --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = {key:String}"
+$CLICKHOUSE_CLIENT "--param_key=5" --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = {key:String} FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
 
-$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key IN ('5000', '6000')"
-$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key IN ('5000', '6000') FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key IN ('5', '6')"
+$CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key IN ('5', '6') FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE keeper_map_with_filter_and_complex_key;"

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
@@ -10,11 +10,11 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS keeper_map_with_filter;"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, value String) ENGINE=KeeperMap('test') PRIMARY KEY key;"
 $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
-$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM keeper_map_with_filter LIMIT 1" | grep "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter LIMIT 1" | grep -A 2 "ReadFromKeeperMap"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
-$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM keeper_map_with_filter WHERE key = '5000'" | grep "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter WHERE key = '5000'" | grep -A 3 "ReadFromKeeperMap"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5000' OR key = '6000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
@@ -34,7 +34,7 @@ $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter_and_complex_key (
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
-$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'" | grep "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'" | grep -A 3 "ReadFromKeeperMap"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' OR key = '6000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS keeper_map_with_filter;"
-$CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, value String) ENGINE=KeeperMap('test') PRIMARY KEY key;"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, value String) ENGINE=KeeperMap(concat(currentDatabase(), '_simple')) PRIMARY KEY key;"
 $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
 $CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter LIMIT 1" | grep -A 2 "ReadFromKeeperMap"
@@ -29,7 +29,7 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE keeper_map_with_filter;"
 
 # Same test, but with complex key
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS keeper_map_with_filter_and_complex_key;"
-$CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter_and_complex_key (key String, value String) ENGINE=KeeperMap('test_complex') PRIMARY KEY hex(toFloat32(key));"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter_and_complex_key (key String, value String) ENGINE=KeeperMap(concat(currentDatabase(), '_complex')) PRIMARY KEY hex(toFloat32(key));"
 $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter_and_complex_key (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'"

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-ordinary-database
+# Tag no-ordinary-database: KeeperMap doesn't support Ordinary database
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -9,8 +10,11 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS keeper_map_with_filter;"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, value String) ENGINE=KeeperMap('test') PRIMARY KEY key;"
 $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
+$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM keeper_map_with_filter LIMIT 1" | grep "ReadFromKeeperMap"
+
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM keeper_map_with_filter WHERE key = '5000'" | grep "ReadFromKeeperMap"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5000' OR key = '6000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
@@ -30,6 +34,7 @@ $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter_and_complex_key (
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"
+$CLICKHOUSE_CLIENT --query "EXPLAIN PIPELINE SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000'" | grep "ReadFromKeeperMap"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' OR key = '6000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter_and_complex_key WHERE key = '5000' OR key = '6000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"


### PR DESCRIPTION
The previous implementation doesn't work with the new analyzer. Continuation for #56391

Closes #81740

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix filter by key for Redis and KeeperMap storages

