### PR TITLE
Minor vector search improvements

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/annindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/annindexes.md
@@ -352,6 +352,10 @@ Query id: a2a9d0c8-a525-45c1-96ca-c5a11fa66f47
     └─────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+:::note
+A query run without rescoring (`vector_search_with_rescoring = 0`) and with parallel replicas enabled may fall back to rescoring.
+:::
+
 ### Performance tuning {#performance-tuning}
 
 **Tuning Compression**

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6785,6 +6785,7 @@ If ClickHouse performs rescoring for queries that use the vector similarity inde
 Without rescoring, the vector similarity index returns the rows containing the best matches directly.
 With rescoring, the rows are extrapolated to granule level and all rows in the granule are checked again.
 In most situations, rescoring helps only marginally with accuracy but it deteriorates performance of vector search queries significantly.
+Note: A query run without rescoring and with parallel replicas enabled may fall back to rescoring.
 )", BETA) \
     DECLARE(VectorSearchFilterStrategy, vector_search_filter_strategy, VectorSearchFilterStrategy::AUTO, R"(
 If a vector search query has a WHERE clause, this setting determines if it is evaluated first (pre-filtering) OR if the vector similarity index is checked first (post-filtering). Possible values:

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6621,6 +6621,31 @@ Enable `IF NOT EXISTS` for `CREATE` statement by default. If either this setting
     DECLARE(Bool, enforce_strict_identifier_format, false, R"(
 If enabled, only allow identifiers containing alphanumeric characters and underscores.
 )", 0) \
+    DECLARE_WITH_ALIAS(Bool, allow_experimental_vector_similarity_index, false, R"(
+Enable vector similarity index.
+)", BETA, enable_vector_similarity_index) \
+    DECLARE(UInt64, max_limit_for_vector_search_queries, 1'000, R"(
+SELECT queries with LIMIT bigger than this setting cannot use vector similarity indices. Helps to prevent memory overflows in vector similarity indices.
+)", BETA) \
+    DECLARE(UInt64, hnsw_candidate_list_size_for_search, 256, R"(
+The size of the dynamic candidate list when searching the vector similarity index, also known as 'ef_search'.
+)", BETA) \
+    DECLARE(Bool, vector_search_with_rescoring, true, R"(
+If ClickHouse performs rescoring for queries that use the vector similarity index.
+Without rescoring, the vector similarity index returns the rows containing the best matches directly.
+With rescoring, the rows are extrapolated to granule level and all rows in the granule are checked again.
+In most situations, rescoring helps only marginally with accuracy but it deteriorates performance of vector search queries significantly.
+Note: A query run without rescoring and with parallel replicas enabled may fall back to rescoring.
+)", BETA) \
+    DECLARE(VectorSearchFilterStrategy, vector_search_filter_strategy, VectorSearchFilterStrategy::AUTO, R"(
+If a vector search query has a WHERE clause, this setting determines if it is evaluated first (pre-filtering) OR if the vector similarity index is checked first (post-filtering). Possible values:
+- 'auto' - Postfiltering (the exact semantics may change in future).
+- 'postfilter' - Use vector similarity index to identify the nearest neighbours, then apply other filters
+- 'prefilter' - Evaluate other filters first, then perform brute-force search to identify neighbours.
+)", BETA) \
+    DECLARE(Float, vector_search_postfilter_multiplier, 1.0, R"(
+Multiply the fetched nearest neighbors from the vector similarity index by this number before performing post-filtering on other predicates.
+)", BETA) \
     DECLARE(Bool, mongodb_throw_on_unsupported_query, true, R"(
 If enabled, MongoDB tables will return an error when a MongoDB query cannot be built. Otherwise, ClickHouse reads the full table and processes it locally. This option does not apply when 'allow_experimental_analyzer=0'.
 )", 0) \
@@ -6771,31 +6796,6 @@ Allows creation of tables with the [TimeSeries](../../engines/table-engines/inte
     DECLARE(Bool, allow_experimental_codecs, false, R"(
 If it is set to true, allow to specify experimental compression codecs (but we don't have those yet and this option does nothing).
 )", EXPERIMENTAL) \
-    DECLARE_WITH_ALIAS(Bool, allow_experimental_vector_similarity_index, false, R"(
-Enable vector similarity index.
-)", BETA, enable_vector_similarity_index) \
-    DECLARE(UInt64, max_limit_for_vector_search_queries, 1'000, R"(
-SELECT queries with LIMIT bigger than this setting cannot use vector similarity indices. Helps to prevent memory overflows in vector similarity indices.
-)", BETA) \
-    DECLARE(UInt64, hnsw_candidate_list_size_for_search, 256, R"(
-The size of the dynamic candidate list when searching the vector similarity index, also known as 'ef_search'.
-)", BETA) \
-    DECLARE(Bool, vector_search_with_rescoring, true, R"(
-If ClickHouse performs rescoring for queries that use the vector similarity index.
-Without rescoring, the vector similarity index returns the rows containing the best matches directly.
-With rescoring, the rows are extrapolated to granule level and all rows in the granule are checked again.
-In most situations, rescoring helps only marginally with accuracy but it deteriorates performance of vector search queries significantly.
-Note: A query run without rescoring and with parallel replicas enabled may fall back to rescoring.
-)", BETA) \
-    DECLARE(VectorSearchFilterStrategy, vector_search_filter_strategy, VectorSearchFilterStrategy::AUTO, R"(
-If a vector search query has a WHERE clause, this setting determines if it is evaluated first (pre-filtering) OR if the vector similarity index is checked first (post-filtering). Possible values:
-- 'auto' - Postfiltering (the exact semantics may change in future).
-- 'postfilter' - Use vector similarity index to identify the nearest neighbours, then apply other filters
-- 'prefilter' - Evaluate other filters first, then perform brute-force search to identify neighbours.
-)", BETA) \
-    DECLARE(Float, vector_search_postfilter_multiplier, 1.0, R"(
-Multiply the fetched nearest neighbors from the vector similarity index by this number before performing post-filtering on other predicates.
-)", BETA) \
     DECLARE(Bool, throw_on_unsupported_query_inside_transaction, true, R"(
 Throw exception if unsupported query is used inside transaction
 )", EXPERIMENTAL) \

--- a/tests/queries/0_stateless/02354_vector_search_rescoring.sql
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring.sql
@@ -1,4 +1,5 @@
 -- Tags: no-fasttest, no-ordinary-database, no-parallel-replicas
+-- no-parallel-replicas: If parallel replicas are on, the optimization (no rescoring) may not work.
 
 -- Test for setting 'vector_search_with_rescoring'
 


### PR DESCRIPTION
This PR has two commits:
- https://github.com/ClickHouse/ClickHouse/pull/84073/commits/492979de4bfb47dd891935923c584a939530b729 adds a comment about rescoring and parallel replicas (motivation: https://github.com/ClickHouse/ClickHouse/pull/83803#discussion_r2214834288)
- https://github.com/ClickHouse/ClickHouse/pull/84073/commits/1ce6c30ad8c338b5a745ace7749508129c512946 moves all vector search settings from the experimental to the regular section in the settings (follow-up to https://github.com/ClickHouse/ClickHouse/pull/80164)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)