### PR TITLE
Improve comment and logging for re-/opened cherry-pick PRs

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -646,16 +646,22 @@ class CherryPickPRs:
 
         assignees = ", ".join(f"@{user.login}" for user in pr.assignees)
         comment_body = (
-            f"Dear {assignees}, this PR is reopened after #{original_pr.number} was "
+            f"Dear {assignees}, this PR is opened while #{original_pr.number} was "
             f"marked as backported. The `{Labels.PR_BACKPORTS_CREATED}` is removed, so "
-            "the original PR can be processed again."
+            "the original PR can be processed again.\n\n"
+            "If the cherry-pick is not needed anymore, then just close this PR."
+        )
+        logging.info(
+            "Label %s should be removed from from #%s due opened cherry-pick PR #%s",
+            Labels.PR_BACKPORTS_CREATED,
+            original_pr.number,
+            pr.number,
         )
         if self.dry_run:
             logging.info(
-                "DRY RUN: would remove label %s from #%s and comment the cherry-pick PR #%s:\n",
-                Labels.PR_BACKPORTS_CREATED,
-                original_pr.number,
+                "DRY RUN: would remove label and comment the cherry-pick PR #%s:\n%s",
                 pr.number,
+                comment_body,
             )
             return
 

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -108,13 +108,29 @@ close it.
         self.pr = pr
         self.repo = repo
 
-        self.cherrypick_branch = f"cherrypick/{name}/{pr.number}"
-        self.backport_branch = f"backport/{name}/{pr.number}"
+        self.cherrypick_branch = self.cp_branch(name, pr.number)
+        self.backport_branch = self.bp_branch(name, pr.number)
         self.cherrypick_pr = None  # type: Optional[PullRequest]
         self.backport_pr = None  # type: Optional[PullRequest]
         self._backported = False
 
         self.pre_check()
+
+    @staticmethod
+    def cp_branch(name: str, pr_number: int) -> str:
+        """
+        Returns the name of the cherry-pick branch for the given release branch and PR
+        number.
+        """
+        return f"cherrypick/{name}/{pr_number}"
+
+    @staticmethod
+    def bp_branch(name: str, pr_number: int) -> str:
+        """
+        Returns the name of the backport branch for the given release branch and PR
+        number.
+        """
+        return f"backport/{name}/{pr_number}"
 
     def pre_check(self):
         self._backported = Shell.check(
@@ -593,6 +609,7 @@ class CherryPickPRs:
         self.repo = gh.get_repo(repo)
         self.dry_run = dry_run
         self.error = None  # type: Optional[Exception]
+        self.release_prs = gh.get_release_pulls(repo)
 
     def get_open_cherry_pick_prs(self) -> PullRequests:
         """
@@ -605,7 +622,7 @@ class CherryPickPRs:
         logging.info("Query to find the cherry-pick PRs:\n %s", query_args)
         return self.gh.get_pulls_from_search(**query_args)
 
-    def remove_backported_labels(self) -> None:
+    def check_open_prs(self) -> None:
         """
         After the cherry-pick PRs are closed, the original PRs are marked as
         `pr-backports-created`. If the cherry-pick PR is reopened, we remove this label
@@ -617,6 +634,28 @@ class CherryPickPRs:
             logging.error("Error while getting open cherry-pick PRs: %s", e)
             self.error = e
             return
+
+        # We need to check if there is an open release branch for each cherry-pick PR
+        for pr in prs.copy():
+            # We need to copy the list, since we will modify it
+            #
+            try:
+                if not self._check_opened_release(pr):
+                    # The cherry-pick PR is not opened in any of the release branches,
+                    # so we can skip it
+                    prs.remove(pr)
+                    continue
+            except Exception as e:
+                logging.error(
+                    "Error while checking opened release branch for cherry-pick PR #%s: %s",
+                    pr.number,
+                    e,
+                )
+                self.error = e
+                continue
+
+        # And then, we need to check if the original PR is marked as backported for any
+        # open cherry-pick PR
         for pr in prs:
             try:
                 self._remove_backported_label(pr)
@@ -626,6 +665,39 @@ class CherryPickPRs:
                 )
                 self.error = e
                 continue
+
+    def _check_opened_release(self, cpp: PullRequest) -> bool:
+        """
+        Check if the original PR is opened in any of the release branches.
+        """
+        # The cherry-pick's head ref is like cherrypick/{release_name}/12345,
+        # so we can extract the release name from it, and then try to find it in the
+        # self.release_prs
+        original_pr_number = int(cpp.head.ref.rsplit("/", maxsplit=1)[-1])
+        if cpp.head.ref in [
+            ReleaseBranch.cp_branch(r.head.ref, original_pr_number)
+            for r in self.release_prs
+        ]:
+            # The release branch is opened, so we can continue
+            return True
+        release_name = cpp.head.ref.split("/", maxsplit=1)[1].rsplit("/", maxsplit=1)[0]
+        logging.info(
+            "An opened release PR `%s` for cherry-pick PR %s is not found, going to close it",
+            release_name,
+            cpp.html_url,
+        )
+        if self.dry_run:
+            logging.info(
+                "DRY RUN: would close and leave a comment in the cherry-pick PR #%s",
+                cpp.number,
+            )
+            return False
+        cpp.create_issue_comment(
+            f"The release branch `{release_name}` for the cherry-pick doesn't have "
+            "an opened PR, closing this PR."
+        )
+        cpp.edit(state="closed")
+        return False
 
     def _remove_backported_label(self, pr: PullRequest) -> None:
         # The `updated_at` is Optional[datetime]
@@ -701,7 +773,7 @@ def main():
     # First, check if some cherry-pick PRs are reopened and original PRs are mared as
     # done
     cpp = CherryPickPRs(gh, args.repo, args.dry_run)
-    cpp.remove_backported_labels()
+    cpp.check_open_prs()
 
     bpp = BackportPRs(gh, args.repo, args.dry_run)
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved the logging for unmarking PRs to backport due to re-/opened cherry-pick PRs.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
