### PR TITLE
Cleanup Protocol code

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -606,6 +606,7 @@ void Connection::receiveHello(const Poco::Timespan & handshake_timeout)
             readVarUInt(server_query_plan_serialization_version, *in);
         }
 
+        server_cluster_function_protocol_version = DBMS_CLUSTER_INITIAL_PROCESSING_PROTOCOL_VERSION;
         if (server_revision >= DBMS_MIN_REVISION_WITH_VERSIONED_CLUSTER_FUNCTION_PROTOCOL)
         {
             readVarUInt(server_cluster_function_protocol_version, *in);

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -227,7 +227,7 @@ private:
     UInt64 server_version_patch = 0;
     UInt64 server_revision = 0;
     UInt64 server_parallel_replicas_protocol_version = 0;
-    UInt64 server_cluster_function_protocol_version = DBMS_CLUSTER_INITIAL_PROCESSING_PROTOCOL_VERSION;
+    UInt64 server_cluster_function_protocol_version = 0;
     UInt64 server_query_plan_serialization_version = 0;
     String server_timezone;
     String server_display_name;

--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -2,6 +2,7 @@
 #include <Common/quoteString.h>
 #include <Common/ProfileEvents.h>
 #include <Common/FailPoint.h>
+#include <Core/ProtocolDefines.h>
 #include <Core/Settings.h>
 
 namespace ProfileEvents

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -4,6 +4,7 @@
 #include <Client/HedgedConnections.h>
 #include <Common/ProfileEvents.h>
 #include <Core/Settings.h>
+#include <Core/ProtocolDefines.h>
 #include <Interpreters/ClientInfo.h>
 #include <Interpreters/Context.h>
 

--- a/src/Client/HedgedConnectionsFactory.cpp
+++ b/src/Client/HedgedConnectionsFactory.cpp
@@ -3,6 +3,7 @@
 #include <Client/HedgedConnectionsFactory.h>
 #include <Common/typeid_cast.h>
 #include <Common/ProfileEvents.h>
+#include <Core/ProtocolDefines.h>
 
 namespace ProfileEvents
 {

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -2,6 +2,7 @@
 
 #include <Common/thread_local_rng.h>
 #include <Core/Protocol.h>
+#include <Core/ProtocolDefines.h>
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <IO/ConnectionTimeouts.h>

--- a/src/Client/Suggest.h
+++ b/src/Client/Suggest.h
@@ -6,6 +6,7 @@
 #include <Client/IServerConnection.h>
 #include <Client/LocalConnection.h>
 #include <Client/LineReader.h>
+#include <Core/ProtocolDefines.h>
 #include <IO/ConnectionTimeouts.h>
 #include <atomic>
 #include <thread>

--- a/src/Core/Protocol.cpp
+++ b/src/Core/Protocol.cpp
@@ -1,0 +1,27 @@
+#include <Core/Protocol.h>
+#include <base/EnumReflection.h>
+
+namespace DB::Protocol
+{
+
+namespace Server
+{
+
+std::string_view toString(UInt64 packet)
+{
+    return magic_enum::enum_name(Enum(packet));
+}
+
+}
+
+namespace Client
+{
+
+std::string_view toString(UInt64 packet)
+{
+    return magic_enum::enum_name(Enum(packet));
+}
+
+}
+
+}

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <string_view>
 #include <base/types.h>
-#include <Core/ProtocolDefines.h>
 
 
 namespace DB
@@ -104,33 +104,7 @@ namespace Protocol
         /// would always be true because of compiler optimization. That would lead to out-of-bounds error
         /// if the packet is invalid.
         /// See https://www.securecoding.cert.org/confluence/display/cplusplus/INT36-CPP.+Do+not+use+out-of-range+enumeration+values
-        inline const char * toString(UInt64 packet)
-        {
-            static const char * data[] = {
-                "Hello",
-                "Data",
-                "Exception",
-                "Progress",
-                "Pong",
-                "EndOfStream",
-                "ProfileInfo",
-                "Totals",
-                "Extremes",
-                "TablesStatusResponse",
-                "Log",
-                "TableColumns",
-                "PartUUIDs",
-                "ReadTaskRequest",
-                "ProfileEvents",
-                "MergeTreeAllRangesAnnouncement",
-                "MergeTreeReadTaskRequest",
-                "TimezoneUpdate",
-                "SSHChallenge",
-            };
-            return packet <= MAX
-                ? data[packet]
-                : "Unknown packet";
-        }
+        std::string_view toString(UInt64 packet);
 
         inline size_t stringsInMessage(UInt64 msg_type)
         {
@@ -172,27 +146,7 @@ namespace Protocol
             MAX = QueryPlan,
         };
 
-        inline const char * toString(UInt64 packet)
-        {
-            static const char * data[] = {
-                "Hello",
-                "Query",
-                "Data",
-                "Cancel",
-                "Ping",
-                "TablesStatusRequest",
-                "KeepAlive",
-                "Scalar",
-                "IgnoredPartUUIDs",
-                "ReadTaskResponse",
-                "MergeTreeReadTaskResponse",
-                "SSHChallengeRequest",
-                "SSHChallengeResponse"
-            };
-            return packet <= MAX
-                ? data[packet]
-                : "Unknown packet";
-        }
+        std::string_view toString(UInt64 packet);
     }
 
     /// Whether the compression must be used.

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -73,6 +73,7 @@
 #endif
 
 #include <Core/Protocol.h>
+#include <Core/ProtocolDefines.h>
 #include <Storages/MergeTree/RequestResponse.h>
 #include <Interpreters/ClientInfo.h>
 

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -33,6 +33,7 @@
 #include <Common/logger_useful.h>
 #include <Common/scope_guard_safe.h>
 #include <Core/Settings.h>
+#include <Core/ProtocolDefines.h>
 
 #include <base/range.h>
 


### PR DESCRIPTION
### Changes
- Use magic_enum for toString to make them less error prone, they alreayd misses QueryPlan.
- Remove inclusing of ProtocolDefines.h into Protocol.h
- Cleanup dependencies

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)