### PR TITLE
Fix no_sign_request config for S3

### DIFF
--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -400,7 +400,6 @@ void StorageS3Configuration::fromAST(ASTs & args, ContextPtr context, bool with_
         s3_settings->auth_settings[S3AuthSetting::no_sign_request] = no_sign_request;
 
     static_configuration = !s3_settings->auth_settings[S3AuthSetting::access_key_id].value.empty() || s3_settings->auth_settings[S3AuthSetting::no_sign_request].changed;
-    s3_settings->auth_settings[S3AuthSetting::no_sign_request] = no_sign_request;
 
     keys = {url.key};
 }

--- a/tests/integration/test_storage_s3/configs/s3_no_sign_request.xml
+++ b/tests/integration/test_storage_s3/configs/s3_no_sign_request.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <s3>
+        <no_sign_request>0</no_sign_request>
+    </s3>
+</clickhouse>

--- a/tests/integration/test_storage_s3/test_invalid_env_credentials.py
+++ b/tests/integration/test_storage_s3/test_invalid_env_credentials.py
@@ -86,6 +86,7 @@ def started_cluster():
         cluster.add_instance(
             "s3_with_invalid_environment_credentials",
             with_minio=True,
+            stay_alive=True,
             env_variables={
                 "AWS_ACCESS_KEY_ID": "aws",
                 "AWS_SECRET_ACCESS_KEY": "aws123",
@@ -93,6 +94,7 @@ def started_cluster():
             main_configs=[
                 "configs/use_environment_credentials.xml",
                 "configs/named_collections.xml",
+                "configs/s3_no_sign_request.xml",
             ],
             user_configs=["configs/users.xml"],
         )
@@ -155,3 +157,62 @@ def test_no_sign_named_collections(started_cluster):
         assert "HTTP response code: 403" in ei.value.stderr
 
     assert "100" == instance.query(f"select count() from s3(s3_json_no_sign)").strip()
+
+
+def test_no_sign_config(started_cluster):
+    instance = started_cluster.instances["s3_with_invalid_environment_credentials"]
+
+    bucket = started_cluster.minio_bucket
+
+    instance.query(
+        f"insert into function s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache5.jsonl', NOSIGN) select * from numbers(100) settings s3_truncate_on_insert=1"
+    )
+
+    with pytest.raises(helpers.client.QueryRuntimeException) as ei:
+        instance.query(
+            f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache5.jsonl')"
+        )
+
+    assert ei.value.returncode == 243
+    assert "HTTP response code: 403" in ei.value.stderr
+
+    def assert_nosign_works():
+        assert (
+            "100"
+            == instance.query(
+                f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache5.jsonl')"
+            ).strip()
+        )
+
+    with instance.with_replace_config(
+        "/etc/clickhouse-server/config.d/s3_no_sign_request.xml",
+        """
+<clickhouse>
+    <s3>
+        <no_sign_request>1</no_sign_request>
+    </s3>
+</clickhouse>
+""",
+    ):
+        instance.restart_clickhouse()
+
+        assert_nosign_works()
+
+    with instance.with_replace_config(
+        "/etc/clickhouse-server/config.d/s3_no_sign_request.xml",
+        f"""
+<clickhouse>
+    <s3>
+        <endpoint_no_sign>
+            <endpoint>http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache5.jsonl</endpoint>
+            <no_sign_request>1</no_sign_request>
+        </endpoint_no_sign>
+    </s3>
+</clickhouse>
+""",
+    ):
+        instance.restart_clickhouse()
+
+        assert_nosign_works()
+
+    instance.restart_clickhouse()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `no_sign_request` for S3 client. It can be used to explicitly avoid signing S3 requests. It can also be defined for specific endpoints using endpoint-based settings.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
