### PR TITLE
fixing JSONEachRowWithProgress

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -98,7 +98,8 @@ static struct InitFiu
     REGULAR(database_replicated_delay_recovery) \
     REGULAR(database_replicated_delay_entry_execution) \
     REGULAR(plain_object_storage_copy_temp_source_file_fail_on_file_move) \
-    REGULAR(plain_object_storage_copy_temp_target_file_fail_on_file_move)
+    REGULAR(plain_object_storage_copy_temp_target_file_fail_on_file_move) \
+    REGULAR(output_format_sleep_on_progress) \
 
 
 namespace FailPoints

--- a/src/Processors/Formats/IOutputFormat.cpp
+++ b/src/Processors/Formats/IOutputFormat.cpp
@@ -4,9 +4,6 @@
 #include <IO/WriteBufferDecorator.h>
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Port.h>
-#include <Common/Logger.h>
-#include <Common/StackTrace.h>
-#include <Common/logger_useful.h>
 #include <Common/FailPoint.h>
 #include <base/sleep.h>
 

--- a/src/Processors/Formats/IOutputFormat.cpp
+++ b/src/Processors/Formats/IOutputFormat.cpp
@@ -4,10 +4,20 @@
 #include <IO/WriteBufferDecorator.h>
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Port.h>
+#include "Common/Logger.h"
+#include "Common/StackTrace.h"
+#include "Common/logger_useful.h"
+#include <Common/FailPoint.h>
+#include <base/sleep.h>
 
 
 namespace DB
 {
+
+namespace FailPoints
+{
+    extern const char output_format_sleep_on_progress[];
+}
 
 IOutputFormat::IOutputFormat(SharedHeader header_, WriteBuffer & out_)
     : IProcessor({header_, header_, header_}, {}), out(out_)
@@ -114,6 +124,9 @@ void IOutputFormat::work()
     if (auto_flush)
         flushImpl();
 
+    if (auto_flush)
+        LOG_ERROR(getLogger("OutputFormat"), "flushImpl from work");
+
     has_input = false;
 }
 
@@ -134,6 +147,9 @@ void IOutputFormat::flush()
 
 void IOutputFormat::write(const Block & block)
 {
+    LOG_ERROR(getLogger("OutputFormat"),
+        "write from \n{}", StackTrace().toString());
+
     std::lock_guard lock(writing_mutex);
 
     if (has_progress_update_to_write)
@@ -147,6 +163,9 @@ void IOutputFormat::write(const Block & block)
 
     if (auto_flush)
         flushImpl();
+
+    if (auto_flush)
+        LOG_ERROR(getLogger("OutputFormat"), "flushImpl from write");
 }
 
 void IOutputFormat::finalizeUnlocked()
@@ -166,6 +185,9 @@ void IOutputFormat::finalizeUnlocked()
 
     if (auto_flush)
         flushImpl();
+
+    LOG_ERROR(getLogger("OutputFormat"),
+        "finalizeImpl from \n{}", StackTrace().toString());
 
     finalizeBuffers();
     finalized = true;
@@ -194,6 +216,11 @@ void IOutputFormat::setExtremes(const Block & extremes)
 
 void IOutputFormat::onProgress(const Progress & progress)
 {
+    fiu_do_on(FailPoints::output_format_sleep_on_progress, {
+        LOG_DEBUG(getLogger("OutputFormat"), "Sleeping for 1 second to simulate slow progress writing");
+        sleepForMilliseconds(1000);
+    });
+
     statistics.progress.incrementPiecewiseAtomically(progress);
     UInt64 elapsed_ns = statistics.watch.elapsedNanoseconds();
     statistics.progress.elapsed_ns = elapsed_ns;
@@ -205,9 +232,13 @@ void IOutputFormat::onProgress(const Progress & progress)
         if (elapsed_ns >= prev_progress_write_ns + 1000 * progress_write_frequency_us)
         {
             std::unique_lock lock(writing_mutex, std::try_to_lock);
+
+            LOG_ERROR(getLogger("OutputFormat"), "progress is locked: {}", bool(lock));
+
             if (lock)
             {
                 writeProgress(statistics.progress);
+                LOG_ERROR(getLogger("OutputFormat"), "flushImpl from progress");
                 flushImpl();
                 prev_progress_write_ns = elapsed_ns;
                 has_progress_update_to_write = false;

--- a/src/Processors/Formats/IOutputFormat.cpp
+++ b/src/Processors/Formats/IOutputFormat.cpp
@@ -207,7 +207,7 @@ void IOutputFormat::onProgress(const Progress & progress)
     fiu_do_on(
         FailPoints::output_format_sleep_on_progress,
         {
-            sleepForSeconds(1);
+            sleepForMilliseconds(100);
         });
 
     statistics.progress.incrementPiecewiseAtomically(progress);
@@ -222,7 +222,7 @@ void IOutputFormat::onProgress(const Progress & progress)
         {
             std::unique_lock lock(writing_mutex, std::try_to_lock);
 
-            if (lock)
+            if (lock && has_progress_update_to_write && !finalized)
             {
                 writeProgress(statistics.progress);
                 flushImpl();

--- a/tests/queries/0_stateless/03567_json_with_progress.reference
+++ b/tests/queries/0_stateless/03567_json_with_progress.reference
@@ -1,0 +1,3 @@
+{"meta":[{"name":"1","type":"UInt8"}]}
+{"row":{"1":1}}
+{"rows_before_limit_at_least":1}

--- a/tests/queries/0_stateless/03567_json_with_progress.sh
+++ b/tests/queries/0_stateless/03567_json_with_progress.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database, no-async-insert
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+on_exit() {
+${CLICKHOUSE_CLIENT} -m --query "
+    SYSTEM DISABLE FAILPOINT output_format_sleep_on_progress;
+"
+}
+
+trap on_exit EXIT
+
+${CLICKHOUSE_CLIENT} -m --query "SYSTEM ENABLE FAILPOINT output_format_sleep_on_progress;"
+
+query="
+SELECT number
+FROM (SELECT number FROM system.numbers_mt LIMIT 10)
+LIMIT 5
+"
+
+
+SETTINGS="default_format=JSONEachRowWithProgress"
+SETTINGS="${SETTINGS}&interactive_delay=1"
+SETTINGS="${SETTINGS}&max_block_size=1&max_threads=10"
+
+${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}&${SETTINGS}" -d "$query"

--- a/tests/queries/0_stateless/03567_json_with_progress.sh
+++ b/tests/queries/0_stateless/03567_json_with_progress.sh
@@ -16,14 +16,13 @@ trap on_exit EXIT
 ${CLICKHOUSE_CLIENT} -m --query "SYSTEM ENABLE FAILPOINT output_format_sleep_on_progress;"
 
 query="
-SELECT number
-FROM (SELECT number FROM system.numbers_mt LIMIT 10)
-LIMIT 5
+SELECT 1
+FROM (SELECT number FROM system.numbers_mt LIMIT 2)
+LIMIT 1
 "
-
 
 SETTINGS="default_format=JSONEachRowWithProgress"
 SETTINGS="${SETTINGS}&interactive_delay=1"
 SETTINGS="${SETTINGS}&max_block_size=1&max_threads=10"
 
-${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}&${SETTINGS}" -d "$query"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&${SETTINGS}" -d "$query" | sed 's/^{"progress":{.*}$//g' | grep -v "^$"

--- a/tests/queries/0_stateless/03567_json_with_progress.sh
+++ b/tests/queries/0_stateless/03567_json_with_progress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database, no-async-insert
+# Tags: no-replicated-database, no-async-insert, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Usage `JSONEachRowWithProgress` format triggers `LOGICAL_ERROR`

```
PipelineExecutor: Code: 49. DB::Exception: Cannot write to finalized buffer: While executing Remote. (LOGICAL_ERROR), Stack trace (when copying this message, always include the lines below):


0. ./ci/tmp/build/./src/Common/Exception.cpp:112: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool)
1. DB::Exception::Exception(PreformattedMessage&&, int)
2. DB::Exception::Exception<>(int, FormatStringHelperImpl<>)
3. ./ci/tmp/build/./src/IO/WriteBuffer.cpp:41: DB::WriteBuffer::write(char const*, unsigned long)
4. ./ci/tmp/build/./src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp:83: DB::JSONEachRowWithProgressRowOutputFormat::writeProgress(DB::Progress const&)
5. ./ci/tmp/build/./src/Processors/Formats/IOutputFormat.cpp:210: DB::IOutputFormat::onProgress(DB::Progress const&)
6. ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
7. ./ci/tmp/build/./src/Processors/Executors/ExecutionThreadContext.cpp:68: DB::ExecutionThreadContext::executeTask()
8. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:305: DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*)
9. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:271: void std::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__function::__default_alloc_func<DB::PipelineExecutor::spawnThreadsImpl(std::shared_ptr<DB::IAcquiredSlot>)::$_0, void ()>>(std::__function::__policy_storage const*)
10. ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
11. ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: void std::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*)
12. ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
13. ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: void* std::__thread_proxy[abi:ne190107]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*)
14. ?
```

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
onProgress call in JSONEachRowWithProgress is synchronized with finalization 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
