### PR TITLE
CI: silence and add debug information for incorrect parsing of test reports

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -82,6 +82,14 @@ class FTResultsProcessor:
                 ):
                     test_name = line.split(" ")[2].split(":")[0]
 
+                    if test_name == "+":
+                        # TODO: investigate and remove
+                        # https://github.com/ClickHouse/ClickHouse/issues/81888
+                        print(
+                            f"ERROR: incorrect test name: {test_name} in line:\n{line}"
+                        )
+                        continue
+
                     test_time = ""
                     try:
                         time_token = line.split("]")[1].strip().split()[0]
@@ -133,7 +141,7 @@ class FTResultsProcessor:
                     )
                 )
             except Exception as e:
-                print(f"ERROR: Failed to parse test results: [{test}]")
+                print(f"ERROR: Failed to parse test results: {test}")
                 traceback.print_exc()
                 self.debug_files.append(self.tests_output_file)
                 if test[0] == "+":


### PR DESCRIPTION
Silence and add debug information for incorrect parsing of test reports

Report:https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=82998&sha=6cc72cc272a7d46ced5ae6c64b7fd24aa4d6965c&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+ParallelReplicas%2C+s3+storage%29&name_2=Tests
Error in log: `ERROR: Failed to parse test results: [('+', 'OK', '', [])]`


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
