### PR TITLE
tests: improve stateless tests for clickhouse-server

### DIFF
--- a/tests/queries/0_stateless/01507_clickhouse_server_start_with_embedded_config.sh
+++ b/tests/queries/0_stateless/01507_clickhouse_server_start_with_embedded_config.sh
@@ -13,7 +13,8 @@ echo "Starting clickhouse-server"
 $CLICKHOUSE_BINARY server -- --tcp_port "$CLICKHOUSE_PORT_TCP" --path "${CLICKHOUSE_TMP}/" > server.log 2>&1 &
 PID=$!
 
-function finish {
+function finish()
+{
     kill $PID
     wait
 }
@@ -45,4 +46,14 @@ $CLICKHOUSE_CLIENT --query "
     CREATE TEMPORARY TABLE t (s String);
     INSERT INTO t VALUES ('World');
     SELECT * FROM t;
-";
+"
+
+kill $PID
+# Dump server.log in case wait hangs
+function trace()
+{
+    cat server.log
+}
+trap trace EXIT
+wait
+trap '' EXIT

--- a/tests/queries/0_stateless/01507_clickhouse_server_start_with_embedded_config.sh
+++ b/tests/queries/0_stateless/01507_clickhouse_server_start_with_embedded_config.sh
@@ -52,7 +52,8 @@ kill $PID
 # Dump server.log in case wait hangs
 function trace()
 {
-    cat "${CLICKHOUSE_TMP}/server.log"
+    # clickhouse-test prints only stderr on timeouts
+    cat "${CLICKHOUSE_TMP}/server.log" >&2
 }
 trap trace EXIT
 wait

--- a/tests/queries/0_stateless/01507_clickhouse_server_start_with_embedded_config.sh
+++ b/tests/queries/0_stateless/01507_clickhouse_server_start_with_embedded_config.sh
@@ -10,7 +10,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "Starting clickhouse-server"
 
-$CLICKHOUSE_BINARY server -- --tcp_port "$CLICKHOUSE_PORT_TCP" --path "${CLICKHOUSE_TMP}/" > server.log 2>&1 &
+$CLICKHOUSE_BINARY server -- --tcp_port "$CLICKHOUSE_PORT_TCP" --path "${CLICKHOUSE_TMP}/" > "${CLICKHOUSE_TMP}/server.log" 2>&1 &
 PID=$!
 
 function finish()
@@ -26,7 +26,7 @@ for i in {1..30}; do
     sleep 1
     $CLICKHOUSE_CLIENT --query "SELECT 1" 2>/dev/null && break
     if [[ $i == 30 ]]; then
-        cat server.log
+        cat "${CLICKHOUSE_TMP}/server.log"
         exit 1
     fi
 done
@@ -52,7 +52,7 @@ kill $PID
 # Dump server.log in case wait hangs
 function trace()
 {
-    cat server.log
+    cat "${CLICKHOUSE_TMP}/server.log"
 }
 trap trace EXIT
 wait

--- a/tests/queries/0_stateless/02922_server_exit_code.sh
+++ b/tests/queries/0_stateless/02922_server_exit_code.sh
@@ -5,8 +5,18 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# Print server log in case of test hungs
+function cleanup()
+{
+    cat "${CLICKHOUSE_TMP}/server.log" >&2
+}
+trap cleanup EXIT
+
 # We will check that the server's exit code corresponds to the exception code if it was terminated after exception.
 # In this example, we provide an invalid path to the server's config, ignore its logs and check the exit code.
 # The exception code is 76 = CANNOT_OPEN_FILE, so the exit code will be 76 % 256.
 
-${CLICKHOUSE_SERVER_BINARY} -- --path /dev/null 2>/dev/null; [[ "$?" == "$((76 % 256))" ]] && echo 'Ok' || echo 'Fail'
+${CLICKHOUSE_SERVER_BINARY} -- --path /dev/null 2>"${CLICKHOUSE_TMP}/server.log"
+[[ "$?" == "$((76 % 256))" ]] && echo 'Ok' || echo 'Fail'
+# Server terminated, reset debug trap
+trap '' EXIT


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This test became flaky recently (first relevant failure from 3 of Jun), but it hangs during server shutdown, let's add some debugging - https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgNDggZGF5Ci8vICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKSAKICAgIEFORCBjaGVja19zdGF0dXMgIT0gJ3N1Y2Nlc3MnCiAgICBBTkQgcG9zaXRpb24odGVzdF9uYW1lLCAnMDE1MDdfY2xpY2tob3VzZV9zZXJ2ZXJfc3RhcnRfd2l0aF9lbWJlZGRlZF9jb25maWcnKSA+IDAKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZQ==