### PR TITLE
Try to fix flaky iceberg metadata cache test

### DIFF
--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -3855,6 +3855,8 @@ def test_metadata_cache(started_cluster, storage_type):
     spark = started_cluster.spark_session
     TABLE_NAME = "test_metadata_cache_" + storage_type + "_" + get_uuid_str()
 
+    instance.query("SYSTEM DROP ICEBERG METADATA CACHE")
+
     write_iceberg_from_df(
         spark,
         generate_data(spark, 0, 10),


### PR DESCRIPTION
Clean the cache before start. Other runs before this one may fill the cache with their files, so it's important to clear cache before the beginning of the test.

Also I looked at another tests with cache, and they also have cache clear at the beginning.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Related to https://github.com/ClickHouse/ClickHouse/issues/83805

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

