### PR TITLE
Fix additional table filters parallel replicas

### DIFF
--- a/src/Interpreters/EnsureAdditionalTableInSelectsSettingsVisitor.cpp
+++ b/src/Interpreters/EnsureAdditionalTableInSelectsSettingsVisitor.cpp
@@ -1,0 +1,52 @@
+#include <Core/Settings.h>
+#include <Interpreters/EnsureAdditionalTableInSelectsSettingsVisitor.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSetQuery.h>
+
+namespace DB
+{
+namespace Setting
+{
+    extern const SettingsMap additional_table_filters;
+}
+
+
+EnsureAdditionalTableInSelectsSettingsVisitor::EnsureAdditionalTableInSelectsSettingsVisitor(const Map & additional_table_filters_)
+    : additional_table_filters(additional_table_filters_)
+{
+}
+
+void EnsureAdditionalTableInSelectsSettingsVisitor::visit(ASTPtr & ast)
+{
+    if (ast->as<ASTSelectQuery>())
+        visitSelectQuery(ast);
+    else
+        visitChildren(ast);
+}
+
+void EnsureAdditionalTableInSelectsSettingsVisitor::visitSelectQuery(ASTPtr & ast)
+{
+    static constexpr std::string_view additional_table_filters_name = "additional_table_filters";
+
+    auto & select_query_ast = ast->as<ASTSelectQuery &>();
+
+    if (auto select_query_settings_ast = select_query_ast.settings())
+    {
+        auto & set_query = select_query_settings_ast->as<ASTSetQuery &>();
+        if (!set_query.changes.tryGet(additional_table_filters_name))
+            set_query.changes.setSetting(additional_table_filters_name, additional_table_filters);
+    }
+    else
+    {
+        auto set_query_ast = std::make_shared<ASTSetQuery>();
+        set_query_ast->is_standalone = false;
+        set_query_ast->changes.setSetting(additional_table_filters_name, additional_table_filters);
+        select_query_ast.setExpression(ASTSelectQuery::Expression::SETTINGS, set_query_ast);
+    }
+}
+void EnsureAdditionalTableInSelectsSettingsVisitor::visitChildren(ASTPtr & ast)
+{
+    for (auto & child : ast->children)
+        visit(child);
+}
+}

--- a/src/Interpreters/EnsureAdditionalTableInSelectsSettingsVisitor.h
+++ b/src/Interpreters/EnsureAdditionalTableInSelectsSettingsVisitor.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Core/Names.h>
+#include <Parsers/IAST_fwd.h>
+
+namespace DB
+{
+
+struct Map;
+
+/// Add additional_table_filters setting to select queries if it is not set
+class EnsureAdditionalTableInSelectsSettingsVisitor
+{
+public:
+    explicit EnsureAdditionalTableInSelectsSettingsVisitor(const Map & additional_table_filters);
+
+    void visit(ASTPtr & ast);
+
+private:
+    const Map & additional_table_filters;
+
+    void visitSelectQuery(ASTPtr & ast);
+    void visitChildren(ASTPtr & ast);
+};
+
+}

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -46,7 +46,6 @@
 #include <Interpreters/RewriteUniqToCountVisitor.h>
 #include <Interpreters/getCustomKeyFilterForParallelReplicas.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ReplaceQueryParameterVisitor.h>
 
 #include <QueryPipeline/Pipe.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
@@ -98,8 +97,6 @@
 #include <Interpreters/HashTablesStatistics.h>
 #include <Interpreters/IJoin.h>
 #include <QueryPipeline/SizeLimits.h>
-#include <base/map.h>
-#include <base/find_symbols.h>
 #include <Common/FieldVisitorToString.h>
 #include <Common/FieldAccurateComparison.h>
 #include <Common/NaNUtils.h>
@@ -437,7 +434,7 @@ ASTPtr parseAdditionalFilterConditionForTable(
             /// Try to parse expression
             ParserExpression parser;
             const auto & settings = context.getSettingsRef();
-            auto query_ast = parseQuery(
+            return parseQuery(
                 parser,
                 filter.data(),
                 filter.data() + filter.size(),
@@ -445,13 +442,6 @@ ASTPtr parseAdditionalFilterConditionForTable(
                 settings[Setting::max_query_size],
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
-
-            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && !context.getQueryParameters().empty())
-            {
-                ReplaceQueryParameterVisitor visitor(context.getQueryParameters());
-                visitor.visit(query_ast);
-            }
-            return query_ast;
         }
     }
 

--- a/src/Interpreters/ReplaceQueryParameterVisitor.h
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.h
@@ -31,6 +31,7 @@ private:
     void visitIdentifier(ASTPtr & ast);
     void visitQueryParameter(ASTPtr & ast);
     void visitChildren(ASTPtr & ast);
+    void visitSetQuery(ASTPtr & ast);
 };
 
 }

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -610,6 +610,21 @@ std::optional<FilterDAGInfo> buildAdditionalFiltersIfNeeded(const StoragePtr & s
                 settings[Setting::max_parser_backtracks]);
             break;
         }
+
+        // Relax condition for cases where the current database of a user is different from the one in the context
+        // e.g. parallel replicas
+        if (table == storage_id.getTableName())
+        {
+            ParserExpression parser;
+            additional_filter_ast = parseQuery(
+                parser,
+                filter.data(),
+                filter.data() + filter.size(),
+                "additional filter",
+                settings[Setting::max_query_size],
+                settings[Setting::max_parser_depth],
+                settings[Setting::max_parser_backtracks]);
+        }
     }
 
     if (!additional_filter_ast)

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -69,7 +69,6 @@
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/getCustomKeyFilterForParallelReplicas.h>
 #include <Interpreters/ClusterProxy/executeQuery.h>
-#include <Interpreters/ReplaceQueryParameterVisitor.h>
 
 #include <Planner/CollectColumnIdentifiers.h>
 #include <Planner/Planner.h>
@@ -84,7 +83,6 @@
 #include <Common/logger_useful.h>
 
 #include <ranges>
-#include <base/find_symbols.h>
 
 namespace DB
 {
@@ -610,12 +608,6 @@ std::optional<FilterDAGInfo> buildAdditionalFiltersIfNeeded(const StoragePtr & s
                 settings[Setting::max_query_size],
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
-
-            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && !planner_context->getQueryContext()->getQueryParameters().empty())
-            {
-                ReplaceQueryParameterVisitor visitor(planner_context->getQueryContext()->getQueryParameters());
-                visitor.visit(additional_filter_ast);
-            }
             break;
         }
     }

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -69,6 +69,7 @@
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/getCustomKeyFilterForParallelReplicas.h>
 #include <Interpreters/ClusterProxy/executeQuery.h>
+#include <Interpreters/ReplaceQueryParameterVisitor.h>
 
 #include <Planner/CollectColumnIdentifiers.h>
 #include <Planner/Planner.h>
@@ -83,6 +84,7 @@
 #include <Common/logger_useful.h>
 
 #include <ranges>
+#include <base/find_symbols.h>
 
 namespace DB
 {
@@ -608,6 +610,12 @@ std::optional<FilterDAGInfo> buildAdditionalFiltersIfNeeded(const StoragePtr & s
                 settings[Setting::max_query_size],
                 settings[Setting::max_parser_depth],
                 settings[Setting::max_parser_backtracks]);
+
+            if (find_first_symbols<'{'>(filter.data(), filter.data() + filter.size()) && !planner_context->getQueryContext()->getQueryParameters().empty())
+            {
+                ReplaceQueryParameterVisitor visitor(planner_context->getQueryContext()->getQueryParameters());
+                visitor.visit(additional_filter_ast);
+            }
             break;
         }
     }

--- a/tests/queries/0_stateless/02346_additional_filters_distr.reference
+++ b/tests/queries/0_stateless/02346_additional_filters_distr.reference
@@ -1,3 +1,6 @@
 4	dddd
 5	a
 6	bb
+4	dddd
+5	a
+6	bb

--- a/tests/queries/0_stateless/02346_additional_filters_distr.sql
+++ b/tests/queries/0_stateless/02346_additional_filters_distr.sql
@@ -18,3 +18,7 @@ create table dist_02346 (x UInt32, y String) engine=Distributed('test_cluster_tw
 set max_rows_to_read=4;
 
 select * from dist_02346 order by x settings additional_table_filters={'dist_02346' : 'x > 3 and x < 7'};
+
+set param_a = 3;
+set param_b = 7;
+select * from dist_02346 order by x settings additional_table_filters={'dist_02346' : 'x > {a:UInt32} and x < {b:UInt32}'};

--- a/tests/queries/0_stateless/02346_additional_filters_index.reference
+++ b/tests/queries/0_stateless/02346_additional_filters_index.reference
@@ -28,3 +28,33 @@ select * from distr_table order by x settings additional_table_filters={'distr_t
 1	a
 2	bb
 2	bb
+set param_a = 3;
+set max_rows_to_read = 2;
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'x > {a:UInt32}'};
+4	dddd
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'x < {a:UInt32}'};
+1	a
+2	bb
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'length(y) >= {a:UInt32}'};
+3	ccc
+4	dddd
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'length(y) < {a:UInt32}'};
+1	a
+2	bb
+set max_rows_to_read = 4;
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'x > {a:UInt32}'};
+4	dddd
+4	dddd
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'x < {a:UInt32}'};
+1	a
+1	a
+2	bb
+2	bb
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'length(y) > {a:UInt32}'};
+4	dddd
+4	dddd
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'length(y) < {a:UInt32}'};
+1	a
+1	a
+2	bb
+2	bb

--- a/tests/queries/0_stateless/02346_additional_filters_index.sql
+++ b/tests/queries/0_stateless/02346_additional_filters_index.sql
@@ -25,3 +25,20 @@ select * from distr_table order by x settings additional_table_filters={'distr_t
 select * from distr_table order by x settings additional_table_filters={'distr_table' : 'length(y) > 3'};
 select * from distr_table order by x settings additional_table_filters={'distr_table' : 'length(y) < 3'};
 
+set param_a = 3;
+
+set max_rows_to_read = 2;
+
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'x > {a:UInt32}'};
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'x < {a:UInt32}'};
+
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'length(y) >= {a:UInt32}'};
+select * from table_1 order by x settings additional_table_filters={'table_1' : 'length(y) < {a:UInt32}'};
+
+set max_rows_to_read = 4;
+
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'x > {a:UInt32}'};
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'x < {a:UInt32}'};
+
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'length(y) > {a:UInt32}'};
+select * from distr_table order by x settings additional_table_filters={'distr_table' : 'length(y) < {a:UInt32}'};

--- a/tests/queries/0_stateless/03393_additional_table_filter_with_param.reference
+++ b/tests/queries/0_stateless/03393_additional_table_filter_with_param.reference
@@ -1,0 +1,31 @@
+-- {echoOn}
+
+DROP TABLE IF EXISTS t_param_filter;
+SET param_a = 3;
+SET param_b = 5;
+CREATE TABLE t_param_filter
+(
+    n Int32,
+) ENGINE = MergeTree()
+ORDER BY n;
+INSERT INTO t_param_filter
+SELECT number
+FROM numbers(10);
+SET allow_experimental_analyzer = 1;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+0
+1
+2
+3
+4
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+4
+SET allow_experimental_analyzer = 0;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+0
+1
+2
+3
+4
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+4

--- a/tests/queries/0_stateless/03393_additional_table_filter_with_param.reference
+++ b/tests/queries/0_stateless/03393_additional_table_filter_with_param.reference
@@ -18,14 +18,12 @@ SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filte
 2
 3
 4
-SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'}, parallel_replicas_local_plan=1;
 4
-SET allow_experimental_analyzer = 0;
-SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
-0
-1
-2
-3
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'}, parallel_replicas_local_plan=0;
 4
-SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SET additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS parallel_replicas_local_plan=1;
+4
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS parallel_replicas_local_plan=0;
 4

--- a/tests/queries/0_stateless/03393_additional_table_filter_with_param.sql
+++ b/tests/queries/0_stateless/03393_additional_table_filter_with_param.sql
@@ -1,0 +1,25 @@
+-- {echoOn}
+
+DROP TABLE IF EXISTS t_param_filter;
+
+SET param_a = 3;
+SET param_b = 5;
+
+CREATE TABLE t_param_filter
+(
+    n Int32,
+) ENGINE = MergeTree()
+ORDER BY n;
+
+INSERT INTO t_param_filter
+SELECT number
+FROM numbers(10);
+
+SET allow_experimental_analyzer = 1;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+
+SET allow_experimental_analyzer = 0;
+SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+

--- a/tests/queries/0_stateless/03393_additional_table_filter_with_param.sql
+++ b/tests/queries/0_stateless/03393_additional_table_filter_with_param.sql
@@ -17,9 +17,9 @@ FROM numbers(10);
 
 SET allow_experimental_analyzer = 1;
 SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
-SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'}, parallel_replicas_local_plan=1;
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'}, parallel_replicas_local_plan=0;
 
-SET allow_experimental_analyzer = 0;
-SELECT n FROM t_param_filter SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
-SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS additional_table_filters = {'t_param_filter': 'n < {b:String}'};
-
+SET additional_table_filters = {'t_param_filter': 'n < {b:String}'};
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS parallel_replicas_local_plan=1;
+SELECT n FROM t_param_filter WHERE n > {a:String} SETTINGS parallel_replicas_local_plan=0;


### PR DESCRIPTION
This PR is based on https://github.com/ClickHouse/ClickHouse/issues/74208, but it has a problem with parallel replicas.

There were two nuances with parallel replicas:
1. Query parameters were not sent to remote replicas.
2. A current database was not sent as well. AFAIU There is no way to send this information because the interserver mode doesn't have a session context and a remote query executor reuses connections (default database can be set on a new connect). So I implemented it through rewriting tables names in `additional_table_filters` to full qualified names (with database). 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
You can now use query parameters in filters inside the `additional_table_filters` settings e.g. `SELECT x FROM nums SETTINGS additional_table_filters = {'nums': 'x < {a:UInt32}'}`. Closes https://github.com/ClickHouse/ClickHouse/issues/74208. Backward incompatible change: now the `additional_table_filters` will apply for all tables with the corresponding name, even if these tables are in different databases.

It is reintroduction of https://github.com/ClickHouse/ClickHouse/pull/77680 (thanks to @wxybear) which is fixed for parallel replicas.



### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
