### PR TITLE
Shutdown s3queue streaming before shutting down any tables

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -115,6 +115,9 @@
     M(ThreadPoolFSReaderThreads, "Number of threads in the thread pool for local_filesystem_read_method=threadpool.") \
     M(ThreadPoolFSReaderThreadsActive, "Number of threads in the thread pool for local_filesystem_read_method=threadpool running a task.") \
     M(ThreadPoolFSReaderThreadsScheduled, "Number of queued or active jobs in the thread pool for local_filesystem_read_method=threadpool.") \
+    M(ObjectStorageQueueShutdownThreads, "Number of threads in object storage queue shutdown pool.") \
+    M(ObjectStorageQueueShutdownThreadsActive, "Number of threads in object storage queue shutdown pool running a task.") \
+    M(ObjectStorageQueueShutdownThreadsScheduled, "Number of queued or active jobs in object storage queue shutdown pool.") \
     M(BackupsIOThreads, "Number of threads in the BackupsIO thread pool.") \
     M(BackupsIOThreadsActive, "Number of threads in the BackupsIO thread pool running a task.") \
     M(BackupsIOThreadsScheduled, "Number of queued or active jobs in the BackupsIO thread pool.") \

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -39,6 +39,7 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/PrimaryIndexCache.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h>
 #include <Storages/MergeTree/VectorSimilarityIndexCache.h>
 #include <Storages/Distributed/DistributedSettings.h>
 #include <Storages/CompressionCodecSelector.h>
@@ -791,6 +792,9 @@ struct ContextSharedPart : boost::noncopyable
 
         /// Waiting for current backups/restores to be finished. This must be done before `DatabaseCatalog::shutdown()`.
         SHUTDOWN(log, "backups worker", backups_worker, shutdown());
+
+        LOG_TRACE(log, "Shutting down object storage queue streaming");
+        ObjectStorageQueueFactory::instance().shutdown();
 
         LOG_TRACE(log, "Shutting down database catalog");
         DatabaseCatalog::shutdown([this]()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -83,6 +83,13 @@ void ObjectStorageQueueFactory::shutdown()
         shutdown_storages = std::vector<StorageID>(storages.begin(), storages.end());
     }
 
+    auto log = getLogger("ObjectStorageFactory::shutdown");
+    if (shutdown_storages.empty())
+    {
+        LOG_DEBUG(log, "There are no queue storages to shutdown");
+        return;
+    }
+
     static const auto default_shutdown_threads = 10;
     ThreadPool pool(
         CurrentMetrics::ObjectStorageQueueShutdownThreads,
@@ -91,6 +98,8 @@ void ObjectStorageQueueFactory::shutdown()
         std::min<size_t>(default_shutdown_threads, shutdown_storages.size()));
 
     ThreadPoolCallbackRunnerLocal<void> runner(pool, "ObjectStorageQueueFactory::shutdown");
+
+    LOG_DEBUG(log, "Will shutdown {} queue storages", shutdown_storages.size());
 
     for (const auto & storage : shutdown_storages)
     {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -1,11 +1,106 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric ObjectStorageQueueShutdownThreads;
+    extern const Metric ObjectStorageQueueShutdownThreadsActive;
+    extern const Metric ObjectStorageQueueShutdownThreadsScheduled;
+}
 
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+}
+
+ObjectStorageQueueFactory & ObjectStorageQueueFactory::instance()
+{
+    static ObjectStorageQueueFactory ret;
+    return ret;
+}
+
+void ObjectStorageQueueFactory::registerTable(const StorageID & storage)
+{
+    std::lock_guard lock(mutex);
+
+    if (shutdown_called)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Shutdown was called");
+
+    const bool inserted = storages.emplace(storage).second;
+    if (!inserted)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table with storage id {} already registered", storage.getNameForLogs());
+}
+
+void ObjectStorageQueueFactory::unregisterTable(const StorageID & storage, bool if_exists)
+{
+    std::lock_guard lock(mutex);
+
+    if (shutdown_called)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Shutdown was called");
+
+    auto it = storages.find(storage);
+    if (it == storages.end())
+    {
+        if (if_exists)
+            return;
+
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Table with storage id {} is not registered", storage.getNameForLogs());
+    }
+    storages.erase(it);
+}
+
+void ObjectStorageQueueFactory::renameTable(const StorageID & from, const StorageID & to)
+{
+    std::lock_guard lock(mutex);
+    if (shutdown_called)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Shutdown was called");
+
+    auto from_it = storages.find(from);
+    if (from_it == storages.end())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table with storage id {} is not registered", from.getNameForLogs());
+
+    auto to_it = storages.find(to);
+    if (to_it != storages.end())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table with storage id {} is already registered", to.getNameForLogs());
+
+    storages.erase(from_it);
+    storages.emplace(to);
+}
+
+void ObjectStorageQueueFactory::shutdown()
+{
+    std::vector<StorageID> shutdown_storages;
+    {
+        std::lock_guard lock(mutex);
+        shutdown_called = true;
+        shutdown_storages = std::vector<StorageID>(storages.begin(), storages.end());
+    }
+
+    static const auto default_shutdown_threads = 10;
+    ThreadPool pool(
+        CurrentMetrics::ObjectStorageQueueShutdownThreads,
+        CurrentMetrics::ObjectStorageQueueShutdownThreadsActive,
+        CurrentMetrics::ObjectStorageQueueShutdownThreadsScheduled,
+        std::min<size_t>(default_shutdown_threads, shutdown_storages.size()));
+
+    ThreadPoolCallbackRunnerLocal<void> runner(pool, "ObjectStorageQueueFactory::shutdown");
+
+    for (const auto & storage : shutdown_storages)
+    {
+        runner([&]()
+        {
+            DatabaseCatalog::instance().tryGetTable(storage, Context::getGlobalContextInstance())->shutdown();
+        });
+    }
+
+    runner.waitForAllToFinish();
 }
 
 ObjectStorageQueueMetadataFactory & ObjectStorageQueueMetadataFactory::instance()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -16,6 +16,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
 }
 
 ObjectStorageQueueFactory & ObjectStorageQueueFactory::instance()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -1,9 +1,39 @@
 #pragma once
-#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
+#include <Common/logger_useful.h>
+#include <Interpreters/StorageID.h>
 #include <boost/noncopyable.hpp>
+#include <unordered_set>
+#include <mutex>
 
 namespace DB
 {
+class ObjectStorageQueueMetadata;
+using ObjectStorageQueueMetadataPtr = std::unique_ptr<ObjectStorageQueueMetadata>;
+
+/**
+ * A class to keep track of all S3(Azure/etc)Queue storages.
+ * Its main purpose is to be able to shutdown such tables
+ * before shutting down all other tables,
+ * to avoid "Table is shutting down" exceptions during processing.
+ */
+class ObjectStorageQueueFactory final : private boost::noncopyable
+{
+public:
+    static ObjectStorageQueueFactory & instance();
+
+    void registerTable(const StorageID & storage);
+
+    void unregisterTable(const StorageID & storage, bool if_exists = false);
+
+    void renameTable(const StorageID & from, const StorageID & to);
+
+    void shutdown();
+
+private:
+    bool shutdown_called = false;
+    std::mutex mutex;
+    std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> storages;
+};
 
 class ObjectStorageQueueMetadataFactory final : private boost::noncopyable
 {

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -260,6 +260,7 @@ void StorageObjectStorageQueue::startup()
     files_metadata = ObjectStorageQueueMetadataFactory::instance().getOrCreate(zk_path, std::move(temp_metadata), getStorageID());
     try
     {
+        ObjectStorageQueueFactory::instance().registerTable(getStorageID());
         files_metadata->startup();
         for (auto & task : streaming_tasks)
             task->activateAndSchedule();
@@ -275,6 +276,12 @@ void StorageObjectStorageQueue::startup()
 
 void StorageObjectStorageQueue::shutdown(bool is_drop)
 {
+    if (shutdown_called)
+        return;
+
+    if (is_drop)
+        ObjectStorageQueueFactory::instance().unregisterTable(getStorageID());
+
     table_is_being_dropped = is_drop;
     shutdown_called = true;
 
@@ -299,6 +306,13 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
         files_metadata.reset();
     }
     LOG_TRACE(log, "Shut down storage");
+}
+
+void StorageObjectStorageQueue::renameInMemory(const StorageID & new_table_id)
+{
+    const auto prev_storage_id = getStorageID();
+    IStorage::renameInMemory(new_table_id);
+    ObjectStorageQueueFactory::instance().renameTable(prev_storage_id, getStorageID());
 }
 
 bool StorageObjectStorageQueue::supportsSubsetOfColumns(const ContextPtr & context_) const
@@ -526,7 +540,9 @@ void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
                 {
                     /// Increase the reschedule interval.
                     std::lock_guard lock(mutex);
-                    reschedule_processing_interval_ms = std::min<size_t>(polling_max_timeout_ms, reschedule_processing_interval_ms + polling_backoff_ms);
+                    reschedule_processing_interval_ms = std::min<size_t>(
+                        polling_max_timeout_ms,
+                        reschedule_processing_interval_ms + polling_backoff_ms);
                 }
 
                 LOG_DEBUG(log, "Stopped streaming to {} attached views", dependencies_count);

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -57,6 +57,8 @@ public:
         ContextPtr local_context,
         AlterLockHolder & table_lock_holder) override;
 
+    void renameInMemory(const StorageID & new_table_id) override;
+
     const auto & getFormatName() const { return configuration->format; }
 
     const fs::path & getZooKeeperPath() const { return zk_path; }

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -877,9 +877,9 @@ def test_shutdown_logs(started_cluster):
 
 def test_shutdown_order(started_cluster):
     node = started_cluster.instances["instance"]
-    table_name = f"test_shutdown_order_{uuid.uuid4()}"
+    table_name = f"test_shutdown_order_{generate_random_string()}"
     dst_table_name = f"a_{table_name}_dst"
-    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+    keeper_path = f"/clickhouse/test_{table_name}}"
     files_path = f"{table_name}_data"
 
     format = "column1 Int32, column2 String"

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -877,7 +877,7 @@ def test_shutdown_logs(started_cluster):
 
 def test_shutdown_order(started_cluster):
     node = started_cluster.instances["instance"]
-    table_name = f"test_shutdown_order"
+    table_name = f"test_shutdown_order_{uuid.uuid4()}"
     dst_table_name = f"a_{table_name}_dst"
     keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
     files_path = f"{table_name}_data"

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -23,6 +23,7 @@ from helpers.s3_queue_common import (
     create_mv,
     generate_random_string,
 )
+from helpers.config_cluster import minio_secret_key
 
 AVAILABLE_MODES = ["unordered", "ordered"]
 
@@ -872,3 +873,94 @@ def test_shutdown_logs(started_cluster):
     )
     assert 1 == check_in_text_log("Shutting down system logs", "DatabaseCatalog")
     assert 0 == check_in_text_log("Shutting down system databases", "DatabaseCatalog")
+
+
+def test_shutdown_order(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = f"test_shutdown_order"
+    dst_table_name = f"a_{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+
+    format = "column1 Int32, column2 String"
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        format=format,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "s3queue_processing_threads_num": 1,
+            "polling_max_timeout_ms": 0,
+            "polling_min_timeout_ms": 0,
+        },
+    )
+
+    def insert():
+        files_to_generate = 10
+        table_name_suffix = f"{uuid.uuid4()}"
+        for i in range(files_to_generate):
+            file_name = f"file_{table_name}_{table_name_suffix}_{i}.csv"
+            s3_function = f"s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/{files_path}/{file_name}', 'minio', '{minio_secret_key}')"
+            node.query(
+                f"INSERT INTO FUNCTION {s3_function} select number, randomString(100) FROM numbers(5000000)"
+            )
+
+    insert()
+
+    mv_table_name = f"{table_name}_mv"
+    create_mv(
+        node,
+        table_name,
+        dst_table_name,
+        mv_name=mv_table_name,
+        format=format,
+        dst_table_engine=f"ReplicatedMergeTree('/clickhouse/tables/{table_name}', 'node')",
+    )
+
+    node.restart_clickhouse()
+
+    def check_in_text_log(message, logger_name):
+        return int(
+            node.query(
+                f"SELECT count() FROM system.text_log WHERE logger_name ilike '%{logger_name}%' and message ilike '%{message}%'"
+            )
+        )
+
+    assert 0 == check_in_text_log(
+        "Failed to process data", f"StorageS3Queue(default.{table_name})"
+    )
+    assert 0 == int(
+        node.query(
+            f"SELECT count() FROM system.s3queue_log WHERE table = '{table_name}' and status = 'Failed'"
+        )
+    )
+    new_table_name = f"{table_name}_new"
+    new_mv_table_name = f"{new_table_name}_mv"
+    node.query(f"DROP TABLE {mv_table_name} SYNC")
+    node.query(f"RENAME TABLE {table_name} to {new_table_name}")
+
+    create_mv(
+        node,
+        new_table_name,
+        dst_table_name,
+        mv_name=new_mv_table_name,
+        format=format,
+        dst_table_exists=True,
+    )
+    insert()
+    time.sleep(0.1)
+
+    node.restart_clickhouse()
+    assert 0 == check_in_text_log(
+        "Failed to process data", f"StorageS3Queue(default.{table_name})"
+    )
+    assert 0 == int(
+        node.query(
+            f"SELECT count() FROM system.s3queue_log WHERE table = '{table_name}' and status = 'Failed'"
+        )
+    )
+
+    node.query(f"DROP TABLE {new_table_name} SYNC")

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -879,7 +879,7 @@ def test_shutdown_order(started_cluster):
     node = started_cluster.instances["instance"]
     table_name = f"test_shutdown_order_{generate_random_string()}"
     dst_table_name = f"a_{table_name}_dst"
-    keeper_path = f"/clickhouse/test_{table_name}}"
+    keeper_path = f"/clickhouse/test_{table_name}"
     files_path = f"{table_name}_data"
 
     format = "column1 Int32, column2 String"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Shutdown S3(Azure/etc)Queue streaming before shutting down any tables on server shutdown.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
