### PR TITLE
Allow writing `ch dig`

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -96,6 +96,7 @@ std::pair<std::string_view, MainFunc> clickhouse_applications[] =
     {"client", mainEntryClickHouseClient},
 #if USE_CHDIG
     {"chdig", mainEntryClickHouseChdig},
+    {"dig", mainEntryClickHouseChdig},
 #endif
     {"benchmark", mainEntryClickHouseBenchmark},
     {"server", mainEntryClickHouseServer},


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Because `clickhouse chdig` and `ch chdig` sound worse.