### PR TITLE
Shutdown DDLWorker before shutting down BackupsWorker

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2778,6 +2778,8 @@ try
             /// (because killAllQueries() will cancel all running backups/restores).
             if (server_settings[ServerSetting::shutdown_wait_backups_and_restores])
                 global_context->waitAllBackupsAndRestores();
+            else
+                global_context->cancelAllBackupsAndRestores();
 
             /// Killing remaining queries.
             if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3364,6 +3364,12 @@ void Context::waitAllBackupsAndRestores() const
         shared->backups_worker->waitAll();
 }
 
+void Context::cancelAllBackupsAndRestores() const
+{
+    if (shared->backups_worker)
+        shared->backups_worker->cancelAll();
+}
+
 BackupsInMemoryHolder & Context::getBackupsInMemory()
 {
     return backups_in_memory;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -810,7 +810,8 @@ struct ContextSharedPart : boost::noncopyable
         Session::shutdownNamedSessions();
 
         /// Stop watching DDL queue in ZooKeeper and wait until currently executed tasks finish.
-        /// This must be done before shutting down BackupsWorker.
+        /// This must be done before closing ZooKeeper connection (because DDLWorker can call Context::getZooKeeper() and resurrect it),
+        /// and before shutting down BackupsWorker (because DDLWorker can start an internal backup or restore).
         SHUTDOWN(log, "ddl worker", ddl_worker, shutdown());
 
         /// Waiting for current backups/restores to be finished. This must be done before shutting down DatabaseCatalog.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -809,7 +809,11 @@ struct ContextSharedPart : boost::noncopyable
         LOG_TRACE(log, "Shutting down named sessions");
         Session::shutdownNamedSessions();
 
-        /// Waiting for current backups/restores to be finished. This must be done before `DatabaseCatalog::shutdown()`.
+        /// Stop watching DDL queue in ZooKeeper and wait until currently executed tasks finish.
+        /// This must be done before shutting down BackupsWorker.
+        SHUTDOWN(log, "ddl worker", ddl_worker, shutdown());
+
+        /// Waiting for current backups/restores to be finished. This must be done before shutting down DatabaseCatalog.
         SHUTDOWN(log, "backups worker", backups_worker, shutdown());
 
         LOG_TRACE(log, "Shutting down object storage queue streaming");
@@ -838,30 +842,17 @@ struct ContextSharedPart : boost::noncopyable
         std::unique_ptr<ExternalUserDefinedExecutableFunctionsLoader> delete_external_user_defined_executable_functions_loader;
         std::unique_ptr<IUserDefinedSQLObjectsStorage> delete_user_defined_sql_objects_storage;
         std::unique_ptr<IWorkloadEntityStorage> delete_workload_entity_storage;
+        std::unique_ptr<DDLWorker> delete_ddl_worker;
 
         BackgroundSchedulePoolPtr delete_buffer_flush_schedule_pool;
         BackgroundSchedulePoolPtr delete_schedule_pool;
         BackgroundSchedulePoolPtr delete_distributed_schedule_pool;
         BackgroundSchedulePoolPtr delete_message_broker_schedule_pool;
 
-        std::unique_ptr<DDLWorker> delete_ddl_worker;
         std::unique_ptr<AccessControl> delete_access_control;
 
         scope_guard delete_dictionaries_xmls;
         scope_guard delete_user_defined_executable_functions_xmls;
-
-        /// Delete DDLWorker before zookeeper.
-        /// Cause it can call Context::getZooKeeper and resurrect it.
-
-        {
-            std::lock_guard lock(mutex);
-            delete_ddl_worker = std::move(ddl_worker);
-        }
-
-        /// DDLWorker should be deleted without lock, cause its internal thread can
-        /// take it as well, which will cause deadlock.
-        LOG_TRACE(log, "Shutting down DDLWorker");
-        delete_ddl_worker.reset();
 
         /// Background operations in cache use background schedule pool.
         /// Deactivate them before destructing it.
@@ -930,6 +921,7 @@ struct ContextSharedPart : boost::noncopyable
             delete_external_user_defined_executable_functions_loader = std::move(external_user_defined_executable_functions_loader);
             delete_user_defined_sql_objects_storage = std::move(user_defined_sql_objects_storage);
             delete_workload_entity_storage = std::move(workload_entity_storage);
+            delete_ddl_worker = std::move(ddl_worker);
 
             delete_buffer_flush_schedule_pool = std::move(buffer_flush_schedule_pool);
             delete_schedule_pool = std::move(schedule_pool);

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1025,6 +1025,7 @@ public:
 
     BackupsWorker & getBackupsWorker() const;
     void waitAllBackupsAndRestores() const;
+    void cancelAllBackupsAndRestores() const;
     BackupsInMemoryHolder & getBackupsInMemory();
     const BackupsInMemoryHolder & getBackupsInMemory() const;
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -142,8 +142,8 @@ DDLWorker::DDLWorker(
 
 void DDLWorker::startup()
 {
-    [[maybe_unused]] bool prev_stop_flag = stop_flag.exchange(false);
-    chassert(prev_stop_flag);
+    chassert(!initialized && !main_thread && !cleanup_thread);
+    stop_flag = false;
     main_thread = std::make_unique<ThreadFromGlobalPool>(&DDLWorker::runMainThread, this);
     cleanup_thread = std::make_unique<ThreadFromGlobalPool>(&DDLWorker::runCleanupThread, this);
 }
@@ -1064,6 +1064,12 @@ void DDLWorker::createStatusDirs(const std::string & node_path, const ZooKeeperP
 
 String DDLWorker::enqueueQuery(DDLLogEntry & entry, const ZooKeeperRetriesInfo & retries_info)
 {
+    if (stop_flag)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't enqueue a query after shutdown");
+
+    if (entry.hosts.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty host list in a distributed DDL task");
+
     String node_path;
     if (retries_info.max_retries > 0)
     {
@@ -1082,9 +1088,6 @@ String DDLWorker::enqueueQuery(DDLLogEntry & entry, const ZooKeeperRetriesInfo &
 
 String DDLWorker::enqueueQueryAttempt(DDLLogEntry & entry)
 {
-    if (entry.hosts.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty host list in a distributed DDL task");
-
     auto zookeeper = context->getZooKeeper();
 
     String query_path_prefix = fs::path(queue_dir) / "query-";

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -88,7 +88,6 @@ public:
 
     bool isCurrentlyActive() const { return initialized && !stop_flag; }
 
-
     /// Returns cached ZooKeeper session (possibly expired).
     ZooKeeperPtr getZooKeeper() const;
     /// If necessary, creates a new session and caches it.
@@ -198,7 +197,7 @@ protected:
     std::shared_ptr<Poco::Event> queue_updated_event = std::make_shared<Poco::Event>();
     std::shared_ptr<Poco::Event> cleanup_event = std::make_shared<Poco::Event>();
     std::atomic<bool> initialized = false;
-    std::atomic<bool> stop_flag = true;
+    std::atomic<bool> stop_flag = false;
 
     std::unique_ptr<ThreadFromGlobalPool> main_thread;
     std::unique_ptr<ThreadFromGlobalPool> cleanup_thread;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Shutdown `DDLWorker` before shutting down `BackupsWorker`.

During shutdown it's necessary to shutdown `DDLWorker` before calling `BackupsWorker::shutdown()` and before shutting down databases, because otherwise the following case is possible:
1. Host1 starts executing `BACKUP ON CLUSTER`
2. Host2 starts shutting down, shuts down `BackupsWorker` and databases
3. Host2: `DDLWorker` on host2 starts executing an internal `BACKUP` query initiated on Host1. And this leads to a failure because `BackupsWorker` and databases have already shut down on step 2
4. Host1 gets a strange error from Host2 that a backup has failed.

The problem was found by a [failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=82818&sha=16c6274321b8d6c14184cc25f19cdd57ffab2189&name_0=PR&name_1=Integration%20tests%20%28asan%2C%20old%20analyzer%2C%206%2F6%29) of test `test_backup_restore_on_cluster/test.py::test_shutdown_waits_for_backup`.

This PR will fix test `test_backup_restore_on_cluster/test.py::test_shutdown_waits_for_backup`
