### PR TITLE
Add _part_granule_offset column

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -968,6 +968,7 @@ ClickHouse versions 22.3 through 22.7 use a different cache configuration, see [
 - `_part_index` — Sequential index of the part in the query result.
 - `_part_starting_offset` — Cumulative starting row of the part in the query result.
 - `_part_offset` — Number of row in the part.
+- `_part_granule_offset` — Number of granule in the part.
 - `_partition_id` — Name of a partition.
 - `_part_uuid` — Unique part identifier (if enabled MergeTree setting `assign_part_uuids`).
 - `_part_data_version` — Data version of part (either min block number or mutation version).

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -301,19 +301,6 @@ MergeTreeReadTaskColumns getReadTaskColumns(
 
     auto add_step = [&](const PrewhereExprStep & step)
     {
-        Names step_column_names;
-
-        /// Virtual columns that are filled by RangeReader
-        /// must be read in the first step before any filtering.
-        if (columns_from_previous_steps.empty())
-        {
-            for (const auto & required_column : required_columns)
-            {
-                if (MergeTreeRangeReader::virtuals_to_fill.contains(required_column))
-                    step_column_names.push_back(required_column);
-            }
-        }
-
         /// Computation results from previous steps might be used in the current step as well. In such a case these
         /// computed columns will be present in the current step inputs. They don't need to be read from the disk so
         /// exclude them from the list of columns to read. This filtering must be done before injecting required
@@ -328,6 +315,7 @@ MergeTreeReadTaskColumns getReadTaskColumns(
         else if (!step.filter_column_name.empty())
             required_source_columns = Names{step.filter_column_name};
 
+        Names step_column_names;
         for (const auto & name : required_source_columns)
         {
             if (!columns_from_previous_steps.contains(name))

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -606,6 +606,7 @@ VirtualColumnsDescription MergeTreeData::createVirtuals(const StorageInMemoryMet
     desc.addEphemeral("_partition_id", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of partition");
     desc.addEphemeral("_sample_factor", std::make_shared<DataTypeFloat64>(), "Sample factor (from the query)");
     desc.addEphemeral("_part_offset", std::make_shared<DataTypeUInt64>(), "Number of row in the part");
+    desc.addEphemeral("_part_granule_offset", std::make_shared<DataTypeUInt64>(), "Number of granule in the part");
     desc.addEphemeral("_part_data_version", std::make_shared<DataTypeUInt64>(), "Data version of part (either min block number or mutation version)");
     desc.addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name");
 

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -189,14 +189,14 @@ size_t MergeTreeRangeReader::DelayedStream::finalize(Columns & columns)
 }
 
 
-MergeTreeRangeReader::Stream::Stream(
-        size_t from_mark, size_t to_mark, size_t current_task_last_mark, IMergeTreeReader * merge_tree_reader_)
-        : current_mark(from_mark), offset_after_current_mark(0)
-        , last_mark(to_mark)
-        , merge_tree_reader(merge_tree_reader_)
-        , index_granularity(&(merge_tree_reader->data_part_info_for_read->getIndexGranularity()))
-        , current_mark_index_granularity(index_granularity->getMarkRows(from_mark))
-        , stream(from_mark, current_task_last_mark, merge_tree_reader)
+MergeTreeRangeReader::Stream::Stream(size_t from_mark, size_t to_mark, size_t current_task_last_mark, IMergeTreeReader * merge_tree_reader_)
+    : merge_tree_reader(merge_tree_reader_)
+    , index_granularity(&(merge_tree_reader->data_part_info_for_read->getIndexGranularity()))
+    , stream(from_mark, current_task_last_mark, merge_tree_reader)
+    , current_mark(from_mark)
+    , current_mark_index_granularity(index_granularity->getMarkRows(from_mark))
+    , offset_after_current_mark(0)
+    , last_mark(to_mark)
 {
     size_t marks_count = index_granularity->getMarksCount();
     if (from_mark >= marks_count)
@@ -258,7 +258,7 @@ size_t MergeTreeRangeReader::Stream::read(Columns & columns, size_t num_rows, bo
 
         offset_after_current_mark += num_rows;
 
-        /// Start new granule; skipped_rows_after_offset is already zero.
+        /// Start new granule.
         if (offset_after_current_mark == current_mark_index_granularity || skip_remaining_rows_in_current_granule)
             toNextMark();
 
@@ -287,7 +287,7 @@ void MergeTreeRangeReader::Stream::skip(size_t num_rows)
 
         if (offset_after_current_mark == current_mark_index_granularity)
         {
-            /// Start new granule; skipped_rows_after_offset is already zero.
+            /// Start new granule.
             toNextMark();
         }
     }
@@ -304,9 +304,10 @@ size_t MergeTreeRangeReader::Stream::finalize(Columns & columns)
 }
 
 
-void MergeTreeRangeReader::ReadResult::addGranule(size_t num_rows_)
+void MergeTreeRangeReader::ReadResult::addGranule(size_t num_rows_, GranuleOffset granule_offset)
 {
     rows_per_granule.push_back(num_rows_);
+    granule_offsets.push_back(std::move(granule_offset));
     total_rows_per_granule += num_rows_;
 }
 
@@ -847,13 +848,12 @@ size_t MergeTreeRangeReader::numPendingRowsInCurrentGranule() const
 
 size_t MergeTreeRangeReader::numRowsInCurrentGranule() const
 {
-    /// If pending_rows is zero, than stream is not initialized.
+    /// Use `current_mark_index_granularity` if the stream is initialized;
+    /// otherwise, fallback to the granularity of the first mark from the reader.
     if (stream.current_mark_index_granularity)
         return stream.current_mark_index_granularity;
-
-    /// We haven't read anything, return first
-    size_t first_mark = merge_tree_reader->getFirstMarkToRead();
-    return index_granularity->getMarkRows(first_mark);
+    else
+        return index_granularity->getMarkRows(merge_tree_reader->getFirstMarkToRead());
 }
 
 size_t MergeTreeRangeReader::currentMark() const
@@ -861,7 +861,7 @@ size_t MergeTreeRangeReader::currentMark() const
     return stream.currentMark();
 }
 
-const NameSet MergeTreeRangeReader::virtuals_to_fill = {"_part_offset", "_block_offset"};
+const NameSet MergeTreeRangeReader::virtuals_to_fill = {"_part_offset", "_block_offset", "_part_granule_offset"};
 
 size_t MergeTreeRangeReader::Stream::numPendingRows() const
 {
@@ -936,6 +936,15 @@ static String addDummyColumnWithRowCount(Block & block, size_t num_rows)
     return dummy_column.name;
 }
 
+static size_t getTotalBytesInColumns(const Columns & columns)
+{
+    size_t total_bytes = 0;
+    for (const auto & column : columns)
+        if (column)
+            total_bytes += column->byteSize();
+    return total_bytes;
+}
+
 MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t max_rows, MarkRanges & ranges)
 {
     ReadResult result(log);
@@ -944,17 +953,11 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
     size_t current_task_last_mark = getLastMark(ranges);
 
     /// The stream could be unfinished by the previous read request because of max_rows limit.
-    /// In this case it will have some rows from the previously started range. We need to save their begin and
-    /// end offsets to properly fill _part_offset column.
-    UInt64 leading_begin_part_offset = 0;
-    UInt64 leading_end_part_offset = 0;
+    /// In this case it will have some rows from the previously started range. We need to save current_mark
+    /// to properly fill ReadRange for query condition cache.
     std::optional<size_t> current_mark;
     if (!stream.isFinished())
-    {
-        leading_begin_part_offset = stream.currentPartOffset();
-        leading_end_part_offset = stream.lastPartOffset();
         current_mark = stream.current_mark;
-    }
 
     /// Stream is lazy. result.num_added_rows is the number of rows added to block which is not equal to
     /// result.num_rows_read until call to stream.finalize(). Also result.num_added_rows may be less than
@@ -987,8 +990,10 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
             auto rows_to_read = std::min(current_space, stream.numPendingRowsInCurrentGranule());
 
             bool last = rows_to_read == space_left;
+            UInt64 starting_offset = stream.currentPartOffset();
+            UInt64 granule_offset = stream.current_mark;
             result.addRows(stream.read(result.columns, rows_to_read, !last));
-            result.addGranule(rows_to_read);
+            result.addGranule(rows_to_read, {starting_offset, granule_offset});
             space_left = (rows_to_read > space_left ? 0 : space_left - rows_to_read);
         }
     }
@@ -1002,15 +1007,16 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
     if (!result.rows_per_granule.empty())
         result.adjustLastGranule();
 
-    fillVirtualColumns(result.columns, result, leading_begin_part_offset, leading_end_part_offset);
+    fillVirtualColumns(result.columns, result);
     result.num_rows = result.numReadRows();
 
     updatePerformanceCounters(result.numReadRows());
+    result.addNumBytesRead(getTotalBytesInColumns(result.columns));
 
     return result;
 }
 
-void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & result, UInt64 leading_begin_part_offset, UInt64 leading_end_part_offset)
+void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & result)
 {
     ColumnPtr part_offset_column;
 
@@ -1023,10 +1029,16 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
         if (columns[pos])
             return;
 
-        if (!part_offset_column)
-            part_offset_column = createPartOffsetColumn(result, leading_begin_part_offset, leading_end_part_offset);
-
-        columns[pos] = part_offset_column;
+        if (column_name == "_part_offset" || column_name == BlockOffsetColumn::name)
+        {
+            if (!part_offset_column)
+                part_offset_column = createPartOffsetColumn(result);
+            columns[pos] = part_offset_column;
+        }
+        else if (column_name == "_part_granule_offset")
+        {
+            columns[pos] = createPartGranuleOffsetColumn(result);
+        }
     };
 
     if (read_sample_block.has("_part_offset"))
@@ -1035,34 +1047,47 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
     /// Column _block_offset is the same as _part_offset if it's not persisted in part.
     if (read_sample_block.has(BlockOffsetColumn::name))
         add_offset_column(BlockOffsetColumn::name);
+
+    if (read_sample_block.has("_part_granule_offset"))
+        add_offset_column("_part_granule_offset");
 }
 
-ColumnPtr MergeTreeRangeReader::createPartOffsetColumn(ReadResult & result, UInt64 leading_begin_part_offset, UInt64 leading_end_part_offset)
+ColumnPtr MergeTreeRangeReader::createPartOffsetColumn(ReadResult & result)
 {
-    size_t num_rows = result.numReadRows();
-
-    auto column = ColumnUInt64::create(num_rows);
+    auto column = ColumnUInt64::create(result.total_rows_per_granule);
     ColumnUInt64::Container & vec = column->getData();
 
-    UInt64 * pos = vec.data();
-    UInt64 * end = &vec[num_rows];
+    UInt64 * pos = vec.begin();
+    const auto & rows_per_granule = result.rows_per_granule;
+    const auto & granule_offsets = result.granule_offsets;
 
-    /// Fill the remaining part of the previous range (it was started in the previous read request).
-    while (pos < end && leading_begin_part_offset < leading_end_part_offset)
-        *pos++ = leading_begin_part_offset++;
-
-    const auto & start_ranges = result.started_ranges;
-
-    /// Fill the ranges which were started in the current read request.
-    for (const auto & start_range : start_ranges)
+    for (size_t i = 0; i < rows_per_granule.size(); ++i)
     {
-        UInt64 start_part_offset = index_granularity->getMarkStartingRow(start_range.range.begin);
-        UInt64 end_part_offset = index_granularity->getMarkStartingRow(start_range.range.end);
-
-        while (pos < end && start_part_offset < end_part_offset)
-            *pos++ = start_part_offset++;
+        iota(pos, rows_per_granule[i], granule_offsets[i].starting_offset);
+        pos += rows_per_granule[i];
     }
 
+    chassert(pos == vec.end());
+    return column;
+}
+
+ColumnPtr MergeTreeRangeReader::createPartGranuleOffsetColumn(ReadResult & result)
+{
+    auto column = ColumnUInt64::create(result.total_rows_per_granule);
+    ColumnUInt64::Container & vec = column->getData();
+
+    UInt64 * pos = vec.begin();
+    const auto & rows_per_granule = result.rows_per_granule;
+    const auto & granule_offsets = result.granule_offsets;
+
+    for (size_t i = 0; i < rows_per_granule.size(); ++i)
+    {
+        UInt64 * next_pos = pos + rows_per_granule[i];
+        std::fill(pos, next_pos, granule_offsets[i].granule_offset);
+        pos = next_pos;
+    }
+
+    chassert(pos == vec.end());
     return column;
 }
 
@@ -1081,14 +1106,6 @@ Columns MergeTreeRangeReader::continueReadingChain(ReadResult & result, size_t &
         /// Last granule may have less rows than index_granularity, so finish reading manually.
         stream.finish();
         return columns;
-    }
-
-    UInt64 leading_begin_part_offset = 0;
-    UInt64 leading_end_part_offset = 0;
-    if (!stream.isFinished())
-    {
-        leading_begin_part_offset = stream.currentPartOffset();
-        leading_end_part_offset = stream.lastPartOffset();
     }
 
     columns.resize(merge_tree_reader->numColumnsInResult());
@@ -1111,21 +1128,29 @@ Columns MergeTreeRangeReader::continueReadingChain(ReadResult & result, size_t &
             stream = Stream(range.begin, range.end, current_task_last_mark, merge_tree_reader);
         }
 
+        /// If it's not the last granule, skip remaining (filtered-out) rows to align to the next mark.
+        /// This is necessary because prewhere filtering may reduce rows_per_granule[i].
         bool last = i + 1 == size;
         num_rows += stream.read(columns, rows_per_granule[i], !last);
     }
 
+    /// The last granule may be incomplete by nature, not due to PREWHERE filtering,
+    /// so we must skip an exact number of rows instead of jumping to the next mark.
     stream.skip(result.num_rows_to_skip_in_last_granule);
     num_rows += stream.finalize(columns);
 
-    /// added_rows may be zero if all columns were read in prewhere and it's ok.
-    if (num_rows && num_rows != result.total_rows_per_granule)
+    /// num_rows may be zero if current step only contains virtual columns to read.
+    if (num_rows == 0)
+        num_rows = result.total_rows_per_granule;
+
+    if (num_rows != result.total_rows_per_granule)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "RangeReader read {} rows, but {} expected.",
                         num_rows, result.total_rows_per_granule);
 
-    fillVirtualColumns(columns, result, leading_begin_part_offset, leading_end_part_offset);
+    fillVirtualColumns(columns, result);
 
     updatePerformanceCounters(num_rows);
+    result.addNumBytesRead(getTotalBytesInColumns(result.columns));
 
     return columns;
 }
@@ -1313,7 +1338,8 @@ static ColumnPtr combineFilters(ColumnPtr first, ColumnPtr second)
     return mut_first;
 }
 
-void MergeTreeRangeReader::executeActionsBeforePrewhere(ReadResult & result, Columns & read_columns, const Block & previous_header, size_t num_read_rows) const
+void MergeTreeRangeReader::executeActionsBeforePrewhere(
+    ReadResult & result, Columns & read_columns, const Block & previous_header, size_t num_read_rows) const
 {
     merge_tree_reader->fillVirtualColumns(read_columns, num_read_rows);
 
@@ -1323,7 +1349,20 @@ void MergeTreeRangeReader::executeActionsBeforePrewhere(ReadResult & result, Col
     bool should_evaluate_missing_defaults;
     merge_tree_reader->fillMissingColumns(read_columns, should_evaluate_missing_defaults, num_read_rows);
 
-    if (result.total_rows_per_granule == num_read_rows && result.num_rows != num_read_rows)
+    if (result.total_rows_per_granule != num_read_rows)
+    {
+        /// This can only happen when all columns are missing during the current read step,
+        /// and num_read_rows is inferred from a previous read.
+        if (result.num_rows != num_read_rows)
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Mismatch in expected row count: total_rows_per_granule={}, num_rows={}, num_read_rows={}. "
+                "This indicates an inconsistency in row filling logic when all columns are missing",
+                result.total_rows_per_granule,
+                result.num_rows,
+                num_read_rows);
+    }
+    else if (result.num_rows != num_read_rows)
     {
         /// We have filter applied from the previous step
         /// So we need to apply it to the newly read rows

--- a/src/Storages/MergeTree/MergeTreeRangeReader.h
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.h
@@ -175,7 +175,7 @@ private:
         bool continue_reading = false;
         bool is_finished = true;
 
-        /// Current position from the begging of file in rows
+        /// Current position from the beginning of file in rows
         size_t position() const;
         size_t readRows(Columns & columns, size_t num_rows);
     };
@@ -186,8 +186,7 @@ private:
     {
     public:
         Stream() = default;
-        Stream(size_t from_mark, size_t to_mark,
-               size_t current_task_last_mark, IMergeTreeReader * merge_tree_reader);
+        Stream(size_t from_mark, size_t to_mark, size_t current_task_last_mark, IMergeTreeReader * merge_tree_reader);
 
         /// Returns the number of rows added to block.
         size_t read(Columns & columns, size_t num_rows, bool skip_remaining_rows_in_current_granule);
@@ -208,19 +207,17 @@ private:
         UInt64 currentPartOffset() const;
         UInt64 lastPartOffset() const;
 
+        IMergeTreeReader * merge_tree_reader = nullptr;
+        const MergeTreeIndexGranularity * index_granularity = nullptr;
+        DelayedStream stream;
         size_t current_mark = 0;
-        /// Invariant: offset_after_current_mark + skipped_rows_after_offset < index_granularity
+        size_t current_mark_index_granularity = 0;
+
+        /// Invariant: offset_after_current_mark <= current_mark_index_granularity
         size_t offset_after_current_mark = 0;
 
         /// Last mark in current range.
         size_t last_mark = 0;
-
-        IMergeTreeReader * merge_tree_reader = nullptr;
-        const MergeTreeIndexGranularity * index_granularity = nullptr;
-
-        size_t current_mark_index_granularity = 0;
-
-        DelayedStream stream;
 
         void checkNotFinished() const;
         void checkEnoughSpaceInCurrentGranule(size_t num_rows) const;
@@ -251,6 +248,13 @@ public:
 
         using NumRows = std::vector<size_t>;
 
+        struct GranuleOffset
+        {
+            UInt64 starting_offset;  /// Granule starting offset within the part
+            UInt64 granule_offset;   /// Granule index within the part
+        };
+        using GranuleOffsets = std::vector<GranuleOffset>;
+
         struct RangeInfo
         {
             size_t num_granules_read_before_start;
@@ -263,16 +267,23 @@ public:
 
         static size_t getLastMark(const MergeTreeRangeReader::ReadResult::RangesInfo & ranges);
 
-        void addGranule(size_t num_rows_);
+        /// Populate @rows_per_granule and @granule_offsets. See comments below.
+        void addGranule(size_t num_rows_, GranuleOffset granule_offset);
         void adjustLastGranule();
+
         void addRows(size_t rows) { num_read_rows += rows; }
+
+        /// Populate @started_ranges. See comments below.
         void addRange(const MarkRange & range) { started_ranges.push_back({rows_per_granule.size(), range}); }
+
+        /// For query condition cache.
         void addReadRange(MarkRange mark_range) { read_mark_ranges.push_back(std::move(mark_range)); }
 
         /// Add current step filter to the result and then for each granule calculate the number of filtered rows at the end.
         /// Remove them and update filter.
         /// Apply the filter to the columns and update num_rows if required
         void optimize(const FilterWithCachedCount & current_filter, bool can_read_incomplete_granules);
+
         /// Remove all rows from granules.
         void clear();
 
@@ -295,11 +306,27 @@ public:
         /// Contains columns that are not included into result but might be needed for default values calculation.
         Block additional_columns;
 
+        /// Track newly initiated granule ranges during startReadingChain. Does not contain the range started in previous read.
+        /// Used to compute _part_offset and align continueReadingChain streams accordingly.
         RangesInfo started_ranges;
-        /// The number of rows read from each granule.
-        /// Granule here is not number of rows between two marks
-        /// It's amount of rows per single reading act
+
+        /// Number of rows intended to be read per granule during the reading chain.
+        ///
+        /// Filled in `startReadingChain` based on initial granule layout and expected row counts.
+        /// May be further filtered in `optimize` when `PREWHERE` filters prune rows early.
+        /// Used by `continueReadingChain` to guide how many rows to fetch from each granule.
+        ///
+        /// Example:
+        ///                 startReadingChain         optimize   continueReadingChain   optimize       ...
+        ///
+        /// Granule i       8192                      4000       4000                   4000
+        /// Granule i+1     8192                      3000       3000                   0 (filtered)
+        /// Granule i+2     8192                      3000       3000                   1000
+        /// Granule i+3     1000 (last incomplete)    1000       1000                   1000
         NumRows rows_per_granule;
+        /// Stores starting row offset and granule index for each granule.
+        /// Used to generate _part_offset and _part_granule_offset columns.
+        GranuleOffsets granule_offsets;
         /// Sum(rows_per_granule)
         size_t total_rows_per_granule = 0;
         /// The number of rows was read at first step. May be zero if no read columns present in part.
@@ -343,8 +370,9 @@ public:
     IMergeTreeReader * getReader() const { return merge_tree_reader; }
 
 private:
-    void fillVirtualColumns(Columns & columns, ReadResult & result, UInt64 leading_begin_part_offset, UInt64 leading_end_part_offset);
-    ColumnPtr createPartOffsetColumn(ReadResult & result, UInt64 leading_begin_part_offset, UInt64 leading_end_part_offset);
+    void fillVirtualColumns(Columns & columns, ReadResult & result);
+    ColumnPtr createPartOffsetColumn(ReadResult & result);
+    ColumnPtr createPartGranuleOffsetColumn(ReadResult & result);
 
     void updatePerformanceCounters(size_t num_rows_read);
 

--- a/tests/queries/0_stateless/02890_describe_table_options.reference
+++ b/tests/queries/0_stateless/02890_describe_table_options.reference
@@ -36,6 +36,7 @@ _part_uuid	UUID			Unique part identifier (if enabled MergeTree setting assign_pa
 _partition_id	LowCardinality(String)			Name of partition			1
 _sample_factor	Float64			Sample factor (from the query)			1
 _part_offset	UInt64			Number of row in the part			1
+_part_granule_offset	UInt64			Number of granule in the part			1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			1
 _disk_name	LowCardinality(String)			Disk name			1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			1
@@ -52,6 +53,7 @@ _part_uuid	UUID			Unique part identifier (if enabled MergeTree setting assign_pa
 _partition_id	LowCardinality(String)			Name of partition			1
 _sample_factor	Float64			Sample factor (from the query)			1
 _part_offset	UInt64			Number of row in the part			1
+_part_granule_offset	UInt64			Number of granule in the part			1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			1
 _disk_name	LowCardinality(String)			Disk name			1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			1
@@ -72,6 +74,7 @@ _part_uuid	UUID			Unique part identifier (if enabled MergeTree setting assign_pa
 _partition_id	LowCardinality(String)			Name of partition			0	1
 _sample_factor	Float64			Sample factor (from the query)			0	1
 _part_offset	UInt64			Number of row in the part			0	1
+_part_granule_offset	UInt64			Number of granule in the part			0	1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			0	1
 _disk_name	LowCardinality(String)			Disk name			0	1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			0	1
@@ -91,6 +94,7 @@ _part_uuid	UUID			Unique part identifier (if enabled MergeTree setting assign_pa
 _partition_id	LowCardinality(String)			Name of partition			0	1
 _sample_factor	Float64			Sample factor (from the query)			0	1
 _part_offset	UInt64			Number of row in the part			0	1
+_part_granule_offset	UInt64			Number of granule in the part			0	1
 _part_data_version	UInt64			Data version of part (either min block number or mutation version)			0	1
 _disk_name	LowCardinality(String)			Disk name			0	1
 _row_exists	UInt8			Persisted mask created by lightweight delete that show whether row exists or is deleted			0	1
@@ -138,6 +142,7 @@ _part_uuid	UUID	1
 _partition_id	LowCardinality(String)	1
 _sample_factor	Float64	1
 _part_offset	UInt64	1
+_part_granule_offset	UInt64	1
 _part_data_version	UInt64	1
 _disk_name	LowCardinality(String)	1
 _row_exists	UInt8	1
@@ -154,6 +159,7 @@ _part_uuid	UUID	1
 _partition_id	LowCardinality(String)	1
 _sample_factor	Float64	1
 _part_offset	UInt64	1
+_part_granule_offset	UInt64	1
 _part_data_version	UInt64	1
 _disk_name	LowCardinality(String)	1
 _row_exists	UInt8	1
@@ -174,6 +180,7 @@ _part_uuid	UUID	0	1
 _partition_id	LowCardinality(String)	0	1
 _sample_factor	Float64	0	1
 _part_offset	UInt64	0	1
+_part_granule_offset	UInt64	0	1
 _part_data_version	UInt64	0	1
 _disk_name	LowCardinality(String)	0	1
 _row_exists	UInt8	0	1
@@ -193,6 +200,7 @@ _part_uuid	UUID	0	1
 _partition_id	LowCardinality(String)	0	1
 _sample_factor	Float64	0	1
 _part_offset	UInt64	0	1
+_part_granule_offset	UInt64	0	1
 _part_data_version	UInt64	0	1
 _disk_name	LowCardinality(String)	0	1
 _row_exists	UInt8	0	1

--- a/tests/queries/0_stateless/03546_part_granule_offset.reference
+++ b/tests/queries/0_stateless/03546_part_granule_offset.reference
@@ -1,0 +1,81 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS test_part_granule_offset;
+CREATE TABLE test_part_granule_offset (n UInt64) ENGINE = MergeTree ORDER BY () SETTINGS index_granularity = 2;
+INSERT INTO test_part_granule_offset SELECT number FROM numbers(101);
+OPTIMIZE TABLE test_part_granule_offset FINAL;
+SELECT _part_granule_offset FROM test_part_granule_offset WHERE n < 10 ORDER BY all;
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+SELECT _part_granule_offset, groupArraySorted(200)(n) FROM test_part_granule_offset GROUP BY _part_granule_offset ORDER BY ALL;
+0	[0,1]
+1	[2,3]
+2	[4,5]
+3	[6,7]
+4	[8,9]
+5	[10,11]
+6	[12,13]
+7	[14,15]
+8	[16,17]
+9	[18,19]
+10	[20,21]
+11	[22,23]
+12	[24,25]
+13	[26,27]
+14	[28,29]
+15	[30,31]
+16	[32,33]
+17	[34,35]
+18	[36,37]
+19	[38,39]
+20	[40,41]
+21	[42,43]
+22	[44,45]
+23	[46,47]
+24	[48,49]
+25	[50,51]
+26	[52,53]
+27	[54,55]
+28	[56,57]
+29	[58,59]
+30	[60,61]
+31	[62,63]
+32	[64,65]
+33	[66,67]
+34	[68,69]
+35	[70,71]
+36	[72,73]
+37	[74,75]
+38	[76,77]
+39	[78,79]
+40	[80,81]
+41	[82,83]
+42	[84,85]
+43	[86,87]
+44	[88,89]
+45	[90,91]
+46	[92,93]
+47	[94,95]
+48	[96,97]
+49	[98,99]
+50	[100]
+SELECT * FROM test_part_granule_offset WHERE _part_granule_offset % 10 = 1 ORDER BY ALL;
+2
+3
+22
+23
+42
+43
+62
+63
+82
+83
+DROP TABLE test_part_granule_offset;

--- a/tests/queries/0_stateless/03546_part_granule_offset.sql
+++ b/tests/queries/0_stateless/03546_part_granule_offset.sql
@@ -1,0 +1,17 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS test_part_granule_offset;
+
+CREATE TABLE test_part_granule_offset (n UInt64) ENGINE = MergeTree ORDER BY () SETTINGS index_granularity = 2;
+
+INSERT INTO test_part_granule_offset SELECT number FROM numbers(101);
+
+OPTIMIZE TABLE test_part_granule_offset FINAL;
+
+SELECT _part_granule_offset FROM test_part_granule_offset WHERE n < 10 ORDER BY all;
+
+SELECT _part_granule_offset, groupArraySorted(200)(n) FROM test_part_granule_offset GROUP BY _part_granule_offset ORDER BY ALL;
+
+SELECT * FROM test_part_granule_offset WHERE _part_granule_offset % 10 = 1 ORDER BY ALL;
+
+DROP TABLE test_part_granule_offset;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `_part_granule_offset` virtual column in MergeTree-family tables. This column indicates the zero-based index of the granule/mark each row belongs to within its data part. This addresses #79572.

This PR also relaxes the restriction that `_part_offset` and `_block_offset` must be read during the first reading step. It further includes some preparatory refactoring extracted from #81526 to simplify the review of that PR.

I'm currently using `_part_granule_offset` to analyze whether the query condition cache fully records all relevant granules.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
