### PR TITLE
add sync to the test 03352_concurrent_rename_alter.sh

### DIFF
--- a/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
+++ b/tests/queries/0_stateless/03352_concurrent_rename_alter.sh
@@ -80,6 +80,9 @@ $CLICKHOUSE_CLIENT --query "
 
     SELECT sleep(randConstant() / toUInt32(-1)) * 0.1 FORMAT Null;
 
+    ALTER TABLE t_rename_alter ADD COLUMN just_for_sync_alters_and_mutations SETTINGS alter_sync = 2;
+    ALTER TABLE t_rename_alter MODIFY COLUMN just_for_sync_alters_and_mutations = 43 SETTINGS mutations_sync = 2;
+
     OPTIMIZE TABLE t_rename_alter FINAL;
 " 2>/dev/null
 # Some concurrent alters may fail because of "Metadata on replica is not up to date with common metadata in Zookeeper"


### PR DESCRIPTION
The test is bad actually.

https://fiddle.clickhouse.com/9973867d-2aa6-4061-b4c0-8761e5579b84
It exploit a loophole that allows to alter column type Tuple in a way which extends  number of elements. Explicit `MODIFY COLUMN` would throw an error here.
 
This 2 commands 
`ALTER TABLE t_rename_alter RENAME COLUMN arr TO arr_tmp;`
`ALTER TABLE t_rename_alter RENAME COLUMN arr_v2 TO arr;`
are converted to 2 alters and 2 mutations
alters:
`DROP COLUMN arr`
`ADD COLUMN arr Array(Tuple(DateTime, UInt64, String, String, String))` (5 elements)
mutations:
`DROP COLUMN arr`
`MOVE arr_v2 to arr` (5 elements)

Alter and mutations could be delayed. They are not synchonized.

When we read from the table we could see metadata with column type `arr as Array(Tuple(DateTime, UInt64, String, String, String))` but have the files on the disk where column `arr as Array(Tuple(DateTime, UInt64, String, String))`.
It tries to apply `CAST`, but it throws the error.


I have added a synchronization. Now all alters and mutations are done before the reading.
When we apply mutations we apply `DROP` and `MOVE` to the files therefore we do not threat old column `arr` with 4 elements in tuple as a new column with 5 elements.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
