### PR TITLE
CI: Run perf comparison with release merge-base on master

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -359,7 +359,8 @@ def main():
             "release_branch_base_sha_with_predecessors"
         )[0]
         Shell.check(
-            f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:", verbose=True
+            f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:",
+            verbose=True,
         )
         Shell.check(
             f"rm -rf ./tests/performance && git checkout {reference_sha} ./tests/performance",

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -59,7 +59,11 @@ def should_skip_job(job_name):
         print("WARNING: no changed files found for PR - do not filter jobs")
         return False, ""
 
-    if Labels.CI_BUILD in _info_cache.pr_labels and "build" not in job_name.lower() and job_name not in PRELIMINARY_JOBS:
+    if (
+        Labels.CI_BUILD in _info_cache.pr_labels
+        and "build" not in job_name.lower()
+        and job_name not in PRELIMINARY_JOBS
+    ):
         return True, f"Skipped, labeled with '{Labels.CI_BUILD}'"
 
     if Labels.DO_NOT_TEST in _info_cache.pr_labels and job_name not in DO_NOT_TEST_JOBS:
@@ -158,6 +162,9 @@ def should_skip_job(job_name):
         and JobNames.PERFORMANCE in job_name
         and "arm" in job_name
     ):
+        if "release_base" in job_name and not _info_cache.pr_number:
+            # comparison with the latest release merge base - do not skip on master
+            return False, ""
         return True, "Skipped, not labeled with 'pr-performance'"
 
     return False, ""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

fix for filter hook to not skip perf job on master

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
