### PR TITLE
Decouple ClickHouseVersion from Settings

### DIFF
--- a/src/Common/ClickHouseVersion.cpp
+++ b/src/Common/ClickHouseVersion.cpp
@@ -1,0 +1,43 @@
+#include <Common/ClickHouseVersion.h>
+
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+
+#include <Core/SettingsEnums.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include <fmt/ranges.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+ClickHouseVersion::ClickHouseVersion(std::string_view version)
+{
+    Strings split;
+    boost::split(split, version, [](char c){ return c == '.'; });
+    components.reserve(split.size());
+    if (split.empty())
+        throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
+
+    for (const auto & split_element : split)
+    {
+        size_t component;
+        ReadBufferFromString buf(split_element);
+        if (!tryReadIntText(component, buf) || !buf.eof())
+            throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
+        components.push_back(component);
+    }
+}
+
+String ClickHouseVersion::toString() const
+{
+    return fmt::format("{}", fmt::join(components, "."));
+}
+
+}

--- a/src/Common/ClickHouseVersion.cpp
+++ b/src/Common/ClickHouseVersion.cpp
@@ -3,8 +3,6 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 
-#include <Core/SettingsEnums.h>
-
 #include <boost/algorithm/string.hpp>
 
 #include <fmt/ranges.h>

--- a/src/Common/ClickHouseVersion.h
+++ b/src/Common/ClickHouseVersion.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <compare>
+#include <vector>
+#include <string_view>
+
+namespace DB
+{
+
+class ClickHouseVersion
+{
+public:
+    explicit ClickHouseVersion(std::string_view version);
+
+    std::string toString() const;
+
+    std::strong_ordering operator<=>(const ClickHouseVersion & other) const = default;
+
+private:
+    std::vector<size_t> components;
+};
+
+}

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -13,31 +13,7 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
-}
-
-ClickHouseVersion::ClickHouseVersion(std::string_view version)
-{
-    Strings split;
-    boost::split(split, version, [](char c){ return c == '.'; });
-    components.reserve(split.size());
-    if (split.empty())
-        throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
-
-    for (const auto & split_element : split)
-    {
-        size_t component;
-        ReadBufferFromString buf(split_element);
-        if (!tryReadIntText(component, buf) || !buf.eof())
-            throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
-        components.push_back(component);
-    }
-}
-
-String ClickHouseVersion::toString() const
-{
-    return fmt::format("{}", fmt::join(components, "."));
 }
 
 static void addSettingsChanges(

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1,12 +1,8 @@
-#include <Core/Defines.h>
 #include <Core/SettingsChangesHistory.h>
-#include <IO/ReadBufferFromString.h>
-#include <IO/ReadHelpers.h>
-#include <boost/algorithm/string.hpp>
+
 #include <Core/SettingsEnums.h>
 
-#include <fmt/ranges.h>
-
+#include <Common/Exception.h>
 
 namespace DB
 {

--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -1,26 +1,14 @@
 #pragma once
 
 #include <Core/Field.h>
+
+#include <Common/ClickHouseVersion.h>
+
 #include <map>
 #include <vector>
 
-
 namespace DB
 {
-
-class ClickHouseVersion
-{
-public:
-    explicit ClickHouseVersion(std::string_view version);
-
-    String toString() const;
-
-    bool operator<(const ClickHouseVersion & other) const { return components < other.components; }
-    bool operator>=(const ClickHouseVersion & other) const { return components >= other.components; }
-
-private:
-    std::vector<size_t> components;
-};
 
 namespace SettingsChangesHistory
 {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add possibility to use `ClickHouseVersion` in other code modules.
