### PR TITLE
Add secure option to KeeperClient

### DIFF
--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -423,7 +423,7 @@ int KeeperClient::main(const std::vector<String> & /* args */)
                 port = "9181";
 
             if ((clickhouse_config.configuration->has(prefix + ".secure")
-                || config().getBool("secure")) && !host.starts_with("secure://"))
+                || config().has("secure")) && !host.starts_with("secure://"))
                 host = "secure://" + host;
 
             zk_args.hosts.push_back(host + ":" + port);

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -439,7 +439,7 @@ int KeeperClient::main(const std::vector<String> & /* args */)
         String host = config().getString("host", "localhost");
         String port = config().getString("port", default_port);
 
-        if (is_secure)
+        if (is_secure && !host.starts_with("secure://"))
             host = "secure://" + host;
 
         zk_args.hosts.push_back(host + ":" + port);

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from os import path as p
 from collections.abc import Generator
-from typing import List, Optional, Sequence, Union, Self
+from typing import List, Optional, Sequence, Union
 
 from helpers.kazoo_client import KazooClientWithImplicitRetries
 from kazoo.exceptions import ConnectionLoss, OperationTimeoutError
@@ -257,7 +257,7 @@ class KeeperClient(object):
     @contextlib.contextmanager
     def from_cluster(
         cls, cluster: ClickHouseCluster, keeper_node: str, port: Optional[int] = None, **kwargs,
-    ) -> Generator[Self]:
+    ) -> Generator["KeeperClient"]:
         client = cls(
             cluster.server_bin_path,
             cluster.get_instance_ip(keeper_node),

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -72,7 +72,7 @@ def get_zk_client(nodename, timeout=30.0):
     return KeeperClient(
         cluster.server_bin_path,
         cluster.get_instance_ip(nodename),
-        cluster.zookeeper_port,
+        port=9181,
         connection_timeout=timeout, secure=True,
     )
 

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -69,8 +69,12 @@ def started_cluster():
 
 
 def get_zk_client(nodename, timeout=30.0):
-    return KeeperClient.from_cluster(cluster, nodename, connection_timeout=timeout, secure=True)
-
+    return KeeperClient(
+        cluster.server_bin_path,
+        cluster.get_instance_ip(nodename),
+        cluster.zookeeper_port,
+        connection_timeout=timeout, secure=True,
+    )
 
 def run_test():
     node_zks = []


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `--secure` option to KeeperClient. Add support for auto-read `tcp_port_secure` from Keeper config.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
