### PR TITLE
Apply ACL for children nodes

### DIFF
--- a/src/Common/StringHashForHeterogeneousLookup.h
+++ b/src/Common/StringHashForHeterogeneousLookup.h
@@ -21,6 +21,11 @@ struct StringHashForHeterogeneousLookup
         return hash_type()(str);
     }
 
+    auto operator()(const StringRef str) const
+    {
+        return hash_type()(str.toView());
+    }
+
     auto operator()(const char * data) const
     {
         return hash_type()(data);

--- a/src/Common/ZooKeeper/ZooKeeperArgs.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.cpp
@@ -274,10 +274,12 @@ void ZooKeeperArgs::initFromKeeperSection(const Poco::Util::AbstractConfiguratio
             config.keys(config_name + "." + key, path_acls_keys);
             for (const auto & path_key : path_acls_keys)
             {
-                String path = config.getString(config_name + "." + key + "." + path_key + ".path");
-                String scheme = config.getString(config_name + "." + key + "." + path_key + ".scheme");
-                String id = config.getString(config_name + "." + key + "." + path_key + ".id");
-                String permissions_str = config.getString(config_name + "." + key + "." + path_key + ".permissions");
+                std::string full_path_key = fmt::format("{}.{}.{}", config_name, key, path_key);
+                String path = config.getString(full_path_key + ".path");
+                String scheme = config.getString(full_path_key + ".scheme");
+                String id = config.getString(full_path_key + ".id");
+                String permissions_str = config.getString(full_path_key + ".permissions");
+                bool apply_to_children = config.getBool(full_path_key + ".apply_to_children", false);
 
                 int32_t permissions = 0;
 
@@ -308,7 +310,7 @@ void ZooKeeperArgs::initFromKeeperSection(const Poco::Util::AbstractConfiguratio
                 acl.id = id;
                 acl.permissions = permissions;
 
-                path_acls[path] = std::move(acl);
+                path_acls[path] = {.acl = std::move(acl), .apply_to_children = apply_to_children};
             }
         }
         else

--- a/src/Common/ZooKeeper/ZooKeeperArgs.h
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Common/StringHashForHeterogeneousLookup.h>
 #include <Common/ZooKeeper/Types.h>
 #include <Common/ZooKeeper/ZooKeeperConstants.h>
 #include <Common/GetPriorityForLoadBalancing.h>
@@ -55,7 +56,20 @@ struct ZooKeeperArgs
     bool prefer_local_availability_zone = false;
     bool availability_zone_autodetect = false;
     String password;
-    std::unordered_map<std::string, Coordination::ACL> path_acls;
+
+    struct PathAclInfo
+    {
+        Coordination::ACL acl;
+        bool apply_to_children = false;
+
+        bool operator==(const PathAclInfo &) const = default;
+    };
+    using PathAclMap = std::unordered_map<
+        std::string,
+        PathAclInfo,
+        DB::StringHashForHeterogeneousLookup,
+        DB::StringHashForHeterogeneousLookup::transparent_key_equal>;
+    PathAclMap path_acls;
 
     SessionLifetimeConfiguration fallback_session_lifetime = {};
     DB::GetPriorityForLoadBalancing get_priority_load_balancing;

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -1266,4 +1266,38 @@ PathMatchResult matchPath(std::string_view path, std::string_view match_to)
     return *first_it == '/' ? IS_CHILD : NOT_MATCH;
 }
 
+namespace
+{
+size_t findLastSlash(StringRef path)
+{
+    if (path.size == 0)
+        return std::string::npos;
+
+    for (size_t i = path.size - 1; i > 0; --i)
+    {
+        if (path.data[i] == '/')
+            return i;
+    }
+
+    if (path.data[0] == '/')
+        return 0;
+
+    return std::string::npos;
+}
+}
+
+StringRef parentNodePath(StringRef path)
+{
+    auto rslash_pos = findLastSlash(path);
+    if (rslash_pos > 0)
+        return StringRef{path.data, rslash_pos};
+    return "/";
+}
+
+StringRef getBaseNodeName(StringRef path)
+{
+    size_t basename_start = findLastSlash(path);
+    return StringRef{path.data + basename_start + 1, path.size - basename_start - 1};
+}
+
 }

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -692,4 +692,9 @@ enum class PathMatchResult : uint8_t
 
 PathMatchResult matchPath(std::string_view path, std::string_view match_to);
 
+StringRef parentNodePath(StringRef path);
+
+StringRef getBaseNodeName(StringRef path);
+
+
 }

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -219,7 +219,7 @@ public:
 
 private:
     ACLs default_acls;
-    std::unordered_map<std::string, Coordination::ACL> path_acls;
+    zkutil::ZooKeeperArgs::PathAclMap path_acls;
 
     zkutil::ZooKeeperArgs args;
     std::atomic<int8_t> original_index{-1};

--- a/src/Coordination/KeeperCommon.cpp
+++ b/src/Coordination/KeeperCommon.cpp
@@ -19,37 +19,6 @@ namespace CoordinationSetting
     extern const CoordinationSettingsUInt64 disk_move_retries_wait_ms;
 }
 
-static size_t findLastSlash(StringRef path)
-{
-    if (path.size == 0)
-        return std::string::npos;
-
-    for (size_t i = path.size - 1; i > 0; --i)
-    {
-        if (path.data[i] == '/')
-            return i;
-    }
-
-    if (path.data[0] == '/')
-        return 0;
-
-    return std::string::npos;
-}
-
-StringRef parentNodePath(StringRef path)
-{
-    auto rslash_pos = findLastSlash(path);
-    if (rslash_pos > 0)
-        return StringRef{path.data, rslash_pos};
-    return "/";
-}
-
-StringRef getBaseNodeName(StringRef path)
-{
-    size_t basename_start = findLastSlash(path);
-    return StringRef{path.data + basename_start + 1, path.size - basename_start - 1};
-}
-
 void moveFileBetweenDisks(
     DiskPtr disk_from,
     const std::string & path_from,

--- a/src/Coordination/KeeperCommon.h
+++ b/src/Coordination/KeeperCommon.h
@@ -63,10 +63,6 @@ struct KeeperRequestForSession
 };
 using KeeperRequestsForSessions = std::vector<KeeperRequestForSession>;
 
-StringRef parentNodePath(StringRef path);
-
-StringRef getBaseNodeName(StringRef path);
-
 inline static constexpr std::string_view tmp_keeper_file_prefix = "tmp_";
 
 void moveFileBetweenDisks(

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -491,9 +491,9 @@ void KeeperStorageSnapshot<Storage>::deserialize(SnapshotDeserializationResult<S
         {
             if (itr.key != "/")
             {
-                auto parent_path = parentNodePath(itr.key);
+                auto parent_path = Coordination::parentNodePath(itr.key);
                 storage.container.updateValue(
-                    parent_path, [path = itr.key](typename Storage::Node & value) { value.addChild(getBaseNodeName(path)); });
+                    parent_path, [path = itr.key](typename Storage::Node & value) { value.addChild(Coordination::getBaseNodeName(path)); });
             }
         }
 

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -171,7 +171,7 @@ KeeperResponsesForSessions processWatchesImpl(
         watches.erase(watch_it);
     }
 
-    auto parent_path = parentNodePath(path);
+    auto parent_path = Coordination::parentNodePath(path);
 
     Strings paths_to_check_for_list_watches;
     if (event_type == Coordination::Event::CREATED)
@@ -617,7 +617,7 @@ void KeeperStorage<Container>::initializeSystemNodes()
                 node.stats.increaseNumChildren();
                 if constexpr (!use_rocksdb)
                 {
-                    node.addChild(getBaseNodeName(keeper_system_path));
+                    node.addChild(Coordination::getBaseNodeName(keeper_system_path));
                     node.invalidateDigestCache();
                 }
             }
@@ -638,9 +638,9 @@ void KeeperStorage<Container>::initializeSystemNodes()
         {
             auto [map_key, _] = container.insert(std::string{path}, child_system_node);
             /// Take child path from key owned by map.
-            auto child_path = getBaseNodeName(map_key->getKey());
+            auto child_path = Coordination::getBaseNodeName(map_key->getKey());
             container.updateValue(
-                parentNodePath(StringRef(path)),
+                Coordination::parentNodePath(StringRef(path)),
                 [child_path](auto & parent)
                 {
                     // don't update stats so digest is okay
@@ -1307,7 +1307,7 @@ template <typename Container>
 bool KeeperStorage<Container>::createNode(
     const std::string & path, String data, const Coordination::Stat & stat, Coordination::ACLs node_acls, bool update_digest)
 {
-    auto parent_path = parentNodePath(path);
+    auto parent_path = Coordination::parentNodePath(path);
     auto node_it = container.find(parent_path);
 
     if (node_it == container.end())
@@ -1336,7 +1336,7 @@ bool KeeperStorage<Container>::createNode(
     {
         auto [map_key, _] = container.insert(path, created_node);
         /// Take child path from key owned by map.
-        auto child_path = getBaseNodeName(map_key->getKey());
+        auto child_path = Coordination::getBaseNodeName(map_key->getKey());
         container.updateValue(
                 parent_path,
                 [child_path](KeeperMemNode & parent)
@@ -1379,8 +1379,8 @@ bool KeeperStorage<Container>::removeNode(const std::string & path, int32_t vers
     else
     {
         container.updateValue(
-            parentNodePath(path),
-            [child_basename = getBaseNodeName(node_it->key)](KeeperMemNode & parent)
+            Coordination::parentNodePath(path),
+            [child_basename = Coordination::getBaseNodeName(node_it->key)](KeeperMemNode & parent)
             {
                 parent.removeChild(child_basename);
             }
@@ -1577,7 +1577,7 @@ template <typename Storage>
 bool checkAuth(const Coordination::ZooKeeperCreateRequest & zk_request, Storage & storage, int64_t session_id, bool is_local)
 {
     auto path = zk_request.getPath();
-    return storage.checkACL(parentNodePath(path), Coordination::ACL::Create, session_id, is_local);
+    return storage.checkACL(Coordination::parentNodePath(path), Coordination::ACL::Create, session_id, is_local);
 }
 
 KeeperResponsesForSessions processWatches(
@@ -1604,7 +1604,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
 
     std::list<KeeperStorageBase::Delta> new_deltas;
 
-    auto parent_path = parentNodePath(zk_request.path);
+    auto parent_path = Coordination::parentNodePath(zk_request.path);
     auto parent_node = storage.uncommitted_state.getNode(parent_path);
     if (parent_node == nullptr)
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZNONODE}};
@@ -1643,7 +1643,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZNODEEXISTS}};
     }
 
-    if (getBaseNodeName(path_created).size == 0)
+    if (Coordination::getBaseNodeName(path_created).size == 0)
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZBADARGUMENTS}};
 
     Coordination::ACLs node_acls;
@@ -1819,7 +1819,7 @@ processLocal(const Coordination::ZooKeeperGetRequest & zk_request, Storage & sto
 template <typename Storage>
 bool checkAuth(const Coordination::ZooKeeperRemoveRequest & zk_request, Storage & storage, int64_t session_id, bool is_local)
 {
-    return storage.checkACL(parentNodePath(zk_request.getPath()), Coordination::ACL::Delete, session_id, is_local);
+    return storage.checkACL(Coordination::parentNodePath(zk_request.getPath()), Coordination::ACL::Delete, session_id, is_local);
 }
 
 KeeperResponsesForSessions processWatches(
@@ -1854,7 +1854,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
         return {KeeperStorageBase::Delta{zxid, Coordination::Error::ZBADARGUMENTS}};
     }
 
-    auto parent_path = parentNodePath(zk_request.path);
+    auto parent_path = Coordination::parentNodePath(zk_request.path);
     auto parent_node = storage.uncommitted_state.getNode(parent_path);
 
     std::optional<UpdateNodeStatDelta> update_parent_delta;
@@ -2071,7 +2071,7 @@ private:
 
         for (auto & [node_path, uncommitted_node] : nodes)
         {
-            if (parentNodePath(node_path) != path)
+            if (Coordination::parentNodePath(node_path) != path)
                 continue;
 
             uncommitted_children.insert(node_path);
@@ -2107,7 +2107,7 @@ private:
 template <typename Storage>
 bool checkAuth(const Coordination::ZooKeeperRemoveRecursiveRequest & zk_request, Storage & storage, int64_t session_id, bool is_local)
 {
-    return storage.checkACL(parentNodePath(zk_request.getPath()), Coordination::ACL::Delete, session_id, is_local);
+    return storage.checkACL(Coordination::parentNodePath(zk_request.getPath()), Coordination::ACL::Delete, session_id, is_local);
 }
 
 KeeperResponsesForSessions processWatches(
@@ -2155,7 +2155,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
 
     auto node = storage.uncommitted_state.getNode(zk_request.path);
 
-    auto parent_path = parentNodePath(zk_request.path);
+    auto parent_path = Coordination::parentNodePath(zk_request.path);
     auto parent_node = storage.uncommitted_state.getNode(parent_path);
 
     std::optional<UpdateNodeStatDelta> update_parent_delta;
@@ -2369,7 +2369,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
     new_stats.data_size = static_cast<uint32_t>(zk_request.data.size());
     new_deltas.emplace_back(zk_request.path, zxid, std::move(node_delta));
 
-    auto parent_path = parentNodePath(zk_request.path);
+    auto parent_path = Coordination::parentNodePath(zk_request.path);
     auto parent_node = storage.uncommitted_state.getNode(parent_path);
     UpdateNodeStatDelta parent_delta(*parent_node);
     ++parent_delta.new_stats.cversion;
@@ -2549,7 +2549,7 @@ bool checkAuth(const Coordination::ZooKeeperCheckRequest & zk_request, Storage &
 {
     auto path = zk_request.getPath();
     return storage.checkACL(
-        zk_request.getOpNum() == Coordination::OpNum::CheckNotExists ? parentNodePath(path) : path,
+        zk_request.getOpNum() == Coordination::OpNum::CheckNotExists ? Coordination::parentNodePath(path) : path,
         Coordination::ACL::Read,
         session_id,
         is_local);
@@ -3163,7 +3163,7 @@ void KeeperStorage<Container>::preprocessRequest(
                     if (!node || node->stats.ephemeralOwner() != session_id)
                         continue;
 
-                    auto parent_node_path = parentNodePath(ephemeral_path).toView();
+                    auto parent_node_path = Coordination::parentNodePath(ephemeral_path).toView();
 
                     auto parent_update_it = parent_updates.find(parent_node_path);
                     if (parent_update_it == parent_updates.end())

--- a/src/Coordination/ZooKeeperDataReader.cpp
+++ b/src/Coordination/ZooKeeperDataReader.cpp
@@ -154,12 +154,12 @@ int64_t deserializeStorageData(Storage & storage, ReadBuffer & in, LoggerPtr log
     {
         if (itr.key != "/")
         {
-            auto parent_path = parentNodePath(itr.key);
+            auto parent_path = Coordination::parentNodePath(itr.key);
             storage.container.updateValue(
                 parent_path,
                 [my_path = itr.key](typename Storage::Node & value)
                 {
-                    value.addChild(getBaseNodeName(my_path));
+                    value.addChild(Coordination::getBaseNodeName(my_path));
                     value.stats.increaseNumChildren();
                 });
         }

--- a/src/Coordination/tests/gtest_coordination_common.h
+++ b/src/Coordination/tests/gtest_coordination_common.h
@@ -11,6 +11,8 @@
 #include <Coordination/KeeperStorage_fwd.h>
 #include <Coordination/KeeperCommon.h>
 
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
+
 #include <Disks/DiskLocal.h>
 
 #include <Poco/Logger.h>
@@ -118,9 +120,9 @@ void addNode(Storage & storage, const std::string & path, const std::string & da
     node.acl_id = acl_id;
     storage.container.insertOrReplace(path, node);
     auto child_it = storage.container.find(path);
-    auto child_path = DB::getBaseNodeName(child_it->key);
+    auto child_path = Coordination::getBaseNodeName(child_it->key);
     storage.container.updateValue(
-        DB::parentNodePath(StringRef{path}),
+        Coordination::parentNodePath(StringRef{path}),
         [&](auto & parent)
         {
             parent.addChild(child_path);

--- a/tests/integration/test_keeper_path_acl/configs/zookeeper_config.xml
+++ b/tests/integration/test_keeper_path_acl/configs/zookeeper_config.xml
@@ -13,10 +13,17 @@
         <path_acls>
             <acl1>
                 <path>/test_path</path>
-                <scheme>digest</scheme>
-                <id>user1:password1</id>
+                <scheme>world</scheme>
+                <id>anyone</id>
                 <permissions>read,write</permissions>
             </acl1>
+            <acl2>
+                <path>/test_path_another</path>
+                <scheme>world</scheme>
+                <id>anyone</id>
+                <permissions>read,write</permissions>
+                <apply_to_children>1</apply_to_children>
+            </acl2>
         </path_acls>
     </zookeeper>
 </clickhouse>

--- a/tests/integration/test_keeper_path_acl/test.py
+++ b/tests/integration/test_keeper_path_acl/test.py
@@ -27,40 +27,54 @@ def test_path_acl(started_cluster):
     node.query(
         "CREATE TABLE IF NOT EXISTS test_table (id UInt64) ENGINE = ReplicatedMergeTree('/test_path', 'replica1') ORDER BY id"
     )
-    node.query("INSERT INTO test_table VALUES (1)")
+    node.query(
+        "CREATE TABLE IF NOT EXISTS test_table_another (id UInt64) ENGINE = ReplicatedMergeTree('/test_path_another', 'replica1') ORDER BY id"
+    )
 
     zk = get_fake_zk(started_cluster, "node")
     zk.add_auth("digest", "testuser:testpass")
 
     try:
-        # Check /test_path created by ReplicatedMergeTree
-        # This path should have path_acls
-        acls_test_path, stat = zk.get_acls("/test_path")
 
-        expected_acls = [
-            ACL(
-                perms=31,
-                id=Id(scheme="digest", id="testuser:HqwT8VeO9JO57VYXpfSjGycetmc="),
-            ),
-            ACL(perms=3, id=Id(scheme="digest", id="user1:password1")),
-        ]
+        def compare_acls(first, second):
+            key_acl = lambda x: (x.perms, x.id.scheme, x.id.id)
+            assert sorted(first, key=key_acl) == sorted(second, key=key_acl)
 
-        assert sorted(
-            acls_test_path, key=lambda x: (x.perms, x.id.scheme, x.id.id)
-        ) == sorted(expected_acls, key=lambda x: (x.perms, x.id.scheme, x.id.id))
+        def check_path_acls(path, apply_acls_to_children):
+            acls_test_path, stat = zk.get_acls(path)
 
-        # Find a child of /test_path and verify its ACLs
-        children = zk.get_children("/test_path")
-        assert len(children) > 0
-        child_path = f"/test_path/{children[0]}"
-        acls_child, stat = zk.get_acls(child_path)
-        expected_child_acls = [
-            ACL(
-                perms=31,
-                id=Id(scheme="digest", id="testuser:HqwT8VeO9JO57VYXpfSjGycetmc="),
-            ),
-        ]
-        assert acls_child == expected_child_acls
+            expected_acls = [
+                ACL(
+                    perms=31,
+                    id=Id(scheme="digest", id="testuser:HqwT8VeO9JO57VYXpfSjGycetmc="),
+                ),
+                ACL(perms=3, id=Id(scheme="world", id="anyone")),
+            ]
+
+            compare_acls(acls_test_path, expected_acls)
+
+            # Find a child of /test_path and verify its ACLs
+            children = zk.get_children(path)
+            assert len(children) > 0
+            child_path = f"/{path}/{children[0]}"
+            acls_child, stat = zk.get_acls(child_path)
+            expected_child_acls = (
+                expected_acls
+                if apply_acls_to_children
+                else [
+                    ACL(
+                        perms=31,
+                        id=Id(
+                            scheme="digest", id="testuser:HqwT8VeO9JO57VYXpfSjGycetmc="
+                        ),
+                    ),
+                ]
+            )
+
+            compare_acls(acls_child, expected_child_acls)
+
+        check_path_acls("/test_path", apply_acls_to_children=False)
+        check_path_acls("/test_path_another", apply_acls_to_children=True)
 
     finally:
         zk.stop()

--- a/tests/integration/test_keeper_path_acl/test.py
+++ b/tests/integration/test_keeper_path_acl/test.py
@@ -53,7 +53,7 @@ def test_path_acl(started_cluster):
 
             compare_acls(acls_test_path, expected_acls)
 
-            # Find a child of /test_path and verify its ACLs
+            # Find a child of path and verify its ACLs
             children = zk.get_children(path)
             assert len(children) > 0
             child_path = f"/{path}/{children[0]}"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add support for applying extra ACL on specific Keeper nodes using `apply_to_children` config.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
