### PR TITLE
Allow to disable s3queue streaming via setting

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -209,6 +209,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 database_catalog_drop_table_concurrency;
     extern const ServerSettingsString default_database;
     extern const ServerSettingsBool disable_internal_dns_cache;
+    extern const ServerSettingsBool s3queue_disable_streaming;
     extern const ServerSettingsUInt64 disk_connections_soft_limit;
     extern const ServerSettingsUInt64 disk_connections_store_limit;
     extern const ServerSettingsUInt64 disk_connections_warn_limit;
@@ -1982,6 +1983,8 @@ try
             global_context->setMaxPendingMutationsToWarn(new_server_settings[ServerSetting::max_pending_mutations_to_warn]);
             global_context->setMaxPendingMutationsExecutionTimeToWarn(new_server_settings[ServerSetting::max_pending_mutations_execution_time_to_warn]);
             global_context->getAccessControl().setAllowTierSettings(new_server_settings[ServerSetting::allow_feature_tier]);
+
+            global_context->setServerSetting("s3queue_disable_streaming", new_server_settings[ServerSetting::s3queue_disable_streaming].value);
 
             global_context->setOSCPUOverloadSettings(new_server_settings[ServerSetting::min_os_cpu_wait_time_ratio_to_drop_connection], new_server_settings[ServerSetting::max_os_cpu_wait_time_ratio_to_drop_connection]);
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -925,6 +925,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(UInt64, global_profiler_real_time_period_ns, 0, R"(Period for real clock timer of global profiler (in nanoseconds). Set 0 value to turn off the real clock global profiler. Recommended value is at least 10000000 (100 times a second) for single queries or 1000000000 (once a second) for cluster-wide profiling.)", 0) \
     DECLARE(UInt64, global_profiler_cpu_time_period_ns, 0, R"(Period for CPU clock timer of global profiler (in nanoseconds). Set 0 value to turn off the CPU clock global profiler. Recommended value is at least 10000000 (100 times a second) for single queries or 1000000000 (once a second) for cluster-wide profiling.)", 0) \
     DECLARE(Bool, enable_azure_sdk_logging, false, R"(Enables logging from Azure sdk)", 0) \
+    DECLARE(Bool, s3queue_disable_streaming, false, "Disable streaming in S3Queue even if the table is created and there are attached materiaized views", 0) \
     DECLARE(UInt64, max_entries_for_hash_table_stats, 10'000, R"(How many entries hash table statistics collected during aggregation is allowed to have)", 0) \
     DECLARE(String, merge_workload, "default", R"(
     Used to regulate how resources are utilized and shared between merges and other workloads. Specified value is used as `workload` setting value for all background merges. Can be overridden by a merge tree setting.
@@ -1213,6 +1214,7 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
 
             {"allow_feature_tier",
                 {std::to_string(context->getAccessControl().getAllowTierSettings()), ChangeableWithoutRestart::Yes}},
+            {"s3queue_disable_streaming", {"0", ChangeableWithoutRestart::Yes}},
 
             {"max_remote_read_network_bandwidth_for_server",
              {context->getRemoteReadThrottler() ? std::to_string(context->getRemoteReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -67,6 +67,7 @@ namespace FailPoints
 namespace ServerSetting
 {
     extern const ServerSettingsUInt64 keeper_multiread_batch_size;
+    extern const ServerSettingsBool s3queue_disable_streaming;
 }
 
 namespace ObjectStorageQueueSetting
@@ -505,41 +506,55 @@ void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
         return;
 
     const auto storage_id = getStorageID();
-    try
+    const auto & settings = getContext()->getServerSettings();
+
+    if (settings[ServerSetting::s3queue_disable_streaming])
     {
-        const size_t dependencies_count = getDependencies();
-        if (dependencies_count)
+        static constexpr auto disabled_streaming_reschedule_period = 5000;
+
+        LOG_TRACE(log, "Streaming is disabled, rescheduling next check in {} ms", disabled_streaming_reschedule_period);
+
+        std::lock_guard lock(mutex);
+        reschedule_processing_interval_ms = disabled_streaming_reschedule_period;
+    }
+    else
+    {
+        try
         {
-            mv_attached.store(true);
-            SCOPE_EXIT({ mv_attached.store(false); });
-
-            LOG_DEBUG(log, "Started streaming to {} attached views", dependencies_count);
-
-            files_metadata->registerIfNot(storage_id, /* active */true);
-
-            if (streamToViews(streaming_tasks_index))
+            const size_t dependencies_count = getDependencies();
+            if (dependencies_count)
             {
-                /// Reset the reschedule interval.
-                std::lock_guard lock(mutex);
-                reschedule_processing_interval_ms = polling_min_timeout_ms;
+                mv_attached.store(true);
+                SCOPE_EXIT({ mv_attached.store(false); });
+
+                LOG_DEBUG(log, "Started streaming to {} attached views", dependencies_count);
+
+                files_metadata->registerIfNot(storage_id, /* active */true);
+
+                if (streamToViews(streaming_tasks_index))
+                {
+                    /// Reset the reschedule interval.
+                    std::lock_guard lock(mutex);
+                    reschedule_processing_interval_ms = polling_min_timeout_ms;
+                }
+                else
+                {
+                    /// Increase the reschedule interval.
+                    std::lock_guard lock(mutex);
+                    reschedule_processing_interval_ms = std::min<size_t>(polling_max_timeout_ms, reschedule_processing_interval_ms + polling_backoff_ms);
+                }
+
+                LOG_DEBUG(log, "Stopped streaming to {} attached views", dependencies_count);
             }
             else
             {
-                /// Increase the reschedule interval.
-                std::lock_guard lock(mutex);
-                reschedule_processing_interval_ms = std::min<size_t>(polling_max_timeout_ms, reschedule_processing_interval_ms + polling_backoff_ms);
+                LOG_TEST(log, "No attached dependencies");
             }
-
-            LOG_DEBUG(log, "Stopped streaming to {} attached views", dependencies_count);
         }
-        else
+        catch (...)
         {
-            LOG_TEST(log, "No attached dependencies");
+            LOG_ERROR(log, "Failed to process data: {}", getCurrentExceptionMessage(true));
         }
-    }
-    catch (...)
-    {
-        LOG_ERROR(log, "Failed to process data: {}", getCurrentExceptionMessage(true));
     }
 
     if (!shutdown_called)

--- a/tests/integration/test_storage_s3_queue/configs/disable_streaming.xml
+++ b/tests/integration/test_storage_s3_queue/configs/disable_streaming.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <s3queue_disable_streaming>0</s3queue_disable_streaming>
+</clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added a new server setting `s3queue_disable_streaming` which disables streaming in tables with S3Queue table engine. This setting is changeable without server restart.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
