### PR TITLE
tests: fix expect test that interacts with bash

### DIFF
--- a/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
@@ -25,12 +25,14 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash
+spawn bash --noprofile --norc -c "PS1='bash) ' bash --noprofile --norc"
 send "source $basedir/../shell_config.sh\r"
+expect "bash) "
 
 send "yes | head -n10000000 | \$CLICKHOUSE_CLIENT --progress --query \"insert into function null('foo String') format TSV\" >/dev/null\r"
 expect "Progress: "
 send "\3"
+expect "bash) "
 
 send "exit\r"
 expect eof

--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
@@ -27,12 +27,14 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash
+spawn bash --noprofile --norc -c "PS1='bash) ' bash --noprofile --norc"
 send "source $basedir/../shell_config.sh\r"
+expect "bash) "
 
 send "yes | head -n10000000 | \$CLICKHOUSE_LOCAL --progress --query \"insert into function null('foo String') format TSV\" >/dev/null\r"
 expect "Progress: "
 send "\3"
+expect "bash) "
 
 send "exit\r"
 expect eof

--- a/tests/queries/0_stateless/02456_progress_tty.expect
+++ b/tests/queries/0_stateless/02456_progress_tty.expect
@@ -19,41 +19,48 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash
+spawn bash --noprofile --norc -c "PS1='bash) ' bash --noprofile --norc"
 send "source $basedir/../shell_config.sh\r"
+expect "bash) "
 
 # Progress is not displayed by default
 send "\$CLICKHOUSE_LOCAL --format TSV --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
 expect -exact "0\tHello\r\n"
 send "\3"
+expect "bash) "
 
 # The option --progress has implicit value of true
 send "\$CLICKHOUSE_LOCAL --format TSV --progress --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null\r"
 expect "Progress: "
 expect "█"
 send "\3"
+expect "bash) "
 
 # It works even if we redirect both stdout and stderr to /dev/null
 send "\$CLICKHOUSE_LOCAL --format TSV --progress --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null 2>&1\r"
 expect "Progress: "
 expect "█"
 send "\3"
+expect "bash) "
 
 # But we can set it to false
 send "\$CLICKHOUSE_LOCAL --format TSV --progress false --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
 expect -exact "0\tHello\r\n"
 send "\3"
+expect "bash) "
 
 # As well as to 0 for the same effect
 send "\$CLICKHOUSE_LOCAL --format TSV --progress 0 --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
 expect -exact "0\tHello\r\n"
 send "\3"
+expect "bash) "
 
 # If we set it to 1, the progress will be displayed as well
 send "\$CLICKHOUSE_LOCAL --format TSV --progress 1 --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null 2>&1\r"
 expect "Progress: "
 expect "█"
 send "\3"
+expect "bash) "
 
 send "exit\r"
 expect eof

--- a/tests/queries/0_stateless/02480_client_option_print_num_processed_rows.expect
+++ b/tests/queries/0_stateless/02480_client_option_print_num_processed_rows.expect
@@ -20,19 +20,24 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash
+spawn bash --noprofile --norc -c "PS1='bash) ' bash --noprofile --norc"
 send "source $basedir/../shell_config.sh\r"
+expect "bash) "
 
 send -- "\$CLICKHOUSE_CLIENT --query 'DROP TABLE IF EXISTS num_processed_rows_test_0' >/dev/null 2>&1\r"
+expect "bash) "
 
 send -- "\$CLICKHOUSE_CLIENT --query 'CREATE TABLE num_processed_rows_test_0 (val String) ENGINE = Memory;' >/dev/null 2>&1\r"
+expect "bash) "
 
 ### When requested we should get the count on exit:
 send -- "\$CLICKHOUSE_CLIENT --processed-rows --query \"INSERT INTO num_processed_rows_test_0 VALUES (\'x\');\" \r"
 expect "Processed rows: 1"
+expect "bash) "
 
 send "yes | head -n7757 | \$CLICKHOUSE_CLIENT --processed-rows --query 'INSERT INTO num_processed_rows_test_0 format TSV\'\r"
 expect "Processed rows: 7757"
+expect "bash) "
 
 
 
@@ -40,9 +45,11 @@ expect "Processed rows: 7757"
 
 send -- "\$CLICKHOUSE_CLIENT --query \"INSERT INTO num_processed_rows_test_0 VALUES (\'x\');\" && echo OK\r"
 expect -exact "OK\r"
+expect "bash) "
 
 send "yes | head -n7757 | \$CLICKHOUSE_CLIENT --query 'INSERT INTO num_processed_rows_test_0 format TSV\' && echo OK\r"
 expect -exact "OK\r"
+expect "bash) "
 
 send "exit\r"
 expect eof

--- a/tests/queries/0_stateless/02493_inconsistent_hex_and_binary_number.expect
+++ b/tests/queries/0_stateless/02493_inconsistent_hex_and_binary_number.expect
@@ -19,27 +19,34 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash
+spawn bash --noprofile --norc -c "PS1='bash) ' bash --noprofile --norc"
 send "source $basedir/../shell_config.sh\r"
+expect "bash) "
 
 send "\$CLICKHOUSE_CLIENT --query 'select 0b'\r"
 expect "(UNKNOWN_IDENTIFIER)"
+expect "bash) "
 
 send "\$CLICKHOUSE_CLIENT --query 'select 0b;'\r"
 expect "(UNKNOWN_IDENTIFIER)"
+expect "bash) "
 
 send "\$CLICKHOUSE_CLIENT --query 'select 0b ;'\r"
 expect "(UNKNOWN_IDENTIFIER)"
+expect "bash) "
 
 
 send "\$CLICKHOUSE_CLIENT --query 'select 0x'\r"
 expect "(UNKNOWN_IDENTIFIER)"
+expect "bash) "
 
 send "\$CLICKHOUSE_CLIENT --query 'select 0x;'\r"
 expect "(UNKNOWN_IDENTIFIER)"
+expect "bash) "
 
 send "\$CLICKHOUSE_CLIENT --query 'select 0x ;'\r"
 expect "(UNKNOWN_IDENTIFIER)"
+expect "bash) "
 
 send "exit\r"
 expect eof


### PR DESCRIPTION
CI found [1]:

    [Kclickhouse@ba4c3b96bd21:~/ubuntu/actions-runner/_work/ClickHouse/ClickHouse$ ^Cexit

    bash: xit: command not found
    clickhouse@ba4c3b96bd21:~/ubuntu/actions-runner/_work/ClickHouse/ClickHouse$ expect: timed out
    , result:

The problem is that we did not wait until we return to `bash`.

And in general **every `send` should have subsequent `expect`**

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=918f463edfad21a38a0ca504f78f48a2c7cebc42&name_0=MasterCI&name_1=Stateless+tests+%28amd_debug%2C+distributed+plan%2C+s3+storage%29&name_2=Tests

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)