### PR TITLE
Reduce query memory tracking drift for executable UDF

### DIFF
--- a/tests/queries/0_stateless/03568_udf_memory_tracking.reference
+++ b/tests/queries/0_stateless/03568_udf_memory_tracking.reference
@@ -1,0 +1,5 @@
+Row 1:
+──────
+queries:            2
+min_less_then_20mb: 1
+max_less_then_20mb: 1

--- a/tests/queries/0_stateless/03568_udf_memory_tracking.sql
+++ b/tests/queries/0_stateless/03568_udf_memory_tracking.sql
@@ -1,0 +1,18 @@
+SET log_queries = 1;
+
+SELECT test_function(number, 0) FROM numbers(100) FORMAT Null SETTINGS max_threads = 1, max_block_size = 1;
+SELECT test_function(number, 0) FROM numbers(200) FORMAT Null SETTINGS max_threads = 1, max_block_size = 1;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT
+    count() AS queries,
+    min(memory_usage) < 20000000 AS min_less_then_20mb,
+    max(memory_usage) < 20000000 AS max_less_then_20mb
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query_kind = 'Select'
+  AND query LIKE '%test_function(number, 0)%'
+FORMAT Vertical;
+


### PR DESCRIPTION
Currently executable functions, when called over multiple blocks during single query execution, will produce a significant overhead in query memory tracker.

Mostly, this is caused by the execution of tasks sending data to shell commands: `TimeoutWriteBufferFromFileDescriptor`, which is a part of `SendDataTask` is created in the query thread and increments its memory counter, but then `SendDataTask`s are executed and destroyed in "anonymous" threads from global pool, decrementing only global memory counter, which causes significant difference in tracked memory values at the query level and the global one, and may lead to MEMORY_LIMIT_EXCEEDED errors.

This patch partially fixes the memory drift, specifically its part produced by `TimeoutWriteBufferFromFileDescriptor` objects, by attaching data sending threads to the query thread group.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce query memory tracking overhead for executable user-defined functions.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
