### PR TITLE
Fix incorrect memory around max_untracked_memory

### DIFF
--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -68,17 +68,23 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
         }
         current_thread->untracked_memory_blocker_level = blocker_level;
 
-        Int64 will_be = current_thread->untracked_memory + size;
-        if (will_be > current_thread->untracked_memory_limit)
+        Int64 previous_untracked_memory = current_thread->untracked_memory;
+        current_thread->untracked_memory += size;
+        if (current_thread->untracked_memory > current_thread->untracked_memory_limit)
         {
-            auto res = memory_tracker->allocImpl(will_be, throw_if_memory_exceeded);
+            Int64 current_untracked_memory = current_thread->untracked_memory;
             current_thread->untracked_memory = 0;
-            return res;
-        }
 
-        /// Update after successful allocations,
-        /// since failed allocations should not be take into account.
-        current_thread->untracked_memory = will_be;
+            try
+            {
+                return memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
+            }
+            catch (...)
+            {
+                current_thread->untracked_memory += previous_untracked_memory;
+                throw;
+            }
+        }
 
         return AllocationTrace(memory_tracker->getSampleProbability(size));
     }

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -242,8 +242,9 @@ void ThreadStatus::flushUntrackedMemory()
         return;
 
     MemoryTrackerBlockerInThread blocker(untracked_memory_blocker_level);
-    memory_tracker.adjustWithUntrackedMemory(untracked_memory);
+    Int64 current_untracked_memory = current_thread->untracked_memory;
     untracked_memory = 0;
+    memory_tracker.adjustWithUntrackedMemory(current_untracked_memory);
 }
 
 bool ThreadStatus::isQueryCanceled() const


### PR DESCRIPTION
### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect memory around max_untracked_memory

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

Due to one tiny allocation inside `MemoryTracker` for logs, recursive allocation from `CurrentMemoryTracker` -> `MemoryTracker` -> `CurrentMemoryTracker` is possible, which will lead to double accounting of `untracked_memory` (this is happens after #81694, before the problem was also there, but it just ignores the inner allocation).

Thanks to @filimonov for the provided test - horizontal merges for wide tables with wide parts (`system.metric_log`) for a few minute (3-5) will lead to ~3GiB of memory drift.

And the rule of thumb is - any accounting of per-thread `untracked_memory` should be done **before** going into `MemoryTracker`.

_Note, that this is the simplest possible fix for now (that will be easy to backport), I will do some refactoring and cleanup later._

Fixes: #82036
Fixes: #83352
Fixes: #82627

Refs:
- [Possible stacktrace](https://pastila.nl/?0023a66c/8bfc8e9135a6edb5312d3387408b2264#P1XgWmDuHq4xgrQ2C4azyQ==) (_obtained with extra patch that adds some sanity checks that leads to endless recursion_)