### PR TITLE
Resubmit improve ordinary database warning

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -797,6 +797,14 @@ void registerDatabaseAtomic(DatabaseFactory & factory)
 {
     auto create_fn = [](const DatabaseFactory::Arguments & args)
     {
+        if (args.database_name.ends_with(DatabaseReplicated::BROKEN_REPLICATED_TABLES_SUFFIX))
+            args.context->addOrUpdateWarningMessage(
+                Context::WarningType::MAYBE_BROKEN_TABLES,
+                PreformattedMessage::create(
+                    "The database {} is probably created during recovering a lost replica. If it has no tables, it can be deleted. If it "
+                    "has tables, it worth to check why they were considered broken.",
+                    backQuoteIfNeed(args.database_name)));
+
         DatabaseMetadataDiskSettings database_metadata_disk_settings;
         auto * engine_define = args.create_query.storage;
         chassert(engine_define);

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -10,6 +10,7 @@
 #include <Databases/DatabaseMetadataDiskSettings.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseOrdinary.h>
+#include <Databases/DatabaseReplicated.h>
 #include <Databases/DatabasesCommon.h>
 #include <Databases/TablesLoader.h>
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
@@ -694,7 +695,16 @@ void registerDatabaseOrdinary(DatabaseFactory & factory)
                 ErrorCodes::UNKNOWN_DATABASE_ENGINE,
                 "Ordinary database engine is deprecated (see also allow_deprecated_database_ordinary setting)");
 
-        args.context->addWarningMessageAboutDatabaseOrdinary(args.database_name);
+        // Do not warn about ordinary databases that is most likely created by recovering replicas
+        if (!args.database_name.ends_with(DatabaseReplicated::BROKEN_TABLES_SUFFIX))
+            args.context->addWarningMessageAboutDatabaseOrdinary(args.database_name);
+        else
+            args.context->addOrUpdateWarningMessage(
+                Context::WarningType::MAYBE_BROKEN_TABLES,
+                PreformattedMessage::create(
+                    "The database {} is probably created during recovering a lost replica. If it has no tables, it can be deleted. If it "
+                    "has tables, it worth to check why they were considered broken.",
+                    backQuoteIfNeed(args.database_name)));
 
         DatabaseMetadataDiskSettings database_metadata_disk_settings;
         auto * engine_define = args.create_query.storage;

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -111,8 +111,6 @@ namespace FailPoints
 
 static constexpr const char * REPLICATED_DATABASE_MARK = "DatabaseReplicated";
 static constexpr const char * DROPPED_MARK = "DROPPED";
-static constexpr const char * BROKEN_TABLES_SUFFIX = "_broken_tables";
-static constexpr const char * BROKEN_REPLICATED_TABLES_SUFFIX = "_broken_replicated_tables";
 static constexpr const char * FIRST_REPLICA_DATABASE_NAME = "first_replica_database_name";
 
 ZooKeeperPtr DatabaseReplicated::getZooKeeper() const

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -42,6 +42,8 @@ class DatabaseReplicated : public DatabaseAtomic
 public:
     static constexpr auto ALL_GROUPS_CLUSTER_PREFIX = "all_groups.";
     static constexpr auto REPLICA_UNSYNCED_MARKER = "\tUNSYNCED";
+    static constexpr auto BROKEN_TABLES_SUFFIX = "_broken_tables";
+    static constexpr auto BROKEN_REPLICATED_TABLES_SUFFIX = "_broken_replicated_tables";
 
     DatabaseReplicated(const String & name_, const String & metadata_path_, UUID uuid,
                        const String & zookeeper_path_, const String & shard_name_, const String & replica_name_,

--- a/tests/integration/helpers/database_disk.py
+++ b/tests/integration/helpers/database_disk.py
@@ -27,11 +27,6 @@ def replace_text_in_metadata(node, metadata_path: str, old_value: str, new_value
 
 def write_metadata(node, metadata_path: str, content: str):
     db_disk_name = get_database_disk_name(node)
-    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /etc/clickhouse-server/config.xml --disk {db_disk_name} --save-logs --query "
-
-    old_metadata = node.exec_in_container(
-        ["bash", "-c", f"{disk_cmd_prefix} 'read --path-from {metadata_path}'"]
-    )
     write_to_file(node, db_disk_name, metadata_path, content)
 
 
@@ -44,5 +39,17 @@ def write_to_file(node, db_disk_name: str, file_path: str, content: str):
             "bash",
             "-c",
             f"""printf "%s" "{escaped_content}" | {disk_cmd_prefix} 'w --path-to {file_path}'""",
+        ]
+    )
+
+
+def move_file(node, source_path: str, destination_path: str):
+    db_disk_name = get_database_disk_name(node)
+    disk_cmd_prefix = f"/usr/bin/clickhouse disks -C /etc/clickhouse-server/config.xml --disk {db_disk_name} --save-logs --query "
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"{disk_cmd_prefix} 'move --path-from {source_path} --path-to {destination_path}'"
         ]
     )

--- a/tests/integration/test_warning_broken_tables/test.py
+++ b/tests/integration/test_warning_broken_tables/test.py
@@ -1,0 +1,128 @@
+import logging
+import os
+import re
+import shutil
+import threading
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+from helpers.test_tools import assert_eq_with_retry, assert_logs_contain
+from helpers.database_disk import get_database_disk_name, replace_text_in_metadata
+
+test_recover_staled_replica_run = 1
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 1}
+)
+node2 = cluster.add_instance(
+    "node2",
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 2},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_warn_on_database_ending_broken_replicated_tables(started_cluster):
+    database_name = "test_warn_on_database_name"
+    ordinary_database_for_broken_tables = f"{database_name}_broken_tables"
+    atomic_database_for_broken_tables = f"{database_name}_broken_replicated_tables"
+
+    for node in [node1, node2]:
+        node.query(f"DROP DATABASE IF EXISTS {database_name} SYNC")
+        node.query(f"DROP DATABASE IF EXISTS {ordinary_database_for_broken_tables} SYNC")
+        node.query(f"DROP DATABASE IF EXISTS {atomic_database_for_broken_tables} SYNC")
+    node1.query(
+        f"CREATE DATABASE {database_name} ENGINE = Replicated('/clickhouse/databases/{database_name}', 'shard1', 'replica1');"
+    )
+    started_cluster.get_kazoo_client("zoo1").set(
+        f"/clickhouse/databases/{database_name}/logs_to_keep", b"4"
+    )
+    node2.query(
+        f"CREATE DATABASE {database_name} ENGINE = Replicated('/clickhouse/databases/{database_name}', 'shard1', 'replica2');"
+    )
+
+    settings = {"distributed_ddl_task_timeout": 0}
+    node1.query(
+        f"CREATE TABLE {database_name}.mt_0 (n Int64) ENGINE = MergeTree ORDER BY n"
+    )
+    node1.query(
+        f"CREATE TABLE {database_name}.rmt_0 (n Int64) ENGINE = ReplicatedMergeTree ORDER BY n"
+    )
+
+    for table in ["mt_0", "rmt_0"]:
+        node1.query(f"INSERT INTO {database_name}.{table} VALUES (42)")
+        node2.query(f"INSERT INTO {database_name}.{table} VALUES (42)")
+
+    node1.query(f"SYSTEM SYNC REPLICA {database_name}.rmt_0")
+
+    with PartitionManager() as pm:
+        pm.drop_instance_zk_connections(node2)
+        node2.query_and_get_error(
+            f"RENAME TABLE {database_name}.mt_0 TO {database_name}.mt_x"
+        )
+
+        for i in range(0, 8):
+            node1.query(
+                f"RENAME TABLE {database_name}.mt_{i} TO {database_name}.mt_{i+1}",
+                settings=settings,
+            )
+
+    query = (
+        f"SELECT name, uuid, create_table_query FROM system.tables WHERE database='{database_name}'"
+        "ORDER BY name SETTINGS show_table_uuid_in_table_create_query_if_not_nil=1"
+    )
+    expected = node1.query(query)
+    assert_eq_with_retry(node2, query, expected)
+
+    logging.debug("Result: %s", node2.query("SHOW DATABASES"))
+
+    warning_message_format = "The database {} is probably created during recovering a lost replica. If it has no tables, it can be deleted. If it has tables, it worth to check why they were considered broken."
+
+    # Currently the Atomic database is created as second, so that will be shown in `system.warnings`
+    warning_count = node2.query(
+        f"SELECT count() FROM system.warnings WHERE message = '{warning_message_format.format(atomic_database_for_broken_tables)}'"
+    )
+    assert warning_count == "1\n"
+
+    # Assert that no warning about ordinary engine
+    warning_about_ordinary_database = node2.query(
+        "SELECT message FROM system.warnings WHERE message ILIKE '%ordinary%'"
+    )
+    assert warning_about_ordinary_database == ""
+
+    # Let's drop the database that showed up in system.warnings
+    node2.query(f"DROP DATABASE {atomic_database_for_broken_tables} SYNC")
+    node2.restart_clickhouse()
+
+    warning_count = node2.query(
+        f"SELECT count() FROM system.warnings WHERE message = '{warning_message_format.format(ordinary_database_for_broken_tables)}'"
+    )
+    assert warning_count == "1\n"
+
+    node2.query(f"DROP DATABASE {ordinary_database_for_broken_tables} SYNC")
+    node2.restart_clickhouse()
+
+    remaining_warnings = node2.query(
+        f"SELECT message FROM system.warnings WHERE message_format_string = '{warning_message_format}'"
+    )
+    assert remaining_warnings == ""
+
+    node1.query(f"DROP DATABASE {database_name} SYNC")
+    node2.query(f"DROP DATABASE {database_name} SYNC")


### PR DESCRIPTION
Resubmits #78841, reverts #83049. Leaving the changelog category as `Not for changelog` because it was reverted only on master, but not on the release branch of 25.6. I hope this PR will get merged before 25.7 is released, so from the users' perspective nothing is changing with 25.7.
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add warning about databases that were potentially created to save broken tables.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
