### PR TITLE
clickhouse-test: obtain stacktrace with gdb if we failed to do this with SIGTSTP

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -542,7 +542,7 @@ def clickhouse_execute_json(
 CAPTURE_CLIENT_STACKTRACE = False
 
 
-def kill_process_group(pgid):
+def kill_process_group(pgid, fatal_log):
     print(f"Killing process group {pgid}")
     print(f"Processes in process group {pgid}:")
     print(
@@ -560,6 +560,25 @@ def kill_process_group(pgid):
                 sleep(0.5)
             else:
                 sleep(10)
+
+            # Let's check maybe clickhouse already printed the stacktrace, then no need to do the same with gdb
+            client_printed_stacktrace = False
+            try:
+                if fatal_log and os.path.exists(fatal_log):
+                    with open(fatal_log, "rb") as f:
+                        if b'This is a signal used for debugging purposes by the user' in f.read():
+                            client_printed_stacktrace = True
+            except:
+                print(f"Cannot read {fatal_log}. Ignoring.")
+
+            if not client_printed_stacktrace:
+                pgrep = subprocess.run(f"pgrep --pgroup {pgid} clickhouse", shell=True, capture_output=True, text=False)
+                processes = pgrep.stdout.decode("utf-8").strip().split("\n")
+                processes = map(lambda x: x.strip(), processes)
+                processes = filter(lambda x: len(x) > 0, processes)
+                processes = list(map(lambda x: int(x.strip()), processes))
+                for child in processes:
+                    print(get_stacktraces_from_gdb(child))
         # NOTE: this still may leave some processes, that had been
         # created by timeout(1), since it also creates new process
         # group. But this should not be a problem with default
@@ -617,7 +636,7 @@ def cleanup_child_processes(pid):
             continue
 
         if child_pgid != pgid:
-            kill_process_group(child_pgid)
+            kill_process_group(child_pgid, None)
 
     # SIGKILL should not be sent, since this will kill the script itself
     os.killpg(pgid, signal.SIGTERM)
@@ -769,32 +788,13 @@ def get_transactions_list(args):
         return f"Cannot get list of transactions: {e}"
 
 
-def kill_gdb_if_any():
-    # Check if we have running gdb.
-    code = subprocess.call("pidof gdb", shell=True)
-    if code != 0:
-        return
-
-    for i in range(5):
-        code = subprocess.call("kill -TERM $(pidof gdb)", shell=True, timeout=30)
-        if code != 0:
-            sleep(i)
-        else:
-            break
-
-
 # collect server stacktraces using gdb
-def get_stacktraces_from_gdb(server_pid):
+def get_stacktraces_from_gdb(pid):
     try:
-        # We could attach gdb to clickhouse-server before running some tests
-        # to print stacktraces of all crashes even if clickhouse cannot print it for some reason.
-        # We should kill existing gdb if any before starting new one.
-        kill_gdb_if_any()
-
-        cmd = f"gdb -batch -ex 'thread apply all backtrace' -p {server_pid}"
+        cmd = f"gdb -batch -ex 'thread apply all backtrace' -p {pid}"
         return subprocess.check_output(cmd, shell=True).decode("utf-8")
     except Exception as e:
-        print(f"Error occurred while receiving stack traces from gdb: {e}")
+        print(f"Error occurred while receiving stack traces from gdb (for {pid}): {e}")
         return None
 
 
@@ -1642,7 +1642,7 @@ class TestCase:
             if proc.returncode is None:
                 f = io.StringIO()
                 with redirect_stdout(f):
-                    kill_process_group(os.getpgid(proc.pid))
+                    kill_process_group(os.getpgid(proc.pid), self.fatal_sanitizer_prefix)
                 kill_output = f.getvalue()
 
         description = ""
@@ -2762,7 +2762,7 @@ def run_tests_array(
                     raise TimeoutError("Test execution timed out")
 
                 signal.signal(signal.SIGALRM, timeout_handler)
-                signal.alarm(int(args.timeout * 1.1) + 5)
+                signal.alarm(int(args.timeout * 1.1) + 60)
                 test_result = None
                 try:
                     test_result = test_case.run(args, test_suite, client_options)
@@ -3098,7 +3098,6 @@ def do_run_tests(
 
             if server_died.is_set():
                 print("Server died, terminating all processes...")
-                kill_gdb_if_any()
                 # Wait for test results
                 sleep(args.timeout)
                 for p in processes:


### PR DESCRIPTION
Sometimes there are very hard to debug cases, this will help.

I used the same approach for debugging https://github.com/ClickHouse/ClickHouse/pull/82444

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)