### PR TITLE
Hide avro schema registry auth in logs

### DIFF
--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -1,19 +1,38 @@
 #include <Parsers/ASTSetQuery.h>
-#include <Parsers/formatSettingName.h>
-#include <Common/SipHash.h>
-#include <Common/FieldVisitorHash.h>
-#include <Common/FieldVisitorToString.h>
-#include <Common/quoteString.h>
+
+#include <Databases/DataLake/DataLakeConstants.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
-#include <Databases/DataLake/DataLakeConstants.h>
-#include <Storages/RabbitMQ/RabbitMQ_fwd.h>
-#include <Storages/NATS/NATS_fwd.h>
+#include <Parsers/formatSettingName.h>
 #include <Storages/Kafka/Kafka_fwd.h>
+#include <Storages/NATS/NATS_fwd.h>
+#include <Storages/RabbitMQ/RabbitMQ_fwd.h>
+#include <Poco/Exception.h>
+#include <Poco/URI.h>
+#include <Common/FieldVisitorHash.h>
+#include <Common/FieldVisitorToString.h>
+#include <Common/SipHash.h>
+#include <Common/quoteString.h>
 
+static constexpr std::string_view format_avro_schema_registry_url = "format_avro_schema_registry_url";
 
 namespace DB
 {
+
+namespace
+{
+std::optional<Poco::URI> tryParseURI(const String & uri)
+{
+    try
+    {
+        return Poco::URI (uri);
+    }
+    catch (const Poco::SyntaxException &)
+    {
+        return std::nullopt;
+    }
+}
+}
 
 class FieldVisitorToSetting : public StaticVisitor<String>
 {
@@ -95,6 +114,21 @@ void ASTSetQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, 
                 return true;
             }
 
+            if (change.name == format_avro_schema_registry_url)
+            {
+                auto uri_string = change.value.safeGet<String>();
+                const auto maybe_uri = tryParseURI(uri_string);
+                if (!maybe_uri || maybe_uri->getUserInfo().empty())
+                    return false;
+
+                const auto & user_info = maybe_uri->getUserInfo();
+                const auto user_name = user_info.substr(0, user_info.find(':'));
+                const auto new_user_info = user_name + ":[HIDDEN]";
+                uri_string.replace(uri_string.find(user_info),user_info.size(), new_user_info);
+                ostr << " = '" << uri_string << "'";
+                return true;
+            }
+
             if (DataLake::DATABASE_ENGINE_NAME == state.create_engine_name)
             {
                 if (DataLake::SETTINGS_TO_HIDE.contains(change.name))
@@ -172,6 +206,9 @@ bool ASTSetQuery::hasSecretParts() const
 {
     for (const auto & change : changes)
     {
+        CustomType custom;
+        if (change.value.tryGet<CustomType>(custom) && custom.isSecret())
+            return true;
         if (DataLake::SETTINGS_TO_HIDE.contains(change.name))
             return true;
         if (RabbitMQ::SETTINGS_TO_HIDE.contains(change.name))
@@ -180,6 +217,13 @@ bool ASTSetQuery::hasSecretParts() const
             return true;
         if (Kafka::SETTINGS_TO_HIDE.contains(change.name))
             return true;
+
+        if (change.name == format_avro_schema_registry_url)
+        {
+            const auto maybe_uri = tryParseURI(change.value.safeGet<String>());
+            if (maybe_uri && !maybe_uri->getUserInfo().empty())
+                return true;
+        }
     }
     return false;
 }

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -285,7 +285,10 @@ def test_create_table():
         (
             f"AzureBlobStorage('BlobEndpoint=https://my-endpoint/;SharedAccessSignature=sp=r&st=2025-09-29T14:58:11Z&se=2025-09-29T00:00:00Z&spr=https&sv=2022-11-02&sr=c&sig=SECRET%SECRET%SECRET%SECRET', 'exampledatasets', 'example.csv')",
             "STD_EXCEPTION",
-        )
+        ),
+        f"Kafka() SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '{password}', format_avro_schema_registry_url = 'http://schema_user:{password}@'",
+        f"Kafka() SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '{password}', format_avro_schema_registry_url = 'http://schema_user:{password}@domain.com'",
+
     ]
 
     def make_test_case(i):
@@ -347,7 +350,7 @@ def test_create_table():
             "CREATE TABLE table16 (`x` int) ENGINE = DeltaLake('http://minio1:9001/root/data/test11.csv.gz', 'minio', '[HIDDEN]')",
             "CREATE TABLE table17 (x int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'CSV') settings mode = 'ordered'",
             "CREATE TABLE table18 (x int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'CSV', 'gzip') settings mode = 'ordered'",
-            # due to sensitive data substituion the query will be normalized, so not "settings" but "SETTINGS"
+            # due to sensitive data substitution the query will be normalized, so not "settings" but "SETTINGS"
             "CREATE TABLE table19 (`x` int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'minio', '[HIDDEN]', 'CSV') SETTINGS mode = 'ordered'",
             "CREATE TABLE table20 (`x` int) ENGINE = S3Queue('http://minio1:9001/root/data/', 'minio', '[HIDDEN]', 'CSV', 'gzip') SETTINGS mode = 'ordered'",
             "CREATE TABLE table21 (`x` int) ENGINE = Iceberg('http://minio1:9001/root/data/test11.csv.gz', 'minio', '[HIDDEN]')",
@@ -362,6 +365,8 @@ def test_create_table():
             f"CREATE TABLE table30 (`x` int) ENGINE = AzureQueue('{azure_storage_account_url}', 'cont', '*', '{azure_account_name}', '[HIDDEN]', 'CSV') SETTINGS mode = 'unordered'",
             f"CREATE TABLE table31 (`x` int) ENGINE = AzureQueue('{azure_storage_account_url}', 'cont', '*', '{azure_account_name}', '[HIDDEN]', 'CSV', 'none') SETTINGS mode = 'unordered'",
             f"CREATE TABLE table32 (`x` int) ENGINE = AzureBlobStorage('{masked_sas_conn_string}', 'exampledatasets', 'example.csv')",
+            "CREATE TABLE table33 (`x` int) ENGINE = Kafka SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '[HIDDEN]', format_avro_schema_registry_url = 'http://schema_user:[HIDDEN]@'",
+            "CREATE TABLE table34 (`x` int) ENGINE = Kafka SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '[HIDDEN]', format_avro_schema_registry_url = 'http://schema_user:[HIDDEN]@domain.com'",
         ],
         must_not_contain=[password],
     )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Mask Avro schema registry authentication details to be not visible to user or in logs.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
