### PR TITLE
Read AWS ECS token from file, attempt #3

### DIFF
--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -780,20 +780,12 @@ S3CredentialsProviderChain::S3CredentialsProviderChain(
             auto token = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN);
             const auto token_path = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN_FILE);
 
-            if (!token_path.empty())
-            {
-                LOG_INFO(logger, "The environment variable value {} is {}", AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN_FILE, token_path);
-
-                String token_from_file;
-
-                ReadBufferFromFile in(token_path);
-                readStringUntilEOF(token_from_file, in);
-                Poco::trimInPlace(token_from_file);
-
-                token = token_from_file;
-            }
-
-            AddProvider(std::make_shared<Aws::Auth::TaskRoleCredentialsProvider>(absolute_uri.c_str(), token.c_str()));
+            AddProvider(std::make_shared<Aws::Auth::GeneralHTTPCredentialsProvider>(
+                relative_uri,
+                absolute_uri,
+                token,
+                token_path
+            ));
 
             /// DO NOT log the value of the authorization token for security purposes.
             LOG_INFO(logger, "Added ECS credentials provider with URI: [{}] to the provider chain with a{} authorization token.",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add expiration to AWS ECS token so it can be reloaded.

Relates to https://github.com/ClickHouse/ClickHouse/pull/72397
