### PR TITLE
Initialize total memory tracker earlier

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -67,11 +67,6 @@
 
 namespace fs = std::filesystem;
 
-namespace CurrentMetrics
-{
-    extern const Metric MemoryTracking;
-}
-
 namespace DB
 {
 
@@ -783,8 +778,6 @@ void LocalServer::processConfig()
     }
 
     total_memory_tracker.setHardLimit(max_server_memory_usage);
-    total_memory_tracker.setDescription("(total)");
-    total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
 
     const double cache_size_to_ram_max_ratio = server_settings[ServerSetting::cache_size_to_ram_max_ratio];
     const size_t max_cache_size = static_cast<size_t>(physical_server_memory * cache_size_to_ram_max_ratio);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -340,8 +340,6 @@ namespace CurrentMetrics
 {
     extern const Metric Revision;
     extern const Metric VersionInteger;
-    extern const Metric MemoryTracking;
-    extern const Metric MergesMutationsMemoryTracking;
     extern const Metric MaxDDLEntryID;
     extern const Metric MaxPushedDDLEntryID;
     extern const Metric StartupScriptsExecutionState;
@@ -1926,8 +1924,6 @@ try
             }
 
             total_memory_tracker.setHardLimit(max_server_memory_usage);
-            total_memory_tracker.setDescription("(total)");
-            total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
 
             size_t merges_mutations_memory_usage_soft_limit = new_server_settings[ServerSetting::merges_mutations_memory_usage_soft_limit];
 
@@ -1954,8 +1950,6 @@ try
             LOG_INFO(log, "Merges and mutations memory limit is set to {}",
                 formatReadableSizeWithBinarySuffix(merges_mutations_memory_usage_soft_limit));
             background_memory_tracker.setSoftLimit(merges_mutations_memory_usage_soft_limit);
-            background_memory_tracker.setDescription("(background)");
-            background_memory_tracker.setMetric(CurrentMetrics::MergesMutationsMemoryTracking);
 
             auto * global_overcommit_tracker = global_context->getGlobalOvercommitTracker();
             total_memory_tracker.setOvercommitTracker(global_overcommit_tracker);

--- a/src/Client/ClientApplicationBase.cpp
+++ b/src/Client/ClientApplicationBase.cpp
@@ -18,11 +18,6 @@
 
 using namespace std::literals;
 
-namespace CurrentMetrics
-{
-    extern const Metric MemoryTracking;
-}
-
 namespace DB
 {
 
@@ -233,8 +228,6 @@ void ClientApplicationBase::init(int argc, char ** argv)
         UInt64 max_client_memory_usage_int = parseWithSizeSuffix<UInt64>(max_client_memory_usage.c_str(), max_client_memory_usage.length());
 
         total_memory_tracker.setHardLimit(max_client_memory_usage_int);
-        total_memory_tracker.setDescription("Global");
-        total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
     }
 
     /// Print stacktrace in case of crash

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -8,6 +8,7 @@
 #include <Common/AsynchronousMetrics.h>
 #include <Common/Exception.h>
 #include <Common/Jemalloc.h>
+#include <Common/MemoryTracker.h>
 #include <Common/PageCache.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
@@ -944,6 +945,8 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
         }
     }
 #endif
+
+    new_values["TrackedMemory"] = { total_memory_tracker.get(), "Memory tracked by ClickHouse (should be equal to MemoryTracking metric), in bytes." };
 
 #if defined(OS_LINUX)
     if (loadavg)

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -83,7 +83,7 @@ private:
     std::atomic<MemoryTracker *> parent {};
 
     /// You could specify custom metric to track memory usage.
-    std::atomic<CurrentMetrics::Metric> metric = CurrentMetrics::end();
+    std::atomic<CurrentMetrics::Metric> metric;
 
     /// This description will be used as prefix into log messages (if isn't nullptr)
     std::atomic<const char *> description_ptr = nullptr;
@@ -118,9 +118,9 @@ public:
     static constexpr auto USAGE_EVENT_NAME = "MemoryTrackerUsage";
     static constexpr auto PEAK_USAGE_EVENT_NAME = "MemoryTrackerPeakUsage";
 
-    explicit MemoryTracker(VariableContext level_ = VariableContext::Thread);
-    explicit MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Thread);
-    MemoryTracker(MemoryTracker * parent_, VariableContext level_, bool log_peak_memory_usage_in_destructor_);
+    explicit MemoryTracker(VariableContext level_ = VariableContext::Thread, CurrentMetrics::Metric metric_ = CurrentMetrics::end(), const char * description = nullptr);
+    explicit MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Thread, CurrentMetrics::Metric metric_ = CurrentMetrics::end(), const char * description = nullptr);
+    MemoryTracker(MemoryTracker * parent_, VariableContext level_, bool log_peak_memory_usage_in_destructor_, CurrentMetrics::Metric metric_ = CurrentMetrics::end(), const char * description = nullptr);
 
     ~MemoryTracker();
 
@@ -213,12 +213,6 @@ public:
     MemoryTracker * getParent()
     {
         return parent.load(std::memory_order_relaxed);
-    }
-
-    /// The memory consumption could be shown in realtime via CurrentMetrics counter
-    void setMetric(CurrentMetrics::Metric metric_)
-    {
-        metric.store(metric_, std::memory_order_relaxed);
     }
 
     CurrentMetrics::Metric getMetric()

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -1,3 +1,4 @@
+#include <Common/ThreadStatus.h>
 #include <Common/TraceSender.h>
 
 #include <IO/WriteBufferFromFileDescriptorDiscardOnFailure.h>
@@ -68,9 +69,9 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
 
         thread_id = CurrentThread::get().thread_id;
     }
-    else
+    else if (const auto * main_thread = MainThreadStatus::get())
     {
-        thread_id = MainThreadStatus::get()->thread_id;
+        thread_id = main_thread->thread_id;
     }
 
     writeChar(false, out);  /// true if requested to stop the collecting thread.

--- a/src/Core/LogsLevel.h
+++ b/src/Core/LogsLevel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 namespace DB
 {
 enum class LogsLevel : uint8_t


### PR DESCRIPTION
Previously it does not takes into account static objects

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/ClickHouse/issues/82036