### PR TITLE
Make SECONDARY_QUERY lazy init StorageObjectStorage

### DIFF
--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -46,7 +46,8 @@ StoragePtr TableFunctionObjectStorageCluster<Definition, Configuration, is_data_
             /* mode */ LoadingStrictnessLevel::CREATE,
             /* distributed_processing */ true,
             /* partition_by_ */nullptr,
-            /* is_table_function */true);
+            /* is_table_function */true,
+            /*lazy_init*/ true);
     }
     else
     {

--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -47,7 +47,7 @@ StoragePtr TableFunctionObjectStorageCluster<Definition, Configuration, is_data_
             /* distributed_processing */ true,
             /* partition_by_ */nullptr,
             /* is_table_function */true,
-            /*lazy_init*/ true);
+            /* lazy_init */ true);
     }
     else
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

If we enable filesystem_caches in cluster mode, there is one situation, we can read all data from our local cache. IMO its better to do lazy init `StorageObjectStorage` for SECONDARY_QUERY. sometimes no need create remoteStorage.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Not for changelog (changelog entry is not required)
