### PR TITLE
Optimize single NOT NULL count() aggregation

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -7,6 +7,7 @@
 #    include <unistd.h>
 #endif
 
+#include <AggregateFunctions/AggregateFunctionCount.h>
 #include <AggregateFunctions/Combinators/AggregateFunctionArray.h>
 #include <AggregateFunctions/Combinators/AggregateFunctionState.h>
 #include <Columns/ColumnAggregateFunction.h>
@@ -166,6 +167,16 @@ size_t getMinBytesForPrefetch()
 
     /// 256KB looks like a reasonable default L2 size. 4 is empirical constant.
     return 4 * std::max<size_t>(l2_size, 256 * 1024);
+}
+
+UInt64 & getCountState(DB::AggregateDataPtr __restrict place) /// NOLINT(readability-non-const-parameter)
+{
+    return *reinterpret_cast<UInt64 *>(place);
+}
+
+UInt64 & getInlineCountState(DB::AggregateDataPtr & ptr)
+{
+    return getCountState(reinterpret_cast<DB::AggregateDataPtr>(&ptr));
 }
 
 }
@@ -498,7 +509,33 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
             all_aggregates_has_trivial_destructor = false;
     }
 
+    if (params.aggregates_size == 1)
+    {
+        /// Check if COUNT() or COUNT(non-nullable column) which can be verified by simply casting to `AggregateFunctionCount *`.
+        if (typeid_cast<const AggregateFunctionCount *>(params.aggregates[0].function.get()))
+            is_simple_count = true;
+    }
+
     method_chosen = chooseAggregationMethod();
+
+    /// TODO(ab): HashMethodSingleLowCardinalityColumn uses a hardcoded internal cache,
+    /// which interferes with inline aggregation (e.g. for COUNT). This needs to be
+    /// refactored to respect the `use_cache` setting.
+    ///
+    /// For now, disable the simple COUNT optimization to avoid incorrect behavior.
+    switch (method_chosen)
+    {
+    #define M(NAME) \
+        case AggregatedDataVariants::Type::NAME: \
+            is_simple_count = false; \
+            break;
+
+        APPLY_FOR_LOW_CARDINALITY_VARIANTS(M)
+    #undef M
+        default:
+            ;
+    }
+
     HashMethodContext::Settings cache_settings;
     cache_settings.max_threads = params.max_threads;
     aggregation_state_cache = AggregatedDataVariants::createCache(method_chosen, cache_settings);
@@ -516,6 +553,9 @@ void Aggregator::compileAggregateFunctionsIfNeeded()
     static std::mutex mutex;
 
     if (!params.compile_aggregate_expressions)
+        return;
+
+    if (is_simple_count)
         return;
 
     std::vector<AggregateFunctionWithOffset> functions_to_compile;
@@ -943,7 +983,7 @@ void NO_INLINE Aggregator::executeImpl(
 {
     UInt64 total_rows = consecutive_keys_cache_stats.hits + consecutive_keys_cache_stats.misses;
     double cache_hit_rate = total_rows ? static_cast<double>(consecutive_keys_cache_stats.hits) / total_rows : 1.0;
-    bool use_cache = cache_hit_rate >= params.min_hit_rate_to_use_consecutive_keys_optimization;
+    bool use_cache = !is_simple_count && cache_hit_rate >= params.min_hit_rate_to_use_consecutive_keys_optimization;
 
     if (use_cache)
     {
@@ -1066,39 +1106,111 @@ void NO_INLINE Aggregator::executeImplBatch(
     {
         if constexpr (std::is_same_v<Method, typename decltype(AggregatedDataVariants::key8)::element_type>)
         {
-            /// We use another method if there are aggregate functions with -Array combinator.
-            bool has_arrays = false;
-            for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
+            if (!all_keys_are_const)
             {
-                if (inst->offsets)
+                if (is_simple_count)
                 {
-                    has_arrays = true;
-                    break;
+                    const auto * key = state.getKeyData();
+                    UInt64 * map = reinterpret_cast<UInt64 *>(method.data.data());
+                    for (size_t i = row_begin; i < row_end; ++i)
+                        ++map[key[i]];
+                    return;
                 }
-            }
 
-            if (!has_arrays && !hasSparseArguments(aggregate_instructions) && !all_keys_are_const)
-            {
+                /// We use another method if there are aggregate functions with -Array combinator.
+                bool has_arrays = false;
                 for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
                 {
-                    inst->batch_that->addBatchLookupTable8(
-                        row_begin,
-                        row_end,
-                        reinterpret_cast<AggregateDataPtr *>(method.data.data()),
-                        inst->state_offset,
-                        [&](AggregateDataPtr & aggregate_data)
-                        {
-                            AggregateDataPtr place = aggregates_pool->alignedAlloc(total_size_of_aggregate_states, align_aggregate_states);
-                            createAggregateStates(place);
-                            aggregate_data = place;
-                        },
-                        state.getKeyData(),
-                        inst->batch_arguments,
-                        aggregates_pool);
+                    if (inst->offsets)
+                    {
+                        has_arrays = true;
+                        break;
+                    }
                 }
-                return;
+
+                if (!has_arrays && !hasSparseArguments(aggregate_instructions))
+                {
+                    for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
+                    {
+                        inst->batch_that->addBatchLookupTable8(
+                            row_begin,
+                            row_end,
+                            reinterpret_cast<AggregateDataPtr *>(method.data.data()),
+                            inst->state_offset,
+                            [&](AggregateDataPtr & aggregate_data)
+                            {
+                                AggregateDataPtr place
+                                    = aggregates_pool->alignedAlloc(total_size_of_aggregate_states, align_aggregate_states);
+                                createAggregateStates(place);
+                                aggregate_data = place;
+                            },
+                            state.getKeyData(),
+                            inst->batch_arguments,
+                            aggregates_pool);
+                    }
+                    return;
+                }
             }
         }
+    }
+
+    if (is_simple_count)
+    {
+        if (all_keys_are_const)
+        {
+            if (!no_more_keys)
+            {
+                auto emplace_result = state.emplaceKey(method.data, 0, *aggregates_pool);
+                if (emplace_result.isInserted())
+                    getInlineCountState(emplace_result.getMapped()) = row_end - row_begin;
+                else
+                    getInlineCountState(emplace_result.getMapped()) += row_end - row_begin;
+            }
+            else
+            {
+                auto find_result = state.findKey(method.data, 0, *aggregates_pool);
+                if (find_result.isFound())
+                    getInlineCountState(find_result.getMapped()) = row_end - row_begin;
+                else if (overflow_row)
+                    getCountState(overflow_row) += row_end - row_begin;
+            }
+        }
+        else if (!no_more_keys)
+        {
+            for (size_t i = row_begin; i < row_end; ++i)
+            {
+                if constexpr (prefetch && HasPrefetchMemberFunc<decltype(method.data), KeyHolder>)
+                {
+                    if (i == row_begin + PrefetchingHelper::iterationsToMeasure())
+                        prefetch_look_ahead = prefetching.calcPrefetchLookAhead();
+
+                    if (i + prefetch_look_ahead < row_end)
+                    {
+                        auto && key_holder = state.getKeyHolder(i + prefetch_look_ahead, *aggregates_pool);
+                        method.data.prefetch(std::move(key_holder));
+                    }
+                }
+
+                auto emplace_result = state.emplaceKey(method.data, i, *aggregates_pool);
+                if (emplace_result.isInserted())
+                    getInlineCountState(emplace_result.getMapped()) = 1;
+                else
+                    ++getInlineCountState(emplace_result.getMapped());
+            }
+        }
+        else
+        {
+            for (size_t i = row_begin; i < row_end; ++i)
+            {
+                auto find_result = state.findKey(method.data, i, *aggregates_pool);
+                if (find_result.isFound())
+                    ++getInlineCountState(find_result.getMapped());
+                else if (overflow_row)
+                    ++getCountState(overflow_row);
+            }
+        }
+
+        return;
     }
 
     /// NOTE: only row_end-row_start is required, but:
@@ -1284,6 +1396,12 @@ void NO_INLINE Aggregator::executeWithoutKeyImpl(
     if (row_begin == row_end)
         return;
 
+    if (is_simple_count)
+    {
+        getCountState(res) += row_end - row_begin;
+        return;
+    }
+
 #if USE_EMBEDDED_COMPILER
     if (use_compiled_functions)
     {
@@ -1382,6 +1500,12 @@ void NO_INLINE Aggregator::executeOnIntervalWithoutKey(
     data_variants.init(AggregatedDataVariants::Type::without_key);
 
     AggregatedDataWithoutKey & res = data_variants.without_key;
+
+    if (is_simple_count)
+    {
+        getCountState(res) += row_end - row_begin;
+        return;
+    }
 
     /// Adding values
     for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
@@ -1857,6 +1981,109 @@ Aggregator::convertToBlockImpl(Method & method, Table & data, Arena * arena, Are
         return BlocksList{std::move(finalized_block)};
     }
     ConvertToBlockResVariant res;
+
+    if (is_simple_count)
+    {
+        /// +1 for nullKeyData, if `data` doesn't have it - not a problem, just some memory for one excessive row will be preallocated
+        const size_t max_block_size = (return_single_block ? data.size() : std::min(params.max_block_size, data.size())) + 1;
+
+        std::optional<OutputBlockColumns> out_cols;
+        std::optional<Sizes> shuffled_key_sizes;
+        BlocksList blocks;
+        AggregateFunctionCountData * states = nullptr;
+        size_t rows_in_current_block = 0;
+        size_t rows_in_states = 0;
+        ColumnUInt64 * out_count_col = nullptr;
+
+        /// Allocates enough count states (+1 for nullKeyData) to store inlined states in data.
+        if (!final)
+        {
+            states = reinterpret_cast<AggregateFunctionCountData *>(
+                arena->alignedAlloc(sizeof(AggregateFunctionCountData) * (data.size() + 1), alignof(AggregateFunctionCountData)));
+        }
+
+        auto init_out_cols = [&]()
+        {
+            out_cols = prepareOutputBlockColumns(params, aggregate_functions, getHeader(final), aggregates_pools, final, max_block_size);
+
+            if (final)
+                out_count_col = assert_cast<ColumnUInt64 *>(out_cols->final_aggregate_columns[0].get());
+
+            if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
+            {
+                /**
+                 * When one_key_nullable_optimization is enabled, null data will be written to the key column and result column in advance.
+                 * And in insertResultsIntoColumns need to allocate memory for null data.
+                 */
+                if (data.hasNullKeyData())
+                {
+                    if (final)
+                    {
+                        out_cols->key_columns[0]->insertDefault();
+                        out_count_col->insertValue(getInlineCountState(data.getNullKeyData()));
+                        data.hasNullKeyData() = false;
+                    }
+                    else
+                    {
+                        out_cols->raw_key_columns[0]->insertDefault();
+                        states[rows_in_states].count = getInlineCountState(data.getNullKeyData());
+                        out_cols->aggregate_columns_data[0]->push_back(reinterpret_cast<AggregateDataPtr>(&states[rows_in_states]));
+
+                        ++rows_in_states;
+                        data.getNullKeyData() = nullptr;
+                        data.hasNullKeyData() = false;
+                    }
+
+                    ++rows_in_current_block;
+                }
+            }
+
+            shuffled_key_sizes = method.shuffleKeyColumns(out_cols->raw_key_columns, key_sizes);
+        };
+
+        init_out_cols();
+        auto fill_blocks = [&]<bool is_final>(const auto & key, auto & mapped)
+        {
+            if (!out_cols.has_value())
+                init_out_cols();
+
+            const auto & key_sizes_ref = shuffled_key_sizes ? *shuffled_key_sizes : key_sizes;
+            method.insertKeyIntoColumns(key, out_cols->raw_key_columns, key_sizes_ref);
+
+            if constexpr (is_final)
+            {
+                out_count_col->insertValue(getInlineCountState(mapped));
+            }
+            else
+            {
+                states[rows_in_states].count = getInlineCountState(mapped);
+                out_cols->aggregate_columns_data[0]->push_back(reinterpret_cast<AggregateDataPtr>(&states[rows_in_states]));
+            }
+
+            ++rows_in_current_block;
+            ++rows_in_states;
+            if (!return_single_block && rows_in_current_block >= max_block_size)
+            {
+                blocks.emplace_back(finalizeBlock(params, getHeader(final), std::move(out_cols.value()), final, rows_in_current_block));
+                out_cols.reset();
+                rows_in_current_block = 0;
+            }
+        };
+
+        if (final)
+            data.forEachValue([&](const auto & key, auto & mapped) { fill_blocks.template operator()<true>(key, mapped); });
+        else
+            data.forEachValue([&](const auto & key, auto & mapped) { fill_blocks.template operator()<false>(key, mapped); });
+
+        if (return_single_block)
+            return finalizeBlock(params, getHeader(final), std::move(out_cols).value(), final, rows_in_current_block);
+
+        if (rows_in_current_block)
+            blocks.emplace_back(finalizeBlock(params, getHeader(final), std::move(out_cols).value(), final, rows_in_current_block));
+
+        return blocks;
+    }
+
     bool use_compiled_functions = false;
     if (final)
     {
@@ -2465,10 +2692,51 @@ void NO_INLINE Aggregator::mergeDataNullKey(
     }
 }
 
+template <typename Table>
+static void NO_INLINE mergeDataNullKeySimpleCount(Table & table_dst, Table & table_src)
+{
+    if (table_src.hasNullKeyData())
+    {
+        if (!table_dst.hasNullKeyData())
+        {
+            table_dst.hasNullKeyData() = true;
+            table_dst.getNullKeyData() = table_src.getNullKeyData();
+        }
+        else
+        {
+            getInlineCountState(table_dst.getNullKeyData()) += getInlineCountState(table_src.getNullKeyData());
+        }
+
+        table_src.hasNullKeyData() = false;
+        table_src.getNullKeyData() = nullptr;
+    }
+}
+
 template <typename Method, typename Table>
 void NO_INLINE Aggregator::mergeDataImpl(
     Table & table_dst, Table & table_src, Arena * arena, bool use_compiled_functions [[maybe_unused]], bool prefetch, std::atomic<bool> & is_cancelled) const
 {
+    if (is_simple_count)
+    {
+        if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
+            mergeDataNullKeySimpleCount(table_dst, table_src);
+
+        auto merge = [&](AggregateDataPtr & __restrict dst, AggregateDataPtr & __restrict src, bool inserted)
+        {
+            if (inserted)
+                getInlineCountState(dst) = getInlineCountState(src);
+            else
+                getInlineCountState(dst) += getInlineCountState(src);
+        };
+
+        if (prefetch)
+            table_src.template mergeToViaEmplace<decltype(merge), true>(table_dst, std::move(merge));
+        else
+            table_src.template mergeToViaEmplace<decltype(merge), false>(table_dst, std::move(merge));
+        table_src.clearAndShrink();
+        return;
+    }
+
     if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
         mergeDataNullKey<Method, Table>(table_dst, table_src, arena);
 
@@ -2528,6 +2796,22 @@ void NO_INLINE Aggregator::mergeDataNoMoreKeysImpl(
     Table & table_src,
     Arena * arena) const
 {
+    if (is_simple_count)
+    {
+        if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
+            mergeDataNullKeySimpleCount(table_dst, table_src);
+
+        table_src.mergeToViaFind(table_dst, [&](AggregateDataPtr & __restrict dst, AggregateDataPtr & __restrict src, bool found)
+        {
+            if (found)
+                getInlineCountState(dst) += getInlineCountState(src);
+            else
+                getCountState(overflows) += getInlineCountState(src);
+        });
+        table_src.clearAndShrink();
+        return;
+    }
+
     /// Note : will create data for NULL key if not exist
     if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
         mergeDataNullKey<Method, Table>(table_dst, table_src, arena);
@@ -2556,6 +2840,21 @@ void NO_INLINE Aggregator::mergeDataOnlyExistingKeysImpl(
     Table & table_src,
     Arena * arena) const
 {
+    if (is_simple_count)
+    {
+        if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
+            mergeDataNullKeySimpleCount(table_dst, table_src);
+
+        table_src.mergeToViaFind(table_dst, [&](AggregateDataPtr & __restrict dst, AggregateDataPtr & __restrict src, bool found)
+        {
+            if (!found)
+                return;
+            getInlineCountState(dst) += getInlineCountState(src);
+        });
+        table_src.clearAndShrink();
+        return;
+    }
+
     /// Note : will create data for NULL key if not exist
     if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
         mergeDataNullKey<Method, Table>(table_dst, table_src, arena);
@@ -2586,6 +2885,17 @@ void NO_INLINE Aggregator::mergeWithoutKeyDataImpl(
     std::atomic<bool> & is_cancelled) const
 {
     AggregatedDataVariantsPtr & res = non_empty_data[0];
+    AggregatedDataWithoutKey & res_data = res->without_key;
+
+    if (is_simple_count)
+    {
+        for (size_t result_num = 1, size = non_empty_data.size(); result_num < size; ++result_num)
+        {
+            AggregatedDataWithoutKey & current_data = non_empty_data[result_num]->without_key;
+            getCountState(res_data) += getCountState(current_data);
+        }
+        return;
+    }
 
     for (size_t i = 0; i < params.aggregates_size; ++i)
     {
@@ -2605,7 +2915,6 @@ void NO_INLINE Aggregator::mergeWithoutKeyDataImpl(
     /// We merge all aggregation results to the first.
     for (size_t result_num = 1, size = non_empty_data.size(); result_num < size; ++result_num)
     {
-        AggregatedDataWithoutKey & res_data = res->without_key;
         AggregatedDataWithoutKey & current_data = non_empty_data[result_num]->without_key;
 
         for (size_t i = 0; i < params.aggregates_size; ++i)
@@ -2800,6 +3109,7 @@ void NO_INLINE Aggregator::mergeStreamsImplCase(
     std::atomic<bool> & is_cancelled,
     Arena * arena_for_keys) const
 {
+    chassert(!is_simple_count);
     std::unique_ptr<AggregateDataPtr[]> places(new AggregateDataPtr[row_end]);
 
     if (!arena_for_keys)
@@ -2901,21 +3211,88 @@ void NO_INLINE Aggregator::mergeStreamsImpl(
 {
     UInt64 total_rows = consecutive_keys_cache_stats.hits + consecutive_keys_cache_stats.misses;
     double cache_hit_rate = total_rows ? static_cast<double>(consecutive_keys_cache_stats.hits) / total_rows : 1.0;
-    bool use_cache = cache_hit_rate >= params.min_hit_rate_to_use_consecutive_keys_optimization;
+    bool use_cache = !is_simple_count && cache_hit_rate >= params.min_hit_rate_to_use_consecutive_keys_optimization;
+
+    auto merge_count_variant = [&]<typename State>(State & state)
+    {
+        chassert(aggregate_columns_data.size() == 1);
+        if (!arena_for_keys)
+            arena_for_keys = aggregates_pool;
+        const auto & other_aggregated_counts = *aggregate_columns_data[0];
+        if (no_more_keys)
+        {
+            for (size_t row = row_begin; row < row_end; row++)
+            {
+                auto find_result = state.findKey(data, row, *arena_for_keys);
+
+                if (find_result.isFound())
+                    getInlineCountState(find_result.getMapped()) += getCountState(other_aggregated_counts[row]);
+                else if (overflow_row)
+                    getCountState(overflow_row) += getCountState(other_aggregated_counts[row]);
+            }
+        }
+        else
+        {
+            for (size_t row = row_begin; row < row_end; row++)
+            {
+                /// clang-tidy complains wrongly about this one when running the analysis from an ARM host.
+                /// The same thing does not fail when cross-compiling from a x86_64 host.
+                /// Furthermore, arena_for_keys is set to be a pointer to the last member of aggregates_pools,
+                /// which is always initialized to have at least 1 arena.
+                auto emplace_result = state.emplaceKey(data, row, *arena_for_keys); /// NOLINT(clang-analyzer-core.NonNullParamChecker)
+                if (emplace_result.isInserted())
+                    getInlineCountState(emplace_result.getMapped()) = getCountState(other_aggregated_counts[row]);
+                else
+                    getInlineCountState(emplace_result.getMapped()) += getCountState(other_aggregated_counts[row]);
+            }
+        }
+    };
 
     if (use_cache)
     {
         typename Method::State state(key_columns, key_sizes, aggregation_state_cache);
-        mergeStreamsImplCase(
-            aggregates_pool, state, data, no_more_keys, overflow_row, row_begin, row_end, aggregate_columns_data, is_cancelled, arena_for_keys);
+        if (is_simple_count)
+        {
+            merge_count_variant(state);
+        }
+        else
+        {
+            mergeStreamsImplCase(
+                aggregates_pool,
+                state,
+                data,
+                no_more_keys,
+                overflow_row,
+                row_begin,
+                row_end,
+                aggregate_columns_data,
+                is_cancelled,
+                arena_for_keys);
+        }
 
         consecutive_keys_cache_stats.update(row_end - row_begin, state.getCacheMissesSinceLastReset());
     }
     else
     {
         typename Method::StateNoCache state(key_columns, key_sizes, aggregation_state_cache);
-        mergeStreamsImplCase(
-            aggregates_pool, state, data, no_more_keys, overflow_row, row_begin, row_end, aggregate_columns_data, is_cancelled, arena_for_keys);
+        if (is_simple_count)
+        {
+            merge_count_variant(state);
+        }
+        else
+        {
+            mergeStreamsImplCase(
+                aggregates_pool,
+                state,
+                data,
+                no_more_keys,
+                overflow_row,
+                row_begin,
+                row_end,
+                aggregate_columns_data,
+                is_cancelled,
+                arena_for_keys);
+        }
     }
 }
 
@@ -2944,6 +3321,16 @@ void NO_INLINE Aggregator::mergeWithoutKeyStreamsImpl(
         AggregateDataPtr place = result.aggregates_pool->alignedAlloc(total_size_of_aggregate_states, align_aggregate_states);
         createAggregateStates(place);
         res = place;
+    }
+
+    if (is_simple_count)
+    {
+        chassert(aggregate_columns_data.size() == 1);
+        const auto & other_aggregated_counts = *aggregate_columns_data[0];
+        for (size_t row = row_begin; row < row_end; ++row)
+            getCountState(res) += getCountState(other_aggregated_counts[row]);
+
+        return;
     }
 
     for (size_t row = row_begin; row < row_end; ++row)
@@ -3306,7 +3693,6 @@ void NO_INLINE Aggregator::convertBlockToTwoLevelImpl(
     const Block & source,
     std::vector<Block> & destinations) const
 {
-    typename Method::State state(key_columns, key_sizes, aggregation_state_cache);
 
     size_t rows = source.rows();
     size_t columns = source.columns();
@@ -3314,23 +3700,48 @@ void NO_INLINE Aggregator::convertBlockToTwoLevelImpl(
     /// Create a 'selector' that will contain bucket index for every row. It will be used to scatter rows to buckets.
     IColumn::Selector selector(rows);
 
-    /// For every row.
-    for (size_t i = 0; i < rows; ++i)
+    /// Disable cache for simple count aggregation
+    if (is_simple_count)
     {
-        if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
+        typename Method::StateNoCache state(key_columns, key_sizes, aggregation_state_cache);
+        for (size_t i = 0; i < rows; ++i)
         {
-            if (state.isNullAt(i))
+            if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
             {
-                selector[i] = 0;
-                continue;
+                if (state.isNullAt(i))
+                {
+                    selector[i] = 0;
+                    continue;
+                }
             }
+
+            /// Calculate bucket number from row hash.
+            auto hash = state.getHash(method.data, i, *pool);
+            auto bucket = method.data.getBucketFromHash(hash);
+
+            selector[i] = bucket;
         }
+    }
+    else
+    {
+        typename Method::State state(key_columns, key_sizes, aggregation_state_cache);
+        for (size_t i = 0; i < rows; ++i)
+        {
+            if constexpr (Method::low_cardinality_optimization || Method::one_key_nullable_optimization)
+            {
+                if (state.isNullAt(i))
+                {
+                    selector[i] = 0;
+                    continue;
+                }
+            }
 
-        /// Calculate bucket number from row hash.
-        auto hash = state.getHash(method.data, i, *pool);
-        auto bucket = method.data.getBucketFromHash(hash);
+            /// Calculate bucket number from row hash.
+            auto hash = state.getHash(method.data, i, *pool);
+            auto bucket = method.data.getBucketFromHash(hash);
 
-        selector[i] = bucket;
+            selector[i] = bucket;
+        }
     }
 
     UInt32 num_buckets = static_cast<UInt32>(destinations.size());

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -315,6 +315,13 @@ private:
     /// How many RAM were used to process the query before processing the first block.
     Int64 memory_usage_before_aggregation = 0;
 
+    /// Indicates whether the aggregation is a simple `count()` / `count(*)` / `count(non-nullable_column)`
+    ///
+    /// If true, we can apply an important performance optimization:
+    /// - The aggregation logic can be inlined, meaning each row is aggregated immediately during hash table probing.
+    /// - There's no need to allocate and maintain full aggregation state.
+    bool is_simple_count = false;
+
     LoggerPtr log = getLogger("Aggregator");
 
     /// For external aggregation.

--- a/src/Processors/Transforms/AggregatingTransform.h
+++ b/src/Processors/Transforms/AggregatingTransform.h
@@ -33,9 +33,6 @@ public:
 using AggregatorList = std::list<Aggregator>;
 using AggregatorListPtr = std::shared_ptr<AggregatorList>;
 
-using AggregatorList = std::list<Aggregator>;
-using AggregatorListPtr = std::shared_ptr<AggregatorList>;
-
 struct AggregatingTransformParams
 {
     Aggregator::Params params;

--- a/tests/queries/0_stateless/02402_external_disk_mertrics.sql
+++ b/tests/queries/0_stateless/02402_external_disk_mertrics.sql
@@ -14,7 +14,7 @@ SET max_memory_usage = '410M';
 SET group_by_two_level_threshold = '100K';
 SET group_by_two_level_threshold_bytes = '50M';
 
-SELECT sum(k), sum(c) FROM (SELECT number AS k, count() AS c FROM (SELECT * FROM system.numbers LIMIT 2097152) GROUP BY k)
+SELECT sum(k), sum(c) FROM (SELECT number AS k, sum(number) AS c FROM (SELECT * FROM system.numbers LIMIT 2097152) GROUP BY k)
 SETTINGS log_comment='02402_external_disk_mertrics/aggregation'
 FORMAT Null;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

When the aggregation query contains only a single `COUNT()` function on a NOT NULL column, the aggregation logic is fully inlined during hash table probing. This avoids allocating and maintaining any aggregation state, significantly reducing memory usage and CPU overhead. This partially addresses #81982.

This optimization improves performance for queries like:

```sql
SELECT COUNT(*) FROM table GROUP BY key

SELECT COUNT(col) FROM table GROUP BY key  -- when `col` is NOT NULL
```

#### ClickBench Q15
```
HEAD:

Queries executed: 104.

localhost:9000, queries: 104, QPS: 4.881, RPS: 488124765.213, MiB/s: 3724.096, result RPS: 48.814, result MiB/s: 0.001.

0%              0.173 sec.
10%             0.184 sec.
20%             0.191 sec.
30%             0.193 sec.
40%             0.197 sec.
50%             0.200 sec.
60%             0.205 sec.
70%             0.210 sec.
80%             0.216 sec.
90%             0.220 sec.
95%             0.223 sec.
99%             0.228 sec.
99.9%           0.233 sec.
99.99%          0.233 sec.

This PR

Queries executed: 106.

localhost:9000, queries: 106, QPS: 6.301, RPS: 630035513.823, MiB/s: 4806.790, result RPS: 63.005, result MiB/s: 0.001.

0%              0.136 sec.
10%             0.143 sec.
20%             0.145 sec.
30%             0.150 sec.
40%             0.153 sec.
50%             0.156 sec.
60%             0.158 sec.
70%             0.159 sec.
80%             0.162 sec.
90%             0.166 sec.
95%             0.173 sec.
99%             0.179 sec.
99.9%           0.195 sec.
99.99%          0.195 sec.
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
