### PR TITLE
Allow only CDLA-Permissive license (forbids CDLA-Sharing)

### DIFF
--- a/utils/list-licenses/list-licenses.sh
+++ b/utils/list-licenses/list-licenses.sh
@@ -99,4 +99,4 @@ do
 done
 
 # Special care for Rust
-find "${LIBS_PATH}/rust_vendor/" -name 'Cargo.toml' | xargs ${GREP_CMD} 'license = "' | (${GREP_CMD} -v -P 'MIT|Apache|MPL|ISC|BSD|Unicode|Zlib|CC0-1.0|CDLA' && echo "Fatal error: unrecognized licenses in the Rust code" >&2 && exit 1 || true)
+find "${LIBS_PATH}/rust_vendor/" -name 'Cargo.toml' | xargs ${GREP_CMD} 'license = "' | (${GREP_CMD} -v -P 'MIT|Apache|MPL|ISC|BSD|Unicode|Zlib|CC0-1.0|CDLA-Permissive' && echo "Fatal error: unrecognized licenses in the Rust code" >&2 && exit 1 || true)


### PR DESCRIPTION
Looks like there can be some issues with it, but apparently it is not widely used anyway, and there is no such license in the rust_vendor now.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)