### PR TITLE
turn off msan for 03008_deduplication_mv_generates_several_blocks_nonreplicated.sh

### DIFF
--- a/tests/queries/0_stateless/03008_deduplication_mv_generates_several_blocks_nonreplicated.sh
+++ b/tests/queries/0_stateless/03008_deduplication_mv_generates_several_blocks_nonreplicated.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-parallel, no-object-storage, no-flaky-check
+# Tags: long, no-fasttest, no-parallel, no-object-storage, no-flaky-check, no-msan
 # Tag no-flaky-check -- not compatible with ThreadFuzzer
+# Tag no-msan -- too long for MSAN
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
[https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHR[…]XN0X2R1cmF0aW9uX21zIERFU0MsIGNoZWNrX3N0YXJ0X3RpbWU=](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9kdXJhdGlvbl9tcywgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMjQgSE9VUgogICAgQU5EIChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBzdGFydHNXaXRoKGhlYWRfcmVwbywgJ0NsaWNrSG91c2UvJykpCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCi8vICAgIEFORCAodGVzdF9zdGF0dXMgTElLRSAnRiUnIE9SIHRlc3Rfc3RhdHVzIExJS0UgJ0UlJykgCi8vICAgIEFORCBjaGVja19zdGF0dXMgIT0gJ3N1Y2Nlc3MnCiAgICBBTkQgcG9zaXRpb24odGVzdF9uYW1lLCAnMDMwMDhfZGVkdXBsaWNhdGlvbl9tdl9nZW5lcmF0ZXNfc2V2ZXJhbF9ibG9ja3Nfbm9ucmVwbGljYXRlZCcpID4gMApPUkRFUiBCWSB0ZXN0X2R1cmF0aW9uX21zIERFU0MsIGNoZWNrX3N0YXJ0X3RpbWU=)

`03008_deduplication_mv_generates_several_blocks_nonreplicated` takes too long time with MSAN

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
