### PR TITLE
Fix abort in `WriteBufferValidUTF8`

### DIFF
--- a/src/IO/WriteBufferValidUTF8.cpp
+++ b/src/IO/WriteBufferValidUTF8.cpp
@@ -142,7 +142,16 @@ void WriteBufferValidUTF8::nextImpl()
 WriteBufferValidUTF8::~WriteBufferValidUTF8()
 {
     if (!canceled)
-        finalize();
+    {
+        try
+        {
+            finalize();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
 }
 
 void WriteBufferValidUTF8::finalizeImpl()

--- a/tests/queries/0_stateless/03567_finalize_write_buffer_valid_utf8.sql
+++ b/tests/queries/0_stateless/03567_finalize_write_buffer_valid_utf8.sql
@@ -1,0 +1,1 @@
+INSERT INTO TABLE FUNCTION file(currentDatabase(), 'JSONColumns', 'c0 Enum(x\'e2\' = 1)') SELECT -1 SETTINGS output_format_json_validate_utf8 = 1; -- { serverError UNKNOWN_ELEMENT_OF_ENUM }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix abort in `WriteBufferValidUTF8`. This closes #83514.

@CheSema, @alesapin, this might not be the best fix, but I wonder why we ignored a bug report for a whole week.