### PR TITLE
Postpone grants check for restores in RMV.

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -517,6 +517,9 @@ void ThreadStatus::finalizePerformanceCounters()
     if (performance_counters_finalized)
         return;
 
+    if (last_rusage->thread_id == 0)
+        return; // Performance counters are not initialized
+
     performance_counters_finalized = true;
     updatePerformanceCounters();
 

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -639,7 +639,7 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(bool append, int32_t roo
     LOG_DEBUG(log, "Refreshing view {}", view_storage_id.getFullTableName());
     execution.progress.reset();
 
-    ContextMutablePtr refresh_context;
+    ContextMutablePtr refresh_context = view->getContext();
     ProcessList::EntryPtr process_list_entry;
     std::optional<StorageID> table_to_drop;
     auto new_table_id = StorageID::createEmpty();

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2069,7 +2069,7 @@ def test_rmv_no_definer():
     assert (
         instance.query(
             "SELECT name FROM system.tables where database='test' AND name='rmv'"
-        )
+        ).strip()
         == "rmv"
     )
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2053,6 +2053,7 @@ def test_required_privileges_with_partial_revokes():
 
 def test_rmv_no_definer():
     backup_name = new_backup_name()
+    instance.query("CREATE DATABASE test")
     instance.query("CREATE USER u1")
     instance.query("GRANT CURRENT GRANTS ON *.* TO u1")
     instance.query("CREATE TABLE test.src (x UInt64) ENGINE = MergeTree ORDER BY x")

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2070,7 +2070,7 @@ def test_rmv_no_definer():
         instance.query(
             "SELECT name FROM system.tables where database='test' AND name='rmv'"
         )
-        == "rmv\n"
+        == "rmv"
     )
 
 # Test for the "clickhouse_backupview" utility.

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2070,7 +2070,7 @@ def test_rmv_no_definer():
         instance.query(
             "SELECT name FROM system.tables where database='test' AND name='rmv'"
         )
-        == "rmv"
+        == "rmv\n"
     )
 
 # Test for the "clickhouse_backupview" utility.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When restoring from backup, the definer user may not be backed up, which will cause the whole backup to be broken.
To fix this, we postpone the permissions check on the target table's creation during restore and only check it during runtime.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
