### PR TITLE
Fix incorrect revoke statement for sources.

### DIFF
--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -384,8 +384,6 @@ void AccessRightsElement::makeBackwardCompatible()
                     parameter.clear();
                 }
             }
-
-            eraseNotGrantable();
         }
     }
 }

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -323,6 +323,10 @@ void AccessRightsElement::replaceDeprecated()
         case AccessType::KAFKA:
         case AccessType::NATS:
         case AccessType::RABBITMQ:
+            if (!anyDatabase())
+                /// This will leave statements like `REVOKE S3 ON system.*` untouched
+                /// These statements will be deleted afterwards with `eraseNotGrantable()`
+                break;
             access_flags = AccessType::READ | AccessType::WRITE;
             parameter = DB::toString(current_access_type);
             break;
@@ -380,6 +384,8 @@ void AccessRightsElement::makeBackwardCompatible()
                     parameter.clear();
                 }
             }
+
+            eraseNotGrantable();
         }
     }
 }

--- a/tests/queries/0_stateless/03313_sources_read_write_grants.reference
+++ b/tests/queries/0_stateless/03313_sources_read_write_grants.reference
@@ -3,3 +3,4 @@ ACCESS DENIED
 1
 2
 3
+3

--- a/tests/queries/0_stateless/03313_sources_read_write_grants.sh
+++ b/tests/queries/0_stateless/03313_sources_read_write_grants.sh
@@ -35,4 +35,7 @@ ${CLICKHOUSE_CLIENT} --query "GRANT FILE ON *.* TO $user";
 ${CLICKHOUSE_CLIENT} --user $user --query "INSERT INTO FUNCTION file('$file') SELECT 'a', 'b'";
 ${CLICKHOUSE_CLIENT} --user $user --query "SELECT count() FROM file('$file')";
 
+${CLICKHOUSE_CLIENT} --query "REVOKE FILE ON system.* FROM $user";
+${CLICKHOUSE_CLIENT} --user $user --query "SELECT count() FROM file('$file')";
+
 ${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user;";


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect behavior when executing `REVOKE S3 ON system.*` revokes S3 permissions for `*.*`. This fixes https://github.com/ClickHouse/ClickHouse/issues/83417

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
