### PR TITLE
tests: fix test_system_metrics (with remote disk database can be unavailable)

### DIFF
--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -27,6 +27,7 @@ node1 = cluster.add_instance(
     main_configs=["configs/overrides.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,
 )
 node2 = cluster.add_instance(
     "node2", main_configs=["configs/overrides.xml"], with_zookeeper=True


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)