### PR TITLE
Start MinIO and Azurite sync

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -345,7 +345,8 @@ class ClickHouseProc:
             self.minio_proc = subprocess.Popen(
                 command, stdout=log_file, stderr=subprocess.STDOUT
             )
-        print(f"Started setup_minio.sh asynchronously with PID {self.minio_proc.pid}")
+            self.minio_proc.wait()
+        print(f"Started setup_minio.sh with PID {self.minio_proc.pid}")
         return True
 
     def start_azurite(self):
@@ -356,7 +357,8 @@ class ClickHouseProc:
             self.azurite_proc = subprocess.Popen(
                 command, stdout=log_file, stderr=subprocess.STDOUT, shell=True
             )
-        print(f"Started azurite asynchronously with PID {self.azurite_proc.pid}")
+            self.azurite_proc.wait()
+        print(f"Started azurite with PID {self.azurite_proc.pid}")
         return True
 
     @staticmethod


### PR DESCRIPTION
### Changelog category (leave one):

- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Scripts to start MinIO and Azurite required to be started synchronously (they launch the process in a background themselves). 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
