### PR TITLE
Fix flaky tests with parquet by partially reverting #82949

### DIFF
--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -46,6 +46,10 @@ namespace ProfileEvents
 
 namespace CurrentMetrics
 {
+    extern const Metric FormatParsingThreads;
+    extern const Metric FormatParsingThreadsActive;
+    extern const Metric FormatParsingThreadsScheduled;
+
     extern const Metric IOThreads;
     extern const Metric IOThreadsActive;
     extern const Metric IOThreadsScheduled;
@@ -582,12 +586,15 @@ ParquetBlockInputFormat::ParquetBlockInputFormat(
     , pending_chunks(PendingChunk::Compare { .row_group_first = format_settings_.parquet.preserve_order })
     , previous_block_missing_values(getPort().getHeader().columns())
 {
-    use_thread_pool = parser_group->max_parsing_threads > 1;
+    if (parser_group->max_parsing_threads > 1)
+        pool = std::make_unique<ThreadPool>(
+            CurrentMetrics::FormatParsingThreads,
+            CurrentMetrics::FormatParsingThreadsActive,
+            CurrentMetrics::FormatParsingThreadsScheduled,
+            parser_group->max_parsing_threads);
 
-    bool row_group_prefetch =
-        !use_thread_pool && parser_group->max_io_threads > 0 &&
-        format_settings.parquet.enable_row_group_prefetch &&
-        !format_settings.parquet.use_native_reader;
+    bool row_group_prefetch = !pool && parser_group->max_io_threads > 0 && format_settings.parquet.enable_row_group_prefetch
+        && !format_settings.parquet.use_native_reader;
     if (row_group_prefetch)
         io_pool = std::make_shared<ThreadPool>(
             CurrentMetrics::IOThreads, CurrentMetrics::IOThreadsActive, CurrentMetrics::IOThreadsScheduled,
@@ -597,8 +604,8 @@ ParquetBlockInputFormat::ParquetBlockInputFormat(
 ParquetBlockInputFormat::~ParquetBlockInputFormat()
 {
     is_stopped = true;
-    if (use_thread_pool)
-        shutdown->shutdown();
+    if (pool)
+        pool->wait();
     if (io_pool)
         io_pool->wait();
 }
@@ -611,10 +618,6 @@ void ParquetBlockInputFormat::initializeIfNeeded()
     parser_group->initOnce([&]
         {
             parser_group->initKeyCondition(getPort().getHeader());
-
-            if (use_thread_pool)
-                parser_group->parsing_runner.initThreadPool(
-                    getFormatParsingThreadPool().get(), parser_group->max_parsing_threads, "ParquetDecoder", CurrentThread::getGroup());
         });
 
     // Create arrow file adapter.
@@ -912,15 +915,12 @@ void ParquetBlockInputFormat::scheduleRowGroup(size_t row_group_batch_idx)
 
     status = RowGroupBatchState::Status::Running;
 
-    parser_group->parsing_runner(
-        [this, row_group_batch_idx, shutdown_ = shutdown]()
+    pool->scheduleOrThrowOnError(
+        [this, row_group_batch_idx, thread_group = CurrentThread::getGroup()]()
         {
-            std::shared_lock shutdown_lock(*shutdown_, std::try_to_lock);
-            if (!shutdown_lock.owns_lock())
-                return;
-
             try
             {
+                ThreadGroupSwitcher switcher(thread_group, "ParquetDecoder");
                 threadFunction(row_group_batch_idx);
             }
             catch (...)
@@ -1089,7 +1089,7 @@ void ParquetBlockInputFormat::scheduleMoreWorkIfNeeded(std::optional<size_t> row
         ++row_group_batches_completed;
     }
 
-    if (use_thread_pool)
+    if (pool)
     {
         size_t max_decoding_threads = parser_group->getParsingThreadsPerReader();
         while (row_group_batches_started - row_group_batches_completed < max_decoding_threads &&
@@ -1152,7 +1152,7 @@ Chunk ParquetBlockInputFormat::read()
         if (row_group_batches_completed == row_group_batches.size())
             return {};
 
-        if (use_thread_pool)
+        if (pool)
             condvar.wait(lock);
         else
             decodeOneChunk(row_group_batches_completed, lock);
@@ -1162,11 +1162,8 @@ Chunk ParquetBlockInputFormat::read()
 void ParquetBlockInputFormat::resetParser()
 {
     is_stopped = true;
-    if (use_thread_pool)
-    {
-        shutdown->shutdown();
-        shutdown = std::make_shared<ShutdownHelper>();
-    }
+    if (pool)
+        pool->wait();
 
     arrow_file.reset();
     metadata.reset();

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -34,7 +34,6 @@
 #include <Interpreters/convertFieldToType.h>
 #include <Storages/MergeTree/KeyCondition.h>
 
-#include <shared_mutex>
 #include <boost/algorithm/string/case_conv.hpp>
 
 namespace ProfileEvents

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -325,8 +325,7 @@ private:
 
     // These are only used when max_decoding_threads > 1.
     size_t row_group_batches_started = 0;
-    bool use_thread_pool = false;
-    std::shared_ptr<ShutdownHelper> shutdown = std::make_shared<ShutdownHelper>();
+    std::unique_ptr<ThreadPool> pool;
     std::shared_ptr<ThreadPool> io_pool;
 
     BlockMissingValues previous_block_missing_values;


### PR DESCRIPTION
Tests with Parquet became flaky, mainly: `00900_long_parquet`, `00900_parquet_time_to_ch_date_time`, `00900_long_parquet_decimal`: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMSBNT05USAogICAgQU5EIChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBzdGFydHNXaXRoKGhlYWRfcmVwbywgJ0NsaWNrSG91c2UvJykpCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgKHRlc3Rfc3RhdHVzIExJS0UgJ0YlJyBPUiB0ZXN0X3N0YXR1cyBMSUtFICdFJScpIAogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBwb3NpdGlvbih0ZXN0X25hbWUsICdfcGFycXVldCcpID4gMApPUkRFUiBCWSBjaGVja19zdGFydF90aW1l

The main suspect were changes introduced here: https://github.com/ClickHouse/ClickHouse/pull/82949 CC @al13n321 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
