### PR TITLE
Disable `03532_crash_in_aggregation_because_of_lost_exception` with distr

### DIFF
--- a/tests/queries/0_stateless/03532_crash_in_aggregation_because_of_lost_exception.sh
+++ b/tests/queries/0_stateless/03532_crash_in_aggregation_because_of_lost_exception.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-random-settings, no-parallel
+# Tags: long, no-random-settings, no-parallel, no-distributed-cache
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


