### PR TITLE
Fix race in ddl worker queue

### DIFF
--- a/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
+++ b/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
@@ -307,7 +307,7 @@ void StorageSystemDDLWorkerQueue::fillData(MutableColumns & res_columns, Context
             for (const auto & host_id_str : finished_hosts.names)
                 finished_status_paths.push_back(fs::path(task.entry_path) / "finished" / host_id_str);
 
-            auto finished_statuses = zookeeper->get(finished_status_paths);
+            auto finished_statuses = zookeeper->tryGet(finished_status_paths);
             for (size_t host_idx = 0; host_idx < finished_hosts.names.size(); ++host_idx)
             {
                 const auto & host_id_str = finished_hosts.names[host_idx];


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix race in ddl worker queue

It is possible to have a `NoNodeException` because the task is currently being deleted:
https://github.com/ClickHouse/ClickHouse/blob/e8b13ddf9d654ba1213de7d3fc5e81a20779350d/src/Storages/System/StorageSystemDDLWorkerQueue.cpp#L310 

So it is make sense to use `tryGet` to set `Removing` state for the task:
https://github.com/ClickHouse/ClickHouse/blob/e8b13ddf9d654ba1213de7d3fc5e81a20779350d/src/Storages/System/StorageSystemDDLWorkerQueue.cpp#L207-L220 


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
