### PR TITLE
Try fix flaky test_dns_cache::test_user_access_ip_change

### DIFF
--- a/tests/integration/test_dns_cache/test.py
+++ b/tests/integration/test_dns_cache/test.py
@@ -260,7 +260,6 @@ def test_user_access_ip_change(cluster_ready, node_name):
         user="root",
     )
 
-
     assert_eq_with_retry(
         node3,
         f"SELECT * FROM remote('{node_name}', 'system', 'one')",
@@ -277,6 +276,9 @@ def test_user_access_ip_change(cluster_ready, node_name):
         sleep_time=10,
     )
 
+    node3_ipv6 = node3.ipv6_address
+    node4_ipv6 = node4.ipv6_address
+
     node.set_hosts(
         [
             ("127.255.255.255", "node3"),
@@ -284,18 +286,33 @@ def test_user_access_ip_change(cluster_ready, node_name):
         ],
     )
 
-    node3_ipv6 = node3.ipv6_address
-    node4_ipv6 = node4.ipv6_address
+    # restart the node and return the time taken for restart
+    def restart_with_timing(node, new_ip):
+        """Restart a single node and return the time taken"""
+        start_time = time.time()
+        cluster.restart_instance_with_ip_change(node, new_ip)
+        elapsed = time.time() - start_time
+        return node.name, elapsed
 
-    restart_start_time = time.time()
+    # restart the nodes concurrently and time each node separately
     with ThreadPoolExecutor(max_workers=2) as pool:
-        pool.map(
-            lambda x: cluster.restart_instance_with_ip_change(*x),
-            ((node3, f"2001:3984:3989::1:88{node_num}3"), (node4, f"2001:3984:3989::1:88{node_num}4"))
+        results = list(
+            pool.map(
+                lambda x: restart_with_timing(x[0], x[1]),
+                [
+                    (node3, f"2001:3984:3989::1:88{node_num}3"),
+                    (node4, f"2001:3984:3989::1:88{node_num}4"),
+                ],
+            )
         )
-    restart_elapsed = time.time() - restart_start_time
 
-    if restart_elapsed < 8:
+    # choose the maximum individual restart time for the timing decision
+    max_individual_restart = max(elapsed for _, elapsed in results)
+    logging.info(f"Slowest node restart: {max_individual_restart:.2f}s")
+
+    if max_individual_restart < 5:
+        # Add small buffer to ensure container networking is stable
+        time.sleep(1)
         with pytest.raises(QueryRuntimeException):
             node3.query(f"SELECT * FROM remote('{node_name}', 'system', 'one')")
     else:


### PR DESCRIPTION
Try to fix flaky test `test_dns_cache/test.py::test_user_access_ip_change`. It looks like we time the total time to 
restart both nodes end to end, which might not be always accurate. Try timing each restart individually for comparison. Example [failure](https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/d74c7c1494679a28583e34811e9fe2bc3181fc5a//integration_tests_release_1_4/integration_run_test_dns_cache_test_py_0.log) from ci and more found in [cidb](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgOTAgZGF5CiAgICBBTkQgKGhlYWRfcmVmID0gJ21hc3RlcicgQU5EIHN0YXJ0c1dpdGgoaGVhZF9yZXBvLCAnQ2xpY2tIb3VzZS8nKSkKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIEFORCAodGVzdF9zdGF0dXMgTElLRSAnRiUnIE9SIHRlc3Rfc3RhdHVzIExJS0UgJ0UlJykgCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgQU5EIHBvc2l0aW9uKHRlc3RfbmFtZSwgJ3Rlc3RfZG5zX2NhY2hlL3Rlc3QucHk6OnRlc3RfdXNlcl9hY2Nlc3NfaXBfY2hhbmdlJykgPiAwCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWU=).
 
Closes: https://github.com/ClickHouse/ClickHouse/issues/80865

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
