### PR TITLE
Fix crash when calculating the size of a block with empty columns

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -444,7 +444,8 @@ size_t Block::bytes() const
 {
     size_t res = 0;
     for (const auto & elem : data)
-        res += elem.column->byteSize();
+        if (elem.column)
+            res += elem.column->byteSize();
 
     return res;
 }
@@ -453,7 +454,8 @@ size_t Block::allocatedBytes() const
 {
     size_t res = 0;
     for (const auto & elem : data)
-        res += elem.column->allocatedBytes();
+        if (elem.column)
+            res += elem.column->allocatedBytes();
 
     return res;
 }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -496,7 +496,7 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
         auto & data = queue_it->second.data;
         size_t entry_data_size = entry->chunk.byteSize();
 
-        assert(data);
+        chassert(data);
         auto size_in_bytes = data->size_in_bytes;
         data->size_in_bytes += entry_data_size;
         /// We rely on the fact that entries are being added to the list in order of creation time in `scheduleDataProcessingJob()`

--- a/tests/queries/0_stateless/03561_async_insert_crash.sh
+++ b/tests/queries/0_stateless/03561_async_insert_crash.sh
@@ -4,7 +4,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-FILE="${USER_FILES_PATH}/03561_async_insert.data"
+FILE="${USER_FILES_PATH}/${CLICKHOUSE_DATABASE}_03561_async_insert.data"
 trap 'rm -f $FILE' EXIT
 
 $CLICKHOUSE_CLIENT -q "

--- a/tests/queries/0_stateless/03561_async_insert_crash.sh
+++ b/tests/queries/0_stateless/03561_async_insert_crash.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+FILE="${USER_FILES_PATH}/03561_async_insert.data"
+trap 'rm -f $FILE' EXIT
+
+$CLICKHOUSE_CLIENT -q "
+  DROP TABLE IF EXISTS t0;
+  CREATE TABLE t0 (c0 Int) ENGINE = Null();
+  INSERT INTO TABLE FUNCTION file('${FILE}', 'JSONColumns', 'c0 Int') SELECT 1 FROM t0 LIMIT 0;
+  SET async_insert = 1;
+  INSERT INTO TABLE t0 (c0) FROM INFILE '${FILE}' FORMAT JSONColumns;
+"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash when calculating the size of a block with empty columns

https://github.com/ClickHouse/ClickHouse/pull/80972/commits/63c3fc9feb55db03a0019d71af65a67259472643 changed async insert to use `squashing.getHeader().cloneWithoutColumns()` to clone a Block when the squash chunk is empty. The problem is that the function `Block::bytes()` (or `allocatedBytes`) does not support having empty columns internally as others do (`rows` for example).

One possible solution would be to change the cloning and use `cloneEmpty` instead, but long term it makes sense to change Block instead as there are other places using `cloneWithoutColumns` and more might decide to use it in the future.

Closes https://github.com/ClickHouse/ClickHouse/issues/83244

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
