### PR TITLE
tests: fix 01825_new_type_json_ghdata_insert_select flakiness

### DIFF
--- a/tests/queries/0_stateless/01825_new_type_json_ghdata_insert_select.sh
+++ b/tests/queries/0_stateless/01825_new_type_json_ghdata_insert_select.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-object-storage, long, no-asan
-# ^ no-object-storage: it is memory-hungry, no-asan: too long
+# Tags: no-fasttest, no-object-storage, long, no-parallel
+# ^ no-object-storage: it is memory-hungry
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01825_new_type_json_ghdata_insert_select.sh
+++ b/tests/queries/0_stateless/01825_new_type_json_ghdata_insert_select.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-object-storage, long, no-parallel
+# Tags: no-fasttest, no-object-storage, long, no-parallel, no-flaky-check
 # ^ no-object-storage: it is memory-hungry
+# ^ no-flaky-check: slow with thread fuzzer
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
On CI it sometimes fails with time limit exceeded [1], I looked at one such report and there were lots of tests in parallel, let's just disable parallelism for this test and enable back run under ASan.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=84052&sha=fca823fc49c4605c6819f7984ef66e784b13970b&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)