### PR TITLE
Less flaky test_cluster_discovery/test_password.py

### DIFF
--- a/tests/integration/test_cluster_discovery/test_password.py
+++ b/tests/integration/test_cluster_discovery/test_password.py
@@ -34,14 +34,23 @@ def start_cluster():
 
 
 def test_connect_with_password(start_cluster):
-    check_on_cluster(
-        [nodes["node0"], nodes["node1"]],
-        len(nodes),
-        cluster_name="test_auto_cluster_with_pwd",
-        what="count()",
-        msg="Wrong nodes count in cluster",
-        query_params={"password": "passwordAbc"},
-    )
+    # Queries with `clusterAllReplicas` below are run without any retry.
+    # Let's wait until all clusters are available on all nodes in system.clusters.
+    all_clusters = [
+        "test_auto_cluster_with_pwd",
+        "test_auto_cluster_with_wrong_pwd",
+        "test_auto_cluster_with_secret",
+        "test_auto_cluster_with_wrong_secret",
+    ]
+    for cluster_name in all_clusters:
+        check_on_cluster(
+            [nodes["node0"], nodes["node1"]],
+            len(nodes),
+            cluster_name=cluster_name,
+            what="count()",
+            msg="Wrong nodes count in cluster",
+            query_params={"password": "passwordAbc"},
+        )
 
     result = nodes["node0"].query(
         "SELECT sum(number) FROM clusterAllReplicas('test_auto_cluster_with_pwd', numbers(3)) GROUP BY hostname()",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Example of recent failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=83381&sha=9751702f59e5fff3518fda09679bcb86da97184c&name_0=PR&name_1=Integration%20tests%20%28release%2C%201%2F4%29

Failure happened because one of the queries from this test reached the second node before cluster configuration was settled down completely, node was half second late to update information in `system.clusters`, so we failed to setup connection here:

https://github.com/ClickHouse/ClickHouse/blob/b89124b65da81e01b7ebe2fa186d0fa4713896c6/src/Server/TCPHandler.cpp#L2110