### PR TITLE
Fix data-races in client, session_timezone overrides and some data-races in some corner cases

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -325,20 +325,20 @@ void Client::initialize(Poco::Util::Application & self)
         config().setString("password", env_password);
 
     /// settings and limits could be specified in config file, but passed settings has higher priority
-    for (const auto & setting : global_context->getSettingsRef().getUnchangedNames())
+    for (const auto & setting : client_context->getSettingsRef().getUnchangedNames())
     {
         String name{setting};
         if (config().has(name))
-            global_context->setSetting(name, config().getString(name));
+            client_context->setSetting(name, config().getString(name));
     }
 
     /// Set path for format schema files
     if (config().has("format_schema_path"))
-        global_context->setFormatSchemaPath(fs::weakly_canonical(config().getString("format_schema_path")));
+        client_context->setFormatSchemaPath(fs::weakly_canonical(config().getString("format_schema_path")));
 
     /// Set the path for google proto files
     if (config().has("google_protos_path"))
-        global_context->setGoogleProtosPath(fs::weakly_canonical(config().getString("google_protos_path")));
+        client_context->setGoogleProtosPath(fs::weakly_canonical(config().getString("google_protos_path")));
 }
 
 
@@ -358,7 +358,8 @@ try
     registerAggregateFunctions();
 
     processConfig();
-    adjustSettings();
+    adjustSettings(client_context);
+
     initTTYBuffer(
         toProgressOption(config().getString("progress", "default")), toProgressOption(config().getString("progress-table", "default")));
     initKeystrokeInterceptor();
@@ -886,9 +887,6 @@ void Client::processOptions(
     if (options.count("opentelemetry-tracestate"))
         global_context->getClientTraceContext().tracestate = options["opentelemetry-tracestate"].as<std::string>();
 
-    /// In case of clickhouse-client the `client_context` can be just an alias for the `global_context`.
-    /// (There is no need to copy the context because clickhouse-client has no background tasks so it won't use that context in parallel.)
-    client_context = global_context;
     initClientContext();
 
     /// Allow to pass-through unknown settings to the server.
@@ -921,7 +919,7 @@ void Client::processConfig()
 
         query_id = config().getString("query_id", "");
         if (!query_id.empty())
-            global_context->setCurrentQueryId(query_id);
+            client_context->setCurrentQueryId(query_id);
     }
 
     if (is_interactive || delayed_interactive)

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -69,5 +69,7 @@ private:
 #endif
     void parseConnectionsCredentials(Poco::Util::AbstractConfiguration & config, const std::string & connection_name);
     std::vector<String> loadWarningMessages();
+
+    std::optional<CurrentThread::QueryScope> query_scope;
 };
 }

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -643,7 +643,7 @@ try
     /// Must be called after we stopped initializing the global context and changing its settings.
     /// After this point the global context must be stayed almost unchanged till shutdown,
     /// and all necessary changes must be made to the client context instead.
-    createClientContext();
+    initClientContext();
 
     if (is_interactive)
     {
@@ -902,7 +902,7 @@ void LocalServer::processConfig()
     /// NOTE: it is important to apply any overrides before
     /// `setDefaultProfiles` calls since it will copy current context (i.e.
     /// there is separate context for Buffer tables).
-    adjustSettings();
+    adjustSettings(global_context);
     applySettingsOverridesForLocal(global_context);
     applyCmdOptions(global_context);
 
@@ -1077,16 +1077,6 @@ void LocalServer::applyCmdOptions(ContextMutablePtr context)
 {
     context->setDefaultFormat(getClientConfiguration().getString("output-format", getClientConfiguration().getString("format", is_interactive ? "PrettyCompact" : "TSV")));
     applyCmdSettings(context);
-}
-
-
-void LocalServer::createClientContext()
-{
-    /// In case of clickhouse-local it's necessary to use a separate context for client-related purposes.
-    /// We can't just change the global context because it is used in background tasks (for example, in merges)
-    /// which don't expect that the global context can suddenly change.
-    client_context = Context::createCopy(global_context);
-    initClientContext();
 }
 
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -575,8 +575,6 @@ void LocalServer::connect()
 int LocalServer::main(const std::vector<std::string> & /*args*/)
 try
 {
-    thread_status.emplace();
-
     StackTrace::setShowAddresses(server_settings[ServerSetting::show_addresses_in_stack_traces]);
 
     setupSignalHandler();
@@ -643,7 +641,8 @@ try
     /// Must be called after we stopped initializing the global context and changing its settings.
     /// After this point the global context must be stayed almost unchanged till shutdown,
     /// and all necessary changes must be made to the client context instead.
-    initClientContext();
+    initClientContext(Context::createCopy(global_context));
+    /// Note, QueryScope will be initialized in the LocalConnection
 
     if (is_interactive)
     {
@@ -1162,6 +1161,8 @@ void LocalServer::readArguments(int argc, char ** argv, Arguments & common_argum
 
 int mainEntryClickHouseLocal(int argc, char ** argv)
 {
+    DB::MainThreadStatus::getInstance();
+
     try
     {
         DB::LocalServer app;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2254,9 +2254,7 @@ void ClientBase::processParsedSingleQuery(
             /// Save all changes in settings to avoid losing them if the connection is lost.
             for (const auto & change : set_query->changes)
             {
-                if (change.name == "profile")
-                    current_profile = change.value.safeGet<String>();
-                else
+                if (change.name != "profile")
                     client_context->applySettingChange(change);
             }
             client_context->resetSettingsToDefaultValue(set_query->default_settings);

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -838,9 +838,10 @@ void ClientBase::adjustSettings(ContextMutablePtr context)
     context->setSettings(settings);
 }
 
-void ClientBase::initClientContext()
+void ClientBase::initClientContext(ContextMutablePtr context)
 {
-    client_context = Context::createCopy(global_context);
+    client_context = context;
+
     client_context->setClientName(std::string(DEFAULT_CLIENT_NAME));
     client_context->setQuotaClientKey(getClientConfiguration().getString("quota_key", ""));
     client_context->setQueryKindInitial();

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -815,13 +815,13 @@ void ClientBase::initLogsOutputStream()
 
 void ClientBase::adjustSettings(ContextMutablePtr context)
 {
-    Settings settings = context->getSettingsCopy();
-
     /// NOTE: Do not forget to set changed=false to avoid sending it to the server (to avoid breakage read only profiles)
 
     /// Do not limit pretty format output in case of --pager specified or in case of stdout is not a tty.
     if (!pager.empty() || !stdout_is_a_tty)
     {
+        Settings settings = context->getSettingsCopy();
+
         if (!context->getSettingsRef()[Setting::output_format_pretty_max_rows].changed)
         {
             settings[Setting::output_format_pretty_max_rows] = std::numeric_limits<UInt64>::max();
@@ -833,9 +833,9 @@ void ClientBase::adjustSettings(ContextMutablePtr context)
             settings[Setting::output_format_pretty_max_value_width] = std::numeric_limits<UInt64>::max();
             settings[Setting::output_format_pretty_max_value_width].changed = false;
         }
-    }
 
-    context->setSettings(settings);
+        context->setSettings(settings);
+    }
 }
 
 void ClientBase::initClientContext(ContextMutablePtr context)

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -274,7 +274,7 @@ protected:
     void adjustSettings(ContextMutablePtr context);
 
     /// Initializes the client context.
-    void initClientContext();
+    void initClientContext(ContextMutablePtr context);
 
     void setDefaultFormatsAndCompressionFromConfiguration();
 
@@ -341,10 +341,6 @@ protected:
     /// Settings specified via command line args
     std::unique_ptr<Settings> cmd_settings;
     std::unique_ptr<MergeTreeSettings> cmd_merge_tree_settings;
-
-    /// thread status should be destructed before shared context because it relies on process list.
-    /// This field may not be initialized in case if we run the client in the embedded mode (SSH).
-    std::optional<ThreadStatus> thread_status;
 
     ServerConnectionPtr connection;
     ConnectionParameters connection_parameters;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -376,8 +376,6 @@ protected:
     String history_file; /// Path to a file containing command history.
     UInt32 history_max_entries; /// Maximum number of entries in the history file.
 
-    String current_profile;
-
     UInt64 server_revision = 0;
     String server_version;
     String prompt;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -271,7 +271,7 @@ protected:
     static bool isFileDescriptorSuitableForInput(int fd);
 
     /// Adjust some settings after command line options and config had been processed.
-    void adjustSettings();
+    void adjustSettings(ContextMutablePtr context);
 
     /// Initializes the client context.
     void initClientContext();
@@ -288,8 +288,6 @@ protected:
     /// This holder may not be initialized in case if we run the client in the embedded mode (SSH).
     SharedContextHolder shared_context;
     ContextMutablePtr global_context;
-
-    /// Client context is a context used only by the client to parse queries, process query parameters and to connect to clickhouse-server.
     ContextMutablePtr client_context;
 
     String default_database;

--- a/src/Common/DateLUT.cpp
+++ b/src/Common/DateLUT.cpp
@@ -155,26 +155,26 @@ const DateLUTImpl & DateLUT::instance()
 {
     const auto & date_lut = getInstance();
 
-    std::string timezone_from_context;
+    std::optional<std::string> timezone_from_context;
     if (DB::CurrentThread::isInitialized())
     {
         const DB::ContextPtr query_context = DB::CurrentThread::get().getQueryContext();
         if (query_context)
-            timezone_from_context = query_context->getSettingsRef()[DB::Setting::session_timezone];
+            timezone_from_context.emplace(query_context->getSettingsRef()[DB::Setting::session_timezone]);
     }
 
-    if (timezone_from_context.empty())
+    if (!timezone_from_context.has_value())
     {
         /// On the server side, timezone is passed in query_context,
         /// but on CH-client side we have no query context,
         /// and each time we modify client's global context
         const DB::ContextPtr global_context = DB::Context::getGlobalContextInstance();
         if (global_context)
-            timezone_from_context = global_context->getSettingsRef()[DB::Setting::session_timezone];
+            timezone_from_context.emplace(global_context->getSettingsRef()[DB::Setting::session_timezone]);
     }
 
-    if (!timezone_from_context.empty())
-        return date_lut.getImplementation(timezone_from_context);
+    if (timezone_from_context.has_value() && !timezone_from_context->empty())
+        return date_lut.getImplementation(*timezone_from_context);
 
     return serverTimezoneInstance();
 }

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -218,7 +218,10 @@ void MemoryTracker::debugLogBigAllocationWithoutCheck(Int64 size [[maybe_unused]
         if (MemoryTrackerDebugBlockerInThread::isBlocked())
             return;
 
-        MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+        MemoryTrackerBlockerInThread tracker_blocker(VariableContext::Global);
+        /// Forbid recursive calls, since the first time debugLogBigAllocationWithoutCheck() can be called from logging,
+        /// and then it may be called again for the line below
+        [[maybe_unused]] MemoryTrackerDebugBlockerInThread debug_blocker;
         LOG_TEST(
             getLogger("MemoryTracker"),
             "Too big allocation ({} bytes) without checking memory limits, "

--- a/src/Server/ClientEmbedded/ClientEmbedded.cpp
+++ b/src/Server/ClientEmbedded/ClientEmbedded.cpp
@@ -215,8 +215,8 @@ try
         toProgressOption(getClientConfiguration().getString("progress-table", "default")));
     initKeystrokeInterceptor();
 
-    client_context = session->sessionContext();
-    initClientContext();
+    initClientContext(session->sessionContext());
+    /// Note, QueryScope will be initialized in the LocalConnection
 
     if (is_interactive)
     {

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -69,8 +69,9 @@ MESSAGES_TO_RETRY = [
 ]
 
 IGNORED_SANITIZER_ERRORS = [
-    "LLVM ERROR: IO failure on output stream: Broken pipe",
     "ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!",
+    # Note, usually such error means that sanitizer has found something but failed to print, so it should not be ignored
+    #"LLVM ERROR: IO failure on output stream: Broken pipe",
 ]
 
 MAX_RETRIES = 3

--- a/tests/queries/0_stateless/02003_memory_limit_in_client.sh
+++ b/tests/queries/0_stateless/02003_memory_limit_in_client.sh
@@ -9,7 +9,7 @@ $CLICKHOUSE_CLIENT --max_memory_usage_in_client=0 -q "SELECT * FROM (SELECT * FR
 
 $CLICKHOUSE_CLIENT --max_result_bytes 0 --max_memory_usage_in_client='5K' -q "SELECT arrayMap(x -> range(x), range(number)) FROM numbers(1000) -- { clientError MEMORY_LIMIT_EXCEEDED }"
 $CLICKHOUSE_CLIENT --max_result_bytes 0 --max_memory_usage_in_client='5k' -q "SELECT arrayMap(x -> range(x), range(number)) FROM numbers(1000) -- { clientError MEMORY_LIMIT_EXCEEDED }"
-$CLICKHOUSE_CLIENT --max_memory_usage_in_client='10M' -q "SELECT * FROM (SELECT * FROM system.numbers LIMIT 600000) as num WHERE num.number=60000"
+$CLICKHOUSE_CLIENT --max_memory_usage_in_client='50M' -q "SELECT * FROM (SELECT * FROM system.numbers LIMIT 600000) as num WHERE num.number=60000"
 $CLICKHOUSE_CLIENT --max_memory_usage_in_client='23G' -q "SELECT * FROM (SELECT * FROM system.numbers LIMIT 600000) as num WHERE num.number=60000"
 $CLICKHOUSE_CLIENT --max_memory_usage_in_client='11T' -q "SELECT * FROM (SELECT * FROM system.numbers LIMIT 600000) as num WHERE num.number=60000"
 

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -31,11 +31,15 @@ expect "set max_distributed"
 # Wait for suggestions to load, they are loaded in background
 set is_done 0
 set timeout 1
-while {$is_done == 0} {
+set total_wait 0
+while {$is_done == 0 && $total_wait < 60} {
     send -- "\t"
     expect {
         "_" {
             set is_done 1
+        }
+        timeout {
+            incr total_wait 1
         }
         default {
             # Reset the expect_after


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data-races in client (by not using global context) and `session_timezone` overrides (previously in case of `session_timezone` was set in i.e. `users.xml`/client options to non empty and in query context to empty, then, value from `users.xml` was used, while this is wrong, now query context will always have a priority over global context)

The problem is that client calls `setSettings()` in the global settings, but this produce a data-race with accessing global settings all over the places [1]:

- `ThreadStatus::finalizePerformanceCounters()`
- `ThreadStatus::initGlobalProfiler()`

  [1]: https://github.com/ClickHouse/ClickHouse/issues/81893#issuecomment-2997271137

But since now we do not set global context anymore, we need to use set proper query context for thread, to make `session_timeout` work after i.e. `SET session_timeout='UTC'` or `SELECT now() SETTINGS session_timeout='UTC'`

Also after client stopped using global context, one more issue pops up - incorrect handling of `session_timezone`, for client it was always OK, since client always adjusted global context before, but for server, if query context overrides it to empty value, while it was non-empty in i.e. `users.xml`, the value from global context was used.

And also various other UBs in some corner cases had been fixed that had been found during running CI on this PR

This is actually a proper fix over #81759, in addition to incomplete #82233

Fixes: #81893