### PR TITLE
Small follow-up to #83304

### DIFF
--- a/src/Interpreters/HashJoin/AddedColumns.h
+++ b/src/Interpreters/HashJoin/AddedColumns.h
@@ -258,7 +258,9 @@ private:
     void addColumn(const ColumnWithTypeAndName & src_column, const std::string & qualified_name)
     {
         columns.push_back(src_column.column->cloneEmpty());
-        columns.back()->reserve(rows_to_add);
+        /// If lazy, we will reserve right after actual insertion into columns, because at that moment we will know the exact number of rows to add.
+        if constexpr (!lazy)
+            columns.back()->reserve(rows_to_add);
         type_name.emplace_back(src_column.type, src_column.name, qualified_name);
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

<img width="1670" alt="Screenshot 2025-07-09 at 21 54 32" src="https://github.com/user-attachments/assets/959c6949-e684-48ff-a32e-94b028e2960f" />

