### PR TITLE
Set salt for auth data when parsing from AST with type SCRAM_SHA256_PASSWORD

### DIFF
--- a/src/Access/AuthenticationData.cpp
+++ b/src/Access/AuthenticationData.cpp
@@ -601,10 +601,12 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
 
         auth_data.setPasswordHashHex(value, validate);
 
-        if (query.type == AuthenticationType::SHA256_PASSWORD && args_size == 2)
+        if ((query.type == AuthenticationType::SHA256_PASSWORD || query.type == AuthenticationType::SCRAM_SHA256_PASSWORD)
+            && args_size == 2)
         {
             String parsed_salt = checkAndGetLiteralArgument<String>(args[1], "salt");
             auth_data.setSalt(parsed_salt);
+            return auth_data;
         }
     }
     else if (query.type == AuthenticationType::LDAP)

--- a/tests/integration/test_scram_sha256_password_with_replicated_zookeeper_replicator/configs/user_directories.xml
+++ b/tests/integration/test_scram_sha256_password_with_replicated_zookeeper_replicator/configs/user_directories.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <user_directories>
+        <replicated>
+            <zookeeper_path>/clickhouse/access/</zookeeper_path>
+        </replicated>
+        <local_directory remove="remove">
+        </local_directory>
+    </user_directories>
+</clickhouse>

--- a/tests/integration/test_scram_sha256_password_with_replicated_zookeeper_replicator/test.py
+++ b/tests/integration/test_scram_sha256_password_with_replicated_zookeeper_replicator/test.py
@@ -1,0 +1,29 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/user_directories.xml"],
+    with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_scram_sha256_password_with_replicated_zookeeper_replicator(start_cluster):
+    node.query("DROP USER IF EXISTS user_scram_sha256_password")
+    node.query(
+        "CREATE USER user_scram_sha256_password IDENTIFIED WITH SCRAM_SHA256_PASSWORD BY 'qwerty14'"
+    )
+    node.query("SELECT 14", user="user_scram_sha256_password", password="qwerty14")
+
+    node.query("DROP USER IF EXISTS user_scram_sha256_password")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set salt for auth data when parsing from AST with type SCRAM_SHA256_PASSWORD

There is a bug when authenticating with `SCRAM_SHA256_PASSWORD`. If `AccessStorage` is `ReplicatedAccessStorage`, we store the user authentication data in Zookeeper. When parsing the data, we must include the case when `type` is `SCRAM_SHA256_PASSWORD`, and set the salt for the authentication data.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
