### PR TITLE
Docs: Update ninja command in build.md

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -100,7 +100,7 @@ cmake -D CMAKE_BUILD_TYPE=Debug ..
 Run ninja to build:
 
 ```sh
-ninja clickhouse-server clickhouse-client
+ninja clickhouse
 ```
 
 If you like to build all the binaries (utilities and tests), run ninja without parameters:


### PR DESCRIPTION
Fix wrong ninja command which fails with:

    ninja: error: no such target 'clickhouse-server'

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
