### PR TITLE
fix a race in IOutputFormat between onProgress and finalize

### DIFF
--- a/src/Processors/Formats/IOutputFormat.cpp
+++ b/src/Processors/Formats/IOutputFormat.cpp
@@ -4,6 +4,7 @@
 #include <IO/WriteBufferDecorator.h>
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Port.h>
+#include <Common/ThreadFuzzer.h>
 
 
 namespace DB
@@ -194,6 +195,8 @@ void IOutputFormat::setExtremes(const Block & extremes)
 
 void IOutputFormat::onProgress(const Progress & progress)
 {
+    ThreadFuzzer::maybeInjectSleep();
+
     statistics.progress.incrementPiecewiseAtomically(progress);
     UInt64 elapsed_ns = statistics.watch.elapsedNanoseconds();
     statistics.progress.elapsed_ns = elapsed_ns;


### PR DESCRIPTION
```DB::Exception: Cannot write to finalized buffer. (LOGICAL_ERROR)```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
fix a race in IOutputFormat between onProgress and finalize, which leads to LOGICAL_ERROR

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
