### PR TITLE
Docs: link promotion card

### DIFF
--- a/docs/en/sql-reference/data-types/newjson.md
+++ b/docs/en/sql-reference/data-types/newjson.md
@@ -9,7 +9,9 @@ title: 'JSON Data Type'
 ---
 
 import {CardSecondary} from '@clickhouse/click-ui/bundled';
+import Link from '@docusaurus/Link'
 
+<Link to="/docs/best-practices/use-json-where-appropriate" style={{textDecoration: 'none', width: '100%'}}>
 <CardSecondary
   badgeState="success"
   badgeText=""
@@ -19,6 +21,7 @@ import {CardSecondary} from '@clickhouse/click-ui/bundled';
   infoUrl="/docs/best-practices/use-json-where-appropriate"
   title="Looking for a guide?"
 />
+</Link>
 <br/>
 
 The `JSON` type stores JavaScript Object Notation (JSON) documents in a single column.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
![Screenshot 2025-07-03 at 14 26 24](https://github.com/user-attachments/assets/ea2b6390-acec-4157-b09c-a054404c3453)

Click-UI component doesn't link through on click off the card, only on the "read-me". Wraps the card in a `<Link>` element to allow clicking through anywhere on the card.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
