### PR TITLE
Handle more errors in storage mongodb uri parsing on attach

### DIFF
--- a/tests/integration/test_storage_mongodb/test.py
+++ b/tests/integration/test_storage_mongodb/test.py
@@ -76,11 +76,8 @@ def test_simple_select(started_cluster):
         == f"{hex(42 * 42)}\n"
     )
 
-    system_warnings_query = "SELECT count() >= 1 FROM system.warnings WHERE message LIKE '%MongoDB%path%ignored%'"
-
-    # Need to restart to clear system.warning from previous run in flaky check
-    # FIXME: we can do `TRUNCATE` after https://github.com/ClickHouse/ClickHouse/pull/82087
-    node.restart_clickhouse()
+    system_warnings_query = "SELECT count() >= 1 FROM system.warnings WHERE message ILIKE '%MongoDB%path%ignored%' OR message ILIKE '%error%parsing%uri%MongoDB%'"
+    node.query("TRUNCATE TABLE system.warnings")
 
     assert node.query(system_warnings_query) == "0\n"
     node.stop_clickhouse()
@@ -91,6 +88,7 @@ def test_simple_select(started_cluster):
     assert node.query(system_warnings_query) == "1\n"
 
     node.query("DROP TABLE simple_mongo_table")
+    node.query("TRUNCATE TABLE system.warnings")
     simple_mongo_table.drop()
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Improved MongoDB storage compatibility when loading tables with malformed URIs from older ClickHouse versions. Tables now attach with warnings instead of failing, maintaining backward compatibility.
