### PR TITLE
Fix build of mysqlxx_pool_test

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -167,6 +167,8 @@ def main():
             targets = "clickhouse-bundle"
         elif build_type == BuildTypes.FUZZERS:
             targets = "fuzzers"
+        elif build_type == BuildTypes.AMD_DEBUG:
+            targets = "-k0 all"
         elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             targets = "-k0 all"
             run_shell("clang-tidy-cache stats", "clang-tidy-cache --show-stats")

--- a/src/Common/mysqlxx/tests/CMakeLists.txt
+++ b/src/Common/mysqlxx/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
-target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx dbms clickhouse_common_config loggers_no_text_log)
+target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx clickhouse_common_config loggers_no_text_log)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Previously due to `dbms` it requires `clickhouse_functions_text`, but it does not need `dbms` at all.

Follow-up: for #80641