### PR TITLE
Fix system.filesystem_read_prefetches_log (fix types mismatch and add support for local reads)

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
@@ -333,9 +333,7 @@ off_t AsynchronousBoundedReadBuffer::seek(off_t offset, int whence)
         {
             ProfileEvents::increment(ProfileEvents::RemoteFSCancelledPrefetches);
             if (read_settings.enable_filesystem_read_prefetches_log)
-            {
                 appendToPrefetchLog(FilesystemPrefetchState::CANCELLED_WITH_SEEK, -1, nullptr);
-            }
         }
 
         break;

--- a/src/Disks/IO/createReadBufferFromFileBase.cpp
+++ b/src/Disks/IO/createReadBufferFromFileBase.cpp
@@ -72,6 +72,11 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
         }
     }
 
+    auto get_prefetches_log = [&]()
+    {
+        return settings.enable_filesystem_read_prefetches_log ? Context::getGlobalContextInstance()->getFilesystemReadPrefetchesLog() : nullptr;
+    };
+
     auto create = [&](size_t buffer_size, size_t buffer_alignment, int actual_flags)
     {
         std::unique_ptr<ReadBufferFromFileBase> res;
@@ -111,7 +116,8 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
                 existing_memory,
                 buffer_alignment,
                 file_size,
-                settings.local_throttler);
+                settings.local_throttler,
+                get_prefetches_log());
 #else
             throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Read method io_uring is only supported in Linux");
 #endif
@@ -128,7 +134,8 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
                 existing_memory,
                 buffer_alignment,
                 file_size,
-                settings.local_throttler);
+                settings.local_throttler,
+                get_prefetches_log());
         }
         else if (settings.local_fs_method == LocalFSReadMethod::pread_threadpool)
         {
@@ -142,7 +149,8 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
                 existing_memory,
                 buffer_alignment,
                 file_size,
-                settings.local_throttler);
+                settings.local_throttler,
+                get_prefetches_log());
         }
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown read method");

--- a/src/IO/AsynchronousReadBufferFromFile.h
+++ b/src/IO/AsynchronousReadBufferFromFile.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/IThrottler.h>
+#include <Interpreters/FilesystemReadPrefetchesLog.h>
 #include <IO/AsynchronousReadBufferFromFileDescriptor.h>
 #include <IO/OpenedFileCache.h>
 
@@ -67,8 +68,9 @@ public:
         char * existing_memory = nullptr,
         size_t alignment = 0,
         std::optional<size_t> file_size_ = std::nullopt,
-        ThrottlerPtr throttler_ = {})
-        : AsynchronousReadBufferFromFileDescriptor(reader_, priority_, -1, buf_size, existing_memory, alignment, file_size_, throttler_)
+        ThrottlerPtr throttler_ = {},
+        FilesystemReadPrefetchesLogPtr prefetches_log_ = nullptr)
+        : AsynchronousReadBufferFromFileDescriptor(reader_, priority_, -1, buf_size, existing_memory, alignment, file_size_, throttler_, prefetches_log_)
         , file_name(file_name_)
     {
         file = OpenedFileCache::instance().get(file_name, flags);

--- a/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp
+++ b/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp
@@ -1,5 +1,6 @@
 #include <ctime>
 #include <optional>
+#include <Common/CurrentThread.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/Exception.h>
@@ -7,8 +8,10 @@
 #include <Common/Throttler.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
+#include <Common/getRandomASCIIString.h>
 #include <IO/AsynchronousReadBufferFromFileDescriptor.h>
 #include <IO/WriteHelpers.h>
+#include <base/getThreadId.h>
 
 
 namespace ProfileEvents
@@ -65,9 +68,33 @@ void AsynchronousReadBufferFromFileDescriptor::prefetch(Priority priority)
     if (prefetch_future.valid())
         return;
 
+    last_prefetch_info.submit_time = std::chrono::system_clock::now();
+    last_prefetch_info.priority = priority;
+
     /// Will request the same amount of data that is read in nextImpl.
     prefetch_buffer.resize(internal_buffer.size());
     prefetch_future = asyncReadInto(prefetch_buffer.data(), prefetch_buffer.size(), priority);
+}
+
+
+void AsynchronousReadBufferFromFileDescriptor::appendToPrefetchLog(FilesystemPrefetchState state, int64_t size, const std::unique_ptr<Stopwatch> & execution_watch)
+{
+    FilesystemReadPrefetchesLogElement elem
+    {
+        .event_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()),
+        .query_id = query_id,
+        .path = getFileName(),
+        .offset = file_offset_of_buffer_end,
+        .size = size,
+        .prefetch_submit_time = last_prefetch_info.submit_time,
+        .execution_watch = execution_watch ? std::optional<Stopwatch>(*execution_watch) : std::nullopt,
+        .priority = last_prefetch_info.priority,
+        .state = state,
+        .thread_id = getThreadId(),
+        .reader_id = current_reader_id,
+    };
+
+    prefetches_log->add(std::move(elem));
 }
 
 
@@ -88,6 +115,9 @@ bool AsynchronousReadBufferFromFileDescriptor::nextImpl()
         prefetch_future = {};
         if (result.size - result.offset > 0)
             prefetch_buffer.swap(memory);
+
+        if (prefetches_log)
+            appendToPrefetchLog(FilesystemPrefetchState::USED, result.size, result.execution_watch);
     }
     else
     {
@@ -122,6 +152,7 @@ void AsynchronousReadBufferFromFileDescriptor::finalize()
     {
         prefetch_future.wait();
         prefetch_future = {};
+        last_prefetch_info = {};
     }
 }
 
@@ -134,13 +165,17 @@ AsynchronousReadBufferFromFileDescriptor::AsynchronousReadBufferFromFileDescript
     char * existing_memory,
     size_t alignment,
     std::optional<size_t> file_size_,
-    ThrottlerPtr throttler_)
+    ThrottlerPtr throttler_,
+    FilesystemReadPrefetchesLogPtr prefetches_log_)
     : ReadBufferFromFileBase(buf_size, existing_memory, alignment, file_size_)
     , reader(reader_)
     , base_priority(priority_)
     , required_alignment(alignment)
     , fd(fd_)
     , throttler(throttler_)
+    , query_id(CurrentThread::isInitialized() && CurrentThread::get().getQueryContext() != nullptr ? CurrentThread::getQueryId() : "")
+    , current_reader_id(getRandomASCIIString(8))
+    , prefetches_log(prefetches_log_)
 {
     if (required_alignment > buf_size)
         throw Exception(
@@ -180,6 +215,7 @@ off_t AsynchronousReadBufferFromFileDescriptor::seek(off_t offset, int whence)
     if (new_pos + (working_buffer.end() - pos) == file_offset_of_buffer_end)
         return new_pos;
 
+    bool read_from_prefetch = false;
     while (true)
     {
         if (file_offset_of_buffer_end - working_buffer.size() <= new_pos && new_pos <= file_offset_of_buffer_end)
@@ -195,9 +231,18 @@ off_t AsynchronousReadBufferFromFileDescriptor::seek(off_t offset, int whence)
         }
         if (prefetch_future.valid())
         {
+            read_from_prefetch = true;
+
             /// Read from prefetch buffer and recheck if the new position is valid inside.
             if (nextImpl())
                 continue;
+        }
+
+        /// Prefetch is cancelled because of seek.
+        if (read_from_prefetch)
+        {
+            if (prefetches_log)
+                appendToPrefetchLog(FilesystemPrefetchState::CANCELLED_WITH_SEEK, -1, nullptr);
         }
 
         break;

--- a/src/IO/AsynchronousReadBufferFromFileDescriptor.h
+++ b/src/IO/AsynchronousReadBufferFromFileDescriptor.h
@@ -2,6 +2,7 @@
 
 #include <IO/ReadBufferFromFileBase.h>
 #include <IO/AsynchronousReader.h>
+#include <Interpreters/FilesystemReadPrefetchesLog.h>
 #include <Common/IThrottler.h>
 #include <Common/Priority.h>
 
@@ -45,7 +46,8 @@ public:
         char * existing_memory = nullptr,
         size_t alignment = 0,
         std::optional<size_t> file_size_ = std::nullopt,
-        ThrottlerPtr throttler_ = {});
+        ThrottlerPtr throttler_ = {},
+        FilesystemReadPrefetchesLogPtr prefetches_log_ = nullptr);
 
     ~AsynchronousReadBufferFromFileDescriptor() override;
 
@@ -73,6 +75,20 @@ public:
 
 private:
     std::future<IAsynchronousReader::Result> asyncReadInto(char * data, size_t size, Priority priority);
+
+    const std::string query_id;
+    const std::string current_reader_id;
+
+    struct LastPrefetchInfo
+    {
+        std::chrono::system_clock::time_point submit_time;
+        Priority priority;
+    };
+    LastPrefetchInfo last_prefetch_info;
+
+    FilesystemReadPrefetchesLogPtr prefetches_log;
+
+    void appendToPrefetchLog(FilesystemPrefetchState state, int64_t size, const std::unique_ptr<Stopwatch> & execution_watch);
 };
 
 }

--- a/src/Interpreters/FilesystemReadPrefetchesLog.cpp
+++ b/src/Interpreters/FilesystemReadPrefetchesLog.cpp
@@ -45,12 +45,12 @@ void FilesystemReadPrefetchesLogElement::appendToBlock(MutableColumns & columns)
     columns[i++]->insert(path);
     columns[i++]->insert(offset);
     columns[i++]->insert(size);
-    columns[i++]->insert(std::chrono::duration_cast<std::chrono::microseconds>(prefetch_submit_time.time_since_epoch()).count());
+    columns[i++]->insert(Decimal64(std::chrono::duration_cast<std::chrono::microseconds>(prefetch_submit_time.time_since_epoch()).count()));
     columns[i++]->insert(priority.value);
     if (execution_watch)
     {
-        columns[i++]->insert(execution_watch->getStart() / 1000);
-        columns[i++]->insert(execution_watch->getEnd() / 1000);
+        columns[i++]->insert(Decimal64(execution_watch->getStart() / 1000));
+        columns[i++]->insert(Decimal64(execution_watch->getEnd() / 1000));
         columns[i++]->insert(execution_watch->elapsedMicroseconds());
     }
     else

--- a/tests/config/config.d/filesystem_read_prefetches_log.yaml
+++ b/tests/config/config.d/filesystem_read_prefetches_log.yaml
@@ -1,0 +1,1 @@
+filesystem_read_prefetches_log: {}

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -114,6 +114,7 @@ ln -sf $SRC_PATH/config.d/logger_trace.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/named_collection.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/ssl_certs.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/filesystem_cache_log.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/filesystem_read_prefetches_log.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/session_log.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/system_unfreeze.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/enable_zero_copy_replication.xml $DEST_SERVER_PATH/config.d/

--- a/tests/queries/0_stateless/03552_filesystem_read_prefetches_log.reference
+++ b/tests/queries/0_stateless/03552_filesystem_read_prefetches_log.reference
@@ -1,0 +1,2 @@
+default	1
+s3_disk	1

--- a/tests/queries/0_stateless/03552_filesystem_read_prefetches_log.sql.j2
+++ b/tests/queries/0_stateless/03552_filesystem_read_prefetches_log.sql.j2
@@ -1,0 +1,17 @@
+-- Tags: no-fasttest, no-random-settings
+-- - no-fasttest -- requires S3
+-- - no-random-settings -- prefetch is non deterministic
+
+drop table if exists test;
+
+{% for disk in ['default', 's3_disk'] %}
+-- Need wide parts to enable prefetch
+create table test (key Int) engine=MergeTree() order by () settings min_bytes_for_wide_part=0, disk = '{{ disk }}';
+-- Need at least 2 parts
+insert into test values (1);
+insert into test values (2);
+select * from test settings local_filesystem_read_prefetch=1, enable_filesystem_read_prefetches_log=1, allow_prefetched_read_pool_for_local_filesystem=1, local_filesystem_read_method='pread_threadpool' format Null settings log_comment = '{{ disk }}';
+system flush logs filesystem_read_prefetches_log, query_log;
+with (select query_id from system.query_log where current_database = currentDatabase() and log_comment = '{{ disk }}' and type != 'QueryStart') as query_id_ select '{{ disk }}', count()>0 from system.filesystem_read_prefetches_log where query_id = query_id_;
+drop table test;
+{% endfor %}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It does not work due to incorrect types in the table definition and in the block, also add system.filesystem_read_prefetches_log for local reads and add a test.