### PR TITLE
Fix 01276_system_licenses after including rust licenses

### DIFF
--- a/tests/queries/0_stateless/01276_system_licenses.reference
+++ b/tests/queries/0_stateless/01276_system_licenses.reference
@@ -1,2 +1,2 @@
 1
-zstd	BSD	/contrib/zstd/LICENSE
+abseil-cpp	Apache	/contrib/abseil-cpp/LICENSE

--- a/tests/queries/0_stateless/01276_system_licenses.sql
+++ b/tests/queries/0_stateless/01276_system_licenses.sql
@@ -1,2 +1,2 @@
 SELECT count() > 10 FROM system.licenses;
-SELECT library_name, license_type, license_path FROM system.licenses WHERE library_name LIKE '%zstd%';
+SELECT library_name, license_type, license_path FROM system.licenses WHERE library_name = 'abseil-cpp';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix 01276_system_licenses after including rust licenses

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/82440

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
