### PR TITLE
Keep track of the number of async tables loading jobs. If there are some running jobs, do not update `tail_ptr` in `TransactionLog::removeOldEntries`

### DIFF
--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <Core/ServerUUID.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
@@ -274,6 +275,17 @@ void TransactionLog::removeOldEntries()
     /// but it's possible that some CSNs are not written into data parts (and we will write them during startup).
     if (!global_context->isServerCompletelyStarted())
         return;
+
+    /// Because `loadTableFromMetadataAsync` is running asynchronously, it is possible that the outdated parts are loading while the `tail_ptr` is updated here.
+    /// It might trigger assertion when the part `create_csn` is lower than `tail_ptr`. Refer: https://github.com/ClickHouse/ClickHouse/issues/60406
+    /// We keep track of `asyncTablesLoadingJobNumber`, and not update `tail_ptr` if there are running jobs.
+    if (!updated_tail_ptr.load(std::memory_order_relaxed) && asyncTablesLoadingJobNumber() != 0)
+    {
+        LOG_TRACE(log, "There are running async tables loading jobs, skip updating tail_ptr");
+        return;
+    }
+
+    updated_tail_ptr.store(true, std::memory_order_relaxed);
 
     /// Also similar problem is possible if some table was not attached during startup (for example, if table is detached permanently).
     /// Also we write CSNs into data parts without fsync, so it's theoretically possible that we wrote CSN, finished transaction,
@@ -638,4 +650,16 @@ void TransactionLog::sync() const
     waitForCSNLoaded(newest_csn);
 }
 
+void TransactionLog::increaseAsyncTablesLoadingJobNumber()
+{
+    async_tables_loading_job_number.fetch_add(1);
+}
+void TransactionLog::decreaseAsyncTablesLoadingJobNumber()
+{
+    async_tables_loading_job_number.fetch_sub(1);
+}
+Int64 TransactionLog::asyncTablesLoadingJobNumber()
+{
+    return async_tables_loading_job_number.load();
+}
 }

--- a/src/Interpreters/TransactionLog.h
+++ b/src/Interpreters/TransactionLog.h
@@ -1,11 +1,12 @@
 #pragma once
-#include <Interpreters/MergeTreeTransaction.h>
-#include <Interpreters/MergeTreeTransactionHolder.h>
-#include <Common/ZooKeeper/ZooKeeper.h>
-#include <Common/ThreadPool.h>
-#include <boost/noncopyable.hpp>
 #include <mutex>
 #include <unordered_map>
+#include <Interpreters/MergeTreeTransaction.h>
+#include <Interpreters/MergeTreeTransactionHolder.h>
+#include <base/types.h>
+#include <boost/noncopyable.hpp>
+#include <Common/ThreadPool.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
 
 namespace DB
 {
@@ -131,6 +132,10 @@ public:
 
     void sync() const;
 
+    static void increaseAsyncTablesLoadingJobNumber();
+    static void decreaseAsyncTablesLoadingJobNumber();
+    static Int64 asyncTablesLoadingJobNumber();
+
 private:
     void loadLogFromZooKeeper() TSA_REQUIRES(mutex);
     void runUpdatingThread();
@@ -147,6 +152,8 @@ private:
     static String serializeCSN(CSN csn);
     static TransactionID deserializeTID(const String & csn_node_content);
     static String serializeTID(const TransactionID & tid);
+
+    inline static std::atomic<Int64> async_tables_loading_job_number{0};
 
     ZooKeeperPtr getZooKeeper() const;
 
@@ -191,6 +198,7 @@ private:
     String last_loaded_entry TSA_GUARDED_BY(mutex);
     /// The oldest CSN such that we store in log entries with TransactionIDs containing this CSN.
     std::atomic<CSN> tail_ptr = Tx::UnknownCSN;
+    std::atomic<bool> updated_tail_ptr{false};
 
     zkutil::EventPtr log_updated_event = std::make_shared<Poco::Event>();
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keep track of the number of async tables loading jobs. If there are some running jobs, do not update `tail_ptr` in `TransactionLog::removeOldEntries`

Because `loadTableFromMetadataAsync` is running asynchronously, it is possible that the outdated parts are loading while the `tail_ptr` is updated here. It might trigger assertion when the part `create_csn` is lower than `tail_ptr`. Refer: https://github.com/ClickHouse/ClickHouse/issues/60406

We keep track of `asyncTablesLoadingJobNumber`, and not update `tail_ptr` if there are running jobs.

Closes #60406
Closes #82718

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
