### PR TITLE
Docs: Remove deprecation notice from 'ngrams' function

### DIFF
--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -351,8 +351,6 @@ Result:
 
 Splits a UTF-8 string into n-grams of `ngramsize` symbols.
 
-This function is equivalent to function [tokens](#tokens) with the `ngram` tokenizer.
-
 **Syntax**
 
 ```sql

--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -349,12 +349,9 @@ Result:
 
 ## ngrams {#ngrams}
 
-<DeprecatedBadge/>
-
 Splits a UTF-8 string into n-grams of `ngramsize` symbols.
-This function is deprecated.
-Please use function [tokens](#tokens) with the `ngram` tokenizer.
-The function might be removed at some point in future.
+
+This function is equivalent to function [tokens](#tokens) with the `ngram` tokenizer.
 
 **Syntax**
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)