### PR TITLE
Fix possible abort and hopefully hungs during BackgroundSchedulePool shutdown

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -372,7 +372,8 @@ void BackgroundSchedulePool::delayExecutionThreadFunction()
 
             while (!shutdown)
             {
-                Poco::Timestamp min_time;
+                Poco::Timestamp current_time;
+                Poco::Timestamp min_time = current_time;
 
                 if (!delayed_tasks.empty())
                 {
@@ -386,8 +387,6 @@ void BackgroundSchedulePool::delayExecutionThreadFunction()
                     delayed_tasks_cond_var.wait(lock.getUnderlyingLock());
                     continue;
                 }
-
-                Poco::Timestamp current_time;
 
                 if (min_time > current_time)
                 {

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -344,6 +344,8 @@ void BackgroundSchedulePool::threadFunction()
             {
                 return shutdown || !tasks.empty();
             });
+            if (shutdown)
+                break;
 
             if (!tasks.empty())
             {
@@ -385,12 +387,16 @@ void BackgroundSchedulePool::delayExecutionThreadFunction()
                 if (!task)
                 {
                     delayed_tasks_cond_var.wait(lock.getUnderlyingLock());
+                    if (shutdown)
+                        break;
                     continue;
                 }
 
                 if (min_time > current_time)
                 {
                     delayed_tasks_cond_var.wait_for(lock.getUnderlyingLock(), std::chrono::microseconds(min_time - current_time));
+                    if (shutdown)
+                        break;
                     continue;
                 }
 

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -2,6 +2,7 @@
 #include <Core/UUID.h>
 
 #include <IO/WriteHelpers.h>
+#include <base/defines.h>
 
 #include <Common/ThreadStatus.h>
 #include <Common/Exception.h>
@@ -21,6 +22,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int CANNOT_SCHEDULE_TASK;
+    extern const int ABORTED;
 }
 
 ///
@@ -226,7 +228,7 @@ BackgroundSchedulePool::BackgroundSchedulePool(size_t size_, CurrentMetrics::Met
             getLogger("BackgroundSchedulePool/" + thread_name),
             "Couldn't get {} threads from global thread pool: {}",
             size_,
-            getCurrentExceptionCode() == DB::ErrorCodes::CANNOT_SCHEDULE_TASK
+            getCurrentExceptionCode() == ErrorCodes::CANNOT_SCHEDULE_TASK
                 ? "Not enough threads. Please make sure max_thread_pool_size is considerably "
                   "bigger than background_schedule_pool_size."
                 : getCurrentExceptionMessage(/* with_stacktrace */ true));
@@ -237,6 +239,9 @@ BackgroundSchedulePool::BackgroundSchedulePool(size_t size_, CurrentMetrics::Met
 
 void BackgroundSchedulePool::increaseThreadsCount(size_t new_threads_count)
 {
+    if (shutdown)
+        throw Exception(ErrorCodes::ABORTED, "Pool already destroyed");
+
     const size_t old_threads_count = threads.size();
 
     if (new_threads_count < old_threads_count)
@@ -254,7 +259,7 @@ void BackgroundSchedulePool::increaseThreadsCount(size_t new_threads_count)
 }
 
 
-BackgroundSchedulePool::~BackgroundSchedulePool()
+void BackgroundSchedulePool::join()
 {
     try
     {
@@ -269,8 +274,10 @@ BackgroundSchedulePool::~BackgroundSchedulePool()
             Stopwatch watch;
             LOG_TRACE(getLogger("BackgroundSchedulePool/" + thread_name), "Waiting for threads to finish.");
             delayed_thread->join();
+            delayed_thread.reset();
             for (auto & thread : threads)
                 thread.join();
+            threads.clear();
             LOG_TRACE(getLogger("BackgroundSchedulePool/" + thread_name), "Threads finished in {}ms.", watch.elapsedMilliseconds());
         }
     }
@@ -278,6 +285,13 @@ BackgroundSchedulePool::~BackgroundSchedulePool()
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
+}
+
+BackgroundSchedulePool::~BackgroundSchedulePool()
+{
+    chassert(shutdown == true, "BackgroundSchedulePool::join() has not been called");
+    chassert(static_cast<bool>(delayed_thread) == false, "BackgroundSchedulePool::delayed_thread has not been joined");
+    chassert(threads.empty(), "BackgroundSchedulePool::threads have not been joined");
 }
 
 

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -54,8 +54,11 @@ public:
     void increaseThreadsCount(size_t new_threads_count);
 
     static BackgroundSchedulePoolPtr create(size_t size, CurrentMetrics::Metric tasks_metric, CurrentMetrics::Metric size_metric, const char * thread_name);
-
     ~BackgroundSchedulePool();
+
+    /// Shutdown the pool (set flag, destroy threads)
+    /// Should be called explicitly before destroying object.
+    void join();
 
 private:
     using TaskInfoPtr = std::shared_ptr<TaskInfo>;

--- a/src/Core/tests/gtest_BackgroundSchedulePool.cpp
+++ b/src/Core/tests/gtest_BackgroundSchedulePool.cpp
@@ -30,6 +30,8 @@ TEST(BackgroundSchedulePool, Schedule)
     condvar.wait(lock, [&] { return counter == ITERATIONS; });
 
     ASSERT_EQ(counter, ITERATIONS);
+
+    pool->join();
 }
 
 TEST(BackgroundSchedulePool, ScheduleAfter)
@@ -56,6 +58,8 @@ TEST(BackgroundSchedulePool, ScheduleAfter)
     condvar.wait(lock, [&] { return counter == ITERATIONS; });
 
     ASSERT_EQ(counter, ITERATIONS);
+
+    pool->join();
 }
 
 /// Previously leads to UB
@@ -69,6 +73,7 @@ TEST(BackgroundSchedulePool, ActivateAfterTerminitePool)
 
         task = pool->createTask("test", [&] {});
         delayed_task = pool->createTask("delayed_test", [&] {});
+        pool->join();
     }
 
     ASSERT_EQ(task->activateAndSchedule(), false);
@@ -91,6 +96,7 @@ TEST(BackgroundSchedulePool, ScheduleAfterTerminitePool)
 
         ASSERT_EQ(task->activate(), true);
         ASSERT_EQ(delayed_task->activate(), true);
+        pool->join();
     }
 
     ASSERT_EQ(task->schedule(), false);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -819,10 +819,12 @@ struct ContextSharedPart : boost::noncopyable
         std::unique_ptr<ExternalUserDefinedExecutableFunctionsLoader> delete_external_user_defined_executable_functions_loader;
         std::unique_ptr<IUserDefinedSQLObjectsStorage> delete_user_defined_sql_objects_storage;
         std::unique_ptr<IWorkloadEntityStorage> delete_workload_entity_storage;
+
         BackgroundSchedulePoolPtr delete_buffer_flush_schedule_pool;
         BackgroundSchedulePoolPtr delete_schedule_pool;
         BackgroundSchedulePoolPtr delete_distributed_schedule_pool;
         BackgroundSchedulePoolPtr delete_message_broker_schedule_pool;
+
         std::unique_ptr<DDLWorker> delete_ddl_worker;
         std::unique_ptr<AccessControl> delete_access_control;
 
@@ -915,10 +917,12 @@ struct ContextSharedPart : boost::noncopyable
             delete_external_user_defined_executable_functions_loader = std::move(external_user_defined_executable_functions_loader);
             delete_user_defined_sql_objects_storage = std::move(user_defined_sql_objects_storage);
             delete_workload_entity_storage = std::move(workload_entity_storage);
+
             delete_buffer_flush_schedule_pool = std::move(buffer_flush_schedule_pool);
             delete_schedule_pool = std::move(schedule_pool);
             delete_distributed_schedule_pool = std::move(distributed_schedule_pool);
             delete_message_broker_schedule_pool = std::move(message_broker_schedule_pool);
+
             delete_access_control = std::move(access_control);
 
             /// Stop trace collector if any
@@ -935,10 +939,19 @@ struct ContextSharedPart : boost::noncopyable
         delete_user_defined_sql_objects_storage.reset();
         delete_workload_entity_storage.reset();
         delete_ddl_worker.reset();
-        delete_buffer_flush_schedule_pool.reset();
-        delete_schedule_pool.reset();
-        delete_distributed_schedule_pool.reset();
-        delete_message_broker_schedule_pool.reset();
+
+        auto join_background_pool = [&](BackgroundSchedulePoolPtr && pool_ptr)
+        {
+            if (!pool_ptr)
+                return;
+            pool_ptr->join();
+            pool_ptr.reset();
+        };
+        join_background_pool(std::move(delete_buffer_flush_schedule_pool));
+        join_background_pool(std::move(delete_schedule_pool));
+        join_background_pool(std::move(delete_distributed_schedule_pool));
+        join_background_pool(std::move(delete_message_broker_schedule_pool));
+
         delete_access_control.reset();
 
         total_memory_tracker.resetOvercommitTracker();


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible abort (due to joining threads from the task) and hopefully hungs (in unit tests) during `BackgroundSchedulePool` shutdown

Fixes: https://github.com/ClickHouse/ClickHouse/issues/80066
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/81473