### PR TITLE
ci: disable zero-copy tests for ReplicatedDatabase

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -315,6 +315,9 @@ if [[ "$USE_ASYNC_INSERT" == "1" ]]; then
 fi
 
 if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
+    # Zero-copy is not compatible with Replicated database due to multi-shard setup
+    rm $DEST_SERVER_PATH/config.d/enable_zero_copy_replication.xml
+
     ln -sf $SRC_PATH/users.d/database_replicated.xml $DEST_SERVER_PATH/users.d/
     ln -sf $SRC_PATH/config.d/database_replicated.xml $DEST_SERVER_PATH/config.d/
     rm $DEST_SERVER_PATH/config.d/zookeeper.xml

--- a/tests/queries/0_stateless/02432_s3_parallel_parts_cleanup.sql
+++ b/tests/queries/0_stateless/02432_s3_parallel_parts_cleanup.sql
@@ -1,5 +1,6 @@
--- Tags: no-fasttest, no-shared-merge-tree
+-- Tags: no-fasttest, no-shared-merge-tree, no-replicated-database
 -- no-shared-merge-tree: depend on custom storage policy
+-- no-replicated-database: incompatible with replicated database (due to multiple shards)
 
 SET send_logs_level = 'fatal';
 

--- a/tests/queries/0_stateless/02432_s3_parallel_parts_cleanup.sql
+++ b/tests/queries/0_stateless/02432_s3_parallel_parts_cleanup.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-shared-merge-tree, no-replicated-database
+-- Tags: no-fasttest, no-shared-merge-tree, no-replicated-database, long
 -- no-shared-merge-tree: depend on custom storage policy
 -- no-replicated-database: incompatible with replicated database (due to multiple shards)
 

--- a/tests/queries/0_stateless/02456_test_zero_copy_mutation.sql
+++ b/tests/queries/0_stateless/02456_test_zero_copy_mutation.sql
@@ -1,3 +1,6 @@
+-- Tags: no-replicated-database
+-- no-replicated-database: incompatible with replicated database (due to multiple shards)
+
 DROP TABLE IF EXISTS mutation_1;
 DROP TABLE IF EXISTS mutation_2;
 

--- a/tests/queries/0_stateless/02477_projection_materialize_and_zero_copy.sql
+++ b/tests/queries/0_stateless/02477_projection_materialize_and_zero_copy.sql
@@ -1,4 +1,5 @@
--- Tags: long, no-parallel
+-- Tags: no-replicated-database, long, no-parallel
+-- no-replicated-database: incompatible with replicated database (due to multiple shards)
 
 DROP TABLE IF EXISTS t;
 

--- a/tests/queries/0_stateless/02485_zero_copy_commit_error.sql
+++ b/tests/queries/0_stateless/02485_zero_copy_commit_error.sql
@@ -1,4 +1,5 @@
--- Tags: no-fasttest, no-shared-merge-tree
+-- Tags: no-fasttest, no-shared-merge-tree, no-replicated-database
+-- no-replicated-database: incompatible with replicated database (due to multiple shards)
 
 create table rmt1 (n int, m int, k int) engine=ReplicatedMergeTree('/test/02485/{database}/rmt', '1') order by n
     settings storage_policy='s3_cache', allow_remote_fs_zero_copy_replication=1, old_parts_lifetime=60, cleanup_delay_period=60, max_cleanup_delay_period=60, cleanup_delay_period_random_add=1, min_bytes_for_wide_part=0, simultaneous_parts_removal_limit=1;

--- a/tests/queries/0_stateless/02488_zero_copy_detached_parts_drop_table.sh
+++ b/tests/queries/0_stateless/02488_zero_copy_detached_parts_drop_table.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, zookeeper, no-shared-merge-tree
+# Tags: no-fasttest, zookeeper, no-shared-merge-tree, no-replicated-database
+# no-replicated-database: incompatible with replicated database (due to multiple shards)
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02494_zero_copy_and_projection_and_mutation_work_together.sql
+++ b/tests/queries/0_stateless/02494_zero_copy_and_projection_and_mutation_work_together.sql
@@ -1,3 +1,6 @@
+-- Tags: no-replicated-database
+-- no-replicated-database: incompatible with replicated database (due to multiple shards)
+
 DROP TABLE IF EXISTS wikistat1;
 DROP TABLE IF EXISTS wikistat2;
 


### PR DESCRIPTION
The problem is is that Replicated database has multiple shards, each shard will have different path in ZooKeeper, but the same in path for zero-copy locks which will lead to "Lock is lost, node does not exist" errors.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/74734

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)