### PR TITLE
Try -falign-functions=64 in attempt for more stable perf tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,9 +299,8 @@ set (CMAKE_C_STANDARD_REQUIRED ON)
 # See https://reviews.llvm.org/D112921
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
 
-# falign-functions=32 prevents from random performance regressions with the code change. Thus, providing more stable
-# benchmarks.
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -falign-functions=32")
+# falign-functions=64 prevents from random performance regressions with the code change. Thus, providing more stable benchmarks.
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -falign-functions=64")
 
 if (ARCH_AMD64)
     # align branches within a 32-Byte boundary to avoid the potential performance loss when code layout change,


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Try -falign-functions=64 in attempt for more stable perf tests

While looking at #78555 I found that some functions in a slower builds are aligned to 32 boundary, let's try 64.

Also few side notes:
- asm for hot functions is the same
- slower builds has smaller insn per cycle
- slower builds has 10x more iTLB-loads

Note, that clang does not support complex alignment required that gcc has, like -falign-functions=n:m:n2:m2

Refs: https://lkml.org/lkml/2015/5/19/1009
Refs: https://github.com/ClickHouse/ClickHouse/pull/21431
Refs: https://github.com/ClickHouse/ClickHouse/issues/78555