### PR TITLE
Fix data races in Iceberg (resubmit of #82088)

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -18,7 +18,10 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h>
 
+#include <Common/SharedMutex.h>
 #include <tuple>
+#include <optional>
+#include <base/defines.h>
 
 
 namespace DB
@@ -43,10 +46,7 @@ public:
         IcebergMetadataFilesCachePtr cache_ptr);
 
     /// Get table schema parsed from metadata.
-    NamesAndTypesList getTableSchema() const override
-    {
-        return *schema_processor.getClickhouseTableSchemaById(relevant_snapshot_schema_id);
-    }
+    NamesAndTypesList getTableSchema() const override;
 
     bool operator==(const IDataLakeMetadata & other) const override
     {
@@ -59,24 +59,12 @@ public:
         const ConfigurationObserverPtr & configuration,
         const ContextPtr & local_context);
 
-    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const override
-    {
-        auto version_if_outdated = getSchemaVersionByFileIfOutdated(local_context, data_path);
-        return version_if_outdated.has_value() ? schema_processor.getClickhouseTableSchemaById(version_if_outdated.value()) : nullptr;
-    }
-
-    std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, const String & data_path) const override
-    {
-        auto version_if_outdated = getSchemaVersionByFileIfOutdated(local_context, data_path);
-        return version_if_outdated.has_value()
-            ? schema_processor.getSchemaTransformationDagByIds(version_if_outdated.value(), relevant_snapshot_schema_id)
-            : nullptr;
-    }
+    std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, const String & data_path) const override;
+    std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, const String & data_path) const override;
 
     bool supportsSchemaEvolution() const override { return true; }
 
-    static Int32
-    parseTableSchema(const Poco::JSON::Object::Ptr & metadata_object, IcebergSchemaProcessor & schema_processor, LoggerPtr metadata_logger);
+    static Int32 parseTableSchema(const Poco::JSON::Object::Ptr & metadata_object, IcebergSchemaProcessor & schema_processor, LoggerPtr metadata_logger);
 
     bool supportsUpdate() const override { return true; }
 
@@ -102,44 +90,35 @@ private:
 
     IcebergMetadataFilesCachePtr manifest_cache;
 
-    std::tuple<Int64, Int32> getVersion() const { return std::make_tuple(relevant_snapshot_id, relevant_snapshot_schema_id); }
+    std::tuple<Int64, Int32> getVersion() const;
 
-    Int32 last_metadata_version;
-    Int32 format_version;
+    mutable SharedMutex mutex;
 
-    mutable std::atomic<bool> schema_id_by_data_file_initialized{false};
-    mutable std::unordered_map<String, Int32> schema_id_by_data_file;
-    mutable std::mutex schema_id_by_data_file_mutex;
+    Int32 last_metadata_version TSA_GUARDED_BY(mutex);
+    const Int32 format_version;
 
+    mutable std::unordered_map<String, Int32> schema_id_by_data_file TSA_GUARDED_BY(mutex);
+    /// Does schema_id_by_data_files initialized and valid?
+    /// Is an optimization to avoid acquiring exclusive lock from get*() method
+    mutable std::atomic_bool schema_id_by_data_files_initialized = false;
 
-    Int32 relevant_snapshot_schema_id;
-    std::optional<Iceberg::IcebergSnapshot> relevant_snapshot;
-    Int64 relevant_snapshot_id{-1};
-    String table_location;
+    Int32 relevant_snapshot_schema_id TSA_GUARDED_BY(mutex);
+    std::optional<Iceberg::IcebergSnapshot> relevant_snapshot TSA_GUARDED_BY(mutex);
+    Int64 relevant_snapshot_id TSA_GUARDED_BY(mutex) {-1};
+    const String table_location;
 
-    mutable std::optional<Strings> cached_unprunned_files_for_last_processed_snapshot;
+    mutable std::optional<Strings> cached_unprunned_files_for_last_processed_snapshot TSA_GUARDED_BY(cached_unprunned_files_for_last_processed_snapshot_mutex);
+    mutable std::mutex cached_unprunned_files_for_last_processed_snapshot_mutex;
 
-    void updateState(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object, bool metadata_file_changed);
-
+    void updateState(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object, bool metadata_file_changed) TSA_REQUIRES(mutex);
     Strings getDataFiles(const ActionsDAG * filter_dag, ContextPtr local_context) const;
-
-    void updateSnapshot(ContextPtr local_context, Poco::JSON::Object::Ptr metadata_object);
-
+    void updateSnapshot(ContextPtr local_context, Poco::JSON::Object::Ptr metadata_object) TSA_REQUIRES(mutex);
     ManifestFileCacheKeys getManifestList(ContextPtr local_context, const String & filename) const;
-    mutable std::vector<Iceberg::ManifestFileEntry> positional_delete_files_for_current_query;
-
-    void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object);
-
-    std::optional<Int32> getSchemaVersionByFileIfOutdated(ContextPtr local_context, String data_path) const;
-
-    void initializeSchemasFromManifestList(ContextPtr local_context, ManifestFileCacheKeys manifest_list_ptr) const;
-
-    void initializeSchemasFromManifestFile(Iceberg::ManifestFilePtr manifest_file_ptr) const;
-
-    Iceberg::ManifestFilePtr getManifestFile(ContextPtr local_context, const String & filename, Int64 inherited_sequence_number) const;
-
+    void addTableSchemaById(Int32 schema_id, Poco::JSON::Object::Ptr metadata_object) TSA_REQUIRES(mutex);
+    std::optional<Int32> getSchemaVersionByFileIfOutdated(String data_path) const TSA_REQUIRES_SHARED(mutex);
+    void initializeSchemasFromManifestList(ContextPtr local_context, ManifestFileCacheKeys manifest_list_ptr) const TSA_REQUIRES(mutex);
+    Iceberg::ManifestFilePtr getManifestFile(ContextPtr local_context, const String & filename, Int64 inherited_sequence_number) const TSA_REQUIRES_SHARED(mutex);
     std::optional<String> getRelevantManifestList(const Poco::JSON::Object::Ptr & metadata);
-
     Iceberg::ManifestFilePtr tryGetManifestFile(const String & filename) const;
 };
 }


### PR DESCRIPTION
**Note, this is a resubmit of #82088, due to revert in #82822**

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data races in Iceberg

There are lots of races possible in Iceberg:
- `cached_unprunned_files_for_last_processed_snapshot` can be accessed easily from multiple queries and updated in parallel (via parallel `SELECT`)
- `relevant_snapshot` can be updated via `StorageObjectStorage::update` (basically any `SELECT` query + `system.tables` via `totalBytes`/`totalRows`)
- `IcebergMetadata::updateSnapshot` is not thread safe either

**So basically we need to protect all non-constant fields in `IcebergMetadata` and `IcebergSchemaProcessor`**

So this PR uses `shared_lock` to guard everything, but allow parallel reads (for `SELECT` and co)

Also it removes `schema_id_by_data_file` initialization from `getDataFiles`, since it is not used later (otherwise locking will be more costly).

v2: fix deadlock - https://pastila.nl/?0002517d/d8e89293604ddfe83765f2cbb471b56f#Fa29m24uqvhqImLMqFsmTg==