### PR TITLE
docs: fix typo

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -1740,7 +1740,7 @@ Settings for the [backup_log](../../operations/system-tables/backup_log.md) syst
 </clickhouse>
 ```
 
-## blog_storage_log {#blog_storage_log}
+## blob_storage_log {#blob_storage_log}
 
 Settings for the [`blob_storage_log`](../system-tables/blob_storage_log.md) system table.
 


### PR DESCRIPTION
s/blog_storage_log/blob_storage_log

### Changelog category (leave one):
- Documentation (changelog entry is not required)