### PR TITLE
test: disable parallel run for test_backup_restore_on_cluster/test_concurrency.py

### DIFF
--- a/tests/integration/parallel_skip.yaml
+++ b/tests/integration/parallel_skip.yaml
@@ -50,3 +50,5 @@
 - test_user_ip_restrictions/
 - test_zookeeper_config_load_balancing/
 - test_zookeeper_fallback_session/
+# Creates too much servers
+- test_backup_restore_on_cluster/test_concurrency.py


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I saw that sometimes clickhouse-server got KILLed, so I think should help

Fixes: https://github.com/ClickHouse/ClickHouse/issues/81783