### PR TITLE
Fix SZ3 for float32

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -167,7 +167,7 @@ void MergeTreeDataPartWriterWide::addStreams(
 
         /// If previous stream is not null it means it was Array offsets stream.
         /// Can't apply lossy compression for offsets.
-        if (prev_stream_name && column_streams[*prev_stream_name]->compressor.getCodec()->isLossyCompression())
+        if (prev_stream_name && *prev_stream_name != stream_name && column_streams[*prev_stream_name]->compressor.getCodec()->isLossyCompression())
             column_streams[*prev_stream_name]->compressor.setCodec(CompressionCodecFactory::instance().getDefaultCodec());
         prev_stream_name = stream_name;
 

--- a/tests/queries/0_stateless/03202_sz3_codec.reference
+++ b/tests/queries/0_stateless/03202_sz3_codec.reference
@@ -27,6 +27,7 @@ Test wide/compact format
 Test with default settings
 -- Test F64
 -- Test F32
+7.60 KiB	15.92 KiB
 Test with custom settings
 -- Test F64
 -- Test F32

--- a/tests/queries/0_stateless/03202_sz3_codec.sql
+++ b/tests/queries/0_stateless/03202_sz3_codec.sql
@@ -108,6 +108,12 @@ AND
     c2.key = c1.key - 1
 LIMIT 10;
 
+SELECT
+    formatReadableSize(sum(data_compressed_bytes)) AS compressed_size,
+    formatReadableSize(sum(data_uncompressed_bytes)) AS uncompressed_size
+FROM system.parts
+WHERE table = 'tab' AND active = 1;
+
 DROP TABLE tab;
 
 SELECT 'Test with custom settings';

--- a/tests/queries/0_stateless/03202_sz3_codec.sql
+++ b/tests/queries/0_stateless/03202_sz3_codec.sql
@@ -112,7 +112,7 @@ SELECT
     formatReadableSize(sum(data_compressed_bytes)) AS compressed_size,
     formatReadableSize(sum(data_uncompressed_bytes)) AS uncompressed_size
 FROM system.parts
-WHERE table = 'tab' AND active = 1;
+WHERE database = currentDatabase() AND table = 'tab' AND active = 1;
 
 DROP TABLE tab;
 

--- a/tests/queries/0_stateless/03202_sz3_codec.sql
+++ b/tests/queries/0_stateless/03202_sz3_codec.sql
@@ -108,6 +108,7 @@ AND
     c2.key = c1.key - 1
 LIMIT 10;
 
+-- This query needs to check that data is really compressed
 SELECT
     formatReadableSize(sum(data_compressed_bytes)) AS compressed_size,
     formatReadableSize(sum(data_uncompressed_bytes)) AS uncompressed_size


### PR DESCRIPTION
In case when we use SZ3 codec with `Array(Float32)`, SZ3 codec will be overwritten and MergeTree will use default codec instead of it. In case `Array(Float64)` everything is OK.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](../docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

