### PR TITLE
Enable cache split into system and data

### DIFF
--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -693,7 +693,7 @@ Cache profile events:
 - `CachedWriteBufferCacheWriteBytes`, `CachedWriteBufferCacheWriteMicroseconds`
 
 ### Split local cache {#split-local-cache}
-It is possible to split local cache into two parts: system cache(stores system information: metadata, index, marks, etc.) and data cache(stores table data information). The settings of both caches could be independently defined.
+It is possible to split local cache into two parts: system cache(stores system information: metadata, index, etc.) and data cache(stores table data information). The settings for both caches could be independently defined.
 ```xml
 <clickhouse>
     <storage_configuration>
@@ -703,7 +703,7 @@ It is possible to split local cache into two parts: system cache(stores system i
                 <endpoint>...</endpoint>
                 ... s3 configuration ...
             </s3>
-            <cache>
+            <s3_cache>
                 <type>cache</type>
                 <disk>s3</disk>
                 <path>/s3_cache/</path>
@@ -728,10 +728,22 @@ It is possible to split local cache into two parts: system cache(stores system i
                     </main>
                 </volumes>
             </s3_cache>
-        <policies>
+        </policies>
     </storage_configuration>
 ```
-In the example above there are two caches `cache_system` and `cache_data`(the name of the cache is `base_cache_name` + "_system"/"_data"). System cache has the `max_size` 1Gi and data cache has 9Gi. By default settings in each cache are taken from base cache settings. So system cache would have LRU cache policy and data cache would have SLRU cache policy. 
+
+In the example above, splitting the cache creates two separate caches named `s3_cache_system` and `s3_cache_data` (derived from the base disk name "s3_cache" with "_system" and "_data" suffixes):
+
+```
+:) SHOW FILESYSTEM CACHE
+   ┌─Caches──────────────────────┐
+1. │ s3_cache_system             │
+2. │ s3_cache_data               │
+   └─────────────────────────────┘
+```
+
+
+The system cache is allocated 1Gi, while the data cache is allocated 9Gi. Each cache can have its own independent configuration. Parameters not explicitly specified within `<system_cache_settings>` or `<data_cache_settings>` will inherit from the parent cache configuration. In this example, the system cache inherits the LRU cache policy from the base configuration, while the data cache overrides it with the SLRU policy.
 
 
 ### Using static Web storage (read-only) {#web-storage}

--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -693,7 +693,7 @@ Cache profile events:
 - `CachedWriteBufferCacheWriteBytes`, `CachedWriteBufferCacheWriteMicroseconds`
 
 ### Split local cache {#split-local-cache}
-It is possible to split local cache into two parts: system cache(stores system information: metadata, index, etc.) and data cache(stores table data information). The settings for both caches could be independently defined.
+It is possible to split local cache into two parts: system cache (stores system information: metadata, index, etc.) and data cache (stores table data information). The settings for both caches could be independently defined.
 ```xml
 <clickhouse>
     <storage_configuration>

--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -734,7 +734,7 @@ It is possible to split local cache into two parts: system cache (stores system 
 
 In the example above, splitting the cache creates two separate caches named `s3_cache_system` and `s3_cache_data` (derived from the base disk name "s3_cache" with "_system" and "_data" suffixes):
 
-```
+```txt
 :) SHOW FILESYSTEM CACHE
    ┌─Caches──────────────────────┐
 1. │ s3_cache_system             │

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
     return implementation_buffer;
 }
 
-void CachedObjectStorage::removeKeyFromCacheIfExists(const std::string & path_key_for_cache, const SplitCacheType cache_type)
+void CachedObjectStorage::removeKeyFromCacheIfExists(const std::string & path_key_for_cache, SplitCacheType cache_type)
 {
     if (path_key_for_cache.empty())
         return;

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -121,7 +121,8 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
     size_t buf_size,
     const WriteSettings & write_settings)
 {
-    auto cache = holder.getCache(defineCacheType(object.local_path));
+    auto cache_type = defineCacheType(object.local_path);
+    auto cache = holder.getCache(cache_type);
     /// Add cache relating settings to WriteSettings.
     auto modified_write_settings = IObjectStorage::patchSettings(write_settings);
     auto implementation_buffer = object_storage->writeObject(object, mode, attributes, buf_size, modified_write_settings);
@@ -131,7 +132,7 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
         && fs::path(object.remote_path).extension() != ".tmp";
 
     /// Need to remove even if cache_on_write == false.
-    removeCacheIfExists(object.remote_path);
+    removeKeyFromCacheIfExists(object.remote_path, cache_type);
 
     if (cache_on_write && cache->isInitialized())
     {
@@ -150,26 +151,25 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
     return implementation_buffer;
 }
 
-void CachedObjectStorage::removeCacheIfExists(const std::string & path_key_for_cache)
+void CachedObjectStorage::removeKeyFromCacheIfExists(const std::string & path_key_for_cache, const SplitCacheType cache_type)
 {
     if (path_key_for_cache.empty())
         return;
-    auto cache = holder.getCache(defineCacheType(path_key_for_cache));
-    /// Add try catch?
+    auto cache = holder.getCache(cache_type);
     if (cache->isInitialized())
         cache->removeKeyIfExists(getCacheKey(path_key_for_cache), FileCache::getCommonUser().user_id);
 }
 
 void CachedObjectStorage::removeObjectIfExists(const StoredObject & object)
 {
-    removeCacheIfExists(object.remote_path);
+    removeKeyFromCacheIfExists(object.remote_path, defineCacheType(object.local_path));
     object_storage->removeObjectIfExists(object);
 }
 
 void CachedObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
 {
     for (const auto & object : objects)
-        removeCacheIfExists(object.remote_path);
+        removeKeyFromCacheIfExists(object.remote_path, defineCacheType(object.local_path));
 
     object_storage->removeObjectsIfExist(objects);
 }

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -23,10 +23,10 @@ namespace FileCacheSetting
 
 CachedObjectStorage::CachedObjectStorage(
     ObjectStoragePtr object_storage_,
-    const FileCachesHolder & holder_,
+    FileCachesHolder && holder_,
     const std::string & cache_config_name_)
     : object_storage(object_storage_)
-    , holder(holder_)
+    , holder(std::move(holder_))
     , cache_config_name(cache_config_name_)
     , log(getLogger(getName()))
 {

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<ReadBufferFromFileBase> CachedObjectStorage::readObject( /// NOL
     if (read_settings.enable_filesystem_cache)
     {
 
-        auto cache = holder.getCache(defineCacheType(object.remote_path));
+        auto cache = holder.getCache(defineCacheType(object.local_path));
         if (cache->isInitialized())
         {
             auto cache_key = FileCacheKey::fromPath(object.remote_path);
@@ -121,7 +121,7 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
     size_t buf_size,
     const WriteSettings & write_settings)
 {
-    auto cache = holder.getCache(defineCacheType(object.remote_path));
+    auto cache = holder.getCache(defineCacheType(object.local_path));
     /// Add cache relating settings to WriteSettings.
     auto modified_write_settings = IObjectStorage::patchSettings(write_settings);
     auto implementation_buffer = object_storage->writeObject(object, mode, attributes, buf_size, modified_write_settings);

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -3,6 +3,7 @@
 #include <IO/BoundedReadBuffer.h>
 #include <Disks/IO/CachedOnDiskWriteBufferFromFile.h>
 #include <Disks/IO/CachedOnDiskReadBufferFromFile.h>
+#include <Disks/ObjectStorages/Cached/FileCachesHolder.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
@@ -22,16 +23,14 @@ namespace FileCacheSetting
 
 CachedObjectStorage::CachedObjectStorage(
     ObjectStoragePtr object_storage_,
-    FileCachePtr cache_,
-    const FileCacheSettings & cache_settings_,
+    const FileCachesHolder & holder_,
     const std::string & cache_config_name_)
     : object_storage(object_storage_)
-    , cache(cache_)
-    , cache_settings(cache_settings_)
+    , holder(holder_)
     , cache_config_name(cache_config_name_)
     , log(getLogger(getName()))
 {
-    cache->initialize();
+    holder.initializeAll();
 }
 
 FileCache::Key CachedObjectStorage::getCacheKey(const std::string & path) const
@@ -79,6 +78,8 @@ std::unique_ptr<ReadBufferFromFileBase> CachedObjectStorage::readObject( /// NOL
 {
     if (read_settings.enable_filesystem_cache)
     {
+
+        auto cache = holder.getCache(defineCacheType(object.remote_path));
         if (cache->isInitialized())
         {
             auto cache_key = FileCacheKey::fromPath(object.remote_path);
@@ -120,6 +121,7 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
     size_t buf_size,
     const WriteSettings & write_settings)
 {
+    auto cache = holder.getCache(defineCacheType(object.remote_path));
     /// Add cache relating settings to WriteSettings.
     auto modified_write_settings = IObjectStorage::patchSettings(write_settings);
     auto implementation_buffer = object_storage->writeObject(object, mode, attributes, buf_size, modified_write_settings);
@@ -152,7 +154,7 @@ void CachedObjectStorage::removeCacheIfExists(const std::string & path_key_for_c
 {
     if (path_key_for_cache.empty())
         return;
-
+    auto cache = holder.getCache(defineCacheType(path_key_for_cache));
     /// Add try catch?
     if (cache->isInitialized())
         cache->removeKeyIfExists(getCacheKey(path_key_for_cache), FileCache::getCommonUser().user_id);

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -20,7 +20,7 @@ namespace DB
 class CachedObjectStorage final : public IObjectStorage
 {
 public:
-    CachedObjectStorage(ObjectStoragePtr object_storage_, const FileCachesHolder & holder_, const String & cache_config_name_);
+    CachedObjectStorage(ObjectStoragePtr object_storage_, FileCachesHolder && holder_, const String & cache_config_name_);
 
     std::string getName() const override { return fmt::format("CachedObjectStorage-{}({})", cache_config_name, object_storage->getName()); }
 
@@ -117,8 +117,6 @@ public:
     ObjectStoragePtr getWrappedObjectStorage() { return object_storage; }
 
     bool supportParallelWrite() const override { return object_storage->supportParallelWrite(); }
-
-    const FileCacheSettings & getCacheSettings(SplitCacheType cache_type) const { return holder.getCacheSetting(cache_type); }
 
 #if USE_AZURE_BLOB_STORAGE
     std::shared_ptr<const AzureBlobStorage::ContainerClient> getAzureBlobStorageClient() const override

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -102,7 +102,7 @@ public:
 
     bool isRemote() const override { return object_storage->isRemote(); }
 
-    void removeCacheIfExists(const std::string & path_key_for_cache) override;
+    void removeKeyFromCacheIfExists(const std::string & path_key_for_cache, const SplitCacheType cache_type);
 
     bool supportsCache() const override { return true; }
 

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -102,7 +102,7 @@ public:
 
     bool isRemote() const override { return object_storage->isRemote(); }
 
-    void removeKeyFromCacheIfExists(const std::string & path_key_for_cache, const SplitCacheType cache_type);
+    void removeKeyFromCacheIfExists(const std::string & path_key_for_cache, SplitCacheType cache_type);
 
     bool supportsCache() const override { return true; }
 

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -118,7 +118,7 @@ public:
 
     bool supportParallelWrite() const override { return object_storage->supportParallelWrite(); }
 
-    const FileCacheSettings & getCacheSettings(CacheType cache_type) const { return holder.getCacheSetting(cache_type); }
+    const FileCacheSettings & getCacheSettings(SplitCacheType cache_type) const { return holder.getCacheSetting(cache_type); }
 
 #if USE_AZURE_BLOB_STORAGE
     std::shared_ptr<const AzureBlobStorage::ContainerClient> getAzureBlobStorageClient() const override

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Disks/ObjectStorages/IObjectStorage.h>
+#include <Disks/ObjectStorages/Cached/FileCachesHolder.h>
 #include <Interpreters/Cache/FileCacheKey.h>
 #include <Interpreters/Cache/FileCacheSettings.h>
 #include "config.h"
@@ -19,7 +20,7 @@ namespace DB
 class CachedObjectStorage final : public IObjectStorage
 {
 public:
-    CachedObjectStorage(ObjectStoragePtr object_storage_, FileCachePtr cache_, const FileCacheSettings & cache_settings_, const String & cache_config_name_);
+    CachedObjectStorage(ObjectStoragePtr object_storage_, const FileCachesHolder & holder_, const String & cache_config_name_);
 
     std::string getName() const override { return fmt::format("CachedObjectStorage-{}({})", cache_config_name, object_storage->getName()); }
 
@@ -117,7 +118,7 @@ public:
 
     bool supportParallelWrite() const override { return object_storage->supportParallelWrite(); }
 
-    const FileCacheSettings & getCacheSettings() const { return cache_settings; }
+    const FileCacheSettings & getCacheSettings(CacheType cache_type) const { return holder.getCacheSetting(cache_type); }
 
 #if USE_AZURE_BLOB_STORAGE
     std::shared_ptr<const AzureBlobStorage::ContainerClient> getAzureBlobStorageClient() const override
@@ -149,8 +150,7 @@ private:
     ReadSettings patchSettings(const ReadSettings & read_settings) const override;
 
     ObjectStoragePtr object_storage;
-    FileCachePtr cache;
-    FileCacheSettings cache_settings;
+    FileCachesHolder holder;
     std::string cache_config_name;
     LoggerPtr log;
 };

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.cpp
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.cpp
@@ -13,7 +13,7 @@ namespace ErrorCodes
 SplitCacheType defineCacheType(const std::string & file_path)
 {
     auto file_extension = fs::path(file_path).extension();
-    return std::find(data_type_extensions.begin(), data_type_extensions.end(), file_extension) != data_type_extensions.end() ? SplitCacheType::DataCache : SplitCacheType::SystemCache;
+    return std::find(data_cache_type.begin(), data_cache_type.end(), file_extension) != data_cache_type.end() ? SplitCacheType::DataCache : SplitCacheType::SystemCache;
 }
 
 FileCachesHolder::FileCachesHolder(std::initializer_list<std::tuple<SplitCacheType, FileCachePtr, FileCacheSettings>> caches_)

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.cpp
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.cpp
@@ -20,11 +20,11 @@ FileCachesHolder::FileCachesHolder(std::initializer_list<std::tuple<SplitCacheTy
 {
     for (auto&& [cache_type, cache, cache_settings] : caches_)
     {
-        if (holder.count(cache_type))
+        if (holder.contains(cache_type))
         {
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Multiple caches with the same type");
         }
-        holder[cache_type] = {std::move(cache), std::move(cache_settings)};
+        holder[cache_type] = {cache, cache_settings};
     }
 }
 
@@ -36,9 +36,9 @@ void FileCachesHolder::setCache(SplitCacheType cache_type, const FileCachePtr & 
 
 FileCachePtr FileCachesHolder::getCache(SplitCacheType cache_type) const
 {
-    if (!holder.count(cache_type))
+    if (!holder.contains(cache_type))
     {
-        if (!holder.count(SplitCacheType::GeneralCache))
+        if (!holder.contains(SplitCacheType::GeneralCache))
         {
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to get cache with non-existing cache_type");
         }
@@ -49,9 +49,9 @@ FileCachePtr FileCachesHolder::getCache(SplitCacheType cache_type) const
 
 const FileCacheSettings & FileCachesHolder::getCacheSetting(SplitCacheType cache_type) const
 {
-    if (!holder.count(cache_type))
+    if (!holder.contains(cache_type))
     {
-        if (!holder.count(SplitCacheType::GeneralCache))
+        if (!holder.contains(SplitCacheType::GeneralCache))
         {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to get cache settings with non-existing cache_type");
         }

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.cpp
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.cpp
@@ -1,0 +1,81 @@
+#include <Disks/ObjectStorages/Cached/FileCachesHolder.h>
+#include <Interpreters/Cache/FileCache.h>
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+CacheType defineCacheType(const std::string & file_path)
+{
+    size_t dot_pos = file_path.find_last_of('.');
+    std::string_view file_extension(file_path.begin(), file_path.begin() + dot_pos);
+    chassert(dot_pos != file_path.size());
+    auto it = std::find_if(file_suffix_to_cache_type.begin(),
+                        file_suffix_to_cache_type.end(),
+                        [&] (const std::pair<std::string, CacheType> & p)
+                        {
+                            return file_extension == p.first;
+                        });
+    if (it == file_suffix_to_cache_type.end())
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cache file has no extension");
+    }
+    return it->second;
+}
+
+FileCachesHolder::FileCachesHolder(std::initializer_list<std::tuple<CacheType, FileCachePtr, FileCacheSettings>> caches_)
+{
+    for (auto&& [cache_type, cache, cache_settings] : caches_)
+    {
+        if (holder[cache_type].first)
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Multiple caches with the same type");
+        }
+        if (cache_type == CacheType::Size)
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "CacheType::Size is not a cache type(read the comment for enum)");
+        }
+        holder[cache_type] = {std::move(cache), std::move(cache_settings)};
+    }
+}
+
+void FileCachesHolder::setCache(CacheType cache_type, const FileCachePtr & system_cache_, FileCacheSettings&& system_cache_settings_)
+{
+    holder[cache_type].first = system_cache_;
+    holder[cache_type].second = std::move(system_cache_settings_);
+}
+
+FileCachePtr FileCachesHolder::getCache(CacheType cache_type) const
+{
+    return holder[cache_type].first;
+}
+
+const FileCacheSettings & FileCachesHolder::getCacheSetting(CacheType cache_type) const
+{
+    return holder[cache_type].second;
+}
+
+void FileCachesHolder::checkCorrectness() const
+{
+    if (getCache(CacheType::GeneralCache) &&
+        (getCache(CacheType::SystemCache) || getCache(CacheType::DataCache)))
+    {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "CacheType::GeneralCache should be the only cache in holder");
+    }
+}
+
+void FileCachesHolder::initializeAll()
+{
+    for (auto&& [cache, cache_settings] : holder)
+    {
+        if (!cache)
+        {
+            continue;
+        }
+        cache->initialize();
+    }
+}
+
+}

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
@@ -11,11 +11,14 @@ enum SplitCacheType
 {
     GeneralCache = 0,
     SystemCache, // cache system data(metadata, index, marks, etc.)
-    DataCache // cache for table data
+    DataCache, // cache table data
 };
 
-constexpr std::array<std::string, 1> data_type_extensions = {".bin"};
+constexpr std::array<std::string, 1> data_cache_type = {".bin"};
+
+bool isDataCacheType(const std::string & file_path);
 SplitCacheType defineCacheType(const std::string & file_path);
+
 
 class FileCachesHolder
 {

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
@@ -2,36 +2,33 @@
 #include <array>
 #include <initializer_list>
 #include <unordered_map>
-#include <map>
 #include <Interpreters/Cache/FileCacheSettings.h>
 
 namespace DB
 {
 
-enum CacheType
+enum SplitCacheType
 {
     GeneralCache = 0,
     SystemCache, // cache system data(metadata, index, marks, etc.)
-    DataCache, // cache table data
-    Size // used for count the amount of cache types(should be the last)
+    DataCache // cache for table data
 };
 
-constexpr std::array<std::pair<std::string, CacheType>, CacheType::Size> file_suffix_to_cache_type = {std::pair("cidx", CacheType::SystemCache)};
-
-CacheType defineCacheType(const std::string & file_path);
+constexpr std::array<std::string, 1> data_type_extensions = {".bin"};
+SplitCacheType defineCacheType(const std::string & file_path);
 
 class FileCachesHolder
 {
 public:
     FileCachesHolder() = default;
-    FileCachesHolder(std::initializer_list<std::tuple<CacheType, FileCachePtr, FileCacheSettings>> caches_);
-    void setCache(CacheType cache_type, const FileCachePtr & system_cache_, FileCacheSettings&& system_cache_settings_);
-    FileCachePtr getCache(CacheType cache_type) const;
-    const FileCacheSettings & getCacheSetting(CacheType cache_type) const;
+    FileCachesHolder(std::initializer_list<std::tuple<SplitCacheType, FileCachePtr, FileCacheSettings>> caches_);
+    void setCache(SplitCacheType cache_type, const FileCachePtr & system_cache_, FileCacheSettings&& system_cache_settings_);
+    FileCachePtr getCache(SplitCacheType cache_type) const;
+    const FileCacheSettings & getCacheSetting(SplitCacheType cache_type) const;
     void initializeAll();
     void checkCorrectness() const;
 private:
-    std::array<std::pair<FileCachePtr, FileCacheSettings>, CacheType::Size> holder;
+    std::unordered_map<SplitCacheType, std::pair<FileCachePtr, FileCacheSettings>> holder;
 };
 
 }

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <array>
+#include <initializer_list>
+#include <unordered_map>
+#include <map>
+#include <Interpreters/Cache/FileCacheSettings.h>
+
+namespace DB
+{
+
+enum CacheType
+{
+    GeneralCache = 0,
+    SystemCache, // cache system data(metadata, index, marks, etc.)
+    DataCache, // cache table data
+    Size // used for count the amount of cache types(should be the last)
+};
+
+constexpr std::array<std::pair<std::string, CacheType>, CacheType::Size> file_suffix_to_cache_type = {std::pair("cidx", CacheType::SystemCache)};
+
+CacheType defineCacheType(const std::string & file_path);
+
+class FileCachesHolder
+{
+public:
+    FileCachesHolder() = default;
+    FileCachesHolder(std::initializer_list<std::tuple<CacheType, FileCachePtr, FileCacheSettings>> caches_);
+    void setCache(CacheType cache_type, const FileCachePtr & system_cache_, FileCacheSettings&& system_cache_settings_);
+    FileCachePtr getCache(CacheType cache_type) const;
+    const FileCacheSettings & getCacheSetting(CacheType cache_type) const;
+    void initializeAll();
+    void checkCorrectness() const;
+private:
+    std::array<std::pair<FileCachePtr, FileCacheSettings>, CacheType::Size> holder;
+};
+
+}

--- a/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
+++ b/src/Disks/ObjectStorages/Cached/FileCachesHolder.h
@@ -14,24 +14,27 @@ enum SplitCacheType
     DataCache, // cache table data
 };
 
-constexpr std::array<std::string, 1> data_cache_type = {".bin"};
+std::string getSplitCacheTypeStr(SplitCacheType cache_type);
 
-bool isDataCacheType(const std::string & file_path);
 SplitCacheType defineCacheType(const std::string & file_path);
 
-
+/// A class, which can store several FileCache objects
+/// with a SplitCacheType defining access to them.
 class FileCachesHolder
 {
 public:
     FileCachesHolder() = default;
-    FileCachesHolder(std::initializer_list<std::tuple<SplitCacheType, FileCachePtr, FileCacheSettings>> caches_);
-    void setCache(SplitCacheType cache_type, const FileCachePtr & system_cache_, FileCacheSettings&& system_cache_settings_);
+    FileCachesHolder(std::initializer_list<std::tuple<SplitCacheType, FileCachePtr>> caches_);
+    FileCachesHolder(FileCachesHolder && file_caches_holder_) = default;
+    FileCachesHolder & operator=(FileCachesHolder && file_caches_holder_) = default;
+
+    void setCache(SplitCacheType cache_type, const FileCachePtr & system_cache_);
     FileCachePtr getCache(SplitCacheType cache_type) const;
-    const FileCacheSettings & getCacheSetting(SplitCacheType cache_type) const;
+    bool hasCache(SplitCacheType cache_type) const;
     void initializeAll();
     void checkCorrectness() const;
 private:
-    std::unordered_map<SplitCacheType, std::pair<FileCachePtr, FileCacheSettings>> holder;
+    std::unordered_map<SplitCacheType, FileCachePtr> holder;
 };
 
 }

--- a/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
+++ b/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
@@ -204,8 +204,8 @@ FileCachesHolder getSplittedCaches(
     );
 
     return {
-        {SplitCacheType::SystemCache, std::move(system_cache), std::move(system_cache_settings)},
-        {SplitCacheType::DataCache, std::move(data_cache), std::move(data_cache_settings)}
+        {SplitCacheType::SystemCache, std::move(system_cache)},
+        {SplitCacheType::DataCache, std::move(data_cache)}
     };
 }
 
@@ -247,11 +247,12 @@ void registerDiskCache(DiskFactory & factory, bool /* global_skip_access_check *
         else
         {
             auto [cache, cache_settings] = getCache(config, config_prefix, context, name, attach, custom_disk);
-            caches_holder.setCache(SplitCacheType::GeneralCache, cache, std::move(cache_settings));
+            caches_holder.setCache(SplitCacheType::GeneralCache, cache);
         }
+        caches_holder.checkCorrectness();
 
         auto disk_object_storage = disk->createDiskObjectStorage();
-        disk_object_storage->wrapWithCache(caches_holder, name);
+        disk_object_storage->wrapWithCache(std::move(caches_holder), name);
 
         LOG_INFO(
             getLogger("DiskCache"),

--- a/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
+++ b/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
@@ -6,7 +6,7 @@
 #include <Common/assert_cast.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/NamedCollections/NamedCollectionsFactory.h>
-#include "Interpreters/Context_fwd.h"
+#include <Interpreters/Context_fwd.h>
 #include <Disks/DiskFactory.h>
 #include <Disks/ObjectStorages/Cached/CachedObjectStorage.h>
 #include <Disks/ObjectStorages/DiskObjectStorage.h>

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -228,7 +228,7 @@ public:
     /// Example: DiskObjectStorage(S3ObjectStorage) -> DiskObjectStorage(CachedObjectStorage(S3ObjectStorage))
     /// There can be any number of cache layers:
     /// DiskObjectStorage(CachedObjectStorage(...CacheObjectStorage(S3ObjectStorage)...))
-    void wrapWithCache(const FileCachesHolder & holder, const String & layer_name);
+    void wrapWithCache(FileCachesHolder && holder, const String & layer_name);
 
     /// Get names of all cache layers. Name is how cache is defined in configuration file.
     NameSet getCacheLayersNames() const override;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -4,6 +4,7 @@
 #include <Disks/ObjectStorages/IObjectStorage.h>
 #include <Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.h>
 #include <Disks/ObjectStorages/IMetadataStorage.h>
+#include <Disks/ObjectStorages/Cached/FileCachesHolder.h>
 #include <Common/re2.h>
 
 #include <base/scope_guard.h>
@@ -227,7 +228,7 @@ public:
     /// Example: DiskObjectStorage(S3ObjectStorage) -> DiskObjectStorage(CachedObjectStorage(S3ObjectStorage))
     /// There can be any number of cache layers:
     /// DiskObjectStorage(CachedObjectStorage(...CacheObjectStorage(S3ObjectStorage)...))
-    void wrapWithCache(FileCachePtr cache, const FileCacheSettings & cache_settings, const String & layer_name);
+    void wrapWithCache(const FileCachesHolder & cache_settings, const String & layer_name);
 
     /// Get names of all cache layers. Name is how cache is defined in configuration file.
     NameSet getCacheLayersNames() const override;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -228,7 +228,7 @@ public:
     /// Example: DiskObjectStorage(S3ObjectStorage) -> DiskObjectStorage(CachedObjectStorage(S3ObjectStorage))
     /// There can be any number of cache layers:
     /// DiskObjectStorage(CachedObjectStorage(...CacheObjectStorage(S3ObjectStorage)...))
-    void wrapWithCache(const FileCachesHolder & cache_settings, const String & layer_name);
+    void wrapWithCache(const FileCachesHolder & holder, const String & layer_name);
 
     /// Get names of all cache layers. Name is how cache is defined in configuration file.
     NameSet getCacheLayersNames() const override;

--- a/src/Disks/ObjectStorages/DiskObjectStorageCache.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageCache.cpp
@@ -8,9 +8,9 @@
 namespace DB
 {
 
-void DiskObjectStorage::wrapWithCache(const FileCachesHolder & holder, const String & layer_name)
+void DiskObjectStorage::wrapWithCache(FileCachesHolder && holder, const String & layer_name)
 {
-    object_storage = std::make_shared<CachedObjectStorage>(object_storage, holder, layer_name);
+    object_storage = std::make_shared<CachedObjectStorage>(object_storage, std::move(holder), layer_name);
 }
 
 NameSet DiskObjectStorage::getCacheLayersNames() const

--- a/src/Disks/ObjectStorages/DiskObjectStorageCache.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageCache.cpp
@@ -1,4 +1,5 @@
 #include <Disks/ObjectStorages/Cached/CachedObjectStorage.h>
+#include <Disks/ObjectStorages/Cached/FileCachesHolder.h>
 
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
 
@@ -7,9 +8,9 @@
 namespace DB
 {
 
-void DiskObjectStorage::wrapWithCache(FileCachePtr cache, const FileCacheSettings & cache_settings, const String & layer_name)
+void DiskObjectStorage::wrapWithCache(const FileCachesHolder & holder, const String & layer_name)
 {
-    object_storage = std::make_shared<CachedObjectStorage>(object_storage, cache, cache_settings, layer_name);
+    object_storage = std::make_shared<CachedObjectStorage>(object_storage, holder, layer_name);
 }
 
 NameSet DiskObjectStorage::getCacheLayersNames() const

--- a/src/Interpreters/Cache/FileCacheSettings.cpp
+++ b/src/Interpreters/Cache/FileCacheSettings.cpp
@@ -176,7 +176,7 @@ void FileCacheSettings::loadFromConfig(
     Poco::Util::AbstractConfiguration::Keys config_keys;
     config.keys(config_prefix, config_keys);
 
-    std::set<std::string> ignore_keys = {"type", "disk", "name"};
+    std::set<std::string> ignore_keys = {"type", "disk", "name", "split_cache", "system_cache_settings", "data_cache_settings"};
     for (const std::string & key : config_keys)
     {
         if (ignore_keys.contains(key))
@@ -201,6 +201,17 @@ void FileCacheSettings::loadFromConfig(
     }
 
     validate();
+}
+
+void FileCacheSettings::loadFromConfigsWithPriority(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::vector<std::string> & config_prefixes,
+    const std::string & cache_path_prefix_if_relative,
+    const std::string & default_cache_path)
+{
+    for (auto&& config_prefix : config_prefixes) {
+        loadFromConfig(config, config_prefix, cache_path_prefix_if_relative, default_cache_path);
+    }
 }
 
 void FileCacheSettings::loadFromCollection(

--- a/src/Interpreters/Cache/FileCacheSettings.cpp
+++ b/src/Interpreters/Cache/FileCacheSettings.cpp
@@ -222,7 +222,7 @@ void FileCacheSettings::loadFromConfigsWithPriority(
     const std::string & cache_path_prefix_if_relative,
     const std::string & default_cache_path)
 {
-    for (auto&& config_prefix : config_prefixes) {
+    for (const auto & config_prefix : config_prefixes) {
         loadFromConfigNoPathCheck(config, config_prefix);
     }
     checkPath(cache_path_prefix_if_relative, default_cache_path);

--- a/src/Interpreters/Cache/FileCacheSettings.cpp
+++ b/src/Interpreters/Cache/FileCacheSettings.cpp
@@ -164,11 +164,9 @@ void FileCacheSettings::dumpToSystemSettingsColumns(
     res_columns[i++]->insert(cache->getFileSegmentsNum());
 }
 
-void FileCacheSettings::loadFromConfig(
+void FileCacheSettings::loadFromConfigNoPathCheck(
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix,
-    const std::string & cache_path_prefix_if_relative,
-    const std::string & default_cache_path)
+    const std::string & config_prefix)
 {
     if (!config.has(config_prefix))
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "There is no path '{}' in configuration file.", config_prefix);
@@ -183,7 +181,12 @@ void FileCacheSettings::loadFromConfig(
             continue;
         impl->set(key, config.getString(config_prefix + "." + key));
     }
+}
 
+void FileCacheSettings::checkPath(
+    const std::string & cache_path_prefix_if_relative,
+    const std::string & default_cache_path)
+{
     if ((*this)[FileCacheSetting::path].changed)
     {
         if (fs::path((*this)[FileCacheSetting::path].value).is_relative())
@@ -203,6 +206,16 @@ void FileCacheSettings::loadFromConfig(
     validate();
 }
 
+void FileCacheSettings::loadFromConfig(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix,
+    const std::string & cache_path_prefix_if_relative,
+    const std::string & default_cache_path)
+{
+    loadFromConfigNoPathCheck(config, config_prefix);
+    checkPath(cache_path_prefix_if_relative, default_cache_path);
+}
+
 void FileCacheSettings::loadFromConfigsWithPriority(
     const Poco::Util::AbstractConfiguration & config,
     const std::vector<std::string> & config_prefixes,
@@ -210,8 +223,9 @@ void FileCacheSettings::loadFromConfigsWithPriority(
     const std::string & default_cache_path)
 {
     for (auto&& config_prefix : config_prefixes) {
-        loadFromConfig(config, config_prefix, cache_path_prefix_if_relative, default_cache_path);
+        loadFromConfigNoPathCheck(config, config_prefix);
     }
+    checkPath(cache_path_prefix_if_relative, default_cache_path);
 }
 
 void FileCacheSettings::loadFromCollection(

--- a/src/Interpreters/Cache/FileCacheSettings.h
+++ b/src/Interpreters/Cache/FileCacheSettings.h
@@ -37,11 +37,14 @@ struct FileCacheSettings
 
     FILE_CACHE_SETTINGS_SUPPORTED_TYPES(FileCacheSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)
 
+
     void loadFromConfig(
         const Poco::Util::AbstractConfiguration & config,
         const std::string & config_prefix,
         const std::string & cache_path_prefix_if_relative,
         const std::string & default_cache_path = "");
+    void loadFromConfigNoPathCheck(const Poco::Util::AbstractConfiguration & config,
+        const std::string & config_prefix);
 
     // load settings from mupltiple config prefixes
     // last element of config_prefixes has the most priority
@@ -65,6 +68,8 @@ struct FileCacheSettings
     bool isPathRelativeInConfig() const { return is_path_relative_in_config; }
 
 private:
+    void checkPath(const std::string & cache_path_prefix_if_relative,
+        const std::string & default_cache_path = "");
     std::unique_ptr<FileCacheSettingsImpl> impl;
     bool is_path_relative_in_config = false;
 };

--- a/src/Interpreters/Cache/FileCacheSettings.h
+++ b/src/Interpreters/Cache/FileCacheSettings.h
@@ -43,6 +43,14 @@ struct FileCacheSettings
         const std::string & cache_path_prefix_if_relative,
         const std::string & default_cache_path = "");
 
+    // load settings from mupltiple config prefixes
+    // last element of config_prefixes has the most priority
+    void loadFromConfigsWithPriority(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::vector<std::string> & config_prefixes,
+        const std::string & cache_path_prefix_if_relative,
+        const std::string & default_cache_path = "");
+
     void loadFromCollection(
         const NamedCollection & collection,
         const std::string & cache_path_prefix_if_relative);

--- a/tests/integration/test_split_cache/configs/split_cache.xml
+++ b/tests/integration/test_split_cache/configs/split_cache.xml
@@ -1,0 +1,35 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <split_cache_disk>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </split_cache_disk>
+            <split_s3_cache>
+                <type>cache</type>
+                <disk>split_cache_disk</disk>
+                <path>/split_cache</path>
+                <split_cache>1</split_cache>
+                <system_cache_settings>
+                    <max_size>1Mi</max_size>
+                    <cache_policy>LRU</cache_policy>
+                </system_cache_settings>
+                <data_cache_settings>
+                    <max_size>60Mi</max_size>
+                    <cache_policy>LRU</cache_policy>
+                </data_cache_settings>
+            </split_s3_cache>
+        </disks>
+        <policies>
+            <split_cache>
+                <volumes>
+                    <main>
+                        <disk>split_s3_cache</disk>
+                    </main>
+                </volumes>
+            </split_cache>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_split_cache/test.py
+++ b/tests/integration/test_split_cache/test.py
@@ -1,0 +1,40 @@
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/split_cache.xml"],
+    stay_alive=True,
+    with_minio=True,
+)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_split_cache(started_cluster):
+    node.query("DROP TABLE IF EXISTS t0")
+    node.query(
+        """CREATE TABLE t0 (
+            key String,
+            value String
+        )
+        ENGINE = MergeTree
+        PRIMARY KEY key
+        SETTINGS storage_policy = 'split_cache'"""
+    )
+    node.query("INSERT INTO t0 VALUES ('key1', 'value1')")
+    assert node.query("SHOW FILESYSTEM CACHES") == "split_s3_cache_system\nsplit_s3_cache_data\n"
+    node.query("DETACH TABLE t0")
+    node.query("ATTACH TABLE t0")
+    node.restart_clickhouse()
+    node.query("DROP TABLE t0")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable splitting S3 cache into two parts: _system_ and _data_. _Data_ cache stores table data(`.bin` part files), _system_ stores all the system information(index, marks, etc.).
Splitting the cache improve the performance of select queries, since the table data caching do not evict the index data, especially when table has huge parts. Also, it improves the CH restart, because almost all the index data will be stored on local disk and there is no need to re-cache.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
- [x] Integration test 

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
