### PR TITLE
Fix flaky 03002_part_log_rmt_fetch_merge_error

### DIFF
--- a/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sh
+++ b/tests/queries/0_stateless/03002_part_log_rmt_fetch_merge_error.sh
@@ -13,7 +13,7 @@ function wait_until()
 {
     local q=$1 && shift
     while [ "$($CLICKHOUSE_CLIENT -m -q "$q")" != "1" ]; do
-        sleep 0.5
+        sleep 1
     done
 }
 
@@ -33,13 +33,17 @@ $CLICKHOUSE_CLIENT -m -q "
     optimize table rmt_master final settings alter_sync=1, optimize_throw_if_noop=1;
 "
 
-$CLICKHOUSE_CLIENT -m -q "
+# wait until rmt_slave will try to fetch the part and reflect this error in system.part_log
+wait_until "
     system flush logs part_log;
+    select count()>0 from system.part_log where table = 'rmt_slave' and database = '$CLICKHOUSE_DATABASE' and error > 0;
+"
+
+$CLICKHOUSE_CLIENT -m -q "
     select 'before';
     select table, event_type, error>0, countIf(error=0) from system.part_log where database = currentDatabase() group by 1, 2, 3 order by 1, 2, 3;
 "
-# wait until rmt_slave will fetch the part and reflect this error in system.part_log
-wait_until "select count()>0 from system.part_log where table = 'rmt_slave' and database = '$CLICKHOUSE_DATABASE' and error > 0"
+
 $CLICKHOUSE_CLIENT -m -q "
     system start replicated sends rmt_master;
     system sync replica rmt_slave;


### PR DESCRIPTION
Fix for the test [failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=83929&sha=latest&name_0=PR&name_1=Stateless+tests+%28amd_tsan%2C+s3+storage%2C+1%2F3%29&name_2=Tests).

Accroding to the logs, the part_log has been flushed before the attempt of merging parts failed, so the fix is to wait for the error before checking it in part_log.

<details>
<summary>Partial log for the test</summary>

```
2025.07.17 21:48:52.213489 [ 36779 ] {84f34da4-62f5-4859-b3a7-47cbb4b5882d} <Trace> InterpreterSystemQuery: SYNC REPLICA test_m719fhog.rmt_slave (2e56dcdc-c939-4bc8-bb7d-5888425e2e34): OK
2025.07.17 21:48:52.582658 [ 2313 ] {} <Trace> 2e56dcdc-c939-4bc8-bb7d-5888425e2e34::all_0_0_1 (MergeFromLogEntryTask): Executing log entry to merge parts all_0_0_0 to all_0_0_1
2025.07.17 21:48:52.583477 [ 2313 ] {} <Information> 2e56dcdc-c939-4bc8-bb7d-5888425e2e34::all_0_0_1 (MergeFromLogEntryTask): Will fetch part all_0_0_1 because setting 'always_fetch_merged_part' is true
2025.07.17 21:48:53.365304 [ 57784 ] {9a0eaf3e-4ef6-44a9-9879-dabd6b7fe4cf} <Debug> executeQuery: (from [::1]:40796) (comment: 03002_part_log_rmt_fetch_merge_error.sh) (query 1, line 2) system flush logs part_log; (stage: Complete)
2025.07.17 21:48:53.509713 [ 2313 ] {} <Information> 2e56dcdc-c939-4bc8-bb7d-5888425e2e34::all_0_0_1 (MergeFromLogEntryTask): Code: 234. DB::Exception: No active replica has part all_0_0_1 or covering part (cannot execute queue-0000000001: MERGE_PARTS with virtual parts [all_0_0_1]). (NO_REPLICA_HAS_PART)
2025.07.17 21:48:53.790893 [ 2316 ] {} <Trace> 2e56dcdc-c939-4bc8-bb7d-5888425e2e34::all_0_0_1 (MergeFromLogEntryTask): Executing log entry to merge parts all_0_0_0 to all_0_0_1
2025.07.17 21:48:53.791779 [ 2316 ] {} <Information> 2e56dcdc-c939-4bc8-bb7d-5888425e2e34::all_0_0_1 (MergeFromLogEntryTask): Will fetch part all_0_0_1 because setting 'always_fetch_merged_part' is true
2025.07.17 21:48:53.824060 [ 2316 ] {} <Debug> test_m719fhog.rmt_slave (2e56dcdc-c939-4bc8-bb7d-5888425e2e34): Fetching part all_0_0_1 from default:/clickhouse/test_m719fhog/replicas/master
2025.07.17 21:48:54.468203 [ 57784 ] {9d014374-bce5-4f01-aad8-7222f569fe5d} <Debug> executeQuery: (from [::1]:40796) (comment: 03002_part_log_rmt_fetch_merge_error.sh) (query 3, line 4) select table, event_type, error>0, countIf(error=0) from system.part_log where database = currentDatabase() group by 1, 2, 3 order by 1, 2, 3; (stage: Complete)
```

</details>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
