### PR TITLE
Make more tests parallelizable

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2559,7 +2559,6 @@ class TestSuite:
         return (
             ("no-parallel" in self.all_tags[test_name])
             or ("sequential" in self.all_tags[test_name])
-            or ("stateful" in self.all_tags[test_name])
         )
 
     def get_selected_tests(self, filter_func):

--- a/tests/queries/0_stateless/00022_merge_prewhere.sql
+++ b/tests/queries/0_stateless/00022_merge_prewhere.sql
@@ -1,6 +1,6 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.merge_hits;
-CREATE TABLE IF NOT EXISTS test.merge_hits AS test.hits ENGINE = Merge(test, '^hits$');
-SELECT count() FROM test.merge_hits WHERE AdvEngineID = 2;
-SELECT count() FROM test.merge_hits PREWHERE AdvEngineID = 2;
-DROP TABLE test.merge_hits;
+DROP TABLE IF EXISTS merge_hits;
+CREATE TABLE IF NOT EXISTS merge_hits AS test.hits ENGINE = Merge(test, '^hits$');
+SELECT count() FROM merge_hits WHERE AdvEngineID = 2;
+SELECT count() FROM merge_hits PREWHERE AdvEngineID = 2;
+DROP TABLE merge_hits;

--- a/tests/queries/0_stateless/00024_random_counters.sql
+++ b/tests/queries/0_stateless/00024_random_counters.sql
@@ -1,4 +1,5 @@
--- Tags: stateful
+-- Tags: stateful, no-parallel
+-- no-parallel: Heavy
 SELECT uniq(UserID), sum(Sign) FROM test.visits WHERE CounterID = 32152608;
 SELECT uniq(UserID), sum(Sign) FROM test.visits WHERE CounterID = 9627212;
 SELECT uniq(UserID), sum(Sign) FROM test.visits WHERE CounterID = 25152951;

--- a/tests/queries/0_stateless/00040_aggregating_materialized_view.sql
+++ b/tests/queries/0_stateless/00040_aggregating_materialized_view.sql
@@ -1,8 +1,8 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.basic_00040;
+DROP TABLE IF EXISTS basic_00040;
 
 set allow_deprecated_syntax_for_merge_tree=1;
-CREATE MATERIALIZED VIEW test.basic_00040
+CREATE MATERIALIZED VIEW basic_00040
 ENGINE = AggregatingMergeTree(StartDate, (CounterID, StartDate), 8192)
 POPULATE AS
 SELECT
@@ -18,7 +18,7 @@ SELECT
     StartDate,
     sumMerge(Visits)	AS Visits,
     uniqMerge(Users)	AS Users
-FROM test.basic_00040
+FROM basic_00040
 GROUP BY StartDate
 ORDER BY StartDate;
 
@@ -27,7 +27,7 @@ SELECT
     StartDate,
     sumMerge(Visits)	AS Visits,
     uniqMerge(Users)	AS Users
-FROM test.basic_00040
+FROM basic_00040
 WHERE CounterID = 942285
 GROUP BY StartDate
 ORDER BY StartDate;
@@ -43,4 +43,4 @@ GROUP BY StartDate
 ORDER BY StartDate;
 
 
-DROP TABLE test.basic_00040;
+DROP TABLE basic_00040;

--- a/tests/queries/0_stateless/00041_aggregating_materialized_view.sql
+++ b/tests/queries/0_stateless/00041_aggregating_materialized_view.sql
@@ -1,8 +1,8 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.basic;
-DROP TABLE IF EXISTS test.visits_null;
+DROP TABLE IF EXISTS basic;
+DROP TABLE IF EXISTS visits_null;
 
-CREATE TABLE test.visits_null
+CREATE TABLE visits_null
 (
     CounterID UInt32,
     StartDate Date,
@@ -11,17 +11,17 @@ CREATE TABLE test.visits_null
 ) ENGINE = Null;
 
 set allow_deprecated_syntax_for_merge_tree=1;
-CREATE MATERIALIZED VIEW test.basic
+CREATE MATERIALIZED VIEW basic
 ENGINE = AggregatingMergeTree(StartDate, (CounterID, StartDate), 8192)
 AS SELECT
     CounterID,
     StartDate,
     sumState(Sign)                  AS Visits,
     uniqState(UserID)               AS Users
-FROM test.visits_null
+FROM visits_null
 GROUP BY CounterID, StartDate;
 
-INSERT INTO test.visits_null
+INSERT INTO visits_null
 SELECT
     CounterID,
     StartDate,
@@ -34,7 +34,7 @@ SELECT
     StartDate,
     sumMerge(Visits)                AS Visits,
     uniqMerge(Users)                AS Users
-FROM test.basic
+FROM basic
 GROUP BY StartDate
 ORDER BY StartDate;
 
@@ -43,7 +43,7 @@ SELECT
     StartDate,
     sumMerge(Visits)                AS Visits,
     uniqMerge(Users)                AS Users
-FROM test.basic
+FROM basic
 WHERE CounterID = 942285
 GROUP BY StartDate
 ORDER BY StartDate;
@@ -59,17 +59,17 @@ GROUP BY StartDate
 ORDER BY StartDate;
 
 
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
-OPTIMIZE TABLE test.basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
+OPTIMIZE TABLE basic;
 
 
-DROP TABLE test.visits_null;
-DROP TABLE test.basic;
+DROP TABLE visits_null;
+DROP TABLE basic;

--- a/tests/queries/0_stateless/00054_merge_tree_partitions.sql
+++ b/tests/queries/0_stateless/00054_merge_tree_partitions.sql
@@ -1,38 +1,38 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.partitions;
+DROP TABLE IF EXISTS partitions;
 set allow_deprecated_syntax_for_merge_tree=1;
-CREATE TABLE test.partitions (EventDate Date, CounterID UInt32) ENGINE = MergeTree(EventDate, CounterID, 8192);
-INSERT INTO test.partitions SELECT EventDate + UserID % 365 AS EventDate, CounterID FROM test.hits WHERE CounterID = 1704509;
+CREATE TABLE partitions (EventDate Date, CounterID UInt32) ENGINE = MergeTree(EventDate, CounterID, 8192);
+INSERT INTO partitions SELECT EventDate + UserID % 365 AS EventDate, CounterID FROM test.hits WHERE CounterID = 1704509;
 
 
-SELECT count() FROM test.partitions;
-SELECT count() FROM test.partitions WHERE EventDate >= toDate('2015-01-01') AND EventDate < toDate('2015-02-01');
-SELECT count() FROM test.partitions WHERE EventDate < toDate('2015-01-01') OR EventDate >= toDate('2015-02-01');
+SELECT count() FROM partitions;
+SELECT count() FROM partitions WHERE EventDate >= toDate('2015-01-01') AND EventDate < toDate('2015-02-01');
+SELECT count() FROM partitions WHERE EventDate < toDate('2015-01-01') OR EventDate >= toDate('2015-02-01');
 
-ALTER TABLE test.partitions DETACH PARTITION 201501;
+ALTER TABLE partitions DETACH PARTITION 201501;
 
-SELECT count() FROM test.partitions;
-SELECT count() FROM test.partitions WHERE EventDate >= toDate('2015-01-01') AND EventDate < toDate('2015-02-01');
-SELECT count() FROM test.partitions WHERE EventDate < toDate('2015-01-01') OR EventDate >= toDate('2015-02-01');
+SELECT count() FROM partitions;
+SELECT count() FROM partitions WHERE EventDate >= toDate('2015-01-01') AND EventDate < toDate('2015-02-01');
+SELECT count() FROM partitions WHERE EventDate < toDate('2015-01-01') OR EventDate >= toDate('2015-02-01');
 
-ALTER TABLE test.partitions ATTACH PARTITION 201501;
+ALTER TABLE partitions ATTACH PARTITION 201501;
 
-SELECT count() FROM test.partitions;
-SELECT count() FROM test.partitions WHERE EventDate >= toDate('2015-01-01') AND EventDate < toDate('2015-02-01');
-SELECT count() FROM test.partitions WHERE EventDate < toDate('2015-01-01') OR EventDate >= toDate('2015-02-01');
-
-
-ALTER TABLE test.partitions DETACH PARTITION 201403;
-
-SELECT count() FROM test.partitions;
-
-INSERT INTO test.partitions SELECT EventDate + UserID % 365 AS EventDate, CounterID FROM test.hits WHERE CounterID = 1704509 AND toStartOfMonth(EventDate) = toDate('2014-03-01');
-
-SELECT count() FROM test.partitions;
-
-ALTER TABLE test.partitions ATTACH PARTITION 201403;
-
-SELECT count() FROM test.partitions;
+SELECT count() FROM partitions;
+SELECT count() FROM partitions WHERE EventDate >= toDate('2015-01-01') AND EventDate < toDate('2015-02-01');
+SELECT count() FROM partitions WHERE EventDate < toDate('2015-01-01') OR EventDate >= toDate('2015-02-01');
 
 
-DROP TABLE test.partitions;
+ALTER TABLE partitions DETACH PARTITION 201403;
+
+SELECT count() FROM partitions;
+
+INSERT INTO partitions SELECT EventDate + UserID % 365 AS EventDate, CounterID FROM test.hits WHERE CounterID = 1704509 AND toStartOfMonth(EventDate) = toDate('2014-03-01');
+
+SELECT count() FROM partitions;
+
+ALTER TABLE partitions ATTACH PARTITION 201403;
+
+SELECT count() FROM partitions;
+
+
+DROP TABLE partitions;

--- a/tests/queries/0_stateless/00056_view.sql
+++ b/tests/queries/0_stateless/00056_view.sql
@@ -1,8 +1,8 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.view;
-CREATE VIEW test.view AS SELECT CounterID, count() AS c FROM test.hits GROUP BY CounterID;
-SELECT count() FROM test.view;
-SELECT c, count() FROM test.view GROUP BY c ORDER BY count() DESC LIMIT 10;
-SELECT * FROM test.view ORDER BY c DESC LIMIT 10;
-SELECT * FROM test.view SAMPLE 0.1 ORDER BY c DESC LIMIT 10;
-DROP TABLE test.view;
+DROP TABLE IF EXISTS view;
+CREATE VIEW view AS SELECT CounterID, count() AS c FROM test.hits GROUP BY CounterID;
+SELECT count() FROM view;
+SELECT c, count() FROM view GROUP BY c ORDER BY count() DESC LIMIT 10;
+SELECT * FROM view ORDER BY c DESC LIMIT 10;
+SELECT * FROM view SAMPLE 0.1 ORDER BY c DESC LIMIT 10;
+DROP TABLE view;

--- a/tests/queries/0_stateless/00061_storage_buffer.sql
+++ b/tests/queries/0_stateless/00061_storage_buffer.sql
@@ -1,23 +1,23 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.hits_dst;
-DROP TABLE IF EXISTS test.hits_buffer;
+DROP TABLE IF EXISTS hits_dst;
+DROP TABLE IF EXISTS hits_buffer;
 
-CREATE TABLE test.hits_dst AS test.hits
+CREATE TABLE hits_dst AS test.hits
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(EventDate)
 ORDER BY (CounterID, EventDate, intHash32(UserID))
 SAMPLE BY intHash32(UserID)
 SETTINGS storage_policy = 'default';
 
-CREATE TABLE test.hits_buffer AS test.hits_dst ENGINE = Buffer(test, hits_dst, 8, 600, 600, 1000000, 1000000, 100000000, 1000000000);
+CREATE TABLE hits_buffer AS hits_dst ENGINE = Buffer(current_database(), hits_dst, 8, 600, 600, 1000000, 1000000, 100000000, 1000000000);
 
-INSERT INTO test.hits_buffer SELECT * FROM test.hits WHERE CounterID = 800784;
-SELECT count() FROM test.hits_buffer;
-SELECT count() FROM test.hits_dst;
+INSERT INTO hits_buffer SELECT * FROM test.hits WHERE CounterID = 800784;
+SELECT count() FROM hits_buffer;
+SELECT count() FROM hits_dst;
 
-OPTIMIZE TABLE test.hits_buffer;
-SELECT count() FROM test.hits_buffer;
-SELECT count() FROM test.hits_dst;
+OPTIMIZE TABLE hits_buffer;
+SELECT count() FROM hits_buffer;
+SELECT count() FROM hits_dst;
 
-DROP TABLE test.hits_dst;
-DROP TABLE test.hits_buffer;
+DROP TABLE hits_dst;
+DROP TABLE hits_buffer;

--- a/tests/queries/0_stateless/00065_loyalty_with_storage_join.sql
+++ b/tests/queries/0_stateless/00065_loyalty_with_storage_join.sql
@@ -1,5 +1,4 @@
 -- Tags: stateful
-USE test;
 
 DROP TABLE IF EXISTS join;
 CREATE TABLE join (UserID UInt64, loyalty Int8) ENGINE = Join(SEMI, LEFT, UserID);
@@ -10,7 +9,7 @@ SELECT
     toInt8(if((sum(SearchEngineID = 2) AS yandex) > (sum(SearchEngineID = 3) AS google),
     yandex / (yandex + google),
     -google / (yandex + google)) * 10) AS loyalty
-FROM hits
+FROM test.hits
 WHERE (SearchEngineID = 2) OR (SearchEngineID = 3)
 GROUP BY UserID
 HAVING (yandex + google) > 10;
@@ -18,7 +17,7 @@ HAVING (yandex + google) > 10;
 SELECT
     loyalty,
     count()
-FROM hits SEMI LEFT JOIN join USING UserID
+FROM test.hits SEMI LEFT JOIN join USING UserID
 GROUP BY loyalty
 ORDER BY loyalty ASC;
 
@@ -28,7 +27,7 @@ ATTACH TABLE join;
 SELECT
     loyalty,
     count()
-FROM hits SEMI LEFT JOIN join USING UserID
+FROM test.hits SEMI LEFT JOIN join USING UserID
 GROUP BY loyalty
 ORDER BY loyalty ASC;
 

--- a/tests/queries/0_stateless/00071_merge_tree_optimize_aio.sql
+++ b/tests/queries/0_stateless/00071_merge_tree_optimize_aio.sql
@@ -1,19 +1,19 @@
 -- Tags: stateful
-DROP TABLE IF EXISTS test.hits_snippet;
+DROP TABLE IF EXISTS hits_snippet;
 
 set allow_deprecated_syntax_for_merge_tree=1;
-CREATE TABLE test.hits_snippet(EventTime DateTime('Asia/Dubai'),  EventDate Date,  CounterID UInt32,  UserID UInt64,  URL String,  Referer String) ENGINE = MergeTree(EventDate, intHash32(UserID), (CounterID, EventDate, intHash32(UserID), EventTime), 8192);
+CREATE TABLE hits_snippet(EventTime DateTime('Asia/Dubai'),  EventDate Date,  CounterID UInt32,  UserID UInt64,  URL String,  Referer String) ENGINE = MergeTree(EventDate, intHash32(UserID), (CounterID, EventDate, intHash32(UserID), EventTime), 8192);
 
 SET min_insert_block_size_rows = 0, min_insert_block_size_bytes = 0;
 SET max_block_size = 4096;
 
-INSERT INTO test.hits_snippet(EventTime, EventDate, CounterID, UserID, URL, Referer) SELECT EventTime, EventDate, CounterID, UserID, URL, Referer FROM test.hits WHERE EventDate = toDate('2014-03-18') ORDER BY EventTime, EventDate, CounterID, UserID, URL, Referer ASC LIMIT 50;
-INSERT INTO test.hits_snippet(EventTime, EventDate, CounterID, UserID, URL, Referer) SELECT EventTime, EventDate, CounterID, UserID, URL, Referer FROM test.hits WHERE EventDate = toDate('2014-03-19') ORDER BY EventTime, EventDate, CounterID, UserID, URL, Referer ASC LIMIT 50;
+INSERT INTO hits_snippet(EventTime, EventDate, CounterID, UserID, URL, Referer) SELECT EventTime, EventDate, CounterID, UserID, URL, Referer FROM test.hits WHERE EventDate = toDate('2014-03-18') ORDER BY EventTime, EventDate, CounterID, UserID, URL, Referer ASC LIMIT 50;
+INSERT INTO hits_snippet(EventTime, EventDate, CounterID, UserID, URL, Referer) SELECT EventTime, EventDate, CounterID, UserID, URL, Referer FROM test.hits WHERE EventDate = toDate('2014-03-19') ORDER BY EventTime, EventDate, CounterID, UserID, URL, Referer ASC LIMIT 50;
 
 SET min_bytes_to_use_direct_io = 8192;
 
-OPTIMIZE TABLE test.hits_snippet;
+OPTIMIZE TABLE hits_snippet;
 
-SELECT EventTime, EventDate, CounterID, UserID, URL, Referer FROM test.hits_snippet ORDER BY EventTime, EventDate, CounterID, UserID, URL, Referer ASC;
+SELECT EventTime, EventDate, CounterID, UserID, URL, Referer FROM hits_snippet ORDER BY EventTime, EventDate, CounterID, UserID, URL, Referer ASC;
 
-DROP TABLE test.hits_snippet;
+DROP TABLE hits_snippet;

--- a/tests/queries/0_stateless/00072_compare_date_and_string_index.sql
+++ b/tests/queries/0_stateless/00072_compare_date_and_string_index.sql
@@ -15,24 +15,24 @@ SELECT count() FROM test.hits WHERE EventDate IN (toDate('2014-03-18'), toDate('
 
 SELECT count() FROM test.hits WHERE EventDate = concat('2014-0', '3-18');
 
-DROP TABLE IF EXISTS test.hits_indexed_by_time;
-CREATE TABLE test.hits_indexed_by_time (EventDate Date, EventTime DateTime('Asia/Dubai')) ENGINE = MergeTree ORDER BY (EventDate, EventTime) SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
-INSERT INTO test.hits_indexed_by_time SELECT EventDate, EventTime FROM test.hits SETTINGS max_block_size = 65000;
+DROP TABLE IF EXISTS hits_indexed_by_time;
+CREATE TABLE hits_indexed_by_time (EventDate Date, EventTime DateTime('Asia/Dubai')) ENGINE = MergeTree ORDER BY (EventDate, EventTime) SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+INSERT INTO hits_indexed_by_time SELECT EventDate, EventTime FROM test.hits SETTINGS max_block_size = 65000;
 
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime = '2014-03-18 01:02:03';
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime < '2014-03-18 01:02:03';
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime > '2014-03-18 01:02:03';
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime <= '2014-03-18 01:02:03';
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime >= '2014-03-18 01:02:03';
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime IN ('2014-03-18 01:02:03', '2014-03-19 04:05:06');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime = '2014-03-18 01:02:03';
+SELECT count() FROM hits_indexed_by_time WHERE EventTime < '2014-03-18 01:02:03';
+SELECT count() FROM hits_indexed_by_time WHERE EventTime > '2014-03-18 01:02:03';
+SELECT count() FROM hits_indexed_by_time WHERE EventTime <= '2014-03-18 01:02:03';
+SELECT count() FROM hits_indexed_by_time WHERE EventTime >= '2014-03-18 01:02:03';
+SELECT count() FROM hits_indexed_by_time WHERE EventTime IN ('2014-03-18 01:02:03', '2014-03-19 04:05:06');
 
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime = toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime < toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime > toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime <= toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime >= toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime IN (toDateTime('2014-03-18 01:02:03', 'Asia/Dubai'), toDateTime('2014-03-19 04:05:06', 'Asia/Dubai'));
+SELECT count() FROM hits_indexed_by_time WHERE EventTime = toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime < toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime > toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime <= toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime >= toDateTime('2014-03-18 01:02:03', 'Asia/Dubai');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime IN (toDateTime('2014-03-18 01:02:03', 'Asia/Dubai'), toDateTime('2014-03-19 04:05:06', 'Asia/Dubai'));
 
-SELECT count() FROM test.hits_indexed_by_time WHERE EventTime = concat('2014-03-18 ', '01:02:03');
+SELECT count() FROM hits_indexed_by_time WHERE EventTime = concat('2014-03-18 ', '01:02:03');
 
-DROP TABLE test.hits_indexed_by_time;
+DROP TABLE hits_indexed_by_time;

--- a/tests/queries/0_stateless/00077_log_tinylog_stripelog.sql
+++ b/tests/queries/0_stateless/00077_log_tinylog_stripelog.sql
@@ -1,4 +1,5 @@
--- Tags: stateful
+-- Tags: stateful, no-parallel
+-- no-parallel: Heavy usage
 SET check_query_single_value_result = 1;
 
 DROP TABLE IF EXISTS test.hits_log;

--- a/tests/queries/0_stateless/00090_thread_pool_deadlock.sh
+++ b/tests/queries/0_stateless/00090_thread_pool_deadlock.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: stateful, deadlock
+# Tags: stateful, deadlock, no-parallel
+# no-parallel: Heavy
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00140_rename.sql
+++ b/tests/queries/0_stateless/00140_rename.sql
@@ -1,5 +1,6 @@
 -- Tags: stateful, no-replicated-database, no-parallel
 -- Tag no-replicated-database: Does not support renaming of multiple tables in single query
+-- Tag: no-parallel: Changes stateful tables
 
 RENAME TABLE test.hits TO test.visits_tmp, test.visits TO test.hits, test.visits_tmp TO test.visits;
 

--- a/tests/queries/0_stateless/00152_insert_different_granularity.sql
+++ b/tests/queries/0_stateless/00152_insert_different_granularity.sql
@@ -1,4 +1,4 @@
--- Tags: stateful, no-tsan, no-replicated-database, no-parallel
+-- Tags: stateful, no-replicated-database
 -- Tag no-replicated-database: Fails due to additional replicas or shards
 
 DROP TABLE IF EXISTS fixed_granularity_table;

--- a/tests/queries/0_stateless/00153_aggregate_arena_race.sql
+++ b/tests/queries/0_stateless/00153_aggregate_arena_race.sql
@@ -1,4 +1,6 @@
 -- Tags: stateful, race
 
+drop table if exists dest00153;
 create temporary table dest00153 (`s` AggregateFunction(groupUniqArray, String)) engine Memory;
 insert into dest00153 select groupUniqArrayState(RefererDomain) from test.hits group by URLDomain;
+drop table if exists dest00153;

--- a/tests/queries/0_stateless/00154_avro.sql
+++ b/tests/queries/0_stateless/00154_avro.sql
@@ -1,13 +1,13 @@
 -- Tags: stateful, no-fasttest
 
-DROP TABLE IF EXISTS test.avro;
+DROP TABLE IF EXISTS avro;
 
 SET max_threads = 1, max_insert_threads = 0, max_block_size = 8192, min_insert_block_size_rows = 8192, min_insert_block_size_bytes = 1048576; -- lower memory usage
 
-CREATE TABLE test.avro AS test.hits ENGINE = File(Avro);
-INSERT INTO test.avro SELECT * FROM test.hits LIMIT 10000;
+CREATE TABLE avro AS test.hits ENGINE = File(Avro);
+INSERT INTO avro SELECT * FROM test.hits LIMIT 10000;
 
 SELECT sum(cityHash64(*)) FROM (SELECT * FROM test.hits LIMIT 10000);
-SELECT sum(cityHash64(*)) FROM test.avro;
+SELECT sum(cityHash64(*)) FROM avro;
 
-DROP TABLE test.avro;
+DROP TABLE avro;

--- a/tests/queries/0_stateless/00157_cache_dictionary.sql
+++ b/tests/queries/0_stateless/00157_cache_dictionary.sql
@@ -1,4 +1,5 @@
 -- Tags: stateful, no-tsan, no-msan, no-asan, no-parallel
+-- no-parallel: Heavy
 
 DROP TABLE IF EXISTS test.hits_1m;
 

--- a/tests/queries/0_stateless/00158_cache_dictionary_has.sql
+++ b/tests/queries/0_stateless/00158_cache_dictionary_has.sql
@@ -1,9 +1,8 @@
--- Tags: stateful, no-parallel
+-- Tags: stateful
 
-CREATE DATABASE IF NOT EXISTS db_dict;
-DROP DICTIONARY IF EXISTS db_dict.cache_hits;
+DROP DICTIONARY IF EXISTS cache_hits;
 
-CREATE DICTIONARY db_dict.cache_hits
+CREATE DICTIONARY cache_hits
 (WatchID UInt64, UserID UInt64, SearchPhrase String)
 PRIMARY KEY WatchID
 SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'hits' PASSWORD '' DB 'test'))
@@ -12,14 +11,13 @@ LAYOUT(CACHE(SIZE_IN_CELLS 100 QUERY_WAIT_TIMEOUT_MILLISECONDS 600000));
 
 SET timeout_before_checking_execution_speed = 300;
 
-SELECT sum(flag) FROM (SELECT dictHas('db_dict.cache_hits', toUInt64(WatchID)) as flag FROM test.hits PREWHERE WatchID % 1400 == 0 LIMIT 100);
+SELECT sum(flag) FROM (SELECT dictHas(current_database() || '.cache_hits', toUInt64(WatchID)) as flag FROM test.hits PREWHERE WatchID % 1400 == 0 LIMIT 100);
 SELECT count() from test.hits PREWHERE WatchID % 1400 == 0;
 
-SELECT sum(flag) FROM (SELECT dictHas('db_dict.cache_hits', toUInt64(WatchID)) as flag FROM test.hits PREWHERE WatchID % 350 == 0 LIMIT 100);
+SELECT sum(flag) FROM (SELECT dictHas(current_database() || '.cache_hits', toUInt64(WatchID)) as flag FROM test.hits PREWHERE WatchID % 350 == 0 LIMIT 100);
 SELECT count() from test.hits PREWHERE WatchID % 350 == 0;
 
-SELECT sum(flag) FROM (SELECT dictHas('db_dict.cache_hits', toUInt64(WatchID)) as flag FROM test.hits PREWHERE WatchID % 5 == 0 LIMIT 100);
+SELECT sum(flag) FROM (SELECT dictHas(current_database() || '.cache_hits', toUInt64(WatchID)) as flag FROM test.hits PREWHERE WatchID % 5 == 0 LIMIT 100);
 SELECT count() from test.hits PREWHERE WatchID % 5 == 0;
 
-DROP DICTIONARY IF EXISTS db_dict.cache_hits;
-DROP DATABASE IF EXISTS db_dict;
+DROP DICTIONARY IF EXISTS cache_hits;

--- a/tests/queries/0_stateless/00167_read_bytes_from_fs.sql
+++ b/tests/queries/0_stateless/00167_read_bytes_from_fs.sql
@@ -1,4 +1,5 @@
--- Tags: stateful, no-random-settings
+-- Tags: stateful, no-random-settings, no-parallel
+-- no-parallel: Heavy query
 
 SET max_memory_usage = '10G';
 SELECT sum(cityHash64(*)) FROM test.hits SETTINGS max_threads=40;

--- a/tests/queries/0_stateless/00170_s3_cache.sql
+++ b/tests/queries/0_stateless/00170_s3_cache.sql
@@ -1,4 +1,5 @@
 -- Tags: stateful, no-parallel, no-random-settings
+-- no-parallel: Heavy and it drops filesystem cache
 
 -- { echo }
 

--- a/tests/queries/0_stateless/03411_iceberg_bucket.sql
+++ b/tests/queries/0_stateless/03411_iceberg_bucket.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-random-settings,
+-- Tags: no-random-settings,
 -- Test is taken both from Iceberg spec (https://iceberg.apache.org/spec/#appendix-b-32-bit-hash-requirements) and reference Iceberg repo (https://github.com/apache/iceberg/blob/6e8718113c08aebf76d8e79a9e2534c89c73407a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java)
 SELECT 'icebergHash';
 SELECT icebergHash(true);

--- a/tests/queries/0_stateless/03457_numeric_indexed_vector_build.sql
+++ b/tests/queries/0_stateless/03457_numeric_indexed_vector_build.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST groupNumericIndexedVector';
 
 DROP TABLE IF EXISTS uin_value_details;

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_bit_promote.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_bit_promote.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations in bit promotion with zero values and Float64 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_i8f64.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_i8f64.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and UInt8 index type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u16f64.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u16f64.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and UInt16 index type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32f32.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32f32.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and Float32 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32f64.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32f64.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and Float64 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i16.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i16.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and Int16 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i32.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i32.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and Int32 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i64.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i64.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and Int64 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i8.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32i8.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and Int8 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u16.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u16.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and UInt16 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u32.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u32.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and UInt32 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u64.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u64.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and UInt64 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u8.sql
+++ b/tests/queries/0_stateless/03458_numeric_indexed_vector_operations_u32u8.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorPointwise operations with zero values and UInt8 value type';
 DROP TABLE IF EXISTS uin_value_details;
 CREATE TABLE uin_value_details

--- a/tests/queries/0_stateless/03459_numeric_indexed_vector_decode.sql
+++ b/tests/queries/0_stateless/03459_numeric_indexed_vector_decode.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST toVectorCompactArray';
 
 DROP TABLE IF EXISTS uin_value_details;

--- a/tests/queries/0_stateless/03460_numeric_indexed_vector_to_value_map.sql
+++ b/tests/queries/0_stateless/03460_numeric_indexed_vector_to_value_map.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 select 'TEST numericIndexedVectorToMap';
 
 DROP TABLE IF EXISTS uin_value_details_int32_int8;

--- a/tests/queries/0_stateless/03461_numeric_indexed_vector_chain.sql
+++ b/tests/queries/0_stateless/03461_numeric_indexed_vector_chain.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 WITH
     numericIndexedVectorBuild(mapFromArrays([1, 2, 3], arrayMap(x -> toFloat64(x), [10, 20, 30]))) AS vec1
 SELECT

--- a/tests/queries/0_stateless/03462_numeric_indexed_vector_serialization.sql
+++ b/tests/queries/0_stateless/03462_numeric_indexed_vector_serialization.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP TABLE IF EXISTS uin_value_details_int32_float64;
 CREATE TABLE uin_value_details_int32_float64
 (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make more tests parallelizable

* For obscure reasons (https://github.com/ClickHouse/ClickHouse/issues/74661#issuecomment-2602008015) when we moved the stateful tests we made all of them not parallel. Many, if not all, are quick and fast so we should mark the non-parallel appropriately and run the rest in parallel.
* There are a bunch of new tests marked as non-parallel without reason and I couldn't come up with one

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
