### PR TITLE
NumericIndexedVector: bump introduced_in in embedded doc to 25.7

### DIFF
--- a/src/Functions/FunctionsNumericIndexedVector.cpp
+++ b/src/Functions/FunctionsNumericIndexedVector.cpp
@@ -22,7 +22,7 @@ REGISTER_FUNCTION(NumericIndexedVector)
 │     │ AggregateFunction(groupNumericIndexedVector, UInt8, UInt8) │
 └─────┴────────────────────────────────────────────────────────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseAdd>(FunctionDocumentation{
@@ -46,7 +46,7 @@ SELECT
 │ {1:10,2:30,3:50,4:30} │ {1:12,2:22,3:32} │
 └───────────────────────┴──────────────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseSubtract>(FunctionDocumentation{
@@ -70,7 +70,7 @@ SELECT
 │ {1:10,2:10,3:10,4:-30} │ {1:8,2:18,3:28} │
 └────────────────────────┴─────────────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseMultiply>(FunctionDocumentation{
@@ -94,7 +94,7 @@ SELECT
 │ {2:200,3:600} │ {1:20,2:40,3:60} │
 └───────────────┴──────────────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseDivide>(FunctionDocumentation{
@@ -118,7 +118,7 @@ SELECT
 │ {2:2,3:1.5} │ {1:5,2:10,3:15} │
 └─────────────┴─────────────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseEqual>(FunctionDocumentation{
@@ -142,7 +142,7 @@ SELECT
 │ {2:1} │ {2:1} │
 └───────┴───────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseNotEqual>(FunctionDocumentation{
@@ -166,7 +166,7 @@ SELECT
 │ {1:1,3:1,4:1} │ {1:1,3:1} │
 └───────────────┴───────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseLess>(FunctionDocumentation{
@@ -190,7 +190,7 @@ SELECT
 │ {3:1,4:1} │ {1:1} │
 └───────────┴───────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseLessEqual>(FunctionDocumentation{
@@ -214,7 +214,7 @@ SELECT
 │ {2:1,3:1,4:1} │ {1:1,2:1} │
 └───────────────┴───────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseGreater>(FunctionDocumentation{
@@ -238,7 +238,7 @@ SELECT
 │ {1:1,3:1} │ {3:1} │
 └───────────┴───────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorPointwiseGreaterEqual>(FunctionDocumentation{
@@ -262,7 +262,7 @@ SELECT
 │ {1:1,2:1,3:1} │ {2:1,3:1} │
 └───────────────┴───────────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorGetValueImpl>(FunctionDocumentation{
@@ -281,7 +281,7 @@ SELECT numericIndexedVectorGetValue(numericIndexedVectorBuild(mapFromArrays([1, 
 │  30 │
 └─────┘
             )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorCardinality>(FunctionDocumentation{
@@ -302,7 +302,7 @@ SELECT numericIndexedVectorCardinality(numericIndexedVectorBuild(mapFromArrays([
 └─────┘
             )"
         }},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorAllValueSum>(FunctionDocumentation{
@@ -323,7 +323,7 @@ SELECT numericIndexedVectorAllValueSum(numericIndexedVectorBuild(mapFromArrays([
 └─────┘
             )"
         }},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorShortDebugString>(FunctionDocumentation{
@@ -344,7 +344,7 @@ Row 1:
 res: {"vector_type":"BSI","index_type":"char8_t","value_type":"char8_t","integer_bit_num":8,"fraction_bit_num":0,"zero_indexes_info":{"cardinality":"0"},"non_zero_indexes_info":{"total_cardinality":"3","all_value_sum":60,"number_of_bitmaps":"8","bitmap_info":{"cardinality":{"0":"0","1":"2","2":"2","3":"2","4":"2","5":"0","6":"0","7":"0"}}}}
             )"
         }},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
     factory.registerFunction<FunctionNumericIndexedVectorToMap>(FunctionDocumentation{
@@ -365,7 +365,7 @@ SELECT numericIndexedVectorToMap(numericIndexedVectorBuild(mapFromArrays([1, 2, 
 └──────────────────┘
             )"
         }},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Arithmetic,
     });
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Bump `introduced_in` from 25.6 to 25.7 as this feature won't be introduced in 25.6

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)