### PR TITLE
tests: fix sanitizers reports (log_path contains prefix, not the file path)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.log
 *.debuglog
 *.stderr
+*.stderr-fatal*
 *.stdout
 
 # llvm-xray logs

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -32,7 +32,6 @@ import socket
 import string
 import subprocess
 import sys
-import tempfile
 import traceback
 import urllib.parse
 
@@ -1646,9 +1645,13 @@ class TestCase:
                 stdout = str(stdfd.read(), errors="replace", encoding="utf-8")
 
         stderr = kill_output
-        stderr += str(
-            self.fatal_sanitizer_log.read(), errors="replace", encoding="utf-8"
-        )
+        for path in glob.glob(self.fatal_sanitizer_prefix + "*"):
+            with open(path, "rb") as stream:
+                content = str(stream.read(), errors="replace", encoding="utf-8")
+                if content:
+                    stderr += f"Path: {path}\n"
+                    stderr += content
+                    stderr += "\n"
         if os.path.exists(self.stderr_file):
             with open(self.stderr_file, "rb") as stdfd:
                 stderr += str(stdfd.read(), errors="replace", encoding="utf-8")
@@ -1833,7 +1836,8 @@ class TestCase:
             os.remove(self.stdout_file)
         if os.path.exists(self.stderr_file):
             os.remove(self.stderr_file)
-        os.remove(self.fatal_sanitizer_log.name)
+        for path in glob.glob(self.fatal_sanitizer_prefix + "*"):
+            os.remove(path)
         if os.path.exists(self.testcase_args.debug_log_file):
             os.remove(self.testcase_args.debug_log_file)
 
@@ -1916,11 +1920,13 @@ class TestCase:
         client = args.testcase_client
         start_time = args.testcase_start_time
         database = args.testcase_database
-        self.fatal_sanitizer_log = tempfile.NamedTemporaryFile(
-            "rb", prefix="clickhouse-test-", suffix=".log", dir=args.test_tmp_dir, delete=False
-        )
 
-        log_opt = " --client_logs_file=" + self.fatal_sanitizer_log.name + " "
+        # NOTE:
+        # - client writes to fatal_sanitizer_prefix
+        # - sanitizers write to fatal_sanitizer_prefix.PID
+        self.fatal_sanitizer_prefix = f"{self.stderr_file}-fatal"
+
+        log_opt = " --client_logs_file=" + self.fatal_sanitizer_prefix + " "
         client_options += log_opt
 
         for env_name in [
@@ -1931,9 +1937,9 @@ class TestCase:
         ]:
             current_options = os.environ.get(env_name, None)
             if current_options is None:
-                os.environ[env_name] = f"log_path={self.fatal_sanitizer_log.name}"
+                os.environ[env_name] = f"log_path={self.fatal_sanitizer_prefix}"
             elif "log_path=" not in current_options:
-                os.environ[env_name] += f":log_path={self.fatal_sanitizer_log.name}"
+                os.environ[env_name] += f":log_path={self.fatal_sanitizer_prefix}"
 
         os.environ["CLICKHOUSE_CLIENT_OPT"] = (
             os.environ["CLICKHOUSE_CLIENT_OPT"]


### PR DESCRIPTION
This time I tested it with sanitizers:

    $ ../tests/clickhouse-test shebang
    Using queries from '/src/ch/clickhouse/tests/queries' directory
    Connecting to ClickHouse server... OK
    Connected to server 25.7.1.1 @ 9042a936b14282ba8d2634a8ec366eb89eb94710 master
    Found 1 parallel tests and 0 sequential tests
    Running about 1 stateless tests (Process-3).
    02203_shebang:                                                          [ FAIL ] 0.33 sec.
    Reason: having stderror:
    Path: /src/ch/clickhouse/tests/queries/0_stateless/test_ggjjtc06/clickhouse-351von_4.10890
    ==================
    WARNING: ThreadSanitizer: data race (pid=10890)
      Write of size 4 at 0x5555569e9718 by thread T2:
        #0 thread2_func <null> (test-tsan+0xe7f68)

      Previous write of size 4 at 0x5555569e9718 by thread T1:
        #0 thread1_func <null> (test-tsan+0xe7f28)

      Location is global 'shared_var' of size 4 at 0x5555569e9718 (test-tsan+0x1495718)

      Thread T2 (tid=10893, running) created by main thread at:
        #0 pthread_create /src/llvm/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1051:3 (test-tsan+0x640da)
        #1 main <null> (test-tsan+0xe7fc5)

      Thread T1 (tid=10892, finished) created by main thread at:
        #0 pthread_create /src/llvm/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1051:3 (test-tsan+0x640da)
        #1 main <null> (test-tsan+0xe7fae)

    SUMMARY: ThreadSanitizer: data race (/tmp/test-tsan+0xe7f68) in thread2_func
    ==================
    ThreadSanitizer: reported 1 warnings
    stdout:
    1
    Database: test_ggjjtc06

    Having 1 errors! 0 tests passed. 0 tests skipped. 0.34 s elapsed (Process-3).
    All tests have finished.

And "Fatal" logs:

    $ ../tests/clickhouse-test shebang
    Using queries from '/src/ch/clickhouse/tests/queries' directory
    Connecting to ClickHouse server... OK
    Connected to server 25.7.1.1 @ 9042a936b14282ba8d2634a8ec366eb89eb94710 master
    Found 1 parallel tests and 0 sequential tests
    Running about 1 stateless tests (Process-3).
    02203_shebang:                                                          [ FAIL ] 0.33 sec.
    Reason: having stderror:
    Path: /src/ch/clickhouse/tests/queries/0_stateless/test_grqdqc9f/clickhouse-p8a4uip4
    foo

    stdout:
    1
    Having 1 errors! 0 tests passed. 0 tests skipped. 0.34 s elapsed (Process-3).
    All tests have finished.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/82234
Help for: https://github.com/ClickHouse/ClickHouse/pull/82168

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)