### PR TITLE
Remove Annoy from list of unsupported analyzer features

### DIFF
--- a/docs/en/operations/analyzer.md
+++ b/docs/en/operations/analyzer.md
@@ -195,6 +195,5 @@ The status can be checked [here](https://github.com/ClickHouse/ClickHouse/issues
 
 The list of features that the new analyzer currently doesn't support is given below:
 
-- Annoy index.
 - Hypothesis index. Work in progress [here](https://github.com/ClickHouse/ClickHouse/pull/48381).
 - Window view is not supported. There are no plans to support it in the future.


### PR DESCRIPTION
Vector search supports the analyzer now.

### Changelog category (leave one):
- Documentation (changelog entry is not required)