### PR TITLE
Fix deadlock while printing sanitizer reports

### DIFF
--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -90,7 +90,8 @@ void childSignalHandler(int sig, siginfo_t * info, void *)
     errno = saved_errno;
 }
 
-void signalHandler(int sig, siginfo_t * info, void * context)
+/// Handler for "fault" or diagnostic signals. Send data about fault to separate thread to write into log.
+static void signalHandler(int sig, siginfo_t * info, void * context)
 {
     if (asynchronous_stack_unwinding && sig == SIGSEGV)
         siglongjmp(asynchronous_stack_unwinding_signal_jump_buffer, 1);

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -179,54 +179,27 @@ static void signalHandler(int sig, siginfo_t * info, void * context)
 }
 
 #if defined(SANITIZER)
-template <typename T>
-struct ValueHolder
-{
-    explicit ValueHolder(T value_) : value(value_)
-    {}
-
-    T value;
-};
-
 extern "C" void __sanitizer_set_death_callback(void (*)());
 
-/// Sanitizers may not expect some function calls from death callback.
-/// Let's try to disable instrumentation to avoid possible issues.
-/// However, this callback may call other functions that are still instrumented.
-/// We can try [[clang::always_inline]] attribute for statements in future (available in clang-15)
-/// See https://github.com/google/sanitizers/issues/1543 and https://github.com/google/sanitizers/issues/1549.
+/// You should be very careful on which functions is called from the death callback, in some cases sanitizers will deadlock.
+/// So let's disable instrumentation to avoid possible issues, but note:
+/// - this will not disable instrumentation for other function calls
+///   (you can try [[clang::always_inline]] attribute if you need to bypass this)
+/// - disabling instrumentation may lead to other problems
+///
+/// See:
+/// - https://github.com/google/sanitizers/issues/1543
+/// - https://github.com/google/sanitizers/issues/1549
 static DISABLE_SANITIZER_INSTRUMENTATION void sanitizerDeathCallback()
 {
     DENY_ALLOCATIONS_IN_SCOPE;
-    /// Also need to send data via pipe. Otherwise it may lead to deadlocks or failures in printing diagnostic info.
 
-    char buf[signal_pipe_buf_size];
-    auto & signal_pipe = HandledSignals::instance().signal_pipe;
-
-    /// Signal pipe can be already closed in BaseDaemon::~BaseDaemon, but
-    /// sanitizerDeathCallback() can be called on exit handlers.
-    if (signal_pipe.fds_rw[1] == -1)
-        return;
-
-    WriteBufferFromFileDescriptorDiscardOnFailure out(signal_pipe.fds_rw[1], signal_pipe_buf_size, buf);
-
-    const StackTrace stack_trace;
-
-    writeBinary(SignalListener::SanitizerTrap, out);
-    writePODBinary(stack_trace, out);
-    /// We create a dummy struct with a constructor so DISABLE_SANITIZER_INSTRUMENTATION is not applied to it
-    /// otherwise, Memory sanitizer can't know that values initiialized inside this function are actually initialized
-    /// because instrumentations are disabled leading to false positives later on
-    ValueHolder<UInt32> thread_id{static_cast<UInt32>(getThreadId())};
-    writeBinary(thread_id.value, out);
-    writePODBinary(current_thread, out);
-    out.finalize();
-
-    /// The time that is usually enough for separate thread to print info into log.
-    sleepForSeconds(20);
+    /// Sanitizer errors cannot be handled properly with our signal handlers, because it leads to deadlock.
+    /// So we need to reset the signal handlers (this does not lead to deadlock),
+    /// but closing the pipe leads to deadlock from death callback, so we will not close it.
+    HandledSignals::instance().reset(/* close_pipe= */ false);
 }
 #endif
-
 
 void HandledSignals::addSignalHandler(const std::vector<int> & signals, signal_function handler, bool register_signal)
 {
@@ -358,30 +331,15 @@ void SignalListener::run()
             UInt32 thread_num{};
             ThreadStatus * thread_ptr{};
 
-            if (sig != SanitizerTrap)
-            {
-                readPODBinary(info, in);
-                readPODBinary(context, in);
-            }
+            readPODBinary(info, in);
+            readPODBinary(context, in);
 
             readPODBinary(stack_trace, in);
-            if (sig != SanitizerTrap)
-                readVectorBinary(thread_frame_pointers, in);
+            readVectorBinary(thread_frame_pointers, in);
             readBinary(thread_num, in);
             readPODBinary(thread_ptr, in);
 
-            /// This allows to receive more signals if failure happens inside onFault function.
-            /// Example: segfault while symbolizing stack trace.
-            try
-            {
-                std::thread([=, this] { onFault(sig, info, context, stack_trace, thread_frame_pointers, thread_num, thread_ptr); })
-                    .detach();
-            }
-            catch (...)
-            {
-                /// Likely cannot allocate thread
-                onFault(sig, info, context, stack_trace, thread_frame_pointers, thread_num, thread_ptr);
-            }
+            onFault(sig, info, context, stack_trace, thread_frame_pointers, thread_num, thread_ptr);
         }
     }
 }
@@ -433,20 +391,13 @@ try
     /// Some of these are not really signals, but our own indications on failure reason.
     if (sig == StdTerminate)
         signal_description = "std::terminate";
-    else if (sig == SanitizerTrap)
-        signal_description = "sanitizer trap";
     else if (sig >= 0)
         signal_description = strsignal(sig); // NOLINT(concurrency-mt-unsafe) // it is not thread-safe but ok in this context
 
     LOG_FATAL(log, "Signal description: {}", signal_description);
 
     String error_message;
-
-    if (sig != SanitizerTrap)
-        error_message = signalToErrorMessage(sig, info, *context);
-    else
-        error_message = "Sanitizer trap.";
-
+    error_message = signalToErrorMessage(sig, info, *context);
     LOG_FATAL(log, fmt::runtime(error_message));
 
     String bare_stacktrace_str;
@@ -575,29 +526,22 @@ try
     Context::getGlobalContextInstance()->handleCrash();
 
     /// Send crash report to developers (if configured)
-    if (sig != SanitizerTrap)
+    if (daemon)
     {
-        if (daemon)
-        {
-            CrashWriter::onSignal(sig, std::string_view(error_message), stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
-        }
+        CrashWriter::onSignal(sig, std::string_view(error_message), stack_trace.getFramePointers(), stack_trace.getOffset(), stack_trace.getSize());
+    }
 
-        /// Advice the user to send it manually.
-        if (std::string_view(VERSION_OFFICIAL).contains("official build"))
+    /// Advice the user to send it manually.
+    if (std::string_view(VERSION_OFFICIAL).contains("official build"))
+    {
+        /// Approximate support period, upper bound.
+        if (time(nullptr) - makeDate(DateLUT::instance(), 2000 + VERSION_MAJOR, VERSION_MINOR, 1) < (365 + 30) * 86400)
         {
-            /// Approximate support period, upper bound.
-            if (time(nullptr) - makeDate(DateLUT::instance(), 2000 + VERSION_MAJOR, VERSION_MINOR, 1) < (365 + 30) * 86400)
-            {
-                LOG_FATAL(log, "Report this error to https://github.com/ClickHouse/ClickHouse/issues");
-            }
-            else
-            {
-                LOG_FATAL(log, "ClickHouse version {} is old and should be upgraded to the latest version.", VERSION_STRING);
-            }
+            LOG_FATAL(log, "Report this error to https://github.com/ClickHouse/ClickHouse/issues");
         }
         else
         {
-            LOG_FATAL(log, "This ClickHouse version is not official and should be upgraded to the official build.");
+            LOG_FATAL(log, "ClickHouse version {} is old and should be upgraded to the latest version.", VERSION_STRING);
         }
     }
 
@@ -635,7 +579,7 @@ HandledSignals::HandledSignals()
     signal_pipe.tryIncreaseSize(1 << 20);
 }
 
-void HandledSignals::reset()
+void HandledSignals::reset(bool close_pipe)
 {
     /// Reset signals to SIG_DFL to avoid trying to write to the signal_pipe that will be closed after.
     for (int sig : handled_signals)
@@ -653,7 +597,8 @@ void HandledSignals::reset()
         }
     }
 
-    signal_pipe.close();
+    if (close_pipe)
+        signal_pipe.close();
 }
 
 HandledSignals::~HandledSignals()

--- a/src/Common/SignalHandlers.h
+++ b/src/Common/SignalHandlers.h
@@ -35,10 +35,6 @@ void terminateRequestedSignalHandler(int sig, siginfo_t *, void *);
 
 void childSignalHandler(int sig, siginfo_t * info, void *);
 
-/** Handler for "fault" or diagnostic signals. Send data about fault to separate thread to write into log.
-  */
-void signalHandler(int sig, siginfo_t * info, void * context);
-
 
 /** To use with std::set_terminate.
   * Collects slightly more info than __gnu_cxx::__verbose_terminate_handler,

--- a/src/Common/SignalHandlers.h
+++ b/src/Common/SignalHandlers.h
@@ -61,7 +61,6 @@ class SignalListener : public Poco::Runnable
 public:
     static constexpr int StdTerminate = -1;
     static constexpr int StopThread = -2;
-    static constexpr int SanitizerTrap = -3;
 
     explicit SignalListener(BaseDaemon * daemon_, LoggerPtr log_);
     void run() override;
@@ -98,7 +97,7 @@ struct HandledSignals
 
     void addSignalHandler(const std::vector<int> & signals, signal_function handler, bool register_signal);
 
-    void reset();
+    void reset(bool close_pipe = true);
 
     static HandledSignals & instance();
 };


### PR DESCRIPTION
The root cause of this patch is that calling our `SIGABRT` handler on sanitizers report lead to deadlock [1] (and also [2]).

<details>

<summary>deadlock</summary>

    Thread 1 (Thread 0x7feecd67c340 (LWP 203595) "clickhouse-clie"):
    0  0x000055add6e78d7a in __sanitizer::FutexWait(__sanitizer::atomic_uint32_t*, unsigned int) ()
    1  0x000055add6e796aa in __sanitizer::Semaphore::Wait() ()
    2  0x000055add6f00ec0 in __tsan::TraceSwitchPartImpl(__tsan::ThreadState*) ()
    3  0x000055add6f03062 in __tsan::TraceRestartFuncEntry(__tsan::ThreadState*, unsigned long) ()
    4  0x000055add6e95183 in __tsan::ScopedInterceptor::ScopedInterceptor(__tsan::ThreadState*, char const*, unsigned long) ()
    5  0x000055add6ecd38a in __interceptor_pthread_setcanceltype ()
    6  0x000055adf620cd49 in clock_nanosleep (clk=1, flags=1, req=0x7ffc4aae2958, rem=0x0) at ./ci/tmp/build/./base/glibc-compatibility/musl/clock_nanosleep.c:22
    7  0x000055adf1583434 in sleepForNanoseconds (nanoseconds=<optimized out>) at ./ci/tmp/build/./base/base/sleep.cpp:50
    8  0x000055adf158357e in sleepForMicroseconds (microseconds=1000000) at ./ci/tmp/build/./base/base/sleep.cpp:56
    9  sleepForMilliseconds (milliseconds=1000) at ./ci/tmp/build/./base/base/sleep.cpp:61
    10 sleepForSeconds (seconds=seconds@entry=1) at ./ci/tmp/build/./base/base/sleep.cpp:66
    11 0x000055ade0ecfc5a in signalHandler (sig=6, info=<optimized out>, context=<optimized out>) at ./ci/tmp/build/./src/Common/SignalHandlers.cpp:134
    12 0x000055add6ea07a6 in __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) ()
    13 0x000055add6ea0cfb in sighandler(int, __sanitizer::__sanitizer_siginfo*, void*) ()
    14 <signal handler called>
    15 0x00007feecd7fd9fc in pthread_kill () from /lib/x86_64-linux-gnu/libc.so.6
    16 0x00007feecd7a9476 in raise () from /lib/x86_64-linux-gnu/libc.so.6
    17 0x00007feecd78f7f3 in abort () from /lib/x86_64-linux-gnu/libc.so.6
    18 0x000055add6e9f267 in __interceptor_abort ()
    19 0x000055add6e8192c in __sanitizer::Abort() ()
    20 0x000055add6e801be in __sanitizer::Die() ()
    21 0x000055add6f119ae in __tsan::OutputReport(__tsan::ThreadState*, __tsan::ScopedReport const&) ()
    22 0x000055add6f12b48 in __tsan::ReportRace(__tsan::ThreadState*, __tsan::RawShadow*, __tsan::Shadow, __tsan::Shadow, unsigned long) ()
    23 0x000055add6e941fd in __tsan_memcpy ()
    24 0x000055ade756a37a in DB::SettingsTraits::Data::operator= (this=this@entry=0x729800006008) at ./ci/tmp/build/./src/Core/Settings.cpp:6975
    25 0x000055ade73aef0d in DB::BaseSettings<DB::SettingsTraits>::operator= (this=0x729800006000) at ./src/Core/BaseSettings.h:109
    26 DB::SettingsImpl::operator= (this=0x729800006000) at ./ci/tmp/build/./src/Core/Settings.cpp:6981
    27 DB::Settings::operator= (this=0x7204000011e0, other=...) at ./ci/tmp/build/./src/Core/Settings.cpp:7188
    28 0x000055ade8d4facb in DB::Context::setSettings (this=0x727800003c00, settings_=...) at ./ci/tmp/build/./src/Interpreters/Context.cpp:2634
    29 0x000055adec1c9b18 in DB::ClientBase::processParsedSingleQuery()::$_0::operator()() const (this=0x7ffc4aae51a8) at ./ci/tmp/build/./src/Client/ClientBase.cpp:2184
    30 BasicScopeGuard<DB::ClientBase::processParsedSingleQuery()::$_0>::invoke (this=0x7ffc4aae51a8) at ./base/base/../base/scope_guard.h:101
    31 BasicScopeGuard<DB::ClientBase::processParsedSingleQuery()::$_0>::~BasicScopeGuard (this=this@entry=0x7ffc4aae51a8) at ./base/base/../base/scope_guard.h:50
    32 0x000055adec1bdf11 in DB::ClientBase::processParsedSingleQuery () at ./ci/tmp/build/./src/Client/ClientBase.cpp:2249
    33 0x000055adec1cb0df in DB::ClientBase::executeMultiQuery (this=this@entry=0x7ffc4aae57e0, all_queries_text=...) at ./ci/tmp/build/./src/Client/ClientBase.cpp:2620
    34 0x000055adec1cc827 in DB::ClientBase::processQueryText (this=this@entry=0x7ffc4aae57e0, text=...) at ./ci/tmp/build/./src/Client/ClientBase.cpp:2814
    35 0x000055adec1d6f8b in DB::ClientBase::runNonInteractive (this=0x7ffc4aae57e0) at ./ci/tmp/build/./src/Client/ClientBase.cpp:3454
    36 0x000055ade0ca051c in DB::Client::main (this=this@entry=0x7ffc4aae57e0) at ./ci/tmp/build/./programs/client/Client.cpp:403
    37 0x000055ade0ca0c61 in non-virtual thunk to DB::Client::main(std::__1::vector<> const&) ()
    38 0x000055adf16df37f in Poco::Util::Application::run (this=0x7ffc4aae6118) at ./ci/tmp/build/./base/poco/Util/src/Application.cpp:315
    39 0x000055ade0caea0c in mainEntryClickHouseClient (argc=argc@entry=222, argv=argv@entry=0x726c00000000) at ./ci/tmp/build/./programs/client/Client.cpp:1139
    40 0x000055add6f1ca05 in main (argc_=<optimized out>, argv_=<optimized out>) at ./ci/tmp/build/./programs/main.cpp:338

</details>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/PRs/82444/ab32d9f910c32d60714bdbdcd52edd0d491bcf1f//stateless_tests_amd_tsan_s3_storage_2_3/job.log
  [2]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a7b448fd6c1832f32f6d266ebc48a7c31e19e69f&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

I've tried multiple ways on fixing it properly (obtaining stacktrace on sanitizers report by signal handler), because TSan (at least) holds lots of internal locks on report [4], so calling functions that will be sanitized will lead to deadlocks.

  [3]: https://pastila.nl/?002a5bc5/f429caae78f767bdf55bad87223a78d6#fN336UL4jWd+8j0v8O388w==
  [4]: https://github.com/llvm/llvm-project/blob/e3af202fd212a66700170717856a8fa9aa7ed426/compiler-rt/lib/tsan/rtl/tsan_rtl_report.cpp#L764-L768

So, let's simply disable this functionality, we already have handling of sanitizer reports by `clickhouse-test` and other CI wrappers, so we should not miss them.

Note, on CI apparently it is able to abort even in case of deadlock [2], likely due to anoterh SIGABRT received during this deadlock (but it may take ~10 minutes).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)