### PR TITLE
Multithreaded benchmarks with c++expr

### DIFF
--- a/utils/c++expr
+++ b/utils/c++expr
@@ -13,6 +13,7 @@ OPTIONS:
     -l LIB          link against LIB (only for -I or -C)
     -b STEPS_NUM    make program to benchmark specified code snippet and run tests with STEPS_NUM each
     -b perf-top     run infinite benchmark and show perf top
+    -j THREADS      Only make sense with -b, run specified number of std::thread in parallel
     -B build-dir    build directory for -I (default: "build")
     -t TESTS_NUM    make program to benchmark specified code snippet and run TESTS_NUM tests
     -o FILE         do not run, just save binary executable file
@@ -25,11 +26,11 @@ EXAMPLES:
   $ c++expr -I -i Interpreters/Context.h 'OUT(sizeof(DB::Context))'
     sizeof(DB::Context) -> 7776
   $ c++expr -I -i Common/Stopwatch.h -b 10000 'Stopwatch sw;'
-    Steps per test: 10000
-    Test #0: 0.0178 us      5.61798e+07 sps
-    ...
-    Test #4: 0.0179 us      5.58659e+07 sps
-    Average: 0.0179 us      5.58659e+07 sps
+     Steps per test: 10000
+     Test #0:   0.025 us         39.526 Mps
+     ...
+     Test #4:   0.026 us         38.314 Mps
+     MainAvg:   0.026 us         38.373 Mps
 EOF
     exit 1
 }
@@ -37,10 +38,11 @@ EOF
 SOURCE_FILE=main.cpp
 GLOBAL=
 OUTPUT_EXECUTABLE=
-INCS="vector iostream typeinfo cstdlib cmath sys/time.h"
+INCS="vector iostream iomanip typeinfo cstdlib cmath sys/time.h"
 LIBS=""
 BUILD_DIR=build
 BENCHMARK_STEPS=0
+THREADS=1
 RUN_PERFTOP=
 BENCHMARK_TESTS=5
 USE_CMAKE=
@@ -55,7 +57,7 @@ KEEP_WORKTREE=0
 #
 
 if [ "$1" == "--help" ] || [ -z "$1" ]; then usage; fi
-while getopts "vc:CIi:l:b:kB:t:o:O:g:" OPT; do
+while getopts "vc:CIi:l:b:j:kB:t:o:O:g:" OPT; do
     case "$OPT" in
     v)      set -x; ;;
     c)      CXX="$OPTARG"; ;;
@@ -64,6 +66,7 @@ while getopts "vc:CIi:l:b:kB:t:o:O:g:" OPT; do
     i)      INCS="$INCS $OPTARG"; ;;
     l)      LIBS="$LIBS $OPTARG"; ;;
     b)      if [ "$OPTARG" = perf-top ]; then BENCHMARK_STEPS=-1; RUN_PERFTOP=y; else BENCHMARK_STEPS="$OPTARG"; fi; ;;
+    j)      THREADS="$OPTARG"; INCS="$INCS mutex thread barrier";;
     B)      BUILD_DIR="$OPTARG"; ;;
     k)      KEEP_WORKTREE=1; ;;
     t)      BENCHMARK_TESTS="$OPTARG"; ;;
@@ -211,12 +214,27 @@ for INC in $INCS; do
 done
 cat <<EOF >>$SOURCE_FILE
 
+#define RESULT(label, us, mps) label << ": " << std::fixed << std::setw(7) << std::setfill(' ') << std::setprecision(3) << (us) << " us\t" << std::setw(7) << std::setfill(' ') << std::setprecision(3) << (mps) << " Mps"
 #define OUT(expr) std::cout << #expr << " -> " << (expr) << std::endl;
+#if $THREADS == 1
+#define SYNC()
+#define LOG(msg) std::cout << "     " << msg << std::endl
+#define LOG_MAIN(msg) LOG(msg)
+#define AVERAGE "MainAvg"
+#else
+std::barrier barrier($THREADS + 1);
+std::mutex log_mutex;
+#define SYNC() barrier.arrive_and_wait()
+#define LOG(msg) { std::scoped_lock lock{log_mutex}; std::cout << "\033[01;3" << (1 + thread_id % 8) << "m[" << std::setw(2) << std::setfill('0') << thread_id << "] " << msg << "\033[00m" << std::endl; } while (false)
+#define LOG_MAIN(msg) { std::scoped_lock lock{log_mutex}; std::cout << "     " << msg << std::endl; } while (false)
+#define AVERAGE "Average"
+#endif
 size_t max_tests = $BENCHMARK_TESTS;
 size_t max_steps = $BENCHMARK_STEPS;
+
 $GLOBAL
-int main(int argc, char** argv) {
-    (void)argc; (void)argv;
+int work(int thread_id = 0) {
+  (void)thread_id;
   try {
 EOF
 
@@ -226,10 +244,9 @@ if [ $BENCHMARK_STEPS -eq 0 ]; then
 EOF
 else
     cat <<EOF >>$SOURCE_FILE
-    std::cout << "Steps per test: " << max_steps << std::endl;
-    if (max_steps == 0) max_steps = 1;
     double total = 0.0;
     for (size_t test = 0; test < max_tests; test++) {
+      SYNC(); // sync with all threads before test
       timeval beg, end;
       gettimeofday(&beg, nullptr);
       for (size_t step = 0; step < max_steps; step++) {
@@ -237,11 +254,14 @@ else
         $EXPR
       }
       gettimeofday(&end, nullptr);
+      SYNC(); // sync with all threads after test
       double interval = (end.tv_sec - beg.tv_sec)*1e6 + (end.tv_usec - beg.tv_usec);
-      std::cout << "Test #" << test << ": " << interval / max_steps << " us\t" << max_steps * 1e6 / interval << " sps" << std::endl;
+      LOG(RESULT("Test #" << test, interval / max_steps, max_steps / interval));
       total += interval;
     }
-    std::cout << "Average: " << total / max_tests / max_steps << " us\t" << max_steps * 1e6 / (total / max_tests)  << " sps" << std::endl;
+    SYNC(); // sync for avg printing
+    LOG(RESULT(AVERAGE, total / max_tests / max_steps, max_steps / (total / max_tests)));
+    SYNC(); // sync for avg printing
 EOF
 fi
 
@@ -254,8 +274,61 @@ cat <<EOF >>$SOURCE_FILE
   }
   return 1;
 }
-#ifdef OUT
+int main(int argc, char** argv) {
+  (void)argc; (void)argv;
+  if (max_steps == 0)
+    max_steps = 1;
+  else
+    LOG_MAIN("Steps per test: " << max_steps);
+EOF
+if [ $THREADS -gt 1 ] && [ $BENCHMARK_STEPS -ne 0 ]; then
+    cat <<EOF >>$SOURCE_FILE
+  std::cout << "Threads: " << $THREADS << std::endl;
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < $THREADS; ++i)
+    threads.emplace_back(work, i);
+  timeval main_beg, main_end;
+  double main_total = 0.0;
+  for (size_t test = 0; test < max_tests; test++) {
+    gettimeofday(&main_beg, nullptr);
+    SYNC(); // sync with all threads before test
+    SYNC(); // sync with all threads after test
+    gettimeofday(&main_end, nullptr);
+    double interval = (main_end.tv_sec - main_beg.tv_sec)*1e6 + (main_end.tv_usec - main_beg.tv_usec);
+    double per_step = interval / (max_steps * $THREADS);
+    double mps = max_steps * $THREADS / interval;
+    LOG_MAIN(RESULT("Test #" << test, per_step, mps));
+    main_total += interval;
+  }
+  double avg = main_total / (max_tests * max_steps * $THREADS);
+  double mps = max_tests * max_steps * $THREADS / main_total;
+  SYNC(); // sync for avg printing
+  SYNC(); // sync for avg printing
+  LOG_MAIN(RESULT("MainAvg", avg, mps));
+  for (auto& thread : threads)
+    thread.join();
+  return 0;
+EOF
+else
+cat <<EOF >>$SOURCE_FILE
+  return work();
+EOF
+fi
+cat <<EOF >>$SOURCE_FILE
+}
+#ifdef OUT // just to avoid unused macro warning
 #undef OUT
+#endif
+#undef LOG
+#undef LOG_MAIN
+#ifdef SYNC
+#undef SYNC
+#endif
+#ifdef AVERAGE
+#undef AVERAGE
+#endif
+#ifdef RESULT
+#undef RESULT
 #endif
 EOF
 

--- a/utils/c++expr
+++ b/utils/c++expr
@@ -225,8 +225,8 @@ cat <<EOF >>$SOURCE_FILE
 std::barrier barrier($THREADS + 1);
 std::mutex log_mutex;
 #define SYNC() barrier.arrive_and_wait()
-#define LOG(msg) { std::scoped_lock lock{log_mutex}; std::cout << "\033[01;3" << (1 + thread_id % 8) << "m[" << std::setw(2) << std::setfill('0') << thread_id << "] " << msg << "\033[00m" << std::endl; } while (false)
-#define LOG_MAIN(msg) { std::scoped_lock lock{log_mutex}; std::cout << "     " << msg << std::endl; } while (false)
+#define LOG(msg) do { std::scoped_lock lock{log_mutex}; std::cout << "\033[01;3" << (1 + thread_id % 8) << "m[" << std::setw(2) << std::setfill('0') << thread_id << "] " << msg << "\033[00m" << std::endl; } while (false)
+#define LOG_MAIN(msg) do { std::scoped_lock lock{log_mutex}; std::cout << "     " << msg << std::endl; } while (false)
 #define AVERAGE "Average"
 #endif
 size_t max_tests = $BENCHMARK_TESTS;
@@ -283,7 +283,7 @@ int main(int argc, char** argv) {
 EOF
 if [ $THREADS -gt 1 ] && [ $BENCHMARK_STEPS -ne 0 ]; then
     cat <<EOF >>$SOURCE_FILE
-  std::cout << "Threads: " << $THREADS << std::endl;
+  LOG_MAIN("Threads: " << $THREADS);
   std::vector<std::thread> threads;
   for (size_t i = 0; i < $THREADS; ++i)
     threads.emplace_back(work, i);


### PR DESCRIPTION
Usage example:
```shell
❯ utils/c++expr -I -i Common/Stopwatch.h -b 1000000 -j 2 'Stopwatch sw;'
     Steps per test: 1000000
     Threads: 2
[00] Test #0:   0.019 us         53.062 Mps
[01] Test #0:   0.019 us         53.045 Mps
     Test #0:   0.012 us         84.424 Mps
[01] Test #1:   0.019 us         53.146 Mps
[00] Test #1:   0.019 us         53.206 Mps
     Test #1:   0.011 us         86.991 Mps
[01] Test #2:   0.019 us         53.208 Mps
[00] Test #2:   0.019 us         53.242 Mps
     Test #2:   0.011 us         87.078 Mps
[01] Test #3:   0.019 us         53.118 Mps
[00] Test #3:   0.019 us         53.220 Mps
     Test #3:   0.011 us         87.078 Mps
[00] Test #4:   0.019 us         53.291 Mps
[01] Test #4:   0.019 us         53.146 Mps
     Test #4:   0.012 us         86.938 Mps
[01] Average:   0.019 us         53.133 Mps
[00] Average:   0.019 us         53.204 Mps
     MainAvg:   0.012 us         86.489 Mps
Exit code: 0
```

More complicated example. Testing how long it takes to increment an atomic int64 under a mutex lock.
```shell
❯ for JOBS in {1..16}; do
      printf "Threads: %2d\t" $JOBS
      utils/c++expr -O "-O3 -std=c++20" -i mutex -b 1000000 -j $JOBS \
        -g '
          std::atomic<uint64_t> counter;
          std::mutex mutex;
        ' \
        '
          std::scoped_lock lk{mutex};
          counter.fetch_add(1, std::memory_order_relaxed);
        ' 2>&1 | grep 'MainAvg'
  done
Threads:  1          MainAvg:   0.010 us         96.041 Mps
Threads:  2          MainAvg:   0.081 us         12.405 Mps
Threads:  3          MainAvg:   0.084 us         11.968 Mps
Threads:  4          MainAvg:   0.102 us          9.803 Mps
Threads:  5          MainAvg:   0.100 us         10.009 Mps
Threads:  6          MainAvg:   0.103 us          9.716 Mps
Threads:  7          MainAvg:   0.115 us          8.673 Mps
Threads:  8          MainAvg:   0.120 us          8.347 Mps
Threads:  9          MainAvg:   0.127 us          7.903 Mps
Threads: 10          MainAvg:   0.126 us          7.962 Mps
Threads: 11          MainAvg:   0.119 us          8.391 Mps
Threads: 12          MainAvg:   0.092 us         10.864 Mps
Threads: 13          MainAvg:   0.093 us         10.798 Mps
Threads: 14          MainAvg:   0.113 us          8.812 Mps
Threads: 15          MainAvg:   0.114 us          8.780 Mps
Threads: 16          MainAvg:   0.115 us          8.713 Mps
```

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
