### PR TITLE
Add comment to bypass large objects check

### DIFF
--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -56,7 +56,7 @@ public:
 
     using Actions = std::vector<Action>;
 
-    /// This map helps to find input position by it's name.
+    /// This map helps to find input position by its name.
     /// Key is a view to input::result_name.
     /// Result is a list because it is allowed for inputs to have same names.
     using NameToInputMap = std::unordered_map<std::string_view, std::list<size_t>>;

--- a/utils/check-large-objects.sh
+++ b/utils/check-large-objects.sh
@@ -13,5 +13,6 @@ if find $1 -name '*.o' | xargs wc -c | grep --regexp='\.o$' | sort -rn | awk '{ 
     | grep -v -f <(printf "%s\n" "${TU_EXCLUDES[@]}")
 then
     echo "^ It's not allowed to have so large translation units."
+    echo "  To bypass this check, configure the build with CHECK_LARGE_OBJECT_SIZES=0"
     exit 1
 fi

--- a/utils/check-large-objects.sh
+++ b/utils/check-large-objects.sh
@@ -13,6 +13,6 @@ if find $1 -name '*.o' | xargs wc -c | grep --regexp='\.o$' | sort -rn | awk '{ 
     | grep -v -f <(printf "%s\n" "${TU_EXCLUDES[@]}")
 then
     echo "^ It's not allowed to have so large translation units."
-    echo "  To bypass this check, configure the build with CHECK_LARGE_OBJECT_SIZES=0"
+    echo "  To bypass this check, configure the build with -DCHECK_LARGE_OBJECT_SIZES=0"
     exit 1
 fi


### PR DESCRIPTION
Add comment to bypass large objects check

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
