### PR TITLE
estimate cardinality by statistics

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -791,7 +791,7 @@ ConditionSelectivityEstimator MergeTreeData::getConditionSelectivityEstimatorByP
             /// TODO: We only have one stats file for every part.
             estimator.incrementRowCount(part.data_part->rows_count);
             for (const auto & stat : stats)
-                estimator.addStatistics(part.data_part->info.getPartNameV1(), stat);
+                estimator.addStatistics(stat);
         }
         catch (...)
         {
@@ -808,7 +808,7 @@ ConditionSelectivityEstimator MergeTreeData::getConditionSelectivityEstimatorByP
                 auto stats = part.data_part->loadStatistics();
                 estimator.incrementRowCount(part.data_part->rows_count);
                 for (const auto & stat : stats)
-                    estimator.addStatistics(part.data_part->info.getPartNameV1(), stat);
+                    estimator.addStatistics(stat);
             }
         }
         catch (...)

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -317,7 +317,7 @@ void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTree
         {
             cond.good = cond.viable;
 
-            cond.estimated_row_count = estimator.estimateRowCount(node);
+            cond.estimated_row_count = estimator.estimateRelationProfile(node).rows;
 
             if (node.getASTNode() != nullptr)
                 LOG_DEBUG(log, "Condition {} has estimated row count {}", node.getASTNode()->dumpTree(), cond.estimated_row_count);

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -602,10 +602,10 @@ static ExecuteTTLType shouldExecuteTTL(const StorageMetadataPtr & metadata_snaps
     return has_ttl_expression ? ExecuteTTLType::RECALCULATE : ExecuteTTLType::NONE;
 }
 
-static std::set<ColumnStatisticsPartPtr> getStatisticsToRecalculate(const StorageMetadataPtr & metadata_snapshot, const NameSet & materialized_stats)
+static std::set<ColumnStatisticsPtr> getStatisticsToRecalculate(const StorageMetadataPtr & metadata_snapshot, const NameSet & materialized_stats)
 {
     const auto & stats_factory = MergeTreeStatisticsFactory::instance();
-    std::set<ColumnStatisticsPartPtr> stats_to_recalc;
+    std::set<ColumnStatisticsPtr> stats_to_recalc;
     const auto & columns = metadata_snapshot->getColumns();
     for (const auto & col_desc : columns)
     {
@@ -725,7 +725,7 @@ static NameSet collectFilesToSkip(
     const std::set<MergeTreeIndexPtr> & indices_to_recalc,
     const String & mrk_extension,
     const std::vector<ProjectionDescriptionRawPtr> & projections_to_skip,
-    const std::set<ColumnStatisticsPartPtr> & stats_to_recalc,
+    const std::set<ColumnStatisticsPtr> & stats_to_recalc,
     const NameSet & updated_columns_in_patches)
 {
     NameSet files_to_skip = source_part->getFileNamesWithoutChecksums();
@@ -1115,7 +1115,7 @@ struct MutationContext
     IMergeTreeDataPart::MinMaxIndexPtr minmax_idx;
 
     std::set<MergeTreeIndexPtr> indices_to_recalc;
-    std::set<ColumnStatisticsPartPtr> stats_to_recalc;
+    std::set<ColumnStatisticsPtr> stats_to_recalc;
     std::set<ProjectionDescriptionRawPtr> projections_to_recalc;
     MergeTreeData::DataPart::Checksums existing_indices_stats_checksums;
     NameSet files_to_skip;

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -15,7 +15,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-Float64 ConditionSelectivityEstimator::estimateRowCount(const RPNBuilderTreeNode & node) const
+RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(const RPNBuilderTreeNode & node) const
 {
     std::vector<RPNElement> rpn = RPNBuilder<RPNElement>(node, [&](const RPNBuilderTreeNode & node_, RPNElement & out)
     {
@@ -89,7 +89,14 @@ Float64 ConditionSelectivityEstimator::estimateRowCount(const RPNBuilderTreeNode
     }
     auto* final_element = rpn_stack.top();
     final_element->finalize(column_estimators);
-    return final_element->selectivity * total_rows;
+    RelationProfile result;
+    result.rows = final_element->selectivity * total_rows;
+    for (const auto & [column_name, estimator] : column_estimators)
+    {
+        Float64 cardinality = std::min(result.rows, estimator.estimateCardinality());
+        result.column_profile.emplace(column_name, cardinality);
+    }
+    return result;
 }
 
 bool ConditionSelectivityEstimator::extractAtomFromTree(const RPNBuilderTreeNode & node, RPNElement & out) const
@@ -158,32 +165,37 @@ void ConditionSelectivityEstimator::incrementRowCount(UInt64 rows)
     total_rows += rows;
 }
 
-void ConditionSelectivityEstimator::addStatistics(String part_name, ColumnStatisticsPartPtr column_stat)
+void ConditionSelectivityEstimator::addStatistics(ColumnStatisticsPtr column_stat)
 {
     if (column_stat != nullptr)
-        column_estimators[column_stat->columnName()].addStatistics(part_name, column_stat);
+        column_estimators[column_stat->columnName()].addStatistics(column_stat);
 }
 
-void ConditionSelectivityEstimator::ColumnSelectivityEstimator::addStatistics(String part_name, ColumnStatisticsPartPtr stats)
+void ConditionSelectivityEstimator::ColumnEstimator::addStatistics(ColumnStatisticsPtr other_stats)
 {
-    if (part_statistics.contains(part_name))
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "part {} has been added in column {}", part_name, stats->columnName());
-    part_statistics[part_name] = stats;
-}
-
-Float64 ConditionSelectivityEstimator::ColumnSelectivityEstimator::estimateRanges(const PlainRanges & ranges) const
-{
-    Float64 partial_cnt = 0;
-    Float64 result = 0;
-    for (const auto & [key, estimator] : part_statistics)
+    /// if (part_statistics.contains(part_name))
+    ///     throw Exception(ErrorCodes::LOGICAL_ERROR, "part {} has been added in column {}", part_name, stats->columnName());
+    if (stats == nullptr)
     {
-        for (const Range & range : ranges.ranges)
-        {
-            result += estimator->estimateRange(range);
-        }
-        partial_cnt += estimator->rowCount();
+        stats = other_stats;
+        return;
     }
-    return result / partial_cnt;
+    stats->merge(other_stats);
+}
+
+Float64 ConditionSelectivityEstimator::ColumnEstimator::estimateRanges(const PlainRanges & ranges) const
+{
+    Float64 result = 0;
+    for (const Range & range : ranges.ranges)
+    {
+        result += stats->estimateRange(range);
+    }
+    return result / stats->rowCount();
+}
+
+Float64 ConditionSelectivityEstimator::ColumnEstimator::estimateCardinality() const
+{
+    return stats->estimateCardinality();
 }
 
 const ConditionSelectivityEstimator::AtomMap ConditionSelectivityEstimator::atom_map

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -70,10 +70,6 @@ private:
 
     struct ColumnEstimator
     {
-        /// We store the part_name and part_statistics.
-        /// then simply get selectivity for every part_statistics and combine them.
-        /// std::map<String, ColumnStatisticsPartPtr> part_statistics;
-
         ColumnStatisticsPtr stats;
 
         void addStatistics(ColumnStatisticsPtr other_stats);

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -60,16 +60,35 @@ IStatistics::IStatistics(const SingleStatisticsDescription & stat_)
 {
 }
 
-ColumnPartStatistics::ColumnPartStatistics(const ColumnStatisticsDescription & stats_desc_, const String & column_name_)
+ColumnStatistics::ColumnStatistics(const ColumnStatisticsDescription & stats_desc_, const String & column_name_)
     : stats_desc(stats_desc_), column_name(column_name_)
 {
 }
 
-void ColumnPartStatistics::build(const ColumnPtr & column)
+void ColumnStatistics::build(const ColumnPtr & column)
 {
     rows += column->size();
     for (const auto & stat : stats)
         stat.second->build(column);
+}
+
+void ColumnStatistics::merge(const ColumnStatisticsPtr & other)
+{
+    rows += other->rows;
+    for (const auto & stat_it : stats)
+    {
+        if (other->stats.contains(stat_it.first))
+        {
+            stat_it.second->merge(other->stats.at(stat_it.first));
+        }
+    }
+    for (const auto & stat_it : other->stats)
+    {
+        if (!stats.contains(stat_it.first))
+        {
+            stats.insert(stat_it);
+        }
+    }
 }
 
 UInt64 IStatistics::estimateCardinality() const
@@ -104,7 +123,7 @@ Float64 IStatistics::estimateRange(const Range & /*range*/) const
 /// Sometimes, it is possible to combine multiple statistics in a clever way. For that reason, all estimation are performed in a central
 /// place (here), and we don't simply pass the predicate to the first statistics object that supports it natively.
 
-Float64 ColumnPartStatistics::estimateLess(const Field & val) const
+Float64 ColumnStatistics::estimateLess(const Field & val) const
 {
     if (stats.contains(StatisticsType::TDigest))
         return stats.at(StatisticsType::TDigest)->estimateLess(val);
@@ -113,12 +132,12 @@ Float64 ColumnPartStatistics::estimateLess(const Field & val) const
     return rows * ConditionSelectivityEstimator::default_cond_range_factor;
 }
 
-Float64 ColumnPartStatistics::estimateGreater(const Field & val) const
+Float64 ColumnStatistics::estimateGreater(const Field & val) const
 {
     return rows - estimateLess(val);
 }
 
-Float64 ColumnPartStatistics::estimateEqual(const Field & val) const
+Float64 ColumnStatistics::estimateEqual(const Field & val) const
 {
     if (stats_desc.data_type->isValueRepresentedByNumber() && stats.contains(StatisticsType::Uniq) && stats.contains(StatisticsType::TDigest))
     {
@@ -145,7 +164,7 @@ Float64 ColumnPartStatistics::estimateEqual(const Field & val) const
     return rows * ConditionSelectivityEstimator::default_cond_equal_factor;
 }
 
-Float64 ColumnPartStatistics::estimateRange(const Range & range) const
+Float64 ColumnStatistics::estimateRange(const Range & range) const
 {
     if (range.empty())
     {
@@ -177,9 +196,18 @@ Float64 ColumnPartStatistics::estimateRange(const Range & range) const
     return right_count - left_count;
 }
 
+UInt64 ColumnStatistics::estimateCardinality() const
+{
+    if (stats.contains(StatisticsType::Uniq))
+    {
+        return stats.at(StatisticsType::Uniq)->estimateCardinality();
+    }
+    return UInt64(rows * rows * ConditionSelectivityEstimator::default_cardinality_ratio);
+}
+
 /// -------------------------------------
 
-void ColumnPartStatistics::serialize(WriteBuffer & buf)
+void ColumnStatistics::serialize(WriteBuffer & buf)
 {
     writeIntBinary(V0, buf);
 
@@ -196,7 +224,7 @@ void ColumnPartStatistics::serialize(WriteBuffer & buf)
         stat_ptr->serialize(buf);
 }
 
-void ColumnPartStatistics::deserialize(ReadBuffer &buf)
+void ColumnStatistics::deserialize(ReadBuffer &buf)
 {
     UInt16 version;
     readIntBinary(version, buf);
@@ -222,17 +250,17 @@ void ColumnPartStatistics::deserialize(ReadBuffer &buf)
     }
 }
 
-String ColumnPartStatistics::getFileName() const
+String ColumnStatistics::getFileName() const
 {
     return STATS_FILE_PREFIX + columnName();
 }
 
-const String & ColumnPartStatistics::columnName() const
+const String & ColumnStatistics::columnName() const
 {
     return column_name;
 }
 
-UInt64 ColumnPartStatistics::rowCount() const
+UInt64 ColumnStatistics::rowCount() const
 {
     return rows;
 }
@@ -283,9 +311,9 @@ void MergeTreeStatisticsFactory::validate(const ColumnStatisticsDescription & st
     }
 }
 
-ColumnStatisticsPartPtr MergeTreeStatisticsFactory::get(const ColumnDescription & column_desc) const
+ColumnStatisticsPtr MergeTreeStatisticsFactory::get(const ColumnDescription & column_desc) const
 {
-    ColumnStatisticsPartPtr column_stat = std::make_shared<ColumnPartStatistics>(column_desc.statistics, column_desc.name);
+    ColumnStatisticsPtr column_stat = std::make_shared<ColumnStatistics>(column_desc.statistics, column_desc.name);
     for (const auto & [type, desc] : column_desc.statistics.types_to_desc)
     {
         auto it = creators.find(type);

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -77,9 +77,9 @@ void ColumnStatistics::merge(const ColumnStatisticsPtr & other)
     rows += other->rows;
     for (const auto & stat_it : stats)
     {
-        if (other->stats.contains(stat_it.first))
+        if (auto it = other->stats.find(stat_it.first); it != other->stats.end())
         {
-            stat_it.second->merge(other->stats.at(stat_it.first));
+            stat_it.second->merge(it->second);
         }
     }
     for (const auto & stat_it : other->stats)
@@ -202,7 +202,8 @@ UInt64 ColumnStatistics::estimateCardinality() const
     {
         return stats.at(StatisticsType::Uniq)->estimateCardinality();
     }
-    return UInt64(rows * rows * ConditionSelectivityEstimator::default_cardinality_ratio);
+    /// if we don't have uniq statistics, we use a mock one, assuming there are 90% different unique values.
+    return UInt64(rows * ConditionSelectivityEstimator::default_cardinality_ratio);
 }
 
 /// -------------------------------------

--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -63,6 +63,12 @@ void StatisticsCountMinSketch::build(const ColumnPtr & column)
     }
 }
 
+void StatisticsCountMinSketch::merge(const StatisticsPtr & other_stats)
+{
+    const StatisticsCountMinSketch * other = typeid_cast<const StatisticsCountMinSketch *>(other_stats.get());
+    sketch.merge(other->sketch);
+}
+
 void StatisticsCountMinSketch::serialize(WriteBuffer & buf)
 {
     Sketch::vector_bytes bytes = sketch.serialize();

--- a/src/Storages/Statistics/StatisticsCountMinSketch.h
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.h
@@ -19,6 +19,7 @@ public:
     Float64 estimateEqual(const Field & val) const override;
 
     void build(const ColumnPtr & column) override;
+    void merge(const StatisticsPtr & other_stats) override;
 
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;

--- a/src/Storages/Statistics/StatisticsMinMax.cpp
+++ b/src/Storages/Statistics/StatisticsMinMax.cpp
@@ -35,6 +35,13 @@ void StatisticsMinMax::build(const ColumnPtr & column)
     row_count += column->size();
 }
 
+void StatisticsMinMax::merge(const StatisticsPtr & other_stats)
+{
+    const StatisticsMinMax * other = typeid_cast<const StatisticsMinMax *>(other_stats.get());
+    min = std::min(min, other->min);
+    max = std::max(max, other->max);
+}
+
 void StatisticsMinMax::serialize(WriteBuffer & buf)
 {
     writeIntBinary(row_count, buf);

--- a/src/Storages/Statistics/StatisticsMinMax.h
+++ b/src/Storages/Statistics/StatisticsMinMax.h
@@ -13,6 +13,7 @@ public:
     StatisticsMinMax(const SingleStatisticsDescription & statistics_description, const DataTypePtr & data_type_);
 
     void build(const ColumnPtr & column) override;
+    void merge(const StatisticsPtr & other_stats) override;
 
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;

--- a/src/Storages/Statistics/StatisticsTDigest.cpp
+++ b/src/Storages/Statistics/StatisticsTDigest.cpp
@@ -27,6 +27,12 @@ void StatisticsTDigest::build(const ColumnPtr & column)
     }
 }
 
+void StatisticsTDigest::merge(const StatisticsPtr & other_stats)
+{
+    const StatisticsTDigest * other = typeid_cast<const StatisticsTDigest*>(other_stats.get());
+    t_digest.merge(other->t_digest);
+}
+
 void StatisticsTDigest::serialize(WriteBuffer & buf)
 {
     t_digest.serialize(buf);

--- a/src/Storages/Statistics/StatisticsTDigest.h
+++ b/src/Storages/Statistics/StatisticsTDigest.h
@@ -12,6 +12,7 @@ public:
     explicit StatisticsTDigest(const SingleStatisticsDescription & description, const DataTypePtr & data_type_);
 
     void build(const ColumnPtr & column) override;
+    void merge(const StatisticsPtr & other_stats) override;
 
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;

--- a/src/Storages/Statistics/StatisticsUniq.cpp
+++ b/src/Storages/Statistics/StatisticsUniq.cpp
@@ -35,6 +35,12 @@ void StatisticsUniq::build(const ColumnPtr & column)
     collector->addBatchSinglePlace(0, column->size(), data, &(raw_ptr), nullptr);
 }
 
+void StatisticsUniq::merge(const StatisticsPtr & other_stats)
+{
+    const StatisticsUniq * other = typeid_cast<const StatisticsUniq *>(other_stats.get());
+    collector->merge(data, other->data, arena.get());
+}
+
 void StatisticsUniq::serialize(WriteBuffer & buf)
 {
     collector->serialize(data, buf);
@@ -46,6 +52,7 @@ void StatisticsUniq::deserialize(ReadBuffer & buf)
 }
 
 UInt64 StatisticsUniq::estimateCardinality() const
+
 {
     auto column = DataTypeUInt64().createColumn();
     collector->insertResultInto(data, *column, nullptr);

--- a/src/Storages/Statistics/StatisticsUniq.cpp
+++ b/src/Storages/Statistics/StatisticsUniq.cpp
@@ -52,7 +52,6 @@ void StatisticsUniq::deserialize(ReadBuffer & buf)
 }
 
 UInt64 StatisticsUniq::estimateCardinality() const
-
 {
     auto column = DataTypeUInt64().createColumn();
     collector->insertResultInto(data, *column, nullptr);

--- a/src/Storages/Statistics/StatisticsUniq.h
+++ b/src/Storages/Statistics/StatisticsUniq.h
@@ -14,6 +14,7 @@ public:
     ~StatisticsUniq() override;
 
     void build(const ColumnPtr & column) override;
+    void merge(const StatisticsPtr & other_stats) override;
 
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -88,17 +88,17 @@ TEST(Statistics, Estimator)
         column_desc.statistics = mock_description;
         return MergeTreeStatisticsFactory::instance().get(column_desc);
     };
-    ColumnStatisticsPartPtr stats_a = mock_statistics("a");
+    ColumnStatisticsPtr stats_a = mock_statistics("a");
     stats_a->build(std::move(a));
-    ColumnStatisticsPartPtr stats_b = mock_statistics("b");
+    ColumnStatisticsPtr stats_b = mock_statistics("b");
     stats_b->build(std::move(b));
-    ColumnStatisticsPartPtr stats_c = mock_statistics("c");
+    ColumnStatisticsPtr stats_c = mock_statistics("c");
     stats_c->build(std::move(c));
 
     ConditionSelectivityEstimator estimator;
-    estimator.addStatistics("onlypart", stats_a);
-    estimator.addStatistics("onlypart", stats_b);
-    estimator.addStatistics("onlypart", stats_c);
+    estimator.addStatistics(stats_a);
+    estimator.addStatistics(stats_b);
+    estimator.addStatistics(stats_c);
     estimator.incrementRowCount(10000);
 
     auto test_impl = [&](const String & expression, Int32 real_result, Float64 eps)
@@ -108,9 +108,9 @@ TEST(Statistics, Estimator)
         RPNBuilderTreeContext tree_context(context, Block{{ DataTypeUInt8().createColumnConstWithDefaultValue(1), std::make_shared<DataTypeUInt8>(), "_dummy" }}, {});
         ASTPtr ast = parseQuery(exp_parser, expression, 10000, 10000, 10000);
         RPNBuilderTreeNode node(ast.get(), tree_context);
-        Float64 estimate_result = estimator.estimateRowCount(node);
-        std::cout << expression << " " << real_result << " "<< estimate_result << std::endl;
-        EXPECT_LT(std::abs(real_result - estimate_result), 10000 * eps);
+        auto estimate_result = estimator.estimateRelationProfile(node);
+        std::cout << expression << " " << real_result << " "<< estimate_result.rows << std::endl;
+        EXPECT_LT(std::abs(real_result - estimate_result.rows), 10000 * eps);
     };
 
     auto test_f = [&](const String & expression, Int32 real_result, Float64 eps = 0.001)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
This PR refactor the estimator a little bit: merge the statistics of different parts to estimate.
no tests are added. the following PR will integrate it with join and test it

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
