### PR TITLE
docs: update AvroConfluent page

### DIFF
--- a/docs/en/interfaces/formats/Avro/AvroConfluent.md
+++ b/docs/en/interfaces/formats/Avro/AvroConfluent.md
@@ -73,7 +73,7 @@ format_avro_schema_registry_url = 'https://<username>:<password>@schema-registry
 
 ## Troubleshooting {#troubleshooting}
 
-To monitor ingestion progress and debug errors with the Kafka consumer, you can query the [`system.kafka_consumers` system table](../../../operations/system-tables/kafka_consumers). If your deployment has multiple replicas (e.g., ClickHouse Cloud), you must use the [`clusterAllReplicas`](../../../sql-reference/table-functions/cluster.md) table function.
+To monitor ingestion progress and debug errors with the Kafka consumer, you can query the [`system.kafka_consumers` system table](../../../operations/system-tables/kafka_consumers.md). If your deployment has multiple replicas (e.g., ClickHouse Cloud), you must use the [`clusterAllReplicas`](../../../sql-reference/table-functions/cluster.md) table function.
 
 ```sql
 SELECT * FROM clusterAllReplicas('default',system.kafka_consumers)

--- a/docs/en/interfaces/formats/Avro/AvroConfluent.md
+++ b/docs/en/interfaces/formats/Avro/AvroConfluent.md
@@ -29,8 +29,8 @@ Each Avro message embeds a schema ID that ClickHouse automatically resolves by q
 
 | Setting                                     | Description                                                                                         | Default |
 |---------------------------------------------|-----------------------------------------------------------------------------------------------------|---------|
-| `input_format_avro_allow_missing_fields`    | For `Avro`/`AvroConfluent`: whether to use a default value instead of erroring when a field is not found in the schema. | `0`     |
-| `input_format_avro_null_as_default`         | For `Avro`/`AvroConfluent`: whether to use a default value instead of erroring when inserting a `null` value into a non-nullable column. |   `0`   |
+| `input_format_avro_allow_missing_fields`    | For `Avro`/`AvroConfluent`: whether to use a default value instead of throwing an error when a field is not found in the schema. | `0`     |
+| `input_format_avro_null_as_default`         | For `Avro`/`AvroConfluent`: whether to use a default value instead of throwing an error when inserting a `null` value into a non-nullable column. |   `0`   |
 | `format_avro_schema_registry_url`           | For `Avro`/`AvroConfluent`: the Confluent Schema Registry URL. For basic authentication, URL-encoded credentials can be included directly in the URL path. |         |
 
 ## Example {#example}

--- a/docs/en/interfaces/formats/Avro/AvroConfluent.md
+++ b/docs/en/interfaces/formats/Avro/AvroConfluent.md
@@ -16,26 +16,26 @@ import DataTypesMatching from './_snippets/data-types-matching.md'
 
 ## Description {#description}
 
-AvroConfluent supports decoding single-object Avro messages commonly used with [Kafka](https://kafka.apache.org/) and [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
-Each Avro message embeds a schema ID that can be resolved to the actual schema with the help of the Schema Registry.
-Schemas are cached once resolved.
+`AvroConfluent` supports decoding single-object, Avro-encoded Kafka messages serialized using the [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html) (or API-compatible services).
+Each Avro message embeds a schema ID that ClickHouse automatically resolves by querying the configured schema registry. Once resolved, schemas are cached for optimal performance.
 
-## Data Types Matching {#data_types-matching-1}
+## Data type mapping {#data-type-mapping}
 
 <DataTypesMatching/>
 
-## Example Usage {#example-usage}
+## Format settings {#format-settings}
 
-To quickly verify schema resolution, you can use [kafkacat](https://github.com/edenhill/kafkacat) with [clickhouse-local](/operations/utilities/clickhouse-local.md):
+[//]: # "NOTE These settings can be set at a session-level, but this isn't common and documenting it too prominently can be confusing to users."
 
-```bash
-$ kafkacat -b kafka-broker  -C -t topic1 -o beginning -f '%s' -c 3 | clickhouse-local   --input-format AvroConfluent --format_avro_schema_registry_url 'http://schema-registry' -S "field1 Int64, field2 String"  -q 'select *  from table'
-1 a
-2 b
-3 c
-```
+| Setting                                     | Description                                                                                         | Default |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------|---------|
+| `input_format_avro_allow_missing_fields`    | For `Avro`/`AvroConfluent`: whether to use a default value instead of erroring when a field is not found in the schema. | `0`     |
+| `input_format_avro_null_as_default`         | For `Avro`/`AvroConfluent`: whether to use a default value instead of erroring when inserting a `null` value into a non-nullable column. |   `0`   |
+| `format_avro_schema_registry_url`           | For `Avro`/`AvroConfluent`: the Confluent Schema Registry URL. For basic authentication, URL-encoded credentials can be included directly in the URL path. |         |
 
-To use `AvroConfluent` with [Kafka](/engines/table-engines/integrations/kafka.md):
+## Example {#example}
+
+To read an Avro-encoded Kafka topic using the [Kafka table engine](/engines/table-engines/integrations/kafka.md), use the `format_avro_schema_registry_url` setting to provide the URL of the Confluent Schema Registry.
 
 ```sql
 CREATE TABLE topic1_stream
@@ -48,25 +48,43 @@ SETTINGS
 kafka_broker_list = 'kafka-broker',
 kafka_topic_list = 'topic1',
 kafka_group_name = 'group1',
-kafka_format = 'AvroConfluent';
-
--- for debug purposes you can set format_avro_schema_registry_url in a session.
--- this way cannot be used in production
-SET format_avro_schema_registry_url = 'http://schema-registry';
+kafka_format = 'AvroConfluent',
+format_avro_schema_registry_url = 'http://schema-registry-url';
 
 SELECT * FROM topic1_stream;
 ```
 
-## Format Settings {#format-settings}
+If your schema registry requires basic authentication (e.g., if you're using Confluent Cloud), you can provide URL-encoded credentials in the `format_avro_schema_registry_url` setting.
 
-The Schema Registry URL is configured with [`format_avro_schema_registry_url`](/operations/settings/settings-formats.md/#format_avro_schema_registry_url).
+```sql
+CREATE TABLE topic1_stream
+(
+    field1 String,
+    field2 String
+)
+ENGINE = Kafka()
+SETTINGS
+kafka_broker_list = 'kafka-broker',
+kafka_topic_list = 'topic1',
+kafka_group_name = 'group1',
+kafka_format = 'AvroConfluent',
+format_avro_schema_registry_url = 'https://<username>:<password>@schema-registry-url';
+```
 
-:::note
-Setting `format_avro_schema_registry_url` needs to be configured in `users.xml` to maintain it's value after a restart. Also you can use the `format_avro_schema_registry_url` setting of the `Kafka` table engine.
-:::
+## Troubleshooting {#troubleshooting}
 
-| Setting                                     | Description                                                                                         | Default |
-|---------------------------------------------|-----------------------------------------------------------------------------------------------------|---------|
-| `input_format_avro_allow_missing_fields`    | For Avro/AvroConfluent format: when field is not found in schema use default value instead of error | `0`     |
-| `input_format_avro_null_as_default`         | For Avro/AvroConfluent format: insert default in case of null and non Nullable column                  |   `0`   |
-| `format_avro_schema_registry_url`           | For AvroConfluent format: Confluent Schema Registry URL.                                            |         |
+To monitor ingestion progress and debug errors with the Kafka consumer, you can query the [`system.kafka_consumers` system table](../../../operations/system-tables/kafka_consumers). If your deployment has multiple replicas (e.g., ClickHouse Cloud), you must use the [`clusterAllReplicas`](../../../sql-reference/table-functions/cluster.md) table function.
+
+```sql
+SELECT * FROM clusterAllReplicas('default',system.kafka_consumers)
+ORDER BY assignments.partition_id ASC;
+```
+
+If you run into schema resolution issues, you can use [kafkacat](https://github.com/edenhill/kafkacat) with [clickhouse-local](/operations/utilities/clickhouse-local.md) to troubleshoot:
+
+```bash
+$ kafkacat -b kafka-broker  -C -t topic1 -o beginning -f '%s' -c 3 | clickhouse-local   --input-format AvroConfluent --format_avro_schema_registry_url 'http://schema-registry' -S "field1 Int64, field2 String"  -q 'select *  from table'
+1 a
+2 b
+3 c
+```


### PR DESCRIPTION
It wasn't clear from the documentation how to set up the Kafka Table Engine to read Avro-encoded messages serialized using a schema registry.

### Changelog category (leave one):
- Documentation (changelog entry is not required)