### PR TITLE
Use Analyzer to generate actions from default expression

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -211,7 +211,11 @@ void QueryAnalyzer::resolve(QueryTreeNodePtr & node, const QueryTreeNodePtr & ta
             }
 
             if (node_type == QueryTreeNodeType::LIST)
+            {
+                QueryExpressionsAliasVisitor visitor(scope.aliases);
+                visitor.visit(node);
                 resolveExpressionNodeList(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+            }
             else
                 resolveExpressionNode(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
 
@@ -256,11 +260,7 @@ void QueryAnalyzer::resolveConstantExpression(QueryTreeNodePtr & node, const Que
     }
 
     if (node_type == QueryTreeNodeType::LIST)
-    {
-        QueryExpressionsAliasVisitor visitor(scope.aliases);
-        visitor.visit(node);
         resolveExpressionNodeList(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
-    }
     else
         resolveExpressionNode(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
 }

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -237,7 +237,6 @@ void QueryAnalyzer::resolve(QueryTreeNodePtr & node, const QueryTreeNodePtr & ta
 void QueryAnalyzer::resolveConstantExpression(QueryTreeNodePtr & node, const QueryTreeNodePtr & table_expression, ContextPtr context)
 {
     IdentifierResolveScope & scope = createIdentifierResolveScope(node, /*parent_scope=*/ nullptr);
-
     if (!scope.context)
         scope.context = context;
 
@@ -257,7 +256,11 @@ void QueryAnalyzer::resolveConstantExpression(QueryTreeNodePtr & node, const Que
     }
 
     if (node_type == QueryTreeNodeType::LIST)
+    {
+        QueryExpressionsAliasVisitor visitor(scope.aliases);
+        visitor.visit(node);
         resolveExpressionNodeList(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+    }
     else
         resolveExpressionNode(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
 }

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -1,29 +1,47 @@
 #include <Interpreters/inplaceBlockConversions.h>
 
+#include <utility>
+
 #include <Core/Block.h>
-#include <Interpreters/TreeRewriter.h>
-#include <Interpreters/ExpressionAnalyzer.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/TreeRewriter.h>
 #include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTWithAlias.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTFunction.h>
-#include <utility>
-#include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/ObjectUtils.h>
-#include <Interpreters/RequiredSourceColumnsVisitor.h>
-#include <Common/checkStackSize.h>
-#include <Storages/ColumnsDescription.h>
-#include <DataTypes/NestedUtils.h>
+#include <Parsers/ASTWithAlias.h>
+
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/NestedUtils.h>
+#include <DataTypes/ObjectUtils.h>
+#include <Interpreters/RequiredSourceColumnsVisitor.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/StorageInMemoryMetadata.h>
+#include <Storages/StorageDummy.h>
+#include <Common/checkStackSize.h>
+
+#include <Planner/CollectTableExpressionData.h>
+#include <Planner/Utils.h>
+#include <Planner/CollectSets.h>
+#include <Planner/PlannerActionsVisitor.h>
+#include <Analyzer/QueryTreeBuilder.h>
+#include <Analyzer/Resolve/QueryAnalyzer.h>
+#include <Analyzer/TableNode.h>
 
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsBool allow_experimental_analyzer;
+}
 
 namespace ErrorCode
 {
@@ -32,7 +50,6 @@ namespace ErrorCode
 
 namespace
 {
-
 /// Add all required expressions for missing columns calculation
 void addDefaultRequiredExpressionsRecursively(
     const Block & block,
@@ -173,6 +190,53 @@ std::optional<ActionsDAG> createExpressions(
     return ActionsDAG::merge(std::move(dag), std::move(actions));
 }
 
+std::optional<ActionsDAG> createExpressionsAnalyzer(
+    const Block & header,
+    ASTPtr expr_list,
+    bool save_unneeded_columns,
+    ContextPtr context)
+{
+    if (!expr_list)
+        return {};
+
+    auto execution_context = Context::createCopy(context);
+    auto expression = buildQueryTree(expr_list, execution_context);
+
+    ColumnsDescription fake_column_descriptions(header.getNamesAndTypesList());
+    auto storage = std::make_shared<StorageDummy>(StorageID{"dummy", "dummy"}, fake_column_descriptions);
+    QueryTreeNodePtr fake_table_expression = std::make_shared<TableNode>(storage, execution_context);
+
+    QueryAnalyzer analyzer(false);
+    analyzer.resolveConstantExpression(expression, fake_table_expression, execution_context);
+
+    GlobalPlannerContextPtr global_planner_context = std::make_shared<GlobalPlannerContext>(nullptr, nullptr, FiltersForTableExpressionMap{});
+    auto planner_context = std::make_shared<PlannerContext>(execution_context, global_planner_context, SelectQueryOptions{});
+
+    collectSourceColumns(expression, planner_context, true /*keep_alias_columns*/);
+    collectSets(expression, *planner_context);
+
+    auto actions = buildActionsDAGFromExpressionNode(expression, header.getColumnsWithTypeAndName(), planner_context, {}).first;
+    chassert(expression->getChildren().size() == actions.getOutputs().size());
+
+    NamesWithAliases result_columns;
+    for (size_t i = 0; i < expression->getChildren().size(); ++i)
+        result_columns.emplace_back(actions.getOutputs()[i]->result_name, expr_list->children[i]->getAliasOrColumnName());
+
+    if (!save_unneeded_columns)
+        actions.addAliases(result_columns);
+    else
+        actions.project(result_columns);
+
+    // Output all the rest columns
+    NameSet outputs;
+    for (const auto & output : actions.getOutputs())
+        outputs.insert(output->result_name);
+    for (const auto & input : actions.getInputs())
+        if (!outputs.contains(input->result_name))
+            actions.getOutputs().push_back(input);
+
+    return actions;
+}
 }
 
 void performRequiredConversions(Block & block, const NamesAndTypesList & required_columns, ContextPtr context)
@@ -181,7 +245,13 @@ void performRequiredConversions(Block & block, const NamesAndTypesList & require
     if (conversion_expr_list->children.empty())
         return;
 
-    if (auto dag = createExpressions(block, conversion_expr_list, true, context))
+    std::optional<ActionsDAG> dag;
+    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        dag = createExpressionsAnalyzer(block, conversion_expr_list, true, context);
+    else
+        dag = createExpressions(block, conversion_expr_list, true, context);
+
+    if (dag)
     {
         auto expression = std::make_shared<ExpressionActions>(std::move(*dag), ExpressionActionsSettings(context));
         expression->execute(block);
@@ -210,6 +280,8 @@ std::optional<ActionsDAG> evaluateMissingDefaults(
         return {};
 
     ASTPtr expr_list = defaultRequiredExpressions(header, required_columns, columns, null_as_default);
+    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        return createExpressionsAnalyzer(header, expr_list, save_unneeded_columns, context);
     return createExpressions(header, expr_list, save_unneeded_columns, context);
 }
 

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -207,7 +207,7 @@ std::optional<ActionsDAG> createExpressionsAnalyzer(
     QueryTreeNodePtr fake_table_expression = std::make_shared<TableNode>(storage, execution_context);
 
     QueryAnalyzer analyzer(false);
-    analyzer.resolveConstantExpression(expression, fake_table_expression, execution_context);
+    analyzer.resolve(expression, fake_table_expression, execution_context);
 
     GlobalPlannerContextPtr global_planner_context = std::make_shared<GlobalPlannerContext>(nullptr, nullptr, FiltersForTableExpressionMap{});
     auto planner_context = std::make_shared<PlannerContext>(execution_context, global_planner_context, SelectQueryOptions{});
@@ -227,7 +227,7 @@ std::optional<ActionsDAG> createExpressionsAnalyzer(
     else
         actions.project(result_columns);
 
-    // Output all the rest columns
+    // Output columns without expression as-is
     NameSet outputs;
     for (const auto & output : actions.getOutputs())
         outputs.insert(output->result_name);

--- a/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.reference
+++ b/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.reference
@@ -3,5 +3,5 @@
 1
 1
 1	[]	[]	[]	0
-CREATE TABLE default.defaults_on_defaults\n(\n    `key` UInt64,\n    `Arr.C1` Array(UInt32) DEFAULT emptyArrayUInt32(),\n    `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C1)),\n    `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(Arr.C2)),\n    `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C3)),\n    `ArrLen` UInt64 DEFAULT length(Arr.C4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.defaults_on_defaults\n(\n    `key` UInt64,\n    `Arr.C1` Array(UInt32) DEFAULT emptyArrayUInt32(),\n    `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C1`)),\n    `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(`Arr.C2`)),\n    `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C3`)),\n    `ArrLen` UInt64 DEFAULT length(`Arr.C4`)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 1

--- a/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.sql
+++ b/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.sql
@@ -9,19 +9,19 @@ INSERT INTO defaults_on_defaults values (1);
 
 ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C1` Array(UInt32) DEFAULT emptyArrayUInt32();
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C1));
+ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C1`));
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(Arr.C2));
+ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(`Arr.C2`));
 
 SELECT 1 from defaults_on_defaults where length(`Arr.C2`) = 0;
 
 SELECT 1 from defaults_on_defaults where length(`Arr.C3`) = 0;
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C3));
+ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C3`));
 
 SELECT 1 from defaults_on_defaults where length(`Arr.C4`) = 0;
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `ArrLen` UInt64 DEFAULT length(Arr.C4);
+ALTER TABLE defaults_on_defaults ADD COLUMN `ArrLen` UInt64 DEFAULT length(`Arr.C4`);
 
 SELECT 1 from defaults_on_defaults where ArrLen = 0;
 

--- a/tests/queries/0_stateless/03560_new_analyzer_default_expression.reference
+++ b/tests/queries/0_stateless/03560_new_analyzer_default_expression.reference
@@ -1,9 +1,13 @@
 -- { echoOn }
-SELECT * FROM with_default ORDER BY ALL;
+SELECT * FROM default ORDER BY ALL;
 1
-SELECT * FROM with_clashing_name ORDER BY ALL;
+SELECT * FROM clashing_name ORDER BY ALL;
 7
-SELECT * FROM with_dependent_defaults ORDER BY ALL;
+SELECT * FROM dependent_defaults ORDER BY ALL;
 7	14	98
-SELECT * FROM with_regular_column ORDER BY ALL;
+SELECT * FROM regular_column ORDER BY ALL;
 2	7	14
+SELECT * FROM complex_name_backward_compat ORDER BY ALL;
+3	7	21
+SELECT * FROM compound_id ORDER BY ALL;
+(1,2)	8

--- a/tests/queries/0_stateless/03560_new_analyzer_default_expression.reference
+++ b/tests/queries/0_stateless/03560_new_analyzer_default_expression.reference
@@ -1,0 +1,9 @@
+-- { echoOn }
+SELECT * FROM with_default ORDER BY ALL;
+1
+SELECT * FROM with_clashing_name ORDER BY ALL;
+7
+SELECT * FROM with_dependent_defaults ORDER BY ALL;
+7	14	98
+SELECT * FROM with_regular_column ORDER BY ALL;
+2	7	14

--- a/tests/queries/0_stateless/03560_new_analyzer_default_expression.sql
+++ b/tests/queries/0_stateless/03560_new_analyzer_default_expression.sql
@@ -1,0 +1,20 @@
+SET enable_analyzer=1;
+
+CREATE TABLE with_default (a Int64 DEFAULT 1) Engine=Memory();
+-- This case is failing with old analyzer, because "_subquery" name prefix has a special treatment.
+CREATE TABLE with_clashing_name (_subquery_test Int64 DEFAULT 7) Engine=Memory();
+CREATE TABLE with_dependent_defaults (a Int64 DEFAULT 7, b Int64 DEFAULT a + 7, c Int64 DEFAULT a * b) Engine=Memory();
+CREATE TABLE with_regular_column (a Int64, b Int64 DEFAULT 7, c Int64 DEFAULT a * b) Engine=Memory();
+
+SET insert_null_as_default=1;
+
+INSERT INTO with_default SELECT NULL FROM system.one;
+INSERT INTO with_clashing_name SELECT NULL FROM system.one;
+INSERT INTO with_dependent_defaults SELECT NULL, NULL, NULL FROM system.one;
+INSERT INTO with_regular_column SELECT 2, NULL, NULL FROM system.one;
+
+-- { echoOn }
+SELECT * FROM with_default ORDER BY ALL;
+SELECT * FROM with_clashing_name ORDER BY ALL;
+SELECT * FROM with_dependent_defaults ORDER BY ALL;
+SELECT * FROM with_regular_column ORDER BY ALL;

--- a/tests/queries/0_stateless/03560_new_analyzer_default_expression.sql
+++ b/tests/queries/0_stateless/03560_new_analyzer_default_expression.sql
@@ -1,20 +1,26 @@
 SET enable_analyzer=1;
 
-CREATE TABLE with_default (a Int64 DEFAULT 1) Engine=Memory();
+CREATE TABLE default (a Int64 DEFAULT 1) Engine=Memory();
 -- This case is failing with old analyzer, because "_subquery" name prefix has a special treatment.
-CREATE TABLE with_clashing_name (_subquery_test Int64 DEFAULT 7) Engine=Memory();
-CREATE TABLE with_dependent_defaults (a Int64 DEFAULT 7, b Int64 DEFAULT a + 7, c Int64 DEFAULT a * b) Engine=Memory();
-CREATE TABLE with_regular_column (a Int64, b Int64 DEFAULT 7, c Int64 DEFAULT a * b) Engine=Memory();
+CREATE TABLE clashing_name (_subquery_test Int64 DEFAULT 7) Engine=Memory();
+CREATE TABLE dependent_defaults (a Int64 DEFAULT 7, b Int64 DEFAULT a + 7, c Int64 DEFAULT a * b) Engine=Memory();
+CREATE TABLE regular_column (a Int64, b Int64 DEFAULT 7, c Int64 DEFAULT a * b) Engine=Memory();
+CREATE TABLE complex_name_backward_compat (a Int64, `b.b` Int64 DEFAULT 7, c Int64 DEFAULT a * `b.b`) Engine=Memory();
+CREATE TABLE compound_id (a Tuple(x Int64, y Int64), b Int64 DEFAULT a.x + 7) Engine=Memory();
 
 SET insert_null_as_default=1;
 
-INSERT INTO with_default SELECT NULL FROM system.one;
-INSERT INTO with_clashing_name SELECT NULL FROM system.one;
-INSERT INTO with_dependent_defaults SELECT NULL, NULL, NULL FROM system.one;
-INSERT INTO with_regular_column SELECT 2, NULL, NULL FROM system.one;
+INSERT INTO default SELECT NULL FROM system.one;
+INSERT INTO clashing_name SELECT NULL FROM system.one;
+INSERT INTO dependent_defaults SELECT NULL, NULL, NULL FROM system.one;
+INSERT INTO regular_column SELECT 2, NULL, NULL FROM system.one;
+INSERT INTO complex_name_backward_compat SELECT 3, NULL, NULL FROM system.one;
+INSERT INTO compound_id (a) VALUES ((1, 2));
 
 -- { echoOn }
-SELECT * FROM with_default ORDER BY ALL;
-SELECT * FROM with_clashing_name ORDER BY ALL;
-SELECT * FROM with_dependent_defaults ORDER BY ALL;
-SELECT * FROM with_regular_column ORDER BY ALL;
+SELECT * FROM default ORDER BY ALL;
+SELECT * FROM clashing_name ORDER BY ALL;
+SELECT * FROM dependent_defaults ORDER BY ALL;
+SELECT * FROM regular_column ORDER BY ALL;
+SELECT * FROM complex_name_backward_compat ORDER BY ALL;
+SELECT * FROM compound_id ORDER BY ALL;


### PR DESCRIPTION
Support creating a default expression using the new analyzer. Fixes 

Related to #78902
Old analyzer, in rare cases, cannot execute valid queries
https://fiddle.clickhouse.com/00614142-12f4-4e1e-9dd7-03d34e8bd8d1

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Require backticks around identifiers with dots in default expressions to prevent them from being parsed as compound identifiers.

