### PR TITLE
Enable join step logical for parallel replicas

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -2151,7 +2151,7 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
 
     const auto & query_context = planner_context->getQueryContext();
     const auto & settings = query_context->getSettingsRef();
-    if (!settings[Setting::query_plan_use_new_logical_join_step] || settings[Setting::allow_experimental_parallel_reading_from_replicas])
+    if (!settings[Setting::query_plan_use_new_logical_join_step])
         return buildQueryPlanForJoinNodeLegacy(
             join_table_expression, std::move(left_join_tree_query_plan), std::move(right_join_tree_query_plan), outer_scope_columns, planner_context, select_query_info);
 

--- a/tests/queries/0_stateless/02967_parallel_replicas_joins_and_analyzer.reference
+++ b/tests/queries/0_stateless/02967_parallel_replicas_joins_and_analyzer.reference
@@ -157,25 +157,26 @@ select * from sub5 order by x;
 Expression
   Sorting
     Expression
-      Join
-        Union
-          Expression
+      Expression
+        Join
+          Union
             Expression
               Expression
-                Join
-                  Expression
+                Expression
+                  Join
                     Expression
-                      ReadFromMergeTree
-                  Expression
-                    ReadFromMemoryStorage
-          Expression
-            ReadFromRemoteParallelReplicas
-        Union
-          Expression
+                      Expression
+                        ReadFromMergeTree
+                    Expression
+                      ReadFromMemoryStorage
             Expression
-              ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
+              ReadFromRemoteParallelReplicas
+          Union
+            Expression
+              Expression
+                ReadFromMergeTree
+            Expression
+              ReadFromRemoteParallelReplicas
 --
 -- ORDER BY in sub1 : sub1 -> WithMergableStage
 with sub1 as (select x, y from tab1 where x != 2 order by y),
@@ -209,28 +210,30 @@ select * from sub5 order by x;
 Expression
   Sorting
     Expression
-      Join
-        Expression
-          Join
-            Union
-              Expression
-                Expression
-                  Expression
-                    ReadFromMergeTree
-              Expression
-                ReadFromRemoteParallelReplicas
-            Union
-              Expression
-                Expression
-                  ReadFromMergeTree
-              Expression
-                ReadFromRemoteParallelReplicas
-        Union
+      Expression
+        Join
           Expression
             Expression
-              ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
+              Join
+                Union
+                  Expression
+                    Expression
+                      Expression
+                        ReadFromMergeTree
+                  Expression
+                    ReadFromRemoteParallelReplicas
+                Union
+                  Expression
+                    Expression
+                      ReadFromMergeTree
+                  Expression
+                    ReadFromRemoteParallelReplicas
+          Union
+            Expression
+              Expression
+                ReadFromMergeTree
+            Expression
+              ReadFromRemoteParallelReplicas
 --
 -- RIGHT JOIN in sub3: sub3 -> WithMergableStage
 with sub1 as (select x, y from tab1 where x != 2),
@@ -419,30 +422,32 @@ SETTINGS enable_parallel_replicas = 1, parallel_replicas_allow_in_with_subquery 
 Expression
   Sorting
     Expression
-      Join
-        Expression
-          Join
-            Expression
-              CreatingSets
-                Expression
-                  Expression
-                    ReadFromMergeTree
-                CreatingSet
-                  Expression
-                    Filter
-                      ReadFromSystemNumbers
-            Union
-              Expression
-                Expression
-                  ReadFromMergeTree
-              Expression
-                ReadFromRemoteParallelReplicas
-        Union
+      Expression
+        Join
           Expression
             Expression
-              ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
+              Join
+                Expression
+                  CreatingSets
+                    Expression
+                      Expression
+                        ReadFromMergeTree
+                    CreatingSet
+                      Expression
+                        Filter
+                          ReadFromSystemNumbers
+                Union
+                  Expression
+                    Expression
+                      ReadFromMergeTree
+                  Expression
+                    ReadFromRemoteParallelReplicas
+          Union
+            Expression
+              Expression
+                ReadFromMergeTree
+            Expression
+              ReadFromRemoteParallelReplicas
 set parallel_replicas_prefer_local_join = 1;
 -- A query with only INNER/LEFT joins is fully send to replicas. JOIN is executed in GLOBAL mode.
 select x, y, r.y, z, rr.z, a from (select l.x, l.y, r.y, r.z as z from (select x, y from tab1 where x != 2) l any left join (select y, z from tab2 where y != 4) r on l.y = r.y) ll any left join (select z, a from tab3 where z != 8) rr on ll.z = rr.z order by x;
@@ -606,26 +611,27 @@ select * from sub5 order by x;
 Expression
   Sorting
     Expression
-      Join
-        Union
-          Expression
+      Expression
+        Join
+          Union
             Expression
               Expression
-                Join
-                  Expression
+                Expression
+                  Join
                     Expression
-                      ReadFromMergeTree
-                  Expression
+                      Expression
+                        ReadFromMergeTree
                     Expression
-                      ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
-        Union
-          Expression
+                      Expression
+                        ReadFromMergeTree
             Expression
-              ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
+              ReadFromRemoteParallelReplicas
+          Union
+            Expression
+              Expression
+                ReadFromMergeTree
+            Expression
+              ReadFromRemoteParallelReplicas
 --
 -- ORDER BY in sub1 : sub1 -> WithMergableStage
 with sub1 as (select x, y from tab1 where x != 2 order by y),
@@ -659,28 +665,30 @@ select * from sub5 order by x;
 Expression
   Sorting
     Expression
-      Join
-        Expression
-          Join
-            Union
-              Expression
-                Expression
-                  Expression
-                    ReadFromMergeTree
-              Expression
-                ReadFromRemoteParallelReplicas
-            Union
-              Expression
-                Expression
-                  ReadFromMergeTree
-              Expression
-                ReadFromRemoteParallelReplicas
-        Union
+      Expression
+        Join
           Expression
             Expression
-              ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
+              Join
+                Union
+                  Expression
+                    Expression
+                      Expression
+                        ReadFromMergeTree
+                  Expression
+                    ReadFromRemoteParallelReplicas
+                Union
+                  Expression
+                    Expression
+                      ReadFromMergeTree
+                  Expression
+                    ReadFromRemoteParallelReplicas
+          Union
+            Expression
+              Expression
+                ReadFromMergeTree
+            Expression
+              ReadFromRemoteParallelReplicas
 --
 -- RIGHT JOIN in sub3: sub3 -> WithMergableStage
 with sub1 as (select x, y from tab1 where x != 2),
@@ -874,27 +882,29 @@ SETTINGS enable_parallel_replicas = 1, parallel_replicas_allow_in_with_subquery 
 Expression
   Sorting
     Expression
-      Join
-        Expression
-          Join
-            Expression
-              CreatingSets
-                Expression
-                  Expression
-                    ReadFromMergeTree
-                CreatingSet
-                  Expression
-                    Filter
-                      ReadFromSystemNumbers
-            Union
-              Expression
-                Expression
-                  ReadFromMergeTree
-              Expression
-                ReadFromRemoteParallelReplicas
-        Union
+      Expression
+        Join
           Expression
             Expression
-              ReadFromMergeTree
-          Expression
-            ReadFromRemoteParallelReplicas
+              Join
+                Expression
+                  CreatingSets
+                    Expression
+                      Expression
+                        ReadFromMergeTree
+                    CreatingSet
+                      Expression
+                        Filter
+                          ReadFromSystemNumbers
+                Union
+                  Expression
+                    Expression
+                      ReadFromMergeTree
+                  Expression
+                    ReadFromRemoteParallelReplicas
+          Union
+            Expression
+              Expression
+                ReadFromMergeTree
+            Expression
+              ReadFromRemoteParallelReplicas


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Joins with parallel replicas now use the join logical step. In case of any issues with join queries using parallel replicas, try `SET query_plan_use_new_logical_join_step=0` and report an issue.