### PR TITLE
Fix explain for key-value engines with optimize=0

### DIFF
--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -594,7 +594,7 @@ private:
     size_t num_streams;
 
     FieldVectorPtr keys;
-    bool all_scan = false;
+    bool all_scan = true;
 };
 
 void StorageEmbeddedRocksDB::read(

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -632,7 +632,7 @@ private:
     bool with_version_column;
 
     FieldVectorPtr keys;
-    bool all_scan = false;
+    bool all_scan = true;
 
     template<typename KeyContainerPtr>
     void initializePipelineImpl(QueryPipelineBuilder & pipeline, KeyContainerPtr key_container);

--- a/src/Storages/StorageRedis.cpp
+++ b/src/Storages/StorageRedis.cpp
@@ -251,7 +251,7 @@ private:
     size_t num_streams;
 
     FieldVectorPtr keys;
-    bool all_scan = false;
+    bool all_scan = true;
 };
 
 void StorageRedis::read(

--- a/tests/integration/test_storage_redis/test.py
+++ b/tests/integration/test_storage_redis/test.py
@@ -461,3 +461,6 @@ def test_get_keys(started_cluster):
     check_query("SELECT * FROM test_get_keys", "FullScan", 0, 3)
     check_query("SELECT * FROM test_get_keys WHERE k = 1", "GetKeys", 1, 1)
     check_query("SELECT * FROM test_get_keys WHERE k in (3, 5)", "GetKeys", 2, 1)
+
+    plan = node.query("EXPLAIN actions=1, optimize=0 SELECT * FROM test_get_keys")
+    assert 'ReadType: FullScan' in plan

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
@@ -1,5 +1,7 @@
     ReadFromEmbeddedRocksDB
     ReadType: FullScan
+      ReadFromEmbeddedRocksDB
+      ReadType: FullScan
 1
 "rows_read":1,
     ReadFromEmbeddedRocksDB

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.reference
@@ -1,7 +1,7 @@
     ReadFromEmbeddedRocksDB
     ReadType: FullScan
-      ReadFromEmbeddedRocksDB
-      ReadType: FullScan
+ReadFromEmbeddedRocksDB
+ReadType:FullScan
 1
 "rows_read":1,
     ReadFromEmbeddedRocksDB

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
@@ -11,6 +11,7 @@ $CLICKHOUSE_CLIENT --query="CREATE TABLE rocksdb_with_filter (key String, value 
 $CLICKHOUSE_CLIENT --query="INSERT INTO rocksdb_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
 $CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM rocksdb_with_filter LIMIT 1" | grep -A 2 "ReadFromEmbeddedRocksDB"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1,optimize=0 SELECT value FROM rocksdb_with_filter" | grep -A 2 "ReadFromEmbeddedRocksDB"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM rocksdb_with_filter WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM rocksdb_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
@@ -11,7 +11,7 @@ $CLICKHOUSE_CLIENT --query="CREATE TABLE rocksdb_with_filter (key String, value 
 $CLICKHOUSE_CLIENT --query="INSERT INTO rocksdb_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10000) n;"
 
 $CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM rocksdb_with_filter LIMIT 1" | grep -A 2 "ReadFromEmbeddedRocksDB"
-$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1,optimize=0 SELECT value FROM rocksdb_with_filter" | grep -A 2 "ReadFromEmbeddedRocksDB"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1,optimize=0 SELECT value FROM rocksdb_with_filter" | grep -A 2 "ReadFromEmbeddedRocksDB" | tr -d "[:blank:]"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM rocksdb_with_filter WHERE key = '5000'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM rocksdb_with_filter WHERE key = '5000' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
@@ -1,7 +1,7 @@
     ReadFromKeeperMap
     ReadType: FullScan
-      ReadFromKeeperMap
-      ReadType: FullScan
+ReadFromKeeperMap
+ReadType:FullScan
 1
 "rows_read":1,
     ReadFromKeeperMap

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.reference
@@ -1,5 +1,7 @@
     ReadFromKeeperMap
     ReadType: FullScan
+      ReadFromKeeperMap
+      ReadType: FullScan
 1
 "rows_read":1,
     ReadFromKeeperMap

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
@@ -11,7 +11,7 @@ $CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, val
 $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10) n;"
 
 $CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter LIMIT 1" | grep -A 2 "ReadFromKeeperMap"
-$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1,optimize=0 SELECT value FROM keeper_map_with_filter" | grep -A 2 "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1,optimize=0 SELECT value FROM keeper_map_with_filter" | grep -A 2 "ReadFromKeeperMap" | tr -d "[:blank:]"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"

--- a/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
+++ b/tests/queries/0_stateless/03541_keeper_map_filter_keys.sh
@@ -11,6 +11,7 @@ $CLICKHOUSE_CLIENT --query="CREATE TABLE keeper_map_with_filter (key String, val
 $CLICKHOUSE_CLIENT --query="INSERT INTO keeper_map_with_filter (*) SELECT n.number, n.number*10 FROM numbers(10) n;"
 
 $CLICKHOUSE_CLIENT --query "EXPLAIN actions=1 SELECT value FROM keeper_map_with_filter LIMIT 1" | grep -A 2 "ReadFromKeeperMap"
+$CLICKHOUSE_CLIENT --query "EXPLAIN actions=1,optimize=0 SELECT value FROM keeper_map_with_filter" | grep -A 2 "ReadFromKeeperMap"
 
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM keeper_map_with_filter WHERE key = '5'"
 $CLICKHOUSE_CLIENT --query "SELECT value FROM keeper_map_with_filter WHERE key = '5' FORMAT JSON" | grep "rows_read" | tr -d "[:blank:]"


### PR DESCRIPTION
Closes #83525
With optimize=0, applyFilters is not called, so all_scan and keys are not initialized by getFilterKeys
It also makes more sense that without a filter `all_scan==true`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
