### PR TITLE
CI: Remove dependencies between ARM and AMD tidy build checks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -205,6 +205,44 @@ jobs:
             python3 -m praktika run 'Build (amd_tidy)' --workflow "MasterCI" --ci |& tee ./ci/tmp/job.log
           fi
 
+  build_arm_tidy:
+    runs-on: [self-hosted, builder-aarch64]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
+    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV90aWR5KQ==') }}
+    name: "Build (arm_tidy)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
+          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+          cat > ./ci/tmp/workflow_config_masterci.json << 'EOF'
+          ${{ needs.config_workflow.outputs.data }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          if command -v ts &> /dev/null; then
+            python3 -m praktika run 'Build (arm_tidy)' --workflow "MasterCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
+          else
+            python3 -m praktika run 'Build (arm_tidy)' --workflow "MasterCI" --ci |& tee ./ci/tmp/job.log
+          fi
+
   build_amd_debug:
     runs-on: [self-hosted, builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -285,7 +285,7 @@ jobs:
 
   build_arm_tidy:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV90aWR5KQ==') }}
     name: "Build (arm_tidy)"
     outputs:
@@ -323,7 +323,7 @@ jobs:
 
   build_amd_debug:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
     outputs:
@@ -361,7 +361,7 @@ jobs:
 
   build_amd_release:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
     outputs:
@@ -399,7 +399,7 @@ jobs:
 
   build_amd_asan:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
     outputs:
@@ -437,7 +437,7 @@ jobs:
 
   build_amd_tsan:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
     outputs:
@@ -475,7 +475,7 @@ jobs:
 
   build_amd_msan:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
     outputs:
@@ -513,7 +513,7 @@ jobs:
 
   build_amd_ubsan:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
     outputs:
@@ -551,7 +551,7 @@ jobs:
 
   build_amd_binary:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
     outputs:
@@ -589,7 +589,7 @@ jobs:
 
   build_arm_release:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"
     outputs:
@@ -627,7 +627,7 @@ jobs:
 
   build_arm_asan:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV9hc2FuKQ==') }}
     name: "Build (arm_asan)"
     outputs:
@@ -665,7 +665,7 @@ jobs:
 
   build_arm_coverage:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV9jb3ZlcmFnZSk=') }}
     name: "Build (arm_coverage)"
     outputs:
@@ -703,7 +703,7 @@ jobs:
 
   build_arm_binary:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, style_check, fast_test, build_amd_tidy, build_arm_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
     outputs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -247,7 +247,7 @@ jobs:
 
   build_amd_tidy:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF90aWR5KQ==') }}
     name: "Build (amd_tidy)"
     outputs:
@@ -285,7 +285,7 @@ jobs:
 
   build_arm_tidy:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_arm]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, build_amd_tidy]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV90aWR5KQ==') }}
     name: "Build (arm_tidy)"
     outputs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -247,7 +247,7 @@ jobs:
 
   build_amd_tidy:
     runs-on: [self-hosted, builder]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm]
+    needs: [config_workflow, dockers_build_amd]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFtZF90aWR5KQ==') }}
     name: "Build (amd_tidy)"
     outputs:
@@ -285,7 +285,7 @@ jobs:
 
   build_arm_tidy:
     runs-on: [self-hosted, builder-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, build_amd_tidy]
+    needs: [config_workflow, dockers_build_arm]
     if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'QnVpbGQgKGFybV90aWR5KQ==') }}
     name: "Build (arm_tidy)"
     outputs:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -81,44 +81,15 @@ class JobConfigs:
         command='python3 ./ci/jobs/build_clickhouse.py --build-type "{PARAMETER}"',
         run_in_docker="clickhouse/binary-builder+--network=host",
         timeout=3600 * 4,
-        digest_config=Job.CacheDigestConfig(
-            include_paths=[
-                "./src",
-                "./contrib/",
-                "./CMakeLists.txt",
-                "./PreLoad.cmake",
-                "./cmake",
-                "./base",
-                "./programs",
-                "./rust",
-                "./ci/jobs/build_clickhouse.py",
-            ],
-            with_git_submodules=True,
-        ),
-    ).parametrize(
-        parameter=[
-            BuildTypes.AMD_TIDY,
-        ],
-        provides=[[]],  # [ArtifactNames.CH_TIDY_BIN],
-        runs_on=[
-            RunnerLabels.BUILDER_AMD,
-        ],
-    )
-    tidy_arm_build_jobs = Job.Config(
-        name=JobNames.BUILD,
-        runs_on=[],  # from parametrize()
-        requires=["Build (amd_tidy)"],
-        command='python3 ./ci/jobs/build_clickhouse.py --build-type "{PARAMETER}"',
-        # --network=host required for ec2 metadata http endpoint to work
-        run_in_docker="clickhouse/binary-builder+--network=host",
-        timeout=3600 * 4,
-        allow_merge_on_failure=True,
         digest_config=build_digest_config,
     ).parametrize(
         parameter=[
+            BuildTypes.AMD_TIDY,
             BuildTypes.ARM_TIDY,
         ],
+        provides=[[], []],
         runs_on=[
+            RunnerLabels.BUILDER_AMD,
             RunnerLabels.BUILDER_ARM,
         ],
     )

--- a/ci/docker/integration/runner/requirements.txt
+++ b/ci/docker/integration/runner/requirements.txt
@@ -65,7 +65,7 @@ paramiko==3.4.0
 pika==1.2.0
 pip==25.0.1
 pluggy==1.5.0
-protobuf==4.25.2
+protobuf==4.25.8
 psycopg-binary==3.2.4
 psycopg2-binary==2.9.6
 psycopg==3.2.4

--- a/ci/docker/stateless-test/requirements.txt
+++ b/ci/docker/stateless-test/requirements.txt
@@ -5,7 +5,7 @@ pandas==1.5.3
 scipy==1.12.0
 pyarrow==18.0.0
 grpcio==1.60.0
-protobuf==4.25.3
+protobuf==4.25.8
 
 # performance tests >>
 clickhouse_driver

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -19,13 +19,12 @@ workflow = Workflow.Config(
         JobConfigs.docs_job,
         JobConfigs.fast_test,
         *JobConfigs.tidy_build_jobs,
-        *JobConfigs.tidy_arm_build_jobs,
         *[
             job.set_dependency(
                 [
                     JobNames.STYLE_CHECK,
                     JobNames.FAST_TEST,
-                    JobConfigs.tidy_build_jobs[0].name,
+                    *[j.name for j in JobConfigs.tidy_build_jobs],
                 ]
             )
             for job in JobConfigs.build_jobs


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
CI: Remove dependencies between ARM and AMD tidy build checks

It does not make sense for the ARM tidy check to wait for the AMD tidy check (specially when they are slow because many file changed), or to wait for the build of AMD docker images.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
