### PR TITLE
ci: fix stress tests (disable auth injection in keeper)

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -18,6 +18,7 @@ USE_AZURE_STORAGE_FOR_MERGE_TREE=${USE_AZURE_STORAGE_FOR_MERGE_TREE:0}
 USE_ASYNC_INSERT=${USE_ASYNC_INSERT:0}
 BUGFIX_VALIDATE_CHECK=0
 NO_AZURE=0
+KEEPER_INJECT_AUTH=1
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -36,6 +37,8 @@ while [[ "$#" -gt 0 ]]; do
 
         --async-insert) USE_ASYNC_INSERT=1 ;;
         --bugfix-validation) BUGFIX_VALIDATE_CHECK=1 ;;
+
+        --no-keeper-inject-auth) KEEPER_INJECT_AUTH=0 ;;
         *) echo "Unknown option: $1" ; exit 1 ;;
     esac
     shift
@@ -213,19 +216,27 @@ else
 fi
 
 # We randomize creating the snapshot on exit for Keeper to test out using older snapshots
-value=$(($RANDOM % 2))
+value=$((RANDOM % 2))
+echo "Replacing create_snapshot_on_exit with $value"
 sed --follow-symlinks -i "s|<create_snapshot_on_exit>[01]</create_snapshot_on_exit>|<create_snapshot_on_exit>$value</create_snapshot_on_exit>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-value=$((($RANDOM + 100) * 2048))
+value=$(((RANDOM + 100) * 2048))
+echo "Replacing latest_logs_cache_size_threshold with $value"
 sed --follow-symlinks -i "s|<latest_logs_cache_size_threshold>[[:digit:]]\+</latest_logs_cache_size_threshold>|<latest_logs_cache_size_threshold>$value</latest_logs_cache_size_threshold>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-value=$((($RANDOM + 100) * 2048))
+value=$(((RANDOM + 100) * 2048))
+echo "Replacing commit_logs_cache_size_threshold with $value"
 sed --follow-symlinks -i "s|<commit_logs_cache_size_threshold>[[:digit:]]\+</commit_logs_cache_size_threshold>|<commit_logs_cache_size_threshold>$value</commit_logs_cache_size_threshold>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-value=$(($RANDOM % 2))
+value=$((RANDOM % 2))
+echo "Replacing digest_enabled_on_commit with $value"
 sed --follow-symlinks -i "s|<digest_enabled_on_commit>[01]</digest_enabled_on_commit>|<digest_enabled_on_commit>$value</digest_enabled_on_commit>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-value=$(($RANDOM % 2))
+value=$((RANDOM % 2))
+if [[ $KEEPER_INJECT_AUTH -eq 0 ]]; then
+    value=0
+fi
+echo "Replacing inject_auth with $value"
 sed --follow-symlinks -i "s|<inject_auth>[01]</inject_auth>|<inject_auth>$value</inject_auth>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
 if [[ -n "$USE_POLYMORPHIC_PARTS" ]] && [[ "$USE_POLYMORPHIC_PARTS" -eq 1 ]]; then
@@ -296,7 +307,11 @@ if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
     rm $DEST_SERVER_PATH/config.d/zookeeper.xml
     rm $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-    value=$(($RANDOM % 2))
+    value=$((RANDOM % 2))
+    if [[ $KEEPER_INJECT_AUTH -eq 0 ]]; then
+        value=0
+    fi
+    echo "Replacing inject_auth with $value (for Replicated database)"
     sed --follow-symlinks -i "s|<inject_auth>[01]</inject_auth>|<inject_auth>$value</inject_auth>|" $DEST_SERVER_PATH/config.d/database_replicated.xml
 
     # There is a bug in config reloading, so we cannot override macros using --macros.replica r2

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -60,7 +60,7 @@ function configure()
     # install test configs
     export USE_DATABASE_ORDINARY=1
     export EXPORT_S3_STORAGE_POLICIES=1
-    /repo/tests/config/install.sh --no-keeper-inject-auth
+    /repo/tests/config/install.sh /etc/clickhouse-server /etc/clickhouse-client --no-keeper-inject-auth
 
     # avoid too slow startup
     sudo cat /etc/clickhouse-server/config.d/keeper_port.xml \

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -60,7 +60,7 @@ function configure()
     # install test configs
     export USE_DATABASE_ORDINARY=1
     export EXPORT_S3_STORAGE_POLICIES=1
-    /repo/tests/config/install.sh
+    /repo/tests/config/install.sh --no-keeper-inject-auth
 
     # avoid too slow startup
     sudo cat /etc/clickhouse-server/config.d/keeper_port.xml \
@@ -69,7 +69,8 @@ function configure()
     sudo mv /etc/clickhouse-server/config.d/keeper_port.xml.tmp /etc/clickhouse-server/config.d/keeper_port.xml
 
     function randomize_config_boolean_value {
-        value=$((RANDOM % 2))
+        local value=$((RANDOM % 2))
+        echo "Replacing $1 with $value"
         sudo cat "/etc/clickhouse-server/config.d/$2.xml" \
         | sed "s|<$1>[01]</$1>|<$1>$value</$1>|" \
         > "/etc/clickhouse-server/config.d/$2.xml.tmp"


### PR DESCRIPTION
The problem is that stress tests run install.sh multiple times, and so the keeper can start with different inject_auth values

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=82088&sha=2fed10a0d4971250c62da5a82ef75927ff13b414&name_0=PR&name_1=Stress%20test%20%28amd_debug%29

Introduced in: #82006

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)