### PR TITLE
 Avoid building big objects in Google Cloud Cpp

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -253,6 +253,8 @@ if(ENABLE_GOOGLE_CLOUD_CPP)
     add_contrib (nlohmann-json-cmake nlohmann-json)
     add_contrib (crc32c-cmake crc32c)
     add_contrib (google-cloud-cpp-cmake google-cloud-cpp) # requires grpc, protobuf, absl, nlohmann's json, crc32c
+else()
+    message(STATUS "Not using Google Cloud Cpp")
 endif()
 
 add_contrib (jwt-cpp-cmake jwt-cpp)

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -111,11 +111,6 @@ if(ENABLE_GOOGLE_CLOUD_CPP_KMS)
         google_cloud_cpp_iam_v1_iam_policy_protos
     )
 
-    # The library is large - avoid bloat.
-    if(OMIT_HEAVY_DEBUG_SYMBOLS)
-        target_compile_options(_gcloud PRIVATE -g0)
-    endif()
-
     target_include_directories(_gcloud SYSTEM PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_INCLUDES})
     target_include_directories(_gcloud SYSTEM PUBLIC ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
     target_link_libraries(_gcloud PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
@@ -123,6 +118,11 @@ else()
     add_library(_gcloud INTERFACE)
     target_include_directories(_gcloud SYSTEM INTERFACE ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
     target_link_libraries(_gcloud INTERFACE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
+endif()
+
+# The library is large - avoid bloat.
+if(OMIT_HEAVY_DEBUG_SYMBOLS)
+    target_compile_options(_gcloud PRIVATE -g0)
 endif()
 
 add_library(ch_contrib::google_cloud_cpp ALIAS _gcloud)

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -95,6 +95,9 @@ list(APPEND GOOGLE_CLOUD_CPP_PRIVATE_LIBS
     google_cloud_cpp_rest_internal
     google_cloud_cpp_storage
     google_cloud_cpp_storage_protos
+)
+
+list(APPEND GOOGLE_CLOUD_CPP_PRIVATE_LIBS_EXTRA
     ch_contrib::crc32c
     ch_contrib::curl
     ch_contrib::nlohmann_json
@@ -102,27 +105,30 @@ list(APPEND GOOGLE_CLOUD_CPP_PRIVATE_LIBS
 
 if(ENABLE_GOOGLE_CLOUD_CPP_KMS)
     list(APPEND GOOGLE_CLOUD_CPP_SOURCES ${GOOGLE_CLOUD_CPP_KMS_SRC})
-    add_library(_gcloud ${GOOGLE_CLOUD_CPP_SOURCES})
+    add_library(_google_cloud_cpp_kms ${GOOGLE_CLOUD_CPP_SOURCES})
 
     list(APPEND GOOGLE_CLOUD_CPP_PRIVATE_LIBS
         google_cloud_cpp_grpc_utils
+        _google_cloud_cpp_kms
         google_cloud_cpp_kms_protos
         google_cloud_cpp_cloud_location_locations_protos
         google_cloud_cpp_iam_v1_iam_policy_protos
     )
 
-    # The library is large - avoid bloat.
-    if(OMIT_HEAVY_DEBUG_SYMBOLS)
-        target_compile_options(_gcloud PRIVATE -g0)
-    endif()
+    target_include_directories(_google_cloud_cpp_kms SYSTEM PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_INCLUDES})
+    target_include_directories(_google_cloud_cpp_kms SYSTEM PUBLIC ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
+    target_link_libraries(_google_cloud_cpp_kms absl::optional ch_contrib::protobuf)
+endif()
 
-    target_include_directories(_gcloud SYSTEM PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_INCLUDES})
-    target_include_directories(_gcloud SYSTEM PUBLIC ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
-    target_link_libraries(_gcloud PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
-else()
-    add_library(_gcloud INTERFACE)
-    target_include_directories(_gcloud SYSTEM INTERFACE ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
-    target_link_libraries(_gcloud INTERFACE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
+add_library(_gcloud INTERFACE)
+target_include_directories(_gcloud SYSTEM INTERFACE ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
+target_link_libraries(_gcloud INTERFACE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS} ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS_EXTRA})
+
+# The library is large - avoid bloat.
+if(OMIT_HEAVY_DEBUG_SYMBOLS)
+    foreach(lib ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
+        target_compile_options(${lib} PRIVATE -g0)
+    endforeach()
 endif()
 
 add_library(ch_contrib::google_cloud_cpp ALIAS _gcloud)

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -106,6 +106,7 @@ list(APPEND GOOGLE_CLOUD_CPP_PRIVATE_LIBS_EXTRA
 if(ENABLE_GOOGLE_CLOUD_CPP_KMS)
     list(APPEND GOOGLE_CLOUD_CPP_SOURCES ${GOOGLE_CLOUD_CPP_KMS_SRC})
     add_library(_google_cloud_cpp_kms ${GOOGLE_CLOUD_CPP_SOURCES})
+    add_dependencies(_google_cloud_cpp_kms google_cloud_cpp_kms_protos)
 
     list(APPEND GOOGLE_CLOUD_CPP_PRIVATE_LIBS
         google_cloud_cpp_grpc_utils

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -111,6 +111,11 @@ if(ENABLE_GOOGLE_CLOUD_CPP_KMS)
         google_cloud_cpp_iam_v1_iam_policy_protos
     )
 
+    # The library is large - avoid bloat.
+    if(OMIT_HEAVY_DEBUG_SYMBOLS)
+        target_compile_options(_gcloud PRIVATE -g0)
+    endif()
+
     target_include_directories(_gcloud SYSTEM PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_INCLUDES})
     target_include_directories(_gcloud SYSTEM PUBLIC ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
     target_link_libraries(_gcloud PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
@@ -118,11 +123,6 @@ else()
     add_library(_gcloud INTERFACE)
     target_include_directories(_gcloud SYSTEM INTERFACE ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
     target_link_libraries(_gcloud INTERFACE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
-endif()
-
-# The library is large - avoid bloat.
-if(OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(_gcloud PRIVATE -g0)
 endif()
 
 add_library(ch_contrib::google_cloud_cpp ALIAS _gcloud)

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -117,7 +117,7 @@ if(ENABLE_GOOGLE_CLOUD_CPP_KMS)
 
     target_include_directories(_google_cloud_cpp_kms SYSTEM PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_INCLUDES})
     target_include_directories(_google_cloud_cpp_kms SYSTEM PUBLIC ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
-    target_link_libraries(_google_cloud_cpp_kms absl::optional gRPC::grpc++)
+    target_link_libraries(_google_cloud_cpp_kms absl::optional ch_contrib::protobuf)
 endif()
 
 add_library(_gcloud INTERFACE)

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -117,7 +117,7 @@ if(ENABLE_GOOGLE_CLOUD_CPP_KMS)
 
     target_include_directories(_google_cloud_cpp_kms SYSTEM PRIVATE ${GOOGLE_CLOUD_CPP_PRIVATE_INCLUDES})
     target_include_directories(_google_cloud_cpp_kms SYSTEM PUBLIC ${GOOGLE_CLOUD_CPP_PUBLIC_INCLUDES})
-    target_link_libraries(_google_cloud_cpp_kms absl::optional ch_contrib::protobuf)
+    target_link_libraries(_google_cloud_cpp_kms absl::optional gRPC::grpc++)
 endif()
 
 add_library(_gcloud INTERFACE)


### PR DESCRIPTION
- Avoid building big objects in Google Cloud Cpp 
- Add status message when not building with Google Cloud Cpp

Follow-up on https://github.com/ClickHouse/ClickHouse/pull/82881 addressing [this comment](https://github.com/ClickHouse/ClickHouse/pull/82881#discussion_r2211056183)

### Before

```bash
$ du -h build/contrib/google-cloud-cpp-cmake/
...
535M    build/contrib/google-cloud-cpp-cmake/

$ ll build/contrib/google-cloud-cpp-cmake/*.a
.rw-rw-r--  54M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/lib_google_cloud_cpp_kms.a
.rw-rw-r-- 492k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_annotations_protos.a
.rw-rw-r-- 1.8M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_client_protos.a
.rw-rw-r-- 496k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_field_behavior_protos.a
.rw-rw-r-- 729k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_http_protos.a
.rw-rw-r-- 168k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_launch_stage_protos.a
.rw-rw-r-- 879k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_resource_protos.a
.rw-rw-r-- 719k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_routing_protos.a
.rw-rw-r-- 2.5M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_cloud_location_locations_protos.a
.rw-rw-r--  12M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_common.a
.rw-rw-r--  16M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_grpc_utils.a
.rw-rw-r-- 970k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_credentials_v1_common_protos.a
.rw-rw-r-- 1.7M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_credentials_v1_iamcredentials_protos.a
.rw-rw-r-- 2.2M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_v1_iam_policy_protos.a
.rw-rw-r-- 498k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_v1_options_protos.a
.rw-rw-r-- 1.0M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_v1_policy_protos.a
.rw-rw-r--  20M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_kms_protos.a
.rw-rw-r-- 2.6M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_longrunning_operations_protos.a
.rw-rw-r--  43M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_rest_internal.a
.rw-rw-r-- 1.5M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_rpc_error_details_protos.a
.rw-rw-r-- 604k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_rpc_status_protos.a
.rw-rw-r-- 101M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_storage.a
.rw-rw-r--  10M ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_storage_protos.a
.rw-rw-r-- 506k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_type_date_protos.a
.rw-rw-r-- 564k ubuntu 21 Jul 11:38 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_type_expr_protos.a
```

### After

```bash
$ du -h build/contrib/google-cloud-cpp-cmake/
...
127M    build/contrib/google-cloud-cpp-cmake/

$ ll build/contrib/google-cloud-cpp-cmake/*.a
.rw-rw-r--  10M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/lib_google_cloud_cpp_kms.a
.rw-rw-r-- 492k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_annotations_protos.a
.rw-rw-r-- 1.8M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_client_protos.a
.rw-rw-r-- 496k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_field_behavior_protos.a
.rw-rw-r-- 729k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_http_protos.a
.rw-rw-r-- 168k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_launch_stage_protos.a
.rw-rw-r-- 879k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_resource_protos.a
.rw-rw-r-- 719k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_api_routing_protos.a
.rw-rw-r-- 540k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_cloud_location_locations_protos.a
.rw-rw-r-- 1.3M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_common.a
.rw-rw-r-- 2.6M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_grpc_utils.a
.rw-rw-r-- 970k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_credentials_v1_common_protos.a
.rw-rw-r-- 1.7M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_credentials_v1_iamcredentials_protos.a
.rw-rw-r-- 495k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_v1_iam_policy_protos.a
.rw-rw-r-- 498k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_v1_options_protos.a
.rw-rw-r-- 1.0M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_iam_v1_policy_protos.a
.rw-rw-r-- 5.0M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_kms_protos.a
.rw-rw-r-- 2.6M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_longrunning_operations_protos.a
.rw-rw-r-- 6.9M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_rest_internal.a
.rw-rw-r-- 1.5M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_rpc_error_details_protos.a
.rw-rw-r-- 604k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_rpc_status_protos.a
.rw-rw-r--  17M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_storage.a
.rw-rw-r-- 3.2M ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_storage_protos.a
.rw-rw-r-- 506k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_type_date_protos.a
.rw-rw-r-- 564k ubuntu 21 Jul 11:41 build/contrib/google-cloud-cpp-cmake/libgoogle_cloud_cpp_type_expr_protos.a
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid building big objects in Google Cloud Cpp
 
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
