### PR TITLE
Fix logical error resolving matcher with multiple JOINs

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2245,12 +2245,12 @@ ProjectionNames QueryAnalyzer::resolveMatcher(QueryTreeNodePtr & matcher_node, I
           * We are taking the nearest JoinNode to check to which table column belongs,
           * because for LEFT/RIGHT join, we convert only the corresponding side.
           */
-        const auto * nearest_query_scope = scope.getNearestQueryScope();
-        const QueryNode * nearest_scope_query_node = nearest_query_scope ? nearest_query_scope->scope_node->as<QueryNode>() : nullptr;
-        const QueryTreeNodePtr & nearest_scope_join_tree = nearest_scope_query_node ? nearest_scope_query_node->getJoinTree() : nullptr;
-        const JoinNode * nearest_scope_join_node = nearest_scope_join_tree ? nearest_scope_join_tree->as<JoinNode>() : nullptr;
-        if (nearest_scope_join_node)
+        for (const auto & table_expression : scope.registered_table_expression_nodes)
         {
+            const JoinNode * nearest_scope_join_node = table_expression->as<JoinNode>();
+            if (!nearest_scope_join_node)
+                continue;
+
             for (auto & [node, node_name] : matched_expression_nodes_with_names)
             {
                 auto join_identifier_side = getColumnSideFromJoinTree(node, *nearest_scope_join_node);

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2267,8 +2267,8 @@ ProjectionNames QueryAnalyzer::resolveMatcher(QueryTreeNodePtr & matcher_node, I
     {
         /** If we are resolving matcher came from the result of JOIN and `join_use_nulls` is set,
           * we need to convert joined column type to Nullable.
-          * We are taking the nearest JoinNode to check to which table column belongs,
-          * because for LEFT/RIGHT join, we convert only the corresponding side.
+          * We are checking all registered_table_expression_nodes which contains all table expressions that are used to resolve matcher.
+          * If it's on null side, we need to convert column type to Nullable.
           */
         for (const auto & table_expression : scope.registered_table_expression_nodes)
         {

--- a/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.reference
+++ b/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.reference
@@ -14,3 +14,10 @@
 0	UInt8
 0	UInt8
 0	UInt8
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+\N	Nullable(UInt8)
+\N	Nullable(UInt8)
+\N	Nullable(UInt8)
+\N	Nullable(UInt8)

--- a/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.reference
+++ b/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.reference
@@ -1,0 +1,16 @@
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+\N	Nullable(UInt8)
+\N	Nullable(UInt8)
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+0	Nullable(UInt8)
+\N	Nullable(UInt8)
+\N	Nullable(UInt8)
+0	UInt8
+0	UInt8
+0	UInt8
+0	UInt8

--- a/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.sql
+++ b/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.sql
@@ -10,6 +10,8 @@ INSERT INTO tableA VALUES ('a'), ('b'), ('c'), ('d'), ('e'), ('f');
 INSERT INTO tableB VALUES ('c', 3), ('d', 4), ('e', 5), ('f', 6), ('g', 7), ('h', 8);
 INSERT INTO tableC VALUES ('d'), ('e'), ('f'), ('g'), ('h'), ('i'), ('j');
 
+SET enable_analyzer = 1;
+
 SET join_use_nulls = 1;
 
 SELECT value2 = 1 as x, toTypeName(x)
@@ -37,6 +39,13 @@ FROM (
 ) ORDER BY 1;
 
 
+SELECT value2 = 1 as x, toTypeName(x)
+FROM (
+    SELECT tableB.*
+    FROM tableA
+    INNER JOIN tableB ON tableB.key = tableA.key
+    RIGHT JOIN tableC AS t ON tableB.key = t.key
+) ORDER BY 1;
 
 DROP TABLE IF EXISTS tableA;
 DROP TABLE IF EXISTS tableB;

--- a/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.sql
+++ b/tests/queries/0_stateless/03546_multiple_join_use_nulls_matcher.sql
@@ -1,0 +1,43 @@
+DROP TABLE IF EXISTS tableA;
+DROP TABLE IF EXISTS tableB;
+DROP TABLE IF EXISTS tableC;
+
+CREATE TABLE tableA ( key String ) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE tableB ( key String, value2 Int32 ) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE tableC ( key String ) ENGINE = MergeTree() ORDER BY tuple();
+
+INSERT INTO tableA VALUES ('a'), ('b'), ('c'), ('d'), ('e'), ('f');
+INSERT INTO tableB VALUES ('c', 3), ('d', 4), ('e', 5), ('f', 6), ('g', 7), ('h', 8);
+INSERT INTO tableC VALUES ('d'), ('e'), ('f'), ('g'), ('h'), ('i'), ('j');
+
+SET join_use_nulls = 1;
+
+SELECT value2 = 1 as x, toTypeName(x)
+FROM (
+    SELECT *
+    FROM tableA
+    LEFT JOIN tableB ON tableB.key = tableA.key
+    LEFT JOIN tableC AS t ON tableB.key = t.key
+) ORDER BY 1;
+
+SELECT value2 = 1 as x, toTypeName(x)
+FROM (
+    SELECT tableB.*
+    FROM tableA
+    LEFT JOIN tableB ON tableB.key = tableA.key
+    LEFT JOIN tableC AS t ON tableB.key = t.key
+) ORDER BY 1;
+
+SELECT value2 = 1 as x, toTypeName(x)
+FROM (
+    SELECT tableB.*
+    FROM tableA
+    INNER JOIN tableB ON tableB.key = tableA.key
+    LEFT JOIN tableC AS t ON tableB.key = t.key
+) ORDER BY 1;
+
+
+
+DROP TABLE IF EXISTS tableA;
+DROP TABLE IF EXISTS tableB;
+DROP TABLE IF EXISTS tableC;


### PR DESCRIPTION


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix logical error when resolving matcher in query with multiple JOINs, close https://github.com/ClickHouse/ClickHouse/issues/81969

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
