### PR TITLE
Fix a crash in S3Queue

### DIFF
--- a/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
+++ b/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
@@ -50,7 +50,7 @@ StoragePtr createQueueStorage(const StorageFactory::Arguments & args)
 
     const bool is_attach = args.mode > LoadingStrictnessLevel::CREATE;
 
-    if (!is_attach)
+    if (!is_attach && args.storage_def->settings)
     {
         if (auto * path_setting = args.storage_def->settings->changes.tryGet("keeper_path"))
         {

--- a/tests/queries/0_stateless/03550_s3queue_no_settings.sql
+++ b/tests/queries/0_stateless/03550_s3queue_no_settings.sql
@@ -1,0 +1,1 @@
+CREATE TABLE s3_queue (name String, value UInt32) ENGINE = S3Queue('http://localhost:11111/test/{a,b,c}.tsv'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03550_s3queue_no_settings.sql
+++ b/tests/queries/0_stateless/03550_s3queue_no_settings.sql
@@ -1,1 +1,3 @@
+-- Tags: no-fasttest
+
 CREATE TABLE s3_queue (name String, value UInt32) ENGINE = S3Queue('http://localhost:11111/test/{a,b,c}.tsv'); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](../docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a crash in S3Queue. Introduced in https://github.com/ClickHouse/ClickHouse/pull/82463

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
