### PR TITLE
Fix hiding named collection values in logs/query_log

### DIFF
--- a/src/Parsers/ASTAlterNamedCollectionQuery.h
+++ b/src/Parsers/ASTAlterNamedCollectionQuery.h
@@ -25,6 +25,8 @@ public:
 
     QueryKind getQueryKind() const override { return QueryKind::Alter; }
 
+    bool hasSecretParts() const override { return true; }
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };

--- a/src/Parsers/ASTCreateNamedCollectionQuery.h
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.h
@@ -26,6 +26,8 @@ public:
 
     std::string getCollectionName() const;
 
+    bool hasSecretParts() const override { return true; }
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix hiding named collection values in logs/query_log. Closes https://github.com/ClickHouse/ClickHouse/issues/82405.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
