### PR TITLE
disallow setting threadpool_writer_pool_size to zero

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -989,7 +989,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(UInt64, prefetch_threadpool_queue_size, 1000000, R"(Number of tasks which is possible to push into prefetches pool)", 0) \
     DECLARE(UInt64, load_marks_threadpool_pool_size, 50, R"(Size of background pool for marks loading)", 0) \
     DECLARE(UInt64, load_marks_threadpool_queue_size, 1000000, R"(Number of tasks which is possible to push into prefetches pool)", 0) \
-    DECLARE(UInt64, threadpool_writer_pool_size, 100, R"(Size of background pool for write requests to object storages)", 0) \
+    DECLARE(NonZeroUInt64, threadpool_writer_pool_size, 100, R"(Size of background pool for write requests to object storages)", 0) \
     DECLARE(UInt64, threadpool_writer_queue_size, 1000000, R"(Number of tasks which is possible to push into background pool for write requests to object storages)", 0) \
     DECLARE(UInt64, iceberg_catalog_threadpool_pool_size, 50, R"(Size of background pool for iceberg catalog)", 0) \
     DECLARE(UInt64, iceberg_catalog_threadpool_queue_size, 1000000, R"(Number of tasks which is possible to push into iceberg catalog pool)", 0) \

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -298,7 +298,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 prefetch_threadpool_queue_size;
     extern const ServerSettingsUInt64 load_marks_threadpool_pool_size;
     extern const ServerSettingsUInt64 load_marks_threadpool_queue_size;
-    extern const ServerSettingsUInt64 threadpool_writer_pool_size;
+    extern const ServerSettingsNonZeroUInt64 threadpool_writer_pool_size;
     extern const ServerSettingsUInt64 threadpool_writer_queue_size;
     extern const ServerSettingsUInt64 iceberg_catalog_threadpool_pool_size;
     extern const ServerSettingsUInt64 iceberg_catalog_threadpool_queue_size;

--- a/tests/integration/test_validate_threadpool_writer_pool_size/configs/invalid_setting.xml
+++ b/tests/integration/test_validate_threadpool_writer_pool_size/configs/invalid_setting.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <threadpool_writer_pool_size>0</threadpool_writer_pool_size>
+</clickhouse>

--- a/tests/integration/test_validate_threadpool_writer_pool_size/test.py
+++ b/tests/integration/test_validate_threadpool_writer_pool_size/test.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+
+# Tests the validation of threadpool_writer_pool_size setting:
+def test_invalid_setting():
+    cluster = ClickHouseCluster(__file__)
+
+    try:
+        cluster.add_instance(
+            "node_invalid_setting",
+            main_configs=["configs/invalid_setting.xml"],
+        )
+
+        # The cluster should fail to start when trying to start the node with invalid settings
+        with pytest.raises(Exception) as exc_info:
+            cluster.start()
+
+            assert (
+                "Code: 36. DB::Exception: A setting's value has to be greater than 0: while parsing setting 'threadpool_writer_pool_size' value. (BAD_ARGUMENTS)"
+                in str(exc_info.value)
+            )
+
+        # Also check that the error logs contain the expected message
+        logs = ""
+        error_logs_file = os.path.join(
+            cluster.instances_dir,
+            "node_invalid_setting",
+            "logs",
+            "clickhouse-server.err.log",
+        )
+        with open(error_logs_file, "r") as f:
+            logs = f.read()
+
+        assert (
+            "Code: 36. DB::Exception: A setting's value has to be greater than 0: while parsing setting 'threadpool_writer_pool_size' value. (BAD_ARGUMENTS)"
+            in logs
+        )
+    finally:
+        cluster.shutdown()


### PR DESCRIPTION
Don't allow `threadpool_writer_pool_size` to be zero to ensure that server operations don't get stuck (see example in https://github.com/ClickHouse/ClickHouse/issues/82480).

Closes: https://github.com/ClickHouse/ClickHouse/issues/82480
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disallow setting `threadpool_writer_pool_size` to zero to ensure that server operations don't get stuck.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
