### PR TITLE
Fix runtime disk config include parameter

### DIFF
--- a/src/Disks/getDiskConfigurationFromAST.cpp
+++ b/src/Disks/getDiskConfigurationFromAST.cpp
@@ -63,7 +63,6 @@ Poco::AutoPtr<Poco::XML::Document> getDiskConfigurationFromASTImpl(const ASTs & 
             throwBadConfiguration("expected the key (key=value) to be identifier");
 
         std::string key = key_identifier->name();
-        
         if (!function_args[1]->as<ASTLiteral>() && !function_args[1]->as<ASTIdentifier>())
             throwBadConfiguration("expected values to be literals or identifiers");
 

--- a/tests/integration/test_disk_configuration/configs/config.d/encrypted_keys.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/encrypted_keys.xml
@@ -1,5 +1,0 @@
-<clickhouse>
-  <disk_encrypted_keys>
-    <key_hex>00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff</key_hex>
-  </disk_encrypted_keys>
-</clickhouse>

--- a/tests/integration/test_disk_configuration/configs/config.d/encrypted_keys.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/encrypted_keys.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+  <disk_encrypted_keys>
+    <key_hex>00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff</key_hex>
+  </disk_encrypted_keys>
+</clickhouse>

--- a/tests/integration/test_disk_configuration/configs/config.d/include_from.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/include_from.xml
@@ -2,4 +2,7 @@
   <include_endpoint>
     <endpoint>http://minio1:9001/root/data/</endpoint>
   </include_endpoint>
+  <disk_encrypted_keys>
+    <key_hex>00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff</key_hex>
+  </disk_encrypted_keys>
 </clickhouse>

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -21,7 +21,6 @@ def start_cluster():
                 "configs/config.d/storage_configuration.xml",
                 "configs/config.d/include_from_path.xml",
                 "configs/config.d/include_from.xml",
-                "configs/config.d/encrypted_keys.xml",
                 "configs/config.d/remote_servers.xml",
             ],
             env_variables={
@@ -38,7 +37,6 @@ def start_cluster():
                 "configs/config.d/storage_configuration.xml",
                 "configs/config.d/include_from_path.xml",
                 "configs/config.d/include_from.xml",
-                "configs/config.d/encrypted_keys.xml",
                 "configs/config.d/remote_servers.xml",
             ],
             with_zookeeper=True,

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -534,9 +534,9 @@ def test_merge_tree_custom_encrypted_disk_include(start_cluster):
 
     This test creates an encrypted disk using the include parameter to reference
     encryption keys defined in a separate configuration file. It verifies that:
-     - The include mechanism correctly merges encryption keys into the disk config
-     - Data can be successfully encrypted and decrypted using the included keys
- """
+    - The include mechanism correctly merges encryption keys into the disk config
+    - Data can be successfully encrypted and decrypted using the included keys
+    """
     node1 = cluster.instances["node1"]
 
     node1.query(


### PR DESCRIPTION

Runtime disk configuration (disk = disk(...)) was incorrectly handling the include parameter by creating an <include> element instead of adding the incl attribute to the disk element.

This PR fixes the XML generation to properly support configuration includes, enabling use cases like:

disk = disk(
    type = encrypted,
    disk = 'default',
    include = 'disk_encrypted_keys',
    algorithm = 'AES_256_CTR'
)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `include` parameter in runtime disk configuration to properly merge included content
