### PR TITLE
Fix `test_keeper_snapshot_on_exit`

### DIFF
--- a/tests/integration/test_keeper_snapshot_on_exit/configs/enable_keeper1.xml
+++ b/tests/integration/test_keeper_snapshot_on_exit/configs/enable_keeper1.xml
@@ -9,7 +9,7 @@
         <coordination_settings>
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>10000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
+            <raft_logs_level>test</raft_logs_level>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/test_keeper_snapshot_on_exit/configs/enable_keeper2.xml
+++ b/tests/integration/test_keeper_snapshot_on_exit/configs/enable_keeper2.xml
@@ -9,7 +9,7 @@
         <coordination_settings>
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>10000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
+            <raft_logs_level>test</raft_logs_level>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/test_keeper_snapshot_on_exit/test.py
+++ b/tests/integration/test_keeper_snapshot_on_exit/test.py
@@ -37,7 +37,9 @@ def test_snapshot_on_exit(started_cluster):
     zk_conn = None
     try:
         zk_conn = get_fake_zk(node1)
-        zk_conn.create("/some_path", b"some_data")
+
+        if not zk_conn.exists("/some_path"):
+            zk_conn.create("/some_path", b"some_data")
 
         zk_conn.stop()
         zk_conn.close()
@@ -58,7 +60,3 @@ def test_snapshot_on_exit(started_cluster):
         if zk_conn:
             zk_conn.stop()
             zk_conn.close()
-
-        zk_conn = get_fake_zk(node1)
-        if zk_conn.exists("/some_path"):
-            zk_conn.delete("/some_path")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Close https://github.com/ClickHouse/ClickHouse/issues/80424

For some reason after restart, node1 raft instance cannot make connection to node2 raft instance when requesting session ID.
I couldn't find a reason why but I removed the place where the issue happens because it's not actually useful. I also increased log level for Raft to make it easier to debug.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
