### PR TITLE
Don't run 01825_new_type_json_ghdata_insert_select in tsan + msan tests

### DIFF
--- a/tests/queries/0_stateless/01825_new_type_json_ghdata_insert_select.sh
+++ b/tests/queries/0_stateless/01825_new_type_json_ghdata_insert_select.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-object-storage, long, no-asan
-# ^ no-object-storage: it is memory-hungry, no-asan: too long
+# Tags: no-fasttest, no-object-storage, long, no-asan, no-tsan, no-msan
+# ^ no-object-storage: it is memory-hungry, no-{a,t,m}san: too long
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Runtimes of test `01825_new_type_json_ghdata_insert_select` in tsan and msan builds are consistently > 100 sec, see [here](https://play.clickhouse.com/play?user=play#U0VMRUNUIHRlc3RfZHVyYXRpb25fbXMvMTAwMCwgYmFzZV9yZXBvLCBwdWxsX3JlcXVlc3RfbnVtYmVyIGFzIHByLCBjaGVja19zdGFydF90aW1lLCBjaGVja19uYW1lLCB0ZXN0X25hbWUsIHRlc3Rfc3RhdHVzLS0sIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgMQogICAgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICAtLSBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJywgJ0JST0tFTicpCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdG9EYXRlKGNoZWNrX3N0YXJ0X3RpbWUpID4gJzIwMjUtMDctMDEnCiAgICBBTkQgdGVzdF9uYW1lIGxpa2UgJyUwMTgyNV9uZXdfdHlwZV9qc29uX2doZGF0YV9pbnNlcnRfc2VsZWN0JScKICAgIEFORCB0ZXN0X2R1cmF0aW9uX21zLzEwMDAgPiAxMDAKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBERVNDClNFVFRJTkdTIHJlYWRfdGhyb3VnaF9kaXN0cmlidXRlZF9jYWNoZT0w). This recently led to timeouts, see [here](https://play.clickhouse.com/play?user=play#U0VMRUNUIHRlc3RfZHVyYXRpb25fbXMvMTAwMCwgYmFzZV9yZXBvLCBwdWxsX3JlcXVlc3RfbnVtYmVyIGFzIHByLCBjaGVja19zdGFydF90aW1lLCBjaGVja19uYW1lLCB0ZXN0X25hbWUsIHRlc3Rfc3RhdHVzLCByZXBvcnRfdXJsCkZST00gY2hlY2tzCldIRVJFIDEKICAgIEFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMAogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicsICdCUk9LRU4nKQogICAgQU5EIHRvRGF0ZShjaGVja19zdGFydF90aW1lKSA+ICcyMDI1LTA2LTAxJwogICAgQU5EIHRlc3RfbmFtZSBsaWtlICclMDE4MjVfbmV3X3R5cGVfanNvbl9naGRhdGFfaW5zZXJ0X3NlbGVjdCUnCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgREVTQwpTRVRUSU5HUyByZWFkX3Rocm91Z2hfZGlzdHJpYnV0ZWRfY2FjaGU9MA==). Therefore exclude the test from tsan and msan builds (this was already done for asan builds).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)