### PR TITLE
Fix MarkCacheHits/MarkCacheMisses for save_marks_in_cache=false

### DIFF
--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -47,6 +47,16 @@ public:
     /// Calculate key from path to file.
     static UInt128 hash(const String & path_to_file);
 
+    MappedPtr get(const Key & key)
+    {
+        auto result = Base::get(key);
+        if (result)
+            ProfileEvents::increment(ProfileEvents::MarkCacheHits);
+        else
+            ProfileEvents::increment(ProfileEvents::MarkCacheMisses);
+        return result;
+    }
+
     template <typename LoadFunc>
     MappedPtr getOrSet(const Key & key, LoadFunc && load)
     {


### PR DESCRIPTION
`save_marks_in_cache=false` uses `get` which is not overwritten:

https://github.com/ClickHouse/ClickHouse/blob/4b5ee93a65da98f6771b4bd46547b4e0dd21f25a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp#L231-L241

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)