### PR TITLE
Fix 03254_timeseries_to_grid_aggregate_function with PR

### DIFF
--- a/tests/queries/0_stateless/03254_timeseries_to_grid_aggregate_function.sql
+++ b/tests/queries/0_stateless/03254_timeseries_to_grid_aggregate_function.sql
@@ -94,7 +94,7 @@ CREATE TABLE ts_data_agg(k UInt64, agg AggregateFunction(timeSeriesResampleToGri
 -- Insert the data splitting it into several pieces
 INSERT INTO ts_data_agg SELECT toUnixTimestamp(timestamp)%3, initializeAggregation('timeSeriesResampleToGridWithStalenessState(100, 200, 10, 15)', timestamp, value) FROM ts_data;
 
-SELECT k, finalizeAggregation(agg) FROM ts_data_agg ORDER BY k;
+SELECT k, finalizeAggregation(agg) FROM ts_data_agg FINAL ORDER BY k;
 
 -- Check that -Merge returns the same result as the result form original table
 SELECT timeSeriesResampleToGridWithStaleness(100, 200, 10, 15)(timestamp, value) FROM ts_data;


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=25f1e120baed0dda00234fa93499101491c08bf5&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%29

Become flaky after https://github.com/ClickHouse/ClickHouse/pull/80425 since parallel distributed insert select with PR can produce more parts with simple select

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)