### PR TITLE
docs: change note recommending PeerDB to recommending ClickPipes

### DIFF
--- a/docs/en/engines/table-engines/integrations/postgresql.md
+++ b/docs/en/engines/table-engines/integrations/postgresql.md
@@ -13,8 +13,8 @@ The PostgreSQL engine allows `SELECT` and `INSERT` queries on data stored on a r
 Currently, only PostgreSQL versions 12 and up are supported.
 :::
 
-:::note Replicating or migrating Postgres data with with PeerDB
-> In addition to the Postgres table engine, you can use [PeerDB](https://docs.peerdb.io/introduction) by ClickHouse to set up a continuous data pipeline from Postgres to ClickHouse. PeerDB is a tool designed specifically to replicate data from Postgres to ClickHouse using change data capture (CDC).
+:::note
+ClickHouse Cloud users are recommended to use [ClickPipes](/integrations/clickpipes) for streaming Postgres data into ClickHouse. This natively supports high-performance insertion while ensuring the separation of concerns with the ability to scale ingestion and cluster resources independently.
 :::
 
 ## Creating a Table {#creating-a-table}


### PR DESCRIPTION
matches text from Kafka docs

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)