### PR TITLE
Forbid to create not insertable tables

### DIFF
--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -44,6 +44,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int CANNOT_GET_CREATE_TABLE_QUERY;
     extern const int BAD_ARGUMENTS;
+    extern const int EMPTY_LIST_OF_COLUMNS_PASSED;
 }
 namespace
 {
@@ -70,6 +71,9 @@ void validateCreateQuery(const ASTCreateQuery & query, ContextPtr context)
     /// SECONDARY_CREATE should check most of the important things.
     const auto columns_desc
         = InterpreterCreateQuery::getColumnsDescription(*columns.columns, context, LoadingStrictnessLevel::SECONDARY_CREATE, false);
+
+    if (columns_desc.getInsertable().empty())
+        throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED, "Cannot CREATE table without insertable columns");
 
     /// Default expressions are only validated in level CREATE, so let's check them now
     DefaultExpressionsInfo default_expr_info{std::make_shared<ASTExpressionList>()};

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -734,7 +734,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
     if (res.getAllPhysical().empty())
         throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED, "Cannot CREATE table without physical columns");
 
-    if (mode <= LoadingStrictnessLevel::SECONDARY_CREATE && !is_restore_from_backup && res.getInsertable().empty())
+    if (mode <= LoadingStrictnessLevel::CREATE && !is_restore_from_backup && res.getInsertable().empty())
         throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED, "Cannot CREATE table without insertable columns");
 
     return res;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -731,9 +731,11 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
     if (mode <= LoadingStrictnessLevel::SECONDARY_CREATE && !is_restore_from_backup && context_->getSettingsRef()[Setting::flatten_nested])
         res.flattenNested();
 
-
     if (res.getAllPhysical().empty())
         throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED, "Cannot CREATE table without physical columns");
+
+    if (mode <= LoadingStrictnessLevel::SECONDARY_CREATE && !is_restore_from_backup && res.getInsertable().empty())
+        throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED, "Cannot CREATE table without insertable columns");
 
     return res;
 }

--- a/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.reference
+++ b/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.reference
@@ -1,5 +1,5 @@
 CREATE DICTIONARY default.dict\n(\n    `id` UInt32,\n    `value` String\n)\nPRIMARY KEY id\nSOURCE(CLICKHOUSE(HOST \'localhost\' PORT 9000 USER \'default\' DB \'default\' TABLE \'view\'))\nLIFETIME(MIN 600 MAX 600)\nLAYOUT(HASHED())
-CREATE TABLE default.`table`\n(\n    `col` String MATERIALIZED dictGet(\'default.dict\', \'value\', toUInt32(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.`table`\n(\n    `col` String MATERIALIZED dictGet(\'default.dict\', \'value\', toUInt32(1)),\n    `phys` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 1	v
 1	v
 1	v

--- a/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.sql
+++ b/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.sql
@@ -14,7 +14,8 @@ SHOW CREATE dict;
 
 CREATE TABLE table
 (
-    col MATERIALIZED dictGet(currentDatabase() || '.dict', 'value', toUInt32(1))
+    col MATERIALIZED dictGet(currentDatabase() || '.dict', 'value', toUInt32(1)),
+    phys Int
 )
 ENGINE = MergeTree()
 ORDER BY tuple();

--- a/tests/queries/0_stateless/03199_join_with_materialized_column.sql
+++ b/tests/queries/0_stateless/03199_join_with_materialized_column.sql
@@ -1,6 +1,6 @@
 SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS table_with_materialized;
-CREATE TABLE table_with_materialized (col String MATERIALIZED 'A') ENGINE = Memory;
+CREATE TABLE table_with_materialized (col String MATERIALIZED 'A', ins Int Ephemeral) ENGINE = Memory;
 SELECT number FROM numbers(1) AS n, table_with_materialized;
 DROP TABLE table_with_materialized;

--- a/tests/queries/0_stateless/03541_table_without_insertable_columns.sql
+++ b/tests/queries/0_stateless/03541_table_without_insertable_columns.sql
@@ -1,0 +1,12 @@
+-- Tags: no-parallel, no-ordinary-database
+-- Tag no-parallel: static UUID
+-- Tag no-ordinary-database: requires UUID
+
+CREATE TABLE no_physical (a Int EPHEMERAL) Engine=Memory; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }
+CREATE TABLE no_physical (a Int ALIAS 1) Engine=Memory; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }
+
+CREATE TABLE no_insertable (a Int MATERIALIZED 1) Engine=Memory; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }
+ATTACH TABLE no_insertable UUID '00000000-0000-0000-0000-000000000001' (a Int MATERIALIZED 1) Engine=Memory;
+
+CREATE TABLE insertable (a Int EPHEMERAL, b Int MATERIALIZED 1) Engine=Memory;
+ALTER TABLE insertable DROP COLUMN a; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }


### PR DESCRIPTION
Materialized columns are physical, but data can't be inserted into such tables without a Default or Ephemeral column.
It can break clickhouse-client in cases like the linked issue.

Closes #72139

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Forbid the creation of a table without insertable columns. 

