### PR TITLE
Hardcode config paths in tests

### DIFF
--- a/tests/queries/0_stateless/01737_clickhouse_server_wait_server_pool_long.sh
+++ b/tests/queries/0_stateless/01737_clickhouse_server_wait_server_pool_long.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 server_opts=(
-    "--config-file=$CUR_DIR/$(basename "${BASH_SOURCE[0]}" .sh).config.xml"
+    "--config-file=$CUR_DIR/01737_clickhouse_server_wait_server_pool_long.config.xml"
     "--"
     # to avoid multiple listen sockets (complexity for port discovering)
     "--listen_host=127.1"

--- a/tests/queries/0_stateless/01954_clickhouse_benchmark_multiple_long.sh
+++ b/tests/queries/0_stateless/01954_clickhouse_benchmark_multiple_long.sh
@@ -5,7 +5,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-BASE="$CUR_DIR/$(basename "${BASH_SOURCE[0]}" .sh)"
+BASE="$CUR_DIR/01954_clickhouse_benchmark_multiple_long"
 
 server_pids=()
 paths=()

--- a/tests/queries/0_stateless/02110_clickhouse_local_custom_tld.sh
+++ b/tests/queries/0_stateless/02110_clickhouse_local_custom_tld.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 function clickhouse_local()
 {
     local opts=(
-        --config "$CURDIR/$(basename "${BASH_SOURCE[0]}" .sh).config.xml"
+        --config "$CURDIR/02110_clickhouse_local_custom_tld.config.xml"
         --top_level_domains_path "$CURDIR"
     )
     $CLICKHOUSE_LOCAL "${opts[@]}" "$@"

--- a/tests/queries/0_stateless/02207_allow_plaintext_and_no_password.sh
+++ b/tests/queries/0_stateless/02207_allow_plaintext_and_no_password.sh
@@ -10,7 +10,7 @@ sed -i 's/<password><\/password>/<password_sha256_hex>c64c5e4e53ea1a9f1427d2713b
  sed -i 's/<!-- <access_management>1<\/access_management> -->/<access_management>1<\/access_management>/g' "$CURDIR"/users.xml
 
 server_opts=(
-    "--config-file=$CURDIR/$(basename "${BASH_SOURCE[0]}" .sh).config.xml"
+    "--config-file=$CURDIR/02207_allow_plaintext_and_no_password.config.xml"
     "--"
     # to avoid multiple listen sockets (complexity for port discovering)
     "--listen_host=127.1"

--- a/tests/queries/0_stateless/02422_allow_implicit_no_password.sh
+++ b/tests/queries/0_stateless/02422_allow_implicit_no_password.sh
@@ -14,7 +14,7 @@ sed -i 's/<password><\/password>/<password_sha256_hex>c64c5e4e53ea1a9f1427d2713b
  sed -i 's/<!-- <access_management>1<\/access_management> -->/<access_management>1<\/access_management>/g' "$CURDIR"/users.xml
 
 server_opts=(
-    "--config-file=$CURDIR/$(basename "${BASH_SOURCE[0]}" .sh).config.xml"
+    "--config-file=$CURDIR/02422_allow_implicit_no_password.config.xml"
     "--"
     # to avoid multiple listen sockets (complexity for port discovering)
     "--listen_host=127.1"

--- a/tests/queries/0_stateless/02802_clickhouse_disks_s3_copy.sh
+++ b/tests/queries/0_stateless/02802_clickhouse_disks_s3_copy.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-config="${BASH_SOURCE[0]/.sh/.xml}"
+config="02802_clickhouse_disks_s3_copy.xml"
 
 function run_test_for_disk()
 {

--- a/tests/queries/0_stateless/02802_clickhouse_disks_s3_copy.sh
+++ b/tests/queries/0_stateless/02802_clickhouse_disks_s3_copy.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-config="02802_clickhouse_disks_s3_copy.xml"
+config="${CUR_DIR}/02802_clickhouse_disks_s3_copy.xml"
 
 function run_test_for_disk()
 {

--- a/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_MergeTree.sh
+++ b/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_MergeTree.sh
@@ -11,7 +11,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 # config for clickhouse-disks (to check leftovers)
-config="${BASH_SOURCE[0]/.sh/.yml}"
+config="02980_s3_plain_DROP_TABLE_MergeTree.yml"
 
 # only in Atomic ATTACH from s3_plain works
 new_database="ordinary_$CLICKHOUSE_DATABASE"

--- a/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_MergeTree.sh
+++ b/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_MergeTree.sh
@@ -11,7 +11,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 # config for clickhouse-disks (to check leftovers)
-config="02980_s3_plain_DROP_TABLE_MergeTree.yml"
+config="${CUR_DIR}/02980_s3_plain_DROP_TABLE_MergeTree.yml"
 
 # only in Atomic ATTACH from s3_plain works
 new_database="ordinary_$CLICKHOUSE_DATABASE"

--- a/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.sh
+++ b/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.sh
@@ -14,7 +14,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-config="02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.yml"
+config="$CUR_DIR/02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.yml"
 
 # only in Atomic ATTACH from s3_plain works
 new_database="ordinary_$CLICKHOUSE_DATABASE"

--- a/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.sh
+++ b/tests/queries/0_stateless/02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.sh
@@ -14,7 +14,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-config="${BASH_SOURCE[0]/.sh/.yml}"
+config="02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.yml"
 
 # only in Atomic ATTACH from s3_plain works
 new_database="ordinary_$CLICKHOUSE_DATABASE"

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
@@ -72,7 +72,7 @@ if [ -e "$data_path$mv_metadata_path" ]; then
     #cat $mv_metadata_path
 else
     # Using a remote DB disk
-    config="${BASH_SOURCE[0]/.sh/.xml}"
+    config="03001_matview_columns_after_modify_query.xml"
     mv_metadata=$(clickhouse-disks -C "$config" --disk "disk_db_remote" --save-logs --query "read $mv_metadata_path") 
     mv_metadata_updated=$(echo $mv_metadata | sed -e 's/`timestamp` DateTime,/`timestamp` DateTime64(9),/g' -e 's/`c12` Nullable(String)/`c12` String/g')
     echo $mv_metadata_updated | clickhouse-disks -C "$config" --disk "disk_db_remote" --save-logs --query "write --path-to $mv_metadata_path"

--- a/tests/queries/0_stateless/03335_empty_blobs_on_azure.sh
+++ b/tests/queries/0_stateless/03335_empty_blobs_on_azure.sh
@@ -8,8 +8,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
-config="${BASH_SOURCE[0]/.sh/.xml}"
-
 CONTAINER="cont-$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr _ -)"
 
 DISK_NAME="$CONTAINER"

--- a/tests/queries/0_stateless/03335_empty_blobs_on_s3.sh
+++ b/tests/queries/0_stateless/03335_empty_blobs_on_s3.sh
@@ -8,8 +8,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
-config="${BASH_SOURCE[0]/.sh/.xml}"
-
 # Create a table on S3 disk with Array column and wide parts
 # Insert a row with empty Array-s so that arr.bin file is empty
 $CLICKHOUSE_CLIENT -m -q "

--- a/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh
+++ b/tests/queries/0_stateless/03344_clickhouse_extract_from_config_try.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # NOTE: Cannot use CLICKHOUSE_EXTRACT_CONFIG, since it uses default config.
 
-prefix=$CUR_DIR/"$(basename "${BASH_SOURCE[0]}" .sh)"
+prefix=$CUR_DIR/"03344_clickhouse_extract_from_config_try"
 
 $CLICKHOUSE_BINARY extract-from-config --key merge_tree.comment --config $prefix.xml
 $CLICKHOUSE_BINARY extract-from-config --key merge_tree.anything_xml --config $prefix.xml |& grep -o 'Not found: merge_tree.anything_xml'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Hardcode config paths in tests

When running CI with some transformations (like replacing engines) we want to rename the test files temporarily. Using `"${BASH_SOURCE[0]}"` to look for config files is broken by that. It's simpler and clearer if the config names are hardcoded

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
