### PR TITLE
MongoDB integration: parse numeric types from string

### DIFF
--- a/docs/en/engines/table-engines/integrations/mongodb.md
+++ b/docs/en/engines/table-engines/integrations/mongodb.md
@@ -60,10 +60,10 @@ ENGINE = MongoDB(uri, collection[, oid_columns]);
 
 | MongoDB                 | ClickHouse                                                            |
 |-------------------------|-----------------------------------------------------------------------|
-| bool, int32, int64      | *any numeric type*, String                                            |
+| bool, int32, int64      | *any numeric type except Decimals*, Boolean, String                   |
 | double                  | Float64, String                                                       |
 | date                    | Date, Date32, DateTime, DateTime64, String                            |
-| string                  | String                                                                |
+| string                  | String, *any numeric type(except Decimals) if formatted correctly*    |
 | document                | String(as JSON)                                                       |
 | array                   | Array, String(as JSON)                                                |
 | oid                     | String                                                                |
@@ -170,7 +170,7 @@ CREATE TABLE sample_mflix_table
     writers Array(String),
     released Date,
     imdb String,
-    year String,
+    year String
 ) ENGINE = MongoDB('mongodb://<USERNAME>:<PASSWORD>@atlas-sql-6634be87cefd3876070caf96-98lxs.a.query.mongodb.net/sample_mflix?ssl=true&authSource=admin', 'movies');
 ```
 

--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -38,46 +38,46 @@ void MongoDBSource::insertValue(IColumn & column, const size_t & idx, const Data
     switch (type->getTypeId())
     {
         case TypeIndex::Int8:
-            assert_cast<ColumnInt8 &>(column).insertValue(BSONElementAsNumber<Int8, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnInt8 &>(column).insertValue(BSONElementAsNumber<Int8>(value.get_value(), name));
             break;
         case TypeIndex::UInt8:
-            assert_cast<ColumnUInt8 &>(column).insertValue(BSONElementAsNumber<UInt8, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnUInt8 &>(column).insertValue(BSONElementAsNumber<UInt8>(value.get_value(), name));
             break;
         case TypeIndex::Int16:
-            assert_cast<ColumnInt16 &>(column).insertValue(BSONElementAsNumber<Int16, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnInt16 &>(column).insertValue(BSONElementAsNumber<Int16>(value.get_value(), name));
             break;
         case TypeIndex::UInt16:
-            assert_cast<ColumnUInt16 &>(column).insertValue(BSONElementAsNumber<UInt16, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnUInt16 &>(column).insertValue(BSONElementAsNumber<UInt16>(value.get_value(), name));
             break;
         case TypeIndex::Int32:
-            assert_cast<ColumnInt32 &>(column).insertValue(BSONElementAsNumber<Int32, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnInt32 &>(column).insertValue(BSONElementAsNumber<Int32>(value.get_value(), name));
             break;
         case TypeIndex::UInt32:
-            assert_cast<ColumnUInt32 &>(column).insertValue(BSONElementAsNumber<UInt32, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnUInt32 &>(column).insertValue(BSONElementAsNumber<UInt32>(value.get_value(), name));
             break;
         case TypeIndex::Int64:
-            assert_cast<ColumnInt64 &>(column).insertValue(BSONElementAsNumber<Int64, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnInt64 &>(column).insertValue(BSONElementAsNumber<Int64>(value.get_value(), name));
             break;
         case TypeIndex::UInt64:
-            assert_cast<ColumnUInt64 &>(column).insertValue(BSONElementAsNumber<UInt64, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnUInt64 &>(column).insertValue(BSONElementAsNumber<UInt64>(value.get_value(), name));
             break;
         case TypeIndex::Int128:
-            assert_cast<ColumnInt128 &>(column).insertValue(BSONElementAsNumber<Int128, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnInt128 &>(column).insertValue(BSONElementAsNumber<Int128>(value.get_value(), name));
             break;
         case TypeIndex::UInt128:
-            assert_cast<ColumnUInt128 &>(column).insertValue(BSONElementAsNumber<UInt128, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnUInt128 &>(column).insertValue(BSONElementAsNumber<UInt128>(value.get_value(), name));
             break;
         case TypeIndex::Int256:
-            assert_cast<ColumnInt256 &>(column).insertValue(BSONElementAsNumber<Int256, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnInt256 &>(column).insertValue(BSONElementAsNumber<Int256>(value.get_value(), name));
             break;
         case TypeIndex::UInt256:
-            assert_cast<ColumnUInt256 &>(column).insertValue(BSONElementAsNumber<UInt256, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnUInt256 &>(column).insertValue(BSONElementAsNumber<UInt256>(value.get_value(), name));
             break;
         case TypeIndex::Float32:
-            assert_cast<ColumnFloat32 &>(column).insertValue(BSONElementAsNumber<Float32, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnFloat32 &>(column).insertValue(BSONElementAsNumber<Float32>(value.get_value(), name));
             break;
         case TypeIndex::Float64:
-            assert_cast<ColumnFloat64 &>(column).insertValue(BSONElementAsNumber<Float64, bsoncxx::document::element>(value, name));
+            assert_cast<ColumnFloat64 &>(column).insertValue(BSONElementAsNumber<Float64>(value.get_value(), name));
             break;
         case TypeIndex::Date:
         {
@@ -134,7 +134,7 @@ void MongoDBSource::insertValue(IColumn & column, const size_t & idx, const Data
         }
         case TypeIndex::String:
         {
-            assert_cast<ColumnString &>(column).insert(BSONElementAsString(value, json_format_settings));
+            assert_cast<ColumnString &>(column).insert(BSONElementAsString(value.get_value(), json_format_settings));
             break;
         }
         case TypeIndex::Array:

--- a/tests/integration/test_storage_mongodb/test.py
+++ b/tests/integration/test_storage_mongodb/test.py
@@ -1321,3 +1321,153 @@ def test_json_serialization(started_cluster):
 
     node.query("DROP TABLE json_serialization_table")
     json_serialization_table.drop()
+
+
+def test_numbers_parsing(started_cluster):
+    cases = [
+        {"type": "Int16", "value": "32767", "ok": True},
+        {"type": "Int16", "value": "-32768", "ok": True},
+        {"type": "Int16", "value": "32767.0", "ok": False},
+        {"type": "Int16", "value": "-32768.0", "ok": False},
+        {"type": "Int16", "value": "12.5", "ok": False},
+        {"type": "Int16", "value": "-0.1", "ok": False},
+        {"type": "Int16", "value": "abc", "ok": False},
+
+        {"type": "UInt16", "value": "65535", "ok": True},
+        {"type": "UInt16", "value": "0", "ok": True},
+        {"type": "UInt16", "value": "65535.0", "ok": False},
+        {"type": "UInt16", "value": "0.0", "ok": False},
+        {"type": "UInt16", "value": "12.34", "ok": False},
+        {"type": "UInt16", "value": "-1.0", "ok": False},
+        {"type": "UInt16", "value": "-32768", "ok": False},
+
+        {"type": "Int32", "value": "2147483647", "ok": True},
+        {"type": "Int32", "value": "-2147483648", "ok": True},
+        {"type": "Int32", "value": "2147483647.0", "ok": False},
+        {"type": "Int32", "value": "-2147483648.0", "ok": False},
+        {"type": "Int32", "value": "12.5", "ok": False},
+        {"type": "Int32", "value": "-0.1", "ok": False},
+        {"type": "Int32", "value": "abc", "ok": False},
+
+        {"type": "UInt32", "value": "4294967295", "ok": True},
+        {"type": "UInt32", "value": "0", "ok": True},
+        {"type": "UInt32", "value": "4294967295.0", "ok": False},
+        {"type": "UInt32", "value": "0.0", "ok": False},
+        {"type": "UInt32", "value": "12.34", "ok": False},
+        {"type": "UInt32", "value": "-1.0", "ok": False},
+        {"type": "UInt32", "value": "-2147483648", "ok": False},
+
+        {"type": "Int64", "value": "9223372036854775807", "ok": True},
+        {"type": "Int64", "value": "-9223372036854775808", "ok": True},
+        {"type": "Int64", "value": "9223372036854775807.0", "ok": False},
+        {"type": "Int64", "value": "-9223372036854775808.0", "ok": False},
+        {"type": "Int64", "value": "12.5", "ok": False},
+        {"type": "Int64", "value": "-0.1", "ok": False},
+        {"type": "Int64", "value": "abc", "ok": False},
+
+        {"type": "UInt64", "value": "18446744073709551615", "ok": True},
+        {"type": "UInt64", "value": "0", "ok": True},
+        {"type": "UInt64", "value": "18446744073709551615.0", "ok": False},
+        {"type": "UInt64", "value": "0.0", "ok": False},
+        {"type": "UInt64", "value": "12.34", "ok": False},
+        {"type": "UInt64", "value": "-1.0", "ok": False},
+        {"type": "UInt64", "value": "-9223372036854775808", "ok": False},
+
+        {"type": "Int128", "value": "170141183460469231731687303715884105727",  "ok": True},
+        {"type": "Int128", "value": "-170141183460469231731687303715884105728", "ok": True},
+        {"type": "Int128", "value": "170141183460469231731687303715884105727.0", "ok": False},
+        {"type": "Int128", "value": "-170141183460469231731687303715884105728.0", "ok": False},
+        {"type": "Int128", "value": "12.5", "ok": False},
+        {"type": "Int128", "value": "-0.1", "ok": False},
+        {"type": "Int128", "value": "abc", "ok": False},
+
+        {"type": "UInt128", "value": "340282366920938463463374607431768211455", "ok": True},
+        {"type": "UInt128", "value": "0", "ok": True},
+        {"type": "UInt128", "value": "340282366920938463463374607431768211455.0", "ok": False},
+        {"type": "UInt128", "value": "0.0", "ok": False},
+        {"type": "UInt128", "value": "12.34", "ok": False},
+        {"type": "UInt128", "value": "-1.0", "ok": False},
+        {"type": "UInt128", "value": "-170141183460469231731687303715884105728", "ok": False},
+
+        {"type": "Int256", "value": "57896044618658097711785492504343953926634992332820282019728792003956564819967", "ok": True},
+        {"type": "Int256", "value": "-57896044618658097711785492504343953926634992332820282019728792003956564819968", "ok": True},
+        {"type": "Int256", "value": "57896044618658097711785492504343953926634992332820282019728792003956564819967.0", "ok": False},
+        {"type": "Int256", "value": "-57896044618658097711785492504343953926634992332820282019728792003956564819968.0", "ok": False},
+        {"type": "Int256", "value": "12.5", "ok": False},
+        {"type": "Int256", "value": "-0.1", "ok": False},
+        {"type": "Int256", "value": "abc", "ok": False},
+
+        {"type": "UInt256", "value": "115792089237316195423570985008687907853269984665640564039457584007913129639935", "ok": True},
+        {"type": "UInt256", "value": "0", "ok": True},
+        {"type": "UInt256", "value": "115792089237316195423570985008687907853269984665640564039457584007913129639935.0", "ok": False},
+        {"type": "UInt256", "value": "0.0", "ok": False},
+        {"type": "UInt256", "value": "12.34", "ok": False},
+        {"type": "UInt256", "value": "-1.0", "ok": False},
+        {"type": "UInt256", "value": "-57896044618658097711785492504343953926634992332820282019728792003956564819968", "ok": False},
+
+        {"type": "Float32", "value": "3.14",     "ok": True},
+        {"type": "Float32", "value": "-2.71",    "ok": True},
+        {"type": "Float32", "value": "0.0",      "ok": True},
+        {"type": "Float32", "value": "-0.0",     "ok": True},
+        {"type": "Float32", "value": "1e38",     "ok": True},
+        {"type": "Float32", "value": "-1e38",    "ok": True},
+        {"type": "Float32", "value": "abc",      "ok": False},
+        {"type": "Float32", "value": "",         "ok": False},
+
+        {"type": "Float64", "value": "3.14",     "ok": True},
+        {"type": "Float64", "value": "-2.71",    "ok": True},
+        {"type": "Float64", "value": "0.0",      "ok": True},
+        {"type": "Float64", "value": "-0.0",     "ok": True},
+        {"type": "Float64", "value": "1e308",    "ok": True},
+        {"type": "Float64", "value": "-1e308",   "ok": True},
+        {"type": "Float64", "value": "abc",      "ok": False},
+        {"type": "Float64", "value": "",         "ok": False},
+    ]
+
+    mongo_connection = get_mongo_connection(started_cluster)
+    db = mongo_connection["test"]
+    db.command("dropAllUsersFromDatabase")
+    db.command("createUser", "root", pwd=mongo_pass, roles=["readWrite"])
+    drop_mongo_collection_if_exists(db, "numbers_parsing_table")
+    numbers_parsing_table = db["numbers_parsing_table"]
+
+    node = started_cluster.instances["node"]
+    node.query(
+        f"""
+        CREATE OR REPLACE TABLE numbers_parsing_table(
+            caseNum UInt8,
+            
+            Int8_ Int8,
+            UInt8_ UInt8,
+            Int16_ Int16,
+            UInt16_ UInt16,
+            Int32_ Int32,
+            UInt32_ UInt32,
+            Int64_ Int64,
+            UInt64_ UInt64,
+            Int128_ Int128,
+            UInt128_ UInt128,
+            Int256_ Int256,
+            UInt256_ UInt256,
+            Float32_ Float32,
+            Float64_ Float64
+        ) ENGINE = MongoDB('mongo1:27017', 'test', 'numbers_parsing_table', 'root', '{mongo_pass}')
+        """
+    )
+
+    for num, case in enumerate(cases):
+        numbers_parsing_table.insert_one({"caseNum": num, f"{case['type']}_": case['value']})
+        query = f"SELECT {case['type']}_ FROM numbers_parsing_table WHERE caseNum = {num}"
+        if case['ok']:
+            if case['value'] in ["0.0"]:
+                assert node.query(query) == f"0\n"
+            elif case['value'] in ["-0.0"]:
+                assert node.query(query) == f"-0\n"
+            else:
+                assert node.query(query) == f"{case['value']}\n"
+        else:
+            with pytest.raises(QueryRuntimeException):
+                node.query(query)
+
+    node.query("DROP TABLE numbers_parsing_table")
+    numbers_parsing_table.drop()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

MongoDB: Implicit parsing of strings to numeric types. Previously, if a string value was received from a MongoDB source for a numeric column in a ClickHouse table, an exception was thrown. Now, the engine attempts to parse the numeric value from the string automatically. Closes https://github.com/ClickHouse/ClickHouse/issues/81167

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->