### PR TITLE
Fix watch count in Keeper

### DIFF
--- a/tests/integration/test_keeper_watches/test.py
+++ b/tests/integration/test_keeper_watches/test.py
@@ -100,3 +100,22 @@ def test_keeper_watches(started_cluster):
     destroy_zk_client(node_zk)
     node_zk = None
     time.sleep(1)
+
+
+def test_ephemeral_watch_session_close(started_cluster):
+    wait_nodes()
+
+    zk = get_fake_zk(node.name)
+
+    watch_triggered = False
+
+    def watch_callback(event):
+        watch_triggered = True
+    try:
+        zk.create("/ephemeral_test_node", b"data", ephemeral=True)
+        zk.exists("/ephemeral_test_node", watch=watch_callback)
+    finally:
+        destroy_zk_client(zk)
+
+    data = keeper_utils.send_4lw_cmd(started_cluster, node, cmd="mntr")
+    assert "zk_watch_count\t0" in data

--- a/tests/integration/test_keeper_watches/test.py
+++ b/tests/integration/test_keeper_watches/test.py
@@ -107,10 +107,9 @@ def test_ephemeral_watch_session_close(started_cluster):
 
     zk = get_fake_zk(node.name)
 
-    watch_triggered = False
 
     def watch_callback(event):
-        watch_triggered = True
+        pass
     try:
         zk.create("/ephemeral_test_node", b"data", ephemeral=True)
         zk.exists("/ephemeral_test_node", watch=watch_callback)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Keeper fix: update total watch count correctly when ephemeral nodes are deleted on session close.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
