### PR TITLE
CI: Use same inject auth value for all nodes

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -232,12 +232,12 @@ value=$((RANDOM % 2))
 echo "Replacing digest_enabled_on_commit with $value"
 sed --follow-symlinks -i "s|<digest_enabled_on_commit>[01]</digest_enabled_on_commit>|<digest_enabled_on_commit>$value</digest_enabled_on_commit>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-value=$((RANDOM % 2))
+inject_auth=$((RANDOM % 2))
 if [[ $KEEPER_INJECT_AUTH -eq 0 ]]; then
-    value=0
+    inject_auth=0
 fi
-echo "Replacing inject_auth with $value"
-sed --follow-symlinks -i "s|<inject_auth>[01]</inject_auth>|<inject_auth>$value</inject_auth>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
+echo "Replacing inject_auth with $inject_auth"
+sed --follow-symlinks -i "s|<inject_auth>[01]</inject_auth>|<inject_auth>$inject_auth</inject_auth>|" $DEST_SERVER_PATH/config.d/keeper_port.xml
 
 if [[ -n "$USE_POLYMORPHIC_PARTS" ]] && [[ "$USE_POLYMORPHIC_PARTS" -eq 1 ]]; then
     ln -sf $SRC_PATH/config.d/polymorphic_parts.xml $DEST_SERVER_PATH/config.d/
@@ -307,12 +307,8 @@ if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
     rm $DEST_SERVER_PATH/config.d/zookeeper.xml
     rm $DEST_SERVER_PATH/config.d/keeper_port.xml
 
-    value=$((RANDOM % 2))
-    if [[ $KEEPER_INJECT_AUTH -eq 0 ]]; then
-        value=0
-    fi
-    echo "Replacing inject_auth with $value (for Replicated database)"
-    sed --follow-symlinks -i "s|<inject_auth>[01]</inject_auth>|<inject_auth>$value</inject_auth>|" $DEST_SERVER_PATH/config.d/database_replicated.xml
+    echo "Replacing inject_auth with $inject_auth (for Replicated database)"
+    sed --follow-symlinks -i "s|<inject_auth>[01]</inject_auth>|<inject_auth>$inject_auth</inject_auth>|" $DEST_SERVER_PATH/config.d/database_replicated.xml
 
     # There is a bug in config reloading, so we cannot override macros using --macros.replica r2
     # And we have to copy configs...


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
