### PR TITLE
Fix "Context has expired" for Iceberg

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -91,22 +91,28 @@ public:
         return std::nullopt;
     }
 
-    std::optional<size_t> totalRows() override
+    std::optional<size_t> totalRows(ContextPtr local_context) override
     {
         assertInitialized();
-        return current_metadata->totalRows();
+        return current_metadata->totalRows(local_context);
     }
 
-    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(const String & data_path) const override
+    std::optional<size_t> totalBytes(ContextPtr local_context) override
     {
         assertInitialized();
-        return current_metadata->getInitialSchemaByPath(data_path);
+        return current_metadata->totalBytes(local_context);
     }
 
-    std::shared_ptr<const ActionsDAG> getSchemaTransformer(const String & data_path) const override
+    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const override
     {
         assertInitialized();
-        return current_metadata->getSchemaTransformer(data_path);
+        return current_metadata->getInitialSchemaByPath(local_context, data_path);
+    }
+
+    std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, const String & data_path) const override
+    {
+        assertInitialized();
+        return current_metadata->getSchemaTransformer(local_context, data_path);
     }
 
     bool hasExternalDynamicMetadata() override

--- a/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
@@ -40,8 +40,8 @@ public:
         const ContextPtr & context,
         bool supports_subset_of_columns);
 
-    virtual std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(const String & /* path */) const { return {}; }
-    virtual std::shared_ptr<const ActionsDAG> getSchemaTransformer(const String & /* path */) const { return {}; }
+    virtual std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr, const String & /* path */) const { return {}; }
+    virtual std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr, const String & /* path */) const { return {}; }
 
     /// Whether metadata is updateable (instead of recreation from scratch)
     /// to the latest version of table state in data lake.
@@ -54,8 +54,8 @@ public:
 
     virtual void modifyFormatSettings(FormatSettings &) const {}
 
-    virtual std::optional<size_t> totalRows() const { return {}; }
-    virtual std::optional<size_t> totalBytes() const { return {}; }
+    virtual std::optional<size_t> totalRows(ContextPtr) const { return {}; }
+    virtual std::optional<size_t> totalBytes(ContextPtr) const { return {}; }
 
 protected:
     ObjectIterator createKeysIterator(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -24,7 +24,7 @@
 namespace DB
 {
 
-class IcebergMetadata : public IDataLakeMetadata, private WithContext
+class IcebergMetadata : public IDataLakeMetadata
 {
 public:
     using ConfigurationObserverPtr = StorageObjectStorage::ConfigurationObserverPtr;
@@ -59,15 +59,15 @@ public:
         const ConfigurationObserverPtr & configuration,
         const ContextPtr & local_context);
 
-    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(const String & data_path) const override
+    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const override
     {
-        auto version_if_outdated = getSchemaVersionByFileIfOutdated(data_path);
+        auto version_if_outdated = getSchemaVersionByFileIfOutdated(local_context, data_path);
         return version_if_outdated.has_value() ? schema_processor.getClickhouseTableSchemaById(version_if_outdated.value()) : nullptr;
     }
 
-    std::shared_ptr<const ActionsDAG> getSchemaTransformer(const String & data_path) const override
+    std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, const String & data_path) const override
     {
-        auto version_if_outdated = getSchemaVersionByFileIfOutdated(data_path);
+        auto version_if_outdated = getSchemaVersionByFileIfOutdated(local_context, data_path);
         return version_if_outdated.has_value()
             ? schema_processor.getSchemaTransformationDagByIds(version_if_outdated.value(), relevant_snapshot_schema_id)
             : nullptr;
@@ -82,10 +82,10 @@ public:
 
     bool update(const ContextPtr & local_context) override;
 
-    IcebergHistory getHistory() const;
+    IcebergHistory getHistory(ContextPtr local_context) const;
 
-    std::optional<size_t> totalRows() const override;
-    std::optional<size_t> totalBytes() const override;
+    std::optional<size_t> totalRows(ContextPtr Local_context) const override;
+    std::optional<size_t> totalBytes(ContextPtr Local_context) const override;
 
 protected:
     ObjectIterator iterate(
@@ -123,20 +123,20 @@ private:
 
     Strings getDataFiles(const ActionsDAG * filter_dag, ContextPtr local_context) const;
 
-    void updateSnapshot(Poco::JSON::Object::Ptr metadata_object);
+    void updateSnapshot(ContextPtr local_context, Poco::JSON::Object::Ptr metadata_object);
 
-    ManifestFileCacheKeys getManifestList(const String & filename) const;
+    ManifestFileCacheKeys getManifestList(ContextPtr local_context, const String & filename) const;
     mutable std::vector<Iceberg::ManifestFileEntry> positional_delete_files_for_current_query;
 
     void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object);
 
-    std::optional<Int32> getSchemaVersionByFileIfOutdated(String data_path) const;
+    std::optional<Int32> getSchemaVersionByFileIfOutdated(ContextPtr local_context, String data_path) const;
 
-    void initializeSchemasFromManifestList(ManifestFileCacheKeys manifest_list_ptr) const;
+    void initializeSchemasFromManifestList(ContextPtr local_context, ManifestFileCacheKeys manifest_list_ptr) const;
 
     void initializeSchemasFromManifestFile(Iceberg::ManifestFilePtr manifest_file_ptr) const;
 
-    Iceberg::ManifestFilePtr getManifestFile(const String & filename, Int64 inherited_sequence_number) const;
+    Iceberg::ManifestFilePtr getManifestFile(ContextPtr local_context, const String & filename, Int64 inherited_sequence_number) const;
 
     std::optional<String> getRelevantManifestList(const Poco::JSON::Object::Ptr & metadata);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -257,7 +257,7 @@ std::optional<UInt64> StorageObjectStorage::totalRows(ContextPtr query_context) 
         /* if_not_updated_before */false,
         /* check_consistent_with_previous_metadata */true);
 
-    return configuration->totalRows();
+    return configuration->totalRows(query_context);
 }
 
 std::optional<UInt64> StorageObjectStorage::totalBytes(ContextPtr query_context) const
@@ -268,7 +268,7 @@ std::optional<UInt64> StorageObjectStorage::totalBytes(ContextPtr query_context)
         /* if_not_updated_before */false,
         /* check_consistent_with_previous_metadata */true);
 
-    return configuration->totalBytes();
+    return configuration->totalBytes(query_context);
 }
 
 ReadFromFormatInfo StorageObjectStorage::Configuration::prepareReadingFromFormat(

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -239,16 +239,16 @@ public:
 
     virtual bool isDataLakeConfiguration() const { return false; }
 
-    virtual std::optional<size_t> totalRows() { return {}; }
-    virtual std::optional<size_t> totalBytes() { return {}; }
+    virtual std::optional<size_t> totalRows(ContextPtr) { return {}; }
+    virtual std::optional<size_t> totalBytes(ContextPtr) { return {}; }
 
     virtual bool hasExternalDynamicMetadata() { return false; }
 
     virtual IDataLakeMetadata * getExternalMetadata() { return nullptr; }
 
-    virtual std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(const String &) const { return {}; }
+    virtual std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr, const String &) const { return {}; }
 
-    virtual std::shared_ptr<const ActionsDAG> getSchemaTransformer(const String &) const { return {}; }
+    virtual std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr, const String &) const { return {}; }
 
     virtual void modifyFormatSettings(FormatSettings &) const {}
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -103,7 +103,7 @@ std::optional<UInt64> StorageObjectStorageCluster::totalRows(ContextPtr query_co
         query_context,
         /* if_not_updated_before */false,
         /* check_consistent_with_previous_metadata */true);
-    return configuration->totalRows();
+    return configuration->totalRows(query_context);
 }
 
 std::optional<UInt64> StorageObjectStorageCluster::totalBytes(ContextPtr query_context) const
@@ -113,7 +113,7 @@ std::optional<UInt64> StorageObjectStorageCluster::totalBytes(ContextPtr query_c
         query_context,
         /* if_not_updated_before */false,
         /* check_consistent_with_previous_metadata */true);
-    return configuration->totalBytes();
+    return configuration->totalBytes(query_context);
 }
 
 void StorageObjectStorageCluster::updateQueryToSendIfNeeded(

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -464,7 +464,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
 
         Block initial_header = read_from_format_info.format_header;
 
-        if (auto initial_schema = configuration->getInitialSchemaByPath(object_info->getPath()))
+        if (auto initial_schema = configuration->getInitialSchemaByPath(context_, object_info->getPath()))
         {
             Block sample_header;
             for (const auto & [name, type] : *initial_schema)
@@ -502,7 +502,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
         if (object_info->data_lake_metadata)
             transformer = object_info->data_lake_metadata->transform;
         else
-            transformer = configuration->getSchemaTransformer(object_info->getPath());
+            transformer = configuration->getSchemaTransformer(context_, object_info->getPath());
 
         if (transformer)
         {

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -547,13 +547,13 @@ std::future<StorageObjectStorageSource::ReaderHolder> StorageObjectStorageSource
 }
 
 std::unique_ptr<ReadBufferFromFileBase> StorageObjectStorageSource::createReadBuffer(
-    ObjectInfo & object_info, const ObjectStoragePtr & object_storage, const ContextPtr & context_, const LoggerPtr & log)
+    ObjectInfo & object_info, const ObjectStoragePtr & object_storage, const ContextPtr & context_, const LoggerPtr & log, const std::optional<ReadSettings> & read_settings)
 {
     const auto & settings = context_->getSettingsRef();
-    const auto & read_settings = context_->getReadSettings();
+    const auto & effective_read_settings = read_settings.has_value() ? read_settings.value() : context_->getReadSettings();
 
     const auto filesystem_cache_name = settings[Setting::filesystem_cache_name].value;
-    bool use_cache = read_settings.enable_filesystem_cache
+    bool use_cache = effective_read_settings.enable_filesystem_cache
         && !filesystem_cache_name.empty()
         && (object_storage->getType() == ObjectStorageType::Azure
             || object_storage->getType() == ObjectStorageType::S3);
@@ -561,14 +561,14 @@ std::unique_ptr<ReadBufferFromFileBase> StorageObjectStorageSource::createReadBu
     if (!object_info.metadata)
     {
         if (!use_cache)
-            return object_storage->readObject(StoredObject(object_info.getPath()), read_settings);
+            return object_storage->readObject(StoredObject(object_info.getPath()), effective_read_settings);
 
         object_info.metadata = object_storage->getObjectMetadata(object_info.getPath());
     }
 
     const auto & object_size = object_info.metadata->size_bytes;
 
-    auto modified_read_settings = read_settings.adjustBufferSize(object_size);
+    auto modified_read_settings = effective_read_settings.adjustBufferSize(object_size);
     /// FIXME: Changing this setting to default value breaks something around parquet reading
     modified_read_settings.remote_read_min_bytes_for_seek = modified_read_settings.remote_fs_buffer_size;
     /// User's object may change, don't cache it.
@@ -623,7 +623,7 @@ std::unique_ptr<ReadBufferFromFileBase> StorageObjectStorageSource::createReadBu
                 cache,
                 FileCache::getCommonUser(),
                 read_buffer_creator,
-                use_async_buffer ? nested_buffer_read_settings : read_settings,
+                use_async_buffer ? nested_buffer_read_settings : effective_read_settings,
                 std::string(CurrentThread::getQueryId()),
                 object_size,
                 /* allow_seeks */true,
@@ -649,10 +649,10 @@ std::unique_ptr<ReadBufferFromFileBase> StorageObjectStorageSource::createReadBu
 
     LOG_TRACE(log, "Downloading object of size {} with initial prefetch", object_size);
 
-    bool prefer_bigger_buffer_size = read_settings.filesystem_cache_prefer_bigger_buffer_size && impl->isCached();
+    bool prefer_bigger_buffer_size = effective_read_settings.filesystem_cache_prefer_bigger_buffer_size && impl->isCached();
     size_t buffer_size = prefer_bigger_buffer_size
-        ? std::max<size_t>(read_settings.remote_fs_buffer_size, DBMS_DEFAULT_BUFFER_SIZE)
-        : read_settings.remote_fs_buffer_size;
+        ? std::max<size_t>(effective_read_settings.remote_fs_buffer_size, DBMS_DEFAULT_BUFFER_SIZE)
+        : effective_read_settings.remote_fs_buffer_size;
     if (object_size)
         buffer_size = std::min<size_t>(object_size, buffer_size);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <Common/re2.h>
 #include <Interpreters/Context_fwd.h>
 #include <IO/Archives/IArchiveReader.h>
@@ -72,7 +73,9 @@ public:
         ObjectInfo & object_info,
         const ObjectStoragePtr & object_storage,
         const ContextPtr & context_,
-        const LoggerPtr & log);
+        const LoggerPtr & log,
+        const std::optional<ReadSettings> & read_settings = std::nullopt);
+
 protected:
     const String name;
     ObjectStoragePtr object_storage;

--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -62,7 +62,7 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
         {
             if (IcebergMetadata * iceberg_metadata = dynamic_cast<IcebergMetadata *>(object_storage->getExternalMetadata(context)); iceberg_metadata)
             {
-                IcebergMetadata::IcebergHistory iceberg_history_items = iceberg_metadata->getHistory();
+                IcebergMetadata::IcebergHistory iceberg_history_items = iceberg_metadata->getHistory(context);
 
                 for (auto & iceberg_history_item : iceberg_history_items)
                 {


### PR DESCRIPTION
Previously Iceberg caches local context with which it has been created, and during update it tries to uses it got this error.

```
StorageSystemTables: Code: 49. DB::Exception: Context has expired. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):

0. ./ci/tmp/build/./src/Common/Exception.cpp:112: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool)
1. DB::Exception::Exception(PreformattedMessage&&, int)
2. DB::Exception::Exception<>(int, FormatStringHelperImpl<>)
3. DB::WithContextImpl<std::shared_ptr<DB::Context const>>::getContext() const
4. ./ci/tmp/build/./src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp:664: DB::IcebergMetadata::getManifestList(String const&) const::$_0::operator()() const
5. ./src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h:126: DB::IcebergMetadata::updateSnapshot(Poco::SharedPtr<Poco::JSON::Object, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::JSON::Object>>)
6. ./ci/tmp/build/./src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp:579: DB::IcebergMetadata::updateState(std::shared_ptr<DB::Context const> const&, Poco::SharedPtr<Poco::JSON::Object, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::JSON::Object>>, bool)
7. ./ci/tmp/build/./src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp:461: DB::IcebergMetadata::update(std::shared_ptr<DB::Context const> const&)
8. ./src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h:182: DB::DataLakeConfiguration<DB::StorageS3Configuration, DB::IcebergMetadata>::updateMetadataObjectIfNeeded(std::shared_ptr<DB::IObjectStorage>, std::shared_ptr<DB::Context const>)
9. ./src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h:59: DB::DataLakeConfiguration<DB::StorageS3Configuration, DB::IcebergMetadata>::update(std::shared_ptr<DB::IObjectStorage>, std::shared_ptr<DB::Context const>)
10. ./ci/tmp/build/./src/Storages/ObjectStorage/StorageObjectStorage.cpp:222: DB::StorageObjectStorage::totalBytes(std::shared_ptr<DB::Context const>) const
11. ./ci/tmp/build/./src/Storages/System/StorageSystemTables.cpp:665: DB::TablesBlockSource::generate()
```

Remove WithContext, and passthrough the query/local context instead.

Also, totalBytes() override was missing for iceberg in configuration, this has been fixed as well.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "Context has expired" for Iceberg