### PR TITLE
Fix recursive static var initialization in ThreadFuzzer

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1076,10 +1076,14 @@ try
     global_context->addOrUpdateWarningMessage(Context::WarningType::SERVER_BUILT_IN_DEBUG_MODE, PreformattedMessage::create("Server was built in debug mode. It will work slowly."));
 #endif
 
-    if (ThreadFuzzer::instance().isEffective())
-        global_context->addOrUpdateWarningMessage(
-            Context::WarningType::THREAD_FUZZER_IS_ENABLED,
-            PreformattedMessage::create("ThreadFuzzer is enabled. Application will run slowly and unstable."));
+    {
+        const auto & thread_fuzzer = ThreadFuzzer::instance();
+        thread_fuzzer.setup();
+        if (thread_fuzzer.isEffective())
+            global_context->addOrUpdateWarningMessage(
+                Context::WarningType::THREAD_FUZZER_IS_ENABLED,
+                PreformattedMessage::create("ThreadFuzzer is enabled. Application will run slowly and unstable."));
+    }
 
 #if defined(SANITIZER)
     auto sanitizers = getSanitizerNames();

--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -52,8 +52,6 @@ namespace ErrorCodes
 ThreadFuzzer::ThreadFuzzer()
 {
     initConfiguration();
-    if (needsSetup())
-        setup();
 
     if (!isEffective())
     {
@@ -280,6 +278,9 @@ void ThreadFuzzer::signalHandler(int)
 
 void ThreadFuzzer::setup() const
 {
+    if (!needsSetup())
+        return;
+
     struct sigaction sa{};
     sa.sa_handler = signalHandler;
     sa.sa_flags = SA_RESTART;

--- a/src/Common/ThreadFuzzer.h
+++ b/src/Common/ThreadFuzzer.h
@@ -52,7 +52,7 @@ public:
     }
 
     bool isEffective() const;
-    bool needsSetup() const;
+    void setup() const;
 
     static void stop();
     static void start();
@@ -76,7 +76,7 @@ private:
     ThreadFuzzer();
 
     void initConfiguration();
-    void setup() const;
+    bool needsSetup() const;
 
     static void signalHandler(int);
 };

--- a/src/Common/tests/gtest_thread_fuzzer.cpp
+++ b/src/Common/tests/gtest_thread_fuzzer.cpp
@@ -8,7 +8,7 @@
 TEST(ThreadFuzzer, mutex)
 {
     /// Initialize ThreadFuzzer::started
-    DB::ThreadFuzzer::instance().isEffective();
+    DB::ThreadFuzzer::instance().setup();
 
     std::mutex mutex;
     std::atomic<size_t> elapsed_ns = 0;


### PR DESCRIPTION
CI found [1]:

    0x00007f59e28479fc in pthread_kill () from /lib/x86_64-linux-gnu/libc.so.6
    0  0x00007f59e28479fc in pthread_kill () from /lib/x86_64-linux-gnu/libc.so.6
    1  0x00007f59e27f3476 in raise () from /lib/x86_64-linux-gnu/libc.so.6
    2  0x00007f59e27d97f3 in abort () from /lib/x86_64-linux-gnu/libc.so.6
    3  0x0000559301190806 in abort_message (format=0x5592dd4fa28e "__cxa_guard_acquire detected recursive initialization: do you have a function-local static variable whose initialization depends on that function?") at /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/contrib/llvm-project/libcxxabi/src/abort_message.cpp:78
    ...
    8  DB::ThreadFuzzer::signalHandler () at /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/src/Common/ThreadFuzzer.cpp:276
    9  <signal handler called>
    10 0x00007f59e288dd7b in setitimer () from /lib/x86_64-linux-gnu/libc.so.6
    11 0x00005592ee025a2b in DB::ThreadFuzzer::setup (this=this@entry=0x559302365048 <DB::ThreadFuzzer::instance()::res>) at /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/src/Common/ThreadFuzzer.cpp:310
    12 0x00005592ee024c61 in DB::ThreadFuzzer::ThreadFuzzer (this=0x559302365048 <DB::ThreadFuzzer::instance()::res>) at /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/src/Common/ThreadFuzzer.cpp:56
    13 0x00005592ee29aeeb in DB::ThreadFuzzer::instance () at /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/src/Common/ThreadFuzzer.h:50
    14 DB::Server::main (this=0x7ffc3e7f5bd8) at /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/programs/server/Server.cpp:1079

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=84098&sha=afe784755359c3c8e9b0835aa9187b88dd890013&name_0=PR&name_1=Stress%20test%20%28amd_debug%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/82091