### PR TITLE
Fix filter conjuncts removal in StorageMerge

### DIFF
--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -1122,7 +1122,9 @@ bool hasUnknownColumn(const QueryTreeNodePtr & node, QueryTreeNodePtr table_expr
             {
                 auto * column_node = current->as<ColumnNode>();
                 auto source = column_node->getColumnSourceOrNull();
-                if (source && table_expression && !source->isEqual(*table_expression))
+                /// Column source can be nullptr if JOIN node was replaced with a table expression.
+                /// In that case column is not from the specified table expression.
+                if (source != table_expression)
                     return true;
                 break;
             }

--- a/src/Storages/transformQueryForExternalDatabaseAnalyzer.cpp
+++ b/src/Storages/transformQueryForExternalDatabaseAnalyzer.cpp
@@ -60,7 +60,8 @@ public:
 
 ASTPtr getASTForExternalDatabaseFromQueryTree(ContextPtr context, const QueryTreeNodePtr & query_tree, const QueryTreeNodePtr & table_expression)
 {
-    auto new_tree = query_tree->clone();
+    auto replacement_table_expression = table_expression->clone();
+    auto new_tree = query_tree->cloneAndReplace(table_expression, replacement_table_expression);
 
     PrepareForExternalDatabaseVisitor visitor;
     visitor.visit(new_tree);
@@ -71,9 +72,9 @@ ASTPtr getASTForExternalDatabaseFromQueryTree(ContextPtr context, const QueryTre
     if (const auto * join_node = join_tree->as<JoinNode>())
     {
         if (join_node->getKind() == JoinKind::Left)
-            allow_where = join_node->getLeftTableExpression()->isEqual(*table_expression);
+            allow_where = join_node->getLeftTableExpression()->isEqual(*replacement_table_expression);
         else if (join_node->getKind() == JoinKind::Right)
-            allow_where = join_node->getRightTableExpression()->isEqual(*table_expression);
+            allow_where = join_node->getRightTableExpression()->isEqual(*replacement_table_expression);
         else
             allow_where = (join_node->getKind() == JoinKind::Inner);
     }
@@ -83,9 +84,9 @@ ASTPtr getASTForExternalDatabaseFromQueryTree(ContextPtr context, const QueryTre
     if (allow_where)
     {
         if (query_node->hasPrewhere())
-            removeExpressionsThatDoNotDependOnTableIdentifiers(query_node->getPrewhere(), table_expression, context);
+            removeExpressionsThatDoNotDependOnTableIdentifiers(query_node->getPrewhere(), replacement_table_expression, context);
         if (query_node->hasWhere())
-            removeExpressionsThatDoNotDependOnTableIdentifiers(query_node->getWhere(), table_expression, context);
+            removeExpressionsThatDoNotDependOnTableIdentifiers(query_node->getWhere(), replacement_table_expression, context);
     }
 
     auto query_node_ast = query_node->toAST({ .add_cast_for_constants = false, .fully_qualified_identifiers = false });

--- a/tests/queries/0_stateless/03549_analyzer_fix_filter_removal.sql
+++ b/tests/queries/0_stateless/03549_analyzer_fix_filter_removal.sql
@@ -1,3 +1,5 @@
+SET allow_experimental_analyzer = 1;
+
 CREATE TABLE m (`key` UInt32) ENGINE = Merge(currentDatabase(), 'a');
 CREATE TABLE b (`key` UInt32, `ID` UInt32) ENGINE = MergeTree ORDER BY key;
 

--- a/tests/queries/0_stateless/03549_analyzer_fix_filter_removal.sql
+++ b/tests/queries/0_stateless/03549_analyzer_fix_filter_removal.sql
@@ -1,0 +1,6 @@
+CREATE TABLE m (`key` UInt32) ENGINE = Merge(currentDatabase(), 'a');
+CREATE TABLE b (`key` UInt32, `ID` UInt32) ENGINE = MergeTree ORDER BY key;
+
+CREATE TABLE a1 (`day` Date, `id` UInt32) ENGINE = Distributed('test_cluster_two_shards', currentDatabase(), a1_replicated, id);
+
+SELECT * FROM m INNER JOIN b USING (key) WHERE ID = 1; -- { serverError UNKNOWN_TABLE }

--- a/tests/queries/0_stateless/03549_analyzer_fix_filter_removal.sql
+++ b/tests/queries/0_stateless/03549_analyzer_fix_filter_removal.sql
@@ -3,4 +3,4 @@ CREATE TABLE b (`key` UInt32, `ID` UInt32) ENGINE = MergeTree ORDER BY key;
 
 CREATE TABLE a1 (`day` Date, `id` UInt32) ENGINE = Distributed('test_cluster_two_shards', currentDatabase(), a1_replicated, id);
 
-SELECT * FROM m INNER JOIN b USING (key) WHERE ID = 1; -- { serverError UNKNOWN_TABLE }
+SELECT * FROM m INNER JOIN b USING (key) WHERE ID = 1; -- { serverError UNKNOWN_TABLE, ALL_CONNECTION_TRIES_FAILED }


### PR DESCRIPTION
### Changelog category (leave one):

- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix filter modification for queries with a JOIN expression with a table with storage `Merge`. Fixes https://github.com/ClickHouse/ClickHouse/issues/82092

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
