### PR TITLE
Fix write with append with `plain_rewritable`/`plain` metadata types

### DIFF
--- a/programs/disks/CommandWrite.cpp
+++ b/programs/disks/CommandWrite.cpp
@@ -7,9 +7,15 @@
 #include <IO/copyData.h>
 #include <Common/TerminalSize.h>
 #include <Common/logger_useful.h>
+#include <Disks/WriteMode.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+}
 
 class CommandWrite final : public ICommand
 {
@@ -18,8 +24,12 @@ public:
     {
         command_name = "write";
         description = "Write a file from `path-from` to `path-to`";
-        options_description.add_options()("path-from", po::value<String>(), "file from which we are reading, defaults to `stdin` (input from `stdin` is finished by Ctrl+D)")(
-            "path-to", po::value<String>(), "file to which we are writing (mandatory, positional)");
+        options_description.add_options()(
+            "path-from",
+            po::value<String>(),
+            "file from which we are reading, defaults to `stdin` (input from `stdin` is finished by Ctrl+D)")(
+            "path-to", po::value<String>(), "file to which we are writing (mandatory, positional)")(
+            "mode", po::value<String>(), "write mode: `rewrite` (default) or `append`");
         positional_options_description.add("path-to", 1);
     }
 
@@ -31,6 +41,18 @@ public:
         std::optional<String> path_from = getValueFromCommandLineOptionsWithOptional<String>(options, "path-from");
 
         String path_to = disk.getRelativeFromRoot(getValueFromCommandLineOptionsThrow<String>(options, "path-to"));
+        std::optional<String> write_mode_param = getValueFromCommandLineOptionsWithOptional<String>(options, "mode");
+        WriteMode write_mode = WriteMode::Rewrite;
+        if (write_mode_param.has_value())
+        {
+            if (*write_mode_param == "rewrite")
+                write_mode = WriteMode::Rewrite;
+            else if (*write_mode_param == "append")
+                write_mode = WriteMode::Append;
+            else
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS, "invalid `mode`, expected `rewrite` or `append`, actual '{}'", *write_mode_param);
+        }
 
         auto in = [&]() -> std::unique_ptr<ReadBufferFromFileBase>
         {
@@ -45,8 +67,14 @@ public:
             return std::make_unique<ReadBufferFromEmptyFile>();
         }();
 
-        LOG_INFO(log, "Writing file from '{}' to '{}' at disk '{}'", path_from.value_or("stdin"), path_to, disk.getDisk()->getName());
-        auto out = disk.getDisk()->writeFile(path_to);
+        LOG_INFO(
+            log,
+            "Writing file from '{}' to '{}' with mode '{}' at disk '{}'",
+            path_from.value_or("stdin"),
+            path_to,
+            write_mode,
+            disk.getDisk()->getName());
+        auto out = disk.getDisk()->writeFile(path_to, DBMS_DEFAULT_BUFFER_SIZE, write_mode);
         copyData(*in, *out);
         out->finalize();
     }

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -26,6 +26,7 @@ namespace ErrorCodes
     extern const int CANNOT_OPEN_FILE;
     extern const int FILE_DOESNT_EXIST;
     extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
+    extern const int NOT_IMPLEMENTED;
 }
 
 DiskObjectStorageTransaction::DiskObjectStorageTransaction(
@@ -529,18 +530,26 @@ struct CopyFileObjectStorageOperation final : public IDiskObjectStorageOperation
         tx->createEmptyMetadataFile(to_path);
         auto source_blobs = metadata_storage.getStorageObjects(from_path); /// Full paths
 
-        for (const auto & object_from : source_blobs)
+        if (source_blobs.empty())
+            return;
+
+        if (!tx->supportAddingBlobToMetadata())
         {
-            auto object_key = destination_object_storage.generateObjectKeyForPath(to_path, std::nullopt /* key_prefix */);
-            auto object_to = StoredObject(object_key.serialize());
+            if (source_blobs.size() > 1)
+                throw Exception(
+                    ErrorCodes::NOT_IMPLEMENTED,
+                    "Unable to copy file '{}' with multiple blobs ({}), disk doesn't support addBlobToMetadata",
+                    from_path,
+                    source_blobs.size());
 
-            object_storage.copyObjectToAnotherObjectStorage(object_from, object_to,read_settings,write_settings, destination_object_storage);
-
-            tx->addBlobToMetadata(to_path, object_key, object_from.bytes_size);
-
-            created_objects.push_back(object_to);
+            copySingleObject</*support_adding_blob_to_metadata=*/false>(tx, source_blobs.front());
+            return;
         }
+
+        for (const auto & object_from : source_blobs)
+            copySingleObject</*support_adding_blob_to_metadata=*/true>(tx, object_from);
     }
+
 
     void undo() override
     {
@@ -549,6 +558,21 @@ struct CopyFileObjectStorageOperation final : public IDiskObjectStorageOperation
 
     void finalize() override
     {
+    }
+
+    template <bool support_adding_blob_to_metadata>
+    void copySingleObject(MetadataTransactionPtr tx, const StoredObject & object_from)
+    {
+        auto object_key = destination_object_storage.generateObjectKeyForPath(to_path, /*key_prefix=*/std::nullopt);
+        auto object_to = StoredObject(object_key.serialize());
+
+        object_storage.copyObjectToAnotherObjectStorage(object_from, object_to, read_settings, write_settings, destination_object_storage);
+        created_objects.push_back(object_to);
+
+        if constexpr (support_adding_blob_to_metadata)
+            tx->addBlobToMetadata(to_path, object_key, object_from.bytes_size);
+        else
+            tx->createMetadataFile(to_path, object_key, object_from.bytes_size);
     }
 };
 
@@ -749,6 +773,9 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
     const WriteSettings & settings,
     bool autocommit)
 {
+    if (mode == WriteMode::Append && !metadata_transaction->supportAddingBlobToMetadata())
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Disk does not support WriteMode::Append");
+
     auto object_key = object_storage.generateObjectKeyForPath(path, std::nullopt /* key_prefix */);
     std::optional<ObjectAttributes> object_attributes;
 

--- a/src/Disks/ObjectStorages/IMetadataStorage.h
+++ b/src/Disks/ObjectStorages/IMetadataStorage.h
@@ -141,7 +141,9 @@ public:
     /// Create metadata file on paths with content (blob_name, size_in_bytes)
     virtual void createMetadataFile(const std::string & path, ObjectStorageKey key, uint64_t size_in_bytes) = 0;
 
-    /// Add to new blob to metadata file (way to implement appends)
+    virtual bool supportAddingBlobToMetadata() { return false; }
+    /// Add to new blob to metadata file (way to implement appends).
+    /// If `addBlobToMetadata` is supported, `supportAddingBlobToMetadata` must return `true`
     virtual void addBlobToMetadata(const std::string & /* path */, ObjectStorageKey /* key */, uint64_t /* size_in_bytes */)
     {
         throwNotImplemented();

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -104,6 +104,8 @@ public:
 
     void createMetadataFile(const std::string & path, ObjectStorageKey object_key, uint64_t size_in_bytes) override;
 
+    bool supportAddingBlobToMetadata() override { return true; }
+
     void addBlobToMetadata(const std::string & path, ObjectStorageKey object_key, uint64_t size_in_bytes) override;
 
     void setLastModified(const std::string & path, const Poco::Timestamp & timestamp) override;

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
@@ -117,11 +117,6 @@ public:
 
     const IMetadataStorage & getStorageForNonTransactionalReads() const override;
 
-    void addBlobToMetadata(const std::string & /* path */, ObjectStorageKey /* object_key */, uint64_t /* size_in_bytes */) override
-    {
-        /// Noop
-    }
-
     void setLastModified(const String &, const Poco::Timestamp &) override
     {
         /// Noop

--- a/tests/queries/0_stateless/03566_write_disks_with_append_mode.reference
+++ b/tests/queries/0_stateless/03566_write_disks_with_append_mode.reference
@@ -1,0 +1,16 @@
+test_local_disk_metadata_local_object_storage
+abc
+abc123
+abc123def
+test_local_disk_metadata_s3_object_storage
+abc
+abc123
+abc123def
+test_plain_metadata_s3_object_storage
+abc
+abc
+abc
+test_plain_rewriteable_metadata_s3_object_storage
+abc
+abc
+abc

--- a/tests/queries/0_stateless/03566_write_disks_with_append_mode.sh
+++ b/tests/queries/0_stateless/03566_write_disks_with_append_mode.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+config="$CUR_DIR/03566_write_disks_with_append_mode.xml"
+
+function test_append()
+{
+    disk_name="$1"
+    echo "$disk_name"
+    file_name="file_03566_$(random_str 10).txt"
+    printf "%s" "abc" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write $file_name"
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "read $file_name"
+
+    printf "%s" "123" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write --mode append $file_name" 2>/dev/null
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "read $file_name"
+
+    printf "%s" "def" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write --mode append $file_name" 2>/dev/null
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "read $file_name"
+
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "remove $file_name"
+}
+
+test_append "test_local_disk_metadata_local_object_storage"
+test_append "test_local_disk_metadata_s3_object_storage"
+test_append "test_plain_metadata_s3_object_storage"
+test_append "test_plain_rewriteable_metadata_s3_object_storage"
+
+

--- a/tests/queries/0_stateless/03566_write_disks_with_append_mode.xml
+++ b/tests/queries/0_stateless/03566_write_disks_with_append_mode.xml
@@ -1,0 +1,36 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <test_local_disk_metadata_local_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <metadata_type>local</metadata_type>
+                <path>disks/03566/test_disk/</path>
+            </test_local_disk_metadata_local_object_storage>
+            <test_local_disk_metadata_s3_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>local</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_disk</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </test_local_disk_metadata_s3_object_storage>
+            <test_plain_metadata_s3_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_disk</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </test_plain_metadata_s3_object_storage>
+            <test_plain_rewriteable_metadata_s3_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_disk</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </test_plain_rewriteable_metadata_s3_object_storage>
+        </disks>
+    </storage_configuration>
+</clickhouse>

--- a/tests/queries/0_stateless/03578_copy_file_in_object_storage.reference
+++ b/tests/queries/0_stateless/03578_copy_file_in_object_storage.reference
@@ -1,0 +1,16 @@
+test_local_disk_metadata_local_object_storage
+abc123def
+abc123def
+abc123def
+test_local_disk_metadata_s3_object_storage
+abc123def
+abc123def
+abc123def
+test_plain_metadata_s3_object_storage
+abc
+abc
+abc
+test_plain_rewriteable_metadata_s3_object_storage
+abc
+abc
+abc

--- a/tests/queries/0_stateless/03578_copy_file_in_object_storage.sh
+++ b/tests/queries/0_stateless/03578_copy_file_in_object_storage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+config="$CUR_DIR/03578_copy_file_in_object_storage.xml"
+
+function test_copy()
+{
+    disk_name="$1"
+    echo "$disk_name"
+    file_name_src="file_src_03578_$(random_str 10).txt"
+    file_name_existing_target="file_existing_target_03578_$(random_str 10).txt"
+    file_name_non_existing_target="file_non_existing_target_03578_$(random_str 10).txt"
+
+    printf "%s" "abc" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write $file_name_src"
+    printf "%s" "123" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write --mode append $file_name_src" 2>/dev/null
+    printf "%s" "def" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write --mode append $file_name_src" 2>/dev/null
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "read $file_name_src"
+
+    printf "%s" "xyz" | clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "write $file_name_existing_target"
+
+
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "cp --path-from $file_name_src --path-to $file_name_existing_target"
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "read $file_name_existing_target"
+
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "cp --path-from $file_name_src --path-to $file_name_non_existing_target"
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "read $file_name_non_existing_target"
+
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "remove $file_name_src"
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "remove $file_name_existing_target"
+    clickhouse-disks -C "$config" --disk "$disk_name" --save-logs --query "remove $file_name_non_existing_target"
+}
+
+test_copy "test_local_disk_metadata_local_object_storage"
+test_copy "test_local_disk_metadata_s3_object_storage"
+# For these following disks, adding new blob to metadata is not supported, when appending, it fails.
+test_copy "test_plain_metadata_s3_object_storage"
+test_copy "test_plain_rewriteable_metadata_s3_object_storage"
+
+

--- a/tests/queries/0_stateless/03578_copy_file_in_object_storage.xml
+++ b/tests/queries/0_stateless/03578_copy_file_in_object_storage.xml
@@ -1,0 +1,36 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <test_local_disk_metadata_local_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <metadata_type>local</metadata_type>
+                <path>disks/03566/test_disk/</path>
+            </test_local_disk_metadata_local_object_storage>
+            <test_local_disk_metadata_s3_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>local</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_disk</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </test_local_disk_metadata_s3_object_storage>
+            <test_plain_metadata_s3_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_disk</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </test_plain_metadata_s3_object_storage>
+            <test_plain_rewriteable_metadata_s3_object_storage>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_disk</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </test_plain_rewriteable_metadata_s3_object_storage>
+        </disks>
+    </storage_configuration>
+</clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix write with append (in MergeTree used for experimental transactions) with `plain_rewritable`/`plain` metadata types, previously they were simply ignored

1) Remove noop addBlobToMetadata in MetadataStorageFromPlainObjectStorageTransaction
2) Add supportAddingBlobToMetadata to MetadataStorageFromDiskTransaction indicating if addBlobToMetadata is supported
3) Handle DiskObjectStorageTransaction::writeFile and CopyFileObjectStorageOperation with supportAddingBlobToMetadata

Internal explanation:

* In `MetadataStorageFromDisk`, we store mapping: local_path -> `DiskObjectStorageMetadata`
In `DiskObjectStorageMetadata`, it has a list of blobs stored in [ObjectKeysWithMetadata keys_with_meta](https://github.com/ClickHouse/ClickHouse/blob/master/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h#L25);
It is a 1-to-n mapping from a local_path to multiple blobs. Each `object_key` in  `keys_with_meta` points to the blob stored in the object storage.
When writing with append, it simply adds a new blob to `keys_with_meta` in `DiskObjectStorageMetadata`. The buffer will point to the newly created object in the object storage.

* In `MetadataStorageFromPlainObjectStorage`, things are different.
It uses `object_storage->generateObjectKeyForPath` to generate the remote_path from the local_path. In other words, it is a 1-to-1 mapping from `local_path` to `remote_path`.
* In `MetadataStorageFromPlainRewritableObjectStorage`, it inherits from `MetadataStorageFromPlainObjectStorage`, which has `std::shared_ptr<InMemoryDirectoryPathMap> path_map`.
In the object storage, we store in `_meta` a mapping from `remote_directory_path` to `local_directory_path`.
Under `remote_directory_path`, there are files which belong to `local_directory_path`.
The directory paths and files are loaded into `path_map` during initialization or refresh.
It is also a 1-to-1 mapping

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
