### PR TITLE
Rename haveExplicitNames and have_explicit_names

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -646,8 +646,8 @@ DataTypePtr QueryFuzzer::fuzzDataType(DataTypePtr type)
         for (const auto & element : type_tuple->getElements())
             elements.push_back(fuzzDataType(element));
 
-        return type_tuple->haveExplicitNames() ? std::make_shared<DataTypeTuple>(elements, type_tuple->getElementNames())
-                                               : std::make_shared<DataTypeTuple>(elements);
+        return type_tuple->hasExplicitNames() ? std::make_shared<DataTypeTuple>(elements, type_tuple->getElementNames())
+                                              : std::make_shared<DataTypeTuple>(elements);
     }
 
     const auto * type_map = typeid_cast<const DataTypeMap *>(type.get());

--- a/src/DataTypes/DataTypeLowCardinalityHelpers.cpp
+++ b/src/DataTypes/DataTypeLowCardinalityHelpers.cpp
@@ -37,7 +37,7 @@ DataTypePtr recursiveRemoveLowCardinality(const DataTypePtr & type)
         for (auto & element : elements)
             element = recursiveRemoveLowCardinality(element);
 
-        if (tuple_type->haveExplicitNames())
+        if (tuple_type->hasExplicitNames())
             return std::make_shared<DataTypeTuple>(elements, tuple_type->getElementNames());
         return std::make_shared<DataTypeTuple>(elements);
     }

--- a/src/DataTypes/DataTypeMap.cpp
+++ b/src/DataTypes/DataTypeMap.cpp
@@ -39,7 +39,7 @@ DataTypeMap::DataTypeMap(const DataTypePtr & nested_)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "Expected Array(Tuple(key, value)) type, got {}", nested->getName());
 
-    if (type_tuple->haveExplicitNames())
+    if (type_tuple->hasExplicitNames())
     {
         const auto & names = type_tuple->getElementNames();
         if (names[0] != "keys" || names[1] != "values")

--- a/src/DataTypes/DataTypeTuple.cpp
+++ b/src/DataTypes/DataTypeTuple.cpp
@@ -39,7 +39,7 @@ namespace ErrorCodes
 
 
 DataTypeTuple::DataTypeTuple(const DataTypes & elems_)
-    : elems(elems_), have_explicit_names(false)
+    : elems(elems_), has_explicit_names(false)
 {
     /// Automatically assigned names in form of '1', '2', ...
     size_t size = elems.size();
@@ -64,7 +64,7 @@ static std::optional<Exception> checkTupleNames(const Strings & names)
 }
 
 DataTypeTuple::DataTypeTuple(const DataTypes & elems_, const Strings & names_)
-    : elems(elems_), names(names_), have_explicit_names(true)
+    : elems(elems_), names(names_), has_explicit_names(true)
 {
     size_t size = elems.size();
     if (names.size() != size)
@@ -85,7 +85,7 @@ std::string DataTypeTuple::doGetName() const
         if (i != 0)
             s << ", ";
 
-        if (have_explicit_names)
+        if (has_explicit_names)
             s << backQuoteIfNeed(names[i]) << ' ';
 
         s << elems[i]->getName();
@@ -101,7 +101,7 @@ std::string DataTypeTuple::doGetPrettyName(size_t indent) const
     WriteBufferFromOwnString s;
 
     /// If the Tuple is named, we will output it in multiple lines with indentation.
-    if (have_explicit_names)
+    if (has_explicit_names)
     {
         s << "Tuple(\n";
 
@@ -352,12 +352,12 @@ SerializationPtr DataTypeTuple::doGetDefaultSerialization() const
 
     for (size_t i = 0; i < elems.size(); ++i)
     {
-        String elem_name = have_explicit_names ? names[i] : toString(i + 1);
+        String elem_name = has_explicit_names ? names[i] : toString(i + 1);
         auto serialization = elems[i]->getDefaultSerialization();
         serializations[i] = std::make_shared<SerializationNamed>(serialization, elem_name, SubstreamType::TupleElement);
     }
 
-    return std::make_shared<SerializationTuple>(std::move(serializations), have_explicit_names);
+    return std::make_shared<SerializationTuple>(std::move(serializations), has_explicit_names);
 }
 
 SerializationPtr DataTypeTuple::getSerialization(const SerializationInfo & info) const
@@ -367,12 +367,12 @@ SerializationPtr DataTypeTuple::getSerialization(const SerializationInfo & info)
 
     for (size_t i = 0; i < elems.size(); ++i)
     {
-        String elem_name = have_explicit_names ? names[i] : toString(i + 1);
+        String elem_name = has_explicit_names ? names[i] : toString(i + 1);
         auto serialization = elems[i]->getSerialization(*info_tuple.getElementInfo(i));
         serializations[i] = std::make_shared<SerializationNamed>(serialization, elem_name, SubstreamType::TupleElement);
     }
 
-    return std::make_shared<SerializationTuple>(std::move(serializations), have_explicit_names);
+    return std::make_shared<SerializationTuple>(std::move(serializations), has_explicit_names);
 }
 
 MutableSerializationInfoPtr DataTypeTuple::createSerializationInfo(const SerializationInfoSettings & settings) const

--- a/src/DataTypes/DataTypeTuple.h
+++ b/src/DataTypes/DataTypeTuple.h
@@ -22,7 +22,7 @@ class DataTypeTuple final : public IDataType
 private:
     DataTypes elems;
     Strings names;
-    bool have_explicit_names;
+    bool has_explicit_names;
 
 public:
     static constexpr bool is_parametric = true;
@@ -70,7 +70,7 @@ public:
     std::optional<size_t> tryGetPositionByName(const String & name, bool case_insensitive = false) const;
     String getNameByPosition(size_t i) const;
 
-    bool haveExplicitNames() const { return have_explicit_names; }
+    bool hasExplicitNames() const { return has_explicit_names; }
 
     void forEachChild(const ChildCallback & callback) const override;
 };

--- a/src/DataTypes/DataTypesBinaryEncoding.cpp
+++ b/src/DataTypes/DataTypesBinaryEncoding.cpp
@@ -209,7 +209,7 @@ BinaryTypeIndex getBinaryTypeIndex(const DataTypePtr & type)
         case TypeIndex::Tuple:
         {
             const auto & tuple_type = assert_cast<const DataTypeTuple &>(*type);
-            if (tuple_type.haveExplicitNames())
+            if (tuple_type.hasExplicitNames())
                 return BinaryTypeIndex::NamedTuple;
             return BinaryTypeIndex::UnnamedTuple;
         }

--- a/src/DataTypes/NestedUtils.cpp
+++ b/src/DataTypes/NestedUtils.cpp
@@ -82,7 +82,7 @@ static Block flattenImpl(const Block & block, bool flatten_named_tuple)
         {
             const DataTypeArray * type_arr = assert_cast<const DataTypeArray *>(elem.type.get());
             const DataTypeTuple * type_tuple = assert_cast<const DataTypeTuple *>(type_arr->getNestedType().get());
-            if (type_tuple->haveExplicitNames())
+            if (type_tuple->hasExplicitNames())
             {
                 const DataTypes & element_types = type_tuple->getElements();
                 const Strings & names = type_tuple->getElementNames();
@@ -118,7 +118,7 @@ static Block flattenImpl(const Block & block, bool flatten_named_tuple)
         }
         else if (const DataTypeTuple * type_tuple = typeid_cast<const DataTypeTuple *>(elem.type.get()); type_tuple && flatten_named_tuple)
         {
-            if (type_tuple->haveExplicitNames())
+            if (type_tuple->hasExplicitNames())
             {
                 const DataTypes & element_types = type_tuple->getElements();
                 const Strings & names = type_tuple->getElementNames();

--- a/src/DataTypes/ObjectUtils.cpp
+++ b/src/DataTypes/ObjectUtils.cpp
@@ -174,7 +174,7 @@ static auto extractVector(const std::vector<Tuple> & vec)
 
 static DataTypePtr recreateTupleWithElements(const DataTypeTuple & type_tuple, const DataTypes & elements)
 {
-    return type_tuple.haveExplicitNames()
+    return type_tuple.hasExplicitNames()
         ? std::make_shared<DataTypeTuple>(elements, type_tuple.getElementNames())
         : std::make_shared<DataTypeTuple>(elements);
 }

--- a/src/DataTypes/Serializations/SerializationTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationTuple.cpp
@@ -233,7 +233,7 @@ bool SerializationTuple::tryDeserializeText(DB::IColumn & column, DB::ReadBuffer
 void SerializationTuple::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     if (settings.json.write_named_tuples_as_objects
-        && have_explicit_names)
+        && has_explicit_names)
     {
         writeChar('{', ostr);
 
@@ -271,7 +271,7 @@ void SerializationTuple::serializeTextJSON(const IColumn & column, size_t row_nu
 void SerializationTuple::serializeTextJSONPretty(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings, size_t indent) const
 {
     if (settings.json.write_named_tuples_as_objects
-        && have_explicit_names)
+        && has_explicit_names)
     {
         writeCString("{\n", ostr);
 
@@ -318,7 +318,7 @@ ReturnType SerializationTuple::deserializeTupleJSONImpl(IColumn & column, ReadBu
     static constexpr auto throw_exception = std::is_same_v<ReturnType, void>;
 
     if (settings.json.read_named_tuples_as_objects
-        && have_explicit_names)
+        && has_explicit_names)
     {
         skipWhitespaceIfAny(istr);
         if constexpr (throw_exception)

--- a/src/DataTypes/Serializations/SerializationTuple.h
+++ b/src/DataTypes/Serializations/SerializationTuple.h
@@ -12,8 +12,8 @@ public:
     using ElementSerializationPtr = std::shared_ptr<const SerializationNamed>;
     using ElementSerializations = std::vector<ElementSerializationPtr>;
 
-    SerializationTuple(const ElementSerializations & elems_, bool have_explicit_names_)
-        : elems(elems_), have_explicit_names(have_explicit_names_)
+    SerializationTuple(const ElementSerializations & elems_, bool has_explicit_names_)
+        : elems(elems_), has_explicit_names(has_explicit_names_)
     {
     }
 
@@ -75,7 +75,7 @@ public:
 
 private:
     ElementSerializations elems;
-    bool have_explicit_names;
+    bool has_explicit_names;
 
     size_t getPositionByName(const String & name) const;
 

--- a/src/DataTypes/transformTypesRecursively.cpp
+++ b/src/DataTypes/transformTypesRecursively.cpp
@@ -91,7 +91,7 @@ void transformTypesRecursively(DataTypes & types, std::function<void(DataTypes &
             std::vector<DataTypes> nested_types;
             const DataTypeTuple * type_tuple = typeid_cast<const DataTypeTuple *>(types[0].get());
             size_t tuple_size = type_tuple->getElements().size();
-            bool have_explicit_names = type_tuple->haveExplicitNames();
+            bool has_explicit_names = type_tuple->hasExplicitNames();
             nested_types.resize(tuple_size);
             for (size_t elem_idx = 0; elem_idx < tuple_size; ++elem_idx)
                 nested_types[elem_idx].reserve(types.size());
@@ -131,7 +131,7 @@ void transformTypesRecursively(DataTypes & types, std::function<void(DataTypes &
 
                 for (size_t i = 0; i != types.size(); ++i)
                 {
-                    if (have_explicit_names)
+                    if (has_explicit_names)
                         types[i] = std::make_shared<DataTypeTuple>(transposed_nested_types[i], element_names);
                     else
                         types[i] = std::make_shared<DataTypeTuple>(transposed_nested_types[i]);

--- a/src/Formats/CapnProtoSerializer.cpp
+++ b/src/Formats/CapnProtoSerializer.cpp
@@ -1267,9 +1267,9 @@ namespace
             const auto * tuple_data_type = assert_cast<const DataTypeTuple *>(data_type.get());
             auto nested_types = tuple_data_type->getElements();
             Names nested_names;
-            bool have_explicit_names = tuple_data_type->haveExplicitNames();
+            bool has_explicit_names = tuple_data_type->hasExplicitNames();
             auto structure_fields = struct_schema.getFields();
-            if (!have_explicit_names)
+            if (!has_explicit_names)
             {
                 if (nested_types.size() != structure_fields.size())
                     throw Exception(

--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -1952,7 +1952,7 @@ std::unique_ptr<JSONExtractTreeNode<JSONParser>> buildJSONExtractTree(const Data
             elements.reserve(tuple_elements.size());
             for (const auto & tuple_element : tuple_elements)
                 elements.emplace_back(buildJSONExtractTree<JSONParser>(tuple_element, source_for_exception_message));
-            return std::make_unique<TupleNode<JSONParser>>(std::move(elements), tuple.haveExplicitNames() ? tuple.getElementNames() : Strings{});
+            return std::make_unique<TupleNode<JSONParser>>(std::move(elements), tuple.hasExplicitNames() ? tuple.getElementNames() : Strings{});
         }
         case TypeIndex::Map:
         {

--- a/src/Formats/ProtobufSerializer.cpp
+++ b/src/Formats/ProtobufSerializer.cpp
@@ -3622,9 +3622,9 @@ namespace
 
                     if (const auto * message_type = field_descriptor.message_type())
                     {
-                        bool have_explicit_names = tuple_data_type.haveExplicitNames();
+                        bool has_explicit_names = tuple_data_type.hasExplicitNames();
                         Names element_names;
-                        if (have_explicit_names)
+                        if (has_explicit_names)
                         {
                             element_names = tuple_data_type.getElementNames();
                         }

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -501,7 +501,7 @@ namespace
             if (isTuple(type))
             {
                 const auto * tuple_type = assert_cast<const DataTypeTuple *>(type.get());
-                if (tuple_type->haveExplicitNames())
+                if (tuple_type->hasExplicitNames())
                     return;
 
                 if (checkIfTypesAreEqual(tuple_type->getElements()))
@@ -536,7 +536,7 @@ namespace
             if (isTuple(type))
             {
                 const auto & tuple_type = assert_cast<const DataTypeTuple &>(*type);
-                if (tuple_type.haveExplicitNames())
+                if (tuple_type.hasExplicitNames())
                     return;
 
                 const auto & current_tuple_size = tuple_type.getElements().size();
@@ -624,7 +624,7 @@ namespace
         for (auto & type : data_types)
         {
             const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get());
-            if (tuple_type && tuple_type->haveExplicitNames())
+            if (tuple_type && tuple_type->hasExplicitNames())
             {
                 const auto & elements = tuple_type->getElements();
                 const auto & names = tuple_type->getElementNames();
@@ -655,7 +655,7 @@ namespace
         for (auto & type : data_types)
         {
             const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get());
-            if (tuple_type && tuple_type->haveExplicitNames())
+            if (tuple_type && tuple_type->hasExplicitNames())
                 type = result_tuple;
         }
     }
@@ -1460,7 +1460,7 @@ void transformFinalInferredJSONTypeIfNeededImpl(DataTypePtr & data_type, const F
     {
         auto nested_types = tuple_type->getElements();
 
-        if (tuple_type->haveExplicitNames())
+        if (tuple_type->hasExplicitNames())
         {
             for (auto & nested_type : nested_types)
                 transformFinalInferredJSONTypeIfNeededImpl(nested_type, settings, json_info, remain_nothing_types);
@@ -1617,7 +1617,7 @@ DataTypePtr makeNullableRecursively(DataTypePtr type, const FormatSettings & set
             nested_types.push_back(nested_type);
         }
 
-        if (tuple_type->haveExplicitNames())
+        if (tuple_type->hasExplicitNames())
             return std::make_shared<DataTypeTuple>(std::move(nested_types), tuple_type->getElementNames());
 
         return std::make_shared<DataTypeTuple>(std::move(nested_types));

--- a/src/Formats/StructureToFormatSchemaUtils.cpp
+++ b/src/Formats/StructureToFormatSchemaUtils.cpp
@@ -110,7 +110,7 @@ NamesAndTypesList getCollectedTupleElements(const DataTypeTuple & tuple_type, bo
 {
     const auto & nested_types = tuple_type.getElements();
     Names nested_names;
-    if (tuple_type.haveExplicitNames())
+    if (tuple_type.hasExplicitNames())
     {
         nested_names = tuple_type.getElementNames();
     }

--- a/src/Formats/insertNullAsDefaultIfNeeded.cpp
+++ b/src/Formats/insertNullAsDefaultIfNeeded.cpp
@@ -45,7 +45,7 @@ bool insertNullAsDefaultIfNeeded(ColumnWithTypeAndName & input_column, const Col
         if (tuple_input_type.getElements().size() != tuple_header_type.getElements().size())
             return false;
 
-        bool has_explicit_names = tuple_input_type.haveExplicitNames();
+        bool has_explicit_names = tuple_input_type.hasExplicitNames();
         Names explicit_names = has_explicit_names ? tuple_input_type.getElementNames() : Names{};
 
         Columns nested_input_columns;

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -4692,7 +4692,7 @@ private:
         /// For named tuples allow conversions for tuples with
         /// different sets of elements. If element exists in @to_type
         /// and doesn't exist in @to_type it will be filled by default values.
-        if (from_type->haveExplicitNames() && to_type->haveExplicitNames())
+        if (from_type->hasExplicitNames() && to_type->hasExplicitNames())
         {
             const auto & from_names = from_type->getElementNames();
             std::unordered_map<String, size_t> from_positions;
@@ -4891,7 +4891,7 @@ private:
 
     WrapperType createTupleToObjectDeprecatedWrapper(const DataTypeTuple & from_tuple, bool has_nullable_subcolumns) const
     {
-        if (!from_tuple.haveExplicitNames())
+        if (!from_tuple.hasExplicitNames())
             throw Exception(ErrorCodes::TYPE_MISMATCH,
             "Cast to Object can be performed only from flatten Named Tuple. Got: {}", from_tuple.getName());
 
@@ -5076,8 +5076,8 @@ private:
             new_elements.reserve(elements.size());
             for (const auto & element : elements)
                 new_elements.push_back(convertNestedObjectType(element, new_object_type));
-            return type_tuple->haveExplicitNames() ? std::make_shared<DataTypeTuple>(new_elements, type_tuple->getElementNames())
-                                                   : std::make_shared<DataTypeTuple>(new_elements);
+            return type_tuple->hasExplicitNames() ? std::make_shared<DataTypeTuple>(new_elements, type_tuple->getElementNames())
+                                                  : std::make_shared<DataTypeTuple>(new_elements);
         }
 
         return type;

--- a/src/Functions/flattenTuple.cpp
+++ b/src/Functions/flattenTuple.cpp
@@ -32,7 +32,7 @@ public:
     {
         const auto & type = arguments[0];
         const auto * type_tuple = checkAndGetDataType<DataTypeTuple>(type.get());
-        if (!type_tuple || !type_tuple->haveExplicitNames())
+        if (!type_tuple || !type_tuple->hasExplicitNames())
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                 "Argument for function '{}' must be Named Tuple. Got '{}'",
                 getName(), type->getName());

--- a/src/Functions/reverse.cpp
+++ b/src/Functions/reverse.cpp
@@ -63,7 +63,7 @@ public:
             reversed_types.reserve(element_count);
             reversed_types.assign(original_elements.rbegin(), original_elements.rend());
 
-            if (data_type_tuple.haveExplicitNames())
+            if (data_type_tuple.hasExplicitNames())
             {
                 const auto & original_names = data_type_tuple.getElementNames();
                 Names reversed_names;

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -832,7 +832,7 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
         auto func = makeASTFunction("tupleElement", tuple_ast, literal);
         if (!untuple_alias.empty())
         {
-            auto element_alias = tuple_type->haveExplicitNames() ? element_name : toString(tid);
+            auto element_alias = tuple_type->hasExplicitNames() ? element_name : toString(tid);
             func->setAlias(untuple_alias + "." + element_alias);
         }
 

--- a/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -48,7 +48,7 @@ bool TranslateQualifiedNamesMatcher::Data::matchColumnName(std::string_view name
     /// In case the type is named tuple, check the name recursively.
     if (const DataTypeTuple * type_tuple = typeid_cast<const DataTypeTuple *>(column_type.get()))
     {
-        if (type_tuple->haveExplicitNames() && name.at(column_name.size()) == '.')
+        if (type_tuple->hasExplicitNames() && name.at(column_name.size()) == '.')
         {
             const Strings & names = type_tuple->getElementNames();
             const DataTypes & element_types = type_tuple->getElements();

--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -566,7 +566,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
             return src; /// Already in needed type.
 
         const auto * from_type_tuple = typeid_cast<const DataTypeTuple *>(from_type_hint);
-        if (src.getType() == Field::Types::Tuple && from_type_tuple && from_type_tuple->haveExplicitNames())
+        if (src.getType() == Field::Types::Tuple && from_type_tuple && from_type_tuple->hasExplicitNames())
         {
             const auto & names = from_type_tuple->getElementNames();
             const auto & tuple = src.safeGet<Tuple>();

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -215,7 +215,7 @@ public:
                     {
                         if (const DataTypeTuple * type_tuple = typeid_cast<const DataTypeTuple *>(function_node.getResultType().get()))
                         {
-                            if (type_tuple->haveExplicitNames())
+                            if (type_tuple->hasExplicitNames())
                             {
                                 const auto & names = type_tuple->getElementNames();
                                 size_t size = names.size();

--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -1182,7 +1182,7 @@ static ColumnWithTypeAndName readNonNullableColumnFromArrowColumn(
                 DataTypePtr nested_type_hint;
                 if (tuple_type_hint)
                 {
-                    if (tuple_type_hint->haveExplicitNames() && !is_map_nested_column)
+                    if (tuple_type_hint->hasExplicitNames() && !is_map_nested_column)
                     {
                         auto pos = tuple_type_hint->tryGetPositionByName(field_name, settings.case_insensitive_matching);
                         if (pos)

--- a/src/Processors/Formats/Impl/ArrowFieldIndexUtil.h
+++ b/src/Processors/Formats/Impl/ArrowFieldIndexUtil.h
@@ -192,7 +192,7 @@ private:
         auto nested_type = removeNullable(data_type);
         if (const DB::DataTypeTuple * type_tuple = typeid_cast<const DB::DataTypeTuple *>(nested_type.get()))
         {
-            if (type_tuple->haveExplicitNames())
+            if (type_tuple->hasExplicitNames())
             {
                 auto field_names = type_tuple->getElementNames();
                 auto field_types = type_tuple->getElements();

--- a/src/Processors/Formats/Impl/BSONEachRowRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/BSONEachRowRowOutputFormat.cpp
@@ -460,7 +460,7 @@ void BSONEachRowRowOutputFormat::serializeField(const IColumn & column, const Da
             const auto & tuple_column = assert_cast<const ColumnTuple &>(column);
             const auto & nested_columns = tuple_column.getColumns();
 
-            BSONType bson_type =  tuple_type->haveExplicitNames() ? BSONType::DOCUMENT : BSONType::ARRAY;
+            BSONType bson_type =  tuple_type->hasExplicitNames() ? BSONType::DOCUMENT : BSONType::ARRAY;
             writeBSONTypeAndKeyName(bson_type, name, out);
 
             String current_path = path + "." + name;

--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -914,7 +914,7 @@ updateIncludeTypeIds(DataTypePtr type, const orc::Type * orc_type, bool ignore_c
             const auto * tuple_type = typeid_cast<const DataTypeTuple *>(non_nullable_type.get());
             if (tuple_type)
             {
-                if (tuple_type->haveExplicitNames())
+                if (tuple_type->hasExplicitNames())
                 {
                     std::unordered_map<String, size_t> orc_field_name_to_index;
                     orc_field_name_to_index.reserve(orc_type->getSubtypeCount());
@@ -1893,7 +1893,7 @@ ColumnWithTypeAndName ORCColumnToCHColumn::readColumnFromORCColumn(
                 DataTypePtr nested_type_hint;
                 if (tuple_type_hint)
                 {
-                    if (tuple_type_hint->haveExplicitNames())
+                    if (tuple_type_hint->hasExplicitNames())
                     {
                         auto pos = tuple_type_hint->tryGetPositionByName(field_name, case_insensitive_matching);
                         if (pos)

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -423,7 +423,7 @@ void ColumnsDescription::flattenNested()
             continue;
         }
 
-        if (!type_tuple->haveExplicitNames())
+        if (!type_tuple->hasExplicitNames())
         {
             ++it;
             continue;


### PR DESCRIPTION
Rename haveExplicitNames and have_explicit_names

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
