### PR TITLE
Bump mongo-c-driver to remove usage of harmful function rand()

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -227,7 +227,7 @@
     contrib-openssl = { url = "github:ClickHouse/openssl/2aa34c68d677b447fb85c55167d8d1ab98ba4def"; flake = false; };
     contrib-double-conversion = { url = "github:ClickHouse/double-conversion/4f7a25d8ced8c7cf6eee6fd09d6788eaa23c9afe"; flake = false; };
     contrib-mongo-cxx-driver = { url = "github:ClickHouse/mongo-cxx-driver/3166bdb49b717ce1bc30f46cc2b274ab1de7005b"; flake = false; };
-    contrib-mongo-c-driver = { url = "github:ClickHouse/mongo-c-driver/aabf2f86682aab0a7329160929b8f6654a18216a"; flake = false; };
+    contrib-mongo-c-driver = { url = "github:ClickHouse/mongo-c-driver/4ee76b070b260de5da1e8c8144c028dfc37efbaf"; flake = false; };
     contrib-sz3 = { url = "github:ClickHouse/SZ3/df46e03190b0fa1b46eef016829030170f3553e0"; flake = false; };
     contrib-numactl = { url = "github:ClickHouse/numactl/ff32c618d63ca7ac48cce366c5a04bb3563683a0"; flake = false; };
     contrib-postgres = { url = "github:ClickHouse/postgres/9da0420d861df7542b92058342afd4723e95ef4c"; flake = false; };


### PR DESCRIPTION
Fixes: https://github.com/ClickHouse/ClickHouse/issues/82280

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)