### PR TITLE
Fix possible data-race between suggestion thread and main client thread

### DIFF
--- a/src/Client/LineReader.cpp
+++ b/src/Client/LineReader.cpp
@@ -79,18 +79,20 @@ replxx::Replxx::completions_t LineReader::Suggest::getCompletions(const String &
 
     std::pair<Words::const_iterator, Words::const_iterator> range;
 
-    std::lock_guard lock(mutex);
-
     Words to_search;
     bool no_case = false;
-    /// Only perform case sensitive completion when the prefix string contains any uppercase characters
-    if (std::none_of(prefix.begin(), prefix.end(), [](char32_t x) { return iswupper(static_cast<wint_t>(x)); }))
+
     {
-        to_search = words_no_case;
-        no_case = true;
+        std::lock_guard lock(mutex);
+        /// Only perform case sensitive completion when the prefix string contains any uppercase characters
+        if (std::none_of(prefix.begin(), prefix.end(), [](char32_t x) { return iswupper(static_cast<wint_t>(x)); }))
+        {
+            to_search = words_no_case;
+            no_case = true;
+        }
+        else
+            to_search = words;
     }
-    else
-        to_search = words;
 
     if (custom_completions_callback)
     {

--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -4,6 +4,7 @@
 #include <AggregateFunctions/Combinators/AggregateFunctionCombinatorFactory.h>
 #include <Columns/ColumnString.h>
 #include <Common/Exception.h>
+#include <Common/setThreadName.h>
 #include <Common/typeid_cast.h>
 #include <Common/Macros.h>
 #include "Core/Protocol.h"
@@ -100,6 +101,8 @@ void Suggest::load(ContextPtr context, const ConnectionParameters & connection_p
         /// LocalConnection creates QueryScope for each query
         if constexpr (!std::is_same_v<ConnectionType, LocalConnection>)
             query_scope.emplace(my_context);
+
+        setThreadName("Suggest");
 
         for (size_t retry = 0; retry < 10; ++retry)
         {

--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -94,7 +94,13 @@ void Suggest::load(ContextPtr context, const ConnectionParameters & connection_p
 {
     loading_thread = std::thread([my_context=Context::createCopy(context), connection_parameters, suggestion_limit, this]
     {
+        /// Creates new QueryScope/ThreadStatus to avoid sharing global context, which settings can be modified by the client in another thread.
         ThreadStatus thread_status;
+        std::optional<CurrentThread::QueryScope> query_scope;
+        /// LocalConnection creates QueryScope for each query
+        if constexpr (!std::is_same_v<ConnectionType, LocalConnection>)
+            query_scope.emplace(my_context);
+
         for (size_t retry = 0; retry < 10; ++retry)
         {
             try

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -11,9 +11,7 @@ exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
 set history_file $CLICKHOUSE_TMP/$basename.history
 
 log_user 0
-# FIXME: workaround to obtain the stacktrace of the client in case of timeout
-# (clickhouse-test wrapper does this on timeout)
-set timeout 3600
+set timeout 60
 set uuid ""
 match_max 100000
 expect_after {

--- a/tests/queries/0_stateless/02815_no_throw_in_simple_queries.sh
+++ b/tests/queries/0_stateless/02815_no_throw_in_simple_queries.sh
@@ -31,7 +31,13 @@ log_user 0
 set timeout 60
 match_max 100000
 
-spawn bash -c "$command"
+exp_internal -f $CLICKHOUSE_TMP/$(basename "${BASH_SOURCE[0]}").debuglog 0
+expect_after {
+    -i \$any_spawn_id eof { exp_continue }
+    -i \$any_spawn_id timeout { exit 1 }
+}
+
+spawn $command
 
 expect ":) "
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible data-race between suggestion thread and main client thread

Found on CI [1]:

<details>

<summary>stacktrace</summary>

    WARNING: ThreadSanitizer: data race (pid=328014)
      Write of size 8 at 0x729800008140 by main thread:
        0 __tsan_memcpy <null> (clickhouse+0x8b061be) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        1 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::operator=(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./contrib/llvm-project/libcxx/include/string:2658:22 (clickhouse+0x191548c3) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        2 DB::SettingFieldTimezone::operator=(DB::SettingFieldTimezone const&) ci/tmp/build/./src/Core/SettingsFields.h:468:8 (clickhouse+0x191548c3)
        3 DB::SettingsTraits::Data::operator=(DB::SettingsTraits::Data const&) ci/tmp/build/./src/Core/Settings.cpp:6957:1 (clickhouse+0x191548c3)
        4 DB::BaseSettings<DB::SettingsTraits>::operator=(DB::BaseSettings<DB::SettingsTraits> const&) ci/tmp/build/./src/Core/BaseSettings.h:109:60 (clickhouse+0x18f98aec) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        5 DB::SettingsImpl::operator=(DB::SettingsImpl const&) ci/tmp/build/./src/Core/Settings.cpp:6963:8 (clickhouse+0x18f98aec)
        6 DB::Settings::operator=(DB::Settings const&) ci/tmp/build/./src/Core/Settings.cpp:7170:11 (clickhouse+0x18f98aec)
        7 DB::Context::setSettings(DB::Settings const&) ci/tmp/build/./src/Interpreters/Context.cpp:2618:15 (clickhouse+0x1a6aac4a) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        8 DB::ClientBase::processParsedSingleQuery(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::shared_ptr<DB::IAST>, bool&, unsigned long)::$_0::operator()() const ci/tmp/build/./src/Client/ClientBase.cpp:2180:9 (clickhouse+0x1db11597) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        9 BasicScopeGuard<DB::ClientBase::processParsedSingleQuery(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::shared_ptr<DB::IAST>, bool&, unsigned long)::$_0>::invoke() ci/tmp/build/./base/base/../base/scope_guard.h:101:9 (clickhouse+0x1db11597)
        10 BasicScopeGuard<DB::ClientBase::processParsedSingleQuery(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::shared_ptr<DB::IAST>, bool&, unsigned long)::$_0>::~BasicScopeGuard() ci/tmp/build/./base/base/../base/scope_guard.h:50:26 (clickhouse+0x1db11597)
        11 DB::ClientBase::processParsedSingleQuery(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::shared_ptr<DB::IAST>, bool&, unsigned long) ci/tmp/build/./src/Client/ClientBase.cpp:2245:5 (clickhouse+0x1db0418a) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        12 DB::ClientBase::executeMultiQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Client/ClientBase.cpp:2618:21 (clickhouse+0x1db12b5e) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        13 DB::ClientBase::processQueryText(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Client/ClientBase.cpp:2812:12 (clickhouse+0x1db142a6) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        14 DB::ClientBase::runInteractive() ci/tmp/build/./src/Client/ClientBase.cpp:3367:18 (clickhouse+0x1db1d57b) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        15 DB::Client::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) ci/tmp/build/./programs/client/Client.cpp:399:9 (clickhouse+0x128ba9c1) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        16 non-virtual thunk to DB::Client::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) ci/tmp/build/./programs/client/Client.cpp (clickhouse+0x128bb0a0) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        17 Poco::Util::Application::run() ci/tmp/build/./base/poco/Util/src/Application.cpp:315:8 (clickhouse+0x23017cbe) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        18 mainEntryClickHouseClient(int, char**) ci/tmp/build/./programs/client/Client.cpp:1139:23 (clickhouse+0x128c8ea6) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        19 main ci/tmp/build/./programs/main.cpp:323:21 (clickhouse+0x8b8ea04) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)

      Previous read of size 8 at 0x729800008140 by thread T2:
        0 __tsan_memcpy <null> (clickhouse+0x8b061be) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        1 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::operator=(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./contrib/llvm-project/libcxx/include/string:2658:22 (clickhouse+0x1259a1c7) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        2 DateLUT::instance() ci/tmp/build/./src/Common/DateLUT.cpp:173:35 (clickhouse+0x1259a1c7)
        3 DateLUT::instance(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Common/DateLUT.h:29:20 (clickhouse+0x192bbab2) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        4 TimezoneMixin::TimezoneMixin(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/DataTypes/TimezoneMixin.h:16:21 (clickhouse+0x192bbab2)
        5 DB::DataTypeDateTime::DataTypeDateTime(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/DataTypes/DataTypeDateTime.cpp:13:7 (clickhouse+0x192bb645) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        6 std::__1::shared_ptr<DB::DataTypeDateTime> std::__1::allocate_shared[abi:ne190107]<DB::DataTypeDateTime, std::__1::allocator<DB::DataTypeDateTime>, 0>(std::__1::allocator<DB::DataTypeDateTime> const&) FunctionsExternalDictionaries.cpp (clickhouse+0x8ddfc9b) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        7 std::__1::shared_ptr<DB::DataTypeDateTime> std::__1::make_shared[abi:ne190107]<DB::DataTypeDateTime, 0>() ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:851:10 (clickhouse+0x193bbb51) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        8 DB::create(std::__1::shared_ptr<DB::IAST> const&) ci/tmp/build/./src/DataTypes/registerDataTypeDateTime.cpp:66:16 (clickhouse+0x193bbb51)
        9 decltype(std::declval<std::__1::shared_ptr<DB::IDataType const> (*&)(std::__1::shared_ptr<DB::IAST> const&)>()(std::declval<std::__1::shared_ptr<DB::IAST> const&>())) std::__1::__invoke[abi:ne190107]<std::__1::shared_ptr<DB::IDataType const> (*&)(std::__1::shared_ptr<DB::IAST> const&), std::__1::shared_ptr<DB::IAST> const&>(std::__1::shared_ptr<DB::IDataType const> (*&)(std::__1::shared_ptr<DB::IAST> const&), std::__1::shared_ptr<DB::IAST> const&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x192b5ea3) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        10 std::__1::shared_ptr<DB::IDataType const> std::__1::__invoke_void_return_wrapper<std::__1::shared_ptr<DB::IDataType const>, false>::__call[abi:ne190107]<std::__1::shared_ptr<DB::IDataType const> (*&)(std::__1::shared_ptr<DB::IAST> const&), std::__1::shared_ptr<DB::IAST> const&>(std::__1::shared_ptr<DB::IDataType const> (*&)(std::__1::shared_ptr<DB::IAST> const&), std::__1::shared_ptr<DB::IAST> const&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:216:12 (clickhouse+0x192b5ea3)
        11 std::__1::__function::__default_alloc_func<std::__1::shared_ptr<DB::IDataType const> (*)(std::__1::shared_ptr<DB::IAST> const&), std::__1::shared_ptr<DB::IDataType const> (std::__1::shared_ptr<DB::IAST> const&)>::operator()[abi:ne190107](std::__1::shared_ptr<DB::IAST> const&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x192b5ea3)
        12 std::__1::shared_ptr<DB::IDataType const> std::__1::__function::__policy_invoker<std::__1::shared_ptr<DB::IDataType const> (std::__1::shared_ptr<DB::IAST> const&)>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<std::__1::shared_ptr<DB::IDataType const> (*)(std::__1::shared_ptr<DB::IAST> const&), std::__1::shared_ptr<DB::IDataType const> (std::__1::shared_ptr<DB::IAST> const&)>>(std::__1::__function::__policy_storage const*, std::__1::shared_ptr<DB::IAST> const&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x192b5ea3)
        13 std::__1::__function::__policy_func<std::__1::shared_ptr<DB::IDataType const> (std::__1::shared_ptr<DB::IAST> const&)>::operator()[abi:ne190107](std::__1::shared_ptr<DB::IAST> const&) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x192cfcc6) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        14 std::__1::function<std::__1::shared_ptr<DB::IDataType const> (std::__1::shared_ptr<DB::IAST> const&)>::operator()(std::__1::shared_ptr<DB::IAST> const&) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x192cfcc6)
        15 std::__1::shared_ptr<DB::IDataType const> DB::DataTypeFactory::getImpl<false>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::IAST> const&) const ci/tmp/build/./src/DataTypes/DataTypeFactory.cpp:144:21 (clickhouse+0x192cfcc6)
        16 std::__1::shared_ptr<DB::IDataType const> DB::DataTypeFactory::getImpl<false>(std::__1::shared_ptr<DB::IAST> const&) const ci/tmp/build/./src/DataTypes/DataTypeFactory.cpp:91:16 (clickhouse+0x192cf5f3) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        17 std::__1::shared_ptr<DB::IDataType const> DB::DataTypeFactory::getImpl<false>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const ci/tmp/build/./src/DataTypes/DataTypeFactory.cpp:73:12 (clickhouse+0x192cf18d) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        18 DB::DataTypeFactory::get(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const ci/tmp/build/./src/DataTypes/DataTypeFactory.cpp:35:12 (clickhouse+0x192ccfa0) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        19 DB::NativeReader::read() ci/tmp/build/./src/Formats/NativeReader.cpp:188:45 (clickhouse+0x1dde11c2) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        20 DB::Connection::receiveDataImpl(DB::NativeReader&) ci/tmp/build/./src/Client/Connection.cpp:1396:24 (clickhouse+0x1db4c3c9) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        21 DB::Connection::receiveProfileEvents() ci/tmp/build/./src/Client/Connection.cpp:1408:12 (clickhouse+0x1db4b471) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        22 DB::Connection::receivePacket() ci/tmp/build/./src/Client/Connection.cpp:1345:29 (clickhouse+0x1db4b471)
        23 DB::Suggest::fetch(DB::IServerConnection&, DB::ConnectionTimeouts const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::ClientInfo const&) ci/tmp/build/./src/Client/Suggest.cpp:170:36 (clickhouse+0x1dbbfce0) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        24 void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()::operator()() const ci/tmp/build/./src/Client/Suggest.cpp:103:17 (clickhouse+0x1dbc236e) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        25 decltype(std::declval<void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()>()()) std::__1::__invoke[abi:ne190107]<void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()>(void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x1dbc2038) (BuildId: 50a1015145bb9fb79089f4828db24f2dae0945e5)
        26 void std::__1::__thread_execute[abi:ne190107]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()>&, std::__1::__tuple_indices<...>) ci/tmp/build/./contrib/llvm-project/libcxx/include/__thread/thread.h:192:3 (clickhouse+0x1dbc2038)
        27 void* std::__1::__thread_proxy[abi:ne190107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void DB::Suggest::load<DB::Connection>(std::__1::shared_ptr<DB::Context const>, DB::ConnectionParameters const&, int, bool)::'lambda'()>>(void*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__thread/thread.h:201:3 (clickhouse+0x1dbc2038)

</details>

What is interesting that it has been pops up only after https://github.com/ClickHouse/ClickHouse/pull/81759

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/PRs/82168/8ab5ff7cd742626a263fd7a262d4ff86aa28880d//stateless_tests_amd_tsan_s3_storage_3_3/job.log

Fixes: #81893
Fixes: #81759