### PR TITLE
Text index: remove `CONTAINS_ALL` flag from postings list

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -41,7 +41,7 @@ CREATE TABLE tab
 (
     `key` UInt64,
     `str` String,
-    INDEX inv_idx(str) TYPE text(tokenizer = 'default|ngram|split|no_op' [, ngram_size = N] [, separators = []] [, max_rows_per_postings_list = M]) [GRANULARITY 64]
+    INDEX inv_idx(str) TYPE text(tokenizer = 'default|ngram|split|no_op' [, ngram_size = N] [, separators = []]) [GRANULARITY 64]
 )
 ENGINE = MergeTree
 ORDER BY key
@@ -73,13 +73,6 @@ In case of the `split` tokenizer: if the tokens do not form a [prefix code](http
 To do so, pass the separators in order of descending length.
 For example, with separators = `['%21', '%']` string `%21abc` would be tokenized as `['abc']`, whereas separators = `['%', '%21']` would tokenize to `['21ac']` (which is likely not what you wanted).
 :::
-
-The maximum rows per postings list can be specified via the optional `max_rows_per_postings_list` parameter.
-The parameter can be used to control postings list sizes to avoid generating huge postings list files.
-
-- `max_rows_per_postings_list = 0`: No limitation of maximum rows per postings list.
-- `max_rows_per_postings_list = M`: with `M` should be at least 8192.
-- If not specified: Use a default maximum rows which is 64K.
 
 Being a type of skipping index, text indexes can be dropped or added to a column after table creation:
 

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1585,13 +1585,6 @@ void StatementGenerator::addTableIndex(RandomGenerator & rg, SQLTable & t, const
                 buf += "]";
                 idef->add_params()->set_unescaped_sval(std::move(buf));
             }
-            if (rg.nextBool())
-            {
-                std::uniform_int_distribution<uint32_t> next_dist(8192, 4194304);
-
-                idef->add_params()->set_unescaped_sval(
-                    "max_rows_per_postings_list = " + std::to_string(rg.nextSmallNumber() < 3 ? 0 : next_dist(rg.generator)));
-            }
         }
         break;
         case IndexType::IDX_vector_similarity:

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -17,7 +17,9 @@ namespace DB
 {
 
 GinFilterParameters::GinFilterParameters(
-    String tokenizer_, std::optional<UInt64> ngram_size_, std::optional<std::vector<String>> separators_)
+    String tokenizer_,
+    std::optional<UInt64> ngram_size_,
+    std::optional<std::vector<String>> separators_)
     : tokenizer(std::move(tokenizer_))
     , ngram_size(ngram_size_)
     , separators(separators_)

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -50,7 +50,7 @@ void GinFilter::add(const char * data, size_t len, UInt32 rowID, GinIndexStorePt
     }
     else
     {
-        auto builder = std::make_shared<GinIndexPostingsBuilder>(params.max_rows_per_postings_list);
+        auto builder = std::make_shared<GinIndexPostingsBuilder>();
         builder->add(rowID);
 
         store->setPostingsBuilder(term, builder);

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -17,17 +17,11 @@ namespace DB
 {
 
 GinFilterParameters::GinFilterParameters(
-    String tokenizer_,
-    UInt64 max_rows_per_postings_list_,
-    std::optional<UInt64> ngram_size_,
-    std::optional<std::vector<String>> separators_)
+    String tokenizer_, std::optional<UInt64> ngram_size_, std::optional<std::vector<String>> separators_)
     : tokenizer(std::move(tokenizer_))
-    , max_rows_per_postings_list(max_rows_per_postings_list_)
     , ngram_size(ngram_size_)
     , separators(separators_)
 {
-    if (max_rows_per_postings_list == UNLIMITED_ROWS_PER_POSTINGS_LIST)
-        max_rows_per_postings_list = std::numeric_limits<UInt64>::max();
 }
 
 GinFilter::GinFilter(const GinFilterParameters & params_)

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -9,8 +9,6 @@ namespace DB
 static inline constexpr auto TEXT_INDEX_NAME = "text";
 static inline constexpr UInt64 UNLIMITED_ROWS_PER_POSTINGS_LIST = 0;
 static inline constexpr UInt64 DEFAULT_NGRAM_SIZE = 3;
-static inline constexpr UInt64 MIN_ROWS_PER_POSTINGS_LIST = 8 * 1024;
-static inline constexpr UInt64 DEFAULT_MAX_ROWS_PER_POSTINGS_LIST = 64 * 1024;
 
 enum class GinSearchMode : uint8_t
 {
@@ -22,12 +20,10 @@ struct GinFilterParameters
 {
     GinFilterParameters(
         String tokenizer_,
-        UInt64 max_rows_per_postings_list_,
         std::optional<UInt64> ngram_size_,
         std::optional<std::vector<String>> separators_);
 
     String tokenizer;
-    UInt64 max_rows_per_postings_list;
     /// for ngram tokenizer
     std::optional<UInt64> ngram_size;
     /// for split tokenizer

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -111,9 +111,7 @@ GinIndexPostingsListPtr GinIndexPostingsBuilder::deserialize(ReadBuffer & buffer
         UInt64 num_entries = (header >> 1);
         std::vector<UInt32> values(num_entries);
         for (size_t i = 0; i < num_entries; ++i)
-        {
             readVarUInt(values[i], buffer);
-        }
 
         GinIndexPostingsListPtr postings_list = std::make_shared<GinIndexPostingsList>();
         postings_list->addMany(values.size(), values.data());

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -64,11 +64,17 @@ public:
     static GinIndexPostingsListPtr deserialize(ReadBuffer & buffer);
 
 private:
-    static constexpr int MIN_SIZE_FOR_ROARING_ENCODING = 16;
+    static constexpr size_t MIN_SIZE_FOR_ROARING_ENCODING = 16;
 
     static constexpr size_t ROARING_ENCODING_COMPRESSION_CARDINALITY_THRESHOLD = 5000;
 
-    roaring::Roaring rowid_bitmap;
+    static constexpr size_t ARRAY_CONTAINER_MASK = 0x1;
+
+    static constexpr size_t ROARING_CONTAINER_MASK = 0x0;
+    static constexpr size_t ROARING_COMPRESSED_MASK = 0x1;
+    static constexpr size_t ROARING_UNCOMPRESSED_MASK = 0x0;
+
+    roaring::Roaring rowids;
 };
 
 using GinIndexPostingsBuilderPtr = std::shared_ptr<GinIndexPostingsBuilder>;

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -51,8 +51,6 @@ public:
 class GinIndexPostingsBuilder
 {
 public:
-    explicit GinIndexPostingsBuilder(UInt64 limit);
-
     /// Check whether a row_id is already added
     bool contains(UInt32 row_id) const;
 
@@ -66,32 +64,11 @@ public:
     static GinIndexPostingsListPtr deserialize(ReadBuffer & buffer);
 
 private:
-    constexpr static int MIN_SIZE_FOR_ROARING_ENCODING = 16;
+    static constexpr int MIN_SIZE_FOR_ROARING_ENCODING = 16;
 
-    /// When the list length is no greater than MIN_SIZE_FOR_ROARING_ENCODING, array 'rowid_lst' is used
-    /// As a special case, rowid_lst[0] == CONTAINS_ALL encodes that all rowids are set.
-    std::array<UInt32, MIN_SIZE_FOR_ROARING_ENCODING> rowid_lst;
+    static constexpr size_t ROARING_ENCODING_COMPRESSION_CARDINALITY_THRESHOLD = 5000;
 
-    /// When the list length is greater than MIN_SIZE_FOR_ROARING_ENCODING, roaring bitmap 'rowid_bitmap' is used
     roaring::Roaring rowid_bitmap;
-
-    /// rowid_lst_length stores the number of row IDs in 'rowid_lst' array, can also be a flag(0xFF) indicating that roaring bitmap is used
-    UInt8 rowid_lst_length = 0;
-
-    /// Indicates that all rowids are contained, see 'rowid_lst'
-    static constexpr UInt32 CONTAINS_ALL = std::numeric_limits<UInt32>::max();
-
-    /// Indicates that roaring bitmap is used, see 'rowid_lst_length'.
-    static constexpr UInt8 USES_BIT_MAP = 0xFF;
-
-    /// Clear the postings list and reset it with MATCHALL flags when the size of the postings list is beyond the limit
-    UInt64 size_limit;
-
-    /// Check whether the builder is using roaring bitmap
-    bool useRoaring() const { return rowid_lst_length == USES_BIT_MAP; }
-
-    /// Check whether the postings list has been flagged to contain all row ids
-    bool containsAllRows() const { return rowid_lst[0] == CONTAINS_ALL; }
 };
 
 using GinIndexPostingsBuilderPtr = std::shared_ptr<GinIndexPostingsBuilder>;

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -6,9 +6,6 @@ Test ngram_size argument.
 Test separators argument.
 -- separators must be array.
 -- separators must be an array of strings.
-Test max_rows_per_postings_list argument.
--- max_rows_per_posting_list is set to unlimited rows.
--- max_rows_per_posting_list should be at least 8192.
 Parameters are shuffled.
 Types are incorrect.
 Same argument appears >1 times.

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -119,62 +119,12 @@ CREATE TABLE tab
 ENGINE = MergeTree
 ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
 
-SELECT 'Test max_rows_per_postings_list argument.';
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'ngram', ngram_size = 4, max_rows_per_postings_list = 9999)
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-DROP TABLE tab;
-
-SELECT '-- max_rows_per_posting_list is set to unlimited rows.';
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', max_rows_per_postings_list = 0)
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-DROP TABLE tab;
-
-SELECT '-- max_rows_per_posting_list should be at least 8192.';
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', max_rows_per_postings_list = 8191)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', max_rows_per_postings_list = 8192)
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-DROP TABLE tab;
-
 SELECT 'Parameters are shuffled.';
 
 CREATE TABLE tab
 (
     str String,
-    INDEX idx str TYPE text(max_rows_per_postings_list = 8192, tokenizer = 'default')
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-DROP TABLE tab;
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(max_rows_per_postings_list = 8192, ngram_size = 4, tokenizer = 'ngram')
+    INDEX idx str TYPE text(ngram_size = 4, tokenizer = 'ngram')
 )
 ENGINE = MergeTree
 ORDER BY tuple();
@@ -214,22 +164,6 @@ CREATE TABLE tab
 ENGINE = MergeTree
 ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
 
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(max_rows_per_postings_list)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(max_rows_per_postings_list = '9999')
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
 SELECT 'Same argument appears >1 times.';
 
 CREATE TABLE tab
@@ -244,14 +178,6 @@ CREATE TABLE tab
 (
     str String,
     INDEX idx str TYPE text(tokenizer = 'ngram', ngram_size = 3, ngram_size = 4)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', max_rows_per_postings_list = 9999, max_rows_per_postings_list = 8888)
 )
 ENGINE = MergeTree
 ORDER BY tuple(); -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/02346_text_index_queries.reference
+++ b/tests/queries/0_stateless/02346_text_index_queries.reference
@@ -33,5 +33,3 @@ Test text(tokenizer = "ngram", ngram_size = 2) on UTF-8 data
 af	text
 102	clickhouse你好
 1
-Test max_rows_per_postings_list
-1

--- a/tests/queries/0_stateless/02346_text_index_queries.sql
+++ b/tests/queries/0_stateless/02346_text_index_queries.sql
@@ -170,32 +170,3 @@ SELECT read_rows==2 from system.query_log
         AND type='QueryFinish'
         AND result_rows==1
     LIMIT 1;
-
-
-----------------------------------------------------
-
-SELECT 'Test max_rows_per_postings_list';
-DROP TABLE IF EXISTS tab;
-
--- create table 'tab' with text index parameter (ngrams, max_rows_per_most_list) which is (0, 10240)
-CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE text(tokenizer = 'default', max_rows_per_postings_list = 12040) GRANULARITY 1)
-                     Engine=MergeTree
-                     ORDER BY (k)
-                     AS
-                         (SELECT
-                             number,
-                             format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
-                         FROM numbers(1024));
-SELECT count(s) FROM tab WHERE hasToken(s, '4C4B4B4B4B4B5040');
-DROP TABLE IF EXISTS tab;
-
--- create table 'tab' with GINindex parameter (ngrams, max_rows_per_most_list) which is (0, 123)
--- it should throw exception since max_rows_per_most_list(123) is less than its minimum value(8196)
-CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE text(3, 123) GRANULARITY 1)
-                     Engine=MergeTree
-                     ORDER BY (k)
-                     AS
-                         (SELECT
-                            number,
-                            format('{},{},{},{}', hex(12345678), hex(87654321), hex(number/17 + 5), hex(13579012)) as s
-                         FROM numbers(1024));  -- { serverError INCORRECT_QUERY }


### PR DESCRIPTION
The `CONTAINS_ALL` flag was used to save space in postings list. When set, it indicates the term exists in the range, but exact row ids were unknown.

Since we need to know the exact rows to benefit from text index in the following optimizations, the flag is removed.
The postings list now contains all row ids where term exists.

This PR also contains additional optimization that avoids `zstd` compression on top of Roaring Bitmap (cardinality < 5000). Since Roaring Bitmap is already highly optimized and compressed, `zstd` compression didn't improve the disk space; instead, it increased the size. Observations from experiments showed `zstd` might help when bitmap cardinality >= 5000.
So, we apply `zstd` compression on top of Roaring Bitmap when it contains more than 5000 entries.

Also, remove `max_rows_per_postings_list` text index argument which used to set the `CONTAINS_ALL` flag.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)