### PR TITLE
Tune TCP servers queue (64 by default) based on listen_backlog (4096 by default)

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -432,6 +432,15 @@ static std::string getCanonicalPath(std::string && path)
     return std::move(path);
 }
 
+static constexpr unsigned DEFAULT_LISTEN_BACKLOG = 4096;
+
+static Poco::Net::TCPServerParams::Ptr makeServerParams(const Poco::Util::AbstractConfiguration & config)
+{
+    Poco::Net::TCPServerParams::Ptr params = new Poco::Net::TCPServerParams();
+    params->setMaxQueued(config.getUInt("listen_backlog", DEFAULT_LISTEN_BACKLOG));
+    return params;
+}
+
 Poco::Net::SocketAddress Server::socketBindListen(
     const Poco::Util::AbstractConfiguration & config,
     Poco::Net::ServerSocket & socket,
@@ -448,7 +457,7 @@ Poco::Net::SocketAddress Server::socketBindListen(
         LOG_DEBUG(&logger(), "Requested any available port (port == 0), actual port is {:d}", address.port());
     }
 
-    socket.listen(/* backlog = */ config.getUInt("listen_backlog", 4096));
+    socket.listen(/* backlog = */ config.getUInt("listen_backlog", DEFAULT_LISTEN_BACKLOG));
 
     return address;
 }
@@ -2853,6 +2862,7 @@ void Server::createServers(
     http_params->setTimeout(settings[Setting::http_receive_timeout]);
     http_params->setKeepAliveTimeout(global_context->getServerSettings()[ServerSetting::keep_alive_timeout]);
     http_params->setMaxKeepAliveRequests(static_cast<int>(global_context->getServerSettings()[ServerSetting::max_keep_alive_requests]));
+    http_params->setMaxQueued(config.getUInt("listen_backlog", DEFAULT_LISTEN_BACKLOG));
 
     Poco::Util::AbstractConfiguration::Keys protocols;
     config.keys("protocols", protocols);
@@ -2908,7 +2918,7 @@ void Server::createServers(
                         stack.release(),
                         server_pool,
                         socket,
-                        new Poco::Net::TCPServerParams,
+                        makeServerParams(config),
                         connection_filter));
             });
         }
@@ -2980,7 +2990,7 @@ void Server::createServers(
                         new TCPHandlerFactory(*this, /* secure */ false, /* proxy protocol */ false, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes),
                         server_pool,
                         socket,
-                        new Poco::Net::TCPServerParams,
+                        makeServerParams(config),
                         connection_filter));
             });
         }
@@ -3003,7 +3013,7 @@ void Server::createServers(
                         new TCPHandlerFactory(*this, /* secure */ false, /* proxy protocol */ true, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes),
                         server_pool,
                         socket,
-                        new Poco::Net::TCPServerParams,
+                        makeServerParams(config),
                         connection_filter));
             });
         }
@@ -3027,7 +3037,7 @@ void Server::createServers(
                         new TCPHandlerFactory(*this, /* secure */ true, /* proxy protocol */ false, ProfileEvents::InterfaceNativeReceiveBytes, ProfileEvents::InterfaceNativeSendBytes),
                         server_pool,
                         socket,
-                        new Poco::Net::TCPServerParams,
+                        makeServerParams(config),
                         connection_filter));
     #else
                 UNUSED(port);
@@ -3059,7 +3069,7 @@ void Server::createServers(
                             new SSHPtyHandlerFactory(*this, config),
                             server_pool,
                             socket,
-                            new Poco::Net::TCPServerParams,
+                            makeServerParams(config),
                             connection_filter));
 #else
                 UNUSED(port);
@@ -3081,7 +3091,12 @@ void Server::createServers(
                     listen_host,
                     port_name,
                     "MySQL compatibility protocol: " + address.toString(),
-                    std::make_unique<TCPServer>(new MySQLHandlerFactory(*this, ProfileEvents::InterfaceMySQLReceiveBytes, ProfileEvents::InterfaceMySQLSendBytes), server_pool, socket, new Poco::Net::TCPServerParams, connection_filter));
+                    std::make_unique<TCPServer>(
+                         new MySQLHandlerFactory(*this, ProfileEvents::InterfaceMySQLReceiveBytes, ProfileEvents::InterfaceMySQLSendBytes),
+                         server_pool,
+                         socket,
+                         makeServerParams(config),
+                         connection_filter));
             });
         }
 
@@ -3099,9 +3114,19 @@ void Server::createServers(
                     port_name,
                     "PostgreSQL compatibility protocol: " + address.toString(),
 #if USE_SSL
-                    std::make_unique<TCPServer>(new PostgreSQLHandlerFactory(*this, Poco::Net::SSLManager::CFG_SERVER_PREFIX, ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes), server_pool, socket, new Poco::Net::TCPServerParams, connection_filter));
+                    std::make_unique<TCPServer>(
+                         new PostgreSQLHandlerFactory(*this, Poco::Net::SSLManager::CFG_SERVER_PREFIX, ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes),
+                         server_pool,
+                         socket,
+                         makeServerParams(config),
+                         connection_filter));
 #else
-                    std::make_unique<TCPServer>(new PostgreSQLHandlerFactory(*this, ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes), server_pool, socket, new Poco::Net::TCPServerParams, connection_filter));
+                    std::make_unique<TCPServer>(
+                         new PostgreSQLHandlerFactory(*this, ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes),
+                         server_pool,
+                         socket,
+                         makeServerParams(config),
+                         connection_filter));
 #endif
             });
         }
@@ -3157,6 +3182,7 @@ void Server::createInterserverServers(
     Poco::Net::HTTPServerParams::Ptr http_params = new Poco::Net::HTTPServerParams;
     http_params->setTimeout(settings[Setting::http_receive_timeout]);
     http_params->setKeepAliveTimeout(global_context->getServerSettings()[ServerSetting::keep_alive_timeout]);
+    http_params->setMaxQueued(config.getUInt("listen_backlog", DEFAULT_LISTEN_BACKLOG));
 
     /// Now iterate over interserver_listen_hosts
     for (const auto & interserver_listen_host : interserver_listen_hosts)


### PR DESCRIPTION
64 (default) is too low and you may get "Refusing connection from {}, reached max queue size 64" error:

    2025.06.16 19:46:25.499209 [ 1745 ] {} <Warning> Poco: Refusing connection from [::ffff:127.0.0.1]:44562, reached max queue size 64
    2025.06.16 19:46:25.499258 [ 1745 ] {} <Warning> Poco: Refusing connection from [::ffff:127.0.0.1]:44570, reached max queue size 64
    2025.06.16 19:46:25.499283 [ 1745 ] {} <Warning> Poco: Refusing connection from [::ffff:127.0.0.1]:44576, reached max queue size 64

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Tune TCP servers queue (64 by default) based on listen_backlog (4096 by default)