### PR TITLE
Fix mergeTreeProjection table function when enable_shared_storage_snapshot_in_query is true

### DIFF
--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -72,7 +72,14 @@ void StorageFromMergeTreeProjection::read(
 StorageSnapshotPtr
 StorageFromMergeTreeProjection::getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const
 {
-    return merge_tree.getStorageSnapshot(metadata_snapshot, query_context);
+    auto parent_storage_snapshot = merge_tree.getStorageSnapshot(metadata_snapshot, query_context);
+    const auto & parent_snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*parent_storage_snapshot->data);
+
+    auto data = std::make_unique<MergeTreeData::SnapshotData>();
+    data->parts = parent_snapshot_data.parts;
+    data->mutations_snapshot = parent_snapshot_data.mutations_snapshot;
+
+    return std::make_shared<StorageSnapshot>(*this, metadata_snapshot, ColumnsDescription{}, std::move(data));
 }
 
 }

--- a/tests/queries/0_stateless/03546_merge_tree_projection_shared_snapshot.reference
+++ b/tests/queries/0_stateless/03546_merge_tree_projection_shared_snapshot.reference
@@ -1,0 +1,23 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS test;
+CREATE TABLE test
+(
+    `a` Int32,
+    `b` Int32,
+    PROJECTION p
+    (
+        SELECT
+            a,
+            b,
+            _part_offset
+        ORDER BY b
+    )
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+INSERT INTO test VALUES (1, 1);
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1, enable_shared_storage_snapshot_in_query = 1;
+1
+DROP TABLE test;

--- a/tests/queries/0_stateless/03546_merge_tree_projection_shared_snapshot.sql
+++ b/tests/queries/0_stateless/03546_merge_tree_projection_shared_snapshot.sql
@@ -1,0 +1,26 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test
+(
+    `a` Int32,
+    `b` Int32,
+    PROJECTION p
+    (
+        SELECT
+            a,
+            b,
+            _part_offset
+        ORDER BY b
+    )
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+
+INSERT INTO test VALUES (1, 1);
+
+SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1, enable_shared_storage_snapshot_in_query = 1;
+
+DROP TABLE test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect usage of parent metadata in `mergeTreeProjection` table function when `enable_shared_storage_snapshot_in_query = 1`. This is for #82634.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
