### PR TITLE
03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh reduce noise in logs

### DIFF
--- a/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
+++ b/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
@@ -85,7 +85,7 @@ export -f optimize_thread;
 export -f insert_thread;
 
 
-TIMEOUT=20
+TIMEOUT=10
 
 # Sometimes we detach and attach tables
 timeout $TIMEOUT bash -c alter_thread 2> /dev/null &
@@ -102,10 +102,7 @@ timeout $TIMEOUT bash -c select_thread 2> /dev/null &
 
 timeout $TIMEOUT bash -c optimize_thread 2> /dev/null &
 timeout $TIMEOUT bash -c optimize_thread 2> /dev/null &
-timeout $TIMEOUT bash -c optimize_thread 2> /dev/null &
 
-timeout $TIMEOUT bash -c insert_thread 2> /dev/null &
-timeout $TIMEOUT bash -c insert_thread 2> /dev/null &
 timeout $TIMEOUT bash -c insert_thread 2> /dev/null &
 timeout $TIMEOUT bash -c insert_thread 2> /dev/null &
 timeout $TIMEOUT bash -c insert_thread 2> /dev/null &


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix spamming logs with messages like this one:
`2025.07.15 14:05:47.882005 [ 1992 ] {BgSchPool::dfd18127-a457-4f61-adb8-af412cb095a3} <Trace> test_3g8t3hxy.concurrent_alter_add_drop_steroids_3 (f174e04a-4ff4-406b-a43e-46553889e0d1) (MergerMutator): Nothing to merge in partition all with max_merge_sizes = [63.09 GiB] (looked up 2 ranges)`

Fixes FAIL in 00002_log_and_exception_messages_formatting:
```
~~~
Reason: result differs with reference: ~~
-noisy Trace messages	0.16	 2025-07-15 14:45:23
+noisy Trace messages	0.16163241539989015	Nothing to merge in partition {} with max_merge_sizes = {} (looked up {} ranges)
~~~
```
<br class="Apple-interchange-newline">

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
