### PR TITLE
Add `runner --debug` option to enable ClickHouse root folder mount for debugging

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -227,7 +227,7 @@ will automagically detect the types of variables and only the small diff of two 
 
 Here is how you run a debugger for the server under integration test:
 
-1. Put the **_statically linked binary_** of your debugger into the ClickHouse root folder of your repo. The [nnd](https://github.com/al13n321/nnd) debugger is ideal for this purpose (and for ClickHouse debugging in general).
+1. Put the **_statically linked binary_** of your debugger into the ClickHouse root folder of your repo. The [nnd](https://github.com/al13n321/nnd) debugger is ideal for this purpose (and for ClickHouse debugging in general), it's currently the only supported option.
 2. Go to the integration test `test.py` file and add a new line with a single `breakpoint()` command to debug specific point in your test (to make the server work forever and not die after the test).
 3. Run the integration test with `runner` script as usual but add `--debug` option. It will produce helper shell command in stdout and start testing:
 ```bash

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -229,20 +229,13 @@ Here is how you run a debugger for the server under integration test:
 
 1. Put the **_statically linked binary_** of your debugger into the ClickHouse root folder of your repo. The [nnd](https://github.com/al13n321/nnd) debugger is ideal for this purpose (and for ClickHouse debugging in general).
 2. Go to the integration test `test.py` file and add a new line with a single `breakpoint()` command to debug specific point in your test (to make the server work forever and not die after the test).
-3. Run the integration test with `runner` script as usual but add `--debug` option. It will produce helper shell commands in stdout and start testing:
+3. Run the integration test with `runner` script as usual but add `--debug` option. It will produce helper shell command in stdout and start testing:
 ```bash
-    # =====> DEBUG MODE <=====
-    # ClickHouse root folder will be read=only mounted into /ClickHouse in all containers.
-    # Use the following command to list node containers.
-    runner-nodes() {
-        docker exec clickhouse_integration_tests_160lfw docker ps | grep node
-    }
-
-    # You can use the following command to log into the container and run clickhouse client or debugger.
-    # Tip: place a `breakpoint()` somewhere in your integration test python code before run.
-    runner-bash() {
-        docker exec -it clickhouse_integration_tests_160lfw docker exec -it $1 bash
-    }
+   # =====> DEBUG MODE <=====
+    # ClickHouse root folder will be read-only mounted into /debug in all containers.
+    # Tip: place a `breakpoint()` somewhere in your integration test python code before `runner`.
+    # Open another shell and include:
+        source /path/to/ClickHouse/tests/integration/runner-env.sh
     # =====> DEBUG MODE <=====
 ```
 4. When the test hits a breakpoint, it will show the Python debugger prompt, which is useful by itself for debugging purposes. For example:
@@ -253,18 +246,49 @@ test_throttling/test.py::test_write_throttling[user_remote_throttling]
 -> assert_took(took, should_take)
 (Pdb)
 ```
-5. Open another shell and paste the DEBUG MODE commands there to set up the environment. Then run:
+5. Open another shell and run the command there to set up the environment. Then run:
 ```bash
-❯ runner-nodes
-2e2a25260eae   clickhouse/integration-test:latest         "bash -c 'trap 'pkil…"   4 minutes ago   Up 4 minutes                               roottestthrottling-node-1
+❯ source /path/to/ClickHouse/tests/integration/runner-env.sh
+
+USAGE:
+   runner-client - Run clickhouse client inside an integration test
+   runner-bash   - Open shell on a node inside an integration test
+   runner-nnd    - Attach nnd debugger to a clickhouse server on a node inside an integration test
 ```
 6. You can use either Container ID or Container Name to log into the required node:
 ```
-❯ runner-bash roottestthrottling-node-1
-root@node:/#
+❯ runner-client
+CONTAINER ID   IMAGE                                      COMMAND                  CREATED          STATUS          PORTS                                                            NAMES
+867c67cc9957   clickhouse/integration-test:latest         "bash -c 'trap 'pkil…"   2 seconds ago    Up 1 second                                                                      rootteststoragedelta-node1-1
+64b8744cb71a   clickhouse/integration-test:latest         "bash -c 'trap 'pkil…"   2 seconds ago    Up 1 second                                                                      rootteststoragedelta-node2-1
+414187056a06   clickhouse/clickhouse-server:25.3.3.42     "bash -c 'trap 'pkil…"   2 seconds ago    Up 1 second     8123/tcp, 9000/tcp, 9009/tcp                                     rootteststoragedelta-node_old-1
+f5c9aef75a04   clickhouse/integration-test:latest         "clickhouse server -…"   2 seconds ago    Up 1 second                                                                      rootteststoragedelta-node_with_environment_credentials-1
+c7eae7f0c29d   mcr.microsoft.com/azure-storage/azurite    "docker-entrypoint.s…"   21 seconds ago   Up 20 seconds   10000-10002/tcp, 0.0.0.0:30000->30000/tcp, :::30000->30000/tcp   rootteststoragedelta-azurite1-1
+8a81755f9358   minio/minio:RELEASE.2024-07-31T05-46-26Z   "/usr/bin/docker-ent…"   22 seconds ago   Up 21 seconds   9000-9001/tcp                                                    rootteststoragedelta-minio1-1
+6f11a018f16c   clickhouse/python-bottle:latest            "python3"                22 seconds ago   Up 21 seconds   8080/tcp                                                         rootteststoragedelta-resolver-1
+bf180f6b2f7d   clickhouse/s3-proxy                        "/docker-entrypoint.…"   22 seconds ago   Up 22 seconds   80/tcp, 443/tcp, 8080/tcp                                        rootteststoragedelta-proxy1-1
+0c03e8d780e5   clickhouse/s3-proxy                        "/docker-entrypoint.…"   22 seconds ago   Up 22 seconds   80/tcp, 443/tcp, 8080/tcp                                        rootteststoragedelta-proxy2-1
+1ef790b3251e   clickhouse/integration-test:latest         "clickhouse keeper -…"   28 seconds ago   Up 27 seconds                                                                    rootteststoragedelta-zoo2-1
+a65b504a1e60   clickhouse/integration-test:latest         "clickhouse keeper -…"   28 seconds ago   Up 27 seconds                                                                    rootteststoragedelta-zoo3-1
+51d20a4f40c4   clickhouse/integration-test:latest         "clickhouse keeper -…"   28 seconds ago   Up 28 seconds                                                                    rootteststoragedelta-zoo1-1
+Enter ClickHouse Node CONTAINER ID or NAME (default: 867c67cc9957):
+ClickHouse client version 25.7.1.1.
+Connecting to localhost:9000 as user default.
+Connected to ClickHouse server version 25.7.1.
+node1 :) select 1
+
+SELECT 1
+
+Query id: 7222639b-6d33-4237-85f4-ad4ee04e8691
+
+   ┌─1─┐
+1. │ 1 │
+   └───┘
+
+1 row in set. Elapsed: 0.001 sec.
+
+node1 :) Bye.
 ```
-7. Run `clickhouse client` to connect to the server running in the node container.
-8. Find the PID with `ps aux` and run the debugger in the the node container with `/ClickHouse/nnd -p 767 -d /ClickHouse`
 
 ### Troubleshooting
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2266,7 +2266,7 @@ class ClickHouseCluster:
             return True
         except Exception:
             return False
-        
+
     def get_files_list_in_container(self, container_id, path):
         result = self.exec_in_container(
             container_id,
@@ -2278,7 +2278,7 @@ class ClickHouseCluster:
         )
 
         files = result.strip().splitlines() if result else []
-        return files            
+        return files
 
     def move_file_in_container(self, container_id, old_path, new_path):
         self.exec_in_container(
@@ -3634,6 +3634,7 @@ services:
             - {db_dir}:/var/lib/clickhouse/
             - {logs_dir}:/var/log/clickhouse-server/
             - /etc/passwd:/etc/passwd:ro
+            - /ClickHouse:/ClickHouse:ro
             {binary_volume}
             {external_dirs_volumes}
             {odbc_ini_path}
@@ -4534,7 +4535,7 @@ class ClickHouseInstance:
         return self.cluster.file_exists_in_container(
             self.docker_id, path
         )
-    
+
     def get_files_list_in_container(self, path):
         return self.cluster.get_files_list_in_container(
             self.docker_id, path

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3634,7 +3634,7 @@ services:
             - {db_dir}:/var/lib/clickhouse/
             - {logs_dir}:/var/log/clickhouse-server/
             - /etc/passwd:/etc/passwd:ro
-            - /ClickHouse:/ClickHouse:ro
+            - /debug:/debug:ro
             {binary_volume}
             {external_dirs_volumes}
             {odbc_ini_path}

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -362,7 +362,7 @@ if __name__ == "__main__":
         action="store_true",
         dest="debug",
         default=False,
-        help="Mount ClickHouse source folder from --clickhouse-root into /ClickHouse (read-only)",
+        help="Mount ClickHouse source folder from --clickhouse-root into /debug (read-only)",
     )
 
     parser.add_argument(
@@ -475,7 +475,7 @@ if __name__ == "__main__":
     )
 
     # Mount debug root into container if debug flag is set
-    root_mount = f"--volume={CLICKHOUSE_ROOT}:/ClickHouse:ro" if args.debug else ""
+    debug_mount = f"--volume={CLICKHOUSE_ROOT}:/debug:ro" if args.debug else ""
 
     cmd_base = (
         f"docker run {net} {tty} --rm --name {CONTAINER_NAME} "
@@ -485,7 +485,7 @@ if __name__ == "__main__":
         f"--cap-add=SYS_PTRACE "
         f"--volume={args.binary}:/clickhouse "
         f"--volume={args.base_configs_dir}:/clickhouse-config "
-        f"{root_mount} "
+        f"{debug_mount} "
         f"--volume={args.cases_dir}:/ClickHouse/tests/integration "
         f"--volume={args.utils_dir}/backupview:/ClickHouse/utils/backupview "
         f"--volume={args.utils_dir}/grpc-client/pb2:/ClickHouse/utils/grpc-client/pb2 "
@@ -519,17 +519,10 @@ if __name__ == "__main__":
         print(
             f"""
     # =====> DEBUG MODE <=====
-    # ClickHouse root folder will be read=only mounted into /ClickHouse in all containers.
-    # Use the following command to list node containers.
-    runner-nodes() {{
-        docker exec {CONTAINER_NAME} docker ps | grep node
-    }}
-
-    # You can use the following command to log into the container and run clickhouse client or debugger.
-    # Tip: place a `breakpoint()` somewhere in your integration test python code before run.
-    runner-bash() {{
-        docker exec -it {CONTAINER_NAME} docker exec -it $1 bash
-    }}
+    # ClickHouse root folder will be read-only mounted into /debug in all containers.
+    # Tip: place a `breakpoint()` somewhere in your integration test python code before `runner`.
+    # Open another shell and include:
+        source {CLICKHOUSE_ROOT}/tests/integration/runner-env.sh
     # =====> DEBUG MODE <=====
 """
         )

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -43,7 +43,7 @@ def physical_memory() -> int:
         return int(subprocess.check_output(["sysctl", "-n", "hw.memsize"]).strip())
 
 
-def check_args_and_update_paths(args: argparse.Namespace) -> None:
+def check_args_and_update_paths(args: argparse.Namespace) -> str:
     if args.clickhouse_root:
         if not os.path.isabs(args.clickhouse_root):
             CLICKHOUSE_ROOT = os.path.abspath(args.clickhouse_root)
@@ -124,6 +124,8 @@ def check_args_and_update_paths(args: argparse.Namespace) -> None:
         raise FileNotFoundError(
             f"No users.xml or users.yaml in {args.base_configs_dir}"
         )
+
+    return CLICKHOUSE_ROOT
 
 
 def check_iptables_legacy() -> None:
@@ -356,6 +358,14 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--debug",
+        action="store_true",
+        dest="debug",
+        default=False,
+        help="Mount ClickHouse source folder from --clickhouse-root into /ClickHouse (read-only)",
+    )
+
+    parser.add_argument(
         "--ignore-iptables-legacy-check",
         action="store_true",
         default=False,
@@ -366,7 +376,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    check_args_and_update_paths(args)
+    # Resolve and store ClickHouse root path
+    CLICKHOUSE_ROOT = check_args_and_update_paths(args)
 
     if not args.ignore_iptables_legacy_check:
         check_iptables_legacy()
@@ -463,6 +474,9 @@ if __name__ == "__main__":
         map(lambda x: shlex.quote(x).replace('"', '\\"'), args.tests_list)
     )
 
+    # Mount debug root into container if debug flag is set
+    root_mount = f"--volume={CLICKHOUSE_ROOT}:/ClickHouse:ro" if args.debug else ""
+
     cmd_base = (
         f"docker run {net} {tty} --rm --name {CONTAINER_NAME} "
         "--privileged --dns-search='.' "  # since recent dns search leaks from host
@@ -471,6 +485,7 @@ if __name__ == "__main__":
         f"--cap-add=SYS_PTRACE "
         f"--volume={args.binary}:/clickhouse "
         f"--volume={args.base_configs_dir}:/clickhouse-config "
+        f"{root_mount} "
         f"--volume={args.cases_dir}:/ClickHouse/tests/integration "
         f"--volume={args.utils_dir}/backupview:/ClickHouse/utils/backupview "
         f"--volume={args.utils_dir}/grpc-client/pb2:/ClickHouse/utils/grpc-client/pb2 "
@@ -499,6 +514,25 @@ if __name__ == "__main__":
     if args.pre_pull:
         print(("Running pre pull as: '" + cmd_pre_pull + "'."))
         subprocess.check_call(cmd_pre_pull, shell=True)
+
+    if args.debug:
+        print(
+            f"""
+    # =====> DEBUG MODE <=====
+    # ClickHouse root folder will be read=only mounted into /ClickHouse in all containers.
+    # Use the following command to list node containers.
+    runner-nodes() {{
+        docker exec {CONTAINER_NAME} docker ps | grep node
+    }}
+
+    # You can use the following command to log into the container and run clickhouse client or debugger.
+    # Tip: place a `breakpoint()` somewhere in your integration test python code before run.
+    runner-bash() {{
+        docker exec -it {CONTAINER_NAME} docker exec -it $1 bash
+    }}
+    # =====> DEBUG MODE <=====
+"""
+        )
 
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True, bufsize=0)

--- a/tests/integration/runner-env.sh
+++ b/tests/integration/runner-env.sh
@@ -1,0 +1,41 @@
+#!/bin/zsh
+# Works with bash and zsh
+
+# It should be used with `runner --debug`
+# Tip: place a `breakpoint()` somewhere in your integration test python code before run.
+
+_runner-select-node() {
+    RUNNER_ID1=$(docker ps | grep clickhouse_integration_tests | awk '{print $1; exit}')
+    RUNNER_ID2_DEFAULT=$(docker exec $RUNNER_ID1 docker ps | grep node | awk '{print $1; exit}')
+    docker exec $RUNNER_ID1 docker ps
+    RUNNER_ID2=
+    echo -n "Enter ClickHouse Node CONTAINER ID or NAME (default: $RUNNER_ID2_DEFAULT): "
+    read RUNNER_ID2
+    RUNNER_ID2=${RUNNER_ID2:-$RUNNER_ID2_DEFAULT}
+}
+
+# Runs a clickhouse client for a node inside an integration test.
+runner-client() {
+    _runner-select-node
+    docker exec -it $RUNNER_ID1 docker exec -it $RUNNER_ID2 clickhouse client
+}
+
+# Opens shell on a node inside an integration test.
+runner-bash() {
+    _runner-select-node
+    docker exec -it $RUNNER_ID1 docker exec -it $RUNNER_ID2 bash
+}
+
+# Attaches nnd debugger to a clickhouse server on a node inside an integration test.
+# You have to put statically-linked nnd binary into ClickHouse root folder
+runner-nnd() {
+    _runner-select-node
+    RUNNER_PID=$(docker exec $RUNNER_ID1 docker exec $RUNNER_ID2 sh -c 'ps aux | grep -v grep | grep -v bash | grep -m 1 "clickhouse server" | awk "{print \$2}"')
+    docker exec -it $RUNNER_ID1 docker exec -it $RUNNER_ID2 /debug/nnd -p $RUNNER_PID -d /debug
+}
+
+echo "USAGE:"
+echo "   runner-client - Run clickhouse client inside an integration test"
+echo "   runner-bash   - Open shell on a node inside an integration test"
+echo "   runner-nnd    - Attach nnd debugger to a clickhouse server on a node inside an integration test"
+echo ""


### PR DESCRIPTION
To be able to debug clickhouse server inside integration test container it is useful to have access to the source code. This PR add an option `--debug` that enables this.

### Here is how you run a debugger for the server under integration test
1. Put the **_statically linked binary_** of your debugger into the ClickHouse root folder of your repo. The [nnd](https://github.com/al13n321/nnd) debugger is ideal for this purpose (and for ClickHouse debugging in general).
2. Go to the integration test `test.py` file and add a new line with a single `breakpoint()` command to debug specific point in your test (to make the server work forever and not die after the test).
3. Run the integration test with `runner` script as usual but add `--debug` option. It will produce helper shell command in stdout and start testing:
```bash
   # =====> DEBUG MODE <=====
    # ClickHouse root folder will be read-only mounted into /debug in all containers.
    # Tip: place a `breakpoint()` somewhere in your integration test python code before `runner`.
    # Open another shell and include:
        source /path/to/ClickHouse/tests/integration/runner-env.sh
    # =====> DEBUG MODE <=====
```
4. When the test hits a breakpoint, it will show the Python debugger prompt, which is useful by itself for debugging purposes. For example:
```bash
test_throttling/test.py::test_write_throttling[user_remote_throttling]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /ClickHouse/tests/integration/test_throttling/test.py(493)test_write_throttling()
-> assert_took(took, should_take)
(Pdb)
```
5. Open another shell and run the command there to set up the environment. Then run:
```bash
❯ source /path/to/ClickHouse/tests/integration/runner-env.sh

USAGE:
   runner-client - Run clickhouse client inside an integration test
   runner-bash   - Open shell on a node inside an integration test
   runner-nnd    - Attach nnd debugger to a clickhouse server on a node inside an integration test
```
6. You can use either Container ID or Container Name to log into the required node:
```
❯ runner-client
CONTAINER ID   IMAGE                                      COMMAND                  CREATED          STATUS          PORTS                                                            NAMES
867c67cc9957   clickhouse/integration-test:latest         "bash -c 'trap 'pkil…"   2 seconds ago    Up 1 second                                                                      rootteststoragedelta-node1-1
64b8744cb71a   clickhouse/integration-test:latest         "bash -c 'trap 'pkil…"   2 seconds ago    Up 1 second                                                                      rootteststoragedelta-node2-1
414187056a06   clickhouse/clickhouse-server:25.3.3.42     "bash -c 'trap 'pkil…"   2 seconds ago    Up 1 second     8123/tcp, 9000/tcp, 9009/tcp                                     rootteststoragedelta-node_old-1
f5c9aef75a04   clickhouse/integration-test:latest         "clickhouse server -…"   2 seconds ago    Up 1 second                                                                      rootteststoragedelta-node_with_environment_credentials-1
c7eae7f0c29d   mcr.microsoft.com/azure-storage/azurite    "docker-entrypoint.s…"   21 seconds ago   Up 20 seconds   10000-10002/tcp, 0.0.0.0:30000->30000/tcp, :::30000->30000/tcp   rootteststoragedelta-azurite1-1
8a81755f9358   minio/minio:RELEASE.2024-07-31T05-46-26Z   "/usr/bin/docker-ent…"   22 seconds ago   Up 21 seconds   9000-9001/tcp                                                    rootteststoragedelta-minio1-1
6f11a018f16c   clickhouse/python-bottle:latest            "python3"                22 seconds ago   Up 21 seconds   8080/tcp                                                         rootteststoragedelta-resolver-1
bf180f6b2f7d   clickhouse/s3-proxy                        "/docker-entrypoint.…"   22 seconds ago   Up 22 seconds   80/tcp, 443/tcp, 8080/tcp                                        rootteststoragedelta-proxy1-1
0c03e8d780e5   clickhouse/s3-proxy                        "/docker-entrypoint.…"   22 seconds ago   Up 22 seconds   80/tcp, 443/tcp, 8080/tcp                                        rootteststoragedelta-proxy2-1
1ef790b3251e   clickhouse/integration-test:latest         "clickhouse keeper -…"   28 seconds ago   Up 27 seconds                                                                    rootteststoragedelta-zoo2-1
a65b504a1e60   clickhouse/integration-test:latest         "clickhouse keeper -…"   28 seconds ago   Up 27 seconds                                                                    rootteststoragedelta-zoo3-1
51d20a4f40c4   clickhouse/integration-test:latest         "clickhouse keeper -…"   28 seconds ago   Up 28 seconds                                                                    rootteststoragedelta-zoo1-1
Enter ClickHouse Node CONTAINER ID or NAME (default: 867c67cc9957):
ClickHouse client version 25.7.1.1.
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 25.7.1.
node1 :) select 1

SELECT 1

Query id: 7222639b-6d33-4237-85f4-ad4ee04e8691

   ┌─1─┐
1. │ 1 │
   └───┘

1 row in set. Elapsed: 0.001 sec.

node1 :) Bye.
```
7. Use runner-nnd to start debugging:
<img width="1724" height="1032" alt="Screenshot 2025-07-24 at 22 25 35" src="https://github.com/user-attachments/assets/4fcc068d-9194-43e7-825a-75f24a7c2b45" />


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
