### PR TITLE
Async log improvements

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -38,6 +38,7 @@
 #include <Interpreters/Cache/FileCacheFactory.h>
 #include <Loggers/OwnFormattingChannel.h>
 #include <Loggers/OwnPatternFormatter.h>
+#include <Loggers/OwnSplitChannel.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/SharedThreadPools.h>

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -49,6 +49,7 @@
 
 #include <Loggers/OwnFormattingChannel.h>
 #include <Loggers/OwnPatternFormatter.h>
+#include <Loggers/OwnSplitChannel.h>
 
 #include <Common/config_version.h>
 

--- a/src/Loggers/ExtendedLogChannel.h
+++ b/src/Loggers/ExtendedLogChannel.h
@@ -17,15 +17,6 @@ public:
         : base(&base_)
     {
     }
-    explicit ExtendedLogMessage(const Poco::Message & new_base_, const ExtendedLogMessage & other)
-        : base(&new_base_)
-        , time_seconds(other.time_seconds)
-        , time_microseconds(other.time_microseconds)
-        , time_in_microseconds(other.time_in_microseconds)
-        , thread_id(other.thread_id)
-        , query_id(other.query_id)
-    {
-    }
 
     /// Attach additional data to the message
     static ExtendedLogMessage getFrom(const Poco::Message & base);

--- a/src/Loggers/Loggers.h
+++ b/src/Loggers/Loggers.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Loggers/OwnSplitChannel.h>
-
 #include <Poco/AutoPtr.h>
 #include <Poco/FileChannel.h>
 #include <Poco/Util/Application.h>
@@ -9,6 +7,10 @@
 #include <optional>
 #include <string>
 
+namespace DB
+{
+    class OwnSplitChannelBase;
+}
 
 namespace Poco::Util
 {

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -274,7 +274,7 @@ void OwnAsyncSplitChannel::close()
 class AsyncLogMessage
 {
 public:
-    AsyncLogMessage(const Message & msg_)
+    explicit AsyncLogMessage(const Message & msg_)
         : msg(msg_)
         , msg_ext(ExtendedLogMessage::getFrom(msg))
         , msg_thread_name(getThreadName())
@@ -297,7 +297,7 @@ public:
 };
 
 
-void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr pNotification)
+void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr message)
 {
     std::unique_lock lock(mutex);
     size_t current_size = message_queue.size();
@@ -314,7 +314,7 @@ void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr pNotification)
         dropped_messages = 0;
     }
 
-    message_queue.push_back(pNotification);
+    message_queue.push_back(message);
     condition.notify_one();
 }
 
@@ -422,7 +422,7 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
     {
         if (!async_message)
             return;
-        auto * own_notification = dynamic_cast<const AsyncLogMessage *>(async_message.get());
+        const auto * own_notification = dynamic_cast<const AsyncLogMessage *>(async_message.get());
         {
             if (own_notification)
             {

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -11,6 +11,7 @@
 #include <Common/setThreadName.h>
 
 #include <Poco/Message.h>
+#include <Poco/RefCountedObject.h>
 
 namespace DB
 {
@@ -245,7 +246,7 @@ void OwnAsyncSplitChannel::close()
         {
             do
             {
-                text_log_queue.wakeUpAll();
+                text_log_queue.wakeUp();
             } while (!text_log_thread->tryJoin(100));
             text_log_thread.reset();
         }
@@ -256,7 +257,7 @@ void OwnAsyncSplitChannel::close()
             {
                 do
                 {
-                    queues[i]->wakeUpAll();
+                    queues[i]->wakeUp();
                 } while (!threads[i]->tryJoin(100));
             }
             threads[i].reset();
@@ -271,10 +272,10 @@ void OwnAsyncSplitChannel::close()
     }
 }
 
-class OwnMessageNotification : public Poco::Notification
+class AsyncLogMessage : public Poco::RefCountedObject
 {
 public:
-    explicit OwnMessageNotification(const Message & msg_)
+    AsyncLogMessage(const Message & msg_)
         : msg(msg_)
         , msg_ext(ExtendedLogMessage::getFrom(msg))
         , msg_thread_name(getThreadName())
@@ -296,17 +297,61 @@ public:
     std::string msg_thread_name;
 };
 
+
+void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr pNotification)
+{
+    std::unique_lock lock(mutex);
+    if (message_queue.size() > max_size)
+        return;
+
+    message_queue.push_back(pNotification);
+    condition.notify_one();
+}
+
+AsyncLogMessagePtr AsyncLogMessageQueue::waitDequeueMessage()
+{
+    std::unique_lock lock(mutex);
+    if (!message_queue.empty())
+    {
+        auto & notification = message_queue.front();
+        message_queue.pop_front();
+        return notification.duplicate();
+    }
+
+    condition.wait(lock);
+    if (message_queue.empty())
+        return nullptr;
+
+    auto & notification = message_queue.front();
+    message_queue.pop_front();
+    return notification.duplicate();
+}
+
+AsyncLogMessageQueue::Queue AsyncLogMessageQueue::getCurrentQueueAndClear()
+{
+    std::unique_lock lock(mutex);
+    Queue new_queue;
+    std::swap(message_queue, new_queue);
+    return new_queue;
+}
+
+void AsyncLogMessageQueue::wakeUp()
+{
+    std::unique_lock lock(mutex);
+    condition.notify_one();
+}
+
 void OwnAsyncSplitChannel::log(const Poco::Message & msg)
 {
     LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
     try
     {
-        Poco::AutoPtr<OwnMessageNotification> notification;
+        AsyncLogMessagePtr notification;
         if (const auto & logs_queue = CurrentThread::getInternalTextLogsQueue();
             logs_queue && logs_queue->isNeeded(msg.getPriority(), msg.getSource()))
         {
             /// If we need to push to the TCP queue, do it now since it expects to receive all messages synchronously
-            notification = new OwnMessageNotification(msg);
+            notification = AsyncLogMessagePtr(new AsyncLogMessage(msg), true);
             pushExtendedMessageToInternalTCPTextLogQueue(notification->msg_ext, logs_queue);
         }
 
@@ -315,13 +360,13 @@ void OwnAsyncSplitChannel::log(const Poco::Message & msg)
             return;
 
         if (!notification)
-            notification = new OwnMessageNotification(msg);
+            notification = AsyncLogMessagePtr(new AsyncLogMessage(msg), true);
 
         if (msg.getPriority() <= text_log_max_priority_loaded)
-            text_log_queue.enqueueNotification(notification);
+            text_log_queue.enqueueMessage(notification);
 
-        for (const auto & queue : queues)
-            queue->enqueueNotification(notification);
+        for (auto & queue : queues)
+            queue->enqueueMessage(notification);
     }
     catch (...)
     {
@@ -351,7 +396,7 @@ void OwnAsyncSplitChannel::flushTextLogs()
 
     /// We need to send an empty notification to wake up the thread if necessary
     flush_text_logs = true;
-    text_log_queue.wakeUpAll();
+    text_log_queue.wakeUp();
 
     /// Now we simply wait for the async thread to notify it has finished flushing
     flush_text_logs.wait(true, std::memory_order_seq_cst);
@@ -361,20 +406,20 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
 {
     setThreadName("AsyncLog");
     LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
-    Poco::AutoPtr<Poco::Notification> notification = queues[i]->waitDequeueNotification();
+    auto notification = queues[i]->waitDequeueMessage();
 
-    auto log_notification = [&](Poco::AutoPtr<Poco::Notification> & notif)
+    auto log_notification = [&](auto & async_message)
     {
-        if (!notif)
+        if (!async_message)
             return;
-        const OwnMessageNotification * own_notification = dynamic_cast<const OwnMessageNotification *>(notif.get());
+        auto * own_notification = dynamic_cast<const AsyncLogMessage *>(async_message.get());
         {
             if (own_notification)
             {
                 if (channels[i].second)
                     channels[i].second->logExtended(own_notification->msg_ext); // extended child
                 else
-                    channels[i].first->log(*own_notification->msg_ext.base); // ordinary child
+                    channels[i].first->log(*(own_notification->msg_ext).base); // ordinary child
             }
         }
     };
@@ -382,7 +427,7 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
     while (is_open)
     {
         log_notification(notification);
-        notification = queues[i]->waitDequeueNotification();
+        notification = queues[i]->waitDequeueMessage();
     }
 
     /// Flush everything before closing
@@ -402,9 +447,9 @@ void OwnAsyncSplitChannel::runTextLog()
 {
     setThreadName("AsyncTextLog", true);
 
-    auto log_notification = [](Poco::Notification * message, const std::shared_ptr<SystemLogQueue<TextLogElement>> & text_log_locked)
+    auto log_notification = [](auto & message, const std::shared_ptr<SystemLogQueue<TextLogElement>> & text_log_locked)
     {
-        if (const auto * own_notification = dynamic_cast<const OwnMessageNotification *>(message))
+        if (const auto * own_notification = dynamic_cast<const AsyncLogMessage *>(message.get()))
             logToSystemTextLogQueue(text_log_locked, own_notification->msg_ext, own_notification->msg_thread_name);
     };
 
@@ -421,7 +466,7 @@ void OwnAsyncSplitChannel::runTextLog()
         }
     };
 
-    Poco::AutoPtr<Poco::Notification> notification = text_log_queue.waitDequeueNotification();
+    auto notification = text_log_queue.waitDequeueMessage();
     while (is_open)
     {
         if (flush_text_logs)
@@ -446,7 +491,7 @@ void OwnAsyncSplitChannel::runTextLog()
             log_notification(notification, text_log_locked);
         }
 
-        notification = text_log_queue.waitDequeueNotification();
+        notification = text_log_queue.waitDequeueMessage();
     }
 
     /// We want to flush everything already in the queue before closing so all messages are logged
@@ -480,7 +525,7 @@ void OwnAsyncSplitChannel::addChannel(Poco::AutoPtr<Poco::Channel> channel, cons
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Channel {} is already registered", name);
 
     channels.emplace_back(extended);
-    queues.emplace_back(std::make_unique<Poco::NotificationQueue>());
+    queues.emplace_back(std::make_unique<AsyncLogMessageQueue>());
     threads.emplace_back(nullptr);
     const size_t i = threads.size() - 1;
     runnables.emplace_back(new OwnRunnableForChannel(*this, i));

--- a/src/Loggers/OwnSplitChannel.h
+++ b/src/Loggers/OwnSplitChannel.h
@@ -79,7 +79,7 @@ struct OwnRunnableForChannel;
 struct OwnRunnableForTextLog;
 
 class AsyncLogMessage;
-using AsyncLogMessagePtr = Poco::AutoPtr<AsyncLogMessage>;
+using AsyncLogMessagePtr = std::shared_ptr<AsyncLogMessage>;
 
 class AsyncLogMessageQueue
 {

--- a/src/Loggers/OwnSplitChannel.h
+++ b/src/Loggers/OwnSplitChannel.h
@@ -84,13 +84,13 @@ using AsyncLogMessagePtr = std::shared_ptr<AsyncLogMessage>;
 class AsyncLogMessageQueue
 {
     /// Maximum size of the queue, to prevent memory overflow
-    static constexpr size_t max_size = 100'000;
+    static constexpr size_t max_size = 10'000;
 
 public:
     using Queue = std::deque<AsyncLogMessagePtr>;
 
     /// Enqueues a single message notification
-    void enqueueMessage(AsyncLogMessagePtr pNotification);
+    void enqueueMessage(AsyncLogMessagePtr message);
 
     /// Waits for a message notification to be dequeued and returns it. It might return an empty notification if wakeUp() was called
     /// or a spurious wakeup occurs
@@ -105,6 +105,7 @@ public:
 private:
     Queue message_queue;
     std::condition_variable condition;
+    size_t dropped_messages = 0;
     std::mutex mutex;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Async logs: Limit the max number of entries that are hold in the queue

Note that each channel has its own queue, so a message might be dropped in syslog or console (because they are the slowest ones) but still make it to text files or system.text_log. The number of 10k is arbitrary.

I  replaced Poco's NotificationQueue for our own, simplified, queue. I also tested several no-locks queues with bad results. Either they were slower, had TSAN issues or did not support blocking on pop() which meant we'd need to busy wait. I also tried to replace the condition_variable with an std::atomic_bool. It appeared to be slightly faster in the producer , but it consumed way more CPU in the consumer so I ended up discarding it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
