### PR TITLE
Enable zstd compression for FST blob

### DIFF
--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -389,17 +389,20 @@ GinIndexStore::Format GinIndexStore::writeSegment()
     current_segment.dict_start_offset += getLengthOfVarUInt(uncompressed_size);
 
     Format version = Format::v1;
-    if (uncompressed_size < FST_SIZE_COMPRESSION_THRESHOLD) {
+    if (uncompressed_size < FST_SIZE_COMPRESSION_THRESHOLD)
+    {
         /// Write FST uncompressed blob
         dict_file_stream->write(reinterpret_cast<char *>(buffer.data()), uncompressed_size);
         current_segment.dict_start_offset += uncompressed_size;
-    } else {
+    }
+    else
+    {
         version = Format::v2;
 
-        const auto& codec = GinIndexCompression::zstdCodec();
+        const auto & codec = GinIndexCompression::zstdCodec();
         Memory<> memory;
         memory.resize(codec->getCompressedReserveSize(static_cast<UInt32>(uncompressed_size)));
-        auto compressed_size = codec->compress(reinterpret_cast<char*>(buffer.data()), uncompressed_size, memory.data());
+        auto compressed_size = codec->compress(reinterpret_cast<char *>(buffer.data()), uncompressed_size, memory.data());
 
         /// Write FST compressed size
         writeVarUInt(compressed_size, *dict_file_stream);

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -158,7 +158,7 @@ public:
     UInt32 getNumOfSegments();
 
     /// Get version
-    uint8_t getVersion();
+    Format getVersion();
 
     /// Get current postings list builder
     const GinIndexPostingsBuilderContainer & getPostingsListBuilder() const { return current_postings; }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Currently, FST tree is saved into disk uncompressed. This could lead to slow performance or higher I/O bandwidth while both writing and reading into/from disk.

With this change, `ZSTD` compression would be applied to FST blob when uncompressed size is larger than 100 KiB.

The change shows around 15-20% size reduction on hackernews dataset while maintaining its CPU performance.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
