### PR TITLE
Reuse serializer for ProtobufSingle when no parsing errors occur

### DIFF
--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -41,6 +41,12 @@ void ProtobufRowInputFormat::createReaderAndSerializer()
         *reader);
 }
 
+void ProtobufRowInputFormat::destroyReaderAndSerializer()
+{
+    serializer.reset();
+    reader.reset();
+}
+
 bool ProtobufRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & row_read_extension)
 try
 {
@@ -64,7 +70,7 @@ try
 }
 catch (...)
 {
-    resetParserOnError();
+    destroyReaderAndSerializer();
     throw;
 }
 
@@ -85,12 +91,6 @@ void ProtobufRowInputFormat::syncAfterError()
     reader->endMessage(true);
 }
 
-void ProtobufRowInputFormat::resetParserOnError()
-{
-    serializer.reset();
-    reader.reset();
-}
-
 size_t ProtobufRowInputFormat::countRows(size_t max_block_size)
 try
 {
@@ -109,7 +109,7 @@ try
 }
 catch (...)
 {
-    resetParserOnError();
+    destroyReaderAndSerializer();
     throw;
 }
 

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -42,6 +42,7 @@ void ProtobufRowInputFormat::createReaderAndSerializer()
 }
 
 bool ProtobufRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & row_read_extension)
+try
 {
     if (!reader)
         createReaderAndSerializer();
@@ -61,6 +62,11 @@ bool ProtobufRowInputFormat::readRow(MutableColumns & columns, RowReadExtension 
         row_read_extension.read_columns[column_idx] = false;
     return true;
 }
+catch (...)
+{
+    resetParserOnError();
+    throw;
+}
 
 void ProtobufRowInputFormat::setReadBuffer(ReadBuffer & in_)
 {
@@ -79,14 +85,14 @@ void ProtobufRowInputFormat::syncAfterError()
     reader->endMessage(true);
 }
 
-void ProtobufRowInputFormat::resetParser()
+void ProtobufRowInputFormat::resetParserOnError()
 {
-    IRowInputFormat::resetParser();
     serializer.reset();
     reader.reset();
 }
 
 size_t ProtobufRowInputFormat::countRows(size_t max_block_size)
+try
 {
     if (!reader)
         createReaderAndSerializer();
@@ -100,6 +106,11 @@ size_t ProtobufRowInputFormat::countRows(size_t max_block_size)
     }
 
     return num_rows;
+}
+catch (...)
+{
+    resetParserOnError();
+    throw;
 }
 
 void registerInputFormatProtobuf(FormatFactory & factory)

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.h
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.h
@@ -41,12 +41,12 @@ public:
     String getName() const override { return "ProtobufRowInputFormat"; }
 
     void setReadBuffer(ReadBuffer & in_) override;
-    void resetParser() override;
 
 private:
     bool readRow(MutableColumns & columns, RowReadExtension & row_read_extension) override;
     bool allowSyncAfterError() const override;
     void syncAfterError() override;
+    void resetParserOnError();
 
     bool supportsCountRows() const override { return true; }
     size_t countRows(size_t max_block_size) override;

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.h
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.h
@@ -46,12 +46,12 @@ private:
     bool readRow(MutableColumns & columns, RowReadExtension & row_read_extension) override;
     bool allowSyncAfterError() const override;
     void syncAfterError() override;
-    void resetParserOnError();
 
     bool supportsCountRows() const override { return true; }
     size_t countRows(size_t max_block_size) override;
 
     void createReaderAndSerializer();
+    void destroyReaderAndSerializer();
 
     std::unique_ptr<ProtobufReader> reader;
     std::vector<size_t> missing_column_indices;


### PR DESCRIPTION
Related to #57132

This is a partial resubmit of #59482 which is less intrusive (does't change processing model for all row-based formats), and affects only a ProtobufSingle format (the patch increases messages throughput roughly twice).

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of the ProtobufSingle input format by reusing the serializer when no parsing errors occur.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

cc @azat
cc @Avogar 
