### PR TITLE
Add clang-tidy-cache's log to help debugging

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -100,6 +100,8 @@ RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/M
   && ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64 \
   && rm /MacOSX11.0.sdk.tar.xz
 
+# This is a custom version from a PR to the original clang-tidy-cache: https://github.com/matus-chochlik/ctcache/pull/89
+# Once it's merged (if ever) we'll point back to the original matus-chochlik/ctcache repo.
 ARG CLANG_TIDY_SHA1=a646e24c642c15d85334577fadadc14d041f2f8a
 RUN curl -Lo /usr/bin/clang-tidy-cache.py \
         "https://raw.githubusercontent.com/pamarcos/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \

--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -101,6 +101,8 @@ RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/M
   && rm /MacOSX11.0.sdk.tar.xz
 
 ARG CLANG_TIDY_SHA1=a646e24c642c15d85334577fadadc14d041f2f8a
-RUN curl -Lo /usr/bin/clang-tidy-cache \
+RUN curl -Lo /usr/bin/clang-tidy-cache.py \
         "https://raw.githubusercontent.com/pamarcos/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
-    && chmod +x /usr/bin/clang-tidy-cache
+    && chmod +x /usr/bin/clang-tidy-cache.py
+
+COPY clang-tidy-cache.sh /usr/bin/clang-tidy-cache

--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -100,7 +100,7 @@ RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/M
   && ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64 \
   && rm /MacOSX11.0.sdk.tar.xz
 
-ARG CLANG_TIDY_SHA1=35edad32a0bfb3dafada7201afe28036624906ed
+ARG CLANG_TIDY_SHA1=a646e24c642c15d85334577fadadc14d041f2f8a
 RUN curl -Lo /usr/bin/clang-tidy-cache \
-        "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
+        "https://raw.githubusercontent.com/pamarcos/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
     && chmod +x /usr/bin/clang-tidy-cache

--- a/ci/docker/binary-builder/clang-tidy-cache.sh
+++ b/ci/docker/binary-builder/clang-tidy-cache.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Wrapper to have the output of clang-tidy-cache in a file.
-# This is a workaround for CMake shadowing all output from clang-tidy.
+# This is a workaround for CMake shadowing all output from clang-tidy except for errors.
 
 output=$(clang-tidy-cache.py $@ 2>&1)
 ret=$?
 echo -e "clang-tidy-cache output for \"$@\":\n\t$output" >> /tmp/clang-tidy-cache.log
+echo "$output"
 exit $ret

--- a/ci/docker/binary-builder/clang-tidy-cache.sh
+++ b/ci/docker/binary-builder/clang-tidy-cache.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Wrapper to have the output of clang-tidy-cache in a file.
+# This is a workaround for CMake shadowing all output from clang-tidy.
+
+output=$(clang-tidy-cache.py $@ 2>&1)
+ret=$?
+echo -e "clang-tidy-cache output for \"$@\":\n\t$output" >> /tmp/clang-tidy-cache.log
+exit $ret

--- a/ci/docker/binary-builder/clang-tidy-cache.sh
+++ b/ci/docker/binary-builder/clang-tidy-cache.sh
@@ -5,6 +5,6 @@
 
 output=$(clang-tidy-cache.py $@ 2>&1)
 ret=$?
-echo -e "clang-tidy-cache output for \"$@\":\n\t$output" >> /tmp/clang-tidy-cache.log
+echo -e "clang-tidy-cache output for \"${!#}\":\n\t$output" >> /tmp/clang-tidy-cache.log
 echo "$output"
 exit $ret

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -113,6 +113,7 @@ def main():
         os.environ["SCCACHE_IDLE_TIMEOUT"] = "7200"
         os.environ["SCCACHE_BUCKET"] = Settings.S3_ARTIFACT_PATH
         os.environ["SCCACHE_S3_KEY_PREFIX"] = "ccache/sccache"
+        os.environ["CTCACHE_LOG_LEVEL"] = "debug"
         os.environ["CTCACHE_DIR"] = f"{build_dir}/ccache/clang-tidy-cache"
         os.environ["CTCACHE_S3_BUCKET"] = Settings.S3_ARTIFACT_PATH
         os.environ["CTCACHE_S3_FOLDER"] = "ccache/clang-tidy-cache"

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -171,6 +171,7 @@ def main():
         elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             targets = "-k0 all"
             run_shell("clang-tidy-cache stats", "clang-tidy-cache --show-stats")
+            run_shell("clang-tidy-cache logs", "cat /tmp/clang-tidy-cache.log")
         else:
             targets = "clickhouse-bundle"
         results.append(

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -185,12 +185,10 @@ def main():
         if build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
             clang_tidy_cache_log = "./ci/tmp/clang-tidy-cache.log"
-            run_shell("clang-tidy-cache logs file", "ls -lh /tmp/clang-tidy-cache.log")
-            Shell.check(f"cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}", verbose=True)
-            run_shell("clang-tidy-cache logs file", f"ls -lh {clang_tidy_cache_log}")
+            Shell.check(f"cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}")
             files.append(clang_tidy_cache_log)
             run_shell("clang-tidy-cache log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'
-                                                           '$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
+                                                    f'$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")
         res = results[-1].is_ok()

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -189,7 +189,6 @@ def main():
             files.append(clang_tidy_cache_log)
             run_shell("clang-tidy-cache.log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'
                                                     f'$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
-            run_shell("clang-tidy-cache files not in cache", f'grep -B1 "does not exist in cache" {clang_tidy_cache_log}')
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")
         res = results[-1].is_ok()

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -184,8 +184,13 @@ def main():
         run_shell("sccache stats", "sccache --show-stats")
         if build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
-            files.append("/tmp/clang-tidy-cache.log")
-            run_shell("clang-tidy-cache logs", "cat /tmp/clang-tidy-cache.log")
+            clang_tidy_cache_log = "./ci/tmp/clang-tidy-cache.log"
+            run_shell("clang-tidy-cache logs file", "ls -lh /tmp/clang-tidy-cache.log")
+            Shell.check("cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}")
+            run_shell("clang-tidy-cache logs file", f"ls -lh {clang_tidy_cache_log}")
+            files.append(clang_tidy_cache_log)
+            run_shell("clang-tidy-cache log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'
+                                                          '$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")
         res = results[-1].is_ok()

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -186,11 +186,11 @@ def main():
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
             clang_tidy_cache_log = "./ci/tmp/clang-tidy-cache.log"
             run_shell("clang-tidy-cache logs file", "ls -lh /tmp/clang-tidy-cache.log")
-            Shell.check("cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}")
+            Shell.check(f"cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}")
             run_shell("clang-tidy-cache logs file", f"ls -lh {clang_tidy_cache_log}")
             files.append(clang_tidy_cache_log)
             run_shell("clang-tidy-cache log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'
-                                                          '$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
+                                                           '$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")
         res = results[-1].is_ok()

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -187,8 +187,9 @@ def main():
             clang_tidy_cache_log = "./ci/tmp/clang-tidy-cache.log"
             Shell.check(f"cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}")
             files.append(clang_tidy_cache_log)
-            run_shell("clang-tidy-cache log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'
+            run_shell("clang-tidy-cache.log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'
                                                     f'$(grep "does not exist in cache" {clang_tidy_cache_log} | wc -l) not in cache"')
+            run_shell("clang-tidy-cache files not in cache", f'grep -B1 "does not exist in cache" {clang_tidy_cache_log}')
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")
         res = results[-1].is_ok()

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -162,6 +162,7 @@ def main():
         )
         res = results[-1].is_ok()
 
+    files = []
     if res and JobStages.BUILD in stages:
         run_shell("sccache stats", "sccache --show-stats")
         if build_type == BuildTypes.AMD_DEBUG:
@@ -170,8 +171,7 @@ def main():
             targets = "fuzzers"
         elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             targets = "-k0 all"
-            run_shell("clang-tidy-cache stats", "clang-tidy-cache --show-stats")
-            run_shell("clang-tidy-cache logs", "cat /tmp/clang-tidy-cache.log")
+            run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
         else:
             targets = "clickhouse-bundle"
         results.append(
@@ -183,7 +183,9 @@ def main():
         )
         run_shell("sccache stats", "sccache --show-stats")
         if build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
-            run_shell("clang-tidy-cache stats", "clang-tidy-cache --show-stats")
+            run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
+            files.append("/tmp/clang-tidy-cache.log")
+            run_shell("clang-tidy-cache logs", "cat /tmp/clang-tidy-cache.log")
         run_shell("Output programs", f"ls -l {build_dir}/programs/", verbose=True)
         Shell.check("pwd")
         res = results[-1].is_ok()
@@ -213,7 +215,7 @@ def main():
         )
         res = results[-1].is_ok()
 
-    Result.create_from(results=results, stopwatch=stop_watch).complete_job()
+    Result.create_from(results=results, stopwatch=stop_watch, files=files).complete_job()
 
 
 if __name__ == "__main__":

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -186,7 +186,7 @@ def main():
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
             clang_tidy_cache_log = "./ci/tmp/clang-tidy-cache.log"
             run_shell("clang-tidy-cache logs file", "ls -lh /tmp/clang-tidy-cache.log")
-            Shell.check(f"cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}")
+            Shell.check(f"cp /tmp/clang-tidy-cache.log {clang_tidy_cache_log}", verbose=True)
             run_shell("clang-tidy-cache logs file", f"ls -lh {clang_tidy_cache_log}")
             files.append(clang_tidy_cache_log)
             run_shell("clang-tidy-cache log stats", f'echo "$(grep "exists in cache" {clang_tidy_cache_log} | wc -l) in cache\n'

--- a/src/Functions/randomPrintableASCII.cpp
+++ b/src/Functions/randomPrintableASCII.cpp
@@ -31,6 +31,7 @@ public:
 
     String getName() const override
     {
+        printf("something");
         return name;
     }
 

--- a/src/Functions/randomPrintableASCII.cpp
+++ b/src/Functions/randomPrintableASCII.cpp
@@ -31,7 +31,6 @@ public:
 
     String getName() const override
     {
-        printf("something");
         return name;
     }
 


### PR DESCRIPTION
We've seen several times weird times in the tidy jobs. This PR is to generate a clang-tidy-cache log to help debugging whenever we see unexpected behavior. There''s a parallel PR for ctcache at https://github.com/matus-chochlik/ctcache/pull/89 that hopefully will be accepted.

For now, let's use the clang-tidy-cache version from that PR that allow us to know whether the digest for each file exists or not in the cache.

In order to collect the stdout of clang-tidy-cache, I've had to create yet another wrapper for it that is a simple shell script that stores the result in tmp file. I haven't found any way to tell CMake to show the output of clang-tidy. I'm adding that `clang-tidy-cache.log` as an artifact to the job to help us debug issues in the future.

Sample of the job output. Notice there's already a difference between the hit count from the stats and the ones from the log:
```
>>>> clang-tidy-cache stats

Server host:            localhost
Server port:            5000
Long-term hit rate:     N/A
Hit rate:               99.6 %
Hit count:              3448
Miss count:             13
Miss rate:              0.4 %
Max hash age:           N/A
Max hash hits:          N/A
Cache size:             N/A
Cached hashes:          N/A
Cleaned hashes:         N/A
Cleaned ago:            N/A
Saved ago:              N/A
Uptime:                 N/A
Hit rate (local):       N/A
Hit count (local):      N/A
Miss count (local):     N/A
Miss rate (local):      N/A
Cached hashes (local):  N/A

<<<< clang-tidy-cache stats


>>>> clang-tidy-cache.log stats

3672 in cache
13 not in cache

<<<< clang-tidy-cache.log stats
```

Sample of [clang-tidy-cache.log](https://s3.amazonaws.com/clickhouse-test-reports/PRs/83153/847f9a122d389a6a51e990ef4a73c417ff2f430c//build_amd_tidy/clang-tidy-cache.log):
```
clang-tidy-cache output for "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/utils/self-extracting-executable/decompressor.cpp":
	DEBUG:clang-tidy-cache.py:Digest 6dad180025f38ddb95f8e5d794666f45e62c06ab exists in cache
clang-tidy-cache output for "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/base/base/getThreadId.cpp":
	DEBUG:clang-tidy-cache.py:Digest 0fc56d68b7144be6586b2ab5e5c7aa28db000b1a exists in cache
clang-tidy-cache output for "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/base/base/demangle.cpp":
```

In [this job](https://github.com/ClickHouse/ClickHouse/actions/runs/16056677014/job/45312951082) we can see after I introduced a failure on purpose that failures are still reported as they should:

```
DEBUG:clang-tidy-cache.py:Digest 769d7295a49bdcecbac214f3956759ff7e080f40 does not exist in cache. Calling real clang-tidy
/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/src/Functions/randomPrintableASCII.cpp:34:9: error: use 'std::print' instead of 'printf' [modernize-use-std-print,-warnings-as-errors]
    7 |         printf("something");
      |         ^~~~~~
      |         std::print
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve clang-tidy-cache's stats report to help debugging tidy issues

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
