### PR TITLE
web-ui | add button for show/hide query editor

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -31,7 +31,6 @@
     Nice to have:
     - resizable columns
     - display totals
-    - show/hide the editor
     - check for readonly
     - query caching
     - downloads in any format
@@ -354,8 +353,8 @@
             display: grid;
             place-items: center;
             gap: 1rem;
-            grid-template-columns: auto auto auto 1fr auto auto;
-            grid-template-areas: "run hint hourglass progress-bar progress-text theme";
+            grid-template-columns: auto auto auto 1fr auto auto auto;
+            grid-template-areas: "run hint hourglass progress-bar progress-text toggle-editor theme";
         }
 
         #run
@@ -421,6 +420,13 @@
                 transparent 0%,
                 var(--progress-color) var(--progress),
                 transparent var(--progress));
+        }
+
+        #toggle-editor
+        {
+            cursor: pointer;
+            grid-area: toggle-editor;
+            user-select: none;
         }
 
         #theme
@@ -717,11 +723,12 @@
             <div id="query_div"><textarea autofocus spellcheck="false" autocorrect="false" autocomplete="false" data-gramm="false" class="monospace shadow" id="query"></textarea></div>
             <div id="run_div">
                 <button class="shadow" id="run">Run</button>
-                <div id="hint">&nbsp;(Ctrl/Cmd+Enter)</div>
+                <div id="hint">(Ctrl/Cmd+Enter)</div>
                 <div id="hourglass">⧗</div>
                 <div id="check-mark">✔</div>
                 <div id="progress"></div>
                 <div id="stats"></div>
+                <div id="toggle-editor">📝</div>
                 <div id="theme"><span id="toggle-dark">🌘</span><span id="toggle-light">☀️</span></div>
             </div>
         </div>
@@ -2016,6 +2023,11 @@ if (theme) {
 
 if (run_immediately) {
     post();
+}
+
+document.getElementById('toggle-editor').onclick = function() {
+    const queryDiv = document.getElementById('query_div');
+    queryDiv.style.display = queryDiv.style.display === 'none' ? 'block' : 'none';
 }
 
 document.getElementById('toggle-light').onclick = function() {


### PR DESCRIPTION
### Changelog category (leave one):
- **New Feature**

### Changelog entry:
- Added a new button in the web UI that allows users to hide or show the query editor area. This improves the user experience by giving users more control over the interface layout.

**Motivation**:  
This new button enhances the flexibility of the ClickHouse web UI by allowing users to minimize or expand the query editor area. This can help users with limited screen space or those who prefer a cleaner interface while working with other features of the UI.

**Parameters**:  
- The feature is activated by a new toggle button located near the query editor.

**Example use**:  
- Users can now click the toggle button to hide the query editor area when it's not in use, freeing up space for viewing results or other UI components. Clicking the button again will restore the editor.
