### PR TITLE
fix `system.replicas` selects that fail when storages are shutting down

### DIFF
--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -20,7 +20,6 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/Sources/NullSource.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-// #include "Common/logger_useful.h"
 #include <Common/typeid_cast.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/ThreadPool.h>

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -20,6 +20,7 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/Sources/NullSource.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+// #include "Common/logger_useful.h"
 #include <Common/typeid_cast.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/ThreadPool.h>
@@ -37,6 +38,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int ABORTED;
     extern const int QUERY_WAS_CANCELLED;
 }
 
@@ -503,6 +505,8 @@ Chunk SystemReplicasSource::generate()
 
     bool rows_added = false;
 
+    LoggerPtr logger = getLogger("SystemReplicasSource::generate");
+
     for (; i < futures.size(); ++i)
     {
         if (query_status)
@@ -525,50 +529,64 @@ Chunk SystemReplicasSource::generate()
             }
         }
 
+        const ReplicatedTableStatus * status;
+        try
+        {
+            status = &futures[i].get();
+        }
+        catch (Exception & e)
+        {
+            if (e.code() == ErrorCodes::ABORTED)
+            {
+                tryLogCurrentException(logger, "Received the ABORTED error while trying to get the status of a storage, this is likely because it has been shut down");
+                continue;
+            }
+            throw;
+        }
+
         res_columns[0]->insert((*col_database)[i]);
         res_columns[1]->insert((*col_table)[i]);
         res_columns[2]->insert((*col_engine)[i]);
 
-        const auto & status = futures[i].get();
         size_t col_num = 3;
-        res_columns[col_num++]->insert(status.is_leader);
-        res_columns[col_num++]->insert(status.can_become_leader);
-        res_columns[col_num++]->insert(status.is_readonly);
-        if (status.readonly_start_time != 0)
-            res_columns[col_num++]->insert(status.readonly_start_time);
+        res_columns[col_num++]->insert(status->is_leader);
+        res_columns[col_num++]->insert(status->can_become_leader);
+        res_columns[col_num++]->insert(status->is_readonly);
+        if (status->readonly_start_time != 0)
+            res_columns[col_num++]->insert(status->readonly_start_time);
         else
             res_columns[col_num++]->insertDefault();
-        res_columns[col_num++]->insert(status.is_session_expired);
-        res_columns[col_num++]->insert(status.queue.future_parts);
-        res_columns[col_num++]->insert(status.parts_to_check);
-        res_columns[col_num++]->insert(status.zookeeper_info.zookeeper_name);
-        res_columns[col_num++]->insert(status.zookeeper_info.path);
-        res_columns[col_num++]->insert(status.zookeeper_info.replica_name);
-        res_columns[col_num++]->insert(status.replica_path);
-        res_columns[col_num++]->insert(status.columns_version);
-        res_columns[col_num++]->insert(status.queue.queue_size);
-        res_columns[col_num++]->insert(status.queue.inserts_in_queue);
-        res_columns[col_num++]->insert(status.queue.merges_in_queue);
-        res_columns[col_num++]->insert(status.queue.part_mutations_in_queue);
-        res_columns[col_num++]->insert(status.queue.queue_oldest_time);
-        res_columns[col_num++]->insert(status.queue.inserts_oldest_time);
-        res_columns[col_num++]->insert(status.queue.merges_oldest_time);
-        res_columns[col_num++]->insert(status.queue.part_mutations_oldest_time);
-        res_columns[col_num++]->insert(status.queue.oldest_part_to_get);
-        res_columns[col_num++]->insert(status.queue.oldest_part_to_merge_to);
-        res_columns[col_num++]->insert(status.queue.oldest_part_to_mutate_to);
-        res_columns[col_num++]->insert(status.log_max_index);
-        res_columns[col_num++]->insert(status.log_pointer);
-        res_columns[col_num++]->insert(status.queue.last_queue_update);
-        res_columns[col_num++]->insert(status.absolute_delay);
-        res_columns[col_num++]->insert(status.total_replicas);
-        res_columns[col_num++]->insert(status.active_replicas);
-        res_columns[col_num++]->insert(status.lost_part_count);
-        res_columns[col_num++]->insert(status.last_queue_update_exception);
-        res_columns[col_num++]->insert(status.zookeeper_exception);
+        res_columns[col_num++]->insert(status->is_session_expired);
+        res_columns[col_num++]->insert(status->queue.future_parts);
+        res_columns[col_num++]->insert(status->parts_to_check);
+        res_columns[col_num++]->insert(status->zookeeper_info.zookeeper_name);
+        res_columns[col_num++]->insert(status->zookeeper_info.path);
+        res_columns[col_num++]->insert(status->zookeeper_info.replica_name);
+        res_columns[col_num++]->insert(status->replica_path);
+        res_columns[col_num++]->insert(status->columns_version);
+        res_columns[col_num++]->insert(status->queue.queue_size);
+        res_columns[col_num++]->insert(status->queue.inserts_in_queue);
+        res_columns[col_num++]->insert(status->queue.merges_in_queue);
+        res_columns[col_num++]->insert(status->queue.part_mutations_in_queue);
+        res_columns[col_num++]->insert(status->queue.queue_oldest_time);
+        res_columns[col_num++]->insert(status->queue.inserts_oldest_time);
+        res_columns[col_num++]->insert(status->queue.merges_oldest_time);
+        res_columns[col_num++]->insert(status->queue.part_mutations_oldest_time);
+        res_columns[col_num++]->insert(status->queue.oldest_part_to_get);
+        res_columns[col_num++]->insert(status->queue.oldest_part_to_merge_to);
+        res_columns[col_num++]->insert(status->queue.oldest_part_to_mutate_to);
+        res_columns[col_num++]->insert(status->log_max_index);
+        res_columns[col_num++]->insert(status->log_pointer);
+        res_columns[col_num++]->insert(status->queue.last_queue_update);
+        res_columns[col_num++]->insert(status->absolute_delay);
+        res_columns[col_num++]->insert(status->total_replicas);
+        res_columns[col_num++]->insert(status->active_replicas);
+        res_columns[col_num++]->insert(status->lost_part_count);
+        res_columns[col_num++]->insert(status->last_queue_update_exception);
+        res_columns[col_num++]->insert(status->zookeeper_exception);
 
         Map replica_is_active_values;
-        for (const auto & [name, is_active] : status.replica_is_active)
+        for (const auto & [name, is_active] : status->replica_is_active)
         {
             Tuple is_replica_active_value;
             is_replica_active_value.emplace_back(name);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](../docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When the storage is shutting down, `getStatus` throws an `ErrorCodes::ABORTED` exception. Previously, this would fail the select query. Now we catch the `ErrorCodes::ABORTED` exceptions and intentionally ignore them instead.

This is required for metric collection reliability.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
