### PR TITLE
Don't use minmax pruning for arrays and maps subfields in Iceberg 

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -135,7 +135,7 @@ NameAndTypePair IcebergSchemaProcessor::getFieldCharacteristics(Int32 schema_ver
 
     auto it = clickhouse_types_by_source_ids.find({schema_version, source_id});
     if (it == clickhouse_types_by_source_ids.end())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Field with source id {} is unknown", source_id);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Field with source id {} in schema version {} is unknown", source_id, schema_version);
     return it->second;
 }
 

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -360,6 +360,19 @@ def default_upload_directory(
         raise Exception(f"Unknown iceberg storage type: {storage_type}")
 
 
+def execute_spark_query_general(
+    spark, started_cluster, storage_type: str, table_name: str, query: str
+):
+    spark.sql(query)
+    default_upload_directory(
+        started_cluster,
+        storage_type,
+        f"/iceberg_data/default/{table_name}/",
+        f"/iceberg_data/default/{table_name}/",
+    )
+    return
+
+
 @pytest.mark.parametrize("format_version", ["1", "2"])
 @pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
 def test_single_iceberg_file(started_cluster, format_version, storage_type):
@@ -759,14 +772,13 @@ def test_evolved_schema_simple(
     )
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -1168,14 +1180,13 @@ def test_not_evolved_schema(started_cluster, format_version, storage_type):
     )
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -1487,14 +1498,13 @@ def test_evolved_schema_complex(started_cluster, format_version, storage_type):
     )
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -2046,16 +2056,14 @@ def test_partition_pruning(started_cluster, storage_type, run_on_cluster):
     spark = started_cluster.spark_session
     TABLE_NAME = "test_partition_pruning_" + storage_type + "_" + get_uuid_str()
 
-
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -2233,14 +2241,13 @@ def test_schema_evolution_with_time_travel(
     )
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -2299,7 +2306,6 @@ def test_schema_evolution_with_time_travel(
     error_message = instance.query_and_get_error(f"SELECT * FROM {table_select_expression} ORDER BY ALL SETTINGS iceberg_timestamp_ms = {first_timestamp_ms}")
     assert "No snapshot found in snapshot log before requested timestamp" in error_message
 
-
     second_timestamp_ms = int(datetime.now().timestamp() * 1000)
 
     time.sleep(0.5)
@@ -2335,7 +2341,6 @@ def test_schema_evolution_with_time_travel(
     third_timestamp_ms = int(datetime.now().timestamp() * 1000)
 
     time.sleep(0.5)
-
 
     execute_spark_query(
         f"""
@@ -2646,14 +2651,13 @@ def test_minmax_pruning(started_cluster, storage_type, is_table_function):
     TABLE_NAME = "test_minmax_pruning_" + storage_type + "_" + get_uuid_str()
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -2840,7 +2844,6 @@ def test_minmax_pruning(started_cluster, storage_type, is_table_function):
         f"INSERT INTO {TABLE_NAME} VALUES (1, DATE '2024-01-20', TIMESTAMP '2024-02-20 10:00:00', named_struct('a', DATE '2024-03-15', 'b', TIMESTAMP '2024-02-20 10:00:00'), 'kek', 10, decimal(-8888.999))"
     )
 
-
     assert (
         check_validity_and_get_prunned_files(
             f"SELECT * FROM {creation_expression} WHERE ddd >= 100 ORDER BY ALL"
@@ -2907,14 +2910,13 @@ def test_minmax_pruning_with_null(started_cluster, storage_type):
     TABLE_NAME = "test_minmax_pruning_with_null" + storage_type + "_" + get_uuid_str()
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -3005,14 +3007,13 @@ def test_bucket_partition_pruning(started_cluster, storage_type):
     TABLE_NAME = "test_bucket_partition_pruning_" + storage_type + "_" + get_uuid_str()
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -3059,7 +3060,7 @@ def test_bucket_partition_pruning(started_cluster, storage_type):
     creation_expression = get_creation_expression(
         storage_type, TABLE_NAME, started_cluster, table_function=True
     )
-    
+
     queries = [
         f"SELECT * FROM {creation_expression} WHERE id == 1 ORDER BY ALL",
         f"SELECT * FROM {creation_expression} WHERE value == 20.00 OR event_time == '2024-01-24 14:00:00' ORDER BY ALL",
@@ -3089,14 +3090,13 @@ def test_cluster_table_function_with_partition_pruning(
     )
 
     def execute_spark_query(query: str):
-        spark.sql(query)
-        default_upload_directory(
+        return execute_spark_query_general(
+            spark,
             started_cluster,
             storage_type,
-            f"/iceberg_data/default/{TABLE_NAME}/",
-            f"/iceberg_data/default/{TABLE_NAME}/",
+            TABLE_NAME,
+            query,
         )
-        return
 
     execute_spark_query(
         f"""
@@ -3165,3 +3165,73 @@ def test_compressed_metadata(started_cluster, storage_type):
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster, explicit_metadata_path="")
 
     assert instance.query(f"SELECT * FROM {TABLE_NAME} WHERE not ignore(*)") == "1\tAlice\n2\tBob\n"
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_minmax_pruning_for_arrays_and_maps_subfields_disabled(started_cluster, storage_type):
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    TABLE_NAME = (
+        "test_disable_minmax_pruning_for_arrays_and_maps_subfields_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    def execute_spark_query(query: str):
+        return execute_spark_query_general(
+            spark,
+            started_cluster,
+            storage_type,
+            TABLE_NAME,
+            query,
+        )
+
+    execute_spark_query(
+        f"""
+            DROP TABLE IF EXISTS {TABLE_NAME};
+        """
+    )
+
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+            id BIGINT,
+            measurements ARRAY<DOUBLE>
+            ) USING iceberg
+            TBLPROPERTIES (
+            'write.metadata.metrics.max' = 'measurements.element',
+            'write.metadata.metrics.min' = 'measurements.element'
+            );
+        """
+    )
+
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES
+            (1, array(23.5, 24.1, 22.8, 25.3, 23.9)),
+            (2, array(18.2, 19.5, 17.8, 20.1, 19.3, 18.7)),
+            (3, array(30.0, 31.2, 29.8, 32.1, 30.5, 29.9, 31.0)),
+            (4, array(15.5, 16.2, 14.8, 17.1, 16.5)),
+            (5, array(27.3, 28.1, 26.9, 29.2, 28.5, 27.8, 28.3, 27.6));
+        """
+    )
+
+    default_upload_directory(
+        started_cluster,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    table_creation_expression = get_creation_expression(
+        storage_type,
+        TABLE_NAME,
+        started_cluster,
+        table_function=True,
+        allow_dynamic_metadata_for_data_lakes=True,
+    )
+
+    table_select_expression = table_creation_expression
+
+    instance.query(f"SELECT * FROM {table_select_expression} ORDER BY ALL")


### PR DESCRIPTION
### Changelog category:
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description]
Disable bounds-based file pruning for iceberg array element and iceberg map values, including all their nested subfields