### PR TITLE
Fix crash during lighweight mutation with projections

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1354,6 +1354,10 @@ bool PartMergerWriter::mutateOriginalPartAndPrepareProjections()
                 ProfileEventTimeIncrement<Microseconds> projection_watch(ProfileEvents::MutateTaskProjectionsCalculationMicroseconds);
                 Block block_to_squash = ctx->projections_to_build[i]->calculate(cur_block, ctx->context);
 
+                /// Everything is deleted by lighweight delete
+                if (block_to_squash.rows() == 0)
+                    continue;
+
                 projection_squashes[i].setHeader(block_to_squash.cloneEmpty());
                 squashed_chunk = Squashing::squash(projection_squashes[i].add({block_to_squash.getColumns(), block_to_squash.rows()}));
             }

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -177,7 +177,6 @@ protected:
     void consume(Chunk chunk) override
     {
         num_rows += chunk.getNumRows();
-
         if (num_rows > max_rows_allowed)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection cannot increase the number of rows in a block. It's a bug");
 

--- a/tests/queries/0_stateless/03571_lwd_and_projections.sql
+++ b/tests/queries/0_stateless/03571_lwd_and_projections.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS weird_projections;
+
+CREATE TABLE weird_projections(
+    `account_id` UInt64,
+    `user_id` String,
+    PROJECTION flow_events_by_day_proj
+    (
+        SELECT
+            account_id,
+            countDistinct(user_id) AS total_users
+        GROUP BY
+            account_id
+    )
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{database}/tables/test', '1')
+ORDER BY (account_id)
+SETTINGS index_granularity = 8192, lightweight_mutation_projection_mode = 'rebuild';
+
+INSERT INTO weird_projections SELECT 134 as account_id, toString(account_id) as user_id FROM numbers(10000);
+INSERT INTO weird_projections SELECT 132 as account_id, toString(account_id) as user_id FROM numbers(10000);
+
+OPTIMIZE TABLE weird_projections FINAL;
+
+DELETE FROM weird_projections WHERE account_id = 134;
+
+DROP TABLE IF EXISTS weird_projections;

--- a/tests/queries/0_stateless/03571_lwd_and_projections.sql
+++ b/tests/queries/0_stateless/03571_lwd_and_projections.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS weird_projections;
 CREATE TABLE weird_projections(
     `account_id` UInt64,
     `user_id` String,
-    PROJECTION flow_events_by_day_proj
+    PROJECTION events_by_day_proj
     (
         SELECT
             account_id,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix rare clickhouse crash when table has projection, `lightweight_mutation_projection_mode = 'rebuild'` and user execute lighweight delete which deletes ALL rows from any block in table.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
