### PR TITLE
tests: ignore "ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!"

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1648,6 +1648,7 @@ class TestCase:
         for path in glob.glob(self.fatal_sanitizer_prefix + "*"):
             with open(path, "rb") as stream:
                 content = str(stream.read(), errors="replace", encoding="utf-8")
+                content = "\n".join(filter(lambda l: "ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!" not in l, content.splitlines()))
                 if content:
                     stderr += f"Path: {path}\n"
                     stderr += content


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3343a276be4d5728a70e0dc5a0a11baf7cee0abf&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%202%2F2%29