### PR TITLE
Remove manual flush of async insert queue for coverage

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1910,8 +1910,6 @@ class TestCase:
                     print("FIXME: Race! Cannot remove coverage file: ", str(e))
             # FIXME: This is a race condition. END
 
-            _ = clickhouse_execute(args, "SYSTEM FLUSH ASYNC INSERT QUEUE")
-
             coverage = clickhouse_execute(
                 args,
                 "SELECT length(coverageCurrent())",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove manual flush of async insert queue for coverage.

Running `SYSTEM FLUSH ASYNC INSERT QUEUE` makes async insert tests flaky, as it might run at any moment. Since it's setup to be 1 second max, it's ok to let the server flush.

Closes https://github.com/ClickHouse/ClickHouse/issues/37828

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
