### PR TITLE
CI: Separate log for clickhouse-local in functional tests

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -264,6 +264,7 @@ class ClickHouseProc:
     WD0 = f"{temp_dir}/ft_wd0"
     WD1 = f"{temp_dir}/ft_wd1"
     WD2 = f"{temp_dir}/ft_wd2"
+    CH_LOCAL_ERR_LOG = f"{temp_dir}/clickhouse-local.err.log"
 
     def __init__(
         self, fast_test=False, is_db_replicated=False, is_shared_catalog=False
@@ -702,7 +703,6 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         self._flush_system_logs()
         print("Terminate ClickHouse processes")
 
-        timeout = 60
         Shell.check(f"ps -ef | grep  clickhouse")
         for proc, pid_file, pid, run_path in (
             (self.proc, self.pid_file, self.pid_0, self.run_path0),
@@ -717,33 +717,14 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                     verbose=True,
                 ):
                     print("Failed to stop ClickHouse process gracefully")
-        return self
-
-        # for proc, pid_file, pid in (
-        #     (self.proc, self.pid_file, self.pid_0),
-        #     (self.proc_2, self.pid_file_replica_2, self.pid_2),
-        #     (self.proc_1, self.pid_file_replica_1, self.pid_1),
-        # ):
-        #     if proc and pid:
-        #         try:
-        #             proc.wait(timeout=timeout)
-        #             print(f"Process {proc.pid} terminated gracefully.")
-        #         except Exception:
-        #             print(
-        #                 f"Process {proc.pid} did not terminate in {timeout} seconds, killing it..."
-        #             )
-        #             Shell.check("ps -ef | grep clickhouse | grep -v grep", verbose=True)
-        #             Utils.terminate_process_group(proc.pid, force=True)
-        #             Utils.terminate_process(pid, force=True)
-        #             proc.wait()  # Wait for the process to be fully killed
-        #             print(f"Process {pid} was killed.")
-        #         Shell.check("ps -ef | grep clickhouse | grep -v grep", verbose=True)
 
         if self.minio_proc:
             Utils.terminate_process_group(self.minio_proc.pid)
 
         if self.azurite_proc:
             Utils.terminate_process_group(self.azurite_proc.pid)
+
+        return self
 
     def prepare_logs(self, all=False):
         res = self._get_logs_archives_server()
@@ -760,6 +741,8 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 res.append(self.GDB_LOG)
             if Path(self.DMESG_LOG).exists():
                 res.append(self.DMESG_LOG)
+            if Path(self.CH_LOCAL_ERR_LOG).exists():
+                res.append(self.CH_LOCAL_ERR_LOG)
         self.logs = res
         return res
 
@@ -976,7 +959,7 @@ quit
         #   [1]: https://github.com/ClickHouse/ClickHouse/issues/77320
         #
         # NOTE: we also need to override logger.level, but logger.level will not work
-        command_args_post = "-- --zookeeper.implementation=testkeeper --logger.log=/dev/null --logger.errorlog=/dev/null --logger.console=1"
+        command_args_post = f"-- --zookeeper.implementation=testkeeper --logger.log=/dev/null --logger.errorlog={self.CH_LOCAL_ERR_LOG} --logger.console=1"
 
         Shell.check(
             f"rm -rf {temp_dir}/system_tables && mkdir -p {temp_dir}/system_tables"
@@ -986,7 +969,7 @@ quit
         for table in TABLES:
             path_arg = f" --path {self.run_path0}"
             res = Shell.check(
-                f"{temp_dir}/clickhouse-local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
+                f"cd {self.run_path0} && clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
                 verbose=True,
             )
             if not res:
@@ -998,7 +981,7 @@ quit
             if self.is_shared_catalog or self.is_db_replicated:
                 path_arg = f" --path {self.run_path1}"
                 res = Shell.check(
-                    f"clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.1.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
+                    f"cd {self.run_path1} && clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.1.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
                     verbose=True,
                 )
                 if not res:
@@ -1010,7 +993,7 @@ quit
             if self.is_db_replicated:
                 path_arg = f" --path {self.run_path2}"
                 res = Shell.check(
-                    f"clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.2.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
+                    f"cd {self.run_path2} && clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.2.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
                     verbose=True,
                 )
                 if not res:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow up #82220
clickhouse-local dumps system tables after the test run, its log should be separate from clickhouse-server.err.log to ease the debugging

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
