### PR TITLE
Fix test `01278_min_insert_block_size_rows_for_materialized_views`

### DIFF
--- a/tests/queries/0_stateless/01278_min_insert_block_size_rows_for_materialized_views.sh
+++ b/tests/queries/0_stateless/01278_min_insert_block_size_rows_for_materialized_views.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#Tags: no-flaky-check
+# Tags: no-random-settings
 
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=dce62d318322ab448a93c13f0571ad1ce16ac01f&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%202%2F2%29
Probably some of the randomized settings, like `max_threads`, affected it.