### PR TITLE
Add performance comparison jobs with release branch baseline

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4233,6 +4233,120 @@ jobs:
             python3 -m praktika run 'Performance Comparison (arm_release, master_head, 3/3)' --workflow "MasterCI" --ci |& tee ./ci/tmp/job.log
           fi
 
+  performance_comparison_arm_release_release_base_1_3:
+    runs-on: [self-hosted, func-tester-aarch64]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, build_arm_release]
+    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'UGVyZm9ybWFuY2UgQ29tcGFyaXNvbiAoYXJtX3JlbGVhc2UsIHJlbGVhc2VfYmFzZSwgMS8zKQ==') }}
+    name: "Performance Comparison (arm_release, release_base, 1/3)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
+          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+          cat > ./ci/tmp/workflow_config_masterci.json << 'EOF'
+          ${{ needs.config_workflow.outputs.data }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          if command -v ts &> /dev/null; then
+            python3 -m praktika run 'Performance Comparison (arm_release, release_base, 1/3)' --workflow "MasterCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
+          else
+            python3 -m praktika run 'Performance Comparison (arm_release, release_base, 1/3)' --workflow "MasterCI" --ci |& tee ./ci/tmp/job.log
+          fi
+
+  performance_comparison_arm_release_release_base_2_3:
+    runs-on: [self-hosted, func-tester-aarch64]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, build_arm_release]
+    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'UGVyZm9ybWFuY2UgQ29tcGFyaXNvbiAoYXJtX3JlbGVhc2UsIHJlbGVhc2VfYmFzZSwgMi8zKQ==') }}
+    name: "Performance Comparison (arm_release, release_base, 2/3)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
+          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+          cat > ./ci/tmp/workflow_config_masterci.json << 'EOF'
+          ${{ needs.config_workflow.outputs.data }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          if command -v ts &> /dev/null; then
+            python3 -m praktika run 'Performance Comparison (arm_release, release_base, 2/3)' --workflow "MasterCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
+          else
+            python3 -m praktika run 'Performance Comparison (arm_release, release_base, 2/3)' --workflow "MasterCI" --ci |& tee ./ci/tmp/job.log
+          fi
+
+  performance_comparison_arm_release_release_base_3_3:
+    runs-on: [self-hosted, func-tester-aarch64]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, build_arm_release]
+    if: ${{ !failure() && !cancelled() && !contains(fromJson(needs.config_workflow.outputs.data).cache_success_base64, 'UGVyZm9ybWFuY2UgQ29tcGFyaXNvbiAoYXJtX3JlbGVhc2UsIHJlbGVhc2VfYmFzZSwgMy8zKQ==') }}
+    name: "Performance Comparison (arm_release, release_base, 3/3)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp ./ci/tmp ./ci/tmp
+          mkdir -p ./ci/tmp ./ci/tmp ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+          cat > ./ci/tmp/workflow_config_masterci.json << 'EOF'
+          ${{ needs.config_workflow.outputs.data }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          if command -v ts &> /dev/null; then
+            python3 -m praktika run 'Performance Comparison (arm_release, release_base, 3/3)' --workflow "MasterCI" --ci |& ts '[%Y-%m-%d %H:%M:%S]' | tee ./ci/tmp/job.log
+          else
+            python3 -m praktika run 'Performance Comparison (arm_release, release_base, 3/3)' --workflow "MasterCI" --ci |& tee ./ci/tmp/job.log
+          fi
+
   clickbench_amd_release:
     runs-on: [self-hosted, func-tester]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, build_amd_release]

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -374,18 +374,6 @@ class ArtifactNames:
     FUZZERS = "FUZZERS"
     FUZZERS_CORPUS = "FUZZERS_CORPUS"
 
-    PERF_REPORTS_AMD_1 = "PERF_REPORTS_AMD_1"
-    PERF_REPORTS_AMD_2 = "PERF_REPORTS_AMD_2"
-    PERF_REPORTS_AMD_3 = "PERF_REPORTS_AMD_3"
-    PERF_REPORTS_ARM_1 = "PERF_REPORTS_ARM_1"
-    PERF_REPORTS_ARM_2 = "PERF_REPORTS_ARM_2"
-    PERF_REPORTS_ARM_3 = "PERF_REPORTS_ARM_3"
-    PERF_REPORTS_AMD_1_WITH_RELEASE = "PERF_REPORTS_AMD_1_WITH_RELEASE"
-    PERF_REPORTS_AMD_2_WITH_RELEASE = "PERF_REPORTS_AMD_2_WITH_RELEASE"
-    PERF_REPORTS_AMD_3_WITH_RELEASE = "PERF_REPORTS_AMD_3_WITH_RELEASE"
-
-    PERF_REPORTS_ARM = "PERF_REPORTS_ARM"
-
 
 class ArtifactConfigs:
     clickhouse_binaries = Artifact.Config(
@@ -481,21 +469,4 @@ class ArtifactConfigs:
         name=ArtifactNames.FUZZERS_CORPUS,
         type=Artifact.Type.S3,
         path=f"{TEMP_DIR}/build/programs/*_seed_corpus.zip",
-    )
-    performance_reports = Artifact.Config(
-        name="*",
-        type=Artifact.Type.S3,
-        path=f"{TEMP_DIR}/perf_wd/*.html",
-    ).parametrize(
-        names=[
-            ArtifactNames.PERF_REPORTS_AMD_1,
-            ArtifactNames.PERF_REPORTS_AMD_2,
-            ArtifactNames.PERF_REPORTS_AMD_3,
-            ArtifactNames.PERF_REPORTS_ARM_1,
-            ArtifactNames.PERF_REPORTS_ARM_2,
-            ArtifactNames.PERF_REPORTS_ARM_3,
-            ArtifactNames.PERF_REPORTS_AMD_1_WITH_RELEASE,
-            ArtifactNames.PERF_REPORTS_AMD_2_WITH_RELEASE,
-            ArtifactNames.PERF_REPORTS_AMD_3_WITH_RELEASE,
-        ]
     )

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -717,35 +717,6 @@ class JobConfigs:
             [ArtifactNames.CH_AMD_UBSAN],
         ],
     )
-    performance_comparison_with_prev_release_jobs = Job.Config(
-        name=JobNames.PERFORMANCE,
-        runs_on=["#from param"],
-        command='python3 ./ci/jobs/performance_tests.py --test-options "{PARAMETER}"',
-        # TODO: switch to stateless-test image
-        run_in_docker="clickhouse/performance-comparison",
-        digest_config=Job.CacheDigestConfig(
-            include_paths=[
-                "./tests/performance/",
-                "./ci/jobs/scripts/perf/",
-                "./ci/jobs/performance_tests.py",
-                "./ci/docker/performance-comparison",
-            ],
-        ),
-        timeout=2 * 3600,
-    ).parametrize(
-        parameter=[
-            "amd_release, prev_release, 1/3",
-            "amd_release, prev_release, 2/3",
-            "amd_release, prev_release, 3/3",
-        ],
-        runs_on=[RunnerLabels.FUNC_TESTER_AMD for _ in range(3)],
-        requires=[[ArtifactNames.CH_AMD_RELEASE] for _ in range(3)],
-        provides=[
-            [ArtifactNames.PERF_REPORTS_AMD_1_WITH_RELEASE],
-            [ArtifactNames.PERF_REPORTS_AMD_2_WITH_RELEASE],
-            [ArtifactNames.PERF_REPORTS_AMD_3_WITH_RELEASE],
-        ],
-    )
     performance_comparison_with_master_head_jobs = Job.Config(
         name=JobNames.PERFORMANCE,
         runs_on=["#from param"],
@@ -775,14 +746,31 @@ class JobConfigs:
         + [RunnerLabels.FUNC_TESTER_ARM for _ in range(3)],
         requires=[[ArtifactNames.CH_AMD_RELEASE] for _ in range(3)]
         + [[ArtifactNames.CH_ARM_RELEASE] for _ in range(3)],
-        provides=[
-            [ArtifactNames.PERF_REPORTS_AMD_1],
-            [ArtifactNames.PERF_REPORTS_AMD_2],
-            [ArtifactNames.PERF_REPORTS_AMD_3],
-            [ArtifactNames.PERF_REPORTS_ARM_1],
-            [ArtifactNames.PERF_REPORTS_ARM_2],
-            [ArtifactNames.PERF_REPORTS_ARM_3],
+    )
+    performance_comparison_with_release_base_jobs = Job.Config(
+        name=JobNames.PERFORMANCE,
+        runs_on=["#from param"],
+        command='python3 ./ci/jobs/performance_tests.py --test-options "{PARAMETER}"',
+        # TODO: switch to stateless-test image
+        run_in_docker="clickhouse/performance-comparison",
+        digest_config=Job.CacheDigestConfig(
+            include_paths=[
+                "./tests/performance/",
+                "./ci/jobs/scripts/perf/",
+                "./ci/jobs/performance_tests.py",
+                "./ci/docker/performance-comparison",
+            ],
+        ),
+        timeout=2 * 3600,
+        result_name_for_cidb="Tests",
+    ).parametrize(
+        parameter=[
+            "arm_release, release_base, 1/3",
+            "arm_release, release_base, 2/3",
+            "arm_release, release_base, 3/3",
         ],
+        runs_on=[RunnerLabels.FUNC_TESTER_ARM for _ in range(3)],
+        requires=[[ArtifactNames.CH_ARM_RELEASE] for _ in range(3)],
     )
     clickbench_master_jobs = Job.Config(
         name=JobNames.CLICKBENCH,

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -279,12 +279,22 @@ def parse_args():
 
 def find_prev_build(info, build_type):
     commits = info.get_custom_data("previous_commits_sha") or []
-
+    assert commits, "No commits found to fetch reference build"
     for sha in commits:
         link = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/{build_type}/clickhouse"
         if Shell.check(f"curl -sfI {link} > /dev/null"):
             return link
 
+    return None
+
+
+def find_base_release_build(info, build_type):
+    commits = info.get_custom_data("release_branch_base_sha_with_predecessors") or []
+    assert commits, "No commits found to fetch reference build"
+    for sha in commits:
+        link = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/{build_type}/clickhouse"
+        if Shell.check(f"curl -sfI {link} > /dev/null"):
+            return link
     return None
 
 
@@ -300,7 +310,7 @@ def main():
             batch_num, total_batches = map(int, test_option.split("/"))
         if "master_head" in test_option:
             compare_against_master = True
-        elif "prev_release" in test_option:
+        elif "release_base" in test_option:
             compare_against_release = True
 
     batch_num -= 1
@@ -308,7 +318,7 @@ def main():
 
     assert (
         compare_against_master or compare_against_release
-    ), "test option: head_master or prev_release must be selected"
+    ), "test option: head_master or release_base must be selected"
 
     # release_version = CHVersion.get_release_version_as_dict()
     info = Info()
@@ -321,9 +331,8 @@ def main():
             else:
                 link_for_ref_ch = "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/aarch64/clickhouse"
         elif compare_against_release:
-            # TODO:
-            # link_for_ref_ch = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/{release_version['major']}.{release_version['minor']-1}/{release_version['githash']}/build_arm_release/clickhouse"
-            assert False
+            link_for_ref_ch = find_base_release_build(info, "build_arm_release")
+            assert link_for_ref_ch, "reference clickhouse build has not been found"
         else:
             assert False
     elif Utils.is_amd():
@@ -334,9 +343,8 @@ def main():
             else:
                 link_for_ref_ch = "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/amd64/clickhouse"
         elif compare_against_release:
-            # TODO:
-            # link_for_ref_ch = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/{release_version['major']}.{release_version['minor']-1}/{release_version['githash']}/build_amd_release/clickhouse"
-            assert False
+            link_for_ref_ch = find_base_release_build(info, "build_amd_release")
+            assert link_for_ref_ch, "reference clickhouse build has not been found"
         else:
             assert False
     else:

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -4,6 +4,7 @@ from ci.defs.job_configs import JobConfigs
 from ci.praktika.digest import Digest
 from ci.praktika.info import Info
 from ci.praktika.utils import Shell
+from ci.jobs.scripts.clickhouse_version import CHVersion
 
 if __name__ == "__main__":
     info = Info()
@@ -45,3 +46,27 @@ if __name__ == "__main__":
             commits.pop(0)
 
         info.store_custom_data("previous_commits_sha", commits)
+
+    # store commit sha of release branch base to find binary for performance comparison in the job script later
+    # if info.git_branch == "master" and info.repo_name == "ClickHouse/ClickHouse":
+    Shell.check(
+        f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:"
+    )
+    release_branch_base_sha = CHVersion.get_release_version_as_dict().get("githash")
+    print(f"Release branch base sha: {release_branch_base_sha}")
+    assert release_branch_base_sha
+    release_branch_base_sha_with_predecessors = [
+        s.strip()
+        for s in Shell.get_output(
+            f"git rev-list --max-count=20 {release_branch_base_sha}", verbose=True
+        ).splitlines()
+    ]
+    assert all(len(s) == 40 for s in release_branch_base_sha_with_predecessors)
+    assert release_branch_base_sha_with_predecessors[0] == release_branch_base_sha
+    info.store_custom_data(
+        "release_branch_base_sha_with_predecessors",
+        release_branch_base_sha_with_predecessors,
+    )
+    print(
+        f"Found base commit sha for latest release branch with its predecessors: [{release_branch_base_sha_with_predecessors}]"
+    )

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -52,7 +52,6 @@ workflow = Workflow.Config(
         *ArtifactConfigs.clickhouse_tgzs,
         ArtifactConfigs.fuzzers,
         ArtifactConfigs.fuzzers_corpus,
-        *ArtifactConfigs.performance_reports,
     ],
     dockers=DOCKERS,
     enable_dockers_manifest_merge=True,

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -40,6 +40,7 @@ workflow = Workflow.Config(
         *JobConfigs.ast_fuzzer_jobs,
         *JobConfigs.buzz_fuzzer_jobs,
         *JobConfigs.performance_comparison_with_master_head_jobs,
+        *JobConfigs.performance_comparison_with_release_base_jobs,
         *JobConfigs.clickbench_master_jobs,
         *JobConfigs.sqlancer_master_jobs,
         JobConfigs.sqltest_master_job,

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -61,7 +61,6 @@ workflow = Workflow.Config(
         *JobConfigs.ast_fuzzer_jobs,
         *JobConfigs.buzz_fuzzer_jobs,
         *JobConfigs.performance_comparison_with_master_head_jobs,
-        *JobConfigs.performance_comparison_with_release_base_jobs,
     ],
     artifacts=[
         *ArtifactConfigs.unittests_binaries,

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -61,6 +61,7 @@ workflow = Workflow.Config(
         *JobConfigs.ast_fuzzer_jobs,
         *JobConfigs.buzz_fuzzer_jobs,
         *JobConfigs.performance_comparison_with_master_head_jobs,
+        *JobConfigs.performance_comparison_with_release_base_jobs,
     ],
     artifacts=[
         *ArtifactConfigs.unittests_binaries,
@@ -70,7 +71,6 @@ workflow = Workflow.Config(
         *ArtifactConfigs.clickhouse_tgzs,
         ArtifactConfigs.fuzzers,
         ArtifactConfigs.fuzzers_corpus,
-        *ArtifactConfigs.performance_reports,
     ],
     dockers=DOCKERS,
     enable_dockers_manifest_merge=True,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Added new performance testing jobs that compare against a stable baseline from the merge-base of the latest release branch and master. This provides more consistent performance benchmarking by using a fixed reference point rather than a moving target, making performance regressions and improvements easier to identify and track over time.

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
