### PR TITLE
CI: Fix job result update in the report on rerun

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -335,8 +335,9 @@ class Result(MetaClasses.Serializable):
         assert self.results, "BUG?"
         for i, result_ in enumerate(self.results):
             if result_.name == result.name:
-                if result_.is_completed():
-                    # job was skipped in workflow configuration by user' hook
+                if result_.is_completed() and i > 0:
+                    # i = 0 - it's a current job's result - must be always updated
+                    # i > 0 and result_.is_completed() - job was skipped in workflow configuration by user' hook
                     print(
                         f"NOTE: Job [{result.name}] has completed status [{result_.status}] - do not escalate status to dropped"
                     )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

On job rerun, if former status was set to error for the job, it won't be updated after the rerun in the report - fixed.


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
