### PR TITLE
Replicated DB: consider new replicas with huge replication lag as inactive when waiting for DDL

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -91,6 +91,8 @@ static struct InitFiu
     ONCE(keeper_leader_sets_invalid_digest) \
     ONCE(parallel_replicas_wait_for_unused_replicas) \
     REGULAR(plain_object_storage_copy_fail_on_file_move) \
+    REGULAR(database_replicated_delay_recovery) \
+    REGULAR(database_replicated_delay_entry_execution) \
     REGULAR(plain_object_storage_copy_temp_source_file_fail_on_file_move) \
     REGULAR(plain_object_storage_copy_temp_target_file_fail_on_file_move)
 

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -489,6 +489,7 @@ public:
     /// If the node exists and its value is different, it will wait for it to disappear. It will throw a LOGICAL_ERROR if the node doesn't
     /// disappear automatically after 3x session_timeout.
     void deleteEphemeralNodeIfContentMatches(const std::string & path, const std::string & fast_delete_if_equal_value);
+    void deleteEphemeralNodeIfContentMatches(const std::string & path, std::function<bool(const std::string &)> condition);
 
     Coordination::ReconfigResponse reconfig(
         const std::string & joining,

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -436,6 +436,7 @@ ReplicasInfo DatabaseReplicated::tryGetReplicasInfo(const ClusterPtr & cluster_)
 
                 replicas_info[global_replica_index] = ReplicaInfo{
                     .is_active = replica_active.error == Coordination::Error::ZOK,
+                    .unsynced_after_recovery = ddl_worker && ddl_worker->isUnsyncedAfterRecovery(),
                     .replication_lag = replica_log_ptr.error != Coordination::Error::ZNONODE ? std::optional(max_log_ptr - parse<UInt32>(replica_log_ptr.data)) : std::nullopt,
                     .recovery_time = recovery_time,
                 };

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -8,6 +8,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <base/defines.h>
 #include <Interpreters/QueryFlags.h>
+#include <Parsers/SyncReplicaMode.h>
 
 
 namespace zkutil
@@ -64,7 +65,7 @@ public:
     void detachTablePermanently(ContextPtr context, const String & table_name) override;
     void removeDetachedPermanentlyFlag(ContextPtr context, const String & table_name, const String & table_metadata_path, bool attach) override;
 
-    bool waitForReplicaToProcessAllEntries(UInt64 timeout_ms);
+    bool waitForReplicaToProcessAllEntries(UInt64 timeout_ms, SyncReplicaMode mode = SyncReplicaMode::DEFAULT);
 
     /// Try to execute DLL query on current host as initial query. If query is succeed,
     /// then it will be executed on all replicas.

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -30,6 +30,7 @@ using ZooKeeperMetadataTransactionPtr = std::shared_ptr<ZooKeeperMetadataTransac
 struct ReplicaInfo
 {
     bool is_active;
+    bool unsynced_after_recovery;
     std::optional<UInt32> replication_lag;
     UInt64 recovery_time;
 };
@@ -39,6 +40,7 @@ class DatabaseReplicated : public DatabaseAtomic
 {
 public:
     static constexpr auto ALL_GROUPS_CLUSTER_PREFIX = "all_groups.";
+    static constexpr auto REPLICA_UNSYNCED_MARKER = "UNSYNCED";
 
     DatabaseReplicated(const String & name_, const String & metadata_path_, UUID uuid,
                        const String & zookeeper_path_, const String & shard_name_, const String & replica_name_,

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -41,7 +41,7 @@ class DatabaseReplicated : public DatabaseAtomic
 {
 public:
     static constexpr auto ALL_GROUPS_CLUSTER_PREFIX = "all_groups.";
-    static constexpr auto REPLICA_UNSYNCED_MARKER = "UNSYNCED";
+    static constexpr auto REPLICA_UNSYNCED_MARKER = "\tUNSYNCED";
 
     DatabaseReplicated(const String & name_, const String & metadata_path_, UUID uuid,
                        const String & zookeeper_path_, const String & shard_name_, const String & replica_name_,

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -152,6 +152,7 @@ void DatabaseReplicatedDDLWorker::initializeReplication()
             return active_id == actual_content.substr(0, actual_content.size() - strlen(DatabaseReplicated::REPLICA_UNSYNCED_MARKER));
         return active_id == actual_content;
     });
+    bool first_initialization = active_node_holder == nullptr;
     if (active_node_holder)
         active_node_holder->setAlreadyRemoved();
     active_node_holder.reset();
@@ -217,8 +218,7 @@ void DatabaseReplicatedDDLWorker::initializeReplication()
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Inconsistent database metadata after reconnection to ZooKeeper");
     }
 
-    bool first_initialization = active_node_holder == nullptr;
-    if (is_new_replica || lost_according_to_log_ptr || first_initialization)
+    if (is_new_replica || first_initialization)
     {
         /// The current max_log_ptr might increase significantly while we were executing recoverLostReplica.
         /// If it exceeds max_replication_lag_to_enqueue - this replica will refuse to accept other queries.

--- a/src/Databases/DatabaseReplicatedWorker.h
+++ b/src/Databases/DatabaseReplicatedWorker.h
@@ -39,6 +39,8 @@ public:
 
     UInt64 getCurrentInitializationDurationMs() const;
 
+    bool isUnsyncedAfterRecovery() const { return unsynced_after_recovery; }
+
 private:
     bool initializeMainThread() override;
     void initializeReplication() override;
@@ -59,7 +61,7 @@ private:
 
     String current_task;
     std::atomic<UInt32> logs_to_keep = std::numeric_limits<UInt32>::max();
-
+    std::atomic_bool unsynced_after_recovery = false;
 
     /// EphemeralNodeHolder has reference to ZooKeeper, it may become dangling
     ZooKeeperPtr active_node_holder_zookeeper;

--- a/src/Interpreters/DistributedQueryStatusSource.cpp
+++ b/src/Interpreters/DistributedQueryStatusSource.cpp
@@ -9,6 +9,7 @@
 #include <Interpreters/DistributedQueryStatusSource.h>
 #include <Common/Exception.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
+#include <Databases/DatabaseReplicated.h>
 
 namespace DB
 {
@@ -87,8 +88,16 @@ NameSet DistributedQueryStatusSource::getOfflineHosts(const NameSet & hosts_to_w
     NameSet offline;
     auto res = zookeeper->tryGet(paths);
     for (size_t i = 0; i < res.size(); ++i)
+    {
         if (res[i].error == Coordination::Error::ZNONODE)
             offline.insert(hosts_array[i]);
+
+        if (res[i].data.ends_with(DatabaseReplicated::REPLICA_UNSYNCED_MARKER))
+        {
+            LOG_TRACE(log, "Replica {} is not fully synced after recovery, considering it as offline", hosts_array[i]);
+            offline.insert(hosts_array[i]);
+        }
+    }
 
     if (offline.size() == hosts_to_wait.size())
     {

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -272,6 +272,11 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         {
             ostr << ' ';
             print_identifier(database->as<ASTIdentifier>()->name());
+            if (sync_replica_mode != SyncReplicaMode::DEFAULT)
+            {
+                ostr << ' ';
+                print_keyword(magic_enum::enum_name(sync_replica_mode));
+            }
             break;
         }
         case Type::DROP_REPLICA:

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -327,6 +327,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 return false;
             if (!parseDatabaseAsAST(pos, expected, res->database))
                 return false;
+            if (ParserKeyword{Keyword::STRICT}.ignore(pos, expected))
+                res->sync_replica_mode = SyncReplicaMode::STRICT;
             break;
         }
         case Type::RESTART_DISK:

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1700,7 +1700,7 @@ def test_lag_after_recovery(started_cluster):
     dummy_node.query(
         "system disable failpoint database_replicated_delay_entry_execution"
     )
-    dummy_node.query("system sync database replica lag_after_recovery")
+    dummy_node.query("system sync database replica lag_after_recovery strict")
     assert (
         dummy_node.query(
             "select unsynced_after_recovery from system.clusters where name='lag_after_recovery' and database_replica_name='replica2'"

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -54,6 +54,7 @@ CREATE TABLE system.clusters
     `database_shard_name` String,
     `database_replica_name` String,
     `is_active` Nullable(UInt8),
+    `unsynced_after_recovery` Nullable(UInt8),
     `replication_lag` Nullable(UInt32),
     `recovery_time` Nullable(UInt64),
     `name` String ALIAS cluster


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When `distributed_ddl_output_mode='*_only_active'`, don't wait for new or recovered replicas that have replication lag bigger than `max_replication_lag_to_enqueue`. This should help to avoid `DDL task is not finished on some hosts` when a new replica becomes active after finishing initialization or recovery, but it accumulated huge replication log while initializing. Also, implement `SYSTEM SYNC DATABASE REPLICA STRICT` query that waits for replication log to become below `max_replication_lag_to_enqueue`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
