### PR TITLE
Mark functions `searchAll` and `searchAny` as experimental

### DIFF
--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -757,6 +757,10 @@ Result:
 
 ## searchAny {#searchany}
 
+:::note
+This function can only be used if setting [allow_experimental_full_text_index](/operations/settings/settings#allow_experimental_full_text_index) is true.
+:::
+
 Returns 1, if at least one string needle<sub>i</sub> matches the `input` column and 0 otherwise.
 
 **Syntax**
@@ -811,6 +815,10 @@ Result:
 ```
 
 ## searchAll {#searchall}
+
+:::note
+This function can only be used if setting [allow_experimental_full_text_index](/operations/settings/settings#allow_experimental_full_text_index) is true.
+:::
 
 Like [searchAny](#searchany), but returns 1 only if all string needle<sub>i</sub> matches the `input` column and 0 otherwise.
 

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -791,17 +791,17 @@ Refer [tokens](splitting-merging-functions.md#tokens) for more information about
 Query:
 
 ```sql
-CREATE TABLE `text_table` (
-    `id` UInt32,
-    `msg` String,
-    INDEX idx(msg) TYPE text(tokenizer = 'split', separators = ['()', '\\']) GRANULARITY 1
+CREATE TABLE text_table (
+    id UInt32,
+    msg String,
+    INDEX idx(msg) TYPE text(tokenizer = 'split', separators = ['()', '\\'])
 )
 ENGINE = MergeTree
 ORDER BY id;
 
-INSERT into `text_table` VALUES (1, '()a,\\bc()d'), (2, '()\\a()bc\\d'), (3, ',()a\\,bc,(),d,');
+INSERT INTO text_table VALUES (1, '()a,\\bc()d'), (2, '()\\a()bc\\d'), (3, ',()a\\,bc,(),d,');
 
-SELECT count() from `text_table` where searchAny(msg, ['a', 'd']);
+SELECT count() FROM `text_table` WHERE searchAny(msg, ['a', 'd']);
 ```
 
 Result:
@@ -846,17 +846,17 @@ Refer [tokens](splitting-merging-functions.md#tokens) for more information about
 Query:
 
 ```sql
-CREATE TABLE `text_table` (
-    `id` UInt32,
-    `msg` String,
+CREATE TABLE text_table (
+    id UInt32,
+    msg String,
     INDEX idx(msg) TYPE text(tokenizer = 'split', separators = ['()', '\\']) GRANULARITY 1
 )
 ENGINE = MergeTree
 ORDER BY id;
 
-INSERT into `text_table` VALUES (1, '()a,\\bc()d'), (2, '()\\a()bc\\d'), (3, ',()a\\,bc,(),d,');
+INSERT INTO `text_table` VALUES (1, '()a,\\bc()d'), (2, '()\\a()bc\\d'), (3, ',()a\\,bc,(),d,');
 
-SELECT count() from `text_table` where searchAll(msg, ['a', 'd']);
+SELECT count() FROM `text_table` WHERE searchAll(msg, ['a', 'd']);
 ```
 
 Result:

--- a/src/Functions/text/searchAnyAll.h
+++ b/src/Functions/text/searchAnyAll.h
@@ -28,10 +28,8 @@ class FunctionSearchImpl : public IFunction
 public:
     static constexpr auto name = SearchTraits::name;
 
-    static FunctionPtr create(ContextPtr)
-    {
-        return std::make_shared<FunctionSearchImpl>();
-    }
+    static FunctionPtr create(ContextPtr context);
+    explicit FunctionSearchImpl<SearchTraits>(ContextPtr context);
 
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 2; }
@@ -41,9 +39,10 @@ public:
     void setGinFilterParameters(const GinFilterParameters & params);
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;
-
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override;
+
 private:
+    const bool allow_experimental_full_text_index;
     std::optional<GinFilterParameters> parameters;
 };
 }

--- a/tests/queries/0_stateless/02346_text_index_function_search.sql
+++ b/tests/queries/0_stateless/02346_text_index_function_search.sql
@@ -22,20 +22,20 @@ INSERT INTO tab VALUES (1, 'b', 'b', ['c']);
 
 -- Must accept two arguments
 SELECT id FROM tab WHERE searchAny(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT id FROM tab WHERE searchAny('a', 'b', 'c', 'd', 'e'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT id FROM tab WHERE searchAny('a', 'b', 'c'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT id FROM tab WHERE searchAll(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT id FROM tab WHERE searchAll('a', 'b', 'c', 'd', 'e'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT id FROM tab WHERE searchAll('a', 'b', 'c'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 -- 1st arg must be String or FixedString
 SELECT id FROM tab WHERE searchAny(1, ['a']); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT id FROM tab WHERE searchAll(1, ['a']); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 -- 2nd arg must be const Array(String)
-SELECT id FROM tab WHERE searchAny(message, toFixedString('b', 1)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT id FROM tab WHERE searchAny(message, 'b'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT id FROM tab WHERE searchAny(message, materialize('b')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT id FROM tab WHERE searchAll(message, toFixedString('b', 1)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT id FROM tab WHERE searchAny(message, materialize(['b'])); -- { serverError ILLEGAL_COLUMN }
+SELECT id FROM tab WHERE searchAll(message, 'b'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT id FROM tab WHERE searchAll(message, materialize('b')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT id FROM tab WHERE searchAny(message, arr); -- { serverError ILLEGAL_COLUMN }
-SELECT id FROM tab WHERE searchAll(message, arr); -- { serverError ILLEGAL_COLUMN }
--- search functions should be used with the index column
+SELECT id FROM tab WHERE searchAll(message, materialize(['b'])); -- { serverError ILLEGAL_COLUMN }
+-- search functions must be called on a column with text index
 SELECT id FROM tab WHERE searchAny('a', ['b']); -- { serverError BAD_ARGUMENTS }
 SELECT id FROM tab WHERE searchAny(col_str, ['b']); -- { serverError BAD_ARGUMENTS }
 SELECT id FROM tab WHERE searchAll('a', ['b']); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
@@ -118,7 +118,7 @@ SELECT '';
 SELECT '-------- GIN filter --------';
 SELECT '';
 
-SET allow_experimental_inverted_index=1;
+SET allow_experimental_full_text_index = 1;
 DROP TABLE IF EXISTS 03165_token_ft;
 CREATE TABLE 03165_token_ft
 (


### PR DESCRIPTION
Functions `searchAll` and `searchAny` were marked experimental for now. I have the feeling that we will need to change them in a backward-incompatible way at some point, so this buys some time.

Review note:
- https://github.com/ClickHouse/ClickHouse/commit/d3f9201fa4513834daaaadc6609698d6a3e0c1b9 does tiny fixups
- https://github.com/ClickHouse/ClickHouse/commit/b98986a5dac687db2b8dcf5f9eebe81f80284752 is the actual change

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)