### PR TITLE
no-msan in 00804_test_alter_compression_codecs

### DIFF
--- a/tests/queries/0_stateless/00804_test_alter_compression_codecs.sql
+++ b/tests/queries/0_stateless/00804_test_alter_compression_codecs.sql
@@ -1,3 +1,6 @@
+-- Tags: no-msan
+-- (because the INSERT with 300k rows sometimes takes >5 minutes in msan build, I didn't investigate why)
+
 SET send_logs_level = 'fatal';
 
 DROP TABLE IF EXISTS alter_compression_codec;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Saw it fail twice with msan on seemingly unrelated PRs:
 * https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81090&sha=e40880a998d65e1051a0951b90532eda07489378&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%201%2F4%29
 * https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=82949&sha=f8663c53b2004d961222ef263ef8ffdc97b0c68c&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%201%2F4%29

It normally takes anywhere between 50s and 270s: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGhlYWRfcmVmLCB0ZXN0X2R1cmF0aW9uX21zLCB0ZXN0X3N0YXR1cywgY2hlY2tfc3RhdHVzLCByZXBvcnRfdXJsCkZST00gY2hlY2tzCldIRVJFIDEKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMjQwIEhPVVIKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIC0tQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKSAKICAgIC0tQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIGFuZCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYW1kX21zYW4sIDEvNCknCiAgICBhbmQgdGVzdF9uYW1lID0gJzAwODA0X3Rlc3RfYWx0ZXJfY29tcHJlc3Npb25fY29kZWNzJwpPUkRFUiBCWSBjaGVja19uYW1lLCB0ZXN0X25hbWUsIGNoZWNrX3N0YXJ0X3RpbWU=

But occasionally times out after something like 350s.

The slow part is a simple MergeTree insert with 300k rows:
```sql
INSERT INTO large_alter_table_00804 SELECT toDate('2019-01-01'), number, toString(number + rand()) FROM system.numbers LIMIT 300000;
```
In the failed runs the query completes, seemingly normally, server log doesn't have anything interesting for this query.

Idk why it's so slow and inconsistent in MSAN build. This PR just disabled this test in msan. There may or may not be more to investigate here; maybe the server was overloaded by too many tests in parallel and we need to decrease parallelism for asan tests? or maybe the server was overloaded by one particular bad test running in parallel with this one? or there's some performance bug that gets much worse under msan? I didn't investigate.