### PR TITLE
Read only required columns in correlated subquery with EXISTS

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2936,8 +2936,9 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
 
     if (is_special_function_exists)
     {
+        checkFunctionNodeHasEmptyNullsAction(*function_node_ptr);
         /// Rewrite EXISTS (subquery) into EXISTS (SELECT 1 FROM (subquery) LIMIT 1).
-        auto & exists_subquery_argument = function_node_ptr->getArguments().getNodes().at(0);
+        const auto & exists_subquery_argument = function_node_ptr->getArguments().getNodes().at(0);
 
         auto constant_data_type = std::make_shared<DataTypeUInt64>();
         auto new_exists_subquery = std::make_shared<QueryNode>(Context::createCopy(scope.context));
@@ -2947,47 +2948,21 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
         new_exists_subquery->getJoinTree() = exists_subquery_argument;
         new_exists_subquery->getLimit() = std::make_shared<ConstantNode>(1UL, constant_data_type);
 
-        exists_subquery_argument = std::move(new_exists_subquery);
-    }
+        QueryTreeNodePtr new_exists_argument = new_exists_subquery;
 
-    /// Resolve function arguments
-    bool allow_table_expressions = is_special_function_in || is_special_function_exists;
-    auto arguments_projection_names = resolveExpressionNodeList(
-        function_node_ptr->getArgumentsNode(),
-        scope,
-        true /*allow_lambda_expression*/,
-        allow_table_expressions /*allow_table_expression*/);
+        auto exists_arguments_projection_names = resolveExpressionNode(
+            new_exists_argument,
+            scope,
+            true /*allow_lambda_expression*/,
+            true /*allow_table_expression*/
+        );
 
-    if (is_special_function_exists)
-    {
-        checkFunctionNodeHasEmptyNullsAction(*function_node_ptr);
-        auto & exists_subquery_argument = function_node_ptr->getArguments().getNodes().at(0);
-        bool correlated_exists_subquery = exists_subquery_argument->getNodeType() == QueryTreeNodeType::QUERY
-            ? exists_subquery_argument->as<QueryNode>()->isCorrelated()
-            : exists_subquery_argument->as<UnionNode>()->isCorrelated();
-        if (!correlated_exists_subquery)
+        if (new_exists_subquery->isCorrelated())
         {
-            /// Rewrite EXISTS (subquery) into 1 IN (SELECT 1 FROM (subquery) LIMIT 1).
-            auto constant_data_type = std::make_shared<DataTypeUInt64>();
-
-            function_node_ptr = std::make_shared<FunctionNode>("in");
             function_node_ptr->getArguments().getNodes() = {
-                std::make_shared<ConstantNode>(1UL, constant_data_type),
-                std::move(exists_subquery_argument)
+                std::move(new_exists_argument)
             };
 
-            /// Resolve modified arguments
-            arguments_projection_names = resolveExpressionNodeList(function_node_ptr->getArgumentsNode(),
-                scope,
-                true /*allow_lambda_expression*/,
-                true /*allow_table_expression*/);
-
-            node = function_node_ptr;
-            function_name = "in";
-            is_special_function_in = true;
-        }
-        else
-        {
             /// Subquery is correlated and EXISTS can not be replaced by IN function.
             /// EXISTS function will be replated by JOIN during query planning.
             auto function_exists = std::make_shared<FunctionExists>();
@@ -2997,9 +2972,32 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                 )
             );
 
-            return { calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names) };
+            return { calculateFunctionProjectionName(node, parameters_projection_names, exists_arguments_projection_names) };
+        }
+        else
+        {
+            /// Rewrite EXISTS (subquery) into 1 IN (SELECT 1 FROM (subquery) LIMIT 1).
+            QueryTreeNodePtr constant = std::make_shared<ConstantNode>(1UL, constant_data_type);
+
+            function_node_ptr = std::make_shared<FunctionNode>("in");
+            function_node_ptr->getArguments().getNodes() = {
+                constant,
+                std::move(new_exists_argument)
+            };
+
+            node = function_node_ptr;
+            function_name = "in";
+            is_special_function_in = true;
         }
     }
+
+    /// Resolve function arguments
+    bool allow_table_expressions = is_special_function_in || is_special_function_exists;
+    auto arguments_projection_names = resolveExpressionNodeList(
+        function_node_ptr->getArgumentsNode(),
+        scope,
+        true /*allow_lambda_expression*/,
+        allow_table_expressions /*allow_table_expression*/);
 
     /// Mask arguments if needed
     if (!scope.context->getSettingsRef()[Setting::format_display_secrets_in_show_and_select])

--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -5,6 +5,7 @@
 
 #include <Common/Exception.h>
 #include <Common/typeid_cast.h>
+#include "Processors/QueryPlan/LimitStep.h"
 
 #include <Core/Joins.h>
 #include <Core/Settings.h>
@@ -343,6 +344,12 @@ bool optimizeCorrelatedPlanForExists(QueryPlan & correlated_query_plan)
                 /// Subquery will always produce at least one row
                 return true;
             }
+            node = node->children[0];
+            continue;
+        }
+        if (typeid_cast<LimitStep *>(node->step.get()))
+        {
+            /// TODO: Support LimitStep in decorrelation process.
             node = node->children[0];
             continue;
         }

--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -5,7 +5,6 @@
 
 #include <Common/Exception.h>
 #include <Common/typeid_cast.h>
-#include "Processors/QueryPlan/LimitStep.h"
 
 #include <Core/Joins.h>
 #include <Core/Settings.h>
@@ -29,6 +28,7 @@
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/JoinStepLogical.h>
+#include <Processors/QueryPlan/LimitStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
 
 #include <memory>
@@ -350,6 +350,8 @@ bool optimizeCorrelatedPlanForExists(QueryPlan & correlated_query_plan)
         if (typeid_cast<LimitStep *>(node->step.get()))
         {
             /// TODO: Support LimitStep in decorrelation process.
+            /// For now, we just remove it, because it only increases the number of rows in the result.
+            /// It doesn't affect the result of correlated subquery.
             node = node->children[0];
             continue;
         }

--- a/src/Processors/QueryPlan/LimitStep.h
+++ b/src/Processors/QueryPlan/LimitStep.h
@@ -40,6 +40,8 @@ public:
 
     static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
 
+    bool hasCorrelatedExpressions() const override { return false; }
+
 private:
     void updateOutputHeader() override
     {

--- a/tests/queries/0_stateless/03315_analyzer_correlated_subqueries.reference
+++ b/tests/queries/0_stateless/03315_analyzer_correlated_subqueries.reference
@@ -18,18 +18,30 @@ QUERY id: 0
               LIST id: 9, nodes: 1
                 COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
             PROJECTION COLUMNS
-              count() UInt64
+              1 UInt64
             PROJECTION
               LIST id: 11, nodes: 1
-                FUNCTION id: 12, function_name: count, function_type: aggregate, result_type: UInt64
+                CONSTANT id: 12, constant_value: UInt64_1, constant_value_type: UInt64
             JOIN TREE
-              TABLE id: 13, alias: __table3, table_name: system.one
-            WHERE
-              FUNCTION id: 14, function_name: equals, function_type: ordinary, result_type: UInt8
-                ARGUMENTS
-                  LIST id: 15, nodes: 2
+              QUERY id: 13, alias: __table3, is_subquery: 1, is_correlated: 1
+                CORRELATED COLUMNS
+                  LIST id: 14, nodes: 1
                     COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
-                    CONSTANT id: 16, constant_value: UInt64_2, constant_value_type: UInt8
+                PROJECTION COLUMNS
+                  count() UInt64
+                PROJECTION
+                  LIST id: 15, nodes: 1
+                    FUNCTION id: 16, function_name: count, function_type: aggregate, result_type: UInt64
+                JOIN TREE
+                  TABLE id: 17, alias: __table4, table_name: system.one
+                WHERE
+                  FUNCTION id: 18, function_name: equals, function_type: ordinary, result_type: UInt8
+                    ARGUMENTS
+                      LIST id: 19, nodes: 2
+                        COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
+                        CONSTANT id: 20, constant_value: UInt64_2, constant_value_type: UInt8
+            LIMIT
+              CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt64
 QUERY id: 0
   PROJECTION COLUMNS
     number UInt64
@@ -50,19 +62,27 @@ QUERY id: 0
               LIST id: 9, nodes: 1
                 COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
             PROJECTION COLUMNS
-              1 UInt8
-              dummy UInt8
-              1 UInt8
+              1 UInt64
             PROJECTION
-              LIST id: 11, nodes: 3
-                CONSTANT id: 12, constant_value: UInt64_1, constant_value_type: UInt8
-                COLUMN id: 13, column_name: dummy, result_type: UInt8, source_id: 14
-                CONSTANT id: 15, constant_value: UInt64_1, constant_value_type: UInt8
+              LIST id: 11, nodes: 1
+                CONSTANT id: 12, constant_value: UInt64_1, constant_value_type: UInt64
             JOIN TREE
-              TABLE id: 14, alias: __table3, table_name: system.one
-            WHERE
-              FUNCTION id: 16, function_name: equals, function_type: ordinary, result_type: UInt8
-                ARGUMENTS
-                  LIST id: 17, nodes: 2
+              QUERY id: 13, alias: __table3, is_subquery: 1, is_correlated: 1
+                CORRELATED COLUMNS
+                  LIST id: 14, nodes: 1
                     COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
-                    CONSTANT id: 18, constant_value: UInt64_2, constant_value_type: UInt8
+                PROJECTION COLUMNS
+                  1 UInt8
+                PROJECTION
+                  LIST id: 15, nodes: 1
+                    CONSTANT id: 16, constant_value: UInt64_1, constant_value_type: UInt8
+                JOIN TREE
+                  TABLE id: 17, alias: __table4, table_name: system.one
+                WHERE
+                  FUNCTION id: 18, function_name: equals, function_type: ordinary, result_type: UInt8
+                    ARGUMENTS
+                      LIST id: 19, nodes: 2
+                        COLUMN id: 10, column_name: number, result_type: UInt64, source_id: 3
+                        CONSTANT id: 20, constant_value: UInt64_2, constant_value_type: UInt8
+            LIMIT
+              CONSTANT id: 21, constant_value: UInt64_1, constant_value_type: UInt64

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
@@ -1,0 +1,62 @@
+Expression ((Project names + Projection))
+Actions: COLUMN Const(UInt8) -> 1 UInt8 : 0
+Positions: 0
+  Filter (WHERE)
+  Filter column: exists(__table2) (removed)
+  Actions: INPUT :: 0 -> exists(__table2) UInt8 : 0
+           INPUT :: 1 -> __table1.i1 Int64 : 1
+  Positions: 0
+    Expression
+    Actions: INPUT :: 0 -> __table1.i1 Int64 : 0
+             INPUT :: 1 -> exists(__table2) UInt8 : 1
+    Positions: 0 1
+      Join (JOIN to generate result stream)
+      Type: LEFT
+      Strictness: ANY
+      Algorithm: ConcurrentHashJoin
+      Clauses: [(__table1.i1) = (exists(__table2).__table1.i1)]
+        Expression (Change column names to column identifiers)
+        Actions: INPUT : 0 -> i1 Int64 : 0
+                 ALIAS i1 :: 0 -> __table1.i1 Int64 : 1
+        Positions: 1
+          ReadFromMergeTree (default.test)
+          ReadType: Default
+          Parts: 1
+          Granules: 1
+        Expression ((Create result for always true EXISTS expression + ))
+        Actions: INPUT :: 0 -> __table4.i1 Int64 : 0
+                 INPUT :: 1 -> __table4.i2 Int64 : 1
+                 INPUT : 2 -> __table1.i1 Int64 : 2
+                 COLUMN Const(UInt8) -> exists(__table2) UInt8 : 3
+                 ALIAS __table1.i1 :: 2 -> exists(__table2).__table1.i1 Int64 : 4
+                 FUNCTION materialize(exists(__table2) :: 3) -> materialize(exists(__table2)) UInt8 : 2
+                 ALIAS materialize(exists(__table2)) :: 2 -> exists(__table2) UInt8 : 3
+        Positions: 4 3
+          Expression
+          Actions: INPUT :: 0 -> __table1.i1 Int64 : 0
+                   INPUT :: 1 -> __table4.i1 Int64 : 1
+                   INPUT :: 2 -> __table4.i2 Int64 : 2
+          Positions: 0 1 2
+            Join (JOIN to evaluate correlated expression)
+            Type: INNER
+            Strictness: ALL
+            Algorithm: HashJoin
+            Clauses: [(__table4.i2) = (__table1.i1)]
+              Expression (Change column names to column identifiers)
+              Actions: INPUT : 0 -> i1 Int64 : 0
+                       INPUT : 1 -> i2 Int64 : 1
+                       ALIAS i1 :: 0 -> __table4.i1 Int64 : 2
+                       ALIAS i2 :: 1 -> __table4.i2 Int64 : 0
+              Positions: 2 0
+                ReadFromMergeTree (default.test)
+                ReadType: Default
+                Parts: 1
+                Granules: 1
+              Expression (Change column names to column identifiers)
+              Actions: INPUT : 0 -> i1 Int64 : 0
+                       ALIAS i1 :: 0 -> __table1.i1 Int64 : 1
+              Positions: 1
+                ReadFromMergeTree (default.test)
+                ReadType: Default
+                Parts: 1
+                Granules: 1

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
@@ -41,21 +41,21 @@ Positions: 0
             Type: INNER
             Strictness: ALL
             Algorithm: HashJoin
-            Clauses: [(__table4.i2) = (__table1.i1)]
+            Clauses: [(__table1.i1) = (__table4.i2)]
               Expression (Change column names to column identifiers)
               Actions: INPUT : 0 -> i1 Int64 : 0
-                       INPUT : 1 -> i2 Int64 : 1
-                       ALIAS i1 :: 0 -> __table4.i1 Int64 : 2
-                       ALIAS i2 :: 1 -> __table4.i2 Int64 : 0
-              Positions: 2 0
+                       ALIAS i1 :: 0 -> __table1.i1 Int64 : 1
+              Positions: 1
                 ReadFromMergeTree (default.test)
                 ReadType: Default
                 Parts: 1
                 Granules: 1
               Expression (Change column names to column identifiers)
               Actions: INPUT : 0 -> i1 Int64 : 0
-                       ALIAS i1 :: 0 -> __table1.i1 Int64 : 1
-              Positions: 1
+                       INPUT : 1 -> i2 Int64 : 1
+                       ALIAS i1 :: 0 -> __table4.i1 Int64 : 2
+                       ALIAS i2 :: 1 -> __table4.i2 Int64 : 0
+              Positions: 2 0
                 ReadFromMergeTree (default.test)
                 ReadType: Default
                 Parts: 1

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
@@ -1,0 +1,26 @@
+SET enable_analyzer = 1;
+SET allow_experimental_correlated_subqueries = 1;
+
+CREATE TABLE test(
+    i1 Int64,
+    i2 Int64,
+    i3 Int64,
+    i4 Int64,
+    i5 Int64,
+    i6 Int64,
+    i7 Int64,
+    i8 Int64,
+    i9 Int64,
+    i10 Int64
+)
+ENGINE = MergeTree()
+ORDER BY ();
+
+INSERT INTO test VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+EXPLAIN actions = 1
+SELECT 1 FROM test AS t1
+WHERE EXISTS (
+    SELECT * FROM test AS t2
+    WHERE t1.i1 = t2.i2
+);

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
@@ -1,5 +1,6 @@
 SET enable_analyzer = 1;
 SET allow_experimental_correlated_subqueries = 1;
+SET enable_parallel_replicas = 0;
 
 -- Disable table swaps during query planning
 SET query_plan_join_swap_table = false;

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
@@ -1,6 +1,9 @@
 SET enable_analyzer = 1;
 SET allow_experimental_correlated_subqueries = 1;
 
+-- Disable table swaps during query planning
+SET query_plan_join_swap_table = false;
+
 CREATE TABLE test(
     i1 Int64,
     i2 Int64,

--- a/tests/queries/0_stateless/03546_03545_analyzer_correlated_subquery_exists_asterisk_crash.sql
+++ b/tests/queries/0_stateless/03546_03545_analyzer_correlated_subquery_exists_asterisk_crash.sql
@@ -1,0 +1,10 @@
+set enable_analyzer = 1;
+set allow_experimental_correlated_subqueries = 1;
+set enable_parallel_replicas = 0;
+
+CREATE TABLE test (`i1` Int64, `i2` Int64, `i3` Int64, `i4` Int64, `i5` Int64, `i6` Int64, `i7` Int64, `i8` Int64, `i9` Int64, `i10` Int64) ENGINE = MergeTree ORDER BY tuple();
+
+SELECT * * number
+FROM numbers(
+    exists(SELECT 1 FROM (SELECT        53, *,       materialize(toNullable(53)) FROM test AS t2 PREWHERE * OR (materialize(15) IS NOT NULL) WHERE * OR 1) LIMIT 1) = t1.i1, 5
+    ) -- { serverError UNKNOWN_IDENTIFIER }


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Read only required columns in correlated subquery when it appears to be an argument of function `EXISTS`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
