### PR TITLE
Fix data races in Iceberg

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -29,6 +29,7 @@
 
 #include <Common/logger_useful.h>
 #include <Common/ProfileEvents.h>
+#include <Common/SharedLockGuard.h>
 
 namespace ProfileEvents
 {
@@ -494,6 +495,8 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
 {
     auto configuration_ptr = configuration.lock();
 
+    std::lock_guard lock(mutex);
+
     const auto [metadata_version, metadata_file_path, compression_method]
         = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_ptr, manifest_cache, local_context, log.get());
 
@@ -514,9 +517,15 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
 
     if (previous_snapshot_id != relevant_snapshot_id)
     {
-        cached_unprunned_files_for_last_processed_snapshot = std::nullopt;
-        cached_unprunned_position_deletes_files_for_last_processed_snapshot = std::nullopt;
-        schema_id_by_data_file_initialized.store(false);
+        schema_id_by_data_files_initialized = false;
+        schema_id_by_data_file.clear();
+
+        {
+            std::lock_guard cache_lock(cache_mutex);
+            cached_unprunned_position_deletes_files_for_last_processed_snapshot = std::nullopt;
+            cached_unprunned_files_for_last_processed_snapshot = std::nullopt;
+        }
+
         return true;
     }
     return previous_snapshot_schema_id != relevant_snapshot_schema_id;
@@ -643,25 +652,46 @@ void IcebergMetadata::updateState(const ContextPtr & local_context, Poco::JSON::
     }
 }
 
-std::optional<Int32> IcebergMetadata::getSchemaVersionByFileIfOutdated(ContextPtr local_context, String data_path) const
+std::shared_ptr<NamesAndTypesList> IcebergMetadata::getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const
 {
-    if (!schema_id_by_data_file_initialized.load())
+    if (!schema_id_by_data_files_initialized)
     {
-        std::lock_guard lock(schema_id_by_data_file_mutex);
-        if (!schema_id_by_data_file_initialized.load())
-        {
+        std::lock_guard lock(mutex);
+        if (!schema_id_by_data_files_initialized)
             initializeSchemasFromManifestList(local_context, relevant_snapshot->manifest_list_entries);
-            schema_id_by_data_file_initialized.store(true);
-        }
     }
+
+    SharedLockGuard lock(mutex);
+    auto version_if_outdated = getSchemaVersionByFileIfOutdated(data_path);
+    return version_if_outdated.has_value() ? schema_processor.getClickhouseTableSchemaById(version_if_outdated.value()) : nullptr;
+}
+
+std::shared_ptr<const ActionsDAG> IcebergMetadata::getSchemaTransformer(ContextPtr local_context, const String & data_path) const
+{
+    if (!schema_id_by_data_files_initialized)
+    {
+        std::lock_guard lock(mutex);
+        if (!schema_id_by_data_files_initialized)
+            initializeSchemasFromManifestList(local_context, relevant_snapshot->manifest_list_entries);
+    }
+
+    SharedLockGuard lock(mutex);
+    auto version_if_outdated = getSchemaVersionByFileIfOutdated(data_path);
+    return version_if_outdated.has_value()
+        ? schema_processor.getSchemaTransformationDagByIds(version_if_outdated.value(), relevant_snapshot_schema_id)
+        : nullptr;
+}
+
+std::optional<Int32> IcebergMetadata::getSchemaVersionByFileIfOutdated(String data_path) const
+{
     auto schema_id_it = schema_id_by_data_file.find(data_path);
     if (schema_id_it == schema_id_by_data_file.end())
-    {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot find manifest file for data file: {}", data_path);
-    }
+
     auto schema_id = schema_id_it->second;
     if (schema_id == relevant_snapshot_schema_id)
         return std::nullopt;
+
     return std::optional{schema_id};
 }
 
@@ -685,31 +715,22 @@ DataLakeMetadataPtr IcebergMetadata::create(
 
     Poco::JSON::Object::Ptr object = getMetadataJSONObject(metadata_file_path, object_storage, configuration_ptr, cache_ptr, local_context, log, compression_method);
 
-    IcebergSchemaProcessor schema_processor;
-
     auto format_version = object->getValue<int>(f_format_version);
-
-    auto ptr
-        = std::make_unique<IcebergMetadata>(object_storage, configuration_ptr, local_context, metadata_version, format_version, object, cache_ptr);
-
-    return ptr;
+    return std::make_unique<IcebergMetadata>(object_storage, configuration_ptr, local_context, metadata_version, format_version, object, cache_ptr);
 }
 
 void IcebergMetadata::initializeSchemasFromManifestList(ContextPtr local_context, ManifestFileCacheKeys manifest_list_ptr) const
 {
+    schema_id_by_data_file.clear();
+
     for (const auto & manifest_list_entry : manifest_list_ptr)
     {
         auto manifest_file_ptr = getManifestFile(local_context, manifest_list_entry.manifest_file_path, manifest_list_entry.added_sequence_number);
-        initializeSchemasFromManifestFile(manifest_file_ptr);
+        for (const auto & manifest_file_entry : manifest_file_ptr->getFiles(FileContentType::DATA))
+            schema_id_by_data_file.emplace(manifest_file_entry.file_path, manifest_file_ptr->getSchemaId());
     }
-}
 
-void IcebergMetadata::initializeSchemasFromManifestFile(ManifestFilePtr manifest_file_ptr) const
-{
-    for (const auto & manifest_file_entry : manifest_file_ptr->getFiles(FileContentType::DATA))
-    {
-        schema_id_by_data_file.emplace(manifest_file_entry.file_path, manifest_file_ptr->getSchemaId());
-    }
+    schema_id_by_data_files_initialized = true;
 }
 
 ManifestFileCacheKeys IcebergMetadata::getManifestList(ContextPtr local_context, const String & filename) const
@@ -749,13 +770,9 @@ ManifestFileCacheKeys IcebergMetadata::getManifestList(ContextPtr local_context,
 
     ManifestFileCacheKeys manifest_file_cache_keys;
     if (manifest_cache)
-    {
         manifest_file_cache_keys = manifest_cache->getOrSetManifestFileCacheKeys(IcebergMetadataFilesCache::getKey(configuration_ptr, filename), create_fn);
-    }
     else
-    {
         manifest_file_cache_keys = create_fn();
-    }
     return manifest_file_cache_keys;
 }
 
@@ -765,11 +782,18 @@ IcebergMetadata::IcebergHistory IcebergMetadata::getHistory(ContextPtr local_con
 
     const auto [metadata_version, metadata_file_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_ptr, manifest_cache, local_context, log.get());
 
-    chassert(metadata_version == last_metadata_version);
+    chassert([&]()
+    {
+        SharedLockGuard lock(mutex);
+        return metadata_version == last_metadata_version;
+    }());
 
     auto metadata_object = getMetadataJSONObject(metadata_file_path, object_storage, configuration_ptr, manifest_cache, local_context, log, compression_method);
-
-    chassert(format_version == metadata_object->getValue<int>(f_format_version));
+    chassert([&]()
+    {
+        SharedLockGuard lock(mutex);
+        return format_version == metadata_object->getValue<int>(f_format_version);
+    }());
 
     /// History
     std::vector<Iceberg::IcebergHistoryRecord> iceberg_history;
@@ -883,48 +907,51 @@ ManifestFilePtr IcebergMetadata::getManifestFile(ContextPtr local_context, const
 std::vector<Iceberg::ManifestFileEntry>
 IcebergMetadata::getFilesImpl(const ActionsDAG * filter_dag, FileContentType file_content_type, ContextPtr local_context) const
 {
-    if (!relevant_snapshot)
-        return {};
     if (!local_context && filter_dag)
     {
         throw DB::Exception(
             DB::ErrorCodes::LOGICAL_ERROR,
             "Context is required with non-empty filter_dag to implement partition pruning for Iceberg table");
     }
-    std::optional<std::vector<Iceberg::ManifestFileEntry>> & cached_files = (file_content_type == FileContentType::DATA)
+    bool use_partition_pruning = filter_dag && local_context->getSettingsRef()[Setting::use_iceberg_partition_pruning];
+
+    auto & cached_files = (file_content_type == FileContentType::DATA)
         ? cached_unprunned_files_for_last_processed_snapshot
         : cached_unprunned_position_deletes_files_for_last_processed_snapshot;
-    bool use_partition_pruning = filter_dag && local_context->getSettingsRef()[Setting::use_iceberg_partition_pruning];
-    if (!use_partition_pruning && cached_files.has_value())
-        return cached_files.value();
-
-    std::vector<Iceberg::ManifestFileEntry> files;
-    for (const auto & manifest_list_entry : relevant_snapshot->manifest_list_entries)
     {
-        auto manifest_file_ptr = getManifestFile(local_context, manifest_list_entry.manifest_file_path, manifest_list_entry.added_sequence_number);
-        initializeSchemasFromManifestFile(manifest_file_ptr);
-        const auto & files_in_manifest = manifest_file_ptr->getFiles(file_content_type);
-        for (const auto & manifest_file_entry : files_in_manifest)
-        {
-            ManifestFilesPruner pruner(
-                schema_processor, relevant_snapshot_schema_id,
-                use_partition_pruning ? filter_dag : nullptr,
-                *manifest_file_ptr, local_context);
-                if (manifest_file_entry.status != ManifestEntryStatus::DELETED)
-                {
-                    if (!pruner.canBePruned(manifest_file_entry))
-                    {
-                        files.push_back(manifest_file_entry);
-                    }
-                }
-        }
+        std::lock_guard cache_lock(cache_mutex);
+        if (!use_partition_pruning && cached_files.has_value())
+            return cached_files.value();
     }
 
+    std::vector<Iceberg::ManifestFileEntry> files;
+    {
+        SharedLockGuard lock(mutex);
+        if (!relevant_snapshot)
+            return {};
+        for (const auto & manifest_list_entry : relevant_snapshot->manifest_list_entries)
+        {
+            auto manifest_file_ptr = getManifestFile(local_context, manifest_list_entry.manifest_file_path, manifest_list_entry.added_sequence_number);
+            const auto & files_in_manifest = manifest_file_ptr->getFiles(file_content_type);
+            for (const auto & manifest_file_entry : files_in_manifest)
+            {
+                ManifestFilesPruner pruner(
+                    schema_processor, relevant_snapshot_schema_id,
+                    use_partition_pruning ? filter_dag : nullptr,
+                    *manifest_file_ptr, local_context);
+                    if (manifest_file_entry.status != ManifestEntryStatus::DELETED)
+                    {
+                        if (!pruner.canBePruned(manifest_file_entry))
+                            files.push_back(manifest_file_entry);
+                    }
+            }
+        }
+    }
     std::sort(files.begin(), files.end());
 
-    schema_id_by_data_file_initialized = true;
     if (!use_partition_pruning)
     {
+        std::lock_guard cache_lock(cache_mutex);
         cached_files = files;
         return cached_files.value();
     }
@@ -949,6 +976,7 @@ std::optional<size_t> IcebergMetadata::totalRows(ContextPtr local_context) const
     if (!configuration_ptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Configuration is expired");
 
+    SharedLockGuard lock(mutex);
     if (!relevant_snapshot)
     {
         ProfileEvents::increment(ProfileEvents::IcebergTrivialCountOptimizationApplied);
@@ -987,6 +1015,7 @@ std::optional<size_t> IcebergMetadata::totalBytes(ContextPtr local_context) cons
     if (!configuration_ptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Configuration is expired");
 
+    SharedLockGuard lock(mutex);
     if (!relevant_snapshot)
         return 0;
 
@@ -1015,6 +1044,7 @@ ObjectIterator IcebergMetadata::iterate(
     size_t /* list_batch_size */,
     ContextPtr local_context) const
 {
+    SharedLockGuard lock(mutex);
     return std::make_shared<IcebergKeysIterator>(*this, getDataFiles(filter_dag, local_context), getPositionalDeleteFiles(filter_dag, local_context), object_storage, callback);
 }
 
@@ -1039,9 +1069,7 @@ std::shared_ptr<ISimpleTransform> IcebergMetadata::getPositionDeleteTransformer(
 
     auto configuration_ptr = configuration.lock();
     if (!configuration_ptr)
-    {
         throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Iceberg configuration has expired");
-    }
 
     String delete_object_format = configuration_ptr->format;
     String delete_object_compression_method = configuration_ptr->compression_method;
@@ -1059,7 +1087,7 @@ IcebergDataObjectInfo::IcebergDataObjectInfo(
     : RelativePathWithMetadata(data_object_.file_path, std::move(metadata_))
     , data_object(data_object_)
 {
-    ///Object in position_deletes_objects_ are sorted by common_partition_specification, partition_key_value and added_sequence_number.
+    /// Object in position_deletes_objects_ are sorted by common_partition_specification, partition_key_value and added_sequence_number.
     /// It is done to have an invariant that position deletes objects which corresponds
     /// to the data object form a subsegment in a position_deletes_objects_ vector.
     /// We need to take all position deletes objects which has the same partition schema and value and has added_sequence_number
@@ -1128,6 +1156,19 @@ ObjectInfoPtr IcebergKeysIterator::next(size_t)
             iceberg_metadata, data_files[current_index], std::move(object_metadata), position_deletes_files);
     }
 }
+
+NamesAndTypesList IcebergMetadata::getTableSchema() const
+{
+    SharedLockGuard lock(mutex);
+    return *schema_processor.getClickhouseTableSchemaById(relevant_snapshot_schema_id);
+}
+
+std::tuple<Int64, Int32> IcebergMetadata::getVersion() const
+{
+    SharedLockGuard lock(mutex);
+    return std::make_tuple(relevant_snapshot_id, relevant_snapshot_schema_id);
+}
+
 }
 
 #endif

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -17,6 +17,11 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 
+#include <Common/SharedMutex.h>
+#include <tuple>
+#include <optional>
+#include <base/defines.h>
+
 namespace DB
 {
 
@@ -39,10 +44,7 @@ public:
         IcebergMetadataFilesCachePtr cache_ptr);
 
     /// Get table schema parsed from metadata.
-    NamesAndTypesList getTableSchema() const override
-    {
-        return *schema_processor.getClickhouseTableSchemaById(relevant_snapshot_schema_id);
-    }
+    NamesAndTypesList getTableSchema() const override;
 
     bool operator==(const IDataLakeMetadata & other) const override
     {
@@ -55,19 +57,8 @@ public:
         const ConfigurationObserverPtr & configuration,
         const ContextPtr & local_context);
 
-    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const override
-    {
-        auto version_if_outdated = getSchemaVersionByFileIfOutdated(local_context, data_path);
-        return version_if_outdated.has_value() ? schema_processor.getClickhouseTableSchemaById(version_if_outdated.value()) : nullptr;
-    }
-
-    std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, const String & data_path) const override
-    {
-        auto version_if_outdated = getSchemaVersionByFileIfOutdated(local_context, data_path);
-        return version_if_outdated.has_value()
-            ? schema_processor.getSchemaTransformationDagByIds(version_if_outdated.value(), relevant_snapshot_schema_id)
-            : nullptr;
-    }
+    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const override;
+    std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, const String & data_path) const override;
 
     bool hasPositionDeleteTransformer(const ObjectInfoPtr & object_info) const override;
 
@@ -79,8 +70,7 @@ public:
 
     bool supportsSchemaEvolution() const override { return true; }
 
-    static Int32
-    parseTableSchema(const Poco::JSON::Object::Ptr & metadata_object, IcebergSchemaProcessor & schema_processor, LoggerPtr metadata_logger);
+    static Int32 parseTableSchema(const Poco::JSON::Object::Ptr & metadata_object, IcebergSchemaProcessor & schema_processor, LoggerPtr metadata_logger);
 
     bool supportsUpdate() const override { return true; }
 
@@ -110,47 +100,38 @@ private:
 
     IcebergMetadataFilesCachePtr manifest_cache;
 
-    std::tuple<Int64, Int32> getVersion() const { return std::make_tuple(relevant_snapshot_id, relevant_snapshot_schema_id); }
+    std::tuple<Int64, Int32> getVersion() const;
 
-    Int32 last_metadata_version;
-    Int32 format_version;
+    mutable SharedMutex mutex;
 
-    mutable std::atomic<bool> schema_id_by_data_file_initialized{false};
-    mutable std::unordered_map<String, Int32> schema_id_by_data_file;
-    mutable std::mutex schema_id_by_data_file_mutex;
+    Int32 last_metadata_version TSA_GUARDED_BY(mutex);
+    const Int32 format_version;
 
+    mutable std::unordered_map<String, Int32> schema_id_by_data_file TSA_GUARDED_BY(mutex);
+    /// Does schema_id_by_data_files initialized and valid?
+    /// Is an optimization to avoid acquiring exclusive lock from get*() method
+    mutable std::atomic_bool schema_id_by_data_files_initialized = false;
 
-    Int32 relevant_snapshot_schema_id;
-    std::optional<Iceberg::IcebergSnapshot> relevant_snapshot;
-    Int64 relevant_snapshot_id{-1};
-    String table_location;
+    Int32 relevant_snapshot_schema_id TSA_GUARDED_BY(mutex);
+    std::optional<Iceberg::IcebergSnapshot> relevant_snapshot TSA_GUARDED_BY(mutex);
+    Int64 relevant_snapshot_id TSA_GUARDED_BY(mutex) {-1};
+    const String table_location;
 
-    mutable std::optional<std::vector<Iceberg::ManifestFileEntry>> cached_unprunned_files_for_last_processed_snapshot;
-    mutable std::optional<std::vector<Iceberg::ManifestFileEntry>> cached_unprunned_position_deletes_files_for_last_processed_snapshot;
-
-    void updateState(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object, bool metadata_file_changed);
-
-    std::vector<Iceberg::ManifestFileEntry> getDataFiles(const ActionsDAG * filter_dag, ContextPtr local_context) const;
+    mutable std::optional<std::vector<Iceberg::ManifestFileEntry>> cached_unprunned_files_for_last_processed_snapshot TSA_GUARDED_BY(cache_mutex);
+    mutable std::optional<std::vector<Iceberg::ManifestFileEntry>> cached_unprunned_position_deletes_files_for_last_processed_snapshot TSA_GUARDED_BY(cache_mutex);
+    mutable std::mutex cache_mutex;
 
     std::vector<Iceberg::ManifestFileEntry> getPositionalDeleteFiles(const ActionsDAG * filter_dag, ContextPtr local_context) const;
+    std::vector<Iceberg::ManifestFileEntry> getDataFiles(const ActionsDAG * filter_dag, ContextPtr local_context) const;
 
-    void updateSnapshot(ContextPtr local_context, Poco::JSON::Object::Ptr metadata_object);
-
+    void updateState(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object, bool metadata_file_changed) TSA_REQUIRES(mutex);
+    void updateSnapshot(ContextPtr local_context, Poco::JSON::Object::Ptr metadata_object) TSA_REQUIRES(mutex);
     ManifestFileCacheKeys getManifestList(ContextPtr local_context, const String & filename) const;
-    mutable std::vector<Iceberg::ManifestFileEntry> positional_delete_files_for_current_query;
-
-    void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object);
-
-    std::optional<Int32> getSchemaVersionByFileIfOutdated(ContextPtr local_context, String data_path) const;
-
-    void initializeSchemasFromManifestList(ContextPtr local_context, ManifestFileCacheKeys manifest_list_ptr) const;
-
-    void initializeSchemasFromManifestFile(Iceberg::ManifestFilePtr manifest_file_ptr) const;
-
-    Iceberg::ManifestFilePtr getManifestFile(ContextPtr local_context, const String & filename, Int64 inherited_sequence_number) const;
-
+    void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object) TSA_REQUIRES(mutex);
+    std::optional<Int32> getSchemaVersionByFileIfOutdated(String data_path) const TSA_REQUIRES_SHARED(mutex);
+    void initializeSchemasFromManifestList(ContextPtr local_context, ManifestFileCacheKeys manifest_list_ptr) const TSA_REQUIRES(mutex);
+    Iceberg::ManifestFilePtr getManifestFile(ContextPtr local_context, const String & filename, Int64 inherited_sequence_number) const TSA_REQUIRES_SHARED(mutex);
     std::optional<String> getRelevantManifestList(const Poco::JSON::Object::Ptr & metadata);
-
     Iceberg::ManifestFilePtr tryGetManifestFile(const String & filename) const;
 
     std::vector<Iceberg::ManifestFileEntry> getFilesImpl(const ActionsDAG * filter_dag, Iceberg::FileContentType file_content_type, ContextPtr local_context) const;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data races in Iceberg

### Changes

- `schema_id_by_data_file` should not be initialized in `getDataFiles` we don't use it later (https://github.com/ClickHouse/ClickHouse/pull/81619/files#r2155328743)

### Races

- `cached_unprunned_files_for_last_processed_snapshot` can be accessed easily from multiple queries and updated in parallel (via parallel `SELECT`)
- `relevant_snapshot` can be updated via `StorageObjectStorage::update` (basically any `SELECT` query + `system.tables` via `totalBytes`/`totalRows`)
- `IcebergMetadata::updateSnapshot` is not thread safe either

**So basically we need to protect all non-constant fields in `IcebergMetadata` and `IcebergSchemaProcessor`**

So this PR uses `shared_lock` to guard everything, but allow parallel reads (for `SELECT` and co)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/81619