### PR TITLE
Fix empty table reading with Glue catalog in 25.3

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -304,7 +304,9 @@ std::optional<String> IcebergMetadata::getRelevantManifestList(const Poco::JSON:
 
     auto snapshots = metadata->get("snapshots").extract<Poco::JSON::Array::Ptr>();
 
-    auto current_snapshot_id = metadata->getValue<Int64>("current-snapshot-id");
+    Int64 current_snapshot_id = -1;
+    if (metadata->has("current-snapshot-id"))
+        current_snapshot_id = metadata->getValue<Int64>("current-snapshot-id");
 
     for (size_t i = 0; i < snapshots->size(); ++i)
     {

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -297,3 +297,19 @@ def test_hide_sensitive_info(started_cluster):
     )
     assert "SECRET_1" not in node.query(f"SHOW CREATE DATABASE {CATALOG_NAME}")
     assert "SECRET_2" not in node.query(f"SHOW CREATE DATABASE {CATALOG_NAME}")
+
+
+def test_empty_table(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_list_tables_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(root_namespace)
+
+    table = create_table(catalog, root_namespace, table_name)
+
+    create_clickhouse_glue_database(started_cluster, node, CATALOG_NAME)
+    assert len(node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`")) == 0


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes this bug in 25.3 (for 25.4+ this issue is irrelevant) https://github.com/ClickHouse/ClickHouse/issues/82601

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

