### PR TITLE
Docs: fix ordering of regular functions in sidebar

### DIFF
--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -19,7 +19,7 @@ ClickHouse supports special functions for working with dictionaries that can be 
 ClickHouse supports:
 
 - Dictionaries with a [set of functions](../../sql-reference/functions/ext-dict-functions.md).
-- [Embedded dictionaries](#embedded-dictionaries) with a specific [set of functions](../../sql-reference/functions/ym-dict-functions.md).
+- [Embedded dictionaries](#embedded-dictionaries) with a specific [set of functions](../../sql-reference/functions/embedded-dict-functions.md).
 
 
 :::tip Tutorial

--- a/docs/en/sql-reference/functions/arithmetic-functions.md
+++ b/docs/en/sql-reference/functions/arithmetic-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Arithmetic Functions'
 sidebar_label: 'Arithmetic'
-sidebar_position: 5
 slug: /sql-reference/functions/arithmetic-functions
 title: 'Arithmetic Functions'
 ---

--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Array Functions'
 sidebar_label: 'Arrays'
-sidebar_position: 10
 slug: /sql-reference/functions/array-functions
 title: 'Array Functions'
 ---

--- a/docs/en/sql-reference/functions/array-join.md
+++ b/docs/en/sql-reference/functions/array-join.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for arrayJoin function'
 sidebar_label: 'arrayJoin'
-sidebar_position: 15
 slug: /sql-reference/functions/array-join
 title: 'arrayJoin function'
 ---

--- a/docs/en/sql-reference/functions/bit-functions.md
+++ b/docs/en/sql-reference/functions/bit-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Bit Functions'
 sidebar_label: 'Bit'
-sidebar_position: 20
 slug: /sql-reference/functions/bit-functions
 title: 'Bit Functions'
 ---

--- a/docs/en/sql-reference/functions/bitmap-functions.md
+++ b/docs/en/sql-reference/functions/bitmap-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Bitmap Functions'
 sidebar_label: 'Bitmap'
-sidebar_position: 25
 slug: /sql-reference/functions/bitmap-functions
 title: 'Bitmap Functions'
 ---

--- a/docs/en/sql-reference/functions/comparison-functions.md
+++ b/docs/en/sql-reference/functions/comparison-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Comparison Functions'
 sidebar_label: 'Comparison'
-sidebar_position: 35
 slug: /sql-reference/functions/comparison-functions
 title: 'Comparison Functions'
 ---

--- a/docs/en/sql-reference/functions/conditional-functions.md
+++ b/docs/en/sql-reference/functions/conditional-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Conditional Functions'
 sidebar_label: 'Conditional'
-sidebar_position: 40
 slug: /sql-reference/functions/conditional-functions
 title: 'Conditional Functions'
 ---

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Dates and Times'
-sidebar_label: 'Dates and Times'
+sidebar_label: 'Dates and time'
 slug: /sql-reference/functions/date-time-functions
 title: 'Functions for Working with Dates and Times'
 ---

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Dates and Times'
 sidebar_label: 'Dates and Times'
-sidebar_position: 45
 slug: /sql-reference/functions/date-time-functions
 title: 'Functions for Working with Dates and Times'
 ---

--- a/docs/en/sql-reference/functions/distance-functions.md
+++ b/docs/en/sql-reference/functions/distance-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Distance Functions'
 sidebar_label: 'Distance'
-sidebar_position: 55
 slug: /sql-reference/functions/distance-functions
 title: 'Distance Functions'
 ---

--- a/docs/en/sql-reference/functions/embedded-dict-functions.md
+++ b/docs/en/sql-reference/functions/embedded-dict-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Embedded Dictionaries'
-sidebar_label: 'Embedded Dictionaries'
+sidebar_label: 'Embedded dictionary'
 slug: /sql-reference/functions/ym-dict-functions
 title: 'Functions for Working with Embedded Dictionaries'
 ---

--- a/docs/en/sql-reference/functions/encoding-functions.md
+++ b/docs/en/sql-reference/functions/encoding-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Encoding Functions'
 sidebar_label: 'Encoding'
-sidebar_position: 65
 slug: /sql-reference/functions/encoding-functions
 title: 'Encoding Functions'
 ---

--- a/docs/en/sql-reference/functions/encryption-functions.md
+++ b/docs/en/sql-reference/functions/encryption-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Encryption Functions'
 sidebar_label: 'Encryption'
-sidebar_position: 70
 slug: /sql-reference/functions/encryption-functions
 title: 'Encryption Functions'
 ---

--- a/docs/en/sql-reference/functions/ext-dict-functions.md
+++ b/docs/en/sql-reference/functions/ext-dict-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Dictionaries'
 sidebar_label: 'Dictionaries'
-sidebar_position: 50
 slug: /sql-reference/functions/ext-dict-functions
 title: 'Functions for Working with Dictionaries'
 ---

--- a/docs/en/sql-reference/functions/files.md
+++ b/docs/en/sql-reference/functions/files.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Files'
 sidebar_label: 'Files'
-sidebar_position: 75
 slug: /sql-reference/functions/files
 title: 'Files'
 ---

--- a/docs/en/sql-reference/functions/financial-functions.md
+++ b/docs/en/sql-reference/functions/financial-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Financial Functions'
 sidebar_label: 'Financial'
-sidebar_position: 125
 slug: /sql-reference/functions/financial-functions
 title: 'Financial Functions'
 ---

--- a/docs/en/sql-reference/functions/functions-for-nulls.md
+++ b/docs/en/sql-reference/functions/functions-for-nulls.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Nullable Values'
 sidebar_label: 'Nullable'
-sidebar_position: 135
 slug: /sql-reference/functions/functions-for-nulls
 title: 'Functions for Working with Nullable Values'
 ---

--- a/docs/en/sql-reference/functions/geo/coordinates.md
+++ b/docs/en/sql-reference/functions/geo/coordinates.md
@@ -1,7 +1,7 @@
 ---
 description: 'Documentation for Coordinates'
 sidebar_label: 'Geographical Coordinates'
-sidebar_position: 62
+
 slug: /sql-reference/functions/geo/coordinates
 title: 'Functions for Working with Geographical Coordinates'
 ---

--- a/docs/en/sql-reference/functions/geo/coordinates.md
+++ b/docs/en/sql-reference/functions/geo/coordinates.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Coordinates'
 sidebar_label: 'Geographical Coordinates'
-
 slug: /sql-reference/functions/geo/coordinates
 title: 'Functions for Working with Geographical Coordinates'
 ---

--- a/docs/en/sql-reference/functions/geo/index.md
+++ b/docs/en/sql-reference/functions/geo/index.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Index'
 sidebar_label: 'Geo'
-
 slug: /sql-reference/functions/geo/
 title: 'Geo Functions'
 ---

--- a/docs/en/sql-reference/functions/geo/index.md
+++ b/docs/en/sql-reference/functions/geo/index.md
@@ -1,7 +1,7 @@
 ---
 description: 'Documentation for Index'
 sidebar_label: 'Geo'
-sidebar_position: 62
+
 slug: /sql-reference/functions/geo/
 title: 'Geo Functions'
 ---

--- a/docs/en/sql-reference/functions/hash-functions.md
+++ b/docs/en/sql-reference/functions/hash-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Hash Functions'
 sidebar_label: 'Hash'
-sidebar_position: 85
 slug: /sql-reference/functions/hash-functions
 title: 'Hash Functions'
 ---

--- a/docs/en/sql-reference/functions/in-functions.md
+++ b/docs/en/sql-reference/functions/in-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Implementing the IN Operator'
 sidebar_label: 'IN Operator'
-sidebar_position: 90
 slug: /sql-reference/functions/in-functions
 title: 'Functions for Implementing the IN Operator'
 ---

--- a/docs/en/sql-reference/functions/introspection.md
+++ b/docs/en/sql-reference/functions/introspection.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Introspection Functions'
 sidebar_label: 'Introspection'
-sidebar_position: 100
 slug: /sql-reference/functions/introspection
 title: 'Introspection Functions'
 ---

--- a/docs/en/sql-reference/functions/ip-address-functions.md
+++ b/docs/en/sql-reference/functions/ip-address-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with IPv4 and IPv6 Addresses'
 sidebar_label: 'IP Addresses'
-sidebar_position: 95
 slug: /sql-reference/functions/ip-address-functions
 title: 'Functions for Working with IPv4 and IPv6 Addresses'
 ---

--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Json Functions'
 sidebar_label: 'JSON'
-sidebar_position: 105
 slug: /sql-reference/functions/json-functions
 title: 'JSON Functions'
 ---

--- a/docs/en/sql-reference/functions/logical-functions.md
+++ b/docs/en/sql-reference/functions/logical-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Logical Functions'
 sidebar_label: 'Logical'
-sidebar_position: 110
 slug: /sql-reference/functions/logical-functions
 title: 'Logical Functions'
 ---

--- a/docs/en/sql-reference/functions/machine-learning-functions.md
+++ b/docs/en/sql-reference/functions/machine-learning-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Machine Learning Functions'
 sidebar_label: 'Machine Learning'
-sidebar_position: 115
 slug: /sql-reference/functions/machine-learning-functions
 title: 'Machine Learning Functions'
 ---

--- a/docs/en/sql-reference/functions/math-functions.md
+++ b/docs/en/sql-reference/functions/math-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Mathematical Functions'
 sidebar_label: 'Mathematical'
-sidebar_position: 125
 slug: /sql-reference/functions/math-functions
 title: 'Mathematical Functions'
 ---

--- a/docs/en/sql-reference/functions/nlp-functions.md
+++ b/docs/en/sql-reference/functions/nlp-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Natural Language Processing (NLP) Functions'
 sidebar_label: 'NLP'
-sidebar_position: 130
 slug: /sql-reference/functions/nlp-functions
 title: 'Natural Language Processing (NLP) Functions'
 ---

--- a/docs/en/sql-reference/functions/numeric-indexed-vector-functions.md
+++ b/docs/en/sql-reference/functions/numeric-indexed-vector-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for NumericIndexedVector and Its Functions'
 sidebar_label: 'NumericIndexedVector'
-sidebar_position: 26
 slug: /sql-reference/functions/numeric-indexed-vector-functions
 title: 'NumericIndexedVector Functions'
 ---

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Other Functions'
 sidebar_label: 'Other'
-sidebar_position: 140
 slug: /sql-reference/functions/other-functions
 title: 'Other Functions'
 ---

--- a/docs/en/sql-reference/functions/random-functions.md
+++ b/docs/en/sql-reference/functions/random-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Generating Random Numbers'
 sidebar_label: 'Random Numbers'
-sidebar_position: 145
 slug: /sql-reference/functions/random-functions
 title: 'Functions for Generating Random Numbers'
 ---

--- a/docs/en/sql-reference/functions/random-functions.md
+++ b/docs/en/sql-reference/functions/random-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Generating Random Numbers'
-sidebar_label: 'Random Numbers'
+sidebar_label: 'Random number'
 slug: /sql-reference/functions/random-functions
 title: 'Functions for Generating Random Numbers'
 ---

--- a/docs/en/sql-reference/functions/regular-functions-index.md
+++ b/docs/en/sql-reference/functions/regular-functions-index.md
@@ -1,7 +1,7 @@
 ---
 description: 'Landing page for Regular Functions'
 slug: /sql-reference/functions/regular-functions
-title: 'Regular Functions'
+title: 'Regular functions'
 ---
 
 | Page                                             | Description                                                                                                                     |

--- a/docs/en/sql-reference/functions/rounding-functions.md
+++ b/docs/en/sql-reference/functions/rounding-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Rounding Functions'
 sidebar_label: 'Rounding'
-sidebar_position: 155
 slug: /sql-reference/functions/rounding-functions
 title: 'Rounding Functions'
 ---

--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Splitting Strings'
-sidebar_label: 'Splitting Strings'
+sidebar_label: 'String splitting'
 slug: /sql-reference/functions/splitting-merging-functions
 title: 'Functions for Splitting Strings'
 ---

--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Splitting Strings'
 sidebar_label: 'Splitting Strings'
-sidebar_position: 165
 slug: /sql-reference/functions/splitting-merging-functions
 title: 'Functions for Splitting Strings'
 ---

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Strings'
 sidebar_label: 'Strings'
-sidebar_position: 170
 slug: /sql-reference/functions/string-functions
 title: 'Functions for Working with Strings'
 ---

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Strings'
-sidebar_label: 'Strings'
+sidebar_label: 'String'
 slug: /sql-reference/functions/string-functions
 title: 'Functions for Working with Strings'
 ---

--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Replacing in Strings'
 sidebar_label: 'Replacing in Strings'
-sidebar_position: 150
 slug: /sql-reference/functions/string-replace-functions
 title: 'Functions for Replacing in Strings'
 ---

--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Replacing in Strings'
-sidebar_label: 'Replacing in Strings'
+sidebar_label: 'String replacement'
 slug: /sql-reference/functions/string-replace-functions
 title: 'Functions for Replacing in Strings'
 ---

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Functions for Searching in Strings'
-sidebar_label: 'Searching in Strings'
+sidebar_label: 'String search'
 slug: /sql-reference/functions/string-search-functions
 title: 'Functions for Searching in Strings'
 ---

--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Searching in Strings'
 sidebar_label: 'Searching in Strings'
-sidebar_position: 160
 slug: /sql-reference/functions/string-search-functions
 title: 'Functions for Searching in Strings'
 ---

--- a/docs/en/sql-reference/functions/time-series-functions.md
+++ b/docs/en/sql-reference/functions/time-series-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Time Series Functions'
-sidebar_label: 'Time Series'
+sidebar_label: 'Time-series'
 slug: /sql-reference/functions/time-series-functions
 title: 'Time Series Functions'
 ---

--- a/docs/en/sql-reference/functions/time-series-functions.md
+++ b/docs/en/sql-reference/functions/time-series-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Time Series Functions'
 sidebar_label: 'Time Series'
-sidebar_position: 172
 slug: /sql-reference/functions/time-series-functions
 title: 'Time Series Functions'
 ---

--- a/docs/en/sql-reference/functions/time-window-functions.md
+++ b/docs/en/sql-reference/functions/time-window-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Time Window Functions'
 sidebar_label: 'Time Window'
-sidebar_position: 175
 slug: /sql-reference/functions/time-window-functions
 title: 'Time Window Functions'
 ---

--- a/docs/en/sql-reference/functions/time-window-functions.md
+++ b/docs/en/sql-reference/functions/time-window-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Time Window Functions'
-sidebar_label: 'Time Window'
+sidebar_label: 'Time-window'
 slug: /sql-reference/functions/time-window-functions
 title: 'Time Window Functions'
 ---

--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Tuple Functions'
 sidebar_label: 'Tuples'
-sidebar_position: 180
 slug: /sql-reference/functions/tuple-functions
 title: 'Tuple Functions'
 ---

--- a/docs/en/sql-reference/functions/tuple-map-functions.md
+++ b/docs/en/sql-reference/functions/tuple-map-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Tuple Map Functions'
 sidebar_label: 'Maps'
-sidebar_position: 120
 slug: /sql-reference/functions/tuple-map-functions
 title: 'Map Functions'
 ---

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Type Conversion Functions'
 sidebar_label: 'Type Conversion'
-sidebar_position: 185
 slug: /sql-reference/functions/type-conversion-functions
 title: 'Type Conversion Functions'
 ---

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Documentation for Type Conversion Functions'
-sidebar_label: 'Type Conversion'
+sidebar_label: 'Type conversion'
 slug: /sql-reference/functions/type-conversion-functions
 title: 'Type Conversion Functions'
 ---

--- a/docs/en/sql-reference/functions/udf.md
+++ b/docs/en/sql-reference/functions/udf.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for UDFs User Defined Functions'
 sidebar_label: 'UDF'
-sidebar_position: 15
 slug: /sql-reference/functions/udf
 title: 'UDFs User Defined Functions'
 ---

--- a/docs/en/sql-reference/functions/ulid-functions.md
+++ b/docs/en/sql-reference/functions/ulid-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with ULID'
 sidebar_label: 'ULID'
-sidebar_position: 190
 slug: /sql-reference/functions/ulid-functions
 title: 'Functions for Working with ULID'
 ---

--- a/docs/en/sql-reference/functions/uniqtheta-functions.md
+++ b/docs/en/sql-reference/functions/uniqtheta-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for uniqTheta Functions'
 sidebar_label: 'uniqTheta'
-sidebar_position: 210
 slug: /sql-reference/functions/uniqtheta-functions
 title: 'uniqTheta Functions'
 ---

--- a/docs/en/sql-reference/functions/url-functions.md
+++ b/docs/en/sql-reference/functions/url-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with URLs'
 sidebar_label: 'URLs'
-sidebar_position: 200
 slug: /sql-reference/functions/url-functions
 title: 'Functions for Working with URLs'
 ---

--- a/docs/en/sql-reference/functions/uuid-functions.md
+++ b/docs/en/sql-reference/functions/uuid-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with UUIDs'
 sidebar_label: 'UUIDs'
-sidebar_position: 205
 slug: /sql-reference/functions/uuid-functions
 title: 'Functions for Working with UUIDs'
 ---

--- a/docs/en/sql-reference/functions/ym-dict-functions.md
+++ b/docs/en/sql-reference/functions/ym-dict-functions.md
@@ -1,7 +1,6 @@
 ---
 description: 'Documentation for Functions for Working with Embedded Dictionaries'
 sidebar_label: 'Embedded Dictionaries'
-sidebar_position: 60
 slug: /sql-reference/functions/ym-dict-functions
 title: 'Functions for Working with Embedded Dictionaries'
 ---

--- a/src/Functions/FunctionsBitmap.cpp
+++ b/src/Functions/FunctionsBitmap.cpp
@@ -38,7 +38,7 @@ REGISTER_FUNCTION(Bitmap)
     factory.registerFunction<FunctionBitmapBuild>(documentation_bitmapBuild);
 
     /// Documentation for bitmapToArray
-    FunctionDocumentation::Description description_bitmapToArray = "Converts a bitmap to an array of unsigned integers. It is the opposite of function [`bitmapBuild`](/sql-reference/functions/bitmap-functions#bitmapbuild).";
+    FunctionDocumentation::Description description_bitmapToArray = "Converts a bitmap to an array of unsigned integers. It is the opposite of function [`bitmapBuild`](/sql-reference/functions/bitmap-functions#bitmapBuild).";
     FunctionDocumentation::Syntax syntax_bitmapToArray = "bitmapToArray(bitmap)";
     FunctionDocumentation::Arguments arguments_bitmapToArray = {
         {"bitmap", "Bitmap to convert. [`AggregateFunction(groupBitmap, T)`](/sql-reference/data-types/aggregatefunction)."},

--- a/src/Functions/array/arrayShuffle.cpp
+++ b/src/Functions/array/arrayShuffle.cpp
@@ -204,7 +204,7 @@ Value of limit shall be in range `[1..n]`. Values outside of that range are equi
 :::note
 This function will not materialize constants.
 
-The value of `limit` should be in the range `[1..N]`. Values outside of that range are equivalent to performing full [`arrayShuffle`](#arrayshuffle).
+The value of `limit` should be in the range `[1..N]`. Values outside of that range are equivalent to performing full [`arrayShuffle`](#arrayShuffle).
 :::
     )";
     syntax = "arrayPartialShuffle(arr [, limit[, seed]])";


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
The ordering is mostly alphabetical but there are a few items in the wrong places:

<img width="272" height="468" alt="Screenshot 2025-07-12 at 22 11 44" src="https://github.com/user-attachments/assets/43efc402-e851-4736-85be-6fd30dbd9510" />

 Fixes this
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
