### PR TITLE
Add ci-build to the list of forbidden labels

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/can_be_merged.py
+++ b/ci/jobs/scripts/workflow_hooks/can_be_merged.py
@@ -13,6 +13,7 @@ def check():
         Labels.CI_FUNCTIONAL_FLAKY,
         Labels.CI_INTEGRATION,
         Labels.CI_FUNCTIONAL,
+        Labels.CI_BUILD,
     ]
 
     for label in forbidden_labels:


### PR DESCRIPTION
Add ci-build to the list of forbidden labels

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
