### PR TITLE
Disallow `max_insert_block_size = 0`

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -112,7 +112,7 @@ The `max_block_size` setting indicates the recommended maximum number of rows to
 
 The block size should not be too small to avoid noticeable costs when processing each block. It should also not be too large to ensure that queries with a LIMIT clause execute quickly after processing the first block. When setting `max_block_size`, the goal should be to avoid consuming too much memory when extracting a large number of columns in multiple threads and to preserve at least some cache locality.
 )", 0) \
-    DECLARE(UInt64, max_insert_block_size, DEFAULT_INSERT_BLOCK_SIZE, R"(
+    DECLARE(NonZeroUInt64, max_insert_block_size, DEFAULT_INSERT_BLOCK_SIZE, R"(
 The size of blocks (in a count of rows) to form for insertion into a table.
 This setting only applies in cases when the server forms the blocks.
 For example, for an INSERT via the HTTP interface, the server parses the data format and forms blocks of the specified size.

--- a/tests/queries/0_stateless/03564_zero_insert_block_size.sql
+++ b/tests/queries/0_stateless/03564_zero_insert_block_size.sql
@@ -1,0 +1,5 @@
+-- Test for issue #83620
+
+CREATE TABLE t0 (c0 Int) ENGINE = Memory;
+INSERT INTO TABLE t0 (c0) SETTINGS max_insert_block_size = 0 VALUES (1); -- { clientError BAD_ARGUMENTS }
+DROP TABLE t0;


### PR DESCRIPTION
Resolves: #31367
Resolves: #83620

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Setting `max_insert_block_size` is no longer allowed to be 0.