### PR TITLE
Use self-extraction binary in integration tests

### DIFF
--- a/tests/ci/bugfix_validate_check.py
+++ b/tests/ci/bugfix_validate_check.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Sequence, Tuple
 
 from ci_config import CI
-from env_helper import TEMP_PATH
+from env_helper import IS_CI, TEMP_PATH
 from integration_tests_runner import NO_CHANGES_MSG
 from pr_info import PRInfo
 from report import (
@@ -92,9 +92,9 @@ def main():
     logging.basicConfig(level=logging.INFO)
     # args = parse_args()
     stopwatch = Stopwatch()
-    if (
-        CI.Labels.PR_BUGFIX not in PRInfo().labels
-        and CI.Labels.PR_CRITICAL_BUGFIX not in PRInfo().labels
+    pr_info = PRInfo(pr_event_from_api=IS_CI)
+    if not pr_info.labels.intersection(
+        {CI.Labels.PR_BUGFIX, CI.Labels.PR_CRITICAL_BUGFIX}
     ):
         JobReport(
             description="",
@@ -107,17 +107,16 @@ def main():
         return
 
     jobs_to_validate = [
-        #CI.JobNames.STATELESS_TEST_RELEASE,
+        # CI.JobNames.STATELESS_TEST_RELEASE,
         CI.JobNames.INTEGRATION_TEST,
     ]
-    functional_job_report_file = Path(TEMP_PATH) / "functional_test_job_report.json"
-    integration_job_report_file = Path(TEMP_PATH) / "integration_test_job_report.json"
     jobs_report_files = {
-        #CI.JobNames.STATELESS_TEST_RELEASE: functional_job_report_file,
-        CI.JobNames.INTEGRATION_TEST: integration_job_report_file,
+        # CI.JobNames.STATELESS_TEST_RELEASE: Path(TEMP_PATH) / "functional_test_job_report.json"
+        CI.JobNames.INTEGRATION_TEST: Path(TEMP_PATH)
+        / "integration_test_job_report.json"
     }
     jobs_scripts = {
-        #CI.JobNames.STATELESS_TEST_RELEASE: "functional_test_check.py",
+        # CI.JobNames.STATELESS_TEST_RELEASE: "functional_test_check.py",
         CI.JobNames.INTEGRATION_TEST: "integration_test_check.py",
     }
 

--- a/tests/ci/build_download_helper.py
+++ b/tests/ci/build_download_helper.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import platform
 import sys
 import time
 from pathlib import Path
@@ -279,6 +280,25 @@ def download_clickhouse_binary(
     download_builds_filter(
         check_name, reports_path, result_path, lambda x: x.endswith("clickhouse")
     )
+
+
+def download_clickhouse_master(result_path: Path) -> None:
+    if platform.system() not in ("Linux", "Darwin"):
+        raise DownloadException(
+            f"Unsupported platform {platform.system()} for downloading ClickHouse master build"
+        )
+    arch = "amd64"
+    if platform.system() == "Darwin":
+        arch = "macos"
+    if platform.machine() in ("aarch64", "arm64"):
+        arch = "aarch64"
+        if platform.system() == "Darwin":
+            arch = "macos-aarch64"
+
+    url = (
+        f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/{arch}/clickhouse"
+    )
+    download_build_with_progress(url, result_path / "clickhouse")
 
 
 def get_clickhouse_binary_url(

--- a/tests/ci/build_download_helper.py
+++ b/tests/ci/build_download_helper.py
@@ -282,7 +282,7 @@ def download_clickhouse_binary(
     )
 
 
-def download_clickhouse_master(result_path: Path) -> None:
+def download_clickhouse_master(result_path: Path, full: bool = False) -> None:
     if platform.system() not in ("Linux", "Darwin"):
         raise DownloadException(
             f"Unsupported platform {platform.system()} for downloading ClickHouse master build"
@@ -297,6 +297,7 @@ def download_clickhouse_master(result_path: Path) -> None:
 
     url = (
         f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/{arch}/clickhouse"
+        f"{'-full' if full else ''}"
     )
     download_build_with_progress(url, result_path / "clickhouse")
 

--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -6,16 +6,16 @@ import json
 import logging
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
 import integration_tests_runner as runner
-from build_download_helper import download_all_deb_packages
+from build_download_helper import download_clickhouse_binary, download_clickhouse_master
 from ci_config import CI
 from ci_utils import Utils
 from docker_images_helper import DockerImage, get_docker_image
-from download_release_packages import download_last_release
 from env_helper import REPO_COPY, REPORT_PATH, TEMP_PATH
 from integration_test_images import IMAGES
 from pr_info import PRInfo
@@ -55,15 +55,12 @@ def get_json_params_dict(
 
 def get_env_for_runner(
     check_name: str,
-    build_path: Path,
+    binary_path: Path,
     repo_path: Path,
     result_path: Path,
     work_path: Path,
 ) -> Dict[str, str]:
-    binary_path = build_path / "clickhouse"
-
     my_env = os.environ.copy()
-    my_env["CLICKHOUSE_TESTS_BUILD_PATH"] = build_path.as_posix()
     my_env["CLICKHOUSE_TESTS_SERVER_BIN_PATH"] = binary_path.as_posix()
     my_env["CLICKHOUSE_TESTS_CLIENT_BIN_PATH"] = binary_path.as_posix()
     my_env["CLICKHOUSE_TESTS_REPO_PATH"] = repo_path.as_posix()
@@ -191,12 +188,18 @@ def main():
     build_path.mkdir(parents=True, exist_ok=True)
 
     if validate_bugfix_check:
-        download_last_release(build_path, debug=True)
+        download_clickhouse_master(build_path)
     else:
-        download_all_deb_packages(check_name, reports_path, build_path)
+        download_clickhouse_binary(check_name, reports_path, build_path)
+
+    binary_path = build_path / "clickhouse"
+
+    # Set executable bit and run it for self extraction
+    os.chmod(binary_path, 0o755)
+    subprocess.run(f"{binary_path} local 'SELECT version()'", shell=True, check=True)
 
     my_env = get_env_for_runner(
-        check_name, build_path, repo_path, result_path, work_path
+        check_name, binary_path, repo_path, result_path, work_path
     )
 
     json_path = work_path / "params.json"

--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -188,7 +188,7 @@ def main():
     build_path.mkdir(parents=True, exist_ok=True)
 
     if validate_bugfix_check:
-        download_clickhouse_master(build_path)
+        download_clickhouse_master(build_path, full=True)
     else:
         download_clickhouse_binary(check_name, reports_path, build_path)
 

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -297,37 +297,6 @@ class ClickhouseIntegrationTestsRunner:
                     return True
         return False
 
-    def _install_clickhouse(self, debs_path):
-        for package in (
-            "clickhouse-common-static_",
-            "clickhouse-server_",
-            "clickhouse-client",
-            "clickhouse-common-static-dbg_",
-        ):  # order matters
-            logging.info("Installing package %s", package)
-            for f in os.listdir(debs_path):
-                if package in f:
-                    full_path = os.path.join(debs_path, f)
-                    logging.info("Package found in %s", full_path)
-                    log_name = "install_" + f + ".log"
-                    log_path = os.path.join(self.path(), log_name)
-                    cmd = f"dpkg -x {full_path} ."
-                    logging.info("Executing installation cmd %s", cmd)
-                    with TeePopen(cmd, log_file=log_path) as proc:
-                        if proc.wait() == 0:
-                            logging.info("Installation of %s successfull", full_path)
-                        else:
-                            raise RuntimeError(f"Installation of {full_path} failed")
-                    break
-            else:
-                raise FileNotFoundError(f"Package with {package} not found")
-
-        logging.info("All packages installed")
-        os.chmod(CLICKHOUSE_BINARY_PATH, 0o777)
-        shutil.copy(
-            CLICKHOUSE_BINARY_PATH, os.getenv("CLICKHOUSE_TESTS_SERVER_BIN_PATH")  # type: ignore
-        )
-
     @staticmethod
     def _compress_logs(directory, relpaths, result_path):
         retcode = subprocess.call(
@@ -709,7 +678,7 @@ class ClickhouseIntegrationTestsRunner:
 
         return counters, tests_times, log_paths
 
-    def run_flaky_check(self, build_path, should_fail=False):
+    def run_flaky_check(self, should_fail=False):
         pr_info = self.params["pr_info"]
 
         tests_to_run = get_changed_tests_to_run(pr_info, self.repo_path)
@@ -717,7 +686,6 @@ class ClickhouseIntegrationTestsRunner:
             logging.info("No integration tests to run found")
             return "success", NO_CHANGES_MSG, [(NO_CHANGES_MSG, "OK")], ""
 
-        self._install_clickhouse(build_path)
         logging.info("Found '%s' tests to run", " ".join(tests_to_run))
         result_state = "success"
         description_prefix = "No flaky tests: "
@@ -810,15 +778,15 @@ class ClickhouseIntegrationTestsRunner:
 
         return result_state, status_text, test_result, tests_log_paths
 
-    def run_impl(self, build_path):
+    def run_impl(self):
         stopwatch = Stopwatch()
         if self.flaky_check or self.bugfix_validate_check:
             result_state, status_text, test_result, tests_log_paths = (
-                self.run_flaky_check(build_path, should_fail=self.bugfix_validate_check)
+                self.run_flaky_check(should_fail=self.bugfix_validate_check)
             )
         else:
             result_state, status_text, test_result, tests_log_paths = (
-                self.run_normal_check(build_path)
+                self.run_normal_check()
             )
 
         if self.soft_deadline_time < time.time():
@@ -864,8 +832,7 @@ class ClickhouseIntegrationTestsRunner:
         self._tests_by_hash = groups_by_hash[self.run_by_hash_num]
         return self._tests_by_hash
 
-    def run_normal_check(self, build_path):
-        self._install_clickhouse(build_path)
+    def run_normal_check(self):
         logging.info("Pulling images")
         self._pre_pull_images()
         logging.info(
@@ -1013,11 +980,10 @@ def run():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     repo_path = os.environ.get("CLICKHOUSE_TESTS_REPO_PATH", "")
-    build_path = os.environ.get("CLICKHOUSE_TESTS_BUILD_PATH", "")
     result_path = os.environ.get("CLICKHOUSE_TESTS_RESULT_PATH", "")
     params_path = os.environ.get("CLICKHOUSE_TESTS_JSON_PARAMS_PATH", "")
 
-    assert all((repo_path, build_path, result_path, params_path))
+    assert all((repo_path, result_path, params_path))
 
     with open(params_path, "r", encoding="utf-8") as jfd:
         params = json.loads(jfd.read())
@@ -1030,7 +996,7 @@ def run():
         logging.info("Clearing dmesg before run")
         subprocess.check_call("sudo -E dmesg --clear", shell=True)
 
-    state, description, test_results, _test_log_paths = runner.run_impl(build_path)
+    state, description, test_results, _test_log_paths = runner.run_impl()
     logging.info("Tests finished")
 
     if IS_CI:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -51,18 +51,16 @@ except Exception as e:
 import docker
 from dict2xml import dict2xml
 from docker.models.containers import Container
-from .kazoo_client import KazooClientWithImplicitRetries
 from kazoo.exceptions import KazooException
 from minio import Minio
 
 from . import pytest_xdist_logging_to_separate_files
-from .client import QueryRuntimeException
-from .test_tools import assert_eq_with_retry, exec_query_with_retry
-
-from .client import Client
+from .client import Client, QueryRuntimeException
 from .config_cluster import *
+from .kazoo_client import KazooClientWithImplicitRetries
 from .random_settings import write_random_settings_config
 from .retry_decorator import retry
+from .test_tools import assert_eq_with_retry, exec_query_with_retry
 
 HELPERS_DIR = p.dirname(__file__)
 CLICKHOUSE_ROOT_DIR = p.join(p.dirname(__file__), "../../..")
@@ -299,10 +297,12 @@ def run_rabbitmqctl(rabbitmq_id, cookie, command, timeout=90):
         raise RuntimeError(error_message)
     except subprocess.TimeoutExpired as e:
         # Raised if the command times out
-        output = f". Output: {e.stdout.decode(errors='replace')}" if e.stdout is not None else ""
-        raise RuntimeError(
-            f"rabbitmqctl {command} timed out{output}"
+        output = (
+            f". Output: {e.stdout.decode(errors='replace')}"
+            if e.stdout is not None
+            else ""
         )
+        raise RuntimeError(f"rabbitmqctl {command} timed out{output}")
 
 
 def check_rabbitmq_is_available(rabbitmq_id, cookie):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `clickhouse` binary in integrations tests to get unstripped debug symbols.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
