### PR TITLE
using std::sort speeds up AggregateFunctionLargestTriangleThreeBuckets

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionLargestTriangleThreeBuckets.cpp
+++ b/src/AggregateFunctions/AggregateFunctionLargestTriangleThreeBuckets.cpp
@@ -54,6 +54,7 @@ struct LargestTriangleThreeBucketsData : public StatisticalSample<Float64, Float
         std::vector<size_t> index(this->x.size());
 
         iota(index.data(), index.size(), size_t(0));
+        //std::sort yields performance improvement over ::sort
         std::sort(index.begin(), index.end(), [&](size_t i1, size_t i2) { return this->x[i1] < this->x[i2]; });
 
         SampleX temp_x{};

--- a/src/AggregateFunctions/AggregateFunctionLargestTriangleThreeBuckets.cpp
+++ b/src/AggregateFunctions/AggregateFunctionLargestTriangleThreeBuckets.cpp
@@ -54,7 +54,7 @@ struct LargestTriangleThreeBucketsData : public StatisticalSample<Float64, Float
         std::vector<size_t> index(this->x.size());
 
         iota(index.data(), index.size(), size_t(0));
-        ::sort(index.begin(), index.end(), [&](size_t i1, size_t i2) { return this->x[i1] < this->x[i2]; });
+        std::sort(index.begin(), index.end(), [&](size_t i1, size_t i2) { return this->x[i1] < this->x[i2]; });
 
         SampleX temp_x{};
         SampleY temp_y{};


### PR DESCRIPTION

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
Using std::sort in AggregateFunctionLargestTriangleThreeBuckets increases the throughput of largestTriangleThreeBuckets queries by almost 30%.
For example, the following query
./clickhousebenchmark -i 1 --query "FROM covid19 SELECT untuple(arrayJoin(largestTriangleThreeBuckets(1000)(date, new_confirmed)))"
With ::sort:
localhost:9000, queries: 1, QPS: 0.538, RPS: 6736850.919, MiB/s: 38.549, result RPS: 537.837, result MiB/s: 0.005.
With std::sort
localhost:9000, queries: 1, QPS: 0.684, RPS: 8568119.716, MiB/s: 49.027, result RPS: 684.036, result MiB/s: 0.007.

Tested with no perf degradation on c5, c6a, c7i AWS instances in release mode
