### PR TITLE
Print biggest subtree in snapshot analyzer of Keeper utils

### DIFF
--- a/programs/keeper-utils/KeeperUtils.cpp
+++ b/programs/keeper-utils/KeeperUtils.cpp
@@ -1,7 +1,9 @@
 #include <iostream>
+#include <unordered_map>
 #include <Columns/IColumn.h>
 #include <Coordination/Changelog.h>
 #include <Coordination/CoordinationSettings.h>
+#include <Coordination/KeeperCommon.h>
 #include <Coordination/KeeperLogStore.h>
 #include <Coordination/KeeperStateMachine.h>
 #include <Coordination/KeeperStorage.h>
@@ -61,39 +63,52 @@ uint64_t getSnapshotPathUpToLogIdx(const String & snapshot_path)
     return parse<uint64_t>(name_parts[1]);
 }
 
-void analyzeSnapshot(const std::string & snapshot_path)
+void analyzeSnapshot(const std::string & snapshot_path, bool full_storage, bool with_node_stats)
 {
     try
     {
-        auto disk = std::make_shared<DiskLocal>("SnapshotDisk", snapshot_path);
         auto keeper_context = std::make_shared<KeeperContext>(true, std::make_shared<CoordinationSettings>());
-        keeper_context->setSnapshotDisk(disk);
-
-        // Get list of all files in the snapshot directory
-        std::vector<std::string> snapshot_files;
-        disk->listFiles(snapshot_path, snapshot_files);
-
-        // Filter for snapshot files (snapshot_*.bin or snapshot_*.bin.zstd)
         std::vector<std::string> snapshot_paths;
-        for (const auto & file : snapshot_files)
+        bool specific_snapshot_defined = false;
+        if (snapshot_path.ends_with(".bin") || snapshot_path.ends_with(".bin.zstd"))
         {
-            if (file.starts_with("snapshot_") && (file.ends_with(".bin") || file.ends_with(".bin.zstd")))
-                snapshot_paths.push_back(file);
+            specific_snapshot_defined = true;
+            snapshot_paths.push_back(snapshot_path);
+            std::filesystem::path normalized_path = std::filesystem::weakly_canonical(snapshot_path).parent_path();
+            auto disk = std::make_shared<DiskLocal>("SnapshotDisk", normalized_path.string());
+            keeper_context->setSnapshotDisk(disk);
+        }
+        else
+        {
+            auto disk = std::make_shared<DiskLocal>("SnapshotDisk", snapshot_path);
+            keeper_context->setSnapshotDisk(disk);
+
+            // Get list of all files in the snapshot directory
+            std::vector<std::string> snapshot_files;
+            disk->listFiles(snapshot_path, snapshot_files);
+
+            // Filter for snapshot files (snapshot_*.bin or snapshot_*.bin.zstd);
+            for (const auto & file : snapshot_files)
+            {
+                if (file.starts_with("snapshot_") && (file.ends_with(".bin") || file.ends_with(".bin.zstd")))
+                    snapshot_paths.push_back(file);
+            }
+
+            if (snapshot_paths.empty())
+                throw DB::Exception(ErrorCodes::UNKNOWN_SNAPSHOT, "No snapshot files found in {}", snapshot_path);
+
+            // Sort snapshots by their index (newest first)
+            std::sort(snapshot_paths.begin(), snapshot_paths.end(), std::greater<>());
+
+            std::cout << "Found " << snapshot_paths.size() << " snapshots in " << snapshot_path << ":\n\n";
         }
 
-        if (snapshot_paths.empty())
-            throw DB::Exception(ErrorCodes::UNKNOWN_SNAPSHOT, "No snapshot files found in {}", snapshot_path);
-
-        // Sort snapshots by their index (newest first)
-        std::sort(snapshot_paths.begin(), snapshot_paths.end(), std::greater<>());
-
-        std::cout << "Found " << snapshot_paths.size() << " snapshots in " << snapshot_path << ":\n\n";
 
         for (const auto & snapshot_file : snapshot_paths)
         {
             try
             {
-                std::string full_path = std::filesystem::path(snapshot_path) / snapshot_file;
+                std::string full_path = specific_snapshot_defined ? snapshot_path : (std::filesystem::path(snapshot_path) / snapshot_file).generic_string();
                 std::cout << "=== Snapshot: " << snapshot_file << " ===\n";
 
                 // Create a snapshot manager for each snapshot
@@ -105,24 +120,89 @@ void analyzeSnapshot(const std::string & snapshot_path)
                     500   // storage_tick_time
                 );
 
-                auto result = snapshot_manager.deserializeSnapshotFromBuffer(snapshot_manager.deserializeSnapshotBufferFromDisk(getSnapshotPathUpToLogIdx(full_path)));
+                auto result = snapshot_manager.deserializeSnapshotFromBuffer(
+                    snapshot_manager.deserializeSnapshotBufferFromDisk(getSnapshotPathUpToLogIdx(full_path)),
+                    full_storage);
+
                 if (!result.storage)
                 {
                     std::cerr << "  Warning: Failed to load snapshot data\n\n";
                     continue;
                 }
 
-                // const auto & storage = *result.storage;
                 const auto & snapshot_meta = result.snapshot_meta;
 
-                std::cout << fmt::format("  Last committed log index: {}\n"
-                                        "  Last committed log term: {}\n"
-                                        "  Number of nodes: {}\n"
-                                        "  Digest: {}\n",
-                                        snapshot_meta->get_last_log_idx(),
-                                        snapshot_meta->get_last_log_term(),
-                                        result.storage->getNodesCount(),
-                                        result.storage->getNodesDigest(/*committed=*/true, /*lock_transaction_mutex=*/false).value) << std::endl;
+                if (full_storage)
+                {
+                    std::cout << fmt::format(
+                        "  Last committed log index: {}\n"
+                        "  Last committed log term: {}\n"
+                        "  Number of nodes: {}\n"
+                        "  Digest: {}\n",
+                        snapshot_meta->get_last_log_idx(),
+                        snapshot_meta->get_last_log_term(),
+                        result.storage->getNodesCount(),
+                        result.storage->getNodesDigest(/*committed=*/true, /*lock_transaction_mutex=*/false).value)
+                        << std::endl;
+                }
+                else
+                {
+                    std::cout << fmt::format(
+                        "  Last committed log index: {}\n"
+                        "  Last committed log term: {}\n"
+                        "  Number of paths: {}\n",
+                        snapshot_meta->get_last_log_idx(),
+                        snapshot_meta->get_last_log_term(),
+                        result.paths.size())
+                        << std::endl;
+
+                    if (with_node_stats)
+                    {
+                        std::cout << "Finding biggest subtrees... " << std::endl;
+                        std::unordered_map<StringRef, size_t> subtree_sizes;
+                        for (const auto & path : result.paths)
+                        {
+                            if (path == "/")
+                                continue;
+
+                            StringRef current_path = path;
+                            while (true)
+                            {
+                                auto parent = parentNodePath(current_path);
+                                if (parent == "/") // We are at the root
+                                    break;
+
+                                subtree_sizes[parent]++;
+                                current_path = parent;
+                            }
+                        }
+
+                        using NodeCount = std::pair<size_t, std::string_view>;
+                        auto cmp = [](const NodeCount & a, const NodeCount & b) { return a.first > b.first; };
+                        std::priority_queue<NodeCount, std::vector<NodeCount>, decltype(cmp)> pq(cmp);
+
+                        for (const auto & [node_path, count] : subtree_sizes)
+                        {
+                            pq.emplace(count, node_path);
+                            if (pq.size() > 10)
+                                pq.pop();
+                        }
+
+                        std::vector<NodeCount> top_nodes;
+                        while (!pq.empty())
+                        {
+                            top_nodes.push_back(pq.top());
+                            pq.pop();
+                        }
+                        std::reverse(top_nodes.begin(), top_nodes.end());
+
+                        std::cout << "  Top 10 biggest subtrees:\n";
+                        for (const auto & node : top_nodes)
+                        {
+                            std::cout << fmt::format("    {}: {} descendants\n", node.second, node.first);
+                        }
+                    }
+                }
             }
             catch (const DB::Exception & e)
             {
@@ -1014,7 +1094,9 @@ int mainEntryClickHouseKeeperUtils(int argc, char ** argv)
             po::options_description analyzer_options("Snapshot analyzer options");
             analyzer_options.add_options()
                 ("help,h", "Show help message")
-                ("snapshot-path", po::value<std::string>()->required(), "Path to snapshots directory");
+                ("snapshot-path", po::value<std::string>()->required(), "Path to snapshots directory")
+                ("full-storage", po::bool_switch()->default_value(false), "Load full storage from snapshot")
+                ("with-node-stats", po::bool_switch()->default_value(false), "Calculate and show subtree statistics");
 
             try
             {
@@ -1032,7 +1114,9 @@ int mainEntryClickHouseKeeperUtils(int argc, char ** argv)
                               << "Options:\n"
                               << analyzer_options << "\n"
                               << "Example:\n"
-                              << "  clickhouse-keeper-utils snapshot-analyzer --snapshot-path /path/to/snapshots\n";
+                              << "  clickhouse-keeper-utils snapshot-analyzer --snapshot-path /path/to/snapshots\n"
+                              << "  clickhouse-keeper-utils snapshot-analyzer --snapshot-path /path/to/snapshots --full-storage\n"
+                              << "  clickhouse-keeper-utils snapshot-analyzer --snapshot-path /path/to/snapshots --with-node-stats\n";
                     return 0;
                 }
 
@@ -1041,7 +1125,10 @@ int mainEntryClickHouseKeeperUtils(int argc, char ** argv)
                 po::store(po::command_line_parser(subcommand_args).options(analyzer_options).run(), analyzer_vm);
                 po::notify(analyzer_vm);
 
-                analyzeSnapshot(analyzer_vm["snapshot-path"].as<std::string>());
+                analyzeSnapshot(
+                    analyzer_vm["snapshot-path"].as<std::string>(),
+                    analyzer_vm["full-storage"].as<bool>(),
+                    analyzer_vm["with-node-stats"].as<bool>());
                 return 0;
             }
             catch (const std::exception & e)

--- a/programs/keeper-utils/README.md
+++ b/programs/keeper-utils/README.md
@@ -111,17 +111,31 @@ Analyze Keeper snapshots and print basic information.
 
 #### Usage
 ```bash
-clickhouse-keeper-utils snapshot-analyzer --snapshot-path <path>
+clickhouse-keeper-utils snapshot-analyzer [options]
 ```
 
 #### Options
-- `--snapshot-path` (required): Path to the directory containing Keeper snapshots
-- `--help, -h`: Show help message
+- `--snapshot-path <path>`: Path to the snapshots directory or a specific snapshot file (`.bin` or `.bin.zstd`). This is a required argument.
+- `--full-storage`: If specified, the full storage (including node data) is loaded from the snapshot. This provides more detailed information like node count and digest but is slower. By default, only the node paths are loaded.
+- `--with-node-stats`: If specified (and `--full-storage` is not), it calculates and displays statistics about the biggest subtrees, such as the top 10 nodes with the most descendants.
+- `--help, -h`: Displays the help message.
 
-#### Example
-```bash
-clickhouse-keeper-utils snapshot-analyzer --snapshot-path /var/lib/clickhouse/coordination/snapshots
-```
+#### Examples
+
+1.  **Analyze all snapshots in a directory (basic info):**
+    ```bash
+    clickhouse-keeper-utils snapshot-analyzer --snapshot-path /var/lib/clickhouse/coordination/snapshots/
+    ```
+
+2.  **Analyze a specific snapshot file with subtree statistics:**
+    ```bash
+    clickhouse-keeper-utils snapshot-analyzer --snapshot-path /var/lib/clickhouse/coordination/snapshots/snapshot_123.bin --with-node-stats
+    ```
+
+3.  **Analyze a snapshot with full storage loaded:**
+    ```bash
+    clickhouse-keeper-utils snapshot-analyzer --snapshot-path /var/lib/clickhouse/coordination/snapshots/snapshot_123.bin --full-storage
+    ```
 
 ### 3. changelog-analyzer
 

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -314,7 +314,7 @@ void KeeperStorageSnapshot<Storage>::serialize(const KeeperStorageSnapshot<Stora
 }
 
 template<typename Storage>
-void KeeperStorageSnapshot<Storage>::deserialize(SnapshotDeserializationResult<Storage> & deserialization_result, ReadBuffer & in, KeeperContextPtr keeper_context) TSA_NO_THREAD_SAFETY_ANALYSIS
+void KeeperStorageSnapshot<Storage>::deserialize(SnapshotDeserializationResult<Storage> & deserialization_result, ReadBuffer & in, KeeperContextPtr keeper_context, bool load_full_storage) TSA_NO_THREAD_SAFETY_ANALYSIS
 {
     uint8_t version;
     readBinary(version, in);
@@ -404,6 +404,12 @@ void KeeperStorageSnapshot<Storage>::deserialize(SnapshotDeserializationResult<S
 
         typename Storage::Node node{};
         readNode(node, in, current_version, storage.acl_map, keeper_context->shouldBlockACL());
+
+        if (!load_full_storage)
+        {
+            deserialization_result.paths.push_back(std::string{path});
+            continue;
+        }
 
         using enum Coordination::PathMatchResult;
         auto match_result = Coordination::matchPath(path, keeper_system_path);
@@ -777,7 +783,7 @@ bool KeeperSnapshotManager<Storage>::isZstdCompressed(nuraft::ptr<nuraft::buffer
 }
 
 template<typename Storage>
-SnapshotDeserializationResult<Storage> KeeperSnapshotManager<Storage>::deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer) const
+SnapshotDeserializationResult<Storage> KeeperSnapshotManager<Storage>::deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer, bool load_full_storage) const
 {
     bool is_zstd_compressed = isZstdCompressed(buffer);
 
@@ -791,8 +797,9 @@ SnapshotDeserializationResult<Storage> KeeperSnapshotManager<Storage>::deseriali
 
     SnapshotDeserializationResult<Storage> result;
     result.storage = std::make_unique<Storage>(storage_tick_time, superdigest, keeper_context, /* initialize_system_nodes */ false);
-    KeeperStorageSnapshot<Storage>::deserialize(result, *compressed_reader, keeper_context);
-    result.storage->initializeSystemNodes();
+    KeeperStorageSnapshot<Storage>::deserialize(result, *compressed_reader, keeper_context, load_full_storage);
+    if (load_full_storage)
+        result.storage->initializeSystemNodes();
     return result;
 }
 

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -47,6 +47,10 @@ struct SnapshotDeserializationResult
     SnapshotMetadataPtr snapshot_meta;
     /// Cluster config
     ClusterConfigPtr cluster_config;
+    /// container with all the paths stored in snapshot
+    /// used if we don't want to load entire storage from snapshot
+    /// which can be useful for analyzing snapshot files
+    std::vector<std::string> paths;
 };
 
 /// In memory keeper snapshot. Keeper Storage based on a hash map which can be
@@ -79,7 +83,7 @@ public:
 
     static void serialize(const KeeperStorageSnapshot<Storage> & snapshot, WriteBuffer & out, KeeperContextPtr keeper_context);
 
-    static void deserialize(SnapshotDeserializationResult<Storage> & deserialization_result, ReadBuffer & in, KeeperContextPtr keeper_context);
+    static void deserialize(SnapshotDeserializationResult<Storage> & deserialization_result, ReadBuffer & in, KeeperContextPtr keeper_context, bool load_full_storage = true);
 
     Storage * storage;
 
@@ -152,7 +156,7 @@ public:
     /// Serialize snapshot directly to disk
     SnapshotFileInfoPtr serializeSnapshotToDisk(const KeeperStorageSnapshot<Storage> & snapshot);
 
-    SnapshotDeserializationResult<Storage> deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer) const;
+    SnapshotDeserializationResult<Storage> deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer, bool load_full_storage = true) const;
 
     /// Deserialize snapshot with log index up_to_log_idx from disk into compressed nuraft buffer.
     nuraft::ptr<nuraft::buffer> deserializeSnapshotBufferFromDisk(uint64_t up_to_log_idx) const;

--- a/src/Coordination/tests/gtest_coordination_snapshot.cpp
+++ b/src/Coordination/tests/gtest_coordination_snapshot.cpp
@@ -230,7 +230,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotSimple)
 
     auto debuf = manager.deserializeSnapshotBufferFromDisk(2);
 
-    auto [restored_storage, snapshot_meta, _] = manager.deserializeSnapshotFromBuffer(debuf);
+    auto deser_result = manager.deserializeSnapshotFromBuffer(debuf);
+    const auto & restored_storage = deser_result.storage;
 
     EXPECT_EQ(restored_storage->container.size(), 6);
     EXPECT_EQ(restored_storage->container.getValue("/").getChildren().size(), 3);
@@ -285,7 +286,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotMoreWrites)
     EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin" + this->extension));
 
     auto debuf = manager.deserializeSnapshotBufferFromDisk(50);
-    auto [restored_storage, meta, _] = manager.deserializeSnapshotFromBuffer(debuf);
+    auto deser_result = manager.deserializeSnapshotFromBuffer(debuf);
+    const auto & restored_storage = deser_result.storage;
 
     EXPECT_EQ(restored_storage->container.size(), 54);
     for (size_t i = 0; i < 50; ++i)
@@ -331,7 +333,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotManySnapshots)
     EXPECT_TRUE(fs::exists("./snapshots/snapshot_250.bin" + this->extension));
 
 
-    auto [restored_storage, meta, _] = manager.restoreFromLatestSnapshot();
+    auto deser_result= manager.restoreFromLatestSnapshot();
+    const auto & restored_storage = deser_result.storage;
 
     EXPECT_EQ(restored_storage->container.size(), 254);
 
@@ -395,7 +398,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotMode)
             EXPECT_FALSE(storage.container.contains("/hello_" + std::to_string(i)));
     }
 
-    auto [restored_storage, meta, _] = manager.restoreFromLatestSnapshot();
+    auto deser_result = manager.restoreFromLatestSnapshot();
+    const auto & restored_storage = deser_result.storage;
 
     for (size_t i = 0; i < 50; ++i)
     {
@@ -468,7 +472,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotDifferentCompressions)
 
     auto debuf = new_manager.deserializeSnapshotBufferFromDisk(2);
 
-    auto [restored_storage, snapshot_meta, _] = new_manager.deserializeSnapshotFromBuffer(debuf);
+    auto deser_result = new_manager.deserializeSnapshotFromBuffer(debuf);
+    const auto & restored_storage = deser_result.storage;
 
     EXPECT_EQ(restored_storage->container.size(), 6);
     EXPECT_EQ(restored_storage->container.getValue("/").getChildren().size(), 3);
@@ -557,7 +562,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotBlockACL)
     EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin" + this->extension));
     {
         auto debuf = manager.deserializeSnapshotBufferFromDisk(50);
-        auto [restored_storage, meta, _] = manager.deserializeSnapshotFromBuffer(debuf);
+        auto deser_result = manager.deserializeSnapshotFromBuffer(debuf);
+        const auto & restored_storage = deser_result.storage;
 
         EXPECT_EQ(restored_storage->container.size(), 5);
         EXPECT_EQ(restored_storage->container.getValue(path).acl_id, acl_id);
@@ -566,7 +572,8 @@ TYPED_TEST(CoordinationTest, TestStorageSnapshotBlockACL)
     {
         this->keeper_context->setBlockACL(true);
         auto debuf = manager.deserializeSnapshotBufferFromDisk(50);
-        auto [restored_storage, meta, _] = manager.deserializeSnapshotFromBuffer(debuf);
+        auto deser_result = manager.deserializeSnapshotFromBuffer(debuf);
+        const auto & restored_storage = deser_result.storage;
 
         EXPECT_EQ(restored_storage->container.size(), 5);
         EXPECT_EQ(restored_storage->container.getValue(path).acl_id, 0);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
