### PR TITLE
normalize NaN values in LowCardinality<float> types

### DIFF
--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -14,6 +14,7 @@
 
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
+#include <Common/NaNUtils.h>
 #include <Columns/ColumnsDateTime.h>
 #include <Columns/ColumnsNumber.h>
 
@@ -343,11 +344,29 @@ size_t ColumnUnique<ColumnType>::getNullValueIndex() const
     return 0;
 }
 
+template <typename>
+struct is_float_vector : std::false_type {};
+
+template <typename T>
+requires is_floating_point<T>
+struct is_float_vector<ColumnVector<T>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_float_vector_v = is_float_vector<T>::value;
+
 template <typename ColumnType>
 size_t ColumnUnique<ColumnType>::uniqueInsert(const Field & x)
 {
     if (x.isNull())
         return getNullValueIndex();
+
+    // NaN can contain different sign or mantissa bits, but we need to consider all NaNs equal.
+    if constexpr (is_float_vector_v<ColumnType>)
+        if (isNaN(x.safeGet<typename ColumnType::ValueType>()))
+        {
+            auto nan = NaNOrZero<typename ColumnType::ValueType>();
+            return uniqueInsertData(reinterpret_cast<char *>(&nan), sizeof(nan));
+        }
 
     auto single_value_column = column_holder->cloneEmpty();
     single_value_column->insert(x);
@@ -371,6 +390,15 @@ bool ColumnUnique<ColumnType>::tryUniqueInsert(const Field & x, size_t & index)
     if (!single_value_column->tryInsert(x))
         return false;
 
+    // NaN can contain different sign or mantissa bits, but we need to consider all NaNs equal.
+    if constexpr (is_float_vector_v<ColumnType>)
+        if (isNaN(x.safeGet<typename ColumnType::ValueType>()))
+        {
+            auto nan = NaNOrZero<typename ColumnType::ValueType>();
+            index = uniqueInsertData(reinterpret_cast<char *>(&nan), sizeof(nan));
+            return true;
+        }
+
     auto single_value_data = single_value_column->getDataAt(0);
     index = uniqueInsertData(single_value_data.data, single_value_data.size);
     return true;
@@ -384,6 +412,14 @@ size_t ColumnUnique<ColumnType>::uniqueInsertFrom(const IColumn & src, size_t n)
 
     if (const auto * nullable = checkAndGetColumn<ColumnNullable>(&src))
         return uniqueInsertFrom(nullable->getNestedColumn(), n);
+
+    // NaN can contain different sign or mantissa bits, but we need to consider all NaNs equal.
+    if constexpr (is_float_vector_v<ColumnType>)
+        if (isNaN(src.getFloat64(n)))
+        {
+            auto nan = NaNOrZero<typename ColumnType::ValueType>();
+            return uniqueInsertData(reinterpret_cast<char *>(&nan), sizeof(nan));
+        }
 
     auto ref = src.getDataAt(n);
     return uniqueInsertData(ref.data, ref.size);

--- a/src/Common/NaNUtils.h
+++ b/src/Common/NaNUtils.h
@@ -43,8 +43,9 @@ T NaNOrZero()
 {
     if constexpr (std::is_floating_point_v<T>)
         return std::numeric_limits<T>::quiet_NaN();
-    else
-        return {};
+    if constexpr (std::is_same_v<T, BFloat16>)
+        return BFloat16(std::numeric_limits<Float32>::quiet_NaN());
+    return {};
 }
 
 template <typename T>

--- a/tests/queries/0_stateless/03566_low_cardinality_nan_unique.reference
+++ b/tests/queries/0_stateless/03566_low_cardinality_nan_unique.reference
@@ -1,0 +1,12 @@
+float 32
+nan	1
+nan	2
+nan	3
+float 64
+nan	1
+nan	2
+nan	3
+bfloat 16
+nan	1
+nan	2
+nan	3

--- a/tests/queries/0_stateless/03566_low_cardinality_nan_unique.sql
+++ b/tests/queries/0_stateless/03566_low_cardinality_nan_unique.sql
@@ -1,0 +1,16 @@
+SET allow_suspicious_low_cardinality_types=1;
+
+SELECT 'float 32';
+CREATE TABLE table_f32 (c0 LowCardinality(Float32), c1 Int) ENGINE = MergeTree() ORDER BY (c0, c1);
+INSERT INTO table_f32 VALUES (nan, 3), (-nan, 2), (nan, 1);
+SELECT * FROM table_f32 ORDER BY all;
+
+SELECT 'float 64';
+CREATE TABLE table_f64 (c0 LowCardinality(Float64), c1 Int) ENGINE = MergeTree() ORDER BY (c0, c1);
+INSERT INTO table_f64 VALUES (nan, 3), (-nan, 2), (nan, 1);
+SELECT * FROM table_f64 ORDER BY all;
+
+SELECT 'bfloat 16';
+CREATE TABLE table_f16 (c0 LowCardinality(BFloat16), c1 Int) ENGINE = MergeTree() ORDER BY (c0, c1);
+INSERT INTO table_f16 VALUES (nan, 3), (-nan, 2), (nan, 1);
+SELECT * FROM table_f16 ORDER BY all;


### PR DESCRIPTION
Fixes: #80803
Different NaN representations in `LowCardiality(Float)` are considered not equal ranges during sorting by multiple columns

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix sort of NaN values in `LowCardinality(Float32|Float64|BFloat16)` type

