### PR TITLE
In IMergeTreeDataPart::appendCSNToVersionMetadata, try to rewrite the metadata version if WriteMode::Append is not implemented.

### DIFF
--- a/tests/queries/0_stateless/03562_transaction_with_plain_rewritable_disk.sh
+++ b/tests/queries/0_stateless/03562_transaction_with_plain_rewritable_disk.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tags: no-async-insert
+# no-async-insert: async inserts with 'implicit_transaction' are not supported
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer SYNC"
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE writer (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      name = 03362_reader_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/03362/${CLICKHOUSE_DATABASE}/')
+"
+
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer SETTINGS implicit_transaction=1 VALUES ('Hello')";
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE writer SYNC"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


When appending CSN, if we always using `Rewrite` mode:
https://github.com/ClickHouse/ClickHouse/blob/b3391fa8825915d4b4b4acb3ab8c983cbbafd946/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp#L841

```
  auto impl = object_storage.writeObject(
        object,
        /// We always use mode Rewrite because we simulate append using metadata and different files
        WriteMode::Rewrite,
        object_attributes,
        buf_size,
        settings);
```


But in [MetadataStorageFromPlainObjectStorageTransaction](https://github.com/ClickHouse/ClickHouse/blob/b3391fa8825915d4b4b4acb3ab8c983cbbafd946/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h#L120-L123), `addBlobToMetadata` is a `noop`

```
 void addBlobToMetadata(const std::string & /* path */, ObjectStorageKey /* object_key */, uint64_t /* size_in_bytes */) override
    {
        /// Noop
    }
```

So in `IMergeTreeDataPart::appendCSNToVersionMetadata', when appending the `creation_csn` to `txn_version.txt`, it actually rewrites, making `txn_version.txt` invalid.

If `VersionMetadata::writeCSN` with `WriteMode::Append` fails, we try to rewrite the whole metadata.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/84084

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
