### PR TITLE
Enable Keeper feature flags by default

### DIFF
--- a/src/Coordination/KeeperContext.cpp
+++ b/src/Coordination/KeeperContext.cpp
@@ -50,7 +50,8 @@ KeeperContext::KeeperContext(bool standalone_keeper_, CoordinationSettingsPtr co
         KeeperFeatureFlag::FILTERED_LIST,
         KeeperFeatureFlag::MULTI_READ,
         KeeperFeatureFlag::CHECK_NOT_EXISTS,
-        KeeperFeatureFlag::CREATE_IF_NOT_EXISTS
+        KeeperFeatureFlag::CREATE_IF_NOT_EXISTS,
+        KeeperFeatureFlag::REMOVE_RECURSIVE
     };
 
     for (const auto feature_flag : enabled_by_default_feature_flags)

--- a/src/Coordination/KeeperContext.cpp
+++ b/src/Coordination/KeeperContext.cpp
@@ -45,8 +45,17 @@ KeeperContext::KeeperContext(bool standalone_keeper_, CoordinationSettingsPtr co
     , coordination_settings(std::move(coordination_settings_))
 {
     /// enable by default some feature flags
-    feature_flags.enableFeatureFlag(KeeperFeatureFlag::FILTERED_LIST);
-    feature_flags.enableFeatureFlag(KeeperFeatureFlag::MULTI_READ);
+    static constexpr std::array enabled_by_default_feature_flags
+    {
+        KeeperFeatureFlag::FILTERED_LIST,
+        KeeperFeatureFlag::MULTI_READ,
+        KeeperFeatureFlag::CHECK_NOT_EXISTS,
+        KeeperFeatureFlag::CREATE_IF_NOT_EXISTS
+    };
+
+    for (const auto feature_flag : enabled_by_default_feature_flags)
+        feature_flags.enableFeatureFlag(feature_flag);
+
     system_nodes_with_data[keeper_api_feature_flags_path] = feature_flags.getFeatureFlags();
 
     /// for older clients, the default is equivalent to WITH_MULTI_READ version

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -941,8 +941,8 @@ TYPED_TEST(CoordinationTest, TestFeatureFlags)
     feature_flags.setFeatureFlags(get_response.data);
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::FILTERED_LIST));
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::MULTI_READ));
-    ASSERT_FALSE(feature_flags.isEnabled(KeeperFeatureFlag::CHECK_NOT_EXISTS));
-    ASSERT_FALSE(feature_flags.isEnabled(KeeperFeatureFlag::CREATE_IF_NOT_EXISTS));
+    ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::CHECK_NOT_EXISTS));
+    ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::CREATE_IF_NOT_EXISTS));
     ASSERT_FALSE(feature_flags.isEnabled(KeeperFeatureFlag::REMOVE_RECURSIVE));
 }
 

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -943,7 +943,7 @@ TYPED_TEST(CoordinationTest, TestFeatureFlags)
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::MULTI_READ));
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::CHECK_NOT_EXISTS));
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::CREATE_IF_NOT_EXISTS));
-    ASSERT_FALSE(feature_flags.isEnabled(KeeperFeatureFlag::REMOVE_RECURSIVE));
+    ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::REMOVE_RECURSIVE));
 }
 
 #endif

--- a/tests/integration/test_keeper_feature_flags_config/test.py
+++ b/tests/integration/test_keeper_feature_flags_config/test.py
@@ -36,7 +36,7 @@ def get_connection_zk(nodename, timeout=30.0):
     return _fake_zk_instance
 
 
-def restart_clickhouse(feature_flags=[], expect_fail=True):
+def restart_clickhouse(feature_flags=[], expect_fail=False):
     node.stop_clickhouse()
     node.copy_file_to_container(
         os.path.join(CURRENT_TEST_DIR, "configs/enable_keeper.xml"),
@@ -57,8 +57,10 @@ def restart_clickhouse(feature_flags=[], expect_fail=True):
             feature_flags_config,
         )
 
-    node.start_clickhouse(retry_start=not expect_fail)
-    keeper_utils.wait_until_connected(cluster, node)
+    node.start_clickhouse(expected_to_fail=expect_fail)
+
+    if not expect_fail:
+        keeper_utils.wait_until_connected(cluster, node)
 
 
 def test_keeper_feature_flags(started_cluster):
@@ -81,12 +83,12 @@ def test_keeper_feature_flags(started_cluster):
             assert f"{feature}\t{1 if is_enabled else 0}" in res
 
     assert_feature_flags(
-        [("filtered_list", 1), ("multi_read", 1), ("check_not_exists", 0)]
+        [("filtered_list", 1), ("multi_read", 1), ("remove_recursive", 0)]
     )
 
     feature_flags = [
         ("multi_read", 0),
-        ("check_not_exists", 1),
+        ("remove_recursive", 1),
         ("create_if_not_exists", 1),
     ]
     restart_clickhouse(feature_flags)
@@ -101,5 +103,4 @@ def test_keeper_feature_flags(started_cluster):
     restart_clickhouse(feature_flags)
     assert_feature_flags(feature_flags)
 
-    with pytest.raises(Exception):
-        restart_clickhouse([("invalid_feature", 1)], expect_fail=True)
+    restart_clickhouse([("invalid_feature", 1)], expect_fail=True)

--- a/tests/integration/test_keeper_feature_flags_config/test.py
+++ b/tests/integration/test_keeper_feature_flags_config/test.py
@@ -83,7 +83,7 @@ def test_keeper_feature_flags(started_cluster):
             assert f"{feature}\t{1 if is_enabled else 0}" in res
 
     assert_feature_flags(
-        [("filtered_list", 1), ("multi_read", 1), ("remove_recursive", 0)]
+        [("filtered_list", 1), ("multi_read", 1), ("remove_recursive", 1)]
     )
 
     feature_flags = [


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](../docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable `create_if_not_exists`, `check_not_exists`, `remove_recursive` feature flags in Keeper by default which enable new types of requests.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
