### PR TITLE
Increase timeout for `test_ttl_compatibility` under sanitizers

### DIFF
--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -97,6 +97,10 @@ def test_ttl_columns(started_cluster):
         expected
     )
 
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table_name} SYNC")
+
 
 def test_merge_with_ttl_timeout(started_cluster):
     table = f"test_merge_with_ttl_timeout_{node1.name}_{node2.name}"
@@ -148,6 +152,10 @@ def test_merge_with_ttl_timeout(started_cluster):
         node2, "SELECT countIf(a = 0) FROM {table}".format(table=table), "3\n"
     )
 
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")
+
 
 def test_ttl_many_columns(started_cluster):
     table = f"test_ttl_2{node1.name}_{node2.name}"
@@ -198,6 +206,10 @@ def test_ttl_many_columns(started_cluster):
         node2.query(f"SELECT id, a, _idx, _offset, _partition FROM {table} ORDER BY id")
     ) == TSV(expected)
 
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")
+
 
 @pytest.mark.parametrize(
     "delete_suffix",
@@ -227,6 +239,10 @@ def test_ttl_table(started_cluster, delete_suffix):
 
     assert TSV(node1.query(f"SELECT * FROM {table}")) == TSV("")
     assert TSV(node2.query(f"SELECT * FROM {table}")) == TSV("")
+
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")
 
 
 def test_modify_ttl(started_cluster):
@@ -262,6 +278,10 @@ def test_modify_ttl(started_cluster):
     )
     assert node2.query(f"SELECT id FROM {table}") == ""
 
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")
+
 
 def test_modify_column_ttl(started_cluster):
     table = f"test_modify_column_ttl_{node1.name}_{node2.name}"
@@ -295,6 +315,10 @@ def test_modify_column_ttl(started_cluster):
         f"ALTER TABLE {table} MODIFY COLUMN id UInt32 TTL d + INTERVAL 30 MINUTE SETTINGS replication_alter_partitions_sync = 2"
     )
     assert node2.query(f"SELECT id FROM {table}") == "42\n42\n42\n"
+
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")
 
 
 def test_ttl_double_delete_rule_returns_error(started_cluster):
@@ -412,6 +436,9 @@ def test_ttl_alter_delete(started_cluster, name, engine):
     ).splitlines()
     assert r == ["\t0", "\t0", "hello2\t2"]
 
+    # Cleanup
+    node1.query(f"DROP TABLE {name} SYNC")
+
 
 def test_ttl_empty_parts(started_cluster):
     for node in [node1, node2]:
@@ -499,6 +526,10 @@ def test_ttl_empty_parts(started_cluster):
     )
     assert not node1.contains_in_log(error_msg)
     assert not node2.contains_in_log(error_msg)
+
+    # Cleanup
+    for node in [node1, node2]:
+        node.query("DROP TABLE test_ttl_empty_parts SYNC")
 
 
 @pytest.mark.parametrize(
@@ -608,3 +639,9 @@ def test_ttl_compatibility(started_cluster, node_left, node_right, num_run):
 
     assert node_left.query(f"SELECT id FROM {table}_where ORDER BY id") == "2\n4\n"
     assert node_right.query(f"SELECT id FROM {table}_where ORDER BY id") == "2\n4\n"
+
+    # Cleanup
+    for node in [node_left, node_right]:
+        node.query(f"DROP TABLE {table}_delete SYNC")
+        node.query(f"DROP TABLE {table}_group_by SYNC")
+        node.query(f"DROP TABLE {table}_where SYNC")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Increase timeout for test_ttl_compatibility under sanitizers

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

### Failing reports
[play query](https://play.clickhouse.com/play?user=play#CldJVEgKICAgICd0ZXN0X3R0bF9yZXBsaWNhdGVkL3Rlc3QucHk6OnRlc3RfdHRsX2NvbXBhdGliaWxpdHknIEFTIG5hbWVfc3Vic3RyLAogICAgKCdTdGF0ZWxlc3MgdGVzdHMgKGFzYW4pJywgJ1N0YXRlbGVzcyB0ZXN0cyAoYWRkcmVzcyknLCAnU3RhdGVsZXNzIHRlc3RzIChhZGRyZXNzLCBhY3Rpb25zKScsICdJbnRlZ3JhdGlvbiB0ZXN0cyAoYXNhbikgWzEvM10nLCAnU3RhdGVsZXNzIHRlc3RzICh0c2FuKSBbMS8zXScpIEFTIGJhY2twb3J0X2FuZF9yZWxlYXNlX3NwZWNpZmljX2NoZWNrcwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkLAogICAgY291bnQoKSwKICAgIGdyb3VwVW5pcUFycmF5KHB1bGxfcmVxdWVzdF9udW1iZXIpIEFTIHBycywKICAgIGFueShyZXBvcnRfdXJsKQpGUk9NIGNoZWNrcwpXSEVSRSAoY2hlY2tfc3RhcnRfdGltZSBCRVRXRUVOICcyMDI1LTA2LTAxJyBBTkQgJzIwMjUtMDctMTUnKSBBTkQgKHB1bGxfcmVxdWVzdF9udW1iZXIgTk9UIElOICgKICAgIFNFTEVDVCBwdWxsX3JlcXVlc3RfbnVtYmVyIEFTIHBybgogICAgRlJPTSBjaGVja3MKICAgIFdIRVJFIChwcm4gIT0gMCkgQU5EIChjaGVja19zdGFydF90aW1lIEJFVFdFRU4gJzIwMjUtMDYtMDEnIEFORCAnMjAyNS0wNy0xNScpIEFORCAoY2hlY2tfbmFtZSBJTiAoYmFja3BvcnRfYW5kX3JlbGVhc2Vfc3BlY2lmaWNfY2hlY2tzKSkKKSkgQU5EIChwb3NpdGlvbih0ZXN0X25hbWUsIG5hbWVfc3Vic3RyKSA+IDApIEFORCAodGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJywgJ0ZMQUtZJykpCkdST1VQIEJZIGQKT1JERVIgQlkgZCBERVNDCg==)