### PR TITLE
Fix test_refreshable_mat_view_replicated test_append flakiness

### DIFF
--- a/src/Common/CalendarTimeInterval.cpp
+++ b/src/Common/CalendarTimeInterval.cpp
@@ -59,6 +59,8 @@ CalendarTimeInterval::Intervals CalendarTimeInterval::toIntervals() const
     };
     greedy(months, {{IntervalKind::Kind::Year, 12}, {IntervalKind::Kind::Month, 1}});
     greedy(seconds, {{IntervalKind::Kind::Week, 3600*24*7}, {IntervalKind::Kind::Day, 3600*24}, {IntervalKind::Kind::Hour, 3600}, {IntervalKind::Kind::Minute, 60}, {IntervalKind::Kind::Second, 1}});
+    if (res.empty())
+        res.emplace_back(IntervalKind::Kind::Second, 0);
     return res;
 }
 

--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -247,8 +247,6 @@ def test_append(
     empty,
 ):
     opposite_minutes = math.floor((time.time() + 1800) % 3600 / 60)
-    if opposite_minutes == 0:
-        opposite_minutes = 1
 
     create_sql = CREATE_RMV.render(
         table_name="test_rmv",

--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import time
+import math
 from datetime import datetime
 from typing import Optional
 
@@ -238,11 +239,6 @@ def fn_setup_tables():
     "empty",
     [True, False],
 )
-@pytest.mark.skipif(
-    datetime.now().minute > 57,
-    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
-           'which might trigger it earlier than expected'
-)
 def test_append(
     module_setup_tables,
     fn_setup_tables,
@@ -250,9 +246,10 @@ def test_append(
     with_append,
     empty,
 ):
+    opposite_minutes = math.floor((time.time() + 1800) % 3600 / 60)
     create_sql = CREATE_RMV.render(
         table_name="test_rmv",
-        refresh_interval="EVERY 1 HOUR",
+        refresh_interval=f"EVERY 1 HOUR OFFSET {opposite_minutes} MINUTE",
         to_clause="tgt1",
         select_query=select_query,
         with_append=with_append,
@@ -301,11 +298,6 @@ def test_append(
             "refresh_retry_max_backoff_ms": "20",
         },
     ],
-)
-@pytest.mark.skipif(
-    datetime.now().minute > 57,
-    reason='"EVERY 1 HOUR" refresh interval schedules the refresh to occur at the start of the next hour, '
-           'which might trigger it earlier than expected'
 )
 def test_alters(
     module_setup_tables,

--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -247,6 +247,9 @@ def test_append(
     empty,
 ):
     opposite_minutes = math.floor((time.time() + 1800) % 3600 / 60)
+    if opposite_minutes == 0:
+        opposite_minutes = 1
+
     create_sql = CREATE_RMV.render(
         table_name="test_rmv",
         refresh_interval=f"EVERY 1 HOUR OFFSET {opposite_minutes} MINUTE",


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/81890

The test did `REFRESH EVERY 1 HOUR` and `@pytest.mark.skipif(datetime.now().minute > 57)` to make sure the hourly refresh doesn't happen during the test. This turned out to be unreliable because `skipif` is evaluated before running a *group* of tests, which may take longer than 3 minutes before this test starts. This PR does `EVERY 1 HOUR OFFSET {opposite_minutes} MINUTE` instead, so the first refresh is always scheduled 30 minutes after RMV is created.