### PR TITLE
Add an option to skip tests failing in FIPS mode

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -947,6 +947,7 @@ class FailureReason(enum.Enum):
     NO_SHARED_OR_REPLICATED_MERGE_TREE = "no-shared-or-replicated-merge-tree"
     NO_STATELESS = "no-stateless"
     NO_STATEFUL = "no-stateful"
+    NO_OPENSSL_FIPS = "no-openssl-fips"
 
     # UNKNOWN reasons
     NO_REFERENCE = "no reference file"
@@ -1612,6 +1613,8 @@ class TestCase:
             return FailureReason.NO_STATEFUL
         if "stateful" not in tags and args.no_stateless:
             return FailureReason.NO_STATELESS
+        if tags and ("no-openssl-fips" in tags) and args.openssl_fips:
+            return FailureReason.NO_OPENSSL_FIPS
 
         if tags:
             for build_flag in args.build_flags:
@@ -3947,6 +3950,12 @@ def parse_args():
         action="store_true",
         default=os.environ.get("REPLACE_LOG_MEM_WITH_MT", False),
         help="Replace *Log and Memory engines with MergeTree",
+    )
+    parser.add_argument(
+        "--openssl-fips",
+        action="store_true",
+        default=False,
+        help="Do not include tests that fail in OpenSSL FIPS mode",
     )
 
     parser.add_argument(

--- a/tests/queries/0_stateless/00746_hashing_tuples.sql
+++ b/tests/queries/0_stateless/00746_hashing_tuples.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-openssl-fips
 
 SELECT sipHash64(1, 2, 3);
 SELECT sipHash64(1, 3, 2);

--- a/tests/queries/0_stateless/00751_hashing_ints.sql
+++ b/tests/queries/0_stateless/00751_hashing_ints.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-openssl-fips
 
 SELECT halfMD5(123456);
 SELECT sipHash64(123456);

--- a/tests/queries/0_stateless/02041_openssl_hash_functions_test.sql
+++ b/tests/queries/0_stateless/02041_openssl_hash_functions_test.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-openssl-fips
 
 SELECT hex(halfMD5('test'));
 SELECT hex(MD4('test'));

--- a/tests/queries/0_stateless/02184_hash_functions_and_ip_types.sql
+++ b/tests/queries/0_stateless/02184_hash_functions_and_ip_types.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-openssl-fips
 
 SET output_format_pretty_single_large_number_tip_threshold = 0;
 SET enable_analyzer = 1;

--- a/tests/queries/0_stateless/02713_create_user_substitutions.sh
+++ b/tests/queries/0_stateless/02713_create_user_substitutions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel
+# Tags: no-fasttest, no-parallel, no-openssl-fips
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03174_multiple_authentication_methods.sh
+++ b/tests/queries/0_stateless/03174_multiple_authentication_methods.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-replicated-database
+# Tags: no-fasttest, no-replicated-database, no-openssl-fips
 # Tag no-replicated-database: https://s3.amazonaws.com/clickhouse-test-reports/65277/43e9a7ba4bbf7f20145531b384a31304895b55bc/stateless_tests__release__old_analyzer__s3__databasereplicated__[1_2].html and https://github.com/ClickHouse/ClickHouse/blob/011c694117845500c82f9563c65930429979982f/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh#L4
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

