### PR TITLE
Avoid uuid collision in tests

### DIFF
--- a/tests/queries/0_stateless/01601_detach_permanently.sql
+++ b/tests/queries/0_stateless/01601_detach_permanently.sql
@@ -33,7 +33,7 @@ SELECT 'can still show the create statement';
 SHOW CREATE TABLE test1601_detach_permanently_atomic.test_name_reuse FORMAT Vertical;
 
 SELECT 'can not attach with bad uuid';
-ATTACH TABLE test1601_detach_permanently_atomic.test_name_reuse UUID '00000000-0000-0000-0000-000000000001'　(`number` UInt64　)　ENGINE = MergeTree　ORDER BY tuple()　SETTINGS index_granularity = 8192 ;  -- { serverError TABLE_ALREADY_EXISTS }
+ATTACH TABLE test1601_detach_permanently_atomic.test_name_reuse UUID '00000000-0000-0000-0000-000000001601'　(`number` UInt64　)　ENGINE = MergeTree　ORDER BY tuple()　SETTINGS index_granularity = 8192 ;  -- { serverError TABLE_ALREADY_EXISTS }
 
 SELECT 'can attach with short syntax';
 ATTACH TABLE test1601_detach_permanently_atomic.test_name_reuse;

--- a/tests/queries/0_stateless/03541_table_without_insertable_columns.sql
+++ b/tests/queries/0_stateless/03541_table_without_insertable_columns.sql
@@ -6,7 +6,7 @@ CREATE TABLE no_physical (a Int EPHEMERAL) Engine=Memory; -- { serverError EMPTY
 CREATE TABLE no_physical (a Int ALIAS 1) Engine=Memory; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }
 
 CREATE TABLE no_insertable (a Int MATERIALIZED 1) Engine=Memory; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }
-ATTACH TABLE no_insertable UUID '00000000-0000-0000-0000-000000000001' (a Int MATERIALIZED 1) Engine=Memory;
+ATTACH TABLE no_insertable UUID '00000000-0000-0000-0000-000000003541' (a Int MATERIALIZED 1) Engine=Memory;
 
 CREATE TABLE insertable (a Int EPHEMERAL, b Int MATERIALIZED 1) Engine=Memory;
 ALTER TABLE insertable DROP COLUMN a; -- { serverError EMPTY_LIST_OF_COLUMNS_PASSED }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes https://github.com/ClickHouse/ClickHouse/issues/83719 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
