### PR TITLE
ci: fix *_log tables with non-local default disk

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -28,6 +28,7 @@ common_ft_job_config = Job.Config(
     digest_config=Job.CacheDigestConfig(
         include_paths=[
             "./ci/jobs/functional_tests.py",
+            "./ci/jobs/scripts/clickhouse_proc.py",
             "./tests/queries",
             "./tests/clickhouse-test",
             "./tests/config",

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -967,6 +967,8 @@ quit
         command_args = self.LOGS_SAVER_CLIENT_OPTIONS
         # command_args += f" --config-file={self.ch_config_dir}/config.xml"
         command_args += " --only-system-tables --stacktrace"
+        # we need disk definitions for S3 configurations, but it is OK to always use server config
+        command_args += " --config-file=/etc/clickhouse-server/config.xml"
         # FIXME: Hack for s3_with_keeper (note, that we don't need the disk,
         # the problem is that whenever we need disks all disks will be
         # initialized [1])


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/81751