### PR TITLE
Fix compatibility for `use_legacy_to_time`

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1031,7 +1031,7 @@ The table below shows the behavior of this setting for various date-time functio
     DECLARE(Bool, allow_nonconst_timezone_arguments, false, R"(
 Allow non-const timezone arguments in certain time-related functions like toTimeZone(), fromUnixTimestamp*(), snowflakeToDateTime*()
 )", 0) \
-    DECLARE(Bool, use_legacy_to_time, false, R"(
+    DECLARE(Bool, use_legacy_to_time, true, R"(
 When enabled, allows to use legacy toTime function, which converts a date with time to a certain fixed date, while preserving the time.
 Otherwise, uses a new toTime function, that converts different type of data into the Time type.
 The old legacy function is also unconditionally accessible as toTimeWithFixedDate.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -83,7 +83,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_shared_storage_snapshot_in_query", false, false, "A new setting to share storage snapshot in query"},
             {"merge_tree_storage_snapshot_sleep_ms", 0, 0, "A new setting to debug storage snapshot consistency in query"},
             {"enable_job_stack_trace", false, false, "The setting was disabled by default to avoid performance overhead."},
-            {"use_legacy_to_time", true, false, "New setting. Allows for user to use the old function logic for toTime, which works as toTimeWithFixedDate."},
+            {"use_legacy_to_time", true, true, "New setting. Allows for user to use the old function logic for toTime, which works as toTimeWithFixedDate."},
             {"allow_experimental_time_time64_type", false, false, "New settings. Allows to use a new experimental Time and Time64 data types."},
             {"enable_time_time64_type", false, false, "New settings. Allows to use a new experimental Time and Time64 data types."},
             {"optimize_use_projection_filtering", false, true, "New setting"},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -83,7 +83,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_shared_storage_snapshot_in_query", false, false, "A new setting to share storage snapshot in query"},
             {"merge_tree_storage_snapshot_sleep_ms", 0, 0, "A new setting to debug storage snapshot consistency in query"},
             {"enable_job_stack_trace", false, false, "The setting was disabled by default to avoid performance overhead."},
-            {"use_legacy_to_time", true, true, "New setting. Allows for user to use the old function logic for toTime, which works as toTimeWithFixedDate."},
+            {"use_legacy_to_time", true, false, "New setting. Allows for user to use the old function logic for toTime, which works as toTimeWithFixedDate."},
             {"allow_experimental_time_time64_type", false, false, "New settings. Allows to use a new experimental Time and Time64 data types."},
             {"enable_time_time64_type", false, false, "New settings. Allows to use a new experimental Time and Time64 data types."},
             {"optimize_use_projection_filtering", false, true, "New setting"},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -83,7 +83,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_shared_storage_snapshot_in_query", false, false, "A new setting to share storage snapshot in query"},
             {"merge_tree_storage_snapshot_sleep_ms", 0, 0, "A new setting to debug storage snapshot consistency in query"},
             {"enable_job_stack_trace", false, false, "The setting was disabled by default to avoid performance overhead."},
-            {"use_legacy_to_time", false, false, "New setting. Allows for user to use the old function logic for toTime, which works as toTimeWithFixedDate."},
+            {"use_legacy_to_time", true, false, "New setting. Allows for user to use the old function logic for toTime, which works as toTimeWithFixedDate."},
             {"allow_experimental_time_time64_type", false, false, "New settings. Allows to use a new experimental Time and Time64 data types."},
             {"enable_time_time64_type", false, false, "New settings. Allows to use a new experimental Time and Time64 data types."},
             {"optimize_use_projection_filtering", false, true, "New setting"},

--- a/tests/queries/0_stateless/03365_if_time_time64.sql
+++ b/tests/queries/0_stateless/03365_if_time_time64.sql
@@ -1,3 +1,5 @@
+SET use_legacy_to_time = 0;
+
 SELECT number % 2 ? toTime('00:00:00') : toTime('04:05:06') FROM numbers(2);
 SELECT number % 2 ? toTime('00:00:00') : materialize(toTime('04:05:06')) FROM numbers(2);
 SELECT number % 2 ? materialize(toTime('00:00:00')) : toTime('04:05:06') FROM numbers(2);

--- a/tests/queries/0_stateless/03365_time_time64_as_primary_key.sql
+++ b/tests/queries/0_stateless/03365_time_time64_as_primary_key.sql
@@ -1,4 +1,5 @@
 SET allow_experimental_time_time64_type = 1;
+SET use_legacy_to_time = 0;
 
 DROP TABLE IF EXISTS test_time;
 CREATE TABLE test_time (a Time, b String) engine=MergeTree order by a;

--- a/tests/queries/0_stateless/03365_time_time64_cap_max_time.sql
+++ b/tests/queries/0_stateless/03365_time_time64_cap_max_time.sql
@@ -1,3 +1,5 @@
+SET use_legacy_to_time = 0;
+
 SELECT toTime(1264724816471);
 SELECT toTime(-1264724816471);
 

--- a/tests/queries/0_stateless/03365_time_time64_comparison.sql
+++ b/tests/queries/0_stateless/03365_time_time64_comparison.sql
@@ -1,3 +1,5 @@
+SET use_legacy_to_time = 0;
+
 -- TIME AND TIME
 -- Both positive
 SELECT toTime(12) > toTime(13);

--- a/tests/queries/0_stateless/03365_time_time64_conversions.sql
+++ b/tests/queries/0_stateless/03365_time_time64_conversions.sql
@@ -2,6 +2,7 @@
 
 SET session_timezone = 'UTC';
 SET allow_experimental_time_time64_type = 1;
+SET use_legacy_to_time = 0;
 
 -- Conversion from Time to String 
 SELECT toTime(0)::String;

--- a/tests/queries/0_stateless/03365_time_time64_extreme_values.sql
+++ b/tests/queries/0_stateless/03365_time_time64_extreme_values.sql
@@ -1,3 +1,5 @@
+SET use_legacy_to_time = 0;
+
 -- Within the acceptable range
 SELECT toTime('999:59:59');
 SELECT toTime64('999:59:59.999999999', 9);

--- a/tests/queries/0_stateless/03365_time_time64_operations.sql
+++ b/tests/queries/0_stateless/03365_time_time64_operations.sql
@@ -1,4 +1,5 @@
 SET session_timezone = 'UTC';
+SET use_legacy_to_time = 0;
 -- Operations <Time> + <number>
 SELECT toTime(12) + 1;
 SELECT toTime(12) + 25;

--- a/tests/queries/0_stateless/03365_time_time64_parsing.sql
+++ b/tests/queries/0_stateless/03365_time_time64_parsing.sql
@@ -1,3 +1,5 @@
+SET use_legacy_to_time = 0;
+
 -- Time with three-digit hours
 SELECT toTime('000:00:01');
 SELECT toTime('001:01:01');

--- a/tests/queries/0_stateless/03365_time_time64_with_timezone.sql
+++ b/tests/queries/0_stateless/03365_time_time64_with_timezone.sql
@@ -1,3 +1,5 @@
+SET use_legacy_to_time = 0;
+
 -- Between time/time64 data types, we shouldn't support time zone change as it relates values with date only, so while converting from Time to Time, it shouldn't change
 -- We will probably forbid using timezones with Time/Time64 types
 


### PR DESCRIPTION
Fix compatibility for `use_legacy_to_time`. It should be enabled on old instances.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix compatibility for `use_legacy_to_time`. It should be enabled on old instances.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
