### PR TITLE
tests: enable some debugging for 02160_client_autocomplete_parse_query

### DIFF
--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -11,7 +11,9 @@ exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
 set history_file $CLICKHOUSE_TMP/$basename.history
 
 log_user 0
-set timeout 60
+# FIXME: workaround to obtain the stacktrace of the client in case of timeout
+# (clickhouse-test wrapper does this on timeout)
+set timeout 3600
 set uuid ""
 match_max 100000
 expect_after {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This test is flaky now and I have no idea why (likely after #81759), although I can likely fix the test, but I want to understand the root cause, so let's enable some debugging first

Refs: https://github.com/ClickHouse/ClickHouse/issues/81893