### PR TITLE
Minor changes around MemoryTracker

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -8,6 +8,7 @@
 #include <Common/AsynchronousMetrics.h>
 #include <Common/Exception.h>
 #include <Common/Jemalloc.h>
+#include <Common/MemoryTracker.h>
 #include <Common/PageCache.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
@@ -984,6 +985,8 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
         }
     }
 #endif
+
+    new_values["TrackedMemory"] = { total_memory_tracker.get(), "Memory tracked by ClickHouse (should be equal to MemoryTracking metric), in bytes." };
 
 #if defined(OS_LINUX)
     if (loadavg)

--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -25,9 +25,9 @@ MemoryTracker * getMemoryTracker()
     if (auto * thread_memory_tracker = DB::CurrentThread::getMemoryTracker())
         return thread_memory_tracker;
 
-    /// Once the main thread is initialized,
-    /// total_memory_tracker is initialized too.
-    /// And can be used, since MainThreadStatus is required for profiling.
+    /// Note, we cannot use total_memory_tracker earlier (i.e. just after static variable initialized without this check),
+    /// since the initialization order of static objects is not defined, and total_memory_tracker may not be initialized yet.
+    /// So here we relying on MainThreadStatus initialization.
     if (DB::MainThreadStatus::get())
         return &total_memory_tracker;
 

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -68,9 +68,9 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
 
         thread_id = CurrentThread::get().thread_id;
     }
-    else
+    else if (const auto * main_thread = MainThreadStatus::get())
     {
-        thread_id = MainThreadStatus::get()->thread_id;
+        thread_id = main_thread->thread_id;
     }
 
     writeChar(false, out);  /// true if requested to stop the collecting thread.

--- a/src/Core/LogsLevel.h
+++ b/src/Core/LogsLevel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace DB
 {
 enum class LogsLevel : uint8_t


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I tried to make `total_memory_tracker` available earlier in https://github.com/ClickHouse/ClickHouse/pull/83376, but it turns out that we cannot do this, so just update some comments add one metric and add some missing included and checks.