### PR TITLE
fix: max_memory_usage in operator new

### DIFF
--- a/src/Common/CurrentMemoryTracker.h
+++ b/src/Common/CurrentMemoryTracker.h
@@ -18,5 +18,6 @@ struct CurrentMemoryTracker
     static void injectFault();
 
 private:
-    [[nodiscard]] static AllocationTrace allocImpl(Int64 size, bool throw_if_memory_exceeded);
+    template <bool throw_if_memory_exceeded>
+    [[nodiscard]] static AllocationTrace allocImpl(Int64 size);
 };

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -231,7 +231,8 @@ void MemoryTracker::debugLogBigAllocationWithoutCheck(Int64 size [[maybe_unused]
     }
 }
 
-AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryTracker * query_tracker, double _sample_probability)
+template <bool throw_if_memory_exceeded>
+AllocationTrace MemoryTracker::allocImpl(Int64 size, MemoryTracker * query_tracker, double _sample_probability)
 {
     if (size < 0)
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Negative size ({}) is passed to MemoryTracker. It is a bug.", size);
@@ -259,7 +260,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         if (auto * loaded_next = parent.load(std::memory_order_relaxed))
         {
             MemoryTracker * tracker = level == VariableContext::Process ? this : query_tracker;
-            return loaded_next->allocImpl(size, throw_if_memory_exceeded, tracker, _sample_probability);
+            return loaded_next->allocImpl<throw_if_memory_exceeded>(size, tracker, _sample_probability);
         }
 
         return AllocationTrace(_sample_probability);
@@ -417,16 +418,20 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
     if (auto * loaded_next = parent.load(std::memory_order_relaxed))
     {
         MemoryTracker * tracker = level == VariableContext::Process ? this : query_tracker;
-        return loaded_next->allocImpl(size, throw_if_memory_exceeded, tracker, _sample_probability);
+        return loaded_next->allocImpl<throw_if_memory_exceeded>(size, tracker, _sample_probability);
     }
 
     return AllocationTrace(_sample_probability);
 }
 
+template AllocationTrace MemoryTracker::allocImpl<false>(Int64 size, MemoryTracker * query_tracker, double _sample_probability);
+template AllocationTrace MemoryTracker::allocImpl<true>(Int64 size, MemoryTracker * query_tracker, double _sample_probability);
+
 void MemoryTracker::adjustWithUntrackedMemory(Int64 untracked_memory)
 {
+    constexpr bool throw_if_memory_exceeded = false;
     if (untracked_memory > 0)
-        std::ignore = allocImpl(untracked_memory, /*throw_if_memory_exceeded*/ false);
+        std::ignore = allocImpl<throw_if_memory_exceeded>(untracked_memory);
     else
         std::ignore = free(-untracked_memory);
 }

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -111,7 +111,8 @@ private:
 
     /// allocImpl(...) and free(...) should not be used directly
     friend struct CurrentMemoryTracker;
-    [[nodiscard]] AllocationTrace allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryTracker * query_tracker = nullptr, double _sample_probability = -1.0);
+    template <bool throw_if_memory_exceeded>
+    [[nodiscard]] AllocationTrace allocImpl(Int64 size, MemoryTracker * query_tracker = nullptr, double _sample_probability = -1.0);
     [[nodiscard]] AllocationTrace free(Int64 size, double _sample_probability = -1.0);
 public:
 

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -207,6 +207,15 @@ requires DB::OptionalArgument<TAlign...>
 inline ALWAYS_INLINE size_t trackMemory(std::size_t size, AllocationTrace & trace, TAlign... align)
 {
     std::size_t actual_size = getActualAllocationSize(size, align...);
+    trace = CurrentMemoryTracker::alloc(actual_size);
+    return actual_size;
+}
+
+template <std::same_as<std::align_val_t>... TAlign>
+requires DB::OptionalArgument<TAlign...>
+inline ALWAYS_INLINE size_t trackMemoryNoThrow(std::size_t size, AllocationTrace & trace, TAlign... align)
+{
+    std::size_t actual_size = getActualAllocationSize(size, align...);
     trace = CurrentMemoryTracker::allocNoThrow(actual_size);
     return actual_size;
 }

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -204,7 +204,7 @@ inline ALWAYS_INLINE size_t getActualAllocationSize(size_t size, TAlign... align
 
 template <std::same_as<std::align_val_t>... TAlign>
 requires DB::OptionalArgument<TAlign...>
-inline ALWAYS_INLINE size_t trackMemory(std::size_t size, AllocationTrace & trace, TAlign... align)
+inline ALWAYS_INLINE size_t trackMemoryThrow(std::size_t size, AllocationTrace & trace, TAlign... align)
 {
     std::size_t actual_size = getActualAllocationSize(size, align...);
     trace = CurrentMemoryTracker::alloc(actual_size);
@@ -213,7 +213,7 @@ inline ALWAYS_INLINE size_t trackMemory(std::size_t size, AllocationTrace & trac
 
 template <std::same_as<std::align_val_t>... TAlign>
 requires DB::OptionalArgument<TAlign...>
-inline ALWAYS_INLINE size_t trackMemoryNoThrow(std::size_t size, AllocationTrace & trace, TAlign... align)
+inline ALWAYS_INLINE size_t trackMemory(std::size_t size, AllocationTrace & trace, TAlign... align)
 {
     std::size_t actual_size = getActualAllocationSize(size, align...);
     trace = CurrentMemoryTracker::allocNoThrow(actual_size);

--- a/src/Common/new_delete.cpp
+++ b/src/Common/new_delete.cpp
@@ -50,7 +50,7 @@ static struct InitializeJemallocZoneAllocatorForOSX
 void * operator new(std::size_t size)
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace);
+    std::size_t actual_size = Memory::trackMemoryThrow(size, trace);
     void * ptr = Memory::newImpl(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -59,7 +59,7 @@ void * operator new(std::size_t size)
 void * operator new(std::size_t size, std::align_val_t align)
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace, align);
+    std::size_t actual_size = Memory::trackMemoryThrow(size, trace, align);
     void * ptr = Memory::newImpl(size, align);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -68,7 +68,7 @@ void * operator new(std::size_t size, std::align_val_t align)
 void * operator new[](std::size_t size)
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace);
+    std::size_t actual_size = Memory::trackMemoryThrow(size, trace);
     void * ptr = Memory::newImpl(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -77,7 +77,7 @@ void * operator new[](std::size_t size)
 void * operator new[](std::size_t size, std::align_val_t align)
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace, align);
+    std::size_t actual_size = Memory::trackMemoryThrow(size, trace, align);
     void * ptr = Memory::newImpl(size, align);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -86,7 +86,7 @@ void * operator new[](std::size_t size, std::align_val_t align)
 void * operator new(std::size_t size, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace);
+    std::size_t actual_size = Memory::trackMemory(size, trace);
     void * ptr = Memory::newNoExcept(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -95,7 +95,7 @@ void * operator new(std::size_t size, const std::nothrow_t &) noexcept
 void * operator new[](std::size_t size, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace);
+    std::size_t actual_size = Memory::trackMemory(size, trace);
     void * ptr = Memory::newNoExcept(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -104,7 +104,7 @@ void * operator new[](std::size_t size, const std::nothrow_t &) noexcept
 void * operator new(std::size_t size, std::align_val_t align, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace, align);
+    std::size_t actual_size = Memory::trackMemory(size, trace, align);
     void * ptr = Memory::newNoExcept(size, align);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -113,7 +113,7 @@ void * operator new(std::size_t size, std::align_val_t align, const std::nothrow
 void * operator new[](std::size_t size, std::align_val_t align, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace, align);
+    std::size_t actual_size = Memory::trackMemory(size, trace, align);
     void * ptr = Memory::newNoExcept(size, align);
     trace.onAlloc(ptr, actual_size);
     return ptr;

--- a/src/Common/new_delete.cpp
+++ b/src/Common/new_delete.cpp
@@ -69,7 +69,7 @@ void * operator new[](std::size_t size)
 {
     AllocationTrace trace;
     std::size_t actual_size = Memory::trackMemory(size, trace);
-    void * ptr =  Memory::newImpl(size);
+    void * ptr = Memory::newImpl(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
 }
@@ -86,7 +86,7 @@ void * operator new[](std::size_t size, std::align_val_t align)
 void * operator new(std::size_t size, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace);
+    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace);
     void * ptr = Memory::newNoExcept(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -95,7 +95,7 @@ void * operator new(std::size_t size, const std::nothrow_t &) noexcept
 void * operator new[](std::size_t size, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace);
+    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace);
     void * ptr = Memory::newNoExcept(size);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -104,7 +104,7 @@ void * operator new[](std::size_t size, const std::nothrow_t &) noexcept
 void * operator new(std::size_t size, std::align_val_t align, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace, align);
+    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace, align);
     void * ptr = Memory::newNoExcept(size, align);
     trace.onAlloc(ptr, actual_size);
     return ptr;
@@ -113,7 +113,7 @@ void * operator new(std::size_t size, std::align_val_t align, const std::nothrow
 void * operator new[](std::size_t size, std::align_val_t align, const std::nothrow_t &) noexcept
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace, align);
+    std::size_t actual_size = Memory::trackMemoryNoThrow(size, trace, align);
     void * ptr = Memory::newNoExcept(size, align);
     trace.onAlloc(ptr, actual_size);
     return ptr;

--- a/tests/queries/0_stateless/03560_memory_limit_for_new_delete.sql
+++ b/tests/queries/0_stateless/03560_memory_limit_for_new_delete.sql
@@ -1,0 +1,27 @@
+SET max_memory_usage = 1000000000;
+SET max_threads = 16;
+
+DROP TABLE IF EXISTS table_visits;
+CREATE TABLE IF NOT EXISTS table_visits (
+  `visit_date` Nullable(Date),
+  `visits` Nullable(Float64),
+  `unique_visitors` Nullable(Int64)
+) ENGINE = MergeTree() PARTITION BY tuple()
+ORDER BY tuple();
+
+WITH dateTrunc('month', visit_date) AS month,
+  'nope' AS nope,
+  'all' AS all,
+  'lines' AS lines,
+  sum(visits) AS sum_visits,
+  sum(unique_visitors) AS sum_unique,
+  sum(sum_visits) OVER (PARTITION BY all, nope ORDER BY month ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS win1,
+  sum(sum_unique) OVER (PARTITION BY lines, all ORDER BY month ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS win2
+SELECT
+    multiIf(win1 IS NULL, NULL, (sum_visits / ifnull(win1, 1))),
+    multiIf(win2 IS NULL, NULL, (sum_unique / ifnull(win2, 1))),
+    (sum_visits / sum(sum_visits) OVER (PARTITION BY nope, month)),
+    (sum_unique / sum(sum_unique) OVER (PARTITION BY lines, month))
+FROM table_visits
+GROUP BY month
+LIMIT 10 SETTINGS enable_analyzer = 1; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
`max_memory_usage` has no effect in 24.8 for broken queries with `enable_analyzer = 1`. Server leads to OOM. The reason is infinite loop with `new` allocations of header-blocks without any Allocator's ones between them.

I've reproduced it only with increased `max_threads`. So there's also an issue for `clickhouse-test` that does not catch the trouble with `max_threads = 2`.

PR also improves stack traces displaying `throw_if_memory_exceeded`:
```
4. ./_build/./src/Common/MemoryTracker.cpp:0: AllocationTrace MemoryTracker::allocImpl<true>(long, MemoryTracker*, double) @ 0x0000000007c22bb0
5. ./_build/./src/Common/MemoryTracker.cpp:413: AllocationTrace MemoryTracker::allocImpl<true>(long, MemoryTracker*, double) @ 0x0000000007c2287f
6. ./_build/./src/Common/CurrentMemoryTracker.cpp:83: AllocationTrace CurrentMemoryTracker::allocImpl<true>(long) @ 0x0000000007bdab54
7. ./src/Common/memory.h:0: operator new(unsigned long) @ 0x0000000007bd64ca
```

P.S. Actually this PR is just a cherry-pick into master. I've tested it in this branch https://github.com/4ertus2/ClickHouse/tree/fix_memory_limit_24.8

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Restore MEMORY_LIMIT_EXCEEDED logic in new changed in https://github.com/ClickHouse/ClickHouse/issues/24110
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
