### PR TITLE
Include zero values in the `X-ClickHouse-Summary`

### DIFF
--- a/src/IO/Progress.cpp
+++ b/src/IO/Progress.cpp
@@ -83,7 +83,7 @@ void ProgressValues::write(WriteBuffer & out, UInt64 client_revision) const
     }
 }
 
-void ProgressValues::writeJSON(WriteBuffer & out) const
+void ProgressValues::writeJSON(WriteBuffer & out, bool write_zero_values) const
 {
     /// Numbers are written in double quotes (as strings) to avoid loss of precision
     ///  of 64-bit integers after interpretation by JavaScript.
@@ -92,7 +92,7 @@ void ProgressValues::writeJSON(WriteBuffer & out) const
 
     auto write = [&](const char * name, UInt64 value)
     {
-        if (!value)
+        if (!value && !write_zero_values)
             return;
         if (has_value)
             writeChar(',', out);
@@ -254,9 +254,9 @@ void Progress::write(WriteBuffer & out, UInt64 client_revision) const
     getValues().write(out, client_revision);
 }
 
-void Progress::writeJSON(WriteBuffer & out) const
+void Progress::writeJSON(WriteBuffer & out, DisplayMode mode) const
 {
-    getValues().writeJSON(out);
+    getValues().writeJSON(out, mode == DisplayMode::Verbose);
 }
 
 void Progress::incrementElapsedNs(UInt64 elapsed_ns_)

--- a/src/IO/Progress.h
+++ b/src/IO/Progress.h
@@ -31,7 +31,7 @@ struct ProgressValues
 
     void read(ReadBuffer & in, UInt64 server_revision);
     void write(WriteBuffer & out, UInt64 client_revision) const;
-    void writeJSON(WriteBuffer & out) const;
+    void writeJSON(WriteBuffer & out, bool write_zero_values) const;
 };
 
 struct ReadProgress
@@ -117,8 +117,14 @@ struct Progress
 
     void write(WriteBuffer & out, UInt64 client_revision) const;
 
+    enum class DisplayMode
+    {
+        Verbose,  // Display zero values. Needed for X-ClickHouse-Summary
+        Minimal   // Do not write zero values. Needed to send less data for frequent progress updates (X-ClickHouse-Progress)
+    };
+
     /// Progress in JSON format (single line, without whitespaces) is used in HTTP headers.
-    void writeJSON(WriteBuffer & out) const;
+    void writeJSON(WriteBuffer & out, DisplayMode mode) const;
 
     /// Each value separately is changed atomically (but not whole object).
     bool incrementPiecewiseAtomically(const Progress & rhs);

--- a/src/Processors/Formats/Impl/JSONCompactEachRowWithProgressRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowWithProgressRowOutputFormat.cpp
@@ -79,7 +79,7 @@ void JSONCompactEachRowWithProgressRowOutputFormat::writeProgress(const Progress
     if (value.empty())
         return;
     writeCString("{\"progress\":", *ostr);
-    value.writeJSON(*ostr);
+    value.writeJSON(*ostr, Progress::DisplayMode::Minimal);
     writeCString("}\n", *ostr);
 }
 

--- a/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
@@ -81,7 +81,7 @@ void JSONEachRowWithProgressRowOutputFormat::writeProgress(const Progress & valu
     if (value.empty())
         return;
     writeCString("{\"progress\":", *ostr);
-    value.writeJSON(*ostr);
+    value.writeJSON(*ostr, Progress::DisplayMode::Minimal);
     writeCString("}\n", *ostr);
 }
 

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -74,8 +74,8 @@ void WriteBufferFromHTTPServerResponse::writeHeaderProgressImpl(const char * hea
 void WriteBufferFromHTTPServerResponse::writeHeaderSummary()
 {
     accumulated_progress.incrementElapsedNs(progress_watch.elapsed());
-    /// Write the verbose summary with all the zero values included if any.
-    /// This is needed for the compatibility with other system, for example for the Elixir driver.
+    /// Write the verbose summary with all the zero values included, if any.
+    /// This is needed for compatibility with an old version of the third-party ClickHouse driver for Elixir.
     writeHeaderProgressImpl("X-ClickHouse-Summary: ", Progress::DisplayMode::Verbose);
 }
 

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -74,6 +74,8 @@ void WriteBufferFromHTTPServerResponse::writeHeaderProgressImpl(const char * hea
 void WriteBufferFromHTTPServerResponse::writeHeaderSummary()
 {
     accumulated_progress.incrementElapsedNs(progress_watch.elapsed());
+    /// Write the verbose summary with all the zero values included if any.
+    /// This is needed for the compatibility with other system, for example for the Elixir driver.
     writeHeaderProgressImpl("X-ClickHouse-Summary: ", Progress::DisplayMode::Verbose);
 }
 

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -57,13 +57,13 @@ void WriteBufferFromHTTPServerResponse::startSendHeaders()
     socketSendBytes(header_str.data(), header_str.size());
 }
 
-void WriteBufferFromHTTPServerResponse::writeHeaderProgressImpl(const char * header_name)
+void WriteBufferFromHTTPServerResponse::writeHeaderProgressImpl(const char * header_name, Progress::DisplayMode mode)
 {
     if (is_http_method_head || headers_finished_sending || !headers_started_sending)
         return;
 
     WriteBufferFromOwnString progress_string_writer;
-    accumulated_progress.writeJSON(progress_string_writer);
+    accumulated_progress.writeJSON(progress_string_writer, mode);
     progress_string_writer.finalize();
 
     socketSendBytes(header_name, strlen(header_name));
@@ -74,12 +74,12 @@ void WriteBufferFromHTTPServerResponse::writeHeaderProgressImpl(const char * hea
 void WriteBufferFromHTTPServerResponse::writeHeaderSummary()
 {
     accumulated_progress.incrementElapsedNs(progress_watch.elapsed());
-    writeHeaderProgressImpl("X-ClickHouse-Summary: ");
+    writeHeaderProgressImpl("X-ClickHouse-Summary: ", Progress::DisplayMode::Verbose);
 }
 
 void WriteBufferFromHTTPServerResponse::writeHeaderProgress()
 {
-    writeHeaderProgressImpl("X-ClickHouse-Progress: ");
+    writeHeaderProgressImpl("X-ClickHouse-Progress: ", Progress::DisplayMode::Minimal);
 }
 
 void WriteBufferFromHTTPServerResponse::writeExceptionCode()

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
@@ -80,7 +80,7 @@ private:
     void startSendHeaders();
 
     /// Used to write the header X-ClickHouse-Progress / X-ClickHouse-Summary
-    void writeHeaderProgressImpl(const char * header_name);
+    void writeHeaderProgressImpl(const char * header_name, Progress::DisplayMode mode);
     /// Used to write the header X-ClickHouse-Progress
     void writeHeaderProgress();
     /// Used to write the header X-ClickHouse-Summary

--- a/tests/queries/0_stateless/02136_scalar_progress.reference
+++ b/tests/queries/0_stateless/02136_scalar_progress.reference
@@ -5,4 +5,4 @@
 < X-ClickHouse-Progress: {"read_rows":"100000","read_bytes":"800000","total_rows_to_read":"100001"}
 < X-ClickHouse-Progress: {"read_rows":"100001","read_bytes":"800001","total_rows_to_read":"100001"}
 < X-ClickHouse-Progress: {"read_rows":"100001","read_bytes":"800001","total_rows_to_read":"100001","result_rows":"1","result_bytes":"272"}
-< X-ClickHouse-Summary: {"read_rows":"100001","read_bytes":"800001","total_rows_to_read":"100001","result_rows":"1","result_bytes":"272"}
+< X-ClickHouse-Summary: {"read_rows":"100001","read_bytes":"800001","written_rows":"0","written_bytes":"0","total_rows_to_read":"100001","result_rows":"1","result_bytes":"272"}

--- a/tests/queries/0_stateless/02373_progress_contain_result.reference
+++ b/tests/queries/0_stateless/02373_progress_contain_result.reference
@@ -1,2 +1,2 @@
 < Access-Control-Expose-Headers: X-ClickHouse-Query-Id,X-ClickHouse-Summary,X-ClickHouse-Server-Display-Name,X-ClickHouse-Format,X-ClickHouse-Timezone,X-ClickHouse-Exception-Code
-< X-ClickHouse-Summary: {"read_rows":"100","read_bytes":"800","total_rows_to_read":"100","result_rows":"100","result_bytes":"227"}
+< X-ClickHouse-Summary: {"read_rows":"100","read_bytes":"800","written_rows":"0","written_bytes":"0","total_rows_to_read":"100","result_rows":"100","result_bytes":"227"}

--- a/tests/queries/0_stateless/02423_insert_summary_behaviour.reference
+++ b/tests/queries/0_stateless/02423_insert_summary_behaviour.reference
@@ -1,10 +1,10 @@
 No materialized views
 < Access-Control-Expose-Headers: X-ClickHouse-Query-Id,X-ClickHouse-Summary,X-ClickHouse-Server-Display-Name,X-ClickHouse-Format,X-ClickHouse-Timezone,X-ClickHouse-Exception-Code
-< X-ClickHouse-Summary: {"read_rows":"1","read_bytes":"8","written_rows":"1","written_bytes":"8","result_rows":"1","result_bytes":"8"}
+< X-ClickHouse-Summary: {"read_rows":"1","read_bytes":"8","written_rows":"1","written_bytes":"8","total_rows_to_read":"0","result_rows":"1","result_bytes":"8"}
 < Access-Control-Expose-Headers: X-ClickHouse-Query-Id,X-ClickHouse-Summary,X-ClickHouse-Server-Display-Name,X-ClickHouse-Format,X-ClickHouse-Timezone,X-ClickHouse-Exception-Code
-< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"80","result_rows":"10","result_bytes":"80"}
+< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"80","total_rows_to_read":"0","result_rows":"10","result_bytes":"80"}
 < Access-Control-Expose-Headers: X-ClickHouse-Query-Id,X-ClickHouse-Summary,X-ClickHouse-Server-Display-Name,X-ClickHouse-Format,X-ClickHouse-Timezone,X-ClickHouse-Exception-Code
-< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"80","result_rows":"10","result_bytes":"80"}
+< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"80","total_rows_to_read":"0","result_rows":"10","result_bytes":"80"}
 With materialized views
 < Access-Control-Expose-Headers: X-ClickHouse-Query-Id,X-ClickHouse-Summary,X-ClickHouse-Server-Display-Name,X-ClickHouse-Format,X-ClickHouse-Timezone,X-ClickHouse-Exception-Code
 < X-ClickHouse-Summary: {"read_rows":"5","read_bytes":"40","written_rows":"4","written_bytes":"32","total_rows_to_read":"2","result_rows":"4","result_bytes":"32"}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
After https://github.com/ClickHouse/ClickHouse/pull/73834, the `X-ClickHouse-Progress` and `X-ClickHouse-Summary` header formats have been modified to omit zero values. This PR intends to return the previous behaviour for `X-ClickHouse-Summary` only, because it makes sense. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
