### PR TITLE
Disable async logger due to possible deadlock on shutdown

### DIFF
--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -65,7 +65,7 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
 
     /// Split logs to ordinary log, error log, syslog and console.
     /// Use extended interface of Channel for more comprehensive logging.
-    if (config.getBool("logger.async", true))
+    if (config.getBool("logger.async", false))
         split = new DB::OwnAsyncSplitChannel();
     else
         split = new DB::OwnSplitChannel();


### PR DESCRIPTION
Refs: https://pastila.nl/?0024bdfc/d647932af97f68f225dffef20154f102#aF2+D7zvdKZfYBT3/baJ2w==

Otherwise it breaks some tests, i.e. https://github.com/ClickHouse/ClickHouse/pull/81916

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Introduced in: https://github.com/ClickHouse/ClickHouse/pull/80125