### PR TITLE
clickhouse-client - log a summary of unknown settings

### DIFF
--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -45,7 +45,7 @@ struct BaseSettingsHelpers
     static UInt64 readFlags(ReadBuffer & in);
 private:
     /// For logging the summary of unknown settings instead of logging each one separately.
-    inline static thread_local std::vector<std::string> unknown_settings;
+    inline static thread_local Strings unknown_settings;
     inline static thread_local bool unknown_settings_warning_logged = false;
 
 };

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -27,6 +27,7 @@ struct BaseSettingsHelpers
 {
     [[noreturn]] static void throwSettingNotFound(std::string_view name);
     static void warningSettingNotFound(std::string_view name);
+    static void flushWarnings();
 
     static void writeString(std::string_view str, WriteBuffer & out);
     static String readString(ReadBuffer & in);
@@ -42,6 +43,11 @@ struct BaseSettingsHelpers
     static SettingsTierType getTier(UInt64 flags);
     static void writeFlags(Flags flags, WriteBuffer & out);
     static UInt64 readFlags(ReadBuffer & in);
+private:
+    /// For logging the summary of unknown settings instead of logging each one separately.
+    inline static thread_local std::vector<std::string> unknown_settings;
+    inline static thread_local bool unknown_settings_warning_logged = false;
+
 };
 
 /** Template class to define collections of settings.
@@ -578,6 +584,7 @@ void BaseSettings<TTraits>::read(ReadBuffer & in, SettingsWriteFormat format)
             BaseSettingsHelpers::readString(in);
         }
     }
+    BaseSettingsHelpers::flushWarnings();
 }
 
 template <typename TTraits>


### PR DESCRIPTION
Consolidate unknown settings warnings in clickhouse client and log them as a summary.

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Consolidate unknown settings warnings in clickhouse client and log them as a summary.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
