### PR TITLE
Find the correct starting candidate range in findPKRangesForFinalAfterSkipIndexImpl()

### DIFF
--- a/src/Processors/QueryPlan/PartsSplitter.cpp
+++ b/src/Processors/QueryPlan/PartsSplitter.cpp
@@ -986,11 +986,12 @@ RangesInDataParts findPKRangesForFinalAfterSkipIndexImpl(RangesInDataParts & ran
             continue; /// early exit, intersection infeasible in this part
         }
 
-        auto candidates_start = index_access.findLeftmostMarkGreaterThanValueInRange(part_index, selected_lower_bound.value, MarkRange{0, index_granularity->getMarksCountWithoutFinal() + 1}, false);
+        /// The selected lower bound could be 'fqrst' and granule ranges could be -
+        ///      abcde,...,fcedr, ffagj, fqrst, fqrst, fqrst, ghyrw ....
+        /// candidates_start needs to point to granule starting at "ffagj"
+        auto candidates_start = index_access.findRightmostMarkLessThanValueInRange(part_index, selected_lower_bound.value, MarkRange{0, index_granularity->getMarksCountWithoutFinal() + 1}, false);
         if (!candidates_start)
-            continue; /// no intersection possible in this part
-        if (candidates_start.value() > 0)
-            candidates_start = candidates_start.value() - 1;
+            candidates_start = 0;
 
         auto candidates_end = index_access.findLeftmostMarkGreaterThanValueInRange(part_index, selected_upper_bound.value, MarkRange{0, index_granularity->getMarksCountWithoutFinal() + 1}, false);
         if (!candidates_end)


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/82598. Correctly identify the starting range for intersection check by using `findRightmostMarkLessThanValueInRange()` to reach one range before the lower bound. 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Setting `use_skip_indexes_if_final_exact_mode` implementation (introduced in 25.6) could fail to select a relevant candidate range depending upon `MergeTree` engine settings / data distribution. That has been resolved now.


