### PR TITLE
Bring pre-pull stage for integration tests back

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -231,7 +231,7 @@ class ClickhouseIntegrationTestsRunner:
         cmd = (
             f"cd {self.repo_path}/tests/integration && "
             f"timeout --verbose --signal=KILL 1h ./runner {self._get_runner_opts()} {image_cmd} "
-            "--command ' echo Pre Pull finished ' "
+            "--pre-pull --command ' echo Pre Pull finished ' "
         )
 
         for i in range(5):

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -483,7 +483,7 @@ if __name__ == "__main__":
     cmd = cmd_base + " " + args.command
     cmd_pre_pull = (
         f"{cmd_base} find /ClickHouse/tests/integration/compose -name docker_compose_*.yml "
-        r"-exec docker compose -f '{}' pull \;"
+        r"-exec docker compose -f '{}' pull --quiet \;"
     )
 
     containers = subprocess.check_output(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bring back `--pre-pull` command to the integration tests jobs, it was deleted in #73291

Closes https://github.com/ClickHouse/ClickHouse/issues/83509
Closes https://github.com/ClickHouse/ClickHouse/issues/81182
Closes https://github.com/ClickHouse/ClickHouse/issues/80470
Closes https://github.com/ClickHouse/ClickHouse/issues/75808

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
