### PR TITLE
Follow up to #81868

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -862,7 +862,7 @@ bool CachedOnDiskReadBufferFromFile::nextImplStep()
                 }
             }
 
-            if (!internal_buffer.empty())
+            if (use_external_buffer && !internal_buffer.empty())
                 internal_buffer.resize(original_buffer_size);
 
             chassert(!file_segment.isDownloader());


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow up to https://github.com/ClickHouse/ClickHouse/pull/81868: reverted this line of code to the way it used to be before

