### PR TITLE
Revert "Using file offsets instead of virtual memory addresses in `system.symbols` and `addressToSymbol`"

### DIFF
--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -294,7 +294,7 @@ void StackTrace::forEachFrame(
             }
         }
 
-        if (const auto * symbol = symbol_index.findSymbol(current_frame.physical_addr))
+        if (const auto * symbol = symbol_index.findSymbol(current_frame.virtual_addr))
             current_frame.symbol = demangle(symbol->name);
 
         for (const auto & frame : inline_frames)

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -206,10 +206,10 @@ void collectSymbolsFromProgramHeaders(
                         continue;
 
                     SymbolIndex::Symbol symbol;
-                    symbol.offset_begin = reinterpret_cast<const void *>(
-                        elf_sym[sym_index].st_value);
-                    symbol.offset_end = reinterpret_cast<const void *>(
-                        elf_sym[sym_index].st_value + elf_sym[sym_index].st_size);
+                    symbol.address_begin = reinterpret_cast<const void *>(
+                        info->dlpi_addr + elf_sym[sym_index].st_value);
+                    symbol.address_end = reinterpret_cast<const void *>(
+                        info->dlpi_addr + elf_sym[sym_index].st_value + elf_sym[sym_index].st_size);
                     symbol.name = sym_name;
 
                     /// We are not interested in empty symbols.
@@ -248,6 +248,7 @@ String getBuildIDFromProgramHeaders(dl_phdr_info * info)
 
 
 void collectSymbolsFromELFSymbolTable(
+    dl_phdr_info * info,
     const Elf & elf,
     const Elf::Section & symbol_table,
     const Elf::Section & string_table,
@@ -273,10 +274,10 @@ void collectSymbolsFromELFSymbolTable(
             continue;
 
         SymbolIndex::Symbol symbol;
-        symbol.offset_begin = reinterpret_cast<const void *>(
-            symbol_table_entry->st_value);
-        symbol.offset_end = reinterpret_cast<const void *>(
-            symbol_table_entry->st_value + symbol_table_entry->st_size);
+        symbol.address_begin = reinterpret_cast<const void *>(
+            info->dlpi_addr + symbol_table_entry->st_value);
+        symbol.address_end = reinterpret_cast<const void *>(
+            info->dlpi_addr + symbol_table_entry->st_value + symbol_table_entry->st_size);
         symbol.name = symbol_name;
 
         if (symbol_table_entry->st_size)
@@ -286,6 +287,7 @@ void collectSymbolsFromELFSymbolTable(
 
 
 bool searchAndCollectSymbolsFromELFSymbolTable(
+    dl_phdr_info * info,
     const Elf & elf,
     unsigned section_header_type,
     const char * string_table_name,
@@ -307,7 +309,7 @@ bool searchAndCollectSymbolsFromELFSymbolTable(
         return false;
     }
 
-    collectSymbolsFromELFSymbolTable(elf, *symbol_table, *string_table, symbols);
+    collectSymbolsFromELFSymbolTable(info, elf, *symbol_table, *string_table, symbols);
     return true;
 }
 
@@ -429,11 +431,11 @@ void collectSymbolsFromELF(
     object.name = object_name;
     objects.push_back(std::move(object));
 
-    searchAndCollectSymbolsFromELFSymbolTable(*objects.back().elf, SHT_SYMTAB, ".strtab", symbols);
+    searchAndCollectSymbolsFromELFSymbolTable(info, *objects.back().elf, SHT_SYMTAB, ".strtab", symbols);
 
     /// Unneeded if they were parsed from "program headers" of loaded objects.
 #if defined USE_MUSL
-    searchAndCollectSymbolsFromELFSymbolTable(*objects.back().elf, SHT_DYNSYM, ".dynstr", symbols);
+    searchAndCollectSymbolsFromELFSymbolTable(info, *objects.back().elf, SHT_DYNSYM, ".dynstr", symbols);
 #endif
 }
 
@@ -454,28 +456,13 @@ int collectSymbols(dl_phdr_info * info, size_t, void * data_ptr)
 }
 
 
-const SymbolIndex::Symbol * find(const void * offset, const std::vector<SymbolIndex::Symbol> & vec)
-{
-    /// First range that has left boundary greater than address.
-
-    auto it = std::lower_bound(vec.begin(), vec.end(), offset,
-        [](const SymbolIndex::Symbol & symbol, const void * addr) { return symbol.offset_begin <= addr; });
-
-    if (it == vec.begin())
-        return nullptr;
-    --it; /// Last range that has left boundary less or equals than address.
-
-    if (offset >= it->offset_begin && offset < it->offset_end)
-        return &*it;
-    return nullptr;
-}
-
-const SymbolIndex::Object * find(const void * address, const std::vector<SymbolIndex::Object> & vec)
+template <typename T>
+const T * find(const void * address, const std::vector<T> & vec)
 {
     /// First range that has left boundary greater than address.
 
     auto it = std::lower_bound(vec.begin(), vec.end(), address,
-        [](const SymbolIndex::Object & object, const void * addr) { return object.address_begin <= addr; });
+        [](const T & symbol, const void * addr) { return symbol.address_begin <= addr; });
 
     if (it == vec.begin())
         return nullptr;
@@ -494,28 +481,23 @@ void SymbolIndex::load()
     dl_iterate_phdr(collectSymbols, &data);
 
     ::sort(data.objects.begin(), data.objects.end(), [](const Object & a, const Object & b) { return a.address_begin < b.address_begin; });
-    ::sort(data.symbols.begin(), data.symbols.end(), [](const Symbol & a, const Symbol & b) { return a.offset_begin < b.offset_begin; });
+    ::sort(data.symbols.begin(), data.symbols.end(), [](const Symbol & a, const Symbol & b) { return a.address_begin < b.address_begin; });
 
     /// We found symbols both from loaded program headers and from ELF symbol tables.
     data.symbols.erase(std::unique(data.symbols.begin(), data.symbols.end(), [](const Symbol & a, const Symbol & b)
     {
-        return a.offset_begin == b.offset_begin && a.offset_end == b.offset_end;
+        return a.address_begin == b.address_begin && a.address_end == b.address_end;
     }), data.symbols.end());
 }
 
-const SymbolIndex::Symbol * SymbolIndex::findSymbol(const void * offset) const
+const SymbolIndex::Symbol * SymbolIndex::findSymbol(const void * address) const
 {
-    return find(offset, data.symbols);
+    return find(address, data.symbols);
 }
 
 const SymbolIndex::Object * SymbolIndex::findObject(const void * address) const
 {
     return find(address, data.objects);
-}
-
-const SymbolIndex::Object * SymbolIndex::thisObject() const
-{
-    return findObject(reinterpret_cast<const void *>(+[]{}));
 }
 
 String SymbolIndex::getBuildIDHex() const

--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -25,24 +25,22 @@ public:
 
     struct Symbol
     {
-        /// Here addresses are relative to objects.
-        const void * offset_begin;
-        const void * offset_end;
+        const void * address_begin;
+        const void * address_end;
         const char * name;
     };
 
     struct Object
     {
-        /// Here addresses are absolute virtual memory addresses.
         const void * address_begin;
         const void * address_end;
         std::string name;
         std::shared_ptr<Elf> elf;
     };
 
-    const Symbol * findSymbol(const void * offset) const;
+    /// Address in virtual memory should be passed. These addresses include offset where the object is loaded in memory.
+    const Symbol * findSymbol(const void * address) const;
     const Object * findObject(const void * address) const;
-    const Object * thisObject() const;
 
     const std::vector<Symbol> & symbols() const { return data.symbols; }
     const std::vector<Object> & objects() const { return data.objects; }

--- a/src/Common/examples/symbol_index.cpp
+++ b/src/Common/examples/symbol_index.cpp
@@ -25,14 +25,14 @@ int main(int argc, char ** argv)
     const SymbolIndex & symbol_index = SymbolIndex::instance();
 
     for (const auto & elem : symbol_index.symbols())
-        std::cout << elem.name << ": " << elem.offset_begin << " ... " << elem.offset_end << "\n";
+        std::cout << elem.name << ": " << elem.address_begin << " ... " << elem.address_end << "\n";
     std::cout << "\n";
 
     const void * address = reinterpret_cast<void*>(std::stoull(argv[1], nullptr, 16));
 
     const auto * symbol = symbol_index.findSymbol(address);
     if (symbol)
-        std::cerr << symbol->name << ": " << symbol->offset_begin << " ... " << symbol->offset_end << "\n";
+        std::cerr << symbol->name << ": " << symbol->address_begin << " ... " << symbol->address_end << "\n";
     else
         std::cerr << "SymbolIndex: Not found\n";
 

--- a/src/Functions/addressToLine.h
+++ b/src/Functions/addressToLine.h
@@ -90,7 +90,7 @@ protected:
     {
         const SymbolIndex & symbol_index = SymbolIndex::instance();
 
-        if (const auto * object = symbol_index.thisObject())
+        if (const auto * object = symbol_index.findObject(reinterpret_cast<const void *>(addr)))
         {
             auto dwarf_it = cache.dwarfs.try_emplace(object->name, object->elf).first;
             if (!std::filesystem::exists(object->name))
@@ -99,7 +99,7 @@ protected:
             Dwarf::LocationInfo location;
             std::vector<Dwarf::SymbolizedFrame> frames; // NOTE: not used in FAST mode.
             ResultT result;
-            if (dwarf_it->second.findAddress(addr, location, locationInfoMode, frames))
+            if (dwarf_it->second.findAddress(addr - uintptr_t(object->address_begin), location, locationInfoMode, frames))
             {
                 setResult(result, location, frames);
                 return result;

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -83,7 +83,7 @@ namespace
     class AddressToLineCache
     {
     private:
-        Arena arena;
+       Arena arena;
         using Map = HashMap<uintptr_t, StringRef>;
         Map map;
         std::unordered_map<std::string, Dwarf> dwarfs;
@@ -105,7 +105,7 @@ namespace
         {
             const SymbolIndex & symbol_index = SymbolIndex::instance();
 
-            if (const auto * object = symbol_index.thisObject())
+            if (const auto * object = symbol_index.findObject(reinterpret_cast<const void *>(addr)))
             {
                 auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
                 if (!std::filesystem::exists(object->name))
@@ -114,7 +114,7 @@ namespace
                 Dwarf::LocationInfo location;
                 std::vector<Dwarf::SymbolizedFrame> frames; // NOTE: not used in FAST mode.
                 StringRef result;
-                if (dwarf_it->second.findAddress(addr, location, Dwarf::LocationInfoMode::FAST, frames))
+                if (dwarf_it->second.findAddress(addr - uintptr_t(object->address_begin), location, Dwarf::LocationInfoMode::FAST, frames))
                 {
                     setResult(result, location, frames);
                     return result;

--- a/src/Storages/System/StorageSystemSymbols.cpp
+++ b/src/Storages/System/StorageSystemSymbols.cpp
@@ -73,9 +73,9 @@ protected:
             if (columns_mask[src_index++])
                 res_columns[res_index++]->insert(it->name);
             if (columns_mask[src_index++])
-                res_columns[res_index++]->insert(reinterpret_cast<uintptr_t>(it->offset_begin));
+                res_columns[res_index++]->insert(reinterpret_cast<uintptr_t>(it->address_begin));
             if (columns_mask[src_index++])
-                res_columns[res_index++]->insert(reinterpret_cast<uintptr_t>(it->offset_end));
+                res_columns[res_index++]->insert(reinterpret_cast<uintptr_t>(it->address_end));
 
             ++rows_count;
             ++it;


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#81896

Breaks resolving symbols in `system.stack_trace` - https://pastila.nl/?00a43c59/4e73b6c851db912aa77ec75d2791e88d#XDRC1gU1dslq47Hq3P0olg==

