### PR TITLE
docs: update outdated references to experimental features

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -1,5 +1,5 @@
 ---
-description: 'The Kafka engine works with Apache Kafka and lets you publish or subscribe
+description: 'The Kafka Table Engine can be used to publish works with Apache Kafka and lets you publish or subscribe
   to data flows, organize fault-tolerant storage, and process streams as they become
   available.'
 sidebar_label: 'Kafka'
@@ -13,15 +13,9 @@ import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
 # Kafka
 
-<CloudNotSupportedBadge/>
-
 :::note
-ClickHouse Cloud users are recommended to use [ClickPipes](/integrations/clickpipes) for streaming Kafka data into ClickHouse. This natively supports high-performance insertion while ensuring the separation of concerns with the ability to scale ingestion and cluster resources independently.
+If you're on ClickHouse Cloud, we recommend using [ClickPipes](/integrations/clickpipes) instead. ClickPipes natively supports private network connections, scaling ingestion and cluster resources independently, and comprehensive monitoring for streaming Kafka data into ClickHouse.
 :::
-
-This engine works with [Apache Kafka](http://kafka.apache.org/).
-
-Kafka lets you:
 
 - Publish or subscribe to data flows.
 - Organize fault-tolerant storage.

--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -25,7 +25,7 @@ curl https://clickhouse.com/ | sh
 ```
 
 :::note
-The binary you just downloaded can run all sorts of ClickHouse tools and utilities. If you want to run ClickHouse as a database server, check out the [Quick Start](../../quick-start.mdx).
+The binary you just downloaded can run all sorts of ClickHouse tools and utilities. If you want to run ClickHouse as a database server, check out the [Quick Start](/get-started/quick-start).
 :::
 
 ## Query data in a file using SQL {#query_data_in_file}
@@ -171,7 +171,7 @@ NORTHWOOD    THREE RIVERS    184    731609    ███████████�
 ```
 
 :::tip
-When you are ready to insert your files into ClickHouse, startup a ClickHouse server and insert the results of your `file` and `s3` table functions into a `MergeTree` table. View the [Quick Start](../../quick-start.mdx) for more details.
+When you are ready to insert your files into ClickHouse, startup a ClickHouse server and insert the results of your `file` and `s3` table functions into a `MergeTree` table. View the [Quick Start](/get-started/quick-start) for more details.
 :::
 
 

--- a/docs/en/sql-reference/statements/create/view.md
+++ b/docs/en/sql-reference/statements/create/view.md
@@ -12,7 +12,7 @@ import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
 # CREATE VIEW
 
-Creates a new view. Views can be [normal](#normal-view), [materialized](#materialized-view), [refreshable materialized](#refreshable-materialized-view), and [window](/sql-reference/statements/create/view#window-view) (refreshable materialized view and window view are experimental features).
+Creates a new view. Views can be [normal](#normal-view), [materialized](#materialized-view), [refreshable materialized](#refreshable-materialized-view), and [window](/sql-reference/statements/create/view#window-view).
 
 ## Normal View {#normal-view}
 


### PR DESCRIPTION
There was a small reference to refreshable materialized views as experimental, which is inconsistent with the rest of the documentation. Also removing the "Not available in Cloud" badge for the Kafka Table Enfine, since it is available in Cloud as of the 25.4 rollout.

### Changelog category (leave one):
- Documentation (changelog entry is not required)