### PR TITLE
Fix cleanup in ON CLUSTER backups

### DIFF
--- a/src/Backups/BackupCoordinationCleaner.cpp
+++ b/src/Backups/BackupCoordinationCleaner.cpp
@@ -9,25 +9,25 @@ BackupCoordinationCleaner::BackupCoordinationCleaner(bool is_restore_, const Str
 {
 }
 
-bool BackupCoordinationCleaner::cleanup(bool throw_if_error)
+void BackupCoordinationCleaner::cleanup(bool throw_if_error)
 {
     WithRetries::Kind retries_kind = throw_if_error ? WithRetries::kNormal : WithRetries::kErrorHandling;
-    return cleanupImpl(throw_if_error, retries_kind);
+    cleanupImpl(throw_if_error, retries_kind);
 }
 
-bool BackupCoordinationCleaner::cleanupImpl(bool throw_if_error, WithRetries::Kind retries_kind)
+void BackupCoordinationCleaner::cleanupImpl(bool throw_if_error, WithRetries::Kind retries_kind)
 {
     {
         std::lock_guard lock{mutex};
         if (succeeded)
         {
             LOG_TRACE(log, "Nodes from ZooKeeper are already removed");
-            return true;
+            return;
         }
         if (tried)
         {
             LOG_INFO(log, "Skipped removing nodes from ZooKeeper because because earlier we failed to do that");
-            return false;
+            return;
         }
     }
 
@@ -44,7 +44,6 @@ bool BackupCoordinationCleaner::cleanupImpl(bool throw_if_error, WithRetries::Ki
         std::lock_guard lock{mutex};
         tried = true;
         succeeded = true;
-        return true;
     }
     catch (...)
     {
@@ -57,7 +56,6 @@ bool BackupCoordinationCleaner::cleanupImpl(bool throw_if_error, WithRetries::Ki
 
         if (throw_if_error)
             throw;
-        return false;
     }
 }
 

--- a/src/Backups/BackupCoordinationCleaner.h
+++ b/src/Backups/BackupCoordinationCleaner.h
@@ -14,10 +14,10 @@ class BackupCoordinationCleaner
 public:
     BackupCoordinationCleaner(bool is_restore_, const String & zookeeper_path_, const WithRetries & with_retries_, LoggerPtr log_);
 
-    bool cleanup(bool throw_if_error);
+    void cleanup(bool throw_if_error);
 
 private:
-    bool cleanupImpl(bool throw_if_error, WithRetries::Kind retries_kind);
+    void cleanupImpl(bool throw_if_error, WithRetries::Kind retries_kind);
 
     const bool is_restore;
     const String zookeeper_path;

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -32,10 +32,13 @@ public:
     void setBackupQueryIsSentToOtherHosts() override {}
     bool isBackupQuerySentToOtherHosts() const override { return false; }
     Strings setStage(const String &, const String &, bool) override { return {}; }
-    bool setError(std::exception_ptr, bool) override { return true; }
-    bool waitOtherHostsFinish(bool) const override { return true; }
-    bool finish(bool) override { return true; }
-    bool cleanup(bool) override { return true; }
+    void setError(std::exception_ptr, bool) override { is_error_set = true; }
+    bool isErrorSet() const override { return is_error_set; }
+    void waitOtherHostsFinish(bool) const override {}
+    void finish(bool) override { is_finished = true; }
+    bool finished() const override { return is_finished; }
+    bool allHostsFinished() const override { return finished(); }
+    void cleanup(bool) override {}
 
     void addReplicatedPartNames(const String & table_zk_path, const String & table_name_for_logs, const String & replica_name,
                                 const std::vector<PartNameAndChecksum> & part_names_and_checksums) override;
@@ -81,6 +84,9 @@ private:
     mutable std::mutex file_infos_mutex;
     mutable std::mutex writing_files_mutex;
     mutable std::mutex keeper_map_tables_mutex;
+
+    std::atomic<bool> is_finished = false;
+    std::atomic<bool> is_error_set = false;
 };
 
 }

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -32,7 +32,7 @@ public:
     void setBackupQueryIsSentToOtherHosts() override {}
     bool isBackupQuerySentToOtherHosts() const override { return false; }
     Strings setStage(const String &, const String &, bool) override { return {}; }
-    void setError(std::exception_ptr, bool) override { is_error_set = true; }
+    void setError(std::exception_ptr, bool) override { is_error_set = true; }  /// BackupStarter::onException() has already logged the error.
     bool isErrorSet() const override { return is_error_set; }
     void waitOtherHostsFinish(bool) const override {}
     void finish(bool) override { is_finished = true; }

--- a/src/Backups/BackupCoordinationOnCluster.cpp
+++ b/src/Backups/BackupCoordinationOnCluster.cpp
@@ -188,18 +188,18 @@ BackupCoordinationOnCluster::BackupCoordinationOnCluster(
     , cleaner(/* is_restore = */ false, zookeeper_path, with_retries, log)
     , stage_sync(/* is_restore = */ false, fs::path{zookeeper_path} / "stage", current_host, all_hosts, allow_concurrent_backup_, concurrency_counters_, with_retries, schedule_, process_list_element_, log)
 {
-    try
-    {
-        createRootNodes();
-    }
-    catch (...)
-    {
-        stage_sync.setError(std::current_exception(), /* throw_if_error = */ false);
-        throw;
-    }
+    /// If the current host isn't the initiator then there are other hosts working on this backup (at least the initiator itself).
+    if (current_host != kInitiator)
+        setBackupQueryIsSentToOtherHosts();
 }
 
 BackupCoordinationOnCluster::~BackupCoordinationOnCluster() = default;
+
+void BackupCoordinationOnCluster::startup()
+{
+    stage_sync.startup();
+    createRootNodes();
+}
 
 void BackupCoordinationOnCluster::createRootNodes()
 {
@@ -240,34 +240,39 @@ Strings BackupCoordinationOnCluster::setStage(const String & new_stage, const St
     return {};
 }
 
-bool BackupCoordinationOnCluster::setError(std::exception_ptr exception, bool throw_if_error)
+void BackupCoordinationOnCluster::setError(std::exception_ptr exception, bool throw_if_error)
 {
-    return stage_sync.setError(exception, throw_if_error);
+    stage_sync.setError(exception, throw_if_error);
 }
 
-bool BackupCoordinationOnCluster::waitOtherHostsFinish(bool throw_if_error) const
+bool BackupCoordinationOnCluster::isErrorSet() const
 {
-    return stage_sync.waitOtherHostsFinish(throw_if_error);
+    return stage_sync.isErrorSet();
 }
 
-bool BackupCoordinationOnCluster::finish(bool throw_if_error)
+void BackupCoordinationOnCluster::waitOtherHostsFinish(bool throw_if_error) const
 {
-    return stage_sync.finish(throw_if_error);
+    stage_sync.waitOtherHostsFinish(throw_if_error);
 }
 
-bool BackupCoordinationOnCluster::cleanup(bool throw_if_error)
+void BackupCoordinationOnCluster::finish(bool throw_if_error)
 {
-    /// All the hosts must finish before we remove the coordination nodes.
-    bool expect_other_hosts_finished = stage_sync.isQuerySentToOtherHosts() || !stage_sync.isErrorSet();
-    bool all_hosts_finished = stage_sync.finished() && (stage_sync.otherHostsFinished() || !expect_other_hosts_finished);
-    if (!all_hosts_finished)
-    {
-        auto unfinished_hosts = expect_other_hosts_finished ? stage_sync.getUnfinishedHosts() : Strings{current_host};
-        LOG_INFO(log, "Skipping removing nodes from ZooKeeper because hosts {} didn't finish",
-                 BackupCoordinationStageSync::getHostsDesc(unfinished_hosts));
-        return false;
-    }
-    return cleaner.cleanup(throw_if_error);
+    stage_sync.finish(throw_if_error);
+}
+
+bool BackupCoordinationOnCluster::finished() const
+{
+    return stage_sync.finished();
+}
+
+bool BackupCoordinationOnCluster::allHostsFinished() const
+{
+    return stage_sync.allHostsFinished();
+}
+
+void BackupCoordinationOnCluster::cleanup(bool throw_if_error)
+{
+    cleaner.cleanup(throw_if_error);
 }
 
 ZooKeeperRetriesInfo BackupCoordinationOnCluster::getOnClusterInitializationKeeperRetriesInfo() const

--- a/src/Backups/BackupCoordinationOnCluster.h
+++ b/src/Backups/BackupCoordinationOnCluster.h
@@ -36,13 +36,18 @@ public:
 
     ~BackupCoordinationOnCluster() override;
 
+    void startup() override;
+
     void setBackupQueryIsSentToOtherHosts() override;
     bool isBackupQuerySentToOtherHosts() const override;
     Strings setStage(const String & new_stage, const String & message, bool sync) override;
-    bool setError(std::exception_ptr exception, bool throw_if_error) override;
-    bool waitOtherHostsFinish(bool throw_if_error) const override;
-    bool finish(bool throw_if_error) override;
-    bool cleanup(bool throw_if_error) override;
+    void setError(std::exception_ptr exception, bool throw_if_error) override;
+    bool isErrorSet() const override;
+    void waitOtherHostsFinish(bool throw_if_error) const override;
+    void finish(bool throw_if_error) override;
+    bool finished() const override;
+    bool allHostsFinished() const override;
+    void cleanup(bool throw_if_error) override;
 
     void addReplicatedPartNames(
         const String & table_zk_path,

--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -107,6 +107,7 @@ BackupCoordinationStageSync::BackupCoordinationStageSync(
     , current_host_desc(getHostDesc(current_host))
     , all_hosts(all_hosts_)
     , allow_concurrency(allow_concurrency_)
+    , concurrency_counters(concurrency_counters_)
     , with_retries(with_retries_)
     , schedule(schedule_)
     , process_list_element(process_list_element_)
@@ -128,19 +129,6 @@ BackupCoordinationStageSync::BackupCoordinationStageSync(
     , zk_nodes_changed(std::make_shared<Poco::Event>())
 {
     initializeState();
-    createRootNodes();
-
-    try
-    {
-        createStartAndAliveNodesAndCheckConcurrency(concurrency_counters_);
-        startWatchingThread();
-    }
-    catch (...)
-    {
-        if (setError(std::current_exception(), /* throw_if_error = */ false))
-            finish(/* throw_if_error = */ false);
-        throw;
-    }
 }
 
 
@@ -211,6 +199,14 @@ String BackupCoordinationStageSync::getHostsDesc(const Strings & hosts)
 }
 
 
+void BackupCoordinationStageSync::startup()
+{
+    createRootNodes();
+    createStartAndAliveNodesAndCheckConcurrency();
+    startWatchingThread();
+}
+
+
 void BackupCoordinationStageSync::createRootNodes()
 {
     if ((zookeeper_path.filename() != "stage") || !operation_node_name.starts_with(is_restore ? "restore-" : "backup-")
@@ -230,7 +226,7 @@ void BackupCoordinationStageSync::createRootNodes()
 }
 
 
-void BackupCoordinationStageSync::createStartAndAliveNodesAndCheckConcurrency(BackupConcurrencyCounters & concurrency_counters_)
+void BackupCoordinationStageSync::createStartAndAliveNodesAndCheckConcurrency()
 {
     auto holder = with_retries.createRetriesControlHolder("BackupCoordinationStageSync::createStartAndAliveNodes", WithRetries::kInitialization);
     holder.retries_ctl.retryLoop([&, &zookeeper = holder.faulty_zookeeper]()
@@ -241,7 +237,7 @@ void BackupCoordinationStageSync::createStartAndAliveNodesAndCheckConcurrency(Ba
 
     /// The local concurrency check should be done here after BackupCoordinationStageSync::checkConcurrency() checked that
     /// there are no 'alive' nodes corresponding to other backups or restores.
-    local_concurrency_check.emplace(is_restore, /* on_cluster = */ true, zookeeper_path, allow_concurrency, concurrency_counters_);
+    local_concurrency_check.emplace(is_restore, /* on_cluster = */ true, zookeeper_path, allow_concurrency, concurrency_counters);
 }
 
 
@@ -272,18 +268,6 @@ void BackupCoordinationStageSync::createStartAndAliveNodesAndCheckConcurrency(Co
             {
                 num_hosts = parseFromString<size_t>(num_hosts_str);
                 num_hosts_version = stat.version;
-            }
-        }
-
-        String serialized_error;
-        if (zookeeper->tryGet(error_node_path, serialized_error))
-        {
-            auto [exception, host] = parseErrorNode(serialized_error);
-            if (exception)
-            {
-                std::lock_guard lock{mutex};
-                state.addErrorInfo(exception, host);
-                std::rethrow_exception(exception);
             }
         }
 
@@ -923,17 +907,17 @@ bool BackupCoordinationStageSync::checkIfHostsReachStage(const Strings & hosts, 
 }
 
 
-bool BackupCoordinationStageSync::finish(bool throw_if_error)
+void BackupCoordinationStageSync::finish(bool throw_if_error)
 {
     WithRetries::Kind retries_kind = WithRetries::kNormal;
     if (throw_if_error)
         retries_kind = WithRetries::kErrorHandling;
 
-    return finishImpl(throw_if_error, retries_kind);
+    finishImpl(throw_if_error, retries_kind);
 }
 
 
-bool BackupCoordinationStageSync::finishImpl(bool throw_if_error, WithRetries::Kind retries_kind)
+void BackupCoordinationStageSync::finishImpl(bool throw_if_error, WithRetries::Kind retries_kind)
 {
     {
         std::lock_guard lock{mutex};
@@ -941,14 +925,14 @@ bool BackupCoordinationStageSync::finishImpl(bool throw_if_error, WithRetries::K
         if (finishedNoLock())
         {
             LOG_INFO(log, "The finish node for {} already exists", current_host_desc);
-            return true;
+            return;
         }
 
         if (tried_to_finish[throw_if_error])
         {
             /// We don't repeat creating the finish node, no matter if it was successful or not.
             LOG_INFO(log, "Skipped creating the finish node for {} because earlier we failed to do that", current_host_desc);
-            return false;
+            return;
         }
 
         bool failed_to_set_error = tried_to_set_error && !state.host_with_error;
@@ -957,7 +941,7 @@ bool BackupCoordinationStageSync::finishImpl(bool throw_if_error, WithRetries::K
             /// Tried to create the 'error' node, but failed.
             /// Then it's better not to create the 'finish' node in this case because otherwise other hosts might think we've succeeded.
             LOG_INFO(log, "Skipping creating the finish node for {} because there was an error which we were unable to send to other hosts", current_host_desc);
-            return false;
+            return;
         }
 
         if (current_host == kInitiator)
@@ -986,7 +970,6 @@ bool BackupCoordinationStageSync::finishImpl(bool throw_if_error, WithRetries::K
             with_retries.renewZooKeeper(zookeeper);
             createFinishNodeAndRemoveAliveNode(zookeeper, throw_if_error);
         });
-        return true;
     }
     catch (...)
     {
@@ -996,7 +979,6 @@ bool BackupCoordinationStageSync::finishImpl(bool throw_if_error, WithRetries::K
 
         if (throw_if_error)
             throw;
-        return false;
     }
 }
 
@@ -1006,10 +988,15 @@ void BackupCoordinationStageSync::createFinishNodeAndRemoveAliveNode(Coordinatio
     std::optional<size_t> num_hosts;
     int num_hosts_version = -1;
 
+    auto unfinished_hosts = getUnfinishedHosts();
+    std::vector<std::pair<size_t, String>> non_existent_node_pos;
+    non_existent_node_pos.reserve(unfinished_hosts.size());
+
     for (size_t attempt_no = 1; attempt_no <= max_attempts_after_bad_version; ++attempt_no)
     {
         if (throw_if_error)
         {
+            /// Rethrow the current error if there is an error node.
             if (isErrorSet())
                 rethrowSetError();
 
@@ -1026,7 +1013,7 @@ void BackupCoordinationStageSync::createFinishNodeAndRemoveAliveNode(Coordinatio
             }
         }
 
-        /// The 'num_hosts' node may not exist if createStartAndAliveNodes() failed in the constructor.
+        /// The 'num_hosts' node may not exist if createStartAndAliveNodes() failed when startup() was called.
         if (!num_hosts)
         {
             String num_hosts_str;
@@ -1038,17 +1025,25 @@ void BackupCoordinationStageSync::createFinishNodeAndRemoveAliveNode(Coordinatio
             }
         }
 
-        if (zookeeper->exists(finish_node_path))
+        /// Read the "finish" nodes related to the current host and other hosts and update the current state.
+        /// We need to that here because after calling function finish() we usually call function allHostsFinished().
+        if (std::erase_if(unfinished_hosts, [&](const String & host) { return zookeeper->exists(zookeeper_path / ("finished|" + host)); }))
         {
             std::lock_guard lock{mutex};
-            state.hosts.at(current_host).finished = true;
-            return;
+            for (auto & [host, host_info] : state.hosts)
+            {
+                if (!host_info.finished && (std::find(unfinished_hosts.begin(), unfinished_hosts.end(), host) == unfinished_hosts.end()))
+                    host_info.finished = true;
+            }
         }
+
+        if (finished())
+            return; /// The "finish" node for the current host already exists.
 
         bool start_node_exists = zookeeper->exists(start_node_path);
 
         Coordination::Requests requests;
-        requests.reserve(3);
+        requests.reserve(3 + unfinished_hosts.size());
 
         requests.emplace_back(zkutil::makeCreateRequest(finish_node_path, "", zkutil::CreateMode::Persistent));
 
@@ -1064,6 +1059,17 @@ void BackupCoordinationStageSync::createFinishNodeAndRemoveAliveNode(Coordinatio
         {
             num_hosts_node_pos = requests.size();
             requests.emplace_back(zkutil::makeSetRequest(num_hosts_node_path, toString(start_node_exists ? (*num_hosts - 1) : *num_hosts), num_hosts_version));
+        }
+
+        non_existent_node_pos.clear();
+        for (const String & host : unfinished_hosts)
+        {
+            if (host != current_host)
+            {
+                String node_path = zookeeper_path / ("finished|" + host);
+                non_existent_node_pos.emplace_back(requests.size(), node_path);
+                zkutil::addCheckNotExistsRequest(requests, *zookeeper, node_path);
+            }
         }
 
         Coordination::Responses responses;
@@ -1084,6 +1090,16 @@ void BackupCoordinationStageSync::createFinishNodeAndRemoveAliveNode(Coordinatio
             return;
         }
 
+        auto get_node_failed_check_for_non_existence = [&]() -> String
+        {
+            for (const auto & [pos, node_path] : non_existent_node_pos)
+            {
+                if ((pos < responses.size()) && (responses[pos]->error == Coordination::Error::ZNODEEXISTS))
+                    return node_path;
+            }
+            return "";
+        };
+
         auto show_error_before_next_attempt = [&](const String & message)
         {
             bool will_try_again = (attempt_no < max_attempts_after_bad_version);
@@ -1101,6 +1117,11 @@ void BackupCoordinationStageSync::createFinishNodeAndRemoveAliveNode(Coordinatio
         {
             show_error_before_next_attempt(fmt::format("The version of node {} changed", num_hosts_node_path));
             num_hosts.reset(); /// needs to reread 'num_hosts' again
+        }
+        else if (!get_node_failed_check_for_non_existence().empty())
+        {
+            show_error_before_next_attempt(fmt::format("Node {} exists", get_node_failed_check_for_non_existence()));
+            /// needs another attempt
         }
         else
         {
@@ -1121,7 +1142,7 @@ int BackupCoordinationStageSync::getInitiatorVersion() const
 }
 
 
-bool BackupCoordinationStageSync::waitOtherHostsFinish(bool throw_if_error) const
+void BackupCoordinationStageSync::waitOtherHostsFinish(bool throw_if_error) const
 {
     std::optional<std::chrono::seconds> timeout;
     String reason;
@@ -1133,11 +1154,11 @@ bool BackupCoordinationStageSync::waitOtherHostsFinish(bool throw_if_error) cons
         reason = "after error before cleanup";
     }
 
-    return waitOtherHostsFinishImpl(reason, timeout, throw_if_error);
+    waitOtherHostsFinishImpl(reason, timeout, throw_if_error);
 }
 
 
-bool BackupCoordinationStageSync::waitOtherHostsFinishImpl(const String & reason, std::optional<std::chrono::seconds> timeout, bool throw_if_error) const
+void BackupCoordinationStageSync::waitOtherHostsFinishImpl(const String & reason, std::optional<std::chrono::seconds> timeout, bool throw_if_error) const
 {
     std::unique_lock lock{mutex};
 
@@ -1147,7 +1168,7 @@ bool BackupCoordinationStageSync::waitOtherHostsFinishImpl(const String & reason
     if (other_hosts_finished())
     {
         LOG_TRACE(log, "Other hosts have already finished");
-        return true;
+        return;
     }
 
     bool failed_to_set_error = TSA_SUPPRESS_WARNING_FOR_READ(tried_to_set_error) && !TSA_SUPPRESS_WARNING_FOR_READ(state).host_with_error;
@@ -1156,15 +1177,13 @@ bool BackupCoordinationStageSync::waitOtherHostsFinishImpl(const String & reason
         /// Tried to create the 'error' node, but failed.
         /// Then it's better not to wait for other hosts to finish in this case because other hosts don't know they should finish.
         LOG_INFO(log, "Skipping waiting for other hosts to finish because there was an error which we were unable to send to other hosts");
-        return false;
+        return;
     }
-
-    bool result = false;
 
     /// TSA_NO_THREAD_SAFETY_ANALYSIS is here because Clang Thread Safety Analysis doesn't understand std::unique_lock.
     auto check_if_hosts_finish = [&](bool time_is_out) TSA_NO_THREAD_SAFETY_ANALYSIS
     {
-        return checkIfOtherHostsFinish(reason, timeout, time_is_out, result, throw_if_error);
+        return checkIfOtherHostsFinish(reason, timeout, time_is_out, throw_if_error);
     };
 
     if (timeout)
@@ -1176,13 +1195,11 @@ bool BackupCoordinationStageSync::waitOtherHostsFinishImpl(const String & reason
     {
         state_changed.wait(lock, [&] { return check_if_hosts_finish(/* time_is_out = */ false); });
     }
-
-    return result;
 }
 
 
 bool BackupCoordinationStageSync::checkIfOtherHostsFinish(
-    const String & reason, std::optional<std::chrono::milliseconds> timeout, bool time_is_out, bool & result, bool throw_if_error) const
+    const String & reason, std::optional<std::chrono::milliseconds> timeout, bool time_is_out, bool throw_if_error) const
 {
     if (throw_if_error)
     {
@@ -1214,7 +1231,6 @@ bool BackupCoordinationStageSync::checkIfOtherHostsFinish(
             }
             LOG_INFO(log, "Waited longer than timeout {} for {} to finish{}{}",
                      *timeout, getHostDesc(host), reason_text, host_status);
-            result = false;
             return true; /// stop waiting
         }
 
@@ -1224,7 +1240,6 @@ bool BackupCoordinationStageSync::checkIfOtherHostsFinish(
             chassert(false, "waitOtherHostFinish() can't wait for other hosts to finish after the watching thread stopped");
             if (throw_if_error)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "waitOtherHostsFinish() can't wait for other hosts to finish after the watching thread stopped");
-            result = false;
             return true; /// stop waiting
         }
 
@@ -1233,7 +1248,6 @@ bool BackupCoordinationStageSync::checkIfOtherHostsFinish(
     }
 
     LOG_TRACE(log, "Other hosts finished working on this {}", operation_name);
-    result = true;
     return true; /// stop waiting
 }
 
@@ -1321,7 +1335,7 @@ Strings BackupCoordinationStageSync::getUnfinishedOtherHostsNoLock() const
 }
 
 
-bool BackupCoordinationStageSync::setError(std::exception_ptr exception, bool throw_if_error)
+void BackupCoordinationStageSync::setError(std::exception_ptr exception, bool throw_if_error)
 {
     try
     {
@@ -1329,16 +1343,16 @@ bool BackupCoordinationStageSync::setError(std::exception_ptr exception, bool th
     }
     catch (const Exception & e)
     {
-        return setError(e, throw_if_error);
+        setError(e, throw_if_error);
     }
     catch (...)
     {
-        return setError(Exception{getCurrentExceptionMessageAndPattern(true, true), getCurrentExceptionCode()}, throw_if_error);
+        setError(Exception{getCurrentExceptionMessageAndPattern(true, true), getCurrentExceptionCode()}, throw_if_error);
     }
 }
 
 
-bool BackupCoordinationStageSync::setError(const Exception & exception, bool throw_if_error)
+void BackupCoordinationStageSync::setError(const Exception & exception, bool throw_if_error)
 {
     /// Most likely this exception has been already logged so here we're logging it without stacktrace.
     String exception_message = getExceptionMessage(exception, /* with_stacktrace= */ false, /* check_embedded_stacktrace= */ true);
@@ -1351,13 +1365,13 @@ bool BackupCoordinationStageSync::setError(const Exception & exception, bool thr
             /// We create the error node always before assigning `state.host_with_error`,
             /// thus if `state.host_with_error` is set then we can be sure that the error node exists.
             LOG_INFO(log, "The error node already exists");
-            return true;
+            return;
         }
 
         if (tried_to_set_error)
         {
             LOG_INFO(log, "Skipped creating the error node because earlier we failed to do that");
-            return false;
+            return;
         }
     }
 
@@ -1376,7 +1390,6 @@ bool BackupCoordinationStageSync::setError(const Exception & exception, bool thr
             with_retries.renewZooKeeper(zookeeper);
             createErrorNode(exception, zookeeper);
         });
-        return true;
     }
     catch (...)
     {
@@ -1386,7 +1399,6 @@ bool BackupCoordinationStageSync::setError(const Exception & exception, bool thr
 
         if (throw_if_error)
             throw;
-        return false;
     }
 }
 

--- a/src/Backups/BackupCoordinationStageSync.h
+++ b/src/Backups/BackupCoordinationStageSync.h
@@ -29,6 +29,8 @@ public:
 
     ~BackupCoordinationStageSync();
 
+    void startup();
+
     /// Sets that the BACKUP or RESTORE query was sent to other hosts.
     void setQueryIsSentToOtherHosts();
     bool isQuerySentToOtherHosts() const;
@@ -42,16 +44,16 @@ public:
 
     /// Lets other hosts know that the current host has encountered an error.
     /// The function returns true if it successfully created the error node or if the error node was found already exist.
-    bool setError(std::exception_ptr exception, bool throw_if_error);
+    void setError(std::exception_ptr exception, bool throw_if_error);
     bool isErrorSet() const;
 
     /// Waits until the hosts other than the current host finish their work. Must be called before finish().
     /// Stops waiting and throws an exception if another host encounters an error or if some host gets cancelled.
-    bool waitOtherHostsFinish(bool throw_if_error) const;
+    void waitOtherHostsFinish(bool throw_if_error) const;
     bool otherHostsFinished() const;
 
     /// Lets other hosts know that the current host has finished its work.
-    bool finish(bool throw_if_error);
+    void finish(bool throw_if_error);
     bool finished() const;
 
     /// Returns true if all the hosts have finished.
@@ -73,7 +75,7 @@ private:
     void createRootNodes();
 
     /// Atomically creates both 'start' and 'alive' nodes and also checks that there is no concurrent backup or restore if `allow_concurrency` is false.
-    void createStartAndAliveNodesAndCheckConcurrency(BackupConcurrencyCounters & concurrency_counters_);
+    void createStartAndAliveNodesAndCheckConcurrency();
     void createStartAndAliveNodesAndCheckConcurrency(Coordination::ZooKeeperWithFaultInjection::Ptr zookeeper);
 
     /// Deserialize the version of a node stored in the 'start' node.
@@ -98,7 +100,7 @@ private:
     String getStageNodePath(const String & stage) const;
 
     /// Lets other hosts know that the current host has encountered an error.
-    bool setError(const Exception & exception, bool throw_if_error);
+    void setError(const Exception & exception, bool throw_if_error);
     [[noreturn]] void rethrowSetError() const;
     void createErrorNode(const Exception & exception, Coordination::ZooKeeperWithFaultInjection::Ptr zookeeper);
 
@@ -123,15 +125,15 @@ private:
     bool checkIfHostsReachStage(const Strings & hosts, const String & stage_to_wait, Strings & results) const TSA_REQUIRES(mutex);
 
     /// Creates the 'finish' node.
-    bool finishImpl(bool throw_if_error, WithRetries::Kind retries_kind);
+    void finishImpl(bool throw_if_error, WithRetries::Kind retries_kind);
     void createFinishNodeAndRemoveAliveNode(Coordination::ZooKeeperWithFaultInjection::Ptr zookeeper, bool throw_if_error);
 
     /// Returns the version used by the initiator.
     int getInitiatorVersion() const;
 
     /// Waits until all the other hosts finish their work.
-    bool waitOtherHostsFinishImpl(const String & reason, std::optional<std::chrono::seconds> timeout, bool throw_if_error) const;
-    bool checkIfOtherHostsFinish(const String & reason, std::optional<std::chrono::milliseconds> timeout, bool time_is_out, bool & result, bool throw_if_error) const TSA_REQUIRES(mutex);
+    void waitOtherHostsFinishImpl(const String & reason, std::optional<std::chrono::seconds> timeout, bool throw_if_error) const;
+    bool checkIfOtherHostsFinish(const String & reason, std::optional<std::chrono::milliseconds> timeout, bool time_is_out, bool throw_if_error) const TSA_REQUIRES(mutex);
 
     /// Returns true if all the hosts have finished.
     bool allHostsFinishedNoLock() const TSA_REQUIRES(mutex);
@@ -148,6 +150,7 @@ private:
     const String current_host_desc;
     const Strings all_hosts;
     const bool allow_concurrency;
+    BackupConcurrencyCounters & concurrency_counters;
 
     /// A reference to a field of the parent object which is either BackupCoordinationOnCluster or RestoreCoordinationOnCluster.
     const WithRetries & with_retries;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -34,6 +34,7 @@
 #include <Common/formatReadable.h>
 #include <Common/ThrottlerArray.h>
 #include <Core/Settings.h>
+#include <Core/ServerSettings.h>
 
 #include <boost/range/adaptor/map.hpp>
 
@@ -55,7 +56,12 @@ namespace DB
 
 namespace Setting
 {
-extern const SettingsBool s3_disable_checksum;
+    extern const SettingsBool s3_disable_checksum;
+}
+
+namespace ServerSetting
+{
+    extern const ServerSettingsBool shutdown_wait_backups_and_restores;
 }
 
 namespace ErrorCodes
@@ -314,6 +320,7 @@ BackupsWorker::BackupsWorker(ContextMutablePtr global_context, size_t num_backup
     : thread_pools(std::make_unique<ThreadPools>(num_backup_threads, num_restore_threads))
     , allow_concurrent_backups(global_context->getConfigRef().getBool("backups.allow_concurrent_backups", true))
     , allow_concurrent_restores(global_context->getConfigRef().getBool("backups.allow_concurrent_restores", true))
+    , shutdown_wait_backups_and_restores(global_context->getServerSettings()[ServerSetting::shutdown_wait_backups_and_restores])
     , remove_backup_files_after_failure(global_context->getConfigRef().getBool("backups.remove_backup_files_after_failure", true))
     , test_randomize_order(global_context->getConfigRef().getBool("backups.test_randomize_order", false))
     , test_inject_sleep(global_context->getConfigRef().getBool("backups.test_inject_sleep", false))
@@ -435,6 +442,7 @@ struct BackupsWorker::BackupStarter
             backup_settings.cluster_host_ids = cluster->getHostIDs();
         }
         backup_coordination = backups_worker.makeBackupCoordination(on_cluster, backup_settings, backup_context);
+        backup_coordination->startup();
 
         chassert(!backup);
         backup = backups_worker.openBackupForWriting(backup_info, backup_settings, backup_coordination, backup_context);
@@ -442,12 +450,17 @@ struct BackupsWorker::BackupStarter
         backups_worker.doBackup(backup, backup_query, backup_id, backup_settings, backup_coordination, backup_context, query_context,
                                 on_cluster, cluster);
 
-        backup_coordination->finish(/* throw_if_error = */ true);
-        backup.reset();
-
-        /// The backup coordination is not needed anymore.
         if (!is_internal_backup)
+            backup_coordination->waitOtherHostsFinish(/* throw_if_error = */ true);
+
+        /// Let other hosts know that the current host has finished its work.
+        backup_coordination->finish(/* throw_if_error = */ true);
+
+        /// If the current host is the last host working on this backup then we can remove the coordination info.
+        if (backup_coordination && backup_coordination->allHostsFinished())
             backup_coordination->cleanup(/* throw_if_error = */ true);
+
+        backup.reset();
         backup_coordination.reset();
 
         /// NOTE: setStatus is called after setNumFilesAndSize in order to have actual information in a backup log record
@@ -462,31 +475,37 @@ struct BackupsWorker::BackupStarter
                                (is_internal_backup ? "internal backup" : "backup"),
                                backup_name_for_logging));
 
-        bool should_remove_files_in_backup = backup && !is_internal_backup && backups_worker.remove_backup_files_after_failure;
+        bool backup_is_corrupted = (backup && backup->setIsCorrupted());
 
-        if (backup && !backup->setIsCorrupted())
-            should_remove_files_in_backup = false;
+        /// Let other hosts know we got an error.
+        if (backup_coordination)
+            backup_coordination->setError(std::current_exception(), /* throw_if_error = */ false);
 
-        bool all_hosts_finished = false;
-
-        if (backup_coordination && backup_coordination->setError(std::current_exception(), /* throw_if_error = */ false))
+        /// Let other hosts know that the current host has finished its work.
+        /// We do that only if the error is set to prevent other hosts from thinking that the current host has finished successfully.
+        if (backup_coordination && backup_coordination->isErrorSet())
         {
-            bool other_hosts_finished = !is_internal_backup
-                && (!backup_coordination->isBackupQuerySentToOtherHosts() || backup_coordination->waitOtherHostsFinish(/* throw_if_error = */ false));
-
-            all_hosts_finished = backup_coordination->finish(/* throw_if_error = */ false) && other_hosts_finished;
+            if (!is_internal_backup && backup_coordination->isBackupQuerySentToOtherHosts())
+                backup_coordination->waitOtherHostsFinish(/* throw_if_error = */ false);
+            backup_coordination->finish(/* throw_if_error = */ false);
         }
 
-        if (!all_hosts_finished)
-            should_remove_files_in_backup = false;
-
-        if (backup && should_remove_files_in_backup)
+        /// Remove files of the corrupted backup.
+        if (backup && backup_is_corrupted && backups_worker.remove_backup_files_after_failure && backup_coordination
+            && backup_coordination->isErrorSet() && backup_coordination->finished()
+            && (!backup_coordination->isBackupQuerySentToOtherHosts() || backup_coordination->allHostsFinished()))
+        {
             backup->tryRemoveAllFiles();
+        }
 
         backup.reset();
 
-        if (backup_coordination && all_hosts_finished)
+        /// If the current host is the last host working on this restore then we can remove the coordination info.
+        if (backup_coordination && backup_coordination->finished() &&
+            (!backup_coordination->isBackupQuerySentToOtherHosts() || backup_coordination->allHostsFinished()))
+        {
             backup_coordination->cleanup(/* throw_if_error = */ false);
+        }
 
         backup_coordination.reset();
 
@@ -813,14 +832,21 @@ struct BackupsWorker::RestoreStarter
             restore_settings.cluster_host_ids = cluster->getHostIDs();
         }
         restore_coordination = backups_worker.makeRestoreCoordination(on_cluster, restore_settings, restore_context);
+        restore_coordination->startup();
 
         backups_worker.doRestore(restore_query, restore_id, backup_info, restore_settings, restore_coordination, restore_context, query_context,
                                  on_cluster, cluster);
 
-        /// The restore coordination is not needed anymore.
-        restore_coordination->finish(/* throw_if_error = */ true);
         if (!is_internal_restore)
+            restore_coordination->waitOtherHostsFinish(/* throw_if_error = */ true);
+
+        /// Let other hosts know that the current host has finished its work.
+        restore_coordination->finish(/* throw_if_error = */ true);
+
+        /// If the current host is the last host working on this restore then we can remove the coordination info.
+        if (restore_coordination && restore_coordination->allHostsFinished())
             restore_coordination->cleanup(/* throw_if_error = */ true);
+
         restore_coordination.reset();
 
         LOG_INFO(log, "Restored from {} {} successfully", (is_internal_restore ? "internal backup" : "backup"), backup_name_for_logging);
@@ -832,12 +858,24 @@ struct BackupsWorker::RestoreStarter
         /// Something bad happened, some data were not restored.
         tryLogCurrentException(backups_worker.log, fmt::format("Failed to restore from {} {}", (is_internal_restore ? "internal backup" : "backup"), backup_name_for_logging));
 
-        if (restore_coordination && restore_coordination->setError(std::current_exception(), /* throw_if_error = */ false))
+        /// Let other hosts know we got an error.
+        if (restore_coordination)
+            restore_coordination->setError(std::current_exception(), /* throw_if_error = */ false);
+
+        /// Let other hosts know that the current host has finished its work.
+        /// We do that only if the error is set to prevent other hosts from thinking that the current host has finished successfully.
+        if (restore_coordination && restore_coordination->isErrorSet())
         {
-            bool other_hosts_finished = !is_internal_restore
-                && (!restore_coordination->isRestoreQuerySentToOtherHosts() || restore_coordination->waitOtherHostsFinish(/* throw_if_error = */ false));
-            if (restore_coordination->finish(/* throw_if_error = */ false) && other_hosts_finished)
-                restore_coordination->cleanup(/* throw_if_error = */ false);
+            if (!is_internal_restore && restore_coordination->isRestoreQuerySentToOtherHosts())
+                restore_coordination->waitOtherHostsFinish(/* throw_if_error = */ false);
+            restore_coordination->finish(/* throw_if_error = */ false);
+        }
+
+        /// If the current host is the last host working on this restore then we can remove the coordination info.
+        if (restore_coordination && restore_coordination->finished() &&
+            (!restore_coordination->isRestoreQuerySentToOtherHosts() || restore_coordination->allHostsFinished()))
+        {
+            restore_coordination->cleanup(/* throw_if_error = */ false);
         }
 
         restore_coordination.reset();
@@ -1316,8 +1354,11 @@ std::vector<BackupOperationInfo> BackupsWorker::getAllInfos() const
 
 void BackupsWorker::shutdown()
 {
-    /// Cancel running backups and restores.
-    cancelAll(/* wait= */ true);
+    /// Wait or cancel running backups and restores.
+    if (shutdown_wait_backups_and_restores)
+        waitAll();
+    else
+        cancelAll(/* wait= */ true);
 
     /// Wait for our thread pools (it must be done before destroying them).
     thread_pools->wait();

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -139,6 +139,7 @@ private:
 
     const bool allow_concurrent_backups;
     const bool allow_concurrent_restores;
+    const bool shutdown_wait_backups_and_restores;
     const bool remove_backup_files_after_failure;
     const bool test_randomize_order;
     const bool test_inject_sleep;

--- a/src/Backups/IBackupCoordination.h
+++ b/src/Backups/IBackupCoordination.h
@@ -21,6 +21,8 @@ class IBackupCoordination
 public:
     virtual ~IBackupCoordination() = default;
 
+    virtual void startup() {}
+
     /// Sets that the backup query was sent to other hosts.
     /// Function waitOtherHostsFinish() will check that to find out if it should really wait or not.
     virtual void setBackupQueryIsSentToOtherHosts() = 0;
@@ -30,18 +32,26 @@ public:
     virtual Strings setStage(const String & new_stage, const String & message, bool sync) = 0;
 
     /// Lets other hosts know that the current host has encountered an error.
-    /// Returns true if the information is successfully passed so other hosts can read it.
-    virtual bool setError(std::exception_ptr exception, bool throw_if_error) = 0;
+    virtual void setError(std::exception_ptr exception, bool throw_if_error) = 0;
+
+    /// Returns true if some host (the current host or one of the other hosts) has encountered an error.
+    virtual bool isErrorSet() const = 0;
 
     /// Waits until all the other hosts finish their work.
     /// Stops waiting and throws an exception if another host encounters an error or if some host gets cancelled.
-    virtual bool waitOtherHostsFinish(bool throw_if_error) const = 0;
+    virtual void waitOtherHostsFinish(bool throw_if_error) const = 0;
 
     /// Lets other hosts know that the current host has finished its work.
-    virtual bool finish(bool throw_if_error) = 0;
+    virtual void finish(bool throw_if_error) = 0;
+
+    /// Returns true if this host finished its work (i.e. finish() was called successfully).
+    virtual bool finished() const = 0;
+
+    /// Returns true if all the hosts finished their work.
+    virtual bool allHostsFinished() const = 0;
 
     /// Removes temporary nodes in ZooKeeper.
-    virtual bool cleanup(bool throw_if_error) = 0;
+    virtual void cleanup(bool throw_if_error) = 0;
 
     struct PartNameAndChecksum
     {

--- a/src/Backups/IRestoreCoordination.h
+++ b/src/Backups/IRestoreCoordination.h
@@ -19,6 +19,8 @@ class IRestoreCoordination
 public:
     virtual ~IRestoreCoordination() = default;
 
+    virtual void startup() {}
+
     /// Sets that the restore query was sent to other hosts.
     /// Function waitOtherHostsFinish() will check that to find out if it should really wait or not.
     virtual void setRestoreQueryIsSentToOtherHosts() = 0;
@@ -28,18 +30,26 @@ public:
     virtual Strings setStage(const String & new_stage, const String & message, bool sync) = 0;
 
     /// Lets other hosts know that the current host has encountered an error.
-    /// Returns true if the information is successfully passed so other hosts can read it.
-    virtual bool setError(std::exception_ptr exception, bool throw_if_error) = 0;
+    virtual void setError(std::exception_ptr exception, bool throw_if_error) = 0;
+
+    /// Returns true if some host (the current host or one of the other hosts) has encountered an error.
+    virtual bool isErrorSet() const = 0;
 
     /// Waits until all the other hosts finish their work.
     /// Stops waiting and throws an exception if another host encounters an error or if some host gets cancelled.
-    virtual bool waitOtherHostsFinish(bool throw_if_error) const = 0;
+    virtual void waitOtherHostsFinish(bool throw_if_error) const = 0;
 
     /// Lets other hosts know that the current host has finished its work.
-    virtual bool finish(bool throw_if_error) = 0;
+    virtual void finish(bool throw_if_error) = 0;
+
+    /// Returns true if this host finished its work (i.e. finish() was called successfully).
+    virtual bool finished() const = 0;
+
+    /// Returns true if all the hosts finished their work.
+    virtual bool allHostsFinished() const = 0;
 
     /// Removes temporary nodes in ZooKeeper.
-    virtual bool cleanup(bool throw_if_error) = 0;
+    virtual void cleanup(bool throw_if_error) = 0;
 
     /// Starts creating a table in a replicated database. Returns false if there is another host which is already creating this table.
     virtual bool acquireCreatingTableInReplicatedDatabase(const String & database_zk_path, const String & table_name) = 0;

--- a/src/Backups/RestoreCoordinationLocal.h
+++ b/src/Backups/RestoreCoordinationLocal.h
@@ -23,10 +23,13 @@ public:
     void setRestoreQueryIsSentToOtherHosts() override {}
     bool isRestoreQuerySentToOtherHosts() const override { return false; }
     Strings setStage(const String &, const String &, bool) override { return {}; }
-    bool setError(std::exception_ptr, bool) override { return true; }
-    bool waitOtherHostsFinish(bool) const override { return true; }
-    bool finish(bool) override { return true; }
-    bool cleanup(bool) override { return true; }
+    void setError(std::exception_ptr, bool) override { is_error_set = true; }
+    bool isErrorSet() const override { return is_error_set; }
+    void waitOtherHostsFinish(bool) const override {}
+    void finish(bool) override { is_finished = true; }
+    bool finished() const override { return is_finished; }
+    bool allHostsFinished() const override { return finished(); }
+    void cleanup(bool) override {}
 
     /// Starts creating a table in a replicated database. Returns false if there is another host which is already creating this table.
     bool acquireCreatingTableInReplicatedDatabase(const String & database_zk_path, const String & table_name) override;
@@ -63,6 +66,9 @@ private:
     std::unordered_set<String /* root_zk_path */> acquired_data_in_keeper_map_tables TSA_GUARDED_BY(mutex);
 
     mutable std::mutex mutex;
+
+    std::atomic<bool> is_finished = false;
+    std::atomic<bool> is_error_set = false;
 };
 
 }

--- a/src/Backups/RestoreCoordinationLocal.h
+++ b/src/Backups/RestoreCoordinationLocal.h
@@ -23,7 +23,7 @@ public:
     void setRestoreQueryIsSentToOtherHosts() override {}
     bool isRestoreQuerySentToOtherHosts() const override { return false; }
     Strings setStage(const String &, const String &, bool) override { return {}; }
-    void setError(std::exception_ptr, bool) override { is_error_set = true; }
+    void setError(std::exception_ptr, bool) override { is_error_set = true; }  /// RestoreStarter::onException() has already logged the error.
     bool isErrorSet() const override { return is_error_set; }
     void waitOtherHostsFinish(bool) const override {}
     void finish(bool) override { is_finished = true; }

--- a/src/Backups/RestoreCoordinationOnCluster.cpp
+++ b/src/Backups/RestoreCoordinationOnCluster.cpp
@@ -38,18 +38,18 @@ RestoreCoordinationOnCluster::RestoreCoordinationOnCluster(
     , cleaner(/* is_restore = */ true, zookeeper_path, with_retries, log)
     , stage_sync(/* is_restore = */ true, fs::path{zookeeper_path} / "stage", current_host, all_hosts, allow_concurrent_restore_, concurrency_counters_, with_retries, schedule_, process_list_element_, log)
 {
-    try
-    {
-        createRootNodes();
-    }
-    catch (...)
-    {
-        stage_sync.setError(std::current_exception(), /* throw_if_error = */ false);
-        throw;
-    }
+    /// If the current host isn't the initiator then there are other hosts working on this backup (at least the initiator itself).
+    if (current_host != kInitiator)
+        setRestoreQueryIsSentToOtherHosts();
 }
 
 RestoreCoordinationOnCluster::~RestoreCoordinationOnCluster() = default;
+
+void RestoreCoordinationOnCluster::startup()
+{
+    stage_sync.startup();
+    createRootNodes();
+}
 
 void RestoreCoordinationOnCluster::createRootNodes()
 {
@@ -88,34 +88,39 @@ Strings RestoreCoordinationOnCluster::setStage(const String & new_stage, const S
     return {};
 }
 
-bool RestoreCoordinationOnCluster::setError(std::exception_ptr exception, bool throw_if_error)
+void RestoreCoordinationOnCluster::setError(std::exception_ptr exception, bool throw_if_error)
 {
-    return stage_sync.setError(exception, throw_if_error);
+    stage_sync.setError(exception, throw_if_error);
 }
 
-bool RestoreCoordinationOnCluster::waitOtherHostsFinish(bool throw_if_error) const
+bool RestoreCoordinationOnCluster::isErrorSet() const
 {
-    return stage_sync.waitOtherHostsFinish(throw_if_error);
+    return stage_sync.isErrorSet();
 }
 
-bool RestoreCoordinationOnCluster::finish(bool throw_if_error)
+void RestoreCoordinationOnCluster::waitOtherHostsFinish(bool throw_if_error) const
 {
-    return stage_sync.finish(throw_if_error);
+    stage_sync.waitOtherHostsFinish(throw_if_error);
 }
 
-bool RestoreCoordinationOnCluster::cleanup(bool throw_if_error)
+void RestoreCoordinationOnCluster::finish(bool throw_if_error)
 {
-    /// All the hosts must finish before we remove the coordination nodes.
-    bool expect_other_hosts_finished = stage_sync.isQuerySentToOtherHosts() || !stage_sync.isErrorSet();
-    bool all_hosts_finished = stage_sync.finished() && (stage_sync.otherHostsFinished() || !expect_other_hosts_finished);
-    if (!all_hosts_finished)
-    {
-        auto unfinished_hosts = expect_other_hosts_finished ? stage_sync.getUnfinishedHosts() : Strings{current_host};
-        LOG_INFO(log, "Skipping removing nodes from ZooKeeper because hosts {} didn't finish",
-                 BackupCoordinationStageSync::getHostsDesc(unfinished_hosts));
-        return false;
-    }
-    return cleaner.cleanup(throw_if_error);
+    stage_sync.finish(throw_if_error);
+}
+
+bool RestoreCoordinationOnCluster::finished() const
+{
+    return stage_sync.finished();
+}
+
+bool RestoreCoordinationOnCluster::allHostsFinished() const
+{
+    return stage_sync.allHostsFinished();
+}
+
+void RestoreCoordinationOnCluster::cleanup(bool throw_if_error)
+{
+    cleaner.cleanup(throw_if_error);
 }
 
 ZooKeeperRetriesInfo RestoreCoordinationOnCluster::getOnClusterInitializationKeeperRetriesInfo() const

--- a/src/Backups/RestoreCoordinationOnCluster.h
+++ b/src/Backups/RestoreCoordinationOnCluster.h
@@ -30,13 +30,18 @@ public:
 
     ~RestoreCoordinationOnCluster() override;
 
+    void startup() override;
+
     void setRestoreQueryIsSentToOtherHosts() override;
     bool isRestoreQuerySentToOtherHosts() const override;
     Strings setStage(const String & new_stage, const String & message, bool sync) override;
-    bool setError(std::exception_ptr exception, bool throw_if_error) override;
-    bool waitOtherHostsFinish(bool throw_if_error) const override;
-    bool finish(bool throw_if_error) override;
-    bool cleanup(bool throw_if_error) override;
+    void setError(std::exception_ptr exception, bool throw_if_error) override;
+    bool isErrorSet() const override;
+    void waitOtherHostsFinish(bool throw_if_error) const override;
+    void finish(bool throw_if_error) override;
+    bool finished() const override;
+    bool allHostsFinished() const override;
+    void cleanup(bool throw_if_error) override;
 
     /// Starts creating a table in a replicated database. Returns false if there is another host which is already creating this table.
     bool acquireCreatingTableInReplicatedDatabase(const String & database_zk_path, const String & table_name) override;

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -1183,7 +1183,7 @@ def test_shutdown_waits_for_backup():
 
     # If kill=False the pending backup must be completed
     # If kill=True the pending backup might be completed or failed
-    node2.stop_clickhouse(kill=False)
+    node2.restart_clickhouse(kill=False)
 
     assert_eq_with_retry(
         node1,
@@ -1194,8 +1194,6 @@ def test_shutdown_waits_for_backup():
 
     status = node1.query(f"SELECT status FROM system.backups WHERE id='{id}'").strip()
     assert status == "BACKUP_CREATED"
-
-    node2.start_clickhouse()
 
     node1.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
     node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix cleanup in `ON CLUSTER` backups. We need to clean coordination nodes in ZooKeeper correctly after a backup or restore failed or got cancelled.

This PR is required to fix tests for `ON CLUSTER` backups and restores.
