### PR TITLE
Delete security warning about session_log in config.xml

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1329,10 +1329,7 @@
         <flush_on_crash>true</flush_on_crash>
     </crash_log>
 
-    <!-- Session log. Stores user log in (successful or not) and log out events.
-
-        Note: session log has known security issues and should not be used in production.
-    -->
+    <!-- Session log. Stores user log in (successful or not) and log out events. -->
     <!-- <session_log>
         <database>system</database>
         <table>session_log</table>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Removed security warning about `session_log` from `config.xml` because `session_log` is production-ready now. See [comment](https://github.com/ClickHouse/ClickHouse/issues/51760#issuecomment-3024504794)
