### PR TITLE
CI: Post CI summary from finish job only

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -112,7 +112,7 @@ class GH:
         TAG_COMMENT_END = "<!-- CI automatic comment end :{TAG}: -->"
         cmd_check_created = f'gh api -H "Accept: application/vnd.github.v3+json" \
             "/repos/{repo}/issues/{pr}/comments" \
-            --jq \'[.[] | {{id: .id, body: .body}}]\''
+            --jq \'[.[] | {{id: .id, body: .body}}]\' --paginate'
         output = Shell.get_output(cmd_check_created, verbose=True)
 
         comments = json.loads(output)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -523,38 +523,35 @@ class Runner:
 
         report_url = Info().get_job_report_url(latest=False)
 
-        if (
-            workflow.enable_gh_summary_comment
-            or job.enable_commit_status
-            or (workflow.enable_commit_status_on_failure and not result.is_ok())
+        if workflow.enable_gh_summary_comment and (
+            job.name == Settings.FINISH_WORKFLOW_JOB_NAME or not result.is_ok()
         ):
             _GH_Auth(workflow)
-
-            if workflow.enable_gh_summary_comment:
-                try:
-                    summary_body = GH.ResultSummaryForGH.from_result(
-                        workflow_result
-                    ).to_markdown()
-                    if not GH.post_updateable_comment(
-                        comment_tags_and_bodies={"summary": summary_body},
-                        only_update=True,
-                    ):
-                        print(f"ERROR: failed to post CI summary")
-                except Exception as e:
-                    print(f"ERROR: failed to post CI summary, ex: {e}")
-                    traceback.print_exc()
-
-            if (
-                workflow.enable_commit_status_on_failure and not result.is_ok()
-            ) or job.enable_commit_status:
-                if not GH.post_commit_status(
-                    name=job.name,
-                    status=result.status,
-                    description=result.info.splitlines()[0] if result.info else "",
-                    url=report_url,
+            try:
+                summary_body = GH.ResultSummaryForGH.from_result(
+                    workflow_result
+                ).to_markdown()
+                if not GH.post_updateable_comment(
+                    comment_tags_and_bodies={"summary": summary_body},
+                    only_update=True,
                 ):
-                    env.add_info("Failed to post GH commit status for the job")
-                    print(f"ERROR: Failed to post commit status for the job")
+                    print(f"ERROR: failed to post CI summary")
+            except Exception as e:
+                print(f"ERROR: failed to post CI summary, ex: {e}")
+                traceback.print_exc()
+
+        if (
+            workflow.enable_commit_status_on_failure and not result.is_ok()
+        ) or job.enable_commit_status:
+            _GH_Auth(workflow)
+            if not GH.post_commit_status(
+                name=job.name,
+                status=result.status,
+                description=result.info.splitlines()[0] if result.info else "",
+                url=report_url,
+            ):
+                env.add_info("Failed to post GH commit status for the job")
+                print(f"ERROR: Failed to post commit status for the job")
 
         if workflow.enable_report:
             # to make it visible in GH Actions annotations


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

1. post GH summary from the job only on failure - to save on secret retrieval from aws for GH auth, which can throttle sometimes
2. Add --paginate option into gh api request for comments retrieval to fetch all comments. Fixes new comment creation instead of update of existing one

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
