### PR TITLE
Unblock compilation with CMake 3.28

### DIFF
--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -18,13 +18,6 @@ if(NOT ENABLE_PROTOBUF)
     return()
 endif()
 
-# To supress the following warning:
-# CMake Warning (dev) at contrib/google-cloud-cpp/cmake/CompileProtos.cmake:354 (install):
-#   Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
-#   "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
-#   command to set the policy and suppress this warning.
-cmake_policy(SET CMP0177 OLD)
-
 # Gather sources and options.
 set(GOOGLE_CLOUD_CPP_SOURCES)
 set(GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES)


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/pull/82881/files#diff-696a21c32e8478c1df5d6fc8408503ec3381b844914c26553fed83cc440ce305R21-R26 introduced this to google-cloud-api CMake:

```cmake
# To supress the following warning:
# CMake Warning (dev) at contrib/google-cloud-cpp/cmake/CompileProtos.cmake:354 (install):
#   Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
#   "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
#   command to set the policy and suppress this warning.
cmake_policy(SET CMP0177 OLD)
```

Unfortunately, policy `CMP0177` was only added with CMake 3.31 (see [here](https://cmake.org/cmake/help/latest/policy/CMP0177.html)) whereas Ubuntu 24.04 LTS (which lots of people are using, it is the most recent Ubuntu version available in EC2) only comes with CMake 3.28, see [here](https://packages.ubuntu.com/noble/cmake). So this broke compilation for me. Of course, upgrading CMake is trivial but we should not ask for brand new CMake versions in the first place.

Since the warning that the policy should suppress didn't appear anyways when I commented `cmake_policy` out, I removed it.

@azat 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)