### PR TITLE
Revert "Fix test `02437_drop_mv_restart_replicas`"

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1039,19 +1039,9 @@ void InterpreterSystemQuery::restartReplicas(ContextMutablePtr system_context)
 
     auto access = getContext()->getAccess();
     bool access_is_granted_globally = access->isGranted(AccessType::SYSTEM_RESTART_REPLICA);
-    bool show_tables_is_granted_globally = access->isGranted(AccessType::SHOW_TABLES);
 
     for (auto & elem : catalog.getDatabases())
     {
-        if (!elem.second->canContainMergeTreeTables())
-            continue;
-
-        if (!access_is_granted_globally && !show_tables_is_granted_globally && !access->isGranted(AccessType::SHOW_TABLES, elem.first))
-        {
-            LOG_INFO(log, "Access {} denied, skipping {}", "SHOW TABLES", elem.first);
-            continue;
-        }
-
         for (auto it = elem.second->getTablesIterator(getContext()); it->isValid(); it->next())
         {
             if (dynamic_cast<const StorageReplicatedMergeTree *>(it->table().get()))


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#83321

According to the CI DB this test started to fail right after merging this PR: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDE0NCBIT1VSCiAgICBBTkQgKHN0YXJ0c1dpdGgoaGVhZF9yZXBvLCAnQ2xpY2tIb3VzZS8nKSkKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIEFORCAodGVzdF9zdGF0dXMgTElLRSAnRiUnIE9SIHRlc3Rfc3RhdHVzIExJS0UgJ0UlJykgCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgQU5EIHRlc3RfbmFtZSBJTElLRSAnJTAyMjIxX3N5c3RlbV96b29rZWVwZXJfdW5yZXN0cmljdGVkJScKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSwgY2hlY2tfbmFtZSwgdGVzdF9uYW1lLCBjaGVja19zdGFydF90aW1l