### PR TITLE
Fix inconsistent formatting of parenthesized expressions with aliases in the context when no aliases are allowed

### DIFF
--- a/tests/queries/0_stateless/03558_no_alias_in_single_expressions.sql
+++ b/tests/queries/0_stateless/03558_no_alias_in_single_expressions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY ((c0 AS x)); -- { clientError SYNTAX_ERROR }
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY (c0 AS x); -- { clientError SYNTAX_ERROR }
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY (c0 AS x) DESC; -- { clientError SYNTAX_ERROR }
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY c0 AS x; -- { clientError SYNTAX_ERROR }
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY c0 AS x DESC; -- { clientError SYNTAX_ERROR }
+DELETE FROM t0 WHERE (true AS a0); -- { clientError SYNTAX_ERROR }
+DELETE FROM t0 WHERE true AS a0; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix inconsistent formatting of parenthesized expressions with aliases in the context when no aliases are allowed. Closes #82836. Closes #82837.
