### PR TITLE
Fix noisy debug message

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -19,7 +19,7 @@
 #include <base/defines.h>
 #include <base/sort.h>
 #include <cassert>
-#include <ranges>
+
 #include <Poco/Timestamp.h>
 
 namespace DB
@@ -1512,7 +1512,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
         constexpr auto fmt_string = "Not executing log entry {} of type {} "
                            "because recently it has failed. According to exponential backoff policy, put aside this log entry for {} ms.";
 
-        LOG_DEBUG(LogToStr(out_postpone_reason, log), fmt_string, entry.znode_name, entry.typeToString(), postpone_time);
+        LOG_DEBUG(LogToStr(out_postpone_reason, LogFrequencyLimiter(log, 10)), fmt_string, entry.znode_name, entry.typeToString(), postpone_time);
         return false;
     }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Add rate limiter for the debug message:
Fixes **[issue](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=84040&sha=a8b01c07e316ba7958ebd8432c1681968e8092ac&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+old+analyzer%2C+s3+storage%2C+DatabaseReplicated%2C+sequential%29&name_2=Tests&name_3=00002_log_and_exception_messages_formatting)** found by test

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
