### PR TITLE
CI: Fix praktika.gh.post_pr_comment

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -68,30 +68,6 @@ class GH:
                              -f body=\'{comment_body}\''
                     print(f"Update existing comments [{id}]")
                     return cls.do_command_with_retries(cmd)
-
-        if or_append_to_comment_with_substring:
-            print(f"check comment [{comment_body}] created")
-            pr_comments = f'gh api -H "Accept: application/vnd.github.v3+json" \
-                "/repos/{repo}/issues/{pr}/comments" \
-                --jq \'.[].body\''
-            output = Shell.get_output(pr_comments)
-            if output:
-                comment_ids = []
-                try:
-                    comment_ids = [
-                        json.loads(item.strip()) for item in output.split("\n")
-                    ]
-                except Exception as ex:
-                    print(f"Failed to retrieve PR comments with [{ex}]")
-                for id in comment_ids:
-                    cmd = f'gh api \
-                       -X PATCH \
-                          -H "Accept: application/vnd.github.v3+json" \
-                             "/repos/{repo}/issues/comments/{id}" \
-                             -f body=\'{comment_body}\''
-                    print(f"Update existing comments [{id}]")
-                    return cls.do_command_with_retries(cmd)
-
         cmd = f'gh pr comment {pr} --body "{comment_body}"'
         return cls.do_command_with_retries(cmd)
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Removes accidentally preserved code.
Fixes issue in sync workflow: NameError: name 'or_append_to_comment_with_substring' is not defined. Did you mean: 'or_update_comment_with_substring'?

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
