### PR TITLE
Increase flush interval

### DIFF
--- a/tests/integration/test_storage_kafka/test_intent_sizes.py
+++ b/tests/integration/test_storage_kafka/test_intent_sizes.py
@@ -89,7 +89,7 @@ def test_good_intent_size(kafka_cluster):
 
     produce_message(1)
 
-    create_kafka_query = k.generate_new_create_table_query("kafka", "a String", topic_list=topic_name, format="LineAsString", settings={"kafka_flush_interval_ms": 500})
+    create_kafka_query = k.generate_new_create_table_query("kafka", "a String", topic_list=topic_name, format="LineAsString", settings={"kafka_flush_interval_ms": 3000})
 
     with k.existing_kafka_topic(k.get_admin_client(kafka_cluster), topic_name):
         instance.query(


### PR DESCRIPTION
It happened once that before the last check we polled only a single message instead of two. I am not sure why it happened, in the clickhouse logs it seems like librdkafka only returned a single message. I increased the flush interval to give CH more time to poll all the messages.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
