### PR TITLE
Docs: add a page for `DataLakeCatalog`

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -233,6 +233,7 @@ DESC
 DIEs
 DOGEFI
 Damerau
+Databricks
 DataGrip
 DataLens
 DataPacket
@@ -246,6 +247,7 @@ DatabaseOnDiskThreads
 DatabaseOnDiskThreadsActive
 DatabaseOrdinaryThreads
 DatabaseOrdinaryThreadsActive
+DataLakeCatalog
 DateTime
 DateTimeInputFormat
 DateTimeOutputFormat
@@ -718,6 +720,7 @@ NumberOfDetachedParts
 NumberOfTables
 NumericIndexedVector
 NumericIndexedVectors
+OAuth
 ODBCDriver
 OFNS
 OLAP

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -1,7 +1,6 @@
 ---
-description: ''
+description: 'The DataLakeCatalog database engine enables you to connect ClickHouse to external data catalogs and query open table format data'
 sidebar_label: 'DataLakeCatalog'
-sidebar_position: 60
 slug: /engines/database-engines/datalakecatalog
 title: 'DataLakeCatalog'
 ---

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -9,9 +9,9 @@ title: 'DataLakeCatalog'
 # DataLakeCatalog
 
 The `DataLakeCatalog` database engine enables you to connect ClickHouse to external
-data catalogs and query open table format data (Apache Iceberg, Delta Lake) without 
-the need for data duplication. This transforms ClickHouse into a powerful query 
-engine that works seamlessly with your existing data lake infrastructure.
+data catalogs and query open table format data without the need for data duplication.
+This transforms ClickHouse into a powerful query engine that works seamlessly with
+your existing data lake infrastructure.
 
 ## Supported Catalogs {#supported-catalogs}
 
@@ -36,7 +36,7 @@ SET allow_experimental_database_hms_catalog = 1;
 Databases with the `DataLakeCatalog` engine can be created using the following syntax:
 
 ```sql
-CREATE DATABASE <database_name>
+CREATE DATABASE database_name
 ENGINE = DataLakeCatalog(catalog_endpoint[, user, password])
 SETTINGS
 catalog_type
@@ -61,7 +61,7 @@ The following settings are supported:
 
 ## Examples {#examples}
 
-See below for examples of using the `DataLakeCatalog` engine:
+See below pages for examples of using the `DataLakeCatalog` engine:
 
 * [Unity Catalog](/use-cases/data-lake/unity-catalog)
 * [Glue Catalog](/use-cases/data-lake/glue-catalog)

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -39,7 +39,7 @@ Databases with the `DataLakeCatalog` engine can be created using the following s
 CREATE DATABASE database_name
 ENGINE = DataLakeCatalog(catalog_endpoint[, user, password])
 SETTINGS
-catalog_type
+catalog_type,
 [...]
 ```
 

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -44,19 +44,19 @@ catalog_type,
 
 The following settings are supported:
 
-| Setting                 | Description                                                                   |
-|-------------------------|-------------------------------------------------------------------------------|
-| `catalog_type`          | Type of catalog: `glue`, `unity` (Delta), `rest` (Iceberg), `hive`            |
-| `warehouse`             | The warehouse/database name to use in the catalog (e.g., 'demo', 'test')      |
-| `catalog_credential`    | Authentication credential for the catalog (e.g., API key or token)            |
-| `auth_header`           | Custom HTTP header for authentication with the catalog service                |
-| `auth_scope`            | OAuth2 scope for authentication (if using OAuth)                              |
-| `storage_endpoint`      | Endpoint URL for the underlying storage (e.g., 'http://minio:9000/warehouse') |
-| `oauth_server_uri`      | URI of the OAuth2 authorization server for authentication                     |
-| `vended_credentials`    | Boolean indicating whether to use vended credentials (AWS-specific)           |
-| `aws_access_key_id`     | AWS access key ID for S3/Glue access (if not using vended credentials)        |
-| `aws_secret_access_key` | AWS secret access key for S3/Glue access (if not using vended credentials)    |
-| `region`                | AWS region for the service (e.g., 'us-east-1')                                |
+| Setting                 | Description                                                               |
+|-------------------------|---------------------------------------------------------------------------|
+| `catalog_type`          | Type of catalog: `glue`, `unity` (Delta), `rest` (Iceberg), `hive`        |
+| `warehouse`             | The warehouse/database name to use in the catalog.                        |
+| `catalog_credential`    | Authentication credential for the catalog (e.g., API key or token)        |
+| `auth_header`           | Custom HTTP header for authentication with the catalog service            |
+| `auth_scope`            | OAuth2 scope for authentication (if using OAuth)                          |
+| `storage_endpoint`      | Endpoint URL for the underlying storage                                   |
+| `oauth_server_uri`      | URI of the OAuth2 authorization server for authentication                 |
+| `vended_credentials`    | Boolean indicating whether to use vended credentials (AWS-specific)       |
+| `aws_access_key_id`     | AWS access key ID for S3/Glue access (if not using vended credentials)    |
+| `aws_secret_access_key` | AWS secret access key for S3/Glue access (if not using vended credentials) |
+| `region`                | AWS region for the service (e.g., `us-east-1`)                             |
 
 ## Examples {#examples}
 

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -1,0 +1,67 @@
+---
+description: ''
+sidebar_label: 'DataLakeCatalog'
+sidebar_position: 60
+slug: /engines/database-engines/datalakecatalog
+title: 'DataLakeCatalog'
+---
+
+# DataLakeCatalog
+
+The `DataLakeCatalog` database engine enables you to connect ClickHouse to external
+data catalogs and query open table format data (Apache Iceberg, Delta Lake) without 
+the need for data duplication. This transforms ClickHouse into a powerful query 
+engine that works seamlessly with your existing data lake infrastructure.
+
+## Supported Catalogs {#supported-catalogs}
+
+The `DataLakeCatalog` engine supports the following data catalogs:
+
+- **AWS Glue Catalog** - For Iceberg tables in AWS environments
+- **Databricks Unity Catalog** - For Delta Lake and Iceberg tables
+- **Hive Metastore** - Traditional Hadoop ecosystem catalog
+- **REST Catalogs** - Any catalog supporting the Iceberg REST specification
+
+## Creating a Database {#creating-a-database}
+
+You will need to enable the relevant settings below to use the `DataLakeCatalog` engine:
+
+```sql
+SET allow_experimental_database_iceberg = 1;
+SET allow_experimental_database_unity_catalog = 1;
+SET allow_experimental_database_glue_catalog = 1;
+SET allow_experimental_database_hms_catalog = 1;
+```
+
+Databases with the `DataLakeCatalog` engine can be created using the following syntax:
+
+```sql
+CREATE DATABASE <database_name>
+ENGINE = DataLakeCatalog(catalog_endpoint[, user, password])
+SETTINGS
+catalog_type
+[...]
+```
+
+The following settings are supported:
+
+| Setting                 | Description                                                                   |
+|-------------------------|-------------------------------------------------------------------------------|
+| `catalog_type`          | Type of catalog: `glue`, `unity` (Delta), `rest` (Iceberg), `hive`            |
+| `warehouse`             | The warehouse/database name to use in the catalog (e.g., 'demo', 'test')      |
+| `catalog_credential`    | Authentication credential for the catalog (e.g., API key or token)            |
+| `auth_header`           | Custom HTTP header for authentication with the catalog service                |
+| `auth_scope`            | OAuth2 scope for authentication (if using OAuth)                              |
+| `storage_endpoint`      | Endpoint URL for the underlying storage (e.g., 'http://minio:9000/warehouse') |
+| `oauth_server_uri`      | URI of the OAuth2 authorization server for authentication                     |
+| `vended_credentials`    | Boolean indicating whether to use vended credentials (AWS-specific)           |
+| `aws_access_key_id`     | AWS access key ID for S3/Glue access (if not using vended credentials)        |
+| `aws_secret_access_key` | AWS secret access key for S3/Glue access (if not using vended credentials)    |
+| `region`                | AWS region for the service (e.g., 'us-east-1')                                |
+
+## Examples {#examples}
+
+See below for examples of using the `DataLakeCatalog` engine:
+
+* [Unity Catalog](/use-cases/data-lake/unity-catalog)
+* [Glue Catalog](/use-cases/data-lake/glue-catalog)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Adding a page for this, as we mention `DataLakeCatalog` in a blog post going out later today and need to link to something. It's quite basic at the moment but I will follow up with some more detail.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
