### PR TITLE
Add the feature of SQL interception

### DIFF
--- a/src/Access/Common/SQLInterceptMode.h
+++ b/src/Access/Common/SQLInterceptMode.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <Core/Types.h>
+
+
+/// SQL intercept enum. Used in SQLInterceptMode::type.
+enum class SQLInterceptMode : uint8_t
+{
+    LOG,  /// Query will be executed but log a warnning message.
+    THROW, /// Query will throw an exception.
+};

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6629,6 +6629,62 @@ Note that initially (24.12) there was a server setting (`send_settings_to_client
     DECLARE(Bool, allow_archive_path_syntax, true, R"(
 File/S3 engines/table function will parse paths with '::' as `<archive> :: <file>` if the archive has correct extension.
 )", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_update_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_update_on_cluster, false, R"(Whether enable SQL intercept for update on cluster.
+        If enabled, SQL intercept will be applied to update on cluster queries. If disabled, SQL intercept will not be applied to update on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_update_on_cluster` setting.
+        For example, if `sql_intercept_mode` is `LOG`, then SQL intercept will be applied to update on cluster queries if `enable_sql_intercept_for_update_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode` is `THROW`, then SQL intercept will be applied to update on cluster queries if `enable_sql_intercept_for_update_on_cluster` is enabled and throw an exception.)", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_delete_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_delete_on_cluster, false, R"(Whether enable SQL intercept for delete on cluster.
+        If enabled, SQL intercept will be applied to delete on cluster queries. If disabled, SQL intercept will not be applied to delete on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_delete_on_cluster` setting.
+        For example, if `sql_intercept_mode_for_delete_on_cluster` is `LOG`, then SQL intercept will be applied to delete on cluster queries if `enable_sql_intercept_for_delete_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode_for_delete_on_cluster` is `THROW`, then SQL intercept will be applied to update on cluster queries if `enable_sql_intercept_for_delete_on_cluster` is enabled and throw an exception.)", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_add_column_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_add_column_on_cluster, false, R"(Whether enable SQL intercept for update on cluster.
+        If enabled, SQL intercept will be applied to add column on cluster queries. If disabled, SQL intercept will not be applied to add column on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_add_column_on_cluster` setting.
+        For example, if `sql_intercept_mode_for_add_column_on_cluster` is `LOG`, then SQL intercept will be applied to add column on cluster queries if `sql_intercept_mode_for_add_column_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode_for_add_column_on_cluster` is `THROW`, then SQL intercept will be applied to add column on cluster queries if `sql_intercept_mode_for_add_column_on_cluster` is enabled and throw an exception.)", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_drop_column_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_drop_column_on_cluster, false, R"(Whether enable SQL intercept for drop column on cluster.
+        If enabled, SQL intercept will be applied to drop column on cluster queries. If disabled, SQL intercept will not be applied to drop column on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_drop_column_on_cluster` setting.
+        For example, if `sql_intercept_mode_for_drop_column_on_cluster` is `LOG`, then SQL intercept will be applied to drop column on cluster queries if `sql_intercept_mode_for_drop_column_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode_for_drop_column_on_cluster` is `THROW`, then SQL intercept will be applied to drop column on cluster queries if `sql_intercept_mode_for_drop_column_on_cluster` is enabled and throw an exception.)", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_optimize_final_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_optimize_final_on_cluster, false, R"(Whether enable SQL intercept for optimize final on cluster.
+        If enabled, SQL intercept will be applied to optimize final on cluster queries. If disabled, SQL intercept will not be applied to optimize final on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_optimize_final_on_cluster` setting.
+        For example, if `sql_intercept_mode_for_optimize_final_on_cluster` is `LOG`, then SQL intercept will be applied to optimize final on cluster queries if `sql_intercept_mode_for_optimize_final_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode_for_optimize_final_on_cluster` is `THROW`, then SQL intercept will be applied to optimize final on cluster queries if `sql_intercept_mode_for_optimize_final_on_cluster` is enabled and throw an exception.)", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_drop_table_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_drop_table_on_cluster, false, R"(Whether enable SQL intercept for drop table on cluster.
+        If enabled, SQL intercept will be applied to drop table on cluster queries. If disabled, SQL intercept will not be applied to drop table on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_drop_table_on_cluster` setting.
+        For example, if `sql_intercept_mode_for_drop_table_on_cluster` is `LOG`, then SQL intercept will be applied to drop table on cluster queries if `sql_intercept_mode_for_drop_table_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode_for_drop_table_on_cluster` is `THROW`, then SQL intercept will be applied to drop table on cluster queries if `sql_intercept_mode_for_drop_table_on_cluster` is enabled and throw an exception.)", 0) \
+    DECLARE(SQLInterceptMode, sql_intercept_mode_for_truncate_table_on_cluster, SQLInterceptMode::LOG, R"(The mode of SQL intercept for SQL queries. Possible values:
+        - 'LOG' - log the query and continue execution.
+        - 'THROW' - throw an exception and stop execution.)", 0) \
+    DECLARE(Bool, enable_sql_intercept_for_truncate_table_on_cluster, false, R"(Whether enable SQL intercept for truncate table on cluster.
+        If enabled, SQL intercept will be applied to truncate table on cluster queries. If disabled, SQL intercept will not be applied to truncate table on cluster queries.
+        The intercept policy is defined by the `sql_intercept_mode_for_truncate_table_on_cluster` setting.
+        For example, if `sql_intercept_mode_for_truncate_table_on_cluster` is `LOG`, then SQL intercept will be applied to truncate table on cluster queries if `sql_intercept_mode_for_truncate_table_on_cluster` is enabled and log a warnning message.
+        if `sql_intercept_mode_for_truncate_table_on_cluster` is `THROW`, then SQL intercept will be applied to truncate table on cluster queries if `sql_intercept_mode_for_truncate_table_on_cluster` is enabled and throw an exception.)", 0) \
     DECLARE(Milliseconds, low_priority_query_wait_time_ms, 1000, R"(
 When the query prioritization mechanism is employed (see setting `priority`), low-priority queries wait for higher-priority queries to finish. This setting specifies the duration of waiting.
 )", BETA) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -105,7 +105,8 @@ class WriteBuffer;
     M(CLASS_NAME, UInt64Auto) \
     M(CLASS_NAME, URI) \
     M(CLASS_NAME, VectorSearchFilterStrategy) \
-    M(CLASS_NAME, GeoToH3ArgumentOrder)
+    M(CLASS_NAME, GeoToH3ArgumentOrder) \
+    M(CLASS_NAME, SQLInterceptMode)
 
 
 COMMON_SETTINGS_SUPPORTED_TYPES(Settings, DECLARE_SETTING_TRAIT)

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -19,6 +19,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int UNKNOWN_MYSQL_DATATYPES_SUPPORT_LEVEL;
     extern const int UNKNOWN_UNION;
+    extern const int QUERY_IS_PROHIBITED;
 }
 
 template <typename Type>
@@ -325,5 +326,11 @@ IMPLEMENT_SETTING_ENUM(
     ErrorCodes::BAD_ARGUMENTS,
     {{"lat_lon", GeoToH3ArgumentOrder::LAT_LON},
      {"lon_lat", GeoToH3ArgumentOrder::LON_LAT}})
+
+IMPLEMENT_SETTING_ENUM(
+    SQLInterceptMode,
+    ErrorCodes::QUERY_IS_PROHIBITED,
+    {{"log", SQLInterceptMode::LOG},
+     {"throw", SQLInterceptMode::THROW}})
 
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Access/Common/SQLSecurityDefs.h>
+#include <Access/Common/SQLInterceptMode.h>
 #include <Core/Joins.h>
 #include <Core/LoadBalancing.h>
 #include <Core/LogsLevel.h>
@@ -420,5 +421,13 @@ enum class GeoToH3ArgumentOrder : uint8_t
 };
 
 DECLARE_SETTING_ENUM(GeoToH3ArgumentOrder)
+
+enum class SQLInterceptMode : uint8_t
+{
+    LOG,
+    THROW,
+};
+
+DECLARE_SETTING_ENUM(SQLInterceptMode)
 
 }

--- a/src/Interpreters/SQLInterceptor.cpp
+++ b/src/Interpreters/SQLInterceptor.cpp
@@ -1,0 +1,139 @@
+#include <Common/Logger.h>
+#include <Common/logger_useful.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
+#include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTOptimizeQuery.h>
+#include <Storages/AlterCommands.h>
+#include "SQLInterceptor.h"
+
+namespace DB
+{
+
+namespace Setting
+{
+    extern const SettingsBool enable_sql_intercept_for_update_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_update_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_delete_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_delete_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_add_column_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_add_column_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_drop_column_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_drop_column_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_optimize_final_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_optimize_final_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_drop_table_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_drop_table_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_truncate_table_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_truncate_table_on_cluster;
+}
+
+namespace ErrorCodes
+{
+    extern const int QUERY_IS_PROHIBITED;
+}
+
+static LoggerPtr log = getLogger("SQLInterceptor");
+
+void SQLInterceptor::intercept(const ASTPtr &  ast_ptr, ContextPtr context_ptr)
+{
+    if (auto * alter = ast_ptr->as<ASTAlterQuery>())
+        alterIntercept(*alter, context_ptr);
+    else if (auto * drop = ast_ptr->as<ASTDropQuery>())
+        dropIntercept(*drop, context_ptr);
+    else if (auto * optimize = ast_ptr->as<ASTOptimizeQuery>())
+        optimizeIntercept(*optimize, context_ptr);
+}
+
+void SQLInterceptor::optimizeIntercept(const ASTOptimizeQuery & optimize, ContextPtr context_ptr)
+{
+    if (!optimize.cluster.empty() && optimize.final && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_optimize_final_on_cluster])
+    {
+        if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_optimize_final_on_cluster] == SQLInterceptMode::THROW)
+            throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "OPTIMIZE FINAL mutations not allowed with ON CLUSTER");
+        else
+            LOG_WARNING(log, "OPTIMIZE FINAL mutations with ON CLUSTER is not desirable");
+    }
+}
+
+void SQLInterceptor::dropIntercept(const ASTDropQuery & drop, ContextPtr context_ptr)
+{
+    switch (drop.kind)
+    {
+        case ASTDropQuery::Kind::Drop:
+            if (!drop.cluster.empty() && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_drop_table_on_cluster])
+            {
+                if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_drop_table_on_cluster] == SQLInterceptMode::THROW)
+                    throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "DROP TABLE mutations not allowed with ON CLUSTER");
+                else
+                    LOG_WARNING(log, "DROP TABLE mutations with ON CLUSTER is not desirable");
+            }
+            break;
+        case ASTDropQuery::Kind::Truncate:
+            if (!drop.cluster.empty() && !drop.is_view && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_truncate_table_on_cluster])
+            {
+                if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_truncate_table_on_cluster] == SQLInterceptMode::THROW)
+                    throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "TRUNCATE TABLE mutations not allowed with ON CLUSTER");
+                else
+                    LOG_WARNING(log, "TRUNCATE TABLE mutations with ON CLUSTER is not desirable");
+            }
+            break;
+        default:
+            return;
+    }
+    
+}
+
+void SQLInterceptor::alterIntercept(const ASTAlterQuery & alter, ContextPtr context_ptr)
+{
+    for (auto & child : alter.command_list->children)
+    {
+        auto *  command_ast = child->as<ASTAlterCommand>();
+        switch (command_ast->type)
+        {
+            case ASTAlterCommand::UPDATE:
+                if (!alter.cluster.empty() && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_update_on_cluster])
+                {
+                    if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_update_on_cluster] == SQLInterceptMode::THROW)
+                        throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "UPDATE mutations not allowed with ON CLUSTER");
+                    else
+                        LOG_WARNING(log, "UPDATE mutations with ON CLUSTER is not desirable");
+                }
+                break;
+            case ASTAlterCommand::DELETE:
+                if (!alter.cluster.empty() && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_delete_on_cluster])
+                {
+                    if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_delete_on_cluster] == SQLInterceptMode::THROW)
+                        throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "DELETE mutations not allowed with ON CLUSTER");
+                    else
+                        LOG_WARNING(log, "DELETE mutations with ON CLUSTER is not desirable");
+                }
+                break;
+            case ASTAlterCommand::ADD_COLUMN:
+                if (!alter.cluster.empty() && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_add_column_on_cluster])
+                {
+                    if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_add_column_on_cluster] == SQLInterceptMode::THROW)
+                        throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "ADD COLUMN mutations not allowed with ON CLUSTER");
+                    else
+                        LOG_WARNING(log, "ADD COLUMN mutations with ON CLUSTER is not desirable");
+                }
+                break;
+            case ASTAlterCommand::DROP_COLUMN:
+                if (!alter.cluster.empty() && context_ptr->getSettingsRef()[Setting::enable_sql_intercept_for_drop_column_on_cluster])
+                {
+                    if (context_ptr->getSettingsRef()[Setting::sql_intercept_mode_for_drop_column_on_cluster] == SQLInterceptMode::THROW)
+                        throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "DROP COLUMN mutations not allowed with ON CLUSTER");
+                    else
+                        LOG_WARNING(log, "DROP COLUMN mutations with ON CLUSTER is not desirable");
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+}
+
+}

--- a/src/Interpreters/SQLInterceptor.h
+++ b/src/Interpreters/SQLInterceptor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Interpreters/Context_fwd.h>
+
+namespace DB
+{
+class ASTAlterQuery;
+class ASTDropQuery;
+class ASTOptimizeQuery;
+
+class SQLInterceptor
+{
+public:
+    static void intercept(const ASTPtr & ast_ptr, ContextPtr context);
+    static void alterIntercept(const ASTAlterQuery & alter, ContextPtr  context);
+    static void dropIntercept(const ASTDropQuery & drop, ContextPtr context);
+    static void optimizeIntercept(const ASTOptimizeQuery & optimize, ContextPtr context);
+};
+}

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -66,6 +66,7 @@
 #include <Interpreters/TransactionLog.h>
 #include <Interpreters/executeQuery.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/SQLInterceptor.h>
 #include <Common/ProfileEvents.h>
 #include <Core/ServerSettings.h>
 #include <Core/Settings.h>
@@ -1189,6 +1190,7 @@ static BlockIO executeQueryImpl(
 
         if (out_ast)
         {
+            SQLInterceptor::intercept(out_ast, context);
             /// Interpret SETTINGS clauses as early as possible (before invoking the corresponding interpreter),
             /// to allow settings to take effect.
             InterpreterSetQuery::applySettingsFromQuery(out_ast, context);

--- a/src/Interpreters/tests/gtest_sql_interceptor.cpp
+++ b/src/Interpreters/tests/gtest_sql_interceptor.cpp
@@ -1,0 +1,222 @@
+#include <Core/Settings.h>
+#include <Parsers/parseQuery.h>
+#include <Parsers/ParserQuery.h>
+#include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTOptimizeQuery.h>
+#include <Storages/AlterCommands.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Interpreters/SQLInterceptor.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+namespace DB
+{
+namespace Setting
+{
+    extern const SettingsBool enable_sql_intercept_for_update_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_update_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_delete_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_delete_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_add_column_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_add_column_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_drop_column_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_drop_column_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_optimize_final_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_optimize_final_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_drop_table_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_drop_table_on_cluster;
+    extern const SettingsBool enable_sql_intercept_for_truncate_table_on_cluster;
+    extern const SettingsSQLInterceptMode sql_intercept_mode_for_truncate_table_on_cluster;
+}
+}
+
+TEST(SQLInterceptor, testUpdateOnCluster)
+{
+    const std::string query = "alter table cktest.test2 on cluster default_cluster update CounterID = toUInt32(222) where EventDate='2023-08-01';";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_update_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_update_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_update_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_update_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_update_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_update_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}
+
+TEST(SQLInterceptor, testDeleteOnCluster)
+{
+    const std::string query = "alter table cktest.test2 on cluster default_cluster delete where EventDate='2023-08-01';";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_delete_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_delete_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_delete_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_delete_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_delete_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_delete_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}
+
+TEST(SQLInterceptor, testAddColumnOnCluster)
+{
+    const std::string query = "alter table cktest.test2 on cluster default_cluster add column EventDate Date;";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_add_column_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_add_column_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_add_column_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_add_column_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_add_column_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_add_column_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}
+
+TEST(SQLInterceptor, testDropColumnOnCluster)
+{
+    const std::string query = "alter table cktest.test2 on cluster default_cluster drop column EventDate;";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_drop_column_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_drop_column_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_drop_column_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_drop_column_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_drop_column_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_drop_column_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}
+
+TEST(SQLInterceptor, testOptimizeFinalOnCluster)
+{
+    const std::string query = "optimize table cktest.test2 on cluster default_cluster final DEDUPLICATE;";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_optimize_final_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_optimize_final_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_optimize_final_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_optimize_final_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_optimize_final_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_optimize_final_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}
+
+TEST(SQLInterceptor, testDropTableOnCluster)
+{
+    const std::string query = "drop table cktest.test2 on cluster default_cluster;";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_drop_table_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_drop_table_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_drop_table_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_drop_table_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_drop_table_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_drop_table_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}
+
+TEST(SQLInterceptor, TruncateTableOnCluster)
+{
+    const std::string query = "truncate table cktest.test2 on cluster default_cluster;";
+    auto context = Context::createCopy(getContext().context);
+    Settings settings = context->getSettingsCopy();
+    settings[Setting::sql_intercept_mode_for_truncate_table_on_cluster] = DB::SQLInterceptMode::THROW;
+    // Testing enable_sql_intercept_for_truncate_table_on_cluster default value is false
+    context->setSettings(settings);
+    const char * end = query.c_str() + query.size();
+    ParserQuery parser(end);
+
+    auto ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+
+    // Testing enable_sql_intercept_for_truncate_table_on_cluster been set to true
+    settings[Setting::enable_sql_intercept_for_truncate_table_on_cluster] = true;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_THROW(SQLInterceptor::intercept(ast, context), DB::Exception);
+
+    // Testing sql_intercept_mode_for_truncate_table_on_cluster been set to LOG
+    settings[Setting::sql_intercept_mode_for_truncate_table_on_cluster] = DB::SQLInterceptMode::LOG;
+    context->setSettings(settings);
+    ast = parseQuery(parser, query.c_str(), end, "", 1024, 1024, 1024);
+    ASSERT_NO_THROW(SQLInterceptor::intercept(ast, context));
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allows administrators to intercept specific SQL queries based on configurable rules before execution. Useful for security auditing, query blocking, or compliance.

### Documentation entry for user-facing changes
If 'enable_sql_intercept_for_update_on_cluster' has been set to be true and 'sql_intercept_mode_for_update_on_cluster' been set to be 'throw'  on session or in users.xml, the queries like 'alter table xxxx on cluster update AColumn=xxx' would be intercepted and a DB::Exception will be throw. If 'sql_intercept_mode_for_update_on_cluster' been set to 'warn', then the query would be allow and only log a warning message.
Other settings for SQL interception:
 enable_sql_intercept_for_delete_on_cluster 
-sql_intercept_mode_for_delete_on_cluster
Intercept SQL like 'alter table xxx on cluster xx delete'

 enable_sql_intercept_for_add_column_on_cluster
 sql_intercept_mode_for_add_column_on_cluster
Intercept SQL like 'alter table xxx on cluster xx add column'

 enable_sql_intercept_for_drop_column_on_cluster
 sql_intercept_mode_for_drop_column_on_cluster
Intercept SQL like 'alter table xxx on cluster xx drop column'

 enable_sql_intercept_for_optimize_final_on_cluster
 sql_intercept_mode_for_optimize_final_on_cluster
Intercept SQl like 'optimize table xxx on cluster xx final'

 enable_sql_intercept_for_drop_table_on_cluster
 sql_intercept_mode_for_drop_table_on_cluster
Intercept SQl like 'drop table xxx on cluster xx'

 enable_sql_intercept_for_truncate_table_on_cluster
 sql_intercept_mode_for_truncate_table_on_cluster
Intercept SQL like 'truncate table xxx on cluster xx'

- Motivation: 
Administrators really don't want some specific queries which will bring too much pressure or schema、data inconsistence
on cluster end users often disregard these concerns. Therefore, intercepting some specific queries before execution appears to be a compromise.

- [ ] Documentation is written (mandatory for new features)

- Example use: 
set enable_sql_intercept_for_update_on_cluster=true;
set sql_intercept_mode_for_update_on_cluster='throw'
then execute the query:
alter table cktest.test2 on cluster default_cluster update CounterID = toUInt32(222) where EventDate='2023-08-01';
