### PR TITLE
Optimize MergeTreeReadersChain::getSampleBlock

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadersChain.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadersChain.cpp
@@ -39,9 +39,10 @@ size_t MergeTreeReadersChain::currentMark() const
     return range_readers.empty() ? 0 : range_readers.back().currentMark();
 }
 
-Block MergeTreeReadersChain::getSampleBlock() const
+const Block & MergeTreeReadersChain::getSampleBlock() const
 {
-    return range_readers.empty() ? Block{} : range_readers.back().getSampleBlock();
+    static const Block empty_block;
+    return range_readers.empty() ? empty_block : range_readers.back().getSampleBlock();
 }
 
 bool MergeTreeReadersChain::isCurrentRangeFinished() const

--- a/src/Storages/MergeTree/MergeTreeReadersChain.h
+++ b/src/Storages/MergeTree/MergeTreeReadersChain.h
@@ -22,7 +22,7 @@ public:
     size_t numRowsInCurrentGranule() const;
     size_t currentMark() const;
 
-    Block getSampleBlock() const;
+    const Block & getSampleBlock() const;
     bool isCurrentRangeFinished() const;
 
 private:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimize MergeTreeReadersChain::getSampleBlock

This is a micro-optimization. It takes ~0.5% of the runtime in ClickBench Q1, so I don't expect it to be visible in any perf test. References https://github.com/ClickHouse/ClickHouse/issues/81043

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
