### PR TITLE
Fix CTE identifier resolution

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -4524,6 +4524,11 @@ void QueryAnalyzer::initializeQueryJoinTreeNode(QueryTreeNodePtr & join_tree_nod
 
                 if (resolved_identifier_query_node || resolved_identifier_union_node)
                 {
+                    bool is_cte = (resolved_identifier_query_node != nullptr && resolved_identifier_query_node->isCTE())
+                                || (resolved_identifier_union_node != nullptr && resolved_identifier_union_node->isCTE());
+                    if (is_cte)
+                        cte_copy_to_original_map.emplace(resolved_identifier.get(), table_identifier_resolve_result.resolved_identifier);
+
                     if (table_expression_modifiers.has_value())
                     {
                         throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
@@ -5517,13 +5522,27 @@ void QueryAnalyzer::resolveQueryJoinTreeNode(QueryTreeNodePtr & join_tree_node, 
 {
     auto from_node_type = join_tree_node->getNodeType();
 
+    auto try_get_original_cte_node = [this](const QueryTreeNodePtr & node) -> QueryTreeNodePtr
+    {
+        auto cte_it = cte_copy_to_original_map.find(node.get());
+        return cte_it != cte_copy_to_original_map.end() ? cte_it->second : QueryTreeNodePtr{};
+    };
+
     switch (from_node_type)
     {
         case QueryTreeNodeType::QUERY:
             [[fallthrough]];
         case QueryTreeNodeType::UNION:
         {
+            QueryTreeNodePtr original_cte_node = try_get_original_cte_node(join_tree_node);
+
+            if (original_cte_node)
+                ctes_in_resolve_process.insert(original_cte_node);
+
             resolveExpressionNode(join_tree_node, scope, false /*allow_lambda_expression*/, true /*allow_table_expression*/, true /*ignore_alias=*/);
+
+            if (original_cte_node)
+                ctes_in_resolve_process.erase(original_cte_node);
             break;
         }
         case QueryTreeNodeType::TABLE_FUNCTION:
@@ -5645,9 +5664,6 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
       */
     if (query_node_typed.isResolved())
         return;
-
-    if (query_node_typed.isCTE())
-        ctes_in_resolve_process.emplace(query_node);
 
     bool is_rollup_or_cube = query_node_typed.isGroupByWithRollup() || query_node_typed.isGroupByWithCube();
 
@@ -5992,9 +6008,6 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
         node->removeAlias();
 
     query_node_typed.resolveProjectionColumns(std::move(projection_columns));
-
-    if (query_node_typed.isCTE())
-        ctes_in_resolve_process.erase(query_node);
 }
 
 void QueryAnalyzer::resolveUnion(const QueryTreeNodePtr & union_node, IdentifierResolveScope & scope)
@@ -6003,9 +6016,6 @@ void QueryAnalyzer::resolveUnion(const QueryTreeNodePtr & union_node, Identifier
 
     if (union_node_typed.isResolved())
         return;
-
-    if (union_node_typed.isCTE())
-        ctes_in_resolve_process.insert(union_node);
 
     auto & queries_nodes = union_node_typed.getQueries().getNodes();
 
@@ -6084,9 +6094,6 @@ void QueryAnalyzer::resolveUnion(const QueryTreeNodePtr & union_node, Identifier
 
         union_node_typed.setRecursiveCTETable(std::move(*recursive_cte_table));
     }
-
-    if (union_node_typed.isCTE())
-        ctes_in_resolve_process.erase(union_node);
 }
 
 }

--- a/src/Analyzer/Resolve/QueryAnalyzer.h
+++ b/src/Analyzer/Resolve/QueryAnalyzer.h
@@ -264,6 +264,8 @@ private:
     /// CTEs that are currently in resolve process
     QueryTreeNodePtrWithHashSet ctes_in_resolve_process;
 
+    std::unordered_map<IQueryTreeNode *, QueryTreeNodePtr> cte_copy_to_original_map;
+
     /// Function name to user defined lambda map
     std::unordered_map<std::string, QueryTreeNodePtr> function_name_to_user_defined_lambda;
 

--- a/tests/queries/0_stateless/03408_cte_self_reference.sql
+++ b/tests/queries/0_stateless/03408_cte_self_reference.sql
@@ -21,4 +21,4 @@ WITH `cte1` AS (
         FROM cte2 LEFT ARRAY JOIN values AS value
     )
 )
-SELECT * FROM `cte1` -- { serverError TOO_DEEP_SUBQUERIES }
+SELECT * FROM `cte1` -- { serverError UNKNOWN_TABLE }

--- a/tests/queries/0_stateless/03561_analyzer_cte_cycle_resolve_bug.sql
+++ b/tests/queries/0_stateless/03561_analyzer_cte_cycle_resolve_bug.sql
@@ -1,0 +1,18 @@
+CREATE TABLE users (uid Int16, name String, age Int16) ENGINE=Memory;
+
+INSERT INTO users VALUES (1231, 'John', 33);
+INSERT INTO users VALUES (6666, 'Ksenia', 48);
+INSERT INTO users VALUES (8888, 'Alice', 50);
+
+set enable_analyzer = 1;
+
+WITH
+  users AS (
+    WITH t as (
+      SELECT * FROM users
+    )
+    SELECT * FROM t
+  )
+SELECT *
+FROM users
+FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `TOO_DEEP_SUBQUERIES` exception when CTE definition references another table expression with the same name.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
