### PR TITLE
Always apply filesystem_prefetches_limit

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -188,6 +188,7 @@ namespace Setting
     extern const SettingsBool merge_tree_use_prefixes_deserialization_thread_pool;
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
     extern const SettingsBool enable_shared_storage_snapshot_in_query;
+    extern const SettingsUInt64 filesystem_prefetches_limit;
 }
 
 namespace MergeTreeSetting
@@ -222,6 +223,7 @@ static MergeTreeReaderSettings getMergeTreeReaderSettings(
         .query_condition_cache_store_conditions_as_plaintext = settings[Setting::query_condition_cache_store_conditions_as_plaintext],
         .use_deserialization_prefixes_cache = settings[Setting::merge_tree_use_deserialization_prefixes_cache],
         .use_prefixes_deserialization_thread_pool = settings[Setting::merge_tree_use_prefixes_deserialization_thread_pool],
+        .filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit],
     };
 }
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -57,6 +57,7 @@ struct MergeTreeReaderSettings
     bool query_condition_cache_store_conditions_as_plaintext = false;
     bool use_deserialization_prefixes_cache = false;
     bool use_prefixes_deserialization_thread_pool = false;
+    size_t filesystem_prefetches_limit = 0;
 };
 
 struct MergeTreeWriterSettings

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -31,7 +31,6 @@ namespace Setting
     extern const SettingsBool merge_tree_determine_task_size_by_prewhere_columns;
     extern const SettingsUInt64 filesystem_prefetch_step_bytes;
     extern const SettingsUInt64 filesystem_prefetch_step_marks;
-    extern const SettingsUInt64 filesystem_prefetches_limit;
     extern const SettingsUInt64 prefetch_buffer_size;
 }
 
@@ -423,13 +422,13 @@ void MergeTreePrefetchedReadPool::fillPerThreadTasks(size_t threads, size_t sum_
         sum_marks,
         threads,
         min_marks_per_thread,
-        settings[Setting::filesystem_prefetches_limit].value,
+        reader_settings.filesystem_prefetches_limit,
         total_size_approx);
 
     size_t allowed_memory_usage = settings[Setting::filesystem_prefetch_max_memory_usage];
 
     std::optional<size_t> allowed_prefetches_num
-        = settings[Setting::filesystem_prefetches_limit] ? std::optional<size_t>(settings[Setting::filesystem_prefetches_limit]) : std::nullopt;
+        = reader_settings.filesystem_prefetches_limit ? std::optional<size_t>(reader_settings.filesystem_prefetches_limit) : std::nullopt;
 
     per_thread_tasks.clear();
     size_t total_tasks = 0;

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -109,7 +109,9 @@ void MergeTreeReaderWide::prefetchForAllColumns(
         ? settings.read_settings.remote_fs_prefetch
         : settings.read_settings.local_fs_prefetch;
 
-    if (!do_prefetch || num_columns > settings.filesystem_prefetches_limit || all_mark_ranges.getNumberOfMarks() == 0)
+    if (!do_prefetch || all_mark_ranges.getNumberOfMarks() == 0)
+        return;
+    if (settings.filesystem_prefetches_limit && num_columns > settings.filesystem_prefetches_limit)
         return;
 
     if (deserialize_prefixes)

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -1,6 +1,5 @@
 #include <Storages/MergeTree/MergeTreeReaderWide.h>
 
-#include <Core/Settings.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnSparse.h>
 #include <DataTypes/DataTypeArray.h>
@@ -22,11 +21,6 @@ namespace DB
 namespace
 {
     constexpr auto DATA_FILE_EXTENSION = ".bin";
-}
-
-namespace Setting
-{
-    extern const SettingsUInt64 filesystem_prefetches_limit;
 }
 
 MergeTreeReaderWide::MergeTreeReaderWide(
@@ -115,10 +109,7 @@ void MergeTreeReaderWide::prefetchForAllColumns(
         ? settings.read_settings.remote_fs_prefetch
         : settings.read_settings.local_fs_prefetch;
 
-    const auto & settings = data_part_info_for_read->getContext()->getSettingsRef();
-    auto filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit];
-
-    if (!do_prefetch || num_columns > filesystem_prefetches_limit || all_mark_ranges.getNumberOfMarks() == 0)
+    if (!do_prefetch || num_columns > settings.filesystem_prefetches_limit || all_mark_ranges.getNumberOfMarks() == 0)
         return;
 
     if (deserialize_prefixes)

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
@@ -1,4 +1,8 @@
-SELECT * FROM data_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
-SELECT * FROM data_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	10
-SELECT * FROM data_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
-SELECT * FROM data_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	0
+SELECT * FROM data_wide FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	0	5	0
+SELECT * FROM data_wide FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	0	10	10
+SELECT * FROM data_wide FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	5	0
+SELECT * FROM data_wide FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	10	10
+SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	0	5	0
+SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	0	10	0
+SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	5	0
+SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	10	10

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
@@ -1,4 +1,8 @@
-SELECT * FROM metric_log_full_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
-SELECT * FROM metric_log_packed_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
-SELECT * FROM metric_log_full_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
-SELECT * FROM metric_log_packed_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
+SELECT * FROM data_full_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
+SELECT * FROM data_full_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	10
+SELECT * FROM data_packed_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
+SELECT * FROM data_packed_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	10
+SELECT * FROM data_full_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
+SELECT * FROM data_full_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	0
+SELECT * FROM data_packed_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
+SELECT * FROM data_packed_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	0

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
@@ -5,4 +5,4 @@ SELECT * FROM data_wide FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limi
 SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	0	5	0
 SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	0	10	0
 SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	5	0
-SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	10	10
+SELECT * FROM data_compact FORMAT Null SETTINGS `?` = ?, filesystem_prefetches_limit = ?;	1	10	0

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
@@ -1,0 +1,4 @@
+SELECT * FROM metric_log_full_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
+SELECT * FROM metric_log_packed_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
+SELECT * FROM metric_log_full_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0
+SELECT * FROM metric_log_packed_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	0

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.reference
@@ -1,8 +1,4 @@
-SELECT * FROM data_full_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
-SELECT * FROM data_full_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	10
-SELECT * FROM data_packed_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
-SELECT * FROM data_packed_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	10
-SELECT * FROM data_full_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
-SELECT * FROM data_full_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	0
-SELECT * FROM data_packed_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
-SELECT * FROM data_packed_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	0
+SELECT * FROM data_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
+SELECT * FROM data_wide FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	10
+SELECT * FROM data_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	5	0
+SELECT * FROM data_compact FORMAT Null SETTINGS filesystem_prefetches_limit = ?;	10	0

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
@@ -3,6 +3,9 @@
 -- - no-random-settings -- more deterministic prefetch
 -- - no-parallel-replicas -- other replicas may do prefetch
 
+-- Disable multibuffer, there is a separate test
+SET merge_tree_compact_parts_min_granules_to_multibuffer_read = 129;
+
 {% for min_bytes_for_wide_part in [0, 10e9] %}
 
 {% set table = 'data' +

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
@@ -1,0 +1,39 @@
+-- Tags: no-fasttest, no-random-settings, long, no-parallel-replicas
+-- - no-fasttest -- requires S3
+-- - no-random-settings -- more deterministic prefetch
+-- - no-parallel-replicas -- other replicas may do prefetch
+
+-- Create system.metric_log
+SYSTEM FLUSH LOGS metric_log;
+
+{% for min_bytes_for_wide_part in [0, 10e9] %}
+{% for min_bytes_for_full_part_storage in [0, 10e9] %}
+
+{% set table = 'metric_log' +
+    ('_full' if min_bytes_for_full_part_storage == 0 else '_packed') +
+    ('_wide' if min_bytes_for_wide_part == 0 else '_compact') +
+    ''
+%}
+
+DROP TABLE IF EXISTS {{ table }};
+
+CREATE TABLE {{ table }} AS system.metric_log
+ENGINE = MergeTree
+PARTITION BY tuple()
+ORDER BY (event_date, event_time)
+SETTINGS
+    disk='s3_cache',
+    min_bytes_for_wide_part = {{ min_bytes_for_wide_part }},
+    min_bytes_for_full_part_storage={{ min_bytes_for_full_part_storage }};
+
+INSERT INTO {{ table }} SELECT * FROM generateRandom() LIMIT 400;
+
+SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 100;
+
+{% endfor %}
+{% endfor %}
+
+SYSTEM FLUSH LOGS query_log;
+SELECT normalizeQuery(query), ProfileEvents['RemoteFSPrefetches'] FROM system.query_log
+WHERE current_database = currentDatabase() AND type != 'QueryStart' AND query_kind = 'Select'
+ORDER BY event_time_microseconds;

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
@@ -3,13 +3,10 @@
 -- - no-random-settings -- more deterministic prefetch
 -- - no-parallel-replicas -- other replicas may do prefetch
 
--- Create system.metric_log
-SYSTEM FLUSH LOGS metric_log;
-
 {% for min_bytes_for_wide_part in [0, 10e9] %}
 {% for min_bytes_for_full_part_storage in [0, 10e9] %}
 
-{% set table = 'metric_log' +
+{% set table = 'data' +
     ('_full' if min_bytes_for_full_part_storage == 0 else '_packed') +
     ('_wide' if min_bytes_for_wide_part == 0 else '_compact') +
     ''
@@ -17,10 +14,16 @@ SYSTEM FLUSH LOGS metric_log;
 
 DROP TABLE IF EXISTS {{ table }};
 
-CREATE TABLE {{ table }} AS system.metric_log
+CREATE TABLE {{ table }}
+(
+    {% for i in range(1, 10) %}
+    c{{ i }} String,
+    {% endfor %}
+    c0 String
+)
 ENGINE = MergeTree
 PARTITION BY tuple()
-ORDER BY (event_date, event_time)
+ORDER BY ()
 SETTINGS
     disk='s3_cache',
     min_bytes_for_wide_part = {{ min_bytes_for_wide_part }},
@@ -28,12 +31,13 @@ SETTINGS
 
 INSERT INTO {{ table }} SELECT * FROM generateRandom() LIMIT 400;
 
-SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 100;
+SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 5;
+SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 10;
 
 {% endfor %}
 {% endfor %}
 
 SYSTEM FLUSH LOGS query_log;
-SELECT normalizeQuery(query), ProfileEvents['RemoteFSPrefetches'] FROM system.query_log
+SELECT normalizeQuery(query), Settings['filesystem_prefetches_limit'], ProfileEvents['RemoteFSPrefetches'] FROM system.query_log
 WHERE current_database = currentDatabase() AND type != 'QueryStart' AND query_kind = 'Select'
 ORDER BY event_time_microseconds;

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
@@ -4,10 +4,8 @@
 -- - no-parallel-replicas -- other replicas may do prefetch
 
 {% for min_bytes_for_wide_part in [0, 10e9] %}
-{% for min_bytes_for_full_part_storage in [0, 10e9] %}
 
 {% set table = 'data' +
-    ('_full' if min_bytes_for_full_part_storage == 0 else '_packed') +
     ('_wide' if min_bytes_for_wide_part == 0 else '_compact') +
     ''
 %}
@@ -27,14 +25,13 @@ ORDER BY ()
 SETTINGS
     disk='s3_cache',
     min_bytes_for_wide_part = {{ min_bytes_for_wide_part }},
-    min_bytes_for_full_part_storage={{ min_bytes_for_full_part_storage }};
+    min_bytes_for_full_part_storage=0;
 
 INSERT INTO {{ table }} SELECT * FROM generateRandom() LIMIT 400;
 
 SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 5;
 SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 10;
 
-{% endfor %}
 {% endfor %}
 
 SYSTEM FLUSH LOGS query_log;

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-random-settings, long, no-parallel-replicas
+-- Tags: no-fasttest, no-random-settings, no-parallel-replicas
 -- - no-fasttest -- requires S3
 -- - no-random-settings -- more deterministic prefetch
 -- - no-parallel-replicas -- other replicas may do prefetch

--- a/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
+++ b/tests/queries/0_stateless/03394_filesystem_prefetches_limit.sql.j2
@@ -29,12 +29,14 @@ SETTINGS
 
 INSERT INTO {{ table }} SELECT * FROM generateRandom() LIMIT 400;
 
-SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 5;
-SELECT * FROM {{ table }} FORMAT Null SETTINGS filesystem_prefetches_limit = 10;
+SELECT * FROM {{ table }} FORMAT Null SETTINGS allow_prefetched_read_pool_for_remote_filesystem = 0, filesystem_prefetches_limit = 5;
+SELECT * FROM {{ table }} FORMAT Null SETTINGS allow_prefetched_read_pool_for_remote_filesystem = 0, filesystem_prefetches_limit = 10;
+SELECT * FROM {{ table }} FORMAT Null SETTINGS allow_prefetched_read_pool_for_remote_filesystem = 1, filesystem_prefetches_limit = 5;
+SELECT * FROM {{ table }} FORMAT Null SETTINGS allow_prefetched_read_pool_for_remote_filesystem = 1, filesystem_prefetches_limit = 10;
 
 {% endfor %}
 
 SYSTEM FLUSH LOGS query_log;
-SELECT normalizeQuery(query), Settings['filesystem_prefetches_limit'], ProfileEvents['RemoteFSPrefetches'] FROM system.query_log
+SELECT normalizeQuery(query), Settings['allow_prefetched_read_pool_for_remote_filesystem'], Settings['filesystem_prefetches_limit'], ProfileEvents['RemoteFSPrefetches'] FROM system.query_log
 WHERE current_database = currentDatabase() AND type != 'QueryStart' AND query_kind = 'Select'
 ORDER BY event_time_microseconds;


### PR DESCRIPTION
Previously it was applied only from MergeTreePrefetchedReadPool, which was doing initial prefetch, now it will be respected for all reads.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Always apply `filesystem_prefetches_limit` (not only from `MergeTreePrefetchedReadPool`)

_Note: it has some changes in private as well_