### PR TITLE
Fix crash during waiting for EndOfQuery in client after failed INSERT

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1796,8 +1796,8 @@ void ClientBase::processInsertQuery(String query, ASTPtr parsed_query)
     }
     catch (...)
     {
-        sendCancel(std::current_exception());
-        receiveEndOfQueryForInsert();
+        if (sendCancel(std::current_exception()))
+            receiveEndOfQueryForInsert();
         throw;
     }
 }
@@ -2122,7 +2122,7 @@ bool ClientBase::receiveEndOfQueryForInsert()
     }
 }
 
-void ClientBase::sendCancel(std::exception_ptr exception_ptr)
+bool ClientBase::sendCancel(std::exception_ptr exception_ptr)
 {
     if (!connection->isConnected())
     {
@@ -2133,9 +2133,13 @@ void ClientBase::sendCancel(std::exception_ptr exception_ptr)
             error_stream << getExceptionMessage(exception_ptr, /*with_stacktrace=*/ true);
         }
         error_stream << '\n';
+        return false;
     }
     else
+    {
         connection->sendCancel();
+        return true;
+    }
 }
 
 void ClientBase::cancelQuery()

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -212,7 +212,7 @@ private:
     bool receiveSampleBlock(Block & out, ColumnsDescription & columns_description, ASTPtr parsed_query);
     bool receiveEndOfQueryForInsert();
     void cancelQuery();
-    void sendCancel(std::exception_ptr exception_ptr = nullptr);
+    bool sendCancel(std::exception_ptr exception_ptr = nullptr);
 
     void onProgress(const Progress & value);
     void onTimezoneUpdate(const String & tz);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash in client due to connection left in disconnected state after bad INSERT

Fixes: https://github.com/ClickHouse/ClickHouse/issues/83123#issuecomment-3078776653 (cc @tavplubix )
Follow-up: https://github.com/ClickHouse/ClickHouse/pull/83253