### PR TITLE
Fix MergeTree transactions on disks with plain_rewritable metadata by avoiding append mode

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -307,8 +307,8 @@ bool MergeTreeTransaction::rollback() noexcept
     {
         /// Clear removal_tid from version metadata file, so we will not need to distinguish TIDs that were not committed
         /// and TIDs that were committed long time ago and were removed from the log on log cleanup.
-        part->appendRemovalTIDToVersionMetadata(/* clear */ true);
         part->version.unlockRemovalTID(tid, TransactionInfoContext{part->storage.getStorageID(), part->name});
+        part->appendRemovalTIDToVersionMetadata(/* clear */ true);
     }
 
     assert([&]()

--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -393,7 +393,7 @@ MergeTreeTransactionPtr TransactionLog::beginTransaction()
         txn = std::make_shared<MergeTreeTransaction>(snapshot, ltid, ServerUUID::get(), snapshot_lock);
         bool inserted = running_list.try_emplace(txn->tid.getHash(), txn).second;
         if (!inserted)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "I's a bug: TID {} {} exists", txn->tid.getHash(), txn->tid);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "It's a bug: TID {} {} exists", txn->tid.getHash(), txn->tid);
     }
 
     LOG_TEST(log, "Beginning transaction {} ({})", txn->tid, txn->tid.getHash());

--- a/src/Interpreters/TransactionVersionMetadata.cpp
+++ b/src/Interpreters/TransactionVersionMetadata.cpp
@@ -90,6 +90,7 @@ bool VersionMetadata::tryLockRemovalTID(const TransactionID & tid, const Transac
 
 void VersionMetadata::unlockRemovalTID(const TransactionID & tid, const TransactionInfoContext & context)
 {
+    chassert(!removal_tid.isEmpty());
     LOG_TEST(log, "Unlocking removal_tid by {}, table: {}, part: {}", tid, context.table.getNameForLogs(), context.part_name);
     chassert(!tid.isEmpty());
     TIDHash removal_lock_value = tid.getHash();

--- a/src/Interpreters/TransactionVersionMetadata.h
+++ b/src/Interpreters/TransactionVersionMetadata.h
@@ -67,13 +67,15 @@ struct VersionMetadata
     void read(ReadBuffer & buf);
 
     enum WhichCSN { CREATION, REMOVAL };
-    void writeCSN(WriteBuffer & buf, WhichCSN which_csn, bool internal = false) const;
-    void writeRemovalTID(WriteBuffer & buf, bool clear = false) const;
 
     String toString(bool one_line = true) const;
 
     LoggerPtr log;
     VersionMetadata();
+
+private:
+    void writeCSN(WriteBuffer & buf, WhichCSN which_csn, bool internal = false) const;
+    void writeRemovalTID(WriteBuffer & buf, bool clear = false) const;
 };
 
 DataTypePtr getTransactionIDDataType();

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -930,11 +930,6 @@ SyncGuardPtr DataPartStorageOnDiskBase::getDirectorySyncGuard() const
     return volume->getDisk()->getDirectorySyncGuard(fs::path(root_path) / part_dir);
 }
 
-std::unique_ptr<WriteBufferFromFileBase> DataPartStorageOnDiskBase::writeTransactionFile(WriteMode mode) const
-{
-    return volume->getDisk()->writeFile(fs::path(root_path) / part_dir / IMergeTreeDataPart::TXN_VERSION_METADATA_FILE_NAME, 256, mode);
-}
-
 void DataPartStorageOnDiskBase::removeRecursive()
 {
     executeWriteOperation([&](auto & disk) { disk.removeRecursive(fs::path(root_path) / part_dir); });

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
@@ -104,8 +104,6 @@ public:
     void changeRootPath(const std::string & from_root, const std::string & to_root) override;
     void createDirectories() override;
 
-    std::unique_ptr<WriteBufferFromFileBase> writeTransactionFile(WriteMode mode) const override;
-
     void removeRecursive() override;
     void removeSharedRecursive(bool keep_in_remote_fs) override;
 

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -308,11 +308,6 @@ public:
         return writeFile(name, buf_size, WriteMode::Rewrite, settings);
     }
 
-    /// A special const method to write transaction file.
-    /// It's const, because file with transaction metadata
-    /// can be modified after part creation.
-    virtual std::unique_ptr<WriteBufferFromFileBase> writeTransactionFile(WriteMode mode) const = 0;
-
     virtual void createFile(const String & name) = 0;
     virtual void moveFile(const String & from_name, const String & to_name) = 0;
     virtual void replaceFile(const String & from_name, const String & to_name) = 0;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -756,7 +756,7 @@ private:
     void loadSourcePartsSet();
 
     void writeColumns(const NamesAndTypesList & columns_, const WriteSettings & settings);
-    void writeVersionMetadata(const VersionMetadata & version_, bool fsync_part_dir) const;
+    void writeVersionMetadata(const VersionMetadata & version_, bool fsync) const;
 
     template <typename Writer>
     void writeMetadata(const String & filename, const WriteSettings & settings, Writer && writer);

--- a/tests/queries/0_stateless/03362_merge_tree_with_background_refresh.sh
+++ b/tests/queries/0_stateless/03362_merge_tree_with_background_refresh.sh
@@ -6,6 +6,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+set -e
+
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer SYNC"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader SYNC"
 

--- a/tests/queries/0_stateless/03556_mt_txn_on_plain_rewritable.sh
+++ b/tests/queries/0_stateless/03556_mt_txn_on_plain_rewritable.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-object-storage, no-replicated-database, no-shared-merge-tree
+# Tag no-random-settings: enable after root causing flakiness
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+${CLICKHOUSE_CLIENT} --query "
+drop table if exists test;
+create table test (key Int) engine=MergeTree() order by ()
+SETTINGS table_disk = true,
+  disk = disk(
+      name = 03556_writer_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/03556/${CLICKHOUSE_DATABASE}/');
+insert into test settings implicit_transaction=1 values (1);
+detach table test;
+attach table test;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix MergeTree transactions on disks with plain_rewritable metadata by avoiding append mode

Fixes: https://github.com/ClickHouse/ClickHouse/issues/50666
Fixes: https://github.com/ClickHouse/ClickHouse/issues/83988