### PR TITLE
S3 retry strategy considers query execution time.

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -56,12 +56,14 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool s3_use_adaptive_timeouts;
+    extern const SettingsSeconds max_execution_time;
 }
 
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int TOO_MANY_REDIRECTS;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace S3
@@ -91,6 +93,18 @@ bool Client::RetryStrategy::ShouldRetry(const Aws::Client::AWSError<Aws::Client:
     if (useGCSRewrite(error))
         return false;
 
+    if (auto query_context = CurrentThread::getQueryContext())
+    {
+        /// Check if query is timeout.
+        auto query_start_time = query_context->getClientInfo().initial_query_start_time;
+        auto max_execution_time = query_context->getSettingsRef()[Setting::max_execution_time].totalSeconds();
+        auto now = time(nullptr);
+        if (query_start_time > 0 && query_start_time < now
+            && max_execution_time > 0 && now > query_start_time + max_execution_time)
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED,
+                "Query timeout during S3 request retrying. Elapsed: {} seconds, maximum: {}", now - query_start_time, max_execution_time);
+    }
+
     return error.ShouldRetry();
 }
 
@@ -111,7 +125,23 @@ long Client::RetryStrategy::CalculateDelayBeforeNextRetry(const Aws::Client::AWS
     }
 
     uint64_t backoffLimitedPow = 1ul << std::min(attemptedRetries, 31l);
-    return std::min<uint64_t>(scaleFactor * backoffLimitedPow, maxDelayMs);
+    auto delay_ms = std::min<uint64_t>(scaleFactor * backoffLimitedPow, maxDelayMs);
+
+    if (auto query_context = CurrentThread::getQueryContext())
+    {
+        /// Sleep should not exceed max_execution_time
+        auto query_start_time = query_context->getClientInfo().initial_query_start_time;
+        uint64_t max_execution_time = query_context->getSettingsRef()[Setting::max_execution_time].totalSeconds();
+        auto now = time(nullptr);
+        if (query_start_time > 0 && query_start_time < now && max_execution_time > 0)
+        {
+            uint64_t elapsed = now - query_start_time;
+            uint64_t remain_secs = max_execution_time - std::min(elapsed, max_execution_time);
+            delay_ms = std::min(delay_ms, remain_secs * 1000);
+        }
+    }
+
+    return delay_ms;
 }
 
 /// NOLINTNEXTLINE(google-runtime-int)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

S3 retry strategy consider query execution time.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

When S3 request encounters network problems, the client will retry the request until attempt time reaches `s3_retry_attempts`.

However, each retry will delay by an exponential backoff algorithm (maximum 90000ms, 90s). With attempt time growing, the accumulated execution time will be every large, even dozens of minutes. As the retries are run in one thread, `LimitsCheckingTransform` cannot interrupt the thread when `max_execution_time` elapsed.

Therefore, the S3 retry strategy should consider `max_excution_time`.

By the way, we can only configure `s3_retry_attempts` in S3 retry strategy currently. I add the other two settings (`s3_retry_scale_factor`, `s3_retry_max_delay_ms`) in another PR #82642.