### PR TITLE
fix logging in ~Session()

### DIFF
--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -320,7 +320,7 @@ Session::~Session()
 
     if (notified_session_log_about_login)
     {
-        LOG_DEBUG(log, "{} Logout, user_id: {}", toString(auth_id), toString(*user_id));
+        LOG_DEBUG(log, "{} Logout, user_id: {}", toString(auth_id), toString(user_id.value_or(UUID{})));
         if (auto session_log = getSessionLog())
         {
             session_log->addLogOut(auth_id, user, user_authenticated_with, getClientInfo());


### PR DESCRIPTION
It looks like `user_id` is an `optional` type and so it's possible for it to be empty. When it's empty,  dereferencing it ( i.e. `toString(*user_id)` and converting it to a string for logging in `~Session()` can lead to some crashes.

Closes: https://github.com/ClickHouse/ClickHouse/issues/82491

### Changelog category (leave one):
Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a possible crash in logging while terminating a session as the user_id might sometimes be empty.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
