### PR TITLE
Fix TSan in clang-20

### DIFF
--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -48,6 +48,11 @@ inline ALWAYS_INLINE size_t alignToSizeT(std::align_val_t align) noexcept
     return static_cast<size_t>(align);
 }
 
+inline ALWAYS_INLINE size_t alignUp(size_t size, size_t align) noexcept
+{
+    return (size + align - 1) / align * align;
+}
+
 template <std::same_as<std::align_val_t>... TAlign>
 requires DB::OptionalArgument<TAlign...>
 inline ALWAYS_INLINE void * newImpl(std::size_t size, TAlign... align)
@@ -80,7 +85,7 @@ inline ALWAYS_INLINE void * newImpl(std::size_t size, TAlign... align)
 
     void * ptr = nullptr;
     if constexpr (sizeof...(TAlign) == 1)
-        ptr = aligned_alloc(alignToSizeT(align...), size);
+        ptr = aligned_alloc(alignToSizeT(align...), alignUp(size, alignToSizeT(align...)));
     else
         ptr = malloc(size);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
milovidov@milovidov-pc:~/work/ClickHouse/build_tsan$ ch --query="SELECT * FROM system.events FORMAT Parquet" | programs/clickhouse local --path . --query="INSERT INTO parquet_events FORMAT Parquet"
==2917744==ERROR: ThreadSanitizer: invalid alignment requested in aligned_alloc: 8, alignment must be a power of two and the requested size 0x1e must be a multiple of alignment
    #0 aligned_alloc /home/milovidov/work/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:841:3 (clickhouse+0x8422612) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #1 void* Memory::newImpl<std::align_val_t>(unsigned long, T...) build_tsan/./src/Common/memory.h:83:15 (clickhouse+0x120aeb24) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #2 operator new(unsigned long, std::align_val_t) build_tsan/./src/Common/new_delete.cpp:63:18 (clickhouse+0x120aeb24)
    #3 llvm::allocate_buffer(unsigned long, unsigned long) <null> (clickhouse+0x23c6c8a0) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #4 std::__1::pair<llvm::StringMapIterator<llvm::cl::Option*>, bool> llvm::StringMap<llvm::cl::Option*, llvm::MallocAllocator>::try_emplace_with_hash<llvm::cl::Option*>(llvm::StringRef, unsigned int, llvm::cl::Option*&&) CommandLine.cpp (clickhouse+0x23c3c7a7) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #5 (anonymous namespace)::CommandLineParser::addOption(llvm::cl::Option*, llvm::cl::SubCommand*) CommandLine.cpp (clickhouse+0x23c3c9a7) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #6 llvm::cl::Option::addArgument() <null> (clickhouse+0x23c34f12) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #7 llvm::cl::list<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, llvm::DebugCounter, llvm::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::list<char [14], llvm::cl::OptionHidden, llvm::cl::desc, llvm::cl::MiscFlags, llvm::cl::LocationClass<llvm::DebugCounter>>(char const (&) [14], llvm::cl::OptionHidden const&, llvm::cl::desc const&, llvm::cl::MiscFlags const&, llvm::cl::LocationClass<llvm::DebugCounter> const&) DebugCounter.cpp (clickhouse+0x23c424f9) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #8 (anonymous namespace)::DebugCounterOwner::DebugCounterOwner() DebugCounter.cpp (clickhouse+0x23c4093f) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #9 llvm::DebugCounter::instance() <null> (clickhouse+0x23c40812) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #10 llvm::DebugCounter::registerCounter(llvm::StringRef, llvm::StringRef) PassBuilder.cpp (clickhouse+0x2124720c) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #11 _GLOBAL__sub_I_PassBuilder.cpp PassBuilder.cpp (clickhouse+0x212bc450) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)
    #12 __libc_csu_init <null> (clickhouse+0x28104edc) (BuildId: 9b1e87e40265a3ab67705a2fb49c136e3f25d4a6)

==2917744==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: ThreadSanitizer: invalid-aligned-alloc-alignment build_tsan/./src/Common/memory.h:83:15 in void* Memory::newImpl<std::align_val_t>(unsigned long, T...)
```