### PR TITLE
CI: Fix gh label for release PRs

### DIFF
--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -450,8 +450,10 @@ class ReleaseInfo:
                     verbose=True,
                 )
 
-        # TODO: move to new GH step?
         if self.release_type == "new":
+            release_type = (
+                version.get_stable_release_type()
+            )  # get release type before version is bumped
             print("Update version on master branch")
             branch_upd_version_contributors = self.get_version_bump_branch()
             with checkout(self.commit_sha):
@@ -508,7 +510,7 @@ class ReleaseInfo:
             print("Create Release PR")
             with checkout(self.release_branch):
                 pr_labels = f"--label {CI.Labels.RELEASE}"
-                if version.get_stable_release_type() == VersionType.LTS:
+                if release_type == VersionType.LTS:
                     pr_labels += f" --label {CI.Labels.RELEASE_LTS}"
                 Shell.check(
                     f"""gh pr create --repo {CI.Envs.GITHUB_REPOSITORY} --title 'Release pull request for branch {self.release_branch}' \


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix release/release-lts labels assignment for release PRs

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
