### PR TITLE
Fix: integer overflow in configuration settings.

### DIFF
--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -57,7 +57,7 @@ namespace
 
 
 RoleCache::RoleCache(const AccessControl & access_control_, int expiration_time_seconds)
-    : access_control(access_control_), cache(expiration_time_seconds * 1000 /* 10 minutes by default*/)
+    : access_control(access_control_), cache(std::min(INT_MAX / 1000, expiration_time_seconds) * 1000 /* 10 minutes by default*/)
 {
 }
 

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -57,7 +57,7 @@ namespace
 
 
 RoleCache::RoleCache(const AccessControl & access_control_, int expiration_time_seconds)
-    : access_control(access_control_), cache(std::min(INT_MAX / 1000, expiration_time_seconds) * 1000 /* 10 minutes by default*/)
+    : access_control(access_control_), cache(expiration_time_seconds * 1000ll /* 10 minutes by default*/)
 {
 }
 


### PR DESCRIPTION
Resolves: #83374

### Changelog category (leave one):
- Bug Fix (fix integer overflow in configuration settings)

### Changelog entry (a [user-readable short description](../docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Resolve minor integer overflow in configuration of setting `role_cache_expiration_time_seconds` (issue #83374).