### PR TITLE
Support truncate system.warnings

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -954,6 +954,11 @@ struct ContextSharedPart : boost::noncopyable
         warnings[warning] = message;
     }
 
+    void removeAllWarnings() TSA_REQUIRES(mutex)
+    {
+        warnings.clear();
+    }
+
     void removeWarningMessage(Context::WarningType warning) TSA_REQUIRES(mutex)
     {
         if (warnings.contains(warning))
@@ -1546,6 +1551,12 @@ void Context::removeWarningMessage(WarningType warning) const
 {
     std::lock_guard lock(shared->mutex);
     shared->removeWarningMessage(warning);
+}
+
+void Context::removeAllWarnings() const
+{
+    std::lock_guard lock(shared->mutex);
+    shared->removeAllWarnings();
 }
 
 void Context::setConfig(const ConfigurationPtr & config)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -682,6 +682,7 @@ public:
     void addOrUpdateWarningMessage(WarningType warning, const PreformattedMessage & message) const;
     void addWarningMessageAboutDatabaseOrdinary(const String & database_name) const;
     void removeWarningMessage(WarningType warning) const;
+    void removeAllWarnings() const;
 
     VolumePtr getGlobalTemporaryVolume() const; /// TODO: remove, use `getTempDataOnDisk`
 

--- a/src/Storages/System/StorageSystemWarnings.cpp
+++ b/src/Storages/System/StorageSystemWarnings.cpp
@@ -27,4 +27,10 @@ void StorageSystemWarnings::fillData(MutableColumns & res_columns, ContextPtr co
     }
 }
 
+
+void StorageSystemWarnings::truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr, TableExclusiveLockHolder &)
+{
+    Context::getGlobalContextInstance()->removeAllWarnings();
+}
+
 }

--- a/src/Storages/System/StorageSystemWarnings.h
+++ b/src/Storages/System/StorageSystemWarnings.h
@@ -18,6 +18,8 @@ public:
 
     static ColumnsDescription getColumnsDescription();
 
+    void truncate(const ASTPtr & query_ast, const StorageMetadataPtr & metadata_snapshot , ContextPtr context, TableExclusiveLockHolder & lock_holder) override;
+
 protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
 

--- a/src/Storages/System/StorageSystemWarnings.h
+++ b/src/Storages/System/StorageSystemWarnings.h
@@ -18,7 +18,7 @@ public:
 
     static ColumnsDescription getColumnsDescription();
 
-    void truncate(const ASTPtr & query_ast, const StorageMetadataPtr & metadata_snapshot , ContextPtr context, TableExclusiveLockHolder & lock_holder) override;
+    void truncate(const ASTPtr & query_ast, const StorageMetadataPtr & metadata_snapshot, ContextPtr context, TableExclusiveLockHolder & lock_holder) override;
 
 protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;

--- a/tests/integration/test_system_flush_logs/test.py
+++ b/tests/integration/test_system_flush_logs/test.py
@@ -181,3 +181,11 @@ def test_log_buffer_size_rows_flush_threshold(start_cluster):
     node.exec_in_container(
         ["rm", f"/etc/clickhouse-server/config.d/yyy-override-query_log.xml"]
     )
+
+
+def test_system_warnings(start_cluster):
+    if node.is_debug_build():
+        assert node.query("SELECT count() > 1 FROM system.warnings") == "1\n"
+
+    node.query("TRUNCATE TABLE system.warnings")
+    assert node.query("SELECT count() FROM system.warnings") == "0\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Add support for clearing all warnings from the `system.warnings` table using `TRUNCATE TABLE system.warnings`

This is particularly useful for testing scenarios where you need to verify the contents of `system.warnings` and ensure that sequential test runs don't interfere with each other due to leftover warnings from previous executions.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
