### PR TITLE
Fix 03164_parallel_replicas_range_filter_min_max

### DIFF
--- a/tests/queries/0_stateless/03164_parallel_replicas_range_filter_min_max.sql
+++ b/tests/queries/0_stateless/03164_parallel_replicas_range_filter_min_max.sql
@@ -134,6 +134,8 @@ CREATE TABLE range_filter_custom_range_test_2 (k UInt64) ENGINE=MergeTree ORDER 
 
 INSERT INTO range_filter_custom_range_test_2 SELECT number from numbers(13);
 
+SET send_logs_level = 'error'; -- failed connection tries are ok, `parallel_replicas` cluster contains 1 unavailable node
+
 SELECT count()
 FROM
 (


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bc78680633b11e50574e9dfc2ef1287c963ca6ab&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%201%2F4%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

