### PR TITLE
Fix NULL dereference in fetchSQLiteTableStructure() on error

### DIFF
--- a/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
+++ b/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<NamesAndTypesList> fetchSQLiteTableStructure(sqlite3 * connectio
 
     if (status != SQLITE_OK)
     {
-        String err_msg(err_message);
+        String err_msg(err_message ? err_message : "unknown error");
         sqlite3_free(err_message);
 
         throw Exception(ErrorCodes::SQLITE_ENGINE_ERROR,


### PR DESCRIPTION
CI found [1]:

    BaseDaemon: Address: NULL pointer. Access: read. Address not mapped to object.
    BaseDaemon: Stack trace: 0x00007f33b5ad70bd 0x000055ce7dfba161 0x000055ce89bb8061 0x000055ce8d2c1e18 0x000055ce8d2c1967 0x000055ce8d2c43a4 0x000055ce8d2c31e5 0x000055ce8d0434bb 0x000055ce8a883b5d 0x000055ce8a87c7b0 0x000055ce8a88971c 0x000055ce8ac3c88d 0x000055ce8ac3fd67 0x000055ce8a78351c 0x000055ce8a78160c 0x000055ce8a77ec62 0x000055ce8a777eff 0x000055ce8a793c26 0x000055ce84acc360 0x000055ce84ad217b 0x00007f33b59b9ac3 0x00007f33b5a4b850
    BaseDaemon: 3. ? @ 0x00000000001b20bd
    BaseDaemon: 4. String::basic_string[abi:ne190107]<0>(char const*) @ 0x0000000008e0b161
    BaseDaemon: 5. ./ci/tmp/build/./src/Databases/SQLite/fetchSQLiteTableStructure.cpp:89: DB::fetchSQLiteTableStructure(sqlite3*, String const&) @ 0x0000000014a09061
    BaseDaemon: 6. ./ci/tmp/build/./src/Storages/StorageSQLite.cpp:85: DB::StorageSQLite::getTableStructureFromData(std::shared_ptr<sqlite3> const&, String const&) @ 0x0000000018112e18
    BaseDaemon: 7. ./ci/tmp/build/./src/Storages/StorageSQLite.cpp:69: DB::StorageSQLite::StorageSQLite(DB::StorageID const&, std::shared_ptr<sqlite3>, String const&, String const&, DB::ColumnsDescription const&, DB::ConstraintsDescription const&, String const&, std::shared_ptr<DB::Context const>) @ 0x0000000018112967

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=84112&sha=d21d30e30689009ff84e4339423bac1dccf950a2&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)