### PR TITLE
Apply fix for CVE-2025-6375 in Poco from upstream

### DIFF
--- a/base/poco/Net/include/Poco/Net/MultipartReader.h
+++ b/base/poco/Net/include/Poco/Net/MultipartReader.h
@@ -19,6 +19,7 @@
 
 
 #include <istream>
+#include <memory>
 #include "Poco/BufferedStreamBuf.h"
 #include "Poco/Net/Net.h"
 
@@ -151,7 +152,7 @@ namespace Net
 
         std::istream & _istr;
         std::string _boundary;
-        MultipartInputStream * _pMPI;
+        std::unique_ptr<MultipartInputStream> _pMPI;
     };
 
 

--- a/base/poco/Net/src/MultipartReader.cpp
+++ b/base/poco/Net/src/MultipartReader.cpp
@@ -36,7 +36,6 @@ MultipartStreamBuf::MultipartStreamBuf(std::istream& istr, const std::string& bo
 	_boundary(boundary),
 	_lastPart(false)
 {
-	poco_assert (!boundary.empty() && boundary.length() < STREAM_BUFFER_SIZE - 6);
 }
 
 
@@ -47,7 +46,7 @@ MultipartStreamBuf::~MultipartStreamBuf()
 
 int MultipartStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	poco_assert_dbg (length >= _boundary.length() + 6);
+	poco_assert (!_boundary.empty() && _boundary.length() < length - 6);
 
 	static const int eof = std::char_traits<char>::eof();
 	std::streambuf& buf = *_istr.rdbuf();
@@ -88,7 +87,7 @@ int MultipartStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 					{
 						buf.sbumpc(); // '\n'
 					}
-					return 0;					
+					return 0;
 				}
 				else if (ch == '-' && buf.sgetc() == '-')
 				{
@@ -174,23 +173,21 @@ MultipartInputStream::~MultipartInputStream()
 
 
 MultipartReader::MultipartReader(std::istream& istr):
-	_istr(istr),
-	_pMPI(0)
+	_istr(istr)
 {
 }
 
 
 MultipartReader::MultipartReader(std::istream& istr, const std::string& boundary):
 	_istr(istr),
-	_boundary(boundary),
-	_pMPI(0)
+	_boundary(boundary)
 {
 }
 
 
 MultipartReader::~MultipartReader()
 {
-	delete _pMPI;
+
 }
 
 
@@ -208,8 +205,7 @@ void MultipartReader::nextPart(MessageHeader& messageHeader)
 		throw MultipartException("No more parts available");
 	}
 	parseHeader(messageHeader);
-	delete _pMPI;
-	_pMPI = new MultipartInputStream(_istr, _boundary);
+	_pMPI = std::make_unique<MultipartInputStream>(_istr, _boundary);
 }
 
 
@@ -218,11 +214,11 @@ bool MultipartReader::hasNextPart()
 	return (!_pMPI || !_pMPI->lastPart()) && _istr.good();
 }
 
-	
+
 std::istream& MultipartReader::stream() const
 {
 	poco_check_ptr (_pMPI);
-	
+
 	return *_pMPI;
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply fix for CVE-2025-6375 in Poco from upstream

https://nvd.nist.gov/vuln/detail/CVE-2025-6375
https://github.com/pocoproject/poco/commit/a0822e02ca08c5fa7cf37c7448a0a647c0e332c1
https://github.com/pocoproject/poco/commit/11619a9e95c2ce14a0edfeddb8c1a0a1c926ba7f
