### PR TITLE
Fix misleading `not enough space` error message when restoring a backup on a read-only disk

### DIFF
--- a/src/Disks/IStoragePolicy.h
+++ b/src/Disks/IStoragePolicy.h
@@ -2,10 +2,13 @@
 
 #include <Disks/DiskType.h>
 
+#include <expected>
 #include <memory>
-#include <vector>
 #include <optional>
+#include <vector>
 #include <base/types.h>
+
+#include <Common/LoggingFormatStringHelpers.h>
 
 namespace DB
 {
@@ -20,6 +23,19 @@ using Disks = std::vector<DiskPtr>;
 class IReservation;
 using ReservationSharedPtr = std::shared_ptr<IReservation>;
 using ReservationPtr = std::unique_ptr<IReservation>;
+struct ReservationError
+{
+    int code;
+    PreformattedMessage message;
+
+    template <typename... Args>
+    ReservationError(int code_, FormatStringHelper<Args...> formatter, Args &&... args)
+        : code(code_)
+        , message(formatter.format(std::forward<Args>(args)...))
+    {
+    }
+};
+using ReservationPtrOrError = std::expected<ReservationPtr, ReservationError>;
 using Reservations = std::vector<ReservationPtr>;
 
 using String = std::string;
@@ -44,10 +60,10 @@ public:
     DiskPtr getDiskByName(const String & disk_name) const;
     /// Get free space from most free disk
     virtual UInt64 getMaxUnreservedFreeSpace() const = 0;
-    /// Reserves space on any volume with index > min_volume_index or returns nullptr
-    virtual ReservationPtr reserve(UInt64 bytes, size_t min_volume_index) const = 0;
-    /// Returns valid reservation or nullptr
-    virtual ReservationPtr reserve(UInt64 bytes) const = 0;
+    /// Reserves space on any volume with index > min_volume_index or returns error
+    virtual ReservationPtrOrError reserve(UInt64 bytes, size_t min_volume_index) const = 0;
+    /// Returns valid reservation or error
+    virtual ReservationPtrOrError reserve(UInt64 bytes) const = 0;
     /// Reserves space on any volume or throws
     virtual ReservationPtr reserveAndCheck(UInt64 bytes) const = 0;
     /// Reserves 0 bytes on disk with max available space

--- a/src/Disks/IVolume.cpp
+++ b/src/Disks/IVolume.cpp
@@ -64,4 +64,8 @@ std::optional<UInt64> IVolume::getMaxUnreservedFreeSpace() const
     return res;
 }
 
+bool IVolume::isReadOnly() const
+{
+    return std::all_of(disks.begin(), disks.end(), [](const auto & disk) { return disk->isReadOnly(); });
+}
 }

--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -81,6 +81,9 @@ public:
     Disks & getDisks() { return disks; }
     const Disks & getDisks() const { return disks; }
 
+    /// Returns true if all disks are readonly.
+    virtual bool isReadOnly() const;
+
     /// Returns effective value of whether merges are allowed on this volume (false) or not (true).
     virtual bool areMergesAvoided() const { return false; }
 

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -12,6 +12,7 @@
 #include <Disks/VolumeJBOD.h>
 
 #include <algorithm>
+#include <exception>
 #include <ranges>
 #include <set>
 
@@ -36,6 +37,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_VOLUME;
     extern const int LOGICAL_ERROR;
     extern const int NOT_ENOUGH_SPACE;
+    extern const int READONLY;
 }
 
 
@@ -252,22 +254,30 @@ UInt64 StoragePolicy::getMaxUnreservedFreeSpace() const
 }
 
 
-ReservationPtr StoragePolicy::reserve(UInt64 bytes, size_t min_volume_index) const
+ReservationPtrOrError StoragePolicy::reserve(UInt64 bytes, size_t min_volume_index) const
 {
+    bool all_volumes_read_only = true;
     for (size_t i = min_volume_index; i < volumes.size(); ++i)
     {
         const auto & volume = volumes[i];
+        if (volume->isReadOnly())
+            continue;
+        all_volumes_read_only = false;
         auto reservation = volume->reserve(bytes);
         if (reservation)
             return reservation;
     }
-    LOG_TRACE(log, "Could not reserve {} from volume index {}, total volumes {}", ReadableSize(bytes), min_volume_index, volumes.size());
 
-    return {};
+    if (all_volumes_read_only)
+        return std::unexpected(
+            ReservationError(ErrorCodes::READONLY, "Could not reserve {} because all disk volumes are readonly", ReadableSize(bytes)));
+
+    LOG_TRACE(log, "Could not reserve {} from volume index {}, total volumes {}", ReadableSize(bytes), min_volume_index, volumes.size());
+    return std::unexpected(ReservationError(ErrorCodes::NOT_ENOUGH_SPACE, "Cannot reserve {}, not enough space", ReadableSize(bytes)));
 }
 
 
-ReservationPtr StoragePolicy::reserve(UInt64 bytes) const
+ReservationPtrOrError StoragePolicy::reserve(UInt64 bytes) const
 {
     return reserve(bytes, 0);
 }
@@ -275,9 +285,11 @@ ReservationPtr StoragePolicy::reserve(UInt64 bytes) const
 
 ReservationPtr StoragePolicy::reserveAndCheck(UInt64 bytes) const
 {
-    if (auto res = reserve(bytes, 0))
-        return res;
-    throw Exception(ErrorCodes::NOT_ENOUGH_SPACE, "Cannot reserve {}, not enough space", ReadableSize(bytes));
+    auto res = reserve(bytes, 0);
+    if (res)
+        return std::move(res.value());
+
+    throw Exception(res.error().message, res.error().code);
 }
 
 

--- a/src/Disks/StoragePolicy.h
+++ b/src/Disks/StoragePolicy.h
@@ -53,13 +53,13 @@ public:
     const String & getName() const override{ return name; }
 
     /// Returns valid reservation or nullptr
-    ReservationPtr reserve(UInt64 bytes) const override;
+    ReservationPtrOrError reserve(UInt64 bytes) const override;
 
     /// Reserves space on any volume or throws
     ReservationPtr reserveAndCheck(UInt64 bytes) const override;
 
     /// Reserves space on any volume with index > min_volume_index or returns nullptr
-    ReservationPtr reserve(UInt64 bytes, size_t min_volume_index) const override;
+    ReservationPtrOrError reserve(UInt64 bytes, size_t min_volume_index) const override;
 
     /// Find volume index, which contains disk
     std::optional<size_t> tryGetVolumeIndexByDiskName(const String & disk_name) const override;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8077,13 +8077,16 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::cloneAn
     }
     else
     {
-        auto reservation_on_dst = getStoragePolicy()->reserve(src_part->getBytesOnDisk());
-        if (!reservation_on_dst)
-            throw Exception(ErrorCodes::NOT_ENOUGH_SPACE, "Not enough space on disk.");
+        auto reservation_on_dst_or_error = getStoragePolicy()->reserve(src_part->getBytesOnDisk());
+        if (!reservation_on_dst_or_error)
+        {
+            const auto & error = reservation_on_dst_or_error.error();
+            throw Exception(error.message, error.code);
+        }
         dst_part_storage = src_part_storage->freezeRemote(
             relative_data_path,
             tmp_dst_part_name,
-            /* dst_disk = */ (*reservation_on_dst)->getDisk(),
+            /* dst_disk = */ (*reservation_on_dst_or_error)->getDisk(),
             read_settings,
             write_settings,
             /* save_metadata_callback= */ {},

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7207,7 +7207,6 @@ ReservationPtr MergeTreeData::tryReserveSpacePreferringTTLRules(
     if (!reservation)
     {
         LOG_TRACE(log, "Trying to reserve {} using storage policy from min volume index {}", ReadableSize(expected_size), min_volume_index);
-        auto reservation_or_error = getStoragePolicy()->reserve(expected_size, min_volume_index);
         reservation = getStoragePolicy()->reserve(expected_size, min_volume_index).value_or(nullptr);
     }
 

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -198,7 +198,7 @@ bool MergeTreePartsMover::selectPartsForMove(
         auto min_volume_index = policy->getVolumeIndexByDiskName(move.first->getName()) + 1;
         for (auto && part : move.second.getAccumulatedParts())
         {
-            auto reservation = policy->reserve(part->getBytesOnDisk(), min_volume_index);
+            auto reservation = policy->reserve(part->getBytesOnDisk(), min_volume_index).value_or(nullptr);
             if (!reservation)
             {
                 /// Next parts to move from this disk has greater size and same min volume index.

--- a/tests/integration/helpers/s3_tools.py
+++ b/tests/integration/helpers/s3_tools.py
@@ -8,6 +8,8 @@ from minio import Minio
 
 
 class CloudUploader:
+    def __init__(self, use_relpath=False):
+        self.use_relpath = use_relpath
 
     def upload_directory(self, local_path, remote_blob_path, **kwargs):
         print(kwargs)
@@ -38,9 +40,9 @@ class CloudUploader:
 
 class S3Uploader(CloudUploader):
     def __init__(self, minio_client, bucket_name, use_relpath=False):
+        super().__init__(use_relpath=use_relpath)
         self.minio_client = minio_client
         self.bucket_name = bucket_name
-        self.use_relpath = use_relpath
 
     def upload_file(self, local_path, remote_blob_path, bucket=None):
         print(f"Upload to bucket: {bucket}")
@@ -56,6 +58,7 @@ class S3Uploader(CloudUploader):
 class LocalUploader(CloudUploader):
 
     def __init__(self, clickhouse_node):
+        super().__init__()
         self.clickhouse_node = clickhouse_node
 
     def upload_file(self, local_path, remote_blob_path):
@@ -74,6 +77,7 @@ class LocalUploader(CloudUploader):
 class AzureUploader(CloudUploader):
 
     def __init__(self, blob_service_client, container_name):
+        super().__init__()
         self.blob_service_client = blob_service_client
         self.container_client = self.blob_service_client.get_container_client(
             container_name

--- a/tests/integration/test_backup_restore_s3/configs/disk_s3.xml
+++ b/tests/integration/test_backup_restore_s3/configs/disk_s3.xml
@@ -20,6 +20,7 @@
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
+                <readonly>true</readonly>
             </disk_s3_plain>
             <disk_s3_plain_rewritable>
                 <type>s3_plain_rewritable</type>


### PR DESCRIPTION
Fixes: https://github.com/ClickHouse/clickhouse-private/issues/31429
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix misleading error message when restoring a backup on a read-only disk.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
