### PR TITLE
Isolate S3AuthSettings from `S3ObjectStorage` and `S3/Configuration.cpp`

### DIFF
--- a/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
+++ b/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
@@ -178,7 +178,7 @@ void registerS3ObjectStorage(ObjectStorageFactory & factory)
         auto settings = std::make_unique<S3Settings>();
         settings->loadFromConfigForObjectStorage(config, config_prefix, context->getSettingsRef(), uri.uri.getScheme(), true);
 
-        auto client_getter = std::make_shared<ClientGetterFromAuthSettings>(settings->auth_settings);
+        auto client_getter = std::make_shared<S3ClientGetterFromAuthSettings>(settings->auth_settings);
         auto key_generator = getKeyGenerator(uri, config, config_prefix);
 
         auto object_storage = createObjectStorage<S3ObjectStorage>(
@@ -212,7 +212,7 @@ void registerS3PlainObjectStorage(ObjectStorageFactory & factory)
         auto s3_capabilities = getCapabilitiesFromConfig(config, config_prefix);
         auto settings = std::make_unique<S3Settings>();
         settings->loadFromConfigForObjectStorage(config, config_prefix, context->getSettingsRef(), uri.uri.getScheme(), true);
-        auto client_getter = std::make_shared<ClientGetterFromAuthSettings>(settings->auth_settings);
+        auto client_getter = std::make_shared<S3ClientGetterFromAuthSettings>(settings->auth_settings);
         auto key_generator = getKeyGenerator(uri, config, config_prefix);
 
         auto object_storage = std::make_shared<PlainObjectStorage<S3ObjectStorage>>(
@@ -244,7 +244,7 @@ void registerS3PlainRewritableObjectStorage(ObjectStorageFactory & factory)
             auto s3_capabilities = getCapabilitiesFromConfig(config, config_prefix);
             auto settings = std::make_unique<S3Settings>();
             settings->loadFromConfigForObjectStorage(config, config_prefix, context->getSettingsRef(), uri.uri.getScheme(), true);
-            auto client_getter = std::make_shared<ClientGetterFromAuthSettings>(settings->auth_settings);
+            auto client_getter = std::make_shared<S3ClientGetterFromAuthSettings>(settings->auth_settings);
             auto key_generator = getKeyGenerator(uri, config, config_prefix);
 
             auto metadata_storage_metrics = DB::MetadataStorageMetrics::create<S3ObjectStorage, MetadataStorageType::PlainRewritable>();

--- a/src/Disks/ObjectStorages/S3/ClientGetter.cpp
+++ b/src/Disks/ObjectStorages/S3/ClientGetter.cpp
@@ -1,0 +1,53 @@
+#include <Disks/ObjectStorages/S3/ClientGetter.h>
+
+#include <Disks/ObjectStorages/S3/diskSettings.h>
+#include <Interpreters/Context.h>
+#include <Core/Settings.h>
+
+namespace DB
+{
+
+std::unique_ptr<S3::Client> ClientGetterFromAuthSettings::makeClient(
+    const std::string & endpoint,
+    const S3::S3RequestSettings & request_settings,
+    ContextPtr context,
+    bool for_disk_s3) const
+{
+    return getClient(endpoint, request_settings, *auth_settings.get(), context, for_disk_s3);
+}
+
+std::unique_ptr<S3::Client> ClientGetterFromAuthSettings::makeClient(
+    const S3::URI & url_,
+    const S3::S3RequestSettings & request_settings,
+    ContextPtr context,
+    bool for_disk_s3) const
+{
+    return getClient(url_, request_settings, *auth_settings.get(), context, for_disk_s3);
+}
+
+bool ClientGetterFromAuthSettings::applyNewSettings(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix,
+    const S3::URI & uri,
+    ContextPtr context)
+{
+    auto modified_settings = *auth_settings.get();
+
+    auto auth_settings_from_config = S3::S3AuthSettings(config, context->getSettingsRef(), config_prefix);
+
+    modified_settings.updateIfChanged(auth_settings_from_config);
+
+    if (auto endpoint_settings = context->getStorageS3Settings().getSettings(uri.uri.toString(), context->getUserName()))
+        modified_settings.updateIfChanged(endpoint_settings->auth_settings);
+
+    if (auth_settings.get()->hasUpdates(modified_settings))
+    {
+        auth_settings.set(std::make_unique<S3::S3AuthSettings>(std::move(modified_settings)));
+        return true;
+    }
+
+    return false;
+}
+
+
+}

--- a/src/Disks/ObjectStorages/S3/ClientGetter.h
+++ b/src/Disks/ObjectStorages/S3/ClientGetter.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <IO/S3Settings.h>
+#include <IO/S3/Client.h>
+#include <IO/S3/URI.h>
+#include <Common/MultiVersion.h>
+
+namespace DB
+{
+
+class ClientGetterFromAuthSettings
+{
+public:
+    explicit ClientGetterFromAuthSettings(const S3::S3AuthSettings & auth_settings_)
+        : auth_settings(std::make_unique<S3::S3AuthSettings>(auth_settings_))
+    {}
+
+    std::unique_ptr<S3::Client> makeClient(
+        const std::string & endpoint,
+        const S3::S3RequestSettings & request_settings,
+        ContextPtr context,
+        bool for_disk_s3) const;
+
+    std::unique_ptr<S3::Client> makeClient(
+        const S3::URI & url_,
+        const S3::S3RequestSettings & request_settings,
+        ContextPtr context,
+        bool for_disk_s3) const;
+
+    bool applyNewSettings(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & config_prefix,
+        const S3::URI & uri,
+        ContextPtr context);
+
+private:
+    MultiVersion<S3::S3AuthSettings> auth_settings;
+};
+
+using ClientGetterPtr = std::shared_ptr<ClientGetterFromAuthSettings>;
+
+}

--- a/src/Disks/ObjectStorages/S3/ClientGetter.h
+++ b/src/Disks/ObjectStorages/S3/ClientGetter.h
@@ -8,10 +8,40 @@
 namespace DB
 {
 
-class ClientGetterFromAuthSettings
+class IS3ClientGetter
 {
 public:
-    explicit ClientGetterFromAuthSettings(const S3::S3AuthSettings & auth_settings_)
+
+    virtual std::unique_ptr<S3::Client> makeClient(
+        const std::string & endpoint,
+        const S3::S3RequestSettings & request_settings,
+        ContextPtr context,
+        bool for_disk_s3) const = 0;
+
+    virtual std::unique_ptr<S3::Client> makeClient(
+        const S3::URI & url_,
+        const S3::S3RequestSettings & request_settings,
+        ContextPtr context,
+        bool for_disk_s3) const = 0;
+
+    virtual bool applyNewSettings(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & config_prefix,
+        const S3::URI & uri,
+        ContextPtr context) = 0;
+
+    virtual bool isNoSignRequest() const = 0;
+
+    virtual void addHeaders(const HTTPHeaderEntries & headers) = 0;
+
+    virtual ~IS3ClientGetter() = default;
+};
+
+
+class S3ClientGetterFromAuthSettings : public IS3ClientGetter
+{
+public:
+    explicit S3ClientGetterFromAuthSettings(const S3::S3AuthSettings & auth_settings_)
         : auth_settings(std::make_unique<S3::S3AuthSettings>(auth_settings_))
     {}
 
@@ -19,24 +49,27 @@ public:
         const std::string & endpoint,
         const S3::S3RequestSettings & request_settings,
         ContextPtr context,
-        bool for_disk_s3) const;
+        bool for_disk_s3) const override;
 
     std::unique_ptr<S3::Client> makeClient(
         const S3::URI & url_,
         const S3::S3RequestSettings & request_settings,
         ContextPtr context,
-        bool for_disk_s3) const;
+        bool for_disk_s3) const override;
 
     bool applyNewSettings(
         const Poco::Util::AbstractConfiguration & config,
         const std::string & config_prefix,
         const S3::URI & uri,
-        ContextPtr context);
+        ContextPtr context) override;
 
+    bool isNoSignRequest() const override;
+
+    void addHeaders(const HTTPHeaderEntries & headers) override;
 private:
     MultiVersion<S3::S3AuthSettings> auth_settings;
 };
 
-using ClientGetterPtr = std::shared_ptr<ClientGetterFromAuthSettings>;
+using ClientGetterPtr = std::shared_ptr<IS3ClientGetter>;
 
 }

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -62,25 +62,25 @@ extern const int NO_ELEMENTS_IN_CONFIG;
 
 std::unique_ptr<S3::Client> getClient(
     const std::string & endpoint,
-    const S3Settings & settings,
+    const S3::S3RequestSettings & request_settings,
+    const S3::S3AuthSettings & auth_settings,
     ContextPtr context,
     bool for_disk_s3)
 {
     auto url = S3::URI(endpoint);
     if (!url.key.ends_with('/'))
         url.key.push_back('/');
-    return getClient(url, settings, context, for_disk_s3);
+    return getClient(url, request_settings, auth_settings, context, for_disk_s3);
 }
 
 std::unique_ptr<S3::Client> getClient(
     const S3::URI & url,
-    const S3Settings & settings,
+    const S3::S3RequestSettings & request_settings,
+    const S3::S3AuthSettings & auth_settings,
     ContextPtr context,
     bool for_disk_s3)
 {
     const Settings & global_settings = context->getGlobalContext()->getSettingsRef();
-    const auto & auth_settings = settings.auth_settings;
-    const auto & request_settings = settings.request_settings;
 
     const bool is_s3_express_bucket = S3::isS3ExpressEndpoint(url.endpoint);
     if (is_s3_express_bucket && auth_settings[S3AuthSetting::region].value.empty())

--- a/src/Disks/ObjectStorages/S3/diskSettings.h
+++ b/src/Disks/ObjectStorages/S3/diskSettings.h
@@ -15,13 +15,15 @@ namespace DB
 
 std::unique_ptr<S3::Client> getClient(
     const std::string & endpoint,
-    const S3Settings & settings,
+    const S3::S3RequestSettings & request_settings,
+    const S3::S3AuthSettings & auth_settings,
     ContextPtr context,
     bool for_disk_s3);
 
 std::unique_ptr<S3::Client> getClient(
     const S3::URI & url_,
-    const S3Settings & settings,
+    const S3::S3RequestSettings & request_settings,
+    const S3::S3AuthSettings & auth_settings,
     ContextPtr context,
     bool for_disk_s3);
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -168,7 +168,6 @@ DeltaLake::KernelHelperPtr getKernelHelper(
         case DB::ObjectStorageType::S3:
         {
             const auto * s3_conf = dynamic_cast<const DB::StorageS3Configuration *>(configuration.get());
-            const auto & auth_settings = s3_conf->getAuthSettings();
             const auto & s3_client = object_storage->getS3StorageClient();
             const auto & s3_credentials = s3_client->getCredentials();
             const auto & url = s3_conf->getURL();
@@ -183,7 +182,7 @@ DeltaLake::KernelHelperPtr getKernelHelper(
                 s3_credentials.GetAWSSecretKey(),
                 std::move(region),
                 s3_credentials.GetSessionToken(),
-                auth_settings[S3AuthSetting::no_sign_request]);
+                s3_conf->isNoSignRequest());
         }
         case DB::ObjectStorageType::Local:
         {

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -131,12 +131,13 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
             headers_from_ast.begin(), headers_from_ast.end());
     }
 
-    auto client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
+    auto client_getter = std::make_shared<ClientGetterFromAuthSettings>(s3_settings->auth_settings);
     auto key_generator = createObjectStorageKeysGeneratorAsIsWithPrefix(url.key);
 
     return std::make_shared<S3ObjectStorage>(
-        std::move(client),
-        std::make_unique<S3Settings>(*s3_settings),
+        client_getter,
+        std::make_unique<S3::S3RequestSettings>(s3_settings->request_settings),
+        context,
         url,
         *s3_capabilities,
         key_generator,

--- a/src/Storages/ObjectStorage/S3/Configuration.h
+++ b/src/Storages/ObjectStorage/S3/Configuration.h
@@ -68,7 +68,7 @@ public:
     size_t getMaxNumberOfArguments(bool with_structure = true) const { return with_structure ? max_number_of_arguments_with_structure : max_number_of_arguments_without_structure; }
 
     S3::URI getURL() const { return url; }
-    const S3::S3AuthSettings & getAuthSettings() const { return s3_settings->auth_settings; }
+    bool isNoSignRequest() const { return client_getter->isNoSignRequest(); }
 
     Path getPath() const override { return url.key; }
     void setPath(const Path & path) override { url.key = path; }
@@ -103,7 +103,8 @@ private:
     S3::URI url;
     std::vector<String> keys;
 
-    std::unique_ptr<S3Settings> s3_settings;
+    ClientGetterPtr client_getter;
+    std::shared_ptr<S3::S3RequestSettings> s3_request_settings;
     std::unique_ptr<S3Capabilities> s3_capabilities;
 
     HTTPHeaderEntries headers_from_ast; /// Headers from ast is a part of static configuration.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
