### PR TITLE
Fix equivalence classes in sub-query decorrelation

### DIFF
--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -121,7 +121,7 @@ struct EquivalenceClasses
         }
         else if (class_a && !class_b)
         {
-            /// Add B to exeisting class A
+            /// Add B to existing class A
             class_b = class_a;
             class_a->push_back(b);
         }

--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -37,6 +37,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -109,25 +110,69 @@ CorrelatedPlanStepMap buildCorrelatedPlanStepMap(QueryPlan & correlated_query_pl
 
 struct EquivalenceClasses
 {
-    void add(const String & lhs, const String & rhs)
+    void add(const String & a, const String & b)
     {
-        for (auto & equivalence_class : classes)
+        auto & class_a = member_to_class[a];
+        auto & class_b = member_to_class[b];
+
+        if (!class_a && class_b)
         {
-            if (equivalence_class.contains(lhs))
+            /// Add A to existing class B
+            class_a = class_b;
+            class_b->push_back(a);
+        }
+        else if (class_a && !class_b)
+        {
+            /// Add B to exeisting class A
+            class_b = class_a;
+            class_a->push_back(b);
+        }
+        else if (!class_a && !class_b)
+        {
+            /// Both A and B are new, create a class for them
+            auto new_class = std::make_shared<std::list<String>>();
+            new_class->push_back(a);
+            class_a = new_class;
+            if (a != b)
             {
-                equivalence_class.insert(rhs);
-                return;
-            }
-            if (equivalence_class.contains(rhs))
-            {
-                equivalence_class.insert(lhs);
-                return;
+                new_class->push_back(b);
+                class_b = new_class;
             }
         }
-        classes.emplace_back(std::unordered_set<String>{ lhs, rhs });
+        else
+        {
+            /// A and B already belong to the same class?
+            if (class_a == class_b)
+                return;
+
+            /// Merge class of smaller size into bigger one
+            if (class_a->size() < class_b->size())
+                mergeFromTo(class_a, class_b);
+            else
+                mergeFromTo(class_b, class_a);
+        }
     }
 
-    std::vector<std::unordered_set<String>> classes;
+    std::shared_ptr<const std::list<String>> getClass(const String & name) const
+    {
+        auto it = member_to_class.find(name);
+        if (it == member_to_class.end())
+            return {};
+        return it->second;
+    }
+
+private:
+    void mergeFromTo(std::shared_ptr<std::list<String>> class_from, std::shared_ptr<std::list<String>> class_to)
+    {
+        /// For all existing members of class From set their class to To
+        for (const auto & member_from : *class_from)
+            member_to_class[member_from] = class_to;
+        /// Add all elements from class From to class To
+        class_to->splice(class_to->end(), *class_from);
+    }
+
+    /// Elements that belong to the same class will point to the same list of all elements of this class
+    std::unordered_map<String, std::shared_ptr<std::list<String>>> member_to_class;
 };
 
 struct DecorrelationContext
@@ -198,20 +243,17 @@ QueryPlan decorrelateQueryPlan(
             std::vector<std::pair<const ActionsDAG::Node *, const String &>> expression_renamings;
             for (const auto & correlated_column_identifier : context.correlated_subquery.correlated_column_identifiers)
             {
-                for (const auto & equivalence_class : context.equivalence_class_stack.back().classes)
+                auto equivalence_class = context.equivalence_class_stack.back().getClass(correlated_column_identifier);
+                if (equivalence_class)
                 {
-                    if (equivalence_class.contains(correlated_column_identifier))
+                    for (const auto & column_name : *equivalence_class)
                     {
-                        for (const auto & column_name : equivalence_class)
+                        auto it = decorrelated_nodes_names.find(column_name);
+                        if (it != decorrelated_nodes_names.end())
                         {
-                            auto it = decorrelated_nodes_names.find(column_name);
-                            if (it != decorrelated_nodes_names.end())
-                            {
-                                expression_renamings.emplace_back(it->second, correlated_column_identifier);
-                                break;
-                            }
+                            expression_renamings.emplace_back(it->second, correlated_column_identifier);
+                            break;
                         }
-                        break;
                     }
                 }
             }

--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -36,8 +36,6 @@
 #include <memory>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
-#include <utility>
 
 #include <fmt/format.h>
 

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes_2.reference
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes_2.reference
@@ -1,0 +1,41 @@
+-- {echoOn}
+-- All columns in subquery condition belong to the same equivalence class
+EXPLAIN
+SELECT
+    c1,
+    (
+        SELECT max(c3)
+        FROM  a
+        WHERE a.c1 = b.c2 AND b.c1 = b.c3 AND b.c1 = b.c2 AND b.c2 = b.c4
+    )
+FROM b;
+Expression ((Project names + Projection))
+  Expression
+    Join (JOIN to generate result stream)
+      Expression (Change column names to column identifiers)
+        ReadFromMergeTree (default.b)
+      Expression ((Create renaming actions for scalar subquery + (Create correlated subquery result alias + (Project names + Projection))))
+        Aggregating
+          Expression (Before GROUP BY)
+            Expression ((WHERE + (Renaming correlated columns to equivalent expressions in subquery + Change column names to column identifiers)))
+              ReadFromMergeTree (default.a)
+-- Same query but with slightly different order of conditions in subquery
+EXPLAIN
+SELECT
+    c1,
+    (
+        SELECT max(c3)
+        FROM  a
+        WHERE a.c1 = b.c2 AND b.c1 = b.c2 AND b.c1 = b.c3 AND b.c2 = b.c4
+    )
+FROM b;
+Expression ((Project names + Projection))
+  Expression
+    Join (JOIN to generate result stream)
+      Expression (Change column names to column identifiers)
+        ReadFromMergeTree (default.b)
+      Expression ((Create renaming actions for scalar subquery + (Create correlated subquery result alias + (Project names + Projection))))
+        Aggregating
+          Expression (Before GROUP BY)
+            Expression ((WHERE + (Renaming correlated columns to equivalent expressions in subquery + Change column names to column identifiers)))
+              ReadFromMergeTree (default.a)

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes_2.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes_2.sql
@@ -1,0 +1,34 @@
+SET enable_analyzer = 1;
+SET allow_experimental_correlated_subqueries = 1;
+SET enable_parallel_replicas = 0;
+SET correlated_subqueries_substitute_equivalent_expressions=1;
+SET query_plan_join_swap_table = false;
+
+CREATE TABLE a(c1 Int64, c2 Int64, c3 Int64, c4 Int64) ENGINE = MergeTree() ORDER BY ();
+CREATE TABLE b(c1 Int64, c2 Int64, c3 Int64, c4 Int64) ENGINE = MergeTree() ORDER BY ();
+
+INSERT INTO a VALUES (1, 1, 1, 1), (2, 1, 1, 2);
+INSERT INTO b VALUES (1, 1, 1, 1), (1, 2, 2, 1);
+
+-- {echoOn}
+-- All columns in subquery condition belong to the same equivalence class
+EXPLAIN
+SELECT
+    c1,
+    (
+        SELECT max(c3)
+        FROM  a
+        WHERE a.c1 = b.c2 AND b.c1 = b.c3 AND b.c1 = b.c2 AND b.c2 = b.c4
+    )
+FROM b;
+
+-- Same query but with slightly different order of conditions in subquery
+EXPLAIN
+SELECT
+    c1,
+    (
+        SELECT max(c3)
+        FROM  a
+        WHERE a.c1 = b.c2 AND b.c1 = b.c2 AND b.c1 = b.c3 AND b.c2 = b.c4
+    )
+FROM b;


### PR DESCRIPTION
The fix addresses the issue when equivalence classes are not properly build when just changing the order of conditions: 

WHERE a.c1 = b.c2 AND _b.c1 = b.c3_ AND **b.c1 = b.c2** AND b.c2 = b.c4
WHERE a.c1 = b.c2 AND **b.c1 = b.c2** AND _b.c1 = b.c3_ AND b.c2 = b.c4

In this scenario all mentioned columns belong to the same equivalence class.
And in the 1st case it is properly built: 
```
ADD: '__table3.c2'  ==  '__table3.c4'
CLASSES :
__table3.c4 __table3.c2 
------------------------------------------------------------------------------

ADD: '__table3.c1'  ==  '__table3.c2'
CLASSES :
__table3.c1 __table3.c4 __table3.c2 
------------------------------------------------------------------------------

ADD: '__table3.c1'  ==  '__table3.c3'
CLASSES :
__table3.c3 __table3.c1 __table3.c4 __table3.c2 
------------------------------------------------------------------------------

ADD: '__table2.c1'  ==  '__table3.c2'
CLASSES :
__table2.c1 __table3.c3 __table3.c1 __table3.c4 __table3.c2 
------------------------------------------------------------------------------
```

But in the 2nd case we end up with 2 equivalence classes even though `__table3.c1` is present in both:
```
ADD: '__table3.c2'  ==  '__table3.c4'
CLASSES :
__table3.c4 __table3.c2 
------------------------------------------------------------------------------

ADD: '__table3.c1'  ==  '__table3.c3'
CLASSES :
__table3.c4 __table3.c2 
__table3.c3 __table3.c1 
------------------------------------------------------------------------------

ADD: '__table3.c1'  ==  '__table3.c2'
CLASSES :
__table3.c1 __table3.c4 __table3.c2 
__table3.c3 __table3.c1 
------------------------------------------------------------------------------

ADD: '__table2.c1'  ==  '__table3.c2'
CLASSES :
__table2.c1 __table3.c1 __table3.c4 __table3.c2 
__table3.c3 __table3.c1 
------------------------------------------------------------------------------
```

The fix is to implement proper merging of 2 existing equivalence classes 




### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
