### PR TITLE
Fix logical error "Expected single dictionary argument for function"

### DIFF
--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -308,8 +308,8 @@ JoinActionRef predicateToCondition(const JoinPredicate & predicate, const Action
     left_column.column = nullptr;
     right_column.column = nullptr;
 
-    auto & left_node = findOrAddInput(actions_dag, left_column);
-    auto & right_node = findOrAddInput(actions_dag, right_column);
+    const auto & left_node = findOrAddInput(actions_dag, left_column);
+    const auto & right_node = findOrAddInput(actions_dag, right_column);
 
     auto operator_function = FunctionFactory::instance().get(operatorToFunctionName(predicate.op), nullptr);
     const auto & result_node = actions_dag->addFunction(operator_function, {&left_node, &right_node}, {});

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -300,8 +300,16 @@ const ActionsDAG::Node & findOrAddInput(const ActionsDAGPtr & actions_dag, const
 
 JoinActionRef predicateToCondition(const JoinPredicate & predicate, const ActionsDAGPtr & actions_dag)
 {
-    const auto & left_node = findOrAddInput(actions_dag, predicate.left_node.getColumn());
-    const auto & right_node = findOrAddInput(actions_dag, predicate.right_node.getColumn());
+    ColumnWithTypeAndName left_column = predicate.left_node.getColumn();
+    ColumnWithTypeAndName right_column = predicate.right_node.getColumn();
+
+    /// Constant columns from the JOIN condition will be materialized during the JOIN,
+    /// that's why we can't use them as constants for actions building.
+    left_column.column = nullptr;
+    right_column.column = nullptr;
+
+    auto & left_node = findOrAddInput(actions_dag, left_column);
+    auto & right_node = findOrAddInput(actions_dag, right_column);
 
     auto operator_function = FunctionFactory::instance().get(operatorToFunctionName(predicate.op), nullptr);
     const auto & result_node = actions_dag->addFunction(operator_function, {&left_node, &right_node}, {});

--- a/tests/queries/0_stateless/03571_join_inequality_constants.sql
+++ b/tests/queries/0_stateless/03571_join_inequality_constants.sql
@@ -1,2 +1,4 @@
+SET enable_analyzer = 1;
+
 SELECT id FROM (SELECT toLowCardinality(1) AS id) AS a INNER JOIN (SELECT toLowCardinality(toUInt128(materialize(0))) AS id) AS b USING (id) INNER JOIN a AS t ON b.id < t.id;
 SELECT 1 FROM (SELECT toLowCardinality(0) a) a FULL JOIN a b USING (a) JOIN a c ON b.a > c.a SETTINGS join_use_nulls = true;

--- a/tests/queries/0_stateless/03571_join_inequality_constants.sql
+++ b/tests/queries/0_stateless/03571_join_inequality_constants.sql
@@ -1,0 +1,2 @@
+SELECT id FROM (SELECT toLowCardinality(1) AS id) AS a INNER JOIN (SELECT toLowCardinality(toUInt128(materialize(0))) AS id) AS b USING (id) INNER JOIN a AS t ON b.id < t.id;
+SELECT 1 FROM (SELECT toLowCardinality(0) a) a FULL JOIN a b USING (a) JOIN a c ON b.a > c.a SETTINGS join_use_nulls = true;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the logical error `Expected single dictionary argument for function` while doing JOIN on an inequality condition when one of the columns is `LowCardinality` and the other is a constant. Closes #81779.