### PR TITLE
Update rust toolchain to nightly-2025-07-07

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -51,8 +51,8 @@ RUN ARCH=$(uname -m) && \
     ./rustup-init -y && \
     rm rustup-init && \
     chmod 777 -R /rust && \
-    rustup toolchain install nightly-2024-12-01 --no-self-update && \
-    rustup default nightly-2024-12-01 && \
+    rustup toolchain install nightly-2025-07-07 --no-self-update && \
+    rustup default nightly-2025-07-07 && \
     rustup toolchain remove stable && \
     rustup component add rust-src && \
     rustup target add x86_64-unknown-linux-gnu && \

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -136,6 +136,13 @@ elseif (SANITIZE STREQUAL "thread")
     list(APPEND RUSTFLAGS "-Zsanitizer=thread")
 endif()
 
+list(APPEND RUSTFLAGS
+    # Suppress warnings in delta-kernel-rs
+    "-Adead_code"
+    # Suppress warnings in skim
+    "-Amismatched_lifetime_syntaxes"
+)
+
 list(JOIN RUSTFLAGS " " RUSTFLAGS)
 
 message(STATUS "RUST_CFLAGS: ${RUST_CFLAGS}")

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -35,7 +35,7 @@ endmacro()
 
 # Keep in sync with toolchain in docker images
 # (must be called before find_package(Rust) and inclusion of Corrosion.cmake)
-set(Rust_TOOLCHAIN "nightly-2024-12-01")
+set(Rust_TOOLCHAIN "nightly-2025-07-07")
 
 macro(find_rust)
     set_rust_target()

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -67,8 +67,8 @@ As with C++ dependencies, ClickHouse uses vendoring to control exactly what's in
 Although in release mode any rust modern rustup toolchain version should work with these dependencies, if you plan to enable sanitizers you must use a version that matches the exact same `std` as the one used in CI (for which we vendor the crates):
 
 ```bash
-rustup toolchain install nightly-2024-12-01
-rustup default nightly-2024-12-01
+rustup toolchain install nightly-2025-07-07
+rustup default nightly-2025-07-07
 rustup component add rust-src
 ```
 ## Build ClickHouse {#build-clickhouse}

--- a/flake.nix
+++ b/flake.nix
@@ -223,7 +223,7 @@
     contrib-sqids-cpp = { url = "github:sqids/sqids-cpp/a471f53672e98d49223f598528a533b07b085c61"; flake = false; };
     contrib-idna = { url = "github:ada-url/idna/3c8be01d42b75649f1ac9b697d0ef757eebfe667"; flake = false; };
     contrib-google-cloud-cpp = { url = "github:ClickHouse/google-cloud-cpp/83f30caadb8613fb5c408d8c2fd545291596b53f"; flake = false; };
-    contrib-rust_vendor = { url = "github:ClickHouse/rust_vendor/f81834cd563e858fa63b209c368799be6d599086"; flake = false; };
+    contrib-rust_vendor = { url = "github:ClickHouse/rust_vendor/07d4497f735733b5a893b72e60d82ee373082dbb"; flake = false; };
     contrib-openssl = { url = "github:ClickHouse/openssl/2aa34c68d677b447fb85c55167d8d1ab98ba4def"; flake = false; };
     contrib-double-conversion = { url = "github:ClickHouse/double-conversion/4f7a25d8ced8c7cf6eee6fd09d6788eaa23c9afe"; flake = false; };
     contrib-mongo-cxx-driver = { url = "github:ClickHouse/mongo-cxx-driver/3166bdb49b717ce1bc30f46cc2b274ab1de7005b"; flake = false; };

--- a/rust/vendor.sh
+++ b/rust/vendor.sh
@@ -4,7 +4,7 @@ set -e
 
 # std is required for sanitizers builds
 # and we need to match toolchain version for std (to vendor proper dependencies)
-TOOLCHAIN=nightly-2024-12-01
+TOOLCHAIN=nightly-2025-07-07
 function cargo() { rustup run "$TOOLCHAIN" cargo "$@"; }
 function rustc() { rustup run "$TOOLCHAIN" rustc "$@"; }
 rustup component add --toolchain "$TOOLCHAIN" rust-src

--- a/rust/vendor.sh
+++ b/rust/vendor.sh
@@ -57,6 +57,8 @@ rm -fr "$CH_TOP_DIR"/contrib/rust_vendor/winapi*/lib/*.a
 rm -fr "$CH_TOP_DIR"/contrib/rust_vendor/winapi*/lib/*.lib
 rm -fr "$CH_TOP_DIR"/contrib/rust_vendor/windows*/lib/*.lib
 
+find "$CH_TOP_DIR"/contrib/rust_vendor -name Cargo.toml.orig -type f -delete
+
 echo "*"
 echo "* Do not forget to check contrib/corrosion-cmake/config.toml.in"
 echo "* You need to make sure that it contains everything that is printed under"

--- a/rust/vendor.sh
+++ b/rust/vendor.sh
@@ -57,8 +57,6 @@ rm -fr "$CH_TOP_DIR"/contrib/rust_vendor/winapi*/lib/*.a
 rm -fr "$CH_TOP_DIR"/contrib/rust_vendor/winapi*/lib/*.lib
 rm -fr "$CH_TOP_DIR"/contrib/rust_vendor/windows*/lib/*.lib
 
-find "$CH_TOP_DIR"/contrib/rust_vendor -name Cargo.toml.orig -type f -delete
-
 echo "*"
 echo "* Do not forget to check contrib/corrosion-cmake/config.toml.in"
 echo "* You need to make sure that it contains everything that is printed under"

--- a/rust/workspace/Cargo.lock
+++ b/rust/workspace/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "cxx",
  "cxx-build",
  "skim",
- "term 1.0.2",
+ "term 1.1.0",
 ]
 
 [[package]]
@@ -675,15 +675,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -1365,12 +1356,11 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
+checksum = "a43bddab41f8626c7bdaab872bbba75f8df5847b516d77c569c746e2ae5eb746"
 dependencies = [
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/rust_vendor/pull/43