### PR TITLE
tests: limit concurrency in 03540_system_dashboards (to fix possible flakiness)

### DIFF
--- a/tests/queries/0_stateless/03540_system_dashboards.sh
+++ b/tests/queries/0_stateless/03540_system_dashboards.sh
@@ -11,9 +11,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # - replace default with test_shard_localhost (CI does not have default cluster)
 # - replace log_ with log$ to avoid reading all tables matching $log_ pattern, since this also includes distributed tables from ci-logs
-mapfile queries <<<"$($CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}&default_format=LineAsString" -d "SELECT formatQuerySingleLine(replace(replace(query, '(default', '(test_shard_localhost'), '_log', '_log$')) FROM system.dashboards")"
+mapfile queries <<<"$($CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}&default_format=LineAsString" -d "SELECT encodeURLComponent(formatQuerySingleLine(replace(replace(query, '(default', '(test_shard_localhost'), '_log', '_log$'))) FROM system.dashboards")"
 $CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}" -d "SYSTEM FLUSH LOGS"
 for q in "${queries[@]}"; do
-  $CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}&param_rounding=60&param_seconds=600&serialize_query_plan=0&default_format=Null" -d "$q" || echo "$q" &
-done
-wait
+  echo "${CLICKHOUSE_URL}&param_rounding=60&param_seconds=600&serialize_query_plan=0&default_format=Null&query=$q"
+done | {
+  # - -n1 - we need real parallellism
+  xargs -n1 -P10 $CLICKHOUSE_CURL -sSk
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Even though the initial root cause has been fixed (in https://github.com/ClickHouse/ClickHouse/pull/82045), it still make sense to limit the concurrency