### PR TITLE
Support bloom_filter usage for "has" on const array

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -387,7 +387,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseFunction(const RPNBuilderTreeNo
             if (traverseTreeEquals(function_name, lhs_argument, const_type, const_value, out, parent))
                 return true;
         }
-        else if (lhs_argument.tryGetConstant(const_value, const_type) && (function_name == "equals" || function_name == "notEquals"))
+        else if (lhs_argument.tryGetConstant(const_value, const_type) && (function_name == "has" || function_name == "equals" || function_name == "notEquals"))
         {
             if (traverseTreeEquals(function_name, rhs_argument, const_type, const_value, out, parent))
                 return true;
@@ -530,6 +530,30 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
 }
 
 
+static ColumnPtr createColumnFromConstantArray(const Field & value_field, const DataTypePtr & actual_type)
+{
+    if (value_field.getType() != Field::Types::Array)
+        return nullptr;
+
+    const bool is_nullable = actual_type->isNullable();
+    auto mutable_column = actual_type->createColumn();
+
+    for (const auto & f : value_field.safeGet<Array>())
+    {
+        if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
+            return nullptr;
+
+        auto converted = convertFieldToType(f, *actual_type);
+        if (converted.isNull())
+            return nullptr;
+
+        mutable_column->insert(converted);
+    }
+
+    return std::move(mutable_column);
+}
+
+
 static bool indexOfCanUseBloomFilter(const RPNBuilderTreeNode * parent)
 {
     if (!parent)
@@ -626,21 +650,32 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
 
         if (function_name == "has" || function_name == "indexOf")
         {
-            if (!array_type)
-                return false;
-
-            /// We can treat `indexOf` function similar to `has`.
-            /// But it is little more cumbersome, compare: `has(arr, elem)` and `indexOf(arr, elem) != 0`.
-            /// The `parent` in this context is expected to be function `!=` (`notEquals`).
-            if (function_name == "has" || indexOfCanUseBloomFilter(parent))
+            if (array_type)
             {
-                out.function = RPNElement::FUNCTION_HAS;
-                const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-                auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
-                if (converted_field.isNull())
+                /// We can treat `indexOf` function similar to `has`.
+                /// But it is little more cumbersome, compare: `has(arr, elem)` and `indexOf(arr, elem) != 0`.
+                /// The `parent` in this context is expected to be function `!=` (`notEquals`).
+                if (function_name == "has" || indexOfCanUseBloomFilter(parent))
+                {
+                    out.function = RPNElement::FUNCTION_HAS;
+                    const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
+                    auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
+                    if (converted_field.isNull())
+                        return false;
+
+                    out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithField(actual_type.get(), converted_field)));
+                }
+            }
+            else if (function_name == "has")
+            {
+                const DataTypePtr actual_type = BloomFilter::getPrimitiveType(index_type);
+                ColumnPtr column = createColumnFromConstantArray(value_field, actual_type);
+
+                if (!column)
                     return false;
 
-                out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithField(actual_type.get(), converted_field)));
+                out.function = RPNElement::FUNCTION_HAS_ANY;
+                out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithColumn(actual_type, column, 0, column->size())));
             }
         }
         else if (function_name == "hasAny" || function_name == "hasAll")
@@ -648,29 +683,11 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
             if (!array_type)
                 return false;
 
-            if (value_field.getType() != Field::Types::Array)
-                return false;
-
             const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-            ColumnPtr column;
-            {
-                const bool is_nullable = actual_type->isNullable();
-                auto mutable_column = actual_type->createColumn();
+            ColumnPtr column = createColumnFromConstantArray(value_field, actual_type);
 
-                for (const auto & f : value_field.safeGet<Array>())
-                {
-                    if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
-                        return false;
-
-                    auto converted = convertFieldToType(f, *actual_type);
-                    if (converted.isNull())
-                        return false;
-
-                    mutable_column->insert(converted);
-                }
-
-                column = std::move(mutable_column);
-            }
+            if (!column)
+                return false;
 
             out.function = function_name == "hasAny" ?
                 RPNElement::FUNCTION_HAS_ANY :

--- a/tests/queries/0_stateless/03376_bloom_filter_has_const_array.reference
+++ b/tests/queries/0_stateless/03376_bloom_filter_has_const_array.reference
@@ -1,0 +1,11 @@
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.bloom_filter_has_const_array)
+    Indexes:
+      Skip
+        Name: bf
+        Description: bloom_filter GRANULARITY 1
+        Parts: 1/1
+        Granules: 2/4
+a
+c

--- a/tests/queries/0_stateless/03376_bloom_filter_has_const_array.reference
+++ b/tests/queries/0_stateless/03376_bloom_filter_has_const_array.reference
@@ -1,11 +1,4 @@
-Expression ((Project names + Projection))
-  Filter ((WHERE + Change column names to column identifiers))
-    ReadFromMergeTree (default.bloom_filter_has_const_array)
-    Indexes:
-      Skip
-        Name: bf
-        Description: bloom_filter GRANULARITY 1
-        Parts: 1/1
-        Granules: 2/4
+Description: bloom_filter GRANULARITY 1
+Granules: 2/4
 a
 c

--- a/tests/queries/0_stateless/03376_bloom_filter_has_const_array.sql
+++ b/tests/queries/0_stateless/03376_bloom_filter_has_const_array.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+
+CREATE TABLE bloom_filter_has_const_array
+(
+    `s` String,
+    INDEX bf s TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity = 1;
+
+INSERT INTO bloom_filter_has_const_array VALUES ('a'), ('b'), ('c'), ('d');
+
+SET force_index_by_date = 0, force_primary_key = 0;
+
+EXPLAIN indexes = 1
+SELECT *
+FROM bloom_filter_has_const_array
+WHERE has(['a', 'c'], s);
+
+SELECT *
+FROM bloom_filter_has_const_array
+WHERE has(['a', 'c'], s)
+ORDER BY s;
+
+DROP TABLE IF EXISTS bloom_filter_has_const_array;

--- a/tests/queries/0_stateless/03376_bloom_filter_has_const_array.sql
+++ b/tests/queries/0_stateless/03376_bloom_filter_has_const_array.sql
@@ -13,10 +13,13 @@ INSERT INTO bloom_filter_has_const_array VALUES ('a'), ('b'), ('c'), ('d');
 
 SET force_index_by_date = 0, force_primary_key = 0;
 
-EXPLAIN indexes = 1
-SELECT *
-FROM bloom_filter_has_const_array
-WHERE has(['a', 'c'], s);
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT *
+    FROM bloom_filter_has_const_array
+    WHERE has(['a', 'c'], s)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
 
 SELECT *
 FROM bloom_filter_has_const_array


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry
The bloom filter index is now used for conditions like `has([c1, c2, ...], column)`, where `column` is not of an `Array` type.  
This improves performance for such queries, making them as efficient as the `IN` operator.

### Motivation
This change extends the power of bloom filter indexes to a common query pattern.  
Previously, to use a bloom filter on a scalar column, users had to write `column IN (c1, c2)`.  
Now, they can also use `has([c1, c2], column)` syntax and receive the same performance benefit, allowing the query to skip data granules that don't contain the relevant values.

### Example use
Given a table with a bloom filter index on a non-Array column:

```sql
CREATE TABLE users (
    user_id UInt64,
    name String,
    INDEX bf_idx user_id TYPE bloom_filter
) ENGINE = MergeTree ORDER BY user_id;
```
  The following query will now efficiently use the bf_idx index to filter granules, whereas previously it would have resulted in a full table scan:
  
```sql  
SELECT name FROM users WHERE has([123, 456, 789], user_id);
```