### PR TITLE
Better logging when external sort creates temporary files

### DIFF
--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -234,7 +234,11 @@ void MergeSortingTransform::consume(Chunk chunk)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "TemporaryDataOnDisk is not set for MergeSortingTransform");
             temporary_files_num++;
 
-            LOG_TRACE(log, "Will dump sorting block to disk ({} > {})", formatReadableSizeWithBinarySuffix(query_memory), formatReadableSizeWithBinarySuffix(max_bytes_in_query_before_external_sort));
+            LOG_TRACE(log, "Will dump sorting block ({}, limit: {}) to disk (query memory: {}, limit: {})",
+                formatReadableSizeWithBinarySuffix(sum_bytes_in_blocks),
+                formatReadableSizeWithBinarySuffix(max_bytes_in_block_before_external_sort),
+                formatReadableSizeWithBinarySuffix(query_memory),
+                formatReadableSizeWithBinarySuffix(max_bytes_in_query_before_external_sort));
 
             /// If there's less free disk space than reserve_size, an exception will be thrown
             size_t reserve_size = sum_bytes_in_blocks + min_free_disk_space;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)