### PR TITLE
Remind stale cherrypick PRs

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -34,7 +34,7 @@ from typing import List, Optional
 from ci_buddy import CIBuddy
 from ci_config import Labels
 from ci_utils import Shell
-from env_helper import IS_CI, TEMP_PATH
+from env_helper import GITHUB_REPOSITORY, IS_CI, TEMP_PATH
 from get_robot_token import get_best_robot_token
 from git_helper import GIT_PREFIX, git_runner, is_shallow, stash
 from github_helper import GitHub, PullRequest, PullRequests, Repository
@@ -648,12 +648,10 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--token", help="github token, if not set, used from smm")
-    parser.add_argument(
-        "--repo", default="ClickHouse/ClickHouse", help="repo owner/name"
-    )
+    parser.add_argument("--repo", default=GITHUB_REPOSITORY, help="repo owner/name")
     parser.add_argument(
         "--from-repo",
-        default="ClickHouse/ClickHouse",
+        default=GITHUB_REPOSITORY,
         help="if set, the commits will be taken from this repo, but PRs will be created in the main repo",
     )
     parser.add_argument("--dry-run", action="store_true", help="do not create anything")

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -594,6 +594,8 @@ class BackportPRs:
 
 
 class CherryPickPRs:
+    STALE_THRESHOLD = 30 * 3600  # 30 hours in seconds
+
     def __init__(self, gh: GitHub, repo: str, dry_run: bool):
         self.gh = gh
         self.repo_name = repo
@@ -616,7 +618,7 @@ class CherryPickPRs:
             # The `updated_at` is Optional[datetime]
             cherrypick_updated_ts = (pr.updated_at or datetime.now()).timestamp()
             since_updated = int(datetime.now().timestamp() - cherrypick_updated_ts)
-            if since_updated < 30 * 3600:
+            if since_updated < self.STALE_THRESHOLD:
                 logging.info(
                     "The cherry-pick PR #%s was updated %d seconds ago, "
                     "waiting for the next running",
@@ -701,7 +703,7 @@ def main():
         if IS_CI:
             ci_buddy = CIBuddy()
             ci_buddy.post_job_error(
-                f"The cherry-pick finished with errors: {bpp.error}",
+                f"The backport process finished with errors: {bpp.error}",
                 with_instance_info=True,
                 with_wf_link=True,
                 critical=True,

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -370,7 +370,7 @@ close it.
         return self.name
 
 
-class Backport:
+class BackportPRs:
     def __init__(
         self,
         gh: GitHub,
@@ -635,29 +635,29 @@ def main():
     token = args.token or get_best_robot_token()
 
     gh = GitHub(token, create_cache_dir=False)
-    bp = Backport(
+    bpp = BackportPRs(
         gh,
         args.repo,
         args.from_repo,
         args.dry_run,
     )
     # https://github.com/python/mypy/issues/3004
-    bp.gh.cache_path = temp_path / "gh_cache"
-    bp.receive_release_prs()
-    bp.update_local_release_branches()
-    bp.receive_prs_for_backport(args.reserve_search_days)
-    bp.process_backports()
-    if bp.error is not None:
+    bpp.gh.cache_path = temp_path / "gh_cache"
+    bpp.receive_release_prs()
+    bpp.update_local_release_branches()
+    bpp.receive_prs_for_backport(args.reserve_search_days)
+    bpp.process_backports()
+    if bpp.error is not None:
         logging.error("Finished successfully, but errors occurred!")
         if IS_CI:
             ci_buddy = CIBuddy()
             ci_buddy.post_job_error(
-                f"The cherry-pick finished with errors: {bp.error}",
+                f"The cherry-pick finished with errors: {bpp.error}",
                 with_instance_info=True,
                 with_wf_link=True,
                 critical=True,
             )
-        raise bp.error
+        raise bpp.error
 
 
 if __name__ == "__main__":

--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -14,6 +14,7 @@ class Labels:
     DO_NOT_TEST = "do not test"
     MUST_BACKPORT = "pr-must-backport"
     MUST_BACKPORT_CLOUD = "pr-must-backport-cloud"
+    MUST_BACKPORT_SYNCED = "pr-must-backport-synced"
     JEPSEN_TEST = "jepsen-test"
     SKIP_MERGEABLE_CHECK = "skip mergeable check"
     PR_BACKPORT = "pr-backport"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ping reopened ignored cherrypick PRs.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
