### PR TITLE
Make s3 retry strategy configurable & disk settings reloadable

### DIFF
--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -2,6 +2,7 @@
 
 #if USE_AWS_S3
 #include <Core/Settings.h>
+#include <Core/ServerSettings.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Interpreters/Context.h>
 #include <IO/SharedThreadPools.h>
@@ -35,9 +36,13 @@ namespace Setting
     extern const SettingsBool enable_s3_requests_logging;
     extern const SettingsBool s3_disable_checksum;
     extern const SettingsUInt64 s3_max_connections;
-    extern const SettingsUInt64 s3_max_redirects;
     extern const SettingsBool s3_slow_all_threads_after_network_error;
     extern const SettingsBool s3_slow_all_threads_after_retryable_error;
+}
+
+namespace ServerSetting
+{
+    extern const ServerSettingsUInt64 s3_max_redirects;
 }
 
 namespace S3AuthSetting
@@ -94,6 +99,7 @@ namespace
         }
 
         const auto & request_settings = settings.request_settings;
+        const auto & server_settings = context->getGlobalContext()->getServerSettings();
         const Settings & global_settings = context->getGlobalContext()->getSettingsRef();
         const Settings & local_settings = context->getSettingsRef();
 
@@ -103,10 +109,11 @@ namespace
             role_session_name = settings.auth_settings[S3AuthSetting::role_session_name];
         }
 
+
         S3::PocoHTTPClientConfiguration client_configuration = S3::ClientFactory::instance().createClientConfiguration(
             settings.auth_settings[S3AuthSetting::region],
             context->getRemoteHostFilter(),
-            static_cast<unsigned>(local_settings[Setting::s3_max_redirects]),
+            static_cast<unsigned>(server_settings[ServerSetting::s3_max_redirects]),
             S3::PocoHTTPClientConfiguration::RetryStrategy{
                 .max_retries = static_cast<unsigned>(local_settings[Setting::backup_restore_s3_retry_attempts]),
                 .initial_delay_ms = static_cast<unsigned>(local_settings[Setting::backup_restore_s3_retry_initial_backoff_ms]),

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/Cache/QueryConditionCache.h>
 #include <IO/UncompressedCache.h>
 #include <IO/SharedThreadPools.h>
+#include <IO/S3Defines.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
 #include <Storages/MarkCache.h>
@@ -1140,6 +1141,9 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(UInt64, threadpool_local_fs_reader_queue_size, 1000000, R"(The maximum number of jobs that can be scheduled on the thread pool for reading from local filesystem.)", 0) \
     DECLARE(NonZeroUInt64, threadpool_remote_fs_reader_pool_size, 250, R"(Number of threads in the Thread pool used for reading from remote filesystem when `remote_filesystem_read_method = 'threadpool'`.)", 0) \
     DECLARE(UInt64, threadpool_remote_fs_reader_queue_size, 1000000, R"(The maximum number of jobs that can be scheduled on the thread pool for reading from remote filesystem.)", 0) \
+\
+    DECLARE(UInt64, s3_max_redirects, S3::DEFAULT_MAX_REDIRECTS, R"(Max number of S3 redirects hops allowed.)", 0) \
+    DECLARE(UInt64, s3_retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, R"(Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries)", 0) \
 
 
 // clang-format on

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -423,9 +423,6 @@ The maximum number of retries in case of unexpected errors during Azure blob sto
     DECLARE(UInt64, s3_max_unexpected_write_error_retries, S3::DEFAULT_MAX_UNEXPECTED_WRITE_ERROR_RETRIES, R"(
 The maximum number of retries in case of unexpected errors during S3 write.
 )", 0) \
-    DECLARE(UInt64, s3_max_redirects, S3::DEFAULT_MAX_REDIRECTS, R"(
-Max number of S3 redirects hops allowed.
-)", 0) \
     DECLARE(UInt64, azure_max_redirects, S3::DEFAULT_MAX_REDIRECTS, R"(
 Max number of azure redirects hops allowed.
 )", 0) \
@@ -589,9 +586,6 @@ Possible values:
 )", 0) \
     DECLARE(Bool, s3_disable_checksum, S3::DEFAULT_DISABLE_CHECKSUM, R"(
 Do not calculate a checksum when sending a file to S3. This speeds up writes by avoiding excessive processing passes on a file. It is mostly safe as the data of MergeTree tables is checksummed by ClickHouse anyway, and when S3 is accessed with HTTPS, the TLS layer already provides integrity while transferring through the network. While additional checksums on S3 give defense in depth.
-)", 0) \
-    DECLARE(UInt64, s3_retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, R"(
-Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries
 )", 0) \
     DECLARE(UInt64, s3_request_timeout_ms, S3::DEFAULT_REQUEST_TIMEOUT_MS, R"(
 Idleness timeout for sending and receiving data to/from S3. Fail if a single TCP read or write call blocks for this long.
@@ -7112,6 +7106,8 @@ Sets the evaluation time to be used with promql dialect. 'auto' means the curren
     MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, max_replicated_fetches_network_bandwidth_for_server, 0) \
     MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, max_replicated_sends_network_bandwidth_for_server, 0) \
     MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, max_entries_for_hash_table_stats, 10'000) \
+    MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, s3_max_redirects, S3::DEFAULT_MAX_REDIRECTS) \
+    MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, s3_retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS) \
     /* ---- */ \
     MAKE_OBSOLETE(M, DefaultDatabaseEngine, default_database_engine, DefaultDatabaseEngine::Atomic) \
     MAKE_OBSOLETE(M, UInt64, max_pipeline_depth, 0) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -593,6 +593,12 @@ Do not calculate a checksum when sending a file to S3. This speeds up writes by 
     DECLARE(UInt64, s3_retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, R"(
 Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries
 )", 0) \
+    DECLARE(UInt64, s3_retry_scale_factor, S3::DEFAULT_RETRY_SCALE_FACTOR, R"(
+Setting for Aws::Client::RetryStrategy, scale factor for exponential backoff of sleep time before retry of Aws::Client
+)", 0) \
+    DECLARE(UInt64, s3_retry_max_delay_ms, S3::DEFAULT_RETRY_MAX_DELAY_MS, R"(
+Setting for Aws::Client::RetryStrategy, max sleep time before each retry of Aws::Client
+)", 0) \
     DECLARE(UInt64, s3_request_timeout_ms, S3::DEFAULT_REQUEST_TIMEOUT_MS, R"(
 Idleness timeout for sending and receiving data to/from S3. Fail if a single TCP read or write call blocks for this long.
 )", 0) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -593,12 +593,6 @@ Do not calculate a checksum when sending a file to S3. This speeds up writes by 
     DECLARE(UInt64, s3_retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, R"(
 Setting for Aws::Client::RetryStrategy, Aws::Client does retries itself, 0 means no retries
 )", 0) \
-    DECLARE(UInt64, s3_retry_scale_factor, S3::DEFAULT_RETRY_SCALE_FACTOR, R"(
-Setting for Aws::Client::RetryStrategy, scale factor for exponential backoff of sleep time before retry of Aws::Client
-)", 0) \
-    DECLARE(UInt64, s3_retry_max_delay_ms, S3::DEFAULT_RETRY_MAX_DELAY_MS, R"(
-Setting for Aws::Client::RetryStrategy, max sleep time before each retry of Aws::Client
-)", 0) \
     DECLARE(UInt64, s3_request_timeout_ms, S3::DEFAULT_REQUEST_TIMEOUT_MS, R"(
 Idleness timeout for sending and receiving data to/from S3. Fail if a single TCP read or write call blocks for this long.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -115,8 +115,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_lightweight_update", false, true, "Lightweight updates were moved to Beta. Added an alias for setting 'allow_experimental_lightweight_update'."},
             {"allow_experimental_lightweight_update", false, true, "Lightweight updates were moved to Beta."},
             {"s3_slow_all_threads_after_retryable_error", true, true, "Added an alias for setting `backup_slow_all_threads_after_retryable_s3_error`"},
-            {"s3_retry_scale_factor", 0, 25, "New setting."},
-            {"s3_retry_max_delay_ms", 0, 5000, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.7",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -115,6 +115,8 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_lightweight_update", false, true, "Lightweight updates were moved to Beta. Added an alias for setting 'allow_experimental_lightweight_update'."},
             {"allow_experimental_lightweight_update", false, true, "Lightweight updates were moved to Beta."},
             {"s3_slow_all_threads_after_retryable_error", true, true, "Added an alias for setting `backup_slow_all_threads_after_retryable_s3_error`"},
+            {"s3_retry_scale_factor", 0, 25, "New setting."},
+            {"s3_retry_max_delay_ms", 0, 5000, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.7",
         {

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -31,6 +31,8 @@ namespace Setting
     extern const SettingsBool enable_s3_requests_logging;
     extern const SettingsUInt64 s3_max_redirects;
     extern const SettingsUInt64 s3_retry_attempts;
+    extern const SettingsUInt64 s3_retry_scale_factor;
+    extern const SettingsUInt64 s3_retry_max_delay_ms;
     extern const SettingsBool s3_slow_all_threads_after_network_error;
     extern const SettingsBool s3_slow_all_threads_after_retryable_error;
 }
@@ -67,6 +69,8 @@ namespace S3RequestSetting
 {
     extern const S3RequestSettingsUInt64 max_redirects;
     extern const S3RequestSettingsUInt64 retry_attempts;
+    extern const S3RequestSettingsUInt64 retry_scale_factor;
+    extern const S3RequestSettingsUInt64 retry_max_delay_ms;
     extern const S3RequestSettingsBool slow_all_threads_after_network_error;
     extern const S3RequestSettingsBool enable_request_logging;
 }
@@ -115,6 +119,14 @@ std::unique_ptr<S3::Client> getClient(
     if (!for_disk_s3 && local_settings.isChanged("s3_retry_attempts"))
         s3_retry_attempts = static_cast<unsigned int>(local_settings[Setting::s3_retry_attempts]);
 
+    unsigned int s3_retry_scale_factor = static_cast<unsigned int>(request_settings[S3RequestSetting::retry_scale_factor]);
+    if (!for_disk_s3 && local_settings.isChanged("s3_retry_scale_factor"))
+        s3_retry_scale_factor = static_cast<unsigned int>(local_settings[Setting::s3_retry_scale_factor]);
+
+    unsigned int s3_retry_max_delay_ms = static_cast<unsigned int>(request_settings[S3RequestSetting::retry_max_delay_ms]);
+    if (!for_disk_s3 && local_settings.isChanged("s3_retry_max_delay_ms"))
+        s3_retry_max_delay_ms = static_cast<unsigned int>(local_settings[Setting::s3_retry_max_delay_ms]);
+
     bool s3_slow_all_threads_after_network_error = request_settings[S3RequestSetting::slow_all_threads_after_network_error];
     if (!for_disk_s3 && local_settings.isChanged("s3_slow_all_threads_after_network_error"))
         s3_slow_all_threads_after_network_error = local_settings[Setting::s3_slow_all_threads_after_network_error];
@@ -153,6 +165,9 @@ std::unique_ptr<S3::Client> getClient(
 
     client_configuration.endpointOverride = url.endpoint;
     client_configuration.s3_use_adaptive_timeouts = auth_settings[S3AuthSetting::use_adaptive_timeouts];
+
+    client_configuration.s3_retry_scale_factor = s3_retry_scale_factor;
+    client_configuration.s3_retry_max_delay_ms = s3_retry_max_delay_ms;
 
     if (request_settings.proxy_resolver)
     {

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -63,6 +63,14 @@ namespace S3AuthSetting
     extern const S3AuthSettingsString request_token_path;
 }
 
+namespace S3RequestSetting
+{
+    extern const S3RequestSettingsUInt64 max_redirects;
+    extern const S3RequestSettingsUInt64 retry_attempts;
+    extern const S3RequestSettingsBool slow_all_threads_after_network_error;
+    extern const S3RequestSettingsBool enable_request_logging;
+}
+
 namespace ErrorCodes
 {
 extern const int NO_ELEMENTS_IN_CONFIG;
@@ -86,7 +94,6 @@ std::unique_ptr<S3::Client> getClient(
     ContextPtr context,
     bool for_disk_s3)
 {
-    const Settings & global_settings = context->getGlobalContext()->getSettingsRef();
     const auto & auth_settings = settings.auth_settings;
     const auto & request_settings = settings.request_settings;
 
@@ -100,23 +107,23 @@ std::unique_ptr<S3::Client> getClient(
 
     const Settings & local_settings = context->getSettingsRef();
 
-    int s3_max_redirects = static_cast<int>(global_settings[Setting::s3_max_redirects]);
+    unsigned int s3_max_redirects = static_cast<unsigned int>(request_settings[S3RequestSetting::max_redirects]);
     if (!for_disk_s3 && local_settings.isChanged("s3_max_redirects"))
-        s3_max_redirects = static_cast<int>(local_settings[Setting::s3_max_redirects]);
+        s3_max_redirects = static_cast<unsigned int>(local_settings[Setting::s3_max_redirects]);
 
-    int s3_retry_attempts = static_cast<int>(global_settings[Setting::s3_retry_attempts]);
+    unsigned int s3_retry_attempts = static_cast<unsigned int>(request_settings[S3RequestSetting::retry_attempts]);
     if (!for_disk_s3 && local_settings.isChanged("s3_retry_attempts"))
-        s3_retry_attempts = static_cast<int>(local_settings[Setting::s3_retry_attempts]);
+        s3_retry_attempts = static_cast<unsigned int>(local_settings[Setting::s3_retry_attempts]);
 
-    bool s3_slow_all_threads_after_network_error = static_cast<int>(global_settings[Setting::s3_slow_all_threads_after_network_error]);
+    bool s3_slow_all_threads_after_network_error = request_settings[S3RequestSetting::slow_all_threads_after_network_error];
     if (!for_disk_s3 && local_settings.isChanged("s3_slow_all_threads_after_network_error"))
-        s3_slow_all_threads_after_network_error = static_cast<int>(local_settings[Setting::s3_slow_all_threads_after_network_error]);
+        s3_slow_all_threads_after_network_error = local_settings[Setting::s3_slow_all_threads_after_network_error];
 
     bool s3_slow_all_threads_after_retryable_error = static_cast<int>(global_settings[Setting::s3_slow_all_threads_after_retryable_error]);
     if (!for_disk_s3 && local_settings.isChanged("s3_slow_all_threads_after_retryable_error"))
         s3_slow_all_threads_after_retryable_error = static_cast<int>(local_settings[Setting::s3_slow_all_threads_after_retryable_error]);
 
-    bool enable_s3_requests_logging = global_settings[Setting::enable_s3_requests_logging];
+    bool enable_s3_requests_logging = request_settings[S3RequestSetting::enable_request_logging];
     if (!for_disk_s3 && local_settings.isChanged("enable_s3_requests_logging"))
         enable_s3_requests_logging = local_settings[Setting::enable_s3_requests_logging];
 

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -15,6 +15,7 @@
 #include <IO/HTTPCommon.h>
 #include <IO/HTTPHeaderEntries.h>
 #include <IO/SessionAwareIOStream.h>
+#include <IO/S3Defines.h>
 
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/HttpClient.h>
@@ -46,15 +47,15 @@ struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
 {
     struct RetryStrategy
     {
-        unsigned int max_retries = 10;
+        unsigned int max_retries = DEFAULT_RETRY_ATTEMPTS;
         unsigned int initial_delay_ms = 25;
-        unsigned int max_delay_ms = 5000;
+        unsigned int max_delay_ms = DEFAULT_RETRY_MAX_DELAY_MS;
         double jitter_factor = 0;
     };
     std::function<ProxyConfiguration()> per_request_configuration;
     String force_region;
     const RemoteHostFilter & remote_host_filter;
-    unsigned int s3_max_redirects;
+    unsigned int s3_max_redirects = DEFAULT_MAX_REDIRECTS;
     RetryStrategy retry_strategy;
     bool s3_slow_all_threads_after_network_error;
     bool s3_slow_all_threads_after_retryable_error;

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -48,9 +48,9 @@ struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
     struct RetryStrategy
     {
         unsigned int max_retries = DEFAULT_RETRY_ATTEMPTS;
-        unsigned int initial_delay_ms = 25;
+        unsigned int initial_delay_ms = DEFAULT_RETRY_INITIAL_DELAY_MS;
         unsigned int max_delay_ms = DEFAULT_RETRY_MAX_DELAY_MS;
-        double jitter_factor = 0;
+        double jitter_factor = DEFAULT_RETRY_JITTER_FACTOR;
     };
     std::function<ProxyConfiguration()> per_request_configuration;
     String force_region;

--- a/src/IO/S3Defines.h
+++ b/src/IO/S3Defines.h
@@ -34,6 +34,8 @@ inline static constexpr uint64_t DEFAULT_MAX_SINGLE_READ_TRIES = 4;
 inline static constexpr uint64_t DEFAULT_MAX_UNEXPECTED_WRITE_ERROR_RETRIES = 4;
 inline static constexpr uint64_t DEFAULT_MAX_REDIRECTS = 10;
 inline static constexpr uint64_t DEFAULT_RETRY_ATTEMPTS = 100;
+inline static constexpr uint64_t DEFAULT_RETRY_SCALE_FACTOR = 25;
+inline static constexpr uint64_t DEFAULT_RETRY_MAX_DELAY_MS = 5000;
 inline static constexpr uint64_t DEFAULT_MIN_BYTES_FOR_SEEK = 1024 * 1024;
 inline static constexpr uint64_t DEFAULT_OBJECTS_CHUNK_SIZE_TO_DELETE = 1000;
 

--- a/src/IO/S3Defines.h
+++ b/src/IO/S3Defines.h
@@ -34,8 +34,9 @@ inline static constexpr uint64_t DEFAULT_MAX_SINGLE_READ_TRIES = 4;
 inline static constexpr uint64_t DEFAULT_MAX_UNEXPECTED_WRITE_ERROR_RETRIES = 4;
 inline static constexpr uint64_t DEFAULT_MAX_REDIRECTS = 10;
 inline static constexpr uint64_t DEFAULT_RETRY_ATTEMPTS = 100;
-inline static constexpr uint64_t DEFAULT_RETRY_SCALE_FACTOR = 25;
+inline static constexpr uint64_t DEFAULT_RETRY_INITIAL_DELAY_MS = 25;
 inline static constexpr uint64_t DEFAULT_RETRY_MAX_DELAY_MS = 5000;
+inline static constexpr uint64_t DEFAULT_RETRY_JITTER_FACTOR = 0;
 inline static constexpr uint64_t DEFAULT_MIN_BYTES_FOR_SEEK = 1024 * 1024;
 inline static constexpr uint64_t DEFAULT_OBJECTS_CHUNK_SIZE_TO_DELETE = 1000;
 

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -60,6 +60,10 @@ namespace ErrorCodes
     DECLARE(UInt64, max_get_burst, 0, "", 0) \
     DECLARE(UInt64, max_put_rps, 0, "", 0) \
     DECLARE(UInt64, max_put_burst, 0, "", 0)
+    DECLARE(UInt64, max_redirects, S3::DEFAULT_MAX_REDIRECTS, "", 0) \
+    DECLARE(UInt64, retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, "", 0) \
+    DECLARE(Bool, slow_all_threads_after_network_error, true, "", 0) \
+    DECLARE(Bool, enable_request_logging, false, "", 0)
 
 #define PART_UPLOAD_SETTINGS(DECLARE, ALIAS) \
     DECLARE(UInt64, strict_upload_part_size, 0, "", 0) \

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -59,10 +59,10 @@ namespace ErrorCodes
     DECLARE(UInt64, max_get_rps, 0, "", 0) \
     DECLARE(UInt64, max_get_burst, 0, "", 0) \
     DECLARE(UInt64, max_put_rps, 0, "", 0) \
-    DECLARE(UInt64, max_put_burst, 0, "", 0)
+    DECLARE(UInt64, max_put_burst, 0, "", 0) \
     DECLARE(UInt64, max_redirects, S3::DEFAULT_MAX_REDIRECTS, "", 0) \
     DECLARE(UInt64, retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, "", 0) \
-    DECLARE(UInt64, retry_scale_factor, S3::DEFAULT_RETRY_SCALE_FACTOR, "", 0) \
+    DECLARE(UInt64, retry_initial_delay_ms, S3::DEFAULT_RETRY_INITIAL_DELAY_MS, "", 0) \
     DECLARE(UInt64, retry_max_delay_ms, S3::DEFAULT_RETRY_MAX_DELAY_MS, "", 0) \
     DECLARE(Bool, slow_all_threads_after_network_error, true, "", 0) \
     DECLARE(Bool, enable_request_logging, false, "", 0)

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -62,6 +62,8 @@ namespace ErrorCodes
     DECLARE(UInt64, max_put_burst, 0, "", 0)
     DECLARE(UInt64, max_redirects, S3::DEFAULT_MAX_REDIRECTS, "", 0) \
     DECLARE(UInt64, retry_attempts, S3::DEFAULT_RETRY_ATTEMPTS, "", 0) \
+    DECLARE(UInt64, retry_scale_factor, S3::DEFAULT_RETRY_SCALE_FACTOR, "", 0) \
+    DECLARE(UInt64, retry_max_delay_ms, S3::DEFAULT_RETRY_MAX_DELAY_MS, "", 0) \
     DECLARE(Bool, slow_all_threads_after_network_error, true, "", 0) \
     DECLARE(Bool, enable_request_logging, false, "", 0)
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Make S3 retry strategy configurable and make settings of S3 disk can be hot reload if change the config XML file.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Make 

- s3_max_redirects
- s3_retry_attempts
- s3_slow_all_threads_after_network_error
- s3_enable_request_logging

be reloadable when change the config of a s3 disk.

Make S3 retry strategy can be totally configurable.
