### PR TITLE
Revert 81595 partial

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -977,24 +977,17 @@ The server successfully detected this situation and will download merged part fr
     M(DiskConnectionsErrors, "Number of cases when creation of a connection for disk is failed", ValueType::Number) \
     M(DiskConnectionsElapsedMicroseconds, "Total time spend on creating connections for disk", ValueType::Microseconds) \
     \
-    M(HTTPConnectionsCreated, "Number of created clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsReused, "Number of reused clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsReset, "Number of reset clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsPreserved, "Number of preserved clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsExpired, "Number of expired clients HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsErrors, "Number of cases when creation of a clients HTTP connection failed", ValueType::Number) \
-    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating clients HTTP connections", ValueType::Microseconds) \
+    M(HTTPConnectionsCreated, "Number of created http connections", ValueType::Number) \
+    M(HTTPConnectionsReused, "Number of reused http connections", ValueType::Number) \
+    M(HTTPConnectionsReset, "Number of reset http connections", ValueType::Number) \
+    M(HTTPConnectionsPreserved, "Number of preserved http connections", ValueType::Number) \
+    M(HTTPConnectionsExpired, "Number of expired http connections", ValueType::Number) \
+    M(HTTPConnectionsErrors, "Number of cases when creation of a http connection failed", ValueType::Number) \
+    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating http connections", ValueType::Microseconds) \
     \
-    M(HTTPServerConnectionsCreated, "Number of created server http connections", ValueType::Number) \
-    M(HTTPServerConnectionsReused, "Number of reused server http connections", ValueType::Number) \
-    M(HTTPServerConnectionsPreserved, "Number of preserved server http connections. Connection kept alive successfully", ValueType::Number) \
-    M(HTTPServerConnectionsExpired, "Number of expired server http connections.", ValueType::Number) \
-    M(HTTPServerConnectionsClosed, "Number of closed server http connections. Keep alive has not been negotiated", ValueType::Number) \
-    M(HTTPServerConnectionsReset, "Number of reset server http connections. Server closes connection", ValueType::Number) \
-    \
-    M(AddressesDiscovered, "Total count of new addresses in dns resolve results for HTTP connections", ValueType::Number) \
-    M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for HTTP connections", ValueType::Number) \
-    M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for HTTP connections", ValueType::Number) \
+    M(AddressesDiscovered, "Total count of new addresses in dns resolve results for http connections", ValueType::Number) \
+    M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for http connections", ValueType::Number) \
+    M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for http connections", ValueType::Number) \
     \
     M(ReadWriteBufferFromHTTPRequestsSent, "Number of HTTP requests sent by ReadWriteBufferFromHTTP", ValueType::Number) \
     M(ReadWriteBufferFromHTTPBytes, "Total size of payload bytes received and sent by ReadWriteBufferFromHTTP. Doesn't include HTTP headers.", ValueType::Bytes) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -977,13 +977,13 @@ The server successfully detected this situation and will download merged part fr
     M(DiskConnectionsErrors, "Number of cases when creation of a connection for disk is failed", ValueType::Number) \
     M(DiskConnectionsElapsedMicroseconds, "Total time spend on creating connections for disk", ValueType::Microseconds) \
     \
-    M(HTTPConnectionsCreated, "Number of created client HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsReused, "Number of reused client HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsReset, "Number of reset client HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsPreserved, "Number of preserved client HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsExpired, "Number of expired client HTTP connections", ValueType::Number) \
-    M(HTTPConnectionsErrors, "Number of cases when creation of a client HTTP connection failed", ValueType::Number) \
-    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating client HTTP connections", ValueType::Microseconds) \
+    M(HTTPConnectionsCreated, "Number of created clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsReused, "Number of reused clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsReset, "Number of reset clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsPreserved, "Number of preserved clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsExpired, "Number of expired clients HTTP connections", ValueType::Number) \
+    M(HTTPConnectionsErrors, "Number of cases when creation of a clients HTTP connection failed", ValueType::Number) \
+    M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating clients HTTP connections", ValueType::Microseconds) \
     \
     M(HTTPServerConnectionsCreated, "Number of created server http connections", ValueType::Number) \
     M(HTTPServerConnectionsReused, "Number of reused server http connections", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -985,16 +985,16 @@ The server successfully detected this situation and will download merged part fr
     M(HTTPConnectionsErrors, "Number of cases when creation of a client HTTP connection failed", ValueType::Number) \
     M(HTTPConnectionsElapsedMicroseconds, "Total time spend on creating client HTTP connections", ValueType::Microseconds) \
     \
-    M(HTTPServerConnectionsCreated, "Number of created server HTTP connections", ValueType::Number) \
-    M(HTTPServerConnectionsReused, "Number of reused server HTTP connections", ValueType::Number) \
-    M(HTTPServerConnectionsPreserved, "Number of preserved server HTTP connections. Connection kept alive successfully", ValueType::Number) \
-    M(HTTPServerConnectionsExpired, "Number of expired server HTTP connections.", ValueType::Number) \
-    M(HTTPServerConnectionsClosed, "Number of closed server HTTP connections. Keep alive has not been negotiated", ValueType::Number) \
-    M(HTTPServerConnectionsReset, "Number of reset server HTTP connections. Server closes connection", ValueType::Number) \
+    M(HTTPServerConnectionsCreated, "Number of created server http connections", ValueType::Number) \
+    M(HTTPServerConnectionsReused, "Number of reused server http connections", ValueType::Number) \
+    M(HTTPServerConnectionsPreserved, "Number of preserved server http connections. Connection kept alive successfully", ValueType::Number) \
+    M(HTTPServerConnectionsExpired, "Number of expired server http connections.", ValueType::Number) \
+    M(HTTPServerConnectionsClosed, "Number of closed server http connections. Keep alive has not been negotiated", ValueType::Number) \
+    M(HTTPServerConnectionsReset, "Number of reset server http connections. Server closes connection", ValueType::Number) \
     \
-    M(AddressesDiscovered, "Total count of new addresses in DNS resolve results for HTTP connections", ValueType::Number) \
-    M(AddressesExpired, "Total count of expired addresses which is no longer presented in DNS resolve results for HTTP connections", ValueType::Number) \
-    M(AddressesMarkedAsFailed, "Total count of addresses which have been marked as faulty due to connection errors for HTTP connections", ValueType::Number) \
+    M(AddressesDiscovered, "Total count of new addresses in dns resolve results for HTTP connections", ValueType::Number) \
+    M(AddressesExpired, "Total count of expired addresses which is no longer presented in dns resolve results for HTTP connections", ValueType::Number) \
+    M(AddressesMarkedAsFailed, "Total count of addresses which has been marked as faulty due to connection errors for HTTP connections", ValueType::Number) \
     \
     M(ReadWriteBufferFromHTTPRequestsSent, "Number of HTTP requests sent by ReadWriteBufferFromHTTP", ValueType::Number) \
     M(ReadWriteBufferFromHTTPBytes, "Total size of payload bytes received and sent by ReadWriteBufferFromHTTP. Doesn't include HTTP headers.", ValueType::Bytes) \

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -118,7 +118,7 @@ void HTTPServerConnection::run()
                         {
                             /// server decided to close connection
                             /// usually it is related to the cases:
-                            /// - the request or response stream is not bounded or
+                            /// - the request or respond stream is not bounded or
                             /// - not all data is read from them
                             ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
                         }

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -106,7 +106,7 @@ void HTTPServerConnection::run()
                         bool keep_alive = false;
                         if (!params->getKeepAlive() || !request.canKeepAlive())
                         {
-                            /// Either server is not configured to keep connections alive or client did not ask it
+                            /// Either server is not configured to keep connetions alive or client did not ask it
                             ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsClosed);
                         }
                         else if (session.getMaxKeepAliveRequests() == 0 || !session.canKeepAlive())

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -47,7 +47,7 @@ void HTTPServerConnection::run()
         if (!session.hasMoreRequests())
         {
             if (is_first_request)
-                // it is strange to have a connection being opened but no request has been sent, account it as an error case
+                // it is strange to have a connection being oppend but no request has been sent, account it as an error case
                 ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
             else
                 ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsExpired);

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -2,20 +2,7 @@
 #include <Server/TCPServer.h>
 
 #include <Poco/Net/NetException.h>
-#include <Common/ProfileEvents.h>
 #include <Common/logger_useful.h>
-
-
-namespace ProfileEvents
-{
-    extern const Event HTTPServerConnectionsCreated;
-    extern const Event HTTPServerConnectionsReused;
-    extern const Event HTTPServerConnectionsPreserved;
-    extern const Event HTTPServerConnectionsExpired;
-    extern const Event HTTPServerConnectionsClosed;
-    extern const Event HTTPServerConnectionsReset;
-}
-
 
 namespace DB
 {
@@ -38,28 +25,8 @@ void HTTPServerConnection::run()
     std::string server = params->getSoftwareVersion();
     Poco::Net::HTTPServerSession session(socket(), params);
 
-    ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsCreated);
-
-    while (!stopped && tcp_server.isOpen() && session.connected())
+    while (!stopped && tcp_server.isOpen() && session.hasMoreRequests() && session.connected())
     {
-        const bool is_first_request = params->getMaxKeepAliveRequests() == session.getMaxKeepAliveRequests();
-
-        if (!session.hasMoreRequests())
-        {
-            if (is_first_request)
-                // it is strange to have a connection being oppend but no request has been sent, account it as an error case
-                ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
-            else
-                ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsExpired);
-
-            return;
-        }
-        else
-        {
-            if (!is_first_request)
-                ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReused);
-        }
-
         try
         {
             std::lock_guard lock(mutex);
@@ -102,38 +69,10 @@ void HTTPServerConnection::run()
                             response.sendContinue();
 
                         handler->handleRequest(request, response, write_event);
-
-                        bool keep_alive = false;
-                        if (!params->getKeepAlive() || !request.canKeepAlive())
-                        {
-                            /// Either server is not configured to keep connetions alive or client did not ask it
-                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsClosed);
-                        }
-                        else if (session.getMaxKeepAliveRequests() == 0 || !session.canKeepAlive())
-                        {
-                            /// connection is expired by max request count
-                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsExpired);
-                        }
-                        else if (!response.getKeepAlive())
-                        {
-                            /// server decided to close connection
-                            /// usually it is related to the cases:
-                            /// - the request or respond stream is not bounded or
-                            /// - not all data is read from them
-                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
-                        }
-                        else
-                        {
-                            ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsPreserved);
-                            keep_alive = true;
-                        }
-
-                        session.setKeepAlive(keep_alive);
+                        session.setKeepAlive(params->getKeepAlive() && response.getKeepAlive() && session.canKeepAlive());
                     }
                     else
-                    {
                         sendErrorResponse(session, Poco::Net::HTTPResponse::HTTP_NOT_IMPLEMENTED);
-                    }
                 }
                 catch (Poco::Exception &)
                 {
@@ -195,7 +134,6 @@ void HTTPServerConnection::sendErrorResponse(Poco::Net::HTTPServerSession & sess
     response.setKeepAlive(false);
     response.send();
     session.setKeepAlive(false);
-    ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsReset);
 }
 
 }

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -56,15 +56,11 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
     /// and retry with exactly the same (incomplete) set of rows.
     /// That's why we have to check body size if it's provided.
     if (getChunkedTransferEncoding())
-    {
         stream = std::make_unique<HTTPChunkedReadBuffer>(std::move(in), HTTP_MAX_CHUNK_SIZE);
-        stream_is_bounded = true;
-    }
     else if (hasContentLength())
     {
         size_t content_length = getContentLength();
         stream = std::make_unique<LimitReadBuffer>(std::move(in), LimitReadBuffer::Settings{.read_no_less = content_length, .read_no_more = content_length, .expect_eof = true});
-        stream_is_bounded = true;
     }
     else if (getMethod() != HTTPRequest::HTTP_GET && getMethod() != HTTPRequest::HTTP_HEAD && getMethod() != HTTPRequest::HTTP_DELETE)
     {

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -74,11 +74,8 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
                 "and no chunked/multipart encoding, it may be impossible to distinguish graceful EOF from abnormal connection loss");
     }
     else
-    {
         /// We have to distinguish empty buffer and nullptr.
         stream = std::make_unique<EmptyReadBuffer>();
-        stream_is_bounded = true;
-    }
 }
 
 bool HTTPServerRequest::checkPeerConnected() const

--- a/src/Server/HTTP/HTTPServerRequest.h
+++ b/src/Server/HTTP/HTTPServerRequest.h
@@ -47,14 +47,6 @@ public:
     X509Certificate peerCertificate() const;
 #endif
 
-    bool canKeepAlive() const
-    {
-        if (stream && stream_is_bounded)
-            return stream->eof();
-
-        return false;
-    }
-
 private:
     /// Limits for basic sanity checks when reading a header
     enum Limits
@@ -73,7 +65,6 @@ private:
     Poco::Net::SocketAddress client_address;
     Poco::Net::SocketAddress server_address;
 
-    bool stream_is_bounded = false;
     bool secure;
 
     void readRequest(ReadBuffer & in);

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -10,6 +10,7 @@
 #include <Poco/Net/HTTPHeaderStream.h>
 #include <Poco/Net/HTTPStream.h>
 #include <IO/NullWriteBuffer.h>
+#include <sstream>
 
 
 namespace DB
@@ -39,6 +40,9 @@ std::shared_ptr<WriteBuffer> HTTPServerResponse::send()
         // the connection would be poisoned.
         // Next request over that connection reads previously unreaded message as a HTTP status line
 
+        // Send header
+        Poco::Net::HTTPHeaderOutputStream hs(session);
+        write(hs);
         // make sure that nothing is sent to the client if it was HTTP_HEAD request
         stream = std::make_shared<NullWriteBuffer>(write_event);
 
@@ -49,36 +53,75 @@ std::shared_ptr<WriteBuffer> HTTPServerResponse::send()
         // but if we do, then it is safer to close the connection at the end
         setKeepAlive(false);
 
+        // Send header
+        Poco::Net::HTTPHeaderOutputStream hs(session);
+        write(hs);
         stream = std::make_shared<AutoFinalizedWriteBuffer<WriteBufferFromPocoSocket>>(session.socket(), write_event);
     }
     else if (getChunkedTransferEncoding())
     {
+        // Send header
+        Poco::Net::HTTPHeaderOutputStream hs(session);
+        write(hs);
         stream = std::make_shared<AutoFinalizedWriteBuffer<HTTPWriteBufferChunked>>(session.socket(), write_event);
     }
     else if (hasContentLength())
     {
+        // Send header
+        Poco::Net::HTTPHeaderOutputStream hs(session);
+        write(hs);
         stream = std::make_shared<AutoFinalizedWriteBuffer<HTTPWriteBufferFixedLength>>(session.socket(), getContentLength(), write_event);
     }
     else
     {
         setKeepAlive(false);
-
+        // Send header
+        Poco::Net::HTTPHeaderOutputStream hs(session);
+        write(hs);
         stream = std::make_shared<AutoFinalizedWriteBuffer<WriteBufferFromPocoSocket>>(session.socket(), write_event);
     }
 
-    Poco::Net::HTTPHeaderOutputStream hs(session);
-    beginWrite(hs);
-    hs << "\r\n";
-    hs.flush();
-
+    send_started = true;
     return stream;
 }
 
-/// Only this method is called inside WriteBufferFromHTTPServerResponse
-void HTTPServerResponse::beginWrite(std::ostream & ostr)
+std::pair<std::shared_ptr<WriteBuffer>, std::shared_ptr<WriteBuffer>> HTTPServerResponse::beginSend()
 {
-    allowKeepAliveIFFRequestIsFullyRead();
+    poco_assert(!stream);
+    poco_assert(!header_stream);
 
+    /// NOTE: Code is not exception safe.
+
+    if ((request && request->getMethod() == HTTPRequest::HTTP_HEAD) || getStatus() < 200 || getStatus() == HTTPResponse::HTTP_NO_CONTENT
+        || getStatus() == HTTPResponse::HTTP_NOT_MODIFIED)
+    {
+        throw Poco::Exception("HTTPServerResponse::beginSend is invalid for HEAD request");
+    }
+
+    if (hasContentLength())
+    {
+        throw Poco::Exception("HTTPServerResponse::beginSend is invalid for response with Content-Length header");
+    }
+
+    // Write header to buffer
+    std::stringstream header; //STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    beginWrite(header);
+    // Send header
+    auto str = header.str();
+    header_stream = std::make_shared<AutoFinalizedWriteBuffer<WriteBufferFromPocoSocket>>(session.socket(), write_event, str.size());
+    header_stream->write(str.data(), str.size());
+
+    if (getChunkedTransferEncoding())
+        stream = std::make_shared<AutoFinalizedWriteBuffer<HTTPWriteBufferChunked>>(session.socket(), write_event);
+    else
+        stream = std::make_shared<AutoFinalizedWriteBuffer<WriteBufferFromPocoSocket>>(session.socket(), write_event);
+
+    send_started = true;
+    return std::make_pair(header_stream, stream);
+}
+
+void HTTPServerResponse::beginWrite(std::ostream & ostr) const
+{
     HTTPResponse::beginWrite(ostr);
     send_started = true;
 }
@@ -87,11 +130,9 @@ void HTTPServerResponse::sendBuffer(const void * buffer, std::size_t length)
 {
     setContentLength(static_cast<int>(length));
     setChunkedTransferEncoding(false);
-
     // Send header
     Poco::Net::HTTPHeaderOutputStream hs(session);
-    beginWrite(hs);
-    hs << "\r\n";
+    write(hs);
     hs.flush();
 
     if (request && request->getMethod() != HTTPRequest::HTTP_HEAD)
@@ -125,17 +166,8 @@ void HTTPServerResponse::redirect(const std::string & uri, HTTPStatus status)
 
     // Send header
     Poco::Net::HTTPHeaderOutputStream hs(session);
-    beginWrite(hs);
-    hs << "\r\n";
+    write(hs);
     hs.flush();
 }
 
-void HTTPServerResponse::allowKeepAliveIFFRequestIsFullyRead()
-{
-    /// Connection can only be reused if we've fully read the previous request and all its POST data.
-    /// Otherwise we'd misinterpret the leftover data as part of the next request's header.
-    /// HTTPServerRequest::canKeepAlive() checks that request stream is bounded and is fully read.
-    if (!request || !request->canKeepAlive())
-        setKeepAlive(false);
-}
 }

--- a/src/Server/HTTP/HTTPServerResponse.h
+++ b/src/Server/HTTP/HTTPServerResponse.h
@@ -234,10 +234,17 @@ public:
     /// or redirect() has been called.
     std::shared_ptr<WriteBuffer> send();
 
-    /// Dangerous, it is not a virtual method in HTTPResponse but it is redefined here
+    /// Sends the response headers to the client
+    /// but do not finish headers with \r\n,
+    /// allowing to continue sending additional header fields.
+    ///
+    /// Must not be called after send(), sendFile(), sendBuffer()
+    /// or redirect() has been called.
+    std::pair<std::shared_ptr<WriteBuffer>, std::shared_ptr<WriteBuffer>> beginSend();
+
     /// Override to correctly mark that the data send had been started for
     /// zero-copy response (i.e. replicated fetches).
-    void beginWrite(std::ostream & ostr);
+    void beginWrite(std::ostream & ostr) const;
 
     /// Sends the response header to the client, followed
     /// by the contents of the given buffer.
@@ -276,8 +283,6 @@ public:
     void attachRequest(HTTPServerRequest * request_) { request = request_; }
 
     const Poco::Net::HTTPServerSession & getSession() const { return session; }
-
-    void allowKeepAliveIFFRequestIsFullyRead();
 
 private:
     Poco::Net::HTTPServerSession & session;

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -617,6 +617,31 @@ void HTTPHandler::processQuery(
         {},
         handle_exception_in_output_format,
         query_finish_callback);
+
+    /// HTTPChunkedReadBuffer doesn't consume the final \r\n0\r\n\r\n if the caller reads exactly all bytes,
+    /// without checking for eof() (i.e. trying to read past the end) after that.
+    /// If those leftovers are then seen by the next request's HTTPServerRequest::readRequest,
+    /// it would in theory produce the error:
+    /// Invalid HTTP version string: /?query=I,
+    /// because that extra 0 field shifts all fields by one, and uri ends up interpreted as version.
+    /// There are a few options how to prevent that:
+    /// 1. Officially require that IInputFormat must drain the input buffer, make sure all implementations do that.
+    /// 2. Make the HTTP handler drain the request's POST read buffer after the request.
+    /// 3. Make HTTPChunkedReadBuffer eagerly drain the final \r\n0\r\n\r\n before returning the final bytes of data,
+    //     but that seems very inconvenient to implement because of how zero-copying is done in HTTPChunkedReadBuffer::nextImpl()
+    /// You can find an option (2) implemented below.
+    if (in_post_maybe_compressed->available())
+    {
+        String remaining;
+        readStringUntilEOF(remaining, *in_post_maybe_compressed);
+        auto hex_string = hexString(remaining.data(), remaining.size());
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "There is still some data in the buffer: {}", hex_string);
+#else
+        LOG_WARNING(log, "There is still some data in the buffer: {}", hex_string);
+#endif
+    }
 }
 
 bool HTTPHandler::trySendExceptionToClient(


### PR DESCRIPTION
Full revert https://github.com/ClickHouse/ClickHouse/pull/81661
Partial revert https://github.com/ClickHouse/ClickHouse/pull/81595
The changes for arrow reader and the test `tests/integration/test_http_connection_drain_before_reuse` are left intact, the rest is reverted.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
