### PR TITLE
Try -falign-functions=16 to see how much fresh build will take on CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,9 +299,7 @@ set (CMAKE_C_STANDARD_REQUIRED ON)
 # See https://reviews.llvm.org/D112921
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
 
-# falign-functions=32 prevents from random performance regressions with the code change. Thus, providing more stable
-# benchmarks.
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -falign-functions=32")
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -falign-functions=16")
 
 if (ARCH_AMD64)
     # align branches within a 32-Byte boundary to avoid the potential performance loss when code layout change,


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Try -falign-functions=16

In https://github.com/ClickHouse/ClickHouse/pull/83920 the release build timed out with -falign-functions=64, let's see is it related to cache or not by changing the alignment, that should recompile everything.