### PR TITLE
Async log: Fix missing thread join

### DIFF
--- a/tests/queries/0_stateless/02116_clickhouse_stderr.sh
+++ b/tests/queries/0_stateless/02116_clickhouse_stderr.sh
@@ -22,7 +22,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
     cd "$test_dir" || exit 1
 
     stderr=$(mktemp -t clickhouse.XXXXXX)
-    $CLICKHOUSE_SERVER_BINARY -- --logger.stderr="$stderr" 2>/dev/null
+    # It will fail to start because the port is already in use
+    $CLICKHOUSE_SERVER_BINARY -- --listen_host "${CLICKHOUSE_HOST}" --tcp_port "$CLICKHOUSE_PORT_TCP" --logger.stderr="$stderr" 2>/dev/null
     # -s -- check that stderr was created and is not empty
     test -s "$stderr" || exit 2
     rm "$stderr"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Async log (unreleased): Fix missing thread join

It also does some minor changes to `tests/queries/0_stateless/02116_clickhouse_stderr.sh` so it fails in non-default configurations. It was really hard to understand what the test was relying on.

Closes https://github.com/ClickHouse/ClickHouse/issues/83063

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
