### PR TITLE
clickhouse-test: fix `--test-runs`

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2518,12 +2518,12 @@ class TestSuite:
 
         post_run_check_tests = []
 
-        for test_name, tags in self.all_tags.items():
-            if "post-run-check" in tags:
+        for test_name in self.all_tests:
+            if "post-run-check" in self.all_tags[test_name]:
                 # post_run_check_tests are tests that supposed to run after all normal tests finished
                 post_run_check_tests.append(test_name)
                 continue
-            if self.is_sequential_test(test_name, tags):
+            if self.is_sequential_test(test_name):
                 if not args.no_sequential:
                     self.sequential_tests.append(test_name)
             else:
@@ -2550,13 +2550,7 @@ class TestSuite:
             return False
         return "long" in self.all_tags[test_name]
 
-    def is_sequential_test(self, test_name, tags=None):
-        if tags is not None:
-            return (
-                ("no-parallel" in tags)
-                or ("sequential" in tags)
-                or ("stateful" in tags)
-            )
+    def is_sequential_test(self, test_name):
         if args.sequential:
             if any(s in test_name for s in args.sequential):
                 return True


### PR DESCRIPTION
Fix `clickhouse-tests --test-runs` after it was broken in https://github.com/ClickHouse/ClickHouse/pull/82602#discussion_r2172901846

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
