### PR TITLE
Use rainbow parenthesis coloring only on matching braces

### DIFF
--- a/src/Client/ClientBaseHelpers.cpp
+++ b/src/Client/ClientBaseHelpers.cpp
@@ -268,11 +268,6 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
                 brace_stack.push_back(*highlight_token_iterator);
                 current_color++;
 
-                /// Highlight the opening round bracket and advance.
-                auto highlight_pos = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(begin), highlight_token_iterator->begin - begin);
-                if (highlight_pos < colors.size())
-                    colors[highlight_pos] = color_stack.back();
-
                 ++highlight_token_iterator;
                 continue;
             }
@@ -292,8 +287,12 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
                 if (highlight_pos < colors.size())
                     colors[highlight_pos] = color_stack.back();
 
-                /// If there is no matching opening round bracket, advance.
+                /// Highlight the matching opening round bracket.
                 auto matching_brace_pos = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(begin), brace_stack.back().begin - begin);
+                if (matching_brace_pos < colors.size())
+                    colors[matching_brace_pos] = color_stack.back();
+
+                /// Check if cursor is on the current or matching round brace.
                 auto mapped_cursor_position = static_cast<uint64_t>(cursor_position);
 
                 auto cursor_on_current_brace = mapped_cursor_position == highlight_pos;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

![image](https://github.com/user-attachments/assets/b5f853c0-81c9-4012-b8e4-06ebf631ddd0)

