### PR TITLE
Keeper improvement: add option to clean old and ignore new ACLs

### DIFF
--- a/src/Coordination/KeeperContext.cpp
+++ b/src/Coordination/KeeperContext.cpp
@@ -176,6 +176,8 @@ void KeeperContext::initialize(const Poco::Util::AbstractConfiguration & config,
         precommit_sleep_probability_for_testing = config.getDouble("keeper_server.precommit_sleep_probability_for_testing");
 
     inject_auth = config.getBool("keeper_server.inject_auth", false);
+
+    block_acl = config.getBool("keeper_server.cleanup_old_and_ignore_new_acl", false);
 }
 
 namespace
@@ -586,6 +588,32 @@ void KeeperContext::waitLocalLogsPreprocessedOrShutdown()
 const CoordinationSettings & KeeperContext::getCoordinationSettings() const
 {
     return *coordination_settings;
+}
+
+int64_t KeeperContext::getPrecommitSleepMillisecondsForTesting() const
+{
+    return precommit_sleep_ms_for_testing;
+}
+
+double KeeperContext::getPrecommitSleepProbabilityForTesting() const
+{
+    chassert(precommit_sleep_probability_for_testing >= 0 && precommit_sleep_probability_for_testing <= 1);
+    return precommit_sleep_probability_for_testing;
+}
+
+bool KeeperContext::shouldInjectAuth() const
+{
+    return inject_auth;
+}
+
+bool KeeperContext::shouldBlockACL() const
+{
+    return block_acl;
+}
+
+void KeeperContext::setBlockACL(bool block_acl_)
+{
+    block_acl = block_acl_;
 }
 
 bool KeeperContext::isOperationSupported(Coordination::OpNum operation) const

--- a/src/Coordination/KeeperContext.h
+++ b/src/Coordination/KeeperContext.h
@@ -99,21 +99,14 @@ public:
 
     const CoordinationSettings & getCoordinationSettings() const;
 
-    int64_t getPrecommitSleepMillisecondsForTesting() const
-    {
-        return precommit_sleep_ms_for_testing;
-    }
+    int64_t getPrecommitSleepMillisecondsForTesting() const;
 
-    double getPrecommitSleepProbabilityForTesting() const
-    {
-        chassert(precommit_sleep_probability_for_testing >= 0 && precommit_sleep_probability_for_testing <= 1);
-        return precommit_sleep_probability_for_testing;
-    }
+    double getPrecommitSleepProbabilityForTesting() const;
 
-    bool shouldInjectAuth() const
-    {
-        return inject_auth;
-    }
+    bool shouldInjectAuth() const;
+
+    bool shouldBlockACL() const;
+    void setBlockACL(bool block_acl_);
 
     bool isOperationSupported(Coordination::OpNum operation) const;
 private:
@@ -180,6 +173,8 @@ private:
     CoordinationSettingsPtr coordination_settings;
 
     bool inject_auth = false;
+
+    bool block_acl = false;
 };
 
 using KeeperContextPtr = std::shared_ptr<KeeperContext>;

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -101,7 +101,7 @@ namespace
     }
 
     template<typename Node>
-    void readNode(Node & node, ReadBuffer & in, SnapshotVersion version, ACLMap & acl_map)
+    void readNode(Node & node, ReadBuffer & in, SnapshotVersion version, ACLMap & acl_map, bool cleanup_acl)
     {
         readVarUInt(node.stats.data_size, in);
         if (node.stats.data_size != 0)
@@ -113,6 +113,9 @@ namespace
         if (version >= SnapshotVersion::V1)
         {
             readBinary(node.acl_id, in);
+
+            if (cleanup_acl)
+                node.acl_id = 0;
         }
         else if (version == SnapshotVersion::V0)
         {
@@ -128,7 +131,9 @@ namespace
                 readBinary(acl.id, in);
                 acls.push_back(acl);
             }
-            node.acl_id = acl_map.convertACLs(acls);
+
+            if (!cleanup_acl)
+                node.acl_id = acl_map.convertACLs(acls);
         }
 
         /// Some strange ACLID during deserialization from ZooKeeper
@@ -373,7 +378,9 @@ void KeeperStorageSnapshot<Storage>::deserialize(SnapshotDeserializationResult<S
                 readBinary(acl.id, in);
                 acls.push_back(acl);
             }
-            storage.acl_map.addMapping(acl_id, acls);
+
+            if (!keeper_context->shouldBlockACL())
+                storage.acl_map.addMapping(acl_id, acls);
             current_map_size++;
         }
     }
@@ -396,7 +403,7 @@ void KeeperStorageSnapshot<Storage>::deserialize(SnapshotDeserializationResult<S
         std::string_view path{path_data.get(), path_size};
 
         typename Storage::Node node{};
-        readNode(node, in, current_version, storage.acl_map);
+        readNode(node, in, current_version, storage.acl_map, keeper_context->shouldBlockACL());
 
         using enum Coordination::PathMatchResult;
         auto match_result = Coordination::matchPath(path, keeper_system_path);

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -79,9 +79,10 @@ bool fixupACL(
     const std::vector<Coordination::ACL> & request_acls,
     int64_t session_id,
     const UncommittedState & uncommitted_state,
+    bool block_acl,
     std::vector<Coordination::ACL> & result_acls)
 {
-    if (request_acls.empty())
+    if (block_acl || request_acls.empty())
         return true;
 
     bool valid_found = false;
@@ -1623,7 +1624,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZBADARGUMENTS}};
 
     Coordination::ACLs node_acls;
-    if (!fixupACL(*request_acls, session_id, storage.uncommitted_state, node_acls))
+    if (!fixupACL(*request_acls, session_id, storage.uncommitted_state, keeper_context.shouldBlockACL(), node_acls))
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZINVALIDACL}};
 
     if (zk_request.is_ephemeral)
@@ -2891,7 +2892,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
 
 
     Coordination::ACLs node_acls;
-    if (!fixupACL(zk_request.acls, session_id, uncommitted_state, node_acls))
+    if (!fixupACL(zk_request.acls, session_id, uncommitted_state, keeper_context.shouldBlockACL(), node_acls))
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZINVALIDACL}};
 
     UpdateNodeStatDelta update_stat_delta(*node);

--- a/src/Coordination/RocksDBContainer.h
+++ b/src/Coordination/RocksDBContainer.h
@@ -30,14 +30,16 @@ struct RocksDBContainer
     using Node = Node_;
 
 private:
-    /// MockNode is only use in test to mock `getChildren()` and `getData()`
+    /// MockNode is only used in test
     struct MockNode
     {
+        uint64_t acl_id = 0;
         std::vector<int> children;
         std::string data;
-        MockNode(size_t children_num, std::string_view data_)
-            : children(std::vector<int>(children_num)),
-              data(data_)
+        MockNode(size_t children_num, std::string_view data_, uint64_t acl_id_)
+            : acl_id(acl_id_)
+            , children(std::vector<int>(children_num))
+            , data(data_)
         {
         }
 
@@ -280,7 +282,7 @@ public:
     {
         auto it = find(key);
         chassert(it != end());
-        return MockNode(it->value.stats.numChildren(), it->value.getData());
+        return MockNode(it->value.stats.numChildren(), it->value.getData(), it->value.acl_id);
     }
 
     const_iterator updateValue(StringRef key, ValueUpdater updater)

--- a/src/Coordination/tests/gtest_coordination_common.h
+++ b/src/Coordination/tests/gtest_coordination_common.h
@@ -108,13 +108,14 @@ public:
 };
 
 template <typename Storage>
-void addNode(Storage & storage, const std::string & path, const std::string & data, int64_t ephemeral_owner = 0)
+void addNode(Storage & storage, const std::string & path, const std::string & data, int64_t ephemeral_owner = 0, uint64_t acl_id = 0)
 {
     using Node = typename Storage::Node;
     Node node{};
     node.setData(data);
     if (ephemeral_owner)
         node.stats.setEphemeralOwner(ephemeral_owner);
+    node.acl_id = acl_id;
     storage.container.insertOrReplace(path, node);
     auto child_it = storage.container.find(path);
     auto child_path = DB::getBaseNodeName(child_it->key);

--- a/tests/integration/test_keeper_block_acl/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_block_acl/configs/keeper_config.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <rotate_log_storage_interval>100000</rotate_log_storage_interval>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+        <digest_enabled>true</digest_enabled>
+        <cleanup_old_and_ignore_new_acl>0</cleanup_old_and_ignore_new_acl>
+        <create_snapshot_on_exit>0</create_snapshot_on_exit>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_block_acl/test.py
+++ b/tests/integration/test_keeper_block_acl/test.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+import time
+import pytest
+from kazoo.client import KazooClient
+from kazoo.security import make_acl, make_digest_acl
+from kazoo.exceptions import NoAuthError, AuthFailedError, BadVersionError, NoNodeError
+
+from helpers.cluster import ClickHouseCluster
+
+from helpers import keeper_utils as ku
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/keeper_config.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+def get_fake_zk_with_auth(username, password):
+    zk = ku.get_fake_zk(cluster, "node")
+    zk.add_auth("digest", f"{username}:{password}")
+    return zk
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def wait_node():
+    ku.wait_nodes(cluster, [node])
+
+def setup_node():
+    node.stop_clickhouse()
+    node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/log"])
+    node.exec_in_container(
+        ["rm", "-rf", "/var/lib/clickhouse/coordination/snapshots"]
+    )
+    set_acl_blocking(0)
+    set_snapshot_on_exit(0)
+    node.start_clickhouse()
+    wait_node()
+
+
+def set_acl_blocking(value):
+    node.replace_in_config(
+        "/etc/clickhouse-server/config.d/keeper_config.xml",
+        "<cleanup_old_and_ignore_new_acl>[01]</cleanup_old_and_ignore_new_acl>",
+        f"<cleanup_old_and_ignore_new_acl>{value}</cleanup_old_and_ignore_new_acl>",
+    )
+
+
+def set_snapshot_on_exit(value):
+    node.replace_in_config(
+        "/etc/clickhouse-server/config.d/keeper_config.xml",
+        "<create_snapshot_on_exit>[01]</create_snapshot_on_exit>",
+        f"<create_snapshot_on_exit>{value}</create_snapshot_on_exit>",
+    )
+
+
+def test_keeper_block_acl(started_cluster):
+    setup_node()
+
+    zk_no_auth = None
+    zk_with_auth = None
+
+    def close_zk(zk):
+        if zk is not None:
+            zk.stop()
+            zk.close()
+            zk = None
+
+    try:
+        zk_with_auth = get_fake_zk_with_auth("antonio", "isthebest")
+
+        acl = [make_acl("auth", "", all=True)]
+        zk_with_auth.create("/test_auth_node", b"test_data", acl=acl)
+        zk_with_auth.create("/test_auth_node/child", b"child_data", acl=acl)
+
+        close_zk(zk_with_auth)
+
+        def check_acl_enabled():
+            zk_with_auth = get_fake_zk_with_auth("antonio", "isthebest")
+
+            assert zk_with_auth.get("/test_auth_node")[0] == b"test_data"
+            assert zk_with_auth.get("/test_auth_node/child")[0] == b"child_data"
+
+            close_zk(zk_with_auth)
+
+            zk_no_auth = ku.get_fake_zk(cluster, "node")
+            zk_no_auth.start()
+
+            with pytest.raises(NoAuthError):
+                zk_no_auth.get("/test_auth_node")
+
+            with pytest.raises(NoAuthError):
+                zk_no_auth.get("/test_auth_node/child")
+
+            close_zk(zk_no_auth)
+
+        def check_acl_disabled():
+            zk_with_auth = get_fake_zk_with_auth("antonio", "isthebest")
+
+            assert zk_with_auth.get("/test_auth_node")[0] == b"test_data"
+            assert zk_with_auth.get("/test_auth_node/child")[0] == b"child_data"
+
+            close_zk(zk_with_auth)
+
+            zk_no_auth = ku.get_fake_zk(cluster, "node")
+            zk_no_auth.start()
+
+            assert zk_no_auth.get("/test_auth_node")[0] == b"test_data"
+            assert zk_no_auth.get("/test_auth_node/child")[0] == b"child_data"
+
+            close_zk(zk_no_auth)
+
+        check_acl_enabled()
+
+
+        # enable blocking, all requests are applied from changelog
+        # but ACL is ignored
+        node.stop_clickhouse()
+        set_acl_blocking(1)
+        node.start_clickhouse()
+        wait_node()
+
+        check_acl_disabled()
+
+        # we disable acl blocking again
+        # because nothing is stored in snapshot, logs are reapplied
+        # but this time with ACL
+        node.stop_clickhouse()
+        set_acl_blocking(0)
+        set_snapshot_on_exit(1)
+        node.start_clickhouse()
+        wait_node()
+
+        check_acl_enabled()
+
+        # we enable acl blocking again
+        # this time we load nodes from snapshot
+        node.stop_clickhouse()
+        set_acl_blocking(1)
+        node.start_clickhouse()
+        wait_node()
+
+        check_acl_disabled()
+
+        # blocking is enabled, we try to create a node and verifying
+        # that it will be written to snapshot without ACL
+        zk_with_auth = get_fake_zk_with_auth("antonio", "isthebest")
+        acl = [make_acl("auth", "", all=True)]
+        zk_with_auth.create("/test_auth_node_new", b"test_data", acl=acl)
+        close_zk(zk_with_auth)
+
+        zk_no_auth = ku.get_fake_zk(cluster, "node")
+        zk_no_auth.start()
+        assert zk_no_auth.get("/test_auth_node_new")[0] == b"test_data"
+        close_zk(zk_no_auth)
+
+        node.stop_clickhouse()
+        set_acl_blocking(0)
+        node.start_clickhouse()
+        wait_node()
+
+        zk_no_auth = ku.get_fake_zk(cluster, "node")
+        zk_no_auth.start()
+        assert zk_no_auth.get("/test_auth_node_new")[0] == b"test_data"
+        close_zk(zk_no_auth)
+    finally:
+        for zk in [zk_with_auth, zk_no_auth]:
+            close_zk(zk)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keeper improvement: add new config `keeper_server.cleanup_old_and_ignore_new_acl`. If enabled, all nodes will have their ACLs cleared while ACL for new requests will be ignored. If the goal is to completely remove ACL from nodes, it's important to leave the config enabled until a new snapshot is created.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
