### PR TITLE
Build mutations snapshot using parts visible in query

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -453,6 +453,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     {
         .metadata_version = global_ctx->metadata_snapshot->getMetadataVersion(),
         .min_part_metadata_version = MergeTreeData::getMinMetadataVersion(global_ctx->future_part->parts),
+        .min_part_data_versions = nullptr,
     };
 
     auto mutations_snapshot = global_ctx->data->getMutationsSnapshot(params);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -473,11 +473,6 @@ Int64 MergeTreeData::IMutationsSnapshot::getMinPartDataVersionForPartition(const
     return extractVersion(params.min_part_data_versions, partition_id, std::numeric_limits<Int64>::min());
 }
 
-bool MergeTreeData::IMutationsSnapshot::needCollectMutations(const Params & params)
-{
-    return params.need_data_mutations || params.need_alter_mutations || params.min_part_metadata_version < params.metadata_version;
-}
-
 bool MergeTreeData::IMutationsSnapshot::needIncludeMutationToSnapshot(const Params & params, const MutationCommands & commands)
 {
     for (const auto & command : commands)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -456,30 +456,49 @@ DataPartsLock::~DataPartsLock()
         ProfileEvents::increment(ProfileEvents::PartsLockHoldMicroseconds, lock_watch->elapsedMicroseconds());
 }
 
-MergeTreeData::MutationsSnapshotBase::MutationsSnapshotBase(Params params_, MutationCounters counters_)
-    : params(std::move(params_)), counters(std::move(counters_))
+static Int64 extractVersion(const PartitionIdToMaxBlockPtr & versions, const String & partition_id, Int64 default_value)
 {
+    if (!versions)
+        return default_value;
+
+    auto it = versions->find(partition_id);
+    if (it == versions->end())
+        return default_value;
+
+    return it->second;
 }
 
-bool MergeTreeData::MutationsSnapshotBase::hasSupportedCommands(const MutationCommands & commands) const
+Int64 MergeTreeData::IMutationsSnapshot::getMinPartDataVersionForPartition(const Params & params, const String & partition_id)
 {
-    bool need_data_mutations = hasDataMutations();
-    bool need_alter_mutations = hasAlterMutations();
-    bool need_metatadata_mutations = hasMetadataMutations();
+    return extractVersion(params.min_part_data_versions, partition_id, std::numeric_limits<Int64>::min());
+}
 
+bool MergeTreeData::IMutationsSnapshot::needCollectMutations(const Params & params)
+{
+    return params.need_data_mutations || params.need_alter_mutations || params.min_part_metadata_version < params.metadata_version;
+}
+
+bool MergeTreeData::IMutationsSnapshot::needIncludeMutationToSnapshot(const Params & params, const MutationCommands & commands)
+{
     for (const auto & command : commands)
     {
-        if (need_data_mutations && AlterConversions::isSupportedDataMutation(command.type))
+        if (params.need_data_mutations && AlterConversions::isSupportedDataMutation(command.type))
             return true;
 
-        if (need_alter_mutations && AlterConversions::isSupportedAlterMutation(command.type))
+        if (params.need_alter_mutations && AlterConversions::isSupportedAlterMutation(command.type))
             return true;
 
-        if (need_metatadata_mutations && AlterConversions::isSupportedMetadataMutation(command.type))
+        /// Metadata mutations must be included into the snapshot regardless of the parameters.
+        if (AlterConversions::isSupportedMetadataMutation(command.type))
             return true;
     }
 
     return false;
+}
+
+MergeTreeData::MutationsSnapshotBase::MutationsSnapshotBase(Params params_, MutationCounters counters_)
+    : params(std::move(params_)), counters(std::move(counters_))
+{
 }
 
 void MergeTreeData::MutationsSnapshotBase::addSupportedCommands(const MutationCommands & commands, MutationCommands & result_commands) const
@@ -8873,7 +8892,7 @@ AlterConversionsPtr MergeTreeData::getAlterConversionsForPart(
     const MutationsSnapshotPtr & mutations,
     const ContextPtr & query_context)
 {
-    auto commands = mutations->getAlterMutationCommandsForPart(part);
+    auto commands = mutations->getOnFlyMutationCommandsForPart(part);
     return std::make_shared<AlterConversions>(commands, query_context);
 }
 
@@ -9252,6 +9271,24 @@ Int64 MergeTreeData::getMinMetadataVersion(const DataPartsVector & parts)
     return version;
 }
 
+PartitionIdToMaxBlockPtr MergeTreeData::getMinDataVersionForEachPartition(const DataPartsVector & parts)
+{
+    PartitionIdToMaxBlock partition_to_min_data_version;
+
+    for (const auto & part : parts)
+    {
+        const String & partition_id = part->info.getPartitionId();
+        const Int64 data_version = part->info.getDataVersion();
+
+        if (auto partition_it = partition_to_min_data_version.find(partition_id); partition_it != partition_to_min_data_version.end())
+            partition_it->second = std::min(partition_it->second, data_version);
+        else
+            partition_to_min_data_version.emplace(partition_id, data_version);
+    }
+
+    return std::make_shared<PartitionIdToMaxBlock>(std::move(partition_to_min_data_version));
+}
+
 StorageMetadataPtr MergeTreeData::getInMemoryMetadataPtr() const
 {
     auto query_context = CurrentThread::get().getQueryContext();
@@ -9266,8 +9303,7 @@ StorageMetadataPtr MergeTreeData::getInMemoryMetadataPtr() const
     return cache->emplace(this, IStorage::getInMemoryMetadataPtr()).first->second;
 }
 
-StorageSnapshotPtr
-MergeTreeData::createStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context, bool without_data) const
+StorageSnapshotPtr MergeTreeData::createStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context, bool without_data) const
 {
     if (without_data)
     {
@@ -9292,6 +9328,7 @@ MergeTreeData::createStorageSnapshot(const StorageMetadataPtr & metadata_snapsho
     {
         .metadata_version = metadata_snapshot->getMetadataVersion(),
         .min_part_metadata_version = getMinMetadataVersion(parts),
+        .min_part_data_versions = getMinDataVersionForEachPartition(parts),
         .need_data_mutations = apply_mutations_on_fly,
         .need_alter_mutations = apply_mutations_on_fly,
     };

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -456,7 +456,7 @@ DataPartsLock::~DataPartsLock()
         ProfileEvents::increment(ProfileEvents::PartsLockHoldMicroseconds, lock_watch->elapsedMicroseconds());
 }
 
-static Int64 extractVersion(const PartitionIdToMaxBlockPtr & versions, const String & partition_id, Int64 default_value)
+static Int64 extractVersion(const MergeTreeData::PartitionIdToMinBlockPtr & versions, const String & partition_id, Int64 default_value)
 {
     if (!versions)
         return default_value;
@@ -9271,9 +9271,9 @@ Int64 MergeTreeData::getMinMetadataVersion(const DataPartsVector & parts)
     return version;
 }
 
-PartitionIdToMaxBlockPtr MergeTreeData::getMinDataVersionForEachPartition(const DataPartsVector & parts)
+MergeTreeData::PartitionIdToMinBlockPtr MergeTreeData::getMinDataVersionForEachPartition(const DataPartsVector & parts)
 {
-    PartitionIdToMaxBlock partition_to_min_data_version;
+    PartitionIdToMinBlock partition_to_min_data_version;
 
     for (const auto & part : parts)
     {
@@ -9286,7 +9286,7 @@ PartitionIdToMaxBlockPtr MergeTreeData::getMinDataVersionForEachPartition(const 
             partition_to_min_data_version.emplace(partition_id, data_version);
     }
 
-    return std::make_shared<PartitionIdToMaxBlock>(std::move(partition_to_min_data_version));
+    return std::make_shared<PartitionIdToMinBlock>(std::move(partition_to_min_data_version));
 }
 
 StorageMetadataPtr MergeTreeData::getInMemoryMetadataPtr() const

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -32,7 +32,6 @@
 #include <Storages/PartitionCommands.h>
 #include <Storages/MarkCache.h>
 #include <Interpreters/PartLog.h>
-#include <Interpreters/Context.h>
 #include <Poco/Timestamp.h>
 #include <Common/threadPoolCallbackRunner.h>
 
@@ -166,6 +165,9 @@ public:
     using DataPartStateVector = std::vector<DataPartState>;
 
     using PinnedPartUUIDsPtr = std::shared_ptr<const PinnedPartUUIDs>;
+
+    using PartitionIdToMinBlock = std::unordered_map<String, Int64>;
+    using PartitionIdToMinBlockPtr = std::shared_ptr<const PartitionIdToMinBlock>;
 
     constexpr static auto FORMAT_VERSION_FILE_NAME = "format_version.txt";
     constexpr static auto DETACHED_DIR_NAME = "detached";
@@ -485,7 +487,7 @@ public:
         {
             Int64 metadata_version = -1;
             Int64 min_part_metadata_version = -1;
-            PartitionIdToMaxBlockPtr min_part_data_versions = nullptr;
+            PartitionIdToMinBlockPtr min_part_data_versions = nullptr;
             bool need_data_mutations = false;
             bool need_alter_mutations = false;
         };
@@ -1052,7 +1054,7 @@ public:
     static Int64 getMinMetadataVersion(const DataPartsVector & parts);
 
     /// Returns minimum data version among parts inside each of the partitions.
-    static PartitionIdToMaxBlockPtr getMinDataVersionForEachPartition(const DataPartsVector & parts);
+    static PartitionIdToMinBlockPtr getMinDataVersionForEachPartition(const DataPartsVector & parts);
 
     /// Return alter conversions for part which must be applied on fly.
     static AlterConversionsPtr getAlterConversionsForPart(

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -494,7 +494,6 @@ public:
 
         static Int64 getMinPartDataVersionForPartition(const Params & params, const String & partition_id);
 
-        static bool needCollectMutations(const Params & params);
         static bool needIncludeMutationToSnapshot(const Params & params, const MutationCommands & commands);
 
         virtual ~IMutationsSnapshot() = default;

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -2220,6 +2220,7 @@ bool MutateTask::prepare()
     {
         .metadata_version = ctx->metadata_snapshot->getMetadataVersion(),
         .min_part_metadata_version = ctx->source_part->getMetadataVersion(),
+        .min_part_data_versions = nullptr,
     };
 
     auto mutations_snapshot = ctx->data->getMutationsSnapshot(params);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -2032,7 +2032,7 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
     MutationsSnapshot::MutationsByPartititon mutations_snapshot;
 
     std::lock_guard lock(state_mutex);
-    if (!MergeTreeData::IMutationsSnapshot::needCollectMutations(params))
+    if (!params.need_data_mutations && !params.need_alter_mutations && params.min_part_metadata_version >= params.metadata_version)
         return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot));
 
     for (const auto & [partition_id, mutations] : mutations_by_partition)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1952,8 +1952,13 @@ std::shared_ptr<ReplicatedMergeTreeZooKeeperMergePredicate> ReplicatedMergeTreeQ
     return std::make_shared<ReplicatedMergeTreeZooKeeperMergePredicate>(*this, zookeeper, std::move(partition_ids_hint));
 }
 
+ReplicatedMergeTreeQueue::MutationsSnapshot::MutationsSnapshot(Params params_, MutationCounters counters_, MutationsByPartititon mutations_by_partition_)
+    : MergeTreeData::MutationsSnapshotBase(std::move(params_), std::move(counters_))
+    , mutations_by_partition(std::move(mutations_by_partition_))
+{
+}
 
-MutationCommands ReplicatedMergeTreeQueue::MutationsSnapshot::getAlterMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const
+MutationCommands ReplicatedMergeTreeQueue::MutationsSnapshot::getOnFlyMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const
 {
     auto in_partition = mutations_by_partition.find(part->info.getPartitionId());
     if (in_partition == mutations_by_partition.end())
@@ -2023,26 +2028,27 @@ NameSet ReplicatedMergeTreeQueue::MutationsSnapshot::getAllUpdatedColumns() cons
 
 MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapshot(const MutationsSnapshot::Params & params) const
 {
-    std::lock_guard lock(state_mutex);
+    MutationCounters mutations_snapshot_counters;
+    MutationsSnapshot::MutationsByPartititon mutations_snapshot;
 
-    auto res = std::make_shared<MutationsSnapshot>(params, mutation_counters);
-    if (!res->hasAnyMutations())
-        return res;
+    std::lock_guard lock(state_mutex);
+    if (!MergeTreeData::IMutationsSnapshot::needCollectMutations(params))
+        return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot));
 
     for (const auto & [partition_id, mutations] : mutations_by_partition)
     {
-        auto & in_partition = res->mutations_by_partition[partition_id];
+        const int64_t min_part_data_version = MergeTreeData::IMutationsSnapshot::getMinPartDataVersionForPartition(params, partition_id);
 
-        bool seen_all_data_mutations = !res->hasDataMutations() && !res->hasAlterMutations();
-        bool seen_all_metadata_mutations = !res->hasMetadataMutations();
+        bool seen_all_data_mutations = !params.need_data_mutations && !params.need_alter_mutations;
+        bool seen_all_metadata_mutations = params.min_part_metadata_version >= params.metadata_version;
 
+        auto & partition_snapshot = mutations_snapshot[partition_id];
         for (const auto & [mutation_version, status] : mutations | std::views::reverse)
         {
             if (seen_all_data_mutations && seen_all_metadata_mutations)
                 break;
 
             auto alter_version = status->entry->alter_version;
-
             if (alter_version != -1)
             {
                 if (seen_all_metadata_mutations || alter_version > params.metadata_version)
@@ -2053,8 +2059,11 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
                 {
                     /// Copy a pointer to the whole entry to avoid extracting and copying commands.
                     /// Required commands will be copied later only for specific parts.
-                    if (res->hasSupportedCommands(status->entry->commands))
-                        in_partition.emplace(mutation_version, status->entry);
+                    if (MergeTreeData::IMutationsSnapshot::needIncludeMutationToSnapshot(params, status->entry->commands))
+                    {
+                        partition_snapshot.emplace(mutation_version, status->entry);
+                        incrementMutationsCounters(mutations_snapshot_counters, status->entry->commands);
+                    }
                 }
                 else
                 {
@@ -2063,12 +2072,15 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
             }
             else if (!seen_all_data_mutations)
             {
-                if (!status->is_done)
+                if (mutation_version > min_part_data_version)
                 {
                     /// Copy a pointer to the whole entry to avoid extracting and copying commands.
                     /// Required commands will be copied later only for specific parts.
-                    if (res->hasSupportedCommands(status->entry->commands))
-                        in_partition.emplace(mutation_version, status->entry);
+                    if (MergeTreeData::IMutationsSnapshot::needIncludeMutationToSnapshot(params, status->entry->commands))
+                    {
+                        partition_snapshot.emplace(mutation_version, status->entry);
+                        incrementMutationsCounters(mutations_snapshot_counters, status->entry->commands);
+                    }
                 }
                 else
                 {
@@ -2078,7 +2090,7 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
         }
     }
 
-    return res;
+    return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot));
 }
 
 MutationCounters ReplicatedMergeTreeQueue::getMutationCounters() const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -424,18 +424,16 @@ public:
     struct MutationsSnapshot : public MergeTreeData::MutationsSnapshotBase
     {
     public:
-        MutationsSnapshot() = default;
-        MutationsSnapshot(Params params_, MutationCounters counters_) : MutationsSnapshotBase(std::move(params_), std::move(counters_)) {}
-
         using Params = MergeTreeData::IMutationsSnapshot::Params;
         using MutationsByPartititon = std::unordered_map<String, std::map<Int64, ReplicatedMergeTreeMutationEntryPtr>>;
-
         MutationsByPartititon mutations_by_partition;
 
-        MutationCommands getAlterMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const override;
+        MutationsSnapshot() = default;
+        MutationsSnapshot(Params params_, MutationCounters counters_, MutationsByPartititon mutations_by_partition_);
+
+        MutationCommands getOnFlyMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const override;
         std::shared_ptr<MergeTreeData::IMutationsSnapshot> cloneEmpty() const override { return std::make_shared<MutationsSnapshot>(); }
         NameSet getAllUpdatedColumns() const override;
-        bool hasMetadataMutations() const override { return params.min_part_metadata_version < params.metadata_version; }
     };
 
     /// Return mutation commands for part which could be not applied to

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2633,7 +2633,13 @@ void StorageMergeTree::attachRestoredParts(MutableDataPartsVector && parts)
     }
 }
 
-MutationCommands StorageMergeTree::MutationsSnapshot::getAlterMutationCommandsForPart(const DataPartPtr & part) const
+StorageMergeTree::MutationsSnapshot::MutationsSnapshot(Params params_, MutationCounters counters_, MutationsByVersion mutations_snapshot)
+    : MutationsSnapshotBase(std::move(params_), std::move(counters_))
+    , mutations_by_version(std::move(mutations_snapshot))
+{
+}
+
+MutationCommands StorageMergeTree::MutationsSnapshot::getOnFlyMutationCommandsForPart(const DataPartPtr & part) const
 {
     MutationCommands result;
     UInt64 part_data_version = part->info.getDataVersion();
@@ -2666,21 +2672,25 @@ NameSet StorageMergeTree::MutationsSnapshot::getAllUpdatedColumns() const
 
 MergeTreeData::MutationsSnapshotPtr StorageMergeTree::getMutationsSnapshot(const IMutationsSnapshot::Params & params) const
 {
-    std::lock_guard lock(currently_processing_in_background_mutex);
+    MutationCounters mutations_snapshot_counters;
+    MutationsSnapshot::MutationsByVersion mutations_snapshot;
 
-    auto res = std::make_shared<MutationsSnapshot>(params, mutation_counters);
-    if (!res->hasAnyMutations())
-        return res;
+    std::lock_guard lock(currently_processing_in_background_mutex);
+    if (!MergeTreeData::IMutationsSnapshot::needCollectMutations(params))
+        return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot));
 
     for (const auto & [version, entry] : current_mutations_by_version)
     {
         /// Copy a pointer to all commands to avoid extracting and copying them.
         /// Required commands will be copied later only for specific parts.
-        if (res->hasSupportedCommands(*entry.commands))
-            res->mutations_by_version.emplace(version, entry.commands);
+        if (MergeTreeData::IMutationsSnapshot::needIncludeMutationToSnapshot(params, *entry.commands))
+        {
+            mutations_snapshot.emplace(version, entry.commands);
+            incrementMutationsCounters(mutations_snapshot_counters, *entry.commands);
+        }
     }
 
-    return res;
+    return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot));
 }
 
 MutationCounters StorageMergeTree::getMutationCounters() const

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2676,7 +2676,7 @@ MergeTreeData::MutationsSnapshotPtr StorageMergeTree::getMutationsSnapshot(const
     MutationsSnapshot::MutationsByVersion mutations_snapshot;
 
     std::lock_guard lock(currently_processing_in_background_mutex);
-    if (!MergeTreeData::IMutationsSnapshot::needCollectMutations(params))
+    if (!params.need_data_mutations && !params.need_alter_mutations && mutation_counters.num_metadata <= 0)
         return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot));
 
     for (const auto & [version, entry] : current_mutations_by_version)

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -318,16 +318,15 @@ private:
 
     struct MutationsSnapshot : public MutationsSnapshotBase
     {
-        MutationsSnapshot() = default;
-        MutationsSnapshot(Params params_, MutationCounters counters_) : MutationsSnapshotBase(std::move(params_), std::move(counters_)) {}
-
         using MutationsByVersion = std::map<UInt64, std::shared_ptr<const MutationCommands>>;
         MutationsByVersion mutations_by_version;
 
-        MutationCommands getAlterMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const override;
+        MutationsSnapshot() = default;
+        MutationsSnapshot(Params params_, MutationCounters counters_, MutationsByVersion mutations_snapshot);
+
+        MutationCommands getOnFlyMutationCommandsForPart(const MergeTreeData::DataPartPtr & part) const override;
         std::shared_ptr<MergeTreeData::IMutationsSnapshot> cloneEmpty() const override { return std::make_shared<MutationsSnapshot>(); }
         NameSet getAllUpdatedColumns() const override;
-        bool hasMetadataMutations() const override { return counters.num_metadata > 0; }
     };
 
     class PartMutationBackoffPolicy


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now mutations snapshot will be built from the visible parts snapshot. Also mutation counters used in snapshot will be recalculated from the included mutations
