### PR TITLE
Fix ordering issue of the FST state bitmap encoding

### DIFF
--- a/src/Common/FST.cpp
+++ b/src/Common/FST.cpp
@@ -1,11 +1,12 @@
 // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
-
 #include "FST.h"
+
+#include <Common/Exception.h>
+
 #include <algorithm>
 #include <cassert>
 #include <memory>
 #include <vector>
-#include <Common/Exception.h>
 #include <city.h>
 
 /// "paper" in the comments in this file refers to:
@@ -154,12 +155,13 @@ UInt64 State::serialize(WriteBuffer & write_buffer)
     write_buffer.write(flag);
     written_bytes += 1;
 
+    /// NOTE: Using "UInt8" is important here instead of "char" because of sorting (Bitmap encoding).
+    /// The range should be [0, 255] which is not the case for the range of "char" [-128, 127].
+    std::vector<UInt8> labels;
+    labels.reserve(arcs.size());
     if (getEncodingMethod() == EncodingMethod::Sequential)
     {
         /// Serialize all labels
-        std::vector<char> labels;
-        labels.reserve(arcs.size());
-
         for (auto & [label, state] : arcs)
             labels.push_back(label);
 
@@ -167,32 +169,28 @@ UInt64 State::serialize(WriteBuffer & write_buffer)
         write_buffer.write(label_size);
         written_bytes += 1;
 
-        write_buffer.write(labels.data(), labels.size());
+        write_buffer.write(reinterpret_cast<const char *>(labels.data()), labels.size());
         written_bytes += labels.size();
-
-        /// Serialize all arcs
-        for (char label : labels)
-        {
-            Arc * arc = getArc(label);
-            assert(arc != nullptr);
-            written_bytes += arc->serialize(write_buffer);
-        }
     }
     else
     {
         /// Serialize bitmap
         LabelsAsBitmap bmp;
         for (auto & [label, state] : arcs)
-            bmp.addLabel(label);
-        written_bytes += bmp.serialize(write_buffer);
-
-        /// Serialize all arcs
-        for (auto & [label, state] : arcs)
         {
-            Arc * arc = getArc(label);
-            assert(arc != nullptr);
-            written_bytes += arc->serialize(write_buffer);
+            bmp.addLabel(label);
+            labels.push_back(label);
         }
+        written_bytes += bmp.serialize(write_buffer);
+        std::sort(labels.begin(), labels.end());
+    }
+
+    /// Serialize all arcs
+    for (auto & label: labels)
+    {
+        Arc * arc = getArc(label);
+        assert(arc != nullptr);
+        written_bytes += arc->serialize(write_buffer);
     }
 
     return written_bytes;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The 256-bit bitmap stores the outgoing labels of a state ordered, but outgoing states are saved into disk in the order they appear in the hash table. Therefore, a label would point to a wrong next state while reading from disk.

To fix that, labels should be sorted and states should be saved into disk by the same ordering.

Currently, `Bitmap` encoding of states are not enabled, so cannot be tested.
During the implementation, it was enabled manually.
In the follow-up PRs there will be a new settings to enable it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
