### PR TITLE
Demo: Specify argument types explicitly

### DIFF
--- a/src/Common/FunctionDocumentation.h
+++ b/src/Common/FunctionDocumentation.h
@@ -48,11 +48,14 @@ struct FunctionDocumentation
 
     struct Argument
     {
-        std::string name;
-        std::string description;
+        std::string name;                     /// E.g. "y"
+        std::string description;              /// E.g. "The divisor."
+        std::vector<std::string> types = {};  /// E.g. {"(U)Int*", "Float*"}
+                                              /// Default initialized only during a transition period, see 'argumentsAsString'.
     };
     using Arguments = std::vector<Argument>;
 
+    /// TODO Provide the type explicitly like in Arguments above^^.
     using ReturnedValue = std::string;
 
     struct Example

--- a/src/Functions/toStartOfFiveMinutes.cpp
+++ b/src/Functions/toStartOfFiveMinutes.cpp
@@ -21,7 +21,7 @@ The return type can be configured by setting [`enable_extended_results_for_datet
 toStartOfFiveMinutes(datetime)
     )";
     FunctionDocumentation::Arguments arguments_to_start_of_five_minutes = {
-        {"datetime", "A date with time to round. [`DateTime`](../data-types/datetime.md)/[`DateTime64`](../data-types/datetime64.md)."}
+        {"datetime", "A date with time to round.", {"DateTime", "DateTime64"}}
     };
     FunctionDocumentation::ReturnedValue returned_value_to_start_of_five_minutes = "Returns the date with time rounded to the start of the nearest five-minute interval. [`DateTime`](../data-types/datetime.md)/[`DateTime64`](../data-types/datetime64.md).";
     FunctionDocumentation::Examples examples_to_start_of_five_minutes = {

--- a/src/Functions/toStartOfMinute.cpp
+++ b/src/Functions/toStartOfMinute.cpp
@@ -21,7 +21,7 @@ The return type can be configured by setting [`enable_extended_results_for_datet
 toStartOfMinute(datetime)
     )";
     FunctionDocumentation::Arguments arguments_to_start_of_minute = {
-        {"datetime", "A date with time to convert. [`DateTime`](../data-types/datetime.md)/[`DateTime64`](../data-types/datetime64.md)."}
+        {"datetime", "A date with time to convert.", {"DateTime", "DateTime64"}}
     };
     FunctionDocumentation::ReturnedValue returned_value_to_start_of_minute =
         "Returns the date with time rounded down to the start of the minute. [`DateTime`](../data-types/datetime.md)/[`DateTime64`](../data-types/datetime64.md).";


### PR DESCRIPTION
Relates to the discussion in https://github.com/ClickHouse/ClickHouse/pull/81551#discussion_r2151815217

Demonstrates one approach that I liked most after some thinking and experimentation.

Previously, the developer needed to write:

```cpp
{"datetime", "A date with time to round. [`DateTime`](../data-types/datetime.md)/[`DateTime64`](../data-types/datetime64.md)."}
```

Now it becomes:

```cpp
{"datetime", "A date with time to round.", {"DateTime", "DateTime64"}}
```

Quite intuitive, I think.

A different approach would be to use in-text placeholders, for example something like this:

```cpp
{"datetime", "A date with time to round. DateTime, DateTime64"}
```

... and ClickHouse would then replace the placeholders by the proper links. While this saves some typing the main problem is that the replacing will be fragile. It is better to maintain the types in a separate place.

### Changelog category (leave one):
- Documentation (changelog entry is not required)