### PR TITLE
Fix cache metrics for index marks/uncompressed cache

### DIFF
--- a/src/IO/UncompressedCache.cpp
+++ b/src/IO/UncompressedCache.cpp
@@ -1,19 +1,16 @@
 #include <IO/UncompressedCache.h>
 #include <Common/SipHash.h>
-#include <Common/CurrentMetrics.h>
-
-namespace CurrentMetrics
-{
-    extern const Metric UncompressedCacheBytes;
-    extern const Metric UncompressedCacheCells;
-}
 
 namespace DB
 {
 template class CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
 
-UncompressedCache::UncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
-    : Base(cache_policy, CurrentMetrics::UncompressedCacheBytes, CurrentMetrics::UncompressedCacheCells, max_size_in_bytes, 0, size_ratio)
+UncompressedCache::UncompressedCache(const String & cache_policy,
+    CurrentMetrics::Metric size_in_bytes_metric,
+    CurrentMetrics::Metric count_metric,
+    size_t max_size_in_bytes,
+    double size_ratio)
+    : Base(cache_policy, size_in_bytes_metric, count_metric, max_size_in_bytes, 0, size_ratio)
 {
 }
 

--- a/src/IO/UncompressedCache.h
+++ b/src/IO/UncompressedCache.h
@@ -42,7 +42,11 @@ private:
     using Base = CacheBase<UInt128, UncompressedCacheCell, UInt128TrivialHash, UncompressedSizeWeightFunction>;
 
 public:
-    UncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
+    UncompressedCache(const String & cache_policy,
+        CurrentMetrics::Metric size_in_bytes_metric,
+        CurrentMetrics::Metric count_metric,
+        size_t max_size_in_bytes,
+        double size_ratio);
 
     /// Calculate key from path to file and offset.
     static UInt128 hash(const String & path_to_file, size_t offset);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -205,6 +205,14 @@ namespace CurrentMetrics
     extern const Metric IcebergCatalogThreads;
     extern const Metric IcebergCatalogThreadsActive;
     extern const Metric IcebergCatalogThreadsScheduled;
+    extern const Metric IndexMarkCacheBytes;
+    extern const Metric IndexMarkCacheFiles;
+    extern const Metric MarkCacheBytes;
+    extern const Metric MarkCacheFiles;
+    extern const Metric UncompressedCacheBytes;
+    extern const Metric UncompressedCacheCells;
+    extern const Metric IndexUncompressedCacheBytes;
+    extern const Metric IndexUncompressedCacheCells;
 }
 
 
@@ -3377,7 +3385,7 @@ void Context::setUncompressedCache(const String & cache_policy, size_t max_size_
     if (shared->uncompressed_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Uncompressed cache has been already created.");
 
-    shared->uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, max_size_in_bytes, size_ratio);
+    shared->uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, CurrentMetrics::UncompressedCacheBytes, CurrentMetrics::UncompressedCacheCells, max_size_in_bytes, size_ratio);
 }
 
 void Context::updateUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -3444,7 +3452,7 @@ void Context::setMarkCache(const String & cache_policy, size_t max_cache_size_in
     if (shared->mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mark cache has been already created.");
 
-    shared->mark_cache = std::make_shared<MarkCache>(cache_policy, max_cache_size_in_bytes, size_ratio);
+    shared->mark_cache = std::make_shared<MarkCache>(cache_policy, CurrentMetrics::MarkCacheBytes, CurrentMetrics::MarkCacheFiles, max_cache_size_in_bytes, size_ratio);
 }
 
 void Context::updateMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -3545,7 +3553,7 @@ void Context::setIndexUncompressedCache(const String & cache_policy, size_t max_
     if (shared->index_uncompressed_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache has been already created.");
 
-    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, max_size_in_bytes, size_ratio);
+    shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, CurrentMetrics::IndexUncompressedCacheBytes, CurrentMetrics::IndexUncompressedCacheCells, max_size_in_bytes, size_ratio);
 }
 
 void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config)
@@ -3581,7 +3589,7 @@ void Context::setIndexMarkCache(const String & cache_policy, size_t max_cache_si
     if (shared->index_mark_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index mark cache has been already created.");
 
-    shared->index_mark_cache = std::make_shared<MarkCache>(cache_policy, max_cache_size_in_bytes, size_ratio);
+    shared->index_mark_cache = std::make_shared<MarkCache>(cache_policy, CurrentMetrics::IndexMarkCacheBytes, CurrentMetrics::IndexMarkCacheFiles, max_cache_size_in_bytes, size_ratio);
 }
 
 void Context::updateIndexMarkCacheConfiguration(const Poco::Util::AbstractConfiguration & config)

--- a/src/Storages/MarkCache.cpp
+++ b/src/Storages/MarkCache.cpp
@@ -1,19 +1,16 @@
 #include <Common/SipHash.h>
-#include <Common/CurrentMetrics.h>
 #include <Storages/MarkCache.h>
-
-namespace CurrentMetrics
-{
-    extern const Metric MarkCacheBytes;
-    extern const Metric MarkCacheFiles;
-}
 
 namespace DB
 {
 template class CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
 
-MarkCache::MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio)
-    : Base(cache_policy, CurrentMetrics::MarkCacheBytes, CurrentMetrics::MarkCacheFiles, max_size_in_bytes, 0, size_ratio)
+MarkCache::MarkCache(const String & cache_policy,
+    CurrentMetrics::Metric size_in_bytes_metric,
+    CurrentMetrics::Metric count_metric,
+    size_t max_size_in_bytes,
+    double size_ratio)
+    : Base(cache_policy, size_in_bytes_metric, count_metric, max_size_in_bytes, 0, size_ratio)
 {
 }
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -42,7 +42,11 @@ private:
     using Base = CacheBase<UInt128, MarksInCompressedFile, UInt128TrivialHash, MarksWeightFunction>;
 
 public:
-    MarkCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
+    MarkCache(const String & cache_policy,
+        CurrentMetrics::Metric size_in_bytes_metric,
+        CurrentMetrics::Metric count_metric,
+        size_t max_size_in_bytes,
+        double size_ratio);
 
     /// Calculate key from path to file.
     static UInt128 hash(const String & path_to_file);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `IndexUncompressedCacheBytes`/`IndexUncompressedCacheCells`/`IndexMarkCacheBytes`/`IndexMarkCacheFiles` metrics (previously they were included into metric w/o `Cache` prefix)

Follow-up for: #81023