### PR TITLE
Partially clean warnings.cmake

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -5,7 +5,7 @@
 # - we have to include headers of these libraries as -isystem to avoid warnings from headers
 #   (this is the same behaviour as if these libraries were located in /usr/include)
 # - sometimes warnings from 3rd party libraries may come from macro substitutions in our code
-#   and we have to wrap them with #pragma GCC/clang diagnostic ignored
+#   and we have to wrap them with #pragma clang diagnostic ignored
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 
@@ -19,16 +19,15 @@ endif ()
 # We want to get everything out of the compiler for code quality.
 add_warning(everything)
 add_warning(pedantic)
-add_warning(vla-cxx-extension)
-no_warning(return-type-c-linkage)
-no_warning(zero-length-array)
-no_warning(c++98-compat-pedantic)
-no_warning(c++98-compat)
-no_warning(c++20-compat) # Use constinit in C++20 without warnings
-no_warning(sign-conversion)
-no_warning(implicit-int-conversion)
-no_warning(implicit-int-float-conversion)
-no_warning(ctad-maybe-unsupported) # clang 9+, linux-only
+no_warning(return-type-c-linkage) # Used in some 3rd party libraries like delta-kernel-rs ffi
+no_warning(zero-length-array) # Clang extension
+no_warning(c++98-compat-pedantic) # We don't care about C++98 compatibility (We use aliases, variadic macros...)
+#no_warning(c++98-compat) # We don't care about C++98 compatibility
+no_warning(c++20-compat) # Use C++20 features incompatible with older standards (consteval, constinit, implicit typename...)
+no_warning(sign-conversion) # TODO: Fix the code and enable it
+no_warning(implicit-int-conversion) # TODO: Fix the code and enable it
+no_warning(implicit-int-float-conversion) # TODO: Fix the code and enable it
+no_warning(ctad-maybe-unsupported)
 no_warning(disabled-macro-expansion)
 no_warning(documentation-unknown-command)
 no_warning(double-promotion)
@@ -47,4 +46,3 @@ no_warning(thread-safety-negative) # experimental flag, too many false positives
 no_warning(unsafe-buffer-usage) # too aggressive
 no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
 no_warning(nrvo) # not eliding copy on return - too aggressive
-# TODO Enable conversion, sign-conversion, double-promotion warnings.

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -22,12 +22,10 @@ add_warning(pedantic)
 no_warning(return-type-c-linkage) # Used in some 3rd party libraries like delta-kernel-rs ffi
 no_warning(zero-length-array) # Clang extension
 no_warning(c++98-compat-pedantic) # We don't care about C++98 compatibility (We use aliases, variadic macros...)
-#no_warning(c++98-compat) # We don't care about C++98 compatibility
 no_warning(c++20-compat) # Use C++20 features incompatible with older standards (consteval, constinit, implicit typename...)
 no_warning(sign-conversion) # TODO: Fix the code and enable it
 no_warning(implicit-int-conversion) # TODO: Fix the code and enable it
 no_warning(implicit-int-float-conversion) # TODO: Fix the code and enable it
-no_warning(ctad-maybe-unsupported)
 no_warning(disabled-macro-expansion)
 no_warning(documentation-unknown-command)
 no_warning(double-promotion)

--- a/src/Client/BuzzHouse/Generator/RandomGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/RandomGenerator.cpp
@@ -174,7 +174,7 @@ String RandomGenerator::nextDateTime64(const bool has_subseconds)
 
 double RandomGenerator::randomGauss(const double mean, const double stddev)
 {
-    std::normal_distribution d{mean, stddev};
+    std::normal_distribution<double> d{mean, stddev};
     return d(generator);
 }
 

--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -51,7 +51,7 @@ void ConnectionEstablisher::run(ConnectionEstablisher::TryResult & result, std::
     {
         ProfileEvents::increment(ProfileEvents::DistributedConnectionTries);
         result.entry = pool->get(*timeouts, settings, force_connected);
-        AsyncCallbackSetter async_setter(&*result.entry, std::move(async_callback));
+        AsyncCallbackSetter<Connection> async_setter(&*result.entry, std::move(async_callback));
 
         UInt64 server_revision = 0;
         if (table_to_check)

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -362,7 +362,7 @@ UInt64 MultiplexedConnections::receivePacketTypeUnlocked(AsyncCallback async_cal
 
     try
     {
-        AsyncCallbackSetter async_setter(current_connection, std::move(async_callback));
+        AsyncCallbackSetter<Connection> async_setter(current_connection, std::move(async_callback));
         return current_connection->receivePacketType();
     }
     catch (Exception & e)
@@ -393,7 +393,7 @@ Packet MultiplexedConnections::receivePacketUnlocked(AsyncCallback async_callbac
     Packet packet;
     try
     {
-        AsyncCallbackSetter async_setter(current_connection, std::move(async_callback));
+        AsyncCallbackSetter<Connection> async_setter(current_connection, std::move(async_callback));
         packet = current_connection->receivePacket();
     }
     catch (Exception & e)

--- a/src/Client/PacketReceiver.cpp
+++ b/src/Client/PacketReceiver.cpp
@@ -62,7 +62,7 @@ void PacketReceiver::Task::run(AsyncCallback async_callback, SuspendCallback sus
     while (true)
     {
         {
-            AsyncCallbackSetter async_setter(receiver.connection, async_callback);
+            AsyncCallbackSetter<Connection> async_setter(receiver.connection, async_callback);
             receiver.packet = receiver.connection->receivePacket();
         }
         suspend_callback();

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -121,7 +121,7 @@ public:
 
     MutableColumnPtr cloneResized(size_t size) const override;
 
-    Field operator[](size_t n) const override { return DecimalField(data[n], scale); }
+    Field operator[](size_t n) const override { return DecimalField<ValueType>(data[n], scale); }
     void get(size_t n, Field & res) const override { res = (*this)[n]; }
     std::pair<String, DataTypePtr> getValueNameAndType(size_t n) const override
     {

--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -52,11 +52,7 @@ static ColumnPtr mockColumn(const DataTypePtr & type, size_t rows)
 }
 
 
-#if !defined(DEBUG_OR_SANITIZER_BUILD)
 static NO_INLINE void insertManyFrom(IColumn & dst, const IColumn & src)
-#else
-static NO_INLINE void doInsertManyFrom(IColumn & dst, const IColumn & src)
-#endif
 {
     size_t size = src.size();
     dst.insertManyFrom(src, size / 2, size);

--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -18,7 +18,7 @@ private:
 
 public:
     template <typename StackAlloc, typename Fn>
-    Fiber(StackAlloc && salloc, Fn && fn) : impl(std::allocator_arg_t(), std::forward<StackAlloc>(salloc), RoutineImpl(std::forward<Fn>(fn)))
+    Fiber(StackAlloc && salloc, Fn && fn) : impl(std::allocator_arg_t(), std::forward<StackAlloc>(salloc), RoutineImpl<Fn>(std::forward<Fn>(fn)))
     {
     }
 

--- a/src/Common/HashTable/StringHashSet.h
+++ b/src/Common/HashTable/StringHashSet.h
@@ -97,5 +97,6 @@ public:
         LookupResult it;
         Base::emplace(key_holder, it, inserted);
     }
-
 };
+
+StringHashSet() -> StringHashSet<HashTableAllocator>;

--- a/src/Common/NaNUtils.h
+++ b/src/Common/NaNUtils.h
@@ -11,7 +11,7 @@ inline bool isNaN(T x)
 {
     /// To be sure, that this function is zero-cost for non-floating point types.
     if constexpr (is_floating_point<T>)
-        return DecomposedFloat(x).isNaN();
+        return DecomposedFloat<T>(x).isNaN();
     else
         return false;
 }
@@ -20,7 +20,7 @@ template <typename T>
 inline bool isFinite(T x)
 {
     if constexpr (is_floating_point<T>)
-        return DecomposedFloat(x).isFinite();
+        return DecomposedFloat<T>(x).isFinite();
     else
         return true;
 }
@@ -52,7 +52,7 @@ template <typename T>
 bool signBit(T x)
 {
     if constexpr (is_floating_point<T>)
-        return DecomposedFloat(x).isNegative();
+        return DecomposedFloat<T>(x).isNegative();
     else
         return x < 0;
 }

--- a/src/Common/Scheduler/Nodes/tests/ResourceTest.h
+++ b/src/Common/Scheduler/Nodes/tests/ResourceTest.h
@@ -46,7 +46,7 @@ struct ResourceTestBase
     {
         std::stringstream stream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
         stream << "<resource><node path=\"" << path << "\">" << xml << "</node></resource>";
-        Poco::AutoPtr config{new Poco::Util::XMLConfiguration(stream)};
+        Poco::AutoPtr<Poco::Util::XMLConfiguration> config{new Poco::Util::XMLConfiguration(stream)};
         String config_prefix = "node";
 
         return add<TClass>(event_queue, root_node, path, std::ref(*config), config_prefix);
@@ -404,7 +404,7 @@ struct ResourceTestManager : public ResourceTestBase
     void update(const String & xml)
     {
         std::istringstream stream(xml); // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        Poco::AutoPtr config{new Poco::Util::XMLConfiguration(stream)};
+        Poco::AutoPtr<Poco::Util::XMLConfiguration> config{new Poco::Util::XMLConfiguration(stream)};
         manager->updateConfiguration(*config);
     }
 

--- a/src/Common/Scheduler/Nodes/tests/gtest_resource_class_fair.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_resource_class_fair.cpp
@@ -12,7 +12,7 @@ TEST(SchedulerFairPolicy, Factory)
 {
     ResourceTest t;
 
-    Poco::AutoPtr cfg = new Poco::Util::XMLConfiguration();
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> cfg = new Poco::Util::XMLConfiguration();
     EventQueue event_queue;
     SchedulerNodePtr fair = SchedulerNodeFactory::instance().get("fair", &event_queue, *cfg, "");
     EXPECT_TRUE(dynamic_cast<FairPolicy *>(fair.get()) != nullptr);

--- a/src/Common/Scheduler/Nodes/tests/gtest_resource_class_priority.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_resource_class_priority.cpp
@@ -12,7 +12,7 @@ TEST(SchedulerPriorityPolicy, Factory)
 {
     ResourceTest t;
 
-    Poco::AutoPtr cfg = new Poco::Util::XMLConfiguration();
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> cfg = new Poco::Util::XMLConfiguration();
     EventQueue event_queue;
     SchedulerNodePtr prio = SchedulerNodeFactory::instance().get("priority", &event_queue, *cfg, "");
     EXPECT_TRUE(dynamic_cast<PriorityPolicy *>(prio.get()) != nullptr);

--- a/src/Common/Scheduler/Nodes/tests/gtest_resource_scheduler.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_resource_scheduler.cpp
@@ -180,7 +180,7 @@ TEST(SchedulerRoot, Budget)
 TEST(SchedulerRoot, Cancel)
 {
     // This barrier is used in the scheduler thread, so we should not destroy it before thread in ~ResourceTest
-    std::barrier destruct_sync(2);
+    std::barrier<std::__empty_completion> destruct_sync(2);
 
     ResourceTest t;
 
@@ -191,7 +191,7 @@ TEST(SchedulerRoot, Cancel)
     auto b = r1.addQueue("/prio/B", "<priority>2</priority>");
     r1.registerResource();
 
-    std::barrier sync(2);
+    std::barrier<std::__empty_completion> sync(2);
     std::thread consumer1([&]
     {
         MyRequest request(1,[&]

--- a/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
@@ -377,9 +377,9 @@ TEST(SchedulerWorkloadResourceManager, DropNotEmptyQueue)
     t.query("CREATE WORKLOAD all SETTINGS max_io_requests = 1");
     t.query("CREATE WORKLOAD intermediate IN all");
 
-    std::barrier sync_before_enqueue(2);
-    std::barrier sync_before_drop(3);
-    std::barrier sync_after_drop(2);
+    std::barrier<std::__empty_completion> sync_before_enqueue(2);
+    std::barrier<std::__empty_completion> sync_before_drop(3);
+    std::barrier<std::__empty_completion> sync_after_drop(2);
     t.async("intermediate", "res1", [&] (ResourceLink link)
     {
         TestGuard g(t, link, 1);
@@ -413,9 +413,9 @@ TEST(SchedulerWorkloadResourceManager, DropNotEmptyQueueLong)
     t.query("CREATE WORKLOAD intermediate IN all");
 
     static constexpr int queue_size = 100;
-    std::barrier sync_before_enqueue(2);
-    std::barrier sync_before_drop(2 + queue_size);
-    std::barrier sync_after_drop(2);
+    std::barrier<std::__empty_completion> sync_before_enqueue(2);
+    std::barrier<std::__empty_completion> sync_before_drop(2 + queue_size);
+    std::barrier<std::__empty_completion> sync_after_drop(2);
     t.async("intermediate", "res1", [&] (ResourceLink link)
     {
         TestGuard g(t, link, 1);
@@ -1197,7 +1197,7 @@ TEST(SchedulerWorkloadResourceManager, CPUSchedulingPriorities)
 
 TEST(SchedulerWorkloadResourceManager, CPUSchedulingIndependentPools)
 {
-    std::barrier sync_start(2);
+    std::barrier<std::__empty_completion> sync_start(2);
 
     ResourceTest t;
 

--- a/src/Common/SharedLockGuard.h
+++ b/src/Common/SharedLockGuard.h
@@ -23,5 +23,6 @@ public:
 private:
     Mutex & mutex;
 };
+_LIBCPP_CTAD_SUPPORTED_FOR_TYPE(SharedLockGuard);
 
 }

--- a/src/Common/SpaceSaving.h
+++ b/src/Common/SpaceSaving.h
@@ -295,7 +295,7 @@ public:
 
         for (size_t i = 0; i < count; ++i)
         {
-            std::unique_ptr counter = std::make_unique<Counter>();
+            auto counter = std::make_unique<Counter>();
             counter->read(rb);
             counter->hash = counter_map.hash(counter->key);
             push(std::move(counter));

--- a/src/Common/UniqueLock.h
+++ b/src/Common/UniqueLock.h
@@ -45,6 +45,7 @@ private:
     std::unique_lock<Mutex> unique_lock;
     bool locked = true;
 };
+_LIBCPP_CTAD_SUPPORTED_FOR_TYPE(UniqueLock);
 
 template <template<typename> typename TUniqueLock, typename Mutex>
 class TSA_SCOPED_LOCKABLE LockAndOverCommitTrackerBlocker

--- a/src/Common/mysqlxx/Pool.cpp
+++ b/src/Common/mysqlxx/Pool.cpp
@@ -367,7 +367,7 @@ void Pool::initialize()
 
 Pool::Connection * Pool::allocConnection(bool dont_throw_if_failed_first_time)
 {
-    std::unique_ptr conn_ptr = std::make_unique<Connection>();
+    auto conn_ptr = std::make_unique<Connection>();
 
     try
     {

--- a/src/Common/tests/gtest_async_loader.cpp
+++ b/src/Common/tests/gtest_async_loader.cpp
@@ -350,7 +350,7 @@ TEST(AsyncLoader, CancelExecutingJob)
     AsyncLoaderTest t;
     t.loader.unpause();
 
-    std::barrier sync(2);
+    std::barrier<std::__empty_completion> sync(2);
 
     auto job_func = [&] (AsyncLoader &, const LoadJobPtr &)
     {
@@ -381,7 +381,7 @@ TEST(AsyncLoader, CancelExecutingTask)
 {
     AsyncLoaderTest t(16);
     t.loader.unpause();
-    std::barrier sync(2);
+    std::barrier<std::__empty_completion> sync(2);
 
     auto blocker_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
     {
@@ -587,7 +587,7 @@ TEST(AsyncLoader, CustomDependencyFailure)
     AsyncLoaderTest t(16);
     int error_count = 0;
     std::atomic<size_t> good_count{0};
-    std::barrier canceled_sync(4);
+    std::barrier<std::__empty_completion> canceled_sync(4);
     t.loader.unpause();
 
     std::string_view error_message = "test job failure";
@@ -674,7 +674,7 @@ TEST(AsyncLoader, WaitersLimit)
         waiters_total.fetch_sub(1);
     };
 
-    std::barrier sync(2);
+    std::barrier<std::__empty_completion> sync(2);
     t.loader.unpause();
 
     auto job_func = [&] (AsyncLoader &, const LoadJobPtr &) {
@@ -727,7 +727,7 @@ TEST(AsyncLoader, TestConcurrency)
 
     for (int concurrency = 1; concurrency <= 10; concurrency++)
     {
-        std::barrier sync(concurrency);
+        std::barrier<std::__empty_completion> sync(concurrency);
 
         std::atomic<int> executing{0};
         auto job_func = [&] (AsyncLoader &, const LoadJobPtr &)
@@ -882,7 +882,7 @@ TEST(AsyncLoader, DynamicPriorities)
     for (bool prioritize : {false, true})
     {
         // Although all pools have max_threads=1, workers from different pools can run simultaneously just after `prioritize()` call
-        std::barrier sync(2);
+        std::barrier<std::__empty_completion> sync(2);
         bool wait_sync = prioritize;
         std::mutex schedule_mutex;
         std::string schedule;
@@ -974,7 +974,7 @@ TEST(AsyncLoader, JobPrioritizedWhileWaited)
         {.max_threads = 1, .priority{-1}},
     });
 
-    std::barrier sync(2);
+    std::barrier<std::__empty_completion> sync(2);
 
     LoadJobPtr job_to_wait; // and then to prioritize
 

--- a/src/Common/tests/gtest_interval_tree.cpp
+++ b/src/Common/tests/gtest_interval_tree.cpp
@@ -84,7 +84,7 @@ template <typename IntervalType, typename Value>
 std::map<IntervalType, Value> intervalMapFindIntervals(const IntervalMap<IntervalType, Value> & interval_set, typename IntervalType::IntervalStorageType point)
 {
     std::map<IntervalType, Value> result;
-    CollectIntervalsMapCallback callback(result);
+    CollectIntervalsMapCallback<IntervalType, Value> callback(result);
 
     interval_set.find(point, callback);
 

--- a/src/Common/tests/gtest_proxy_configuration_resolver_provider.cpp
+++ b/src/Common/tests/gtest_proxy_configuration_resolver_provider.cpp
@@ -20,7 +20,7 @@ protected:
     }
 
     static void TearDownTestSuite() {
-        context->setConfig(Poco::AutoPtr(new Poco::Util::MapConfiguration()));
+        context->setConfig(Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration()));
     }
 
     static DB::ContextMutablePtr context;
@@ -45,7 +45,7 @@ TEST_F(ProxyConfigurationResolverProviderTests, EnvironmentResolverShouldBeUsedI
 
 TEST_F(ProxyConfigurationResolverProviderTests, ListHTTPOnly)
 {
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
 
     config->setString("proxy", "");
     config->setString("proxy.http", "");
@@ -61,7 +61,7 @@ TEST_F(ProxyConfigurationResolverProviderTests, ListHTTPOnly)
 
 TEST_F(ProxyConfigurationResolverProviderTests, ListHTTPSOnly)
 {
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
 
     config->setString("proxy", "");
     config->setString("proxy.https", "");
@@ -77,7 +77,7 @@ TEST_F(ProxyConfigurationResolverProviderTests, ListHTTPSOnly)
 
 TEST_F(ProxyConfigurationResolverProviderTests, ListBoth)
 {
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
 
     config->setString("proxy", "");
     config->setString("proxy.http", "");
@@ -98,7 +98,7 @@ TEST_F(ProxyConfigurationResolverProviderTests, ListBoth)
 
 TEST_F(ProxyConfigurationResolverProviderTests, RemoteResolverIsBasedOnProtocolConfigurationHTTPS)
 {
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
 
     config->setString("proxy", "");
     config->setString("proxy.http", "");
@@ -121,7 +121,7 @@ TEST_F(ProxyConfigurationResolverProviderTests, RemoteResolverIsBasedOnProtocolC
 
 TEST_F(ProxyConfigurationResolverProviderTests, RemoteResolverHTTPSOnly)
 {
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
 
     config->setString("proxy", "");
     config->setString("proxy.https", "");
@@ -145,7 +145,7 @@ TEST_F(ProxyConfigurationResolverProviderTests, RemoteResolverHTTPSOnly)
 template <bool DISABLE_TUNNELING_FOR_HTTPS_REQUESTS_OVER_HTTP_PROXY, bool STRING>
 void test_tunneling(DB::ContextMutablePtr context)
 {
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
 
     config->setString("proxy", "");
     config->setString("proxy.https", "");

--- a/src/Common/tests/gtest_threading.cpp
+++ b/src/Common/tests/gtest_threading.cpp
@@ -38,7 +38,7 @@ void TestSharedMutex()
     {
         T sm;
         std::atomic<int> test(0);
-        std::barrier sync(readers + 1);
+        std::barrier<std::__empty_completion> sync(readers + 1);
 
         std::vector<std::thread> threads;
         threads.reserve(readers);
@@ -71,7 +71,7 @@ void TestSharedMutex()
     {
         T sm;
         int test = 0;
-        std::barrier sync(writers);
+        std::barrier<std::__empty_completion> sync(writers);
         std::vector<std::thread> threads;
 
         threads.reserve(writers);
@@ -97,7 +97,7 @@ void TestSharedMutex()
     {
         T sm;
         std::atomic<int> test(0);
-        std::barrier sync(readers + 1);
+        std::barrier<std::__empty_completion> sync(readers + 1);
 
         std::vector<std::thread> threads;
         threads.reserve(readers);
@@ -145,8 +145,8 @@ void TestSharedMutexCancelReader()
     T sm;
     std::atomic<int> successes(0);
     std::atomic<int> cancels(0);
-    std::barrier sync(readers + 1);
-    std::barrier cancel_sync(readers / 2 + 1);
+    std::barrier<std::__empty_completion> sync(readers + 1);
+    std::barrier<std::__empty_completion> cancel_sync(readers / 2 + 1);
     std::vector<std::thread> threads;
 
     std::mutex m;
@@ -219,7 +219,7 @@ void TestSharedMutexCancelWriter()
     T sm;
     std::atomic<int> successes(0);
     std::atomic<int> cancels(0);
-    std::barrier sync(writers);
+    std::barrier<std::__empty_completion> sync(writers);
     std::vector<std::thread> threads;
 
     std::mutex m;

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -740,6 +740,11 @@ private:
     uniform_distribution<T> distribution;
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+MonotonicGenerator() -> MonotonicGenerator<Int32>;
+#pragma clang diagnostic pop
+
 auto RandomishGenerator = [](auto i)
 {
     using T = decltype(i);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -196,7 +196,7 @@ void assertDigest(
     }
 }
 
-template <bool shared = false>
+template <bool shared>
 struct LockGuardWithStats final
 {
     using LockType = std::conditional_t<shared, std::shared_lock<SharedMutex>, std::unique_lock<SharedMutex>>;
@@ -457,7 +457,7 @@ bool KeeperStateMachine<Storage>::preprocess(const KeeperRequestForSession & req
 template<typename Storage>
 void KeeperStateMachine<Storage>::reconfigure(const KeeperRequestForSession& request_for_session)
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     KeeperResponseForSession response = processReconfiguration(request_for_session);
     if (!responses_queue.push(response))
     {
@@ -573,7 +573,7 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
             response_for_session.response = response;
             response_for_session.request = request_for_session->request;
 
-            LockGuardWithStats lock(storage_mutex);
+            LockGuardWithStats<false> lock(storage_mutex);
             session_id = storage->getSessionID(session_id_request.session_timeout_ms);
             LOG_DEBUG(log, "Session ID response {} with timeout {}", session_id, session_id_request.session_timeout_ms);
             response->session_id = session_id;
@@ -666,7 +666,7 @@ bool KeeperStateMachine<Storage>::apply_snapshot(nuraft::snapshot & s)
             snapshot_deserialization_result
                 = snapshot_manager.deserializeSnapshotFromBuffer(snapshot_manager.deserializeSnapshotBufferFromDisk(s.get_last_log_idx()));
 
-        LockGuardWithStats storage_lock(storage_mutex);
+        LockGuardWithStats<false> storage_lock(storage_mutex);
         /// maybe some logs were preprocessed with log idx larger than the snapshot idx
         /// we have to apply them to the new storage
         storage->applyUncommittedState(*snapshot_deserialization_result.storage, snapshot_deserialization_result.snapshot_meta->get_last_log_idx());
@@ -711,7 +711,7 @@ void KeeperStateMachine<Storage>::rollbackRequest(const KeeperRequestForSession 
     if (request_for_session.request->getOpNum() == Coordination::OpNum::SessionID)
         return;
 
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     storage->rollbackRequest(request_for_session.zxid, allow_missing);
 }
 
@@ -731,7 +731,7 @@ void KeeperStateMachine<Storage>::create_snapshot(nuraft::snapshot & s, nuraft::
     auto snapshot_meta_copy = nuraft::snapshot::deserialize(*snp_buf);
     CreateSnapshotTask snapshot_task;
     { /// lock storage for a short period time to turn on "snapshot mode". After that we can read consistent storage state without locking.
-        LockGuardWithStats lock(storage_mutex);
+        LockGuardWithStats<false> lock(storage_mutex);
         snapshot_task.snapshot = std::make_shared<KeeperStorageSnapshot<Storage>>(storage.get(), snapshot_meta_copy, getClusterConfig());
     }
 
@@ -796,7 +796,7 @@ void KeeperStateMachine<Storage>::create_snapshot(nuraft::snapshot & s, nuraft::
         }
         {
             /// Destroy snapshot with lock
-            LockGuardWithStats lock(storage_mutex);
+            LockGuardWithStats<false> lock(storage_mutex);
             LOG_TRACE(log, "Clearing garbage after snapshot");
             /// Turn off "snapshot mode" and clear outdate part of storage state
             storage->clearGarbageAfterSnapshot();
@@ -956,14 +956,14 @@ void KeeperStateMachine<Storage>::processReadRequest(const KeeperRequestForSessi
 template<typename Storage>
 void KeeperStateMachine<Storage>::shutdownStorage()
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     storage->finalize();
 }
 
 template<typename Storage>
 std::vector<int64_t> KeeperStateMachine<Storage>::getDeadSessions()
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getDeadSessions();
 }
 
@@ -976,7 +976,7 @@ int64_t KeeperStateMachine<Storage>::getNextZxid() const
 template<typename Storage>
 KeeperDigest KeeperStateMachine<Storage>::getNodesDigest() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getNodesDigest(false, /*lock_transaction_mutex=*/true);
 }
 
@@ -995,77 +995,77 @@ const KeeperStorageStats & KeeperStateMachine<Storage>::getStorageStats() const 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getNodesCount() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getNodesCount();
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getTotalWatchesCount() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getTotalWatchesCount();
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getWatchedPathsCount() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getWatchedPathsCount();
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getSessionsWithWatchesCount() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getSessionsWithWatchesCount();
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getTotalEphemeralNodesCount() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getTotalEphemeralNodesCount();
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getSessionWithEphemeralNodesCount() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getSessionWithEphemeralNodesCount();
 }
 
 template<typename Storage>
 void KeeperStateMachine<Storage>::dumpWatches(WriteBufferFromOwnString & buf) const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     storage->dumpWatches(buf);
 }
 
 template<typename Storage>
 void KeeperStateMachine<Storage>::dumpWatchesByPath(WriteBufferFromOwnString & buf) const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     storage->dumpWatchesByPath(buf);
 }
 
 template<typename Storage>
 void KeeperStateMachine<Storage>::dumpSessionsAndEphemerals(WriteBufferFromOwnString & buf) const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     storage->dumpSessionsAndEphemerals(buf);
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getApproximateDataSize() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getApproximateDataSize();
 }
 
 template<typename Storage>
 uint64_t KeeperStateMachine<Storage>::getKeyArenaSize() const
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     return storage->getArenaDataSize();
 }
 
@@ -1108,7 +1108,7 @@ ClusterConfigPtr IKeeperStateMachine::getClusterConfig() const
 template<typename Storage>
 void KeeperStateMachine<Storage>::recalculateStorageStats()
 {
-    LockGuardWithStats lock(storage_mutex);
+    LockGuardWithStats<false> lock(storage_mutex);
     LOG_INFO(log, "Recalculating storage stats");
     storage->recalculateStats();
     LOG_INFO(log, "Done recalculating storage stats");

--- a/src/DataTypes/DataTypeDecimalBase.cpp
+++ b/src/DataTypes/DataTypeDecimalBase.cpp
@@ -33,7 +33,7 @@ bool decimalCheckArithmeticOverflow(ContextPtr context)
 template <is_decimal T>
 Field DataTypeDecimalBase<T>::getDefault() const
 {
-    return DecimalField(T(0), scale);
+    return DecimalField<T>(T(0), scale);
 }
 
 template <is_decimal T>

--- a/src/DataTypes/DataTypeLowCardinality.cpp
+++ b/src/DataTypes/DataTypeLowCardinality.cpp
@@ -96,7 +96,7 @@ MutableColumnUniquePtr DataTypeLowCardinality::createColumnUniqueImpl(const IDat
     if (which.isInt() || which.isUInt() || which.isFloat())
     {
         MutableColumnUniquePtr column;
-        TypeListUtils::forEach(TypeListIntAndFloat{}, CreateColumnVector(column, *type, creator));
+        TypeListUtils::forEach(TypeListIntAndFloat{}, CreateColumnVector<Creator>(column, *type, creator));
 
         if (!column)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected numeric type: {}", type->getName());

--- a/src/DataTypes/FieldToDataType.h
+++ b/src/DataTypes/FieldToDataType.h
@@ -51,4 +51,6 @@ public:
     DataTypePtr operator() (const bool & x) const;
 };
 
+FieldToDataType() -> FieldToDataType<LeastSupertypeOnError::Throw>;
+
 }

--- a/src/DataTypes/Serializations/SerializationDecimalBase.cpp
+++ b/src/DataTypes/Serializations/SerializationDecimalBase.cpp
@@ -43,7 +43,7 @@ void SerializationDecimalBase<T>::deserializeBinary(Field & field, ReadBuffer & 
 {
     typename FieldType::NativeType x;
     readBinaryLittleEndian(x, istr);
-    field = DecimalField(T(x), this->scale);
+    field = DecimalField<T>(T(x), this->scale);
 }
 
 template <typename T>

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -152,6 +152,8 @@ public:
 };
 static_assert(sizeof(HashTableGrowerWithPrecalculationAndMaxLoadFactor<>) == 64);
 
+HashTableGrowerWithPrecalculationAndMaxLoadFactor() -> HashTableGrowerWithPrecalculationAndMaxLoadFactor<8>;
+
 /// Above goes various specialisations for the hash table that will be used for
 /// HASHED/SPARSE_HASHED dictionary, it could use one of the following depends
 /// on the layout of the dictionary and types of key/value (for more info see

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -859,7 +859,7 @@ struct ConvertImplGenericToString
         auto col_to = removeNullable(result_type)->createColumn();
 
         {
-            ColumnStringHelpers::WriteHelper write_helper(
+            ColumnStringHelpers::WriteHelper<StringColumnType> write_helper(
                     assert_cast<StringColumnType &>(*col_to),
                     size);
 
@@ -5259,7 +5259,7 @@ private:
             return [this](ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, const ColumnNullable * nullable_source, size_t input_rows_count)
             {
                 auto json_string = ColumnString::create();
-                ColumnStringHelpers::WriteHelper write_helper(assert_cast<ColumnString &>(*json_string), input_rows_count);
+                ColumnStringHelpers::WriteHelper<ColumnString> write_helper(assert_cast<ColumnString &>(*json_string), input_rows_count);
                 auto & write_buffer = write_helper.getWriteBuffer();
                 FormatSettings format_settings = context ? getFormatSettings(context) : FormatSettings{};
                 auto serialization = arguments[0].type->getDefaultSerialization();

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -145,7 +145,7 @@ private:
                 auto full_column = column->convertToFullIfNeeded();
                 auto serialization = arguments[i].type->getDefaultSerialization();
                 auto converted_col_str = ColumnString::create();
-                ColumnStringHelpers::WriteHelper write_helper(*converted_col_str, column->size());
+                ColumnStringHelpers::WriteHelper<ColumnString> write_helper(*converted_col_str, column->size());
                 auto & write_buffer = write_helper.getWriteBuffer();
                 FormatSettings format_settings;
                 for (size_t row = 0; row < column->size(); ++row)

--- a/src/Functions/concatWithSeparator.cpp
+++ b/src/Functions/concatWithSeparator.cpp
@@ -122,7 +122,7 @@ public:
                 auto full_column = column->convertToFullIfNeeded();
                 auto serialization = arguments[i +1].type->getDefaultSerialization();
                 auto converted_col_str = ColumnString::create();
-                ColumnStringHelpers::WriteHelper write_helper(*converted_col_str, column->size());
+                ColumnStringHelpers::WriteHelper<ColumnString> write_helper(*converted_col_str, column->size());
                 auto & write_buffer = write_helper.getWriteBuffer();
                 FormatSettings format_settings;
                 for (size_t row = 0; row < column->size(); ++row)
@@ -135,7 +135,8 @@ public:
                 /// Keep the pointer alive
                 converted_col_ptrs[i] = std::move(converted_col_str);
 
-                /// Same as the normal `ColumnString` branch
+                /// Same as
+                // the normal `ColumnString` branch
                 has_column_string = true;
                 data[2 * i] = &converted_col_ptrs[i]->getChars();
                 offsets[2 * i] = &converted_col_ptrs[i]->getOffsets();

--- a/src/Functions/concatWithSeparator.cpp
+++ b/src/Functions/concatWithSeparator.cpp
@@ -135,8 +135,7 @@ public:
                 /// Keep the pointer alive
                 converted_col_ptrs[i] = std::move(converted_col_str);
 
-                /// Same as
-                // the normal `ColumnString` branch
+                /// Same as the normal `ColumnString` branch
                 has_column_string = true;
                 data[2 * i] = &converted_col_ptrs[i]->getChars();
                 offsets[2 * i] = &converted_col_ptrs[i]->getOffsets();

--- a/src/Functions/format.cpp
+++ b/src/Functions/format.cpp
@@ -104,7 +104,7 @@ public:
                 auto full_column = column->convertToFullIfNeeded();
                 auto serialization = arguments[i].type->getDefaultSerialization();
                 auto converted_col_str = ColumnString::create();
-                ColumnStringHelpers::WriteHelper write_helper(*converted_col_str, column->size());
+                ColumnStringHelpers::WriteHelper<ColumnString> write_helper(*converted_col_str, column->size());
                 auto & write_buffer = write_helper.getWriteBuffer();
                 FormatSettings format_settings;
                 for (size_t row = 0; row < column->size(); ++row)

--- a/src/Functions/now64.cpp
+++ b/src/Functions/now64.cpp
@@ -51,8 +51,7 @@ Field nowSubsecond(UInt32 scale)
     else if (adjust_scale > 0)
         components.fractional /= intExp10(adjust_scale);
 
-    return DecimalField(DecimalUtils::decimalFromComponents<DateTime64>(components, scale),
-                        scale);
+    return DecimalField<DateTime64>(DecimalUtils::decimalFromComponents<DateTime64>(components, scale), scale);
 }
 
 /// Get the current time. (It is a constant, it is evaluated once for the entire query.)

--- a/src/Functions/randDistribution.cpp
+++ b/src/Functions/randDistribution.cpp
@@ -164,7 +164,7 @@ struct BinomialDistribution
         if (p < 0.0f || p > 1.0f)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument of function {} should be inside [0, 1] because it is a probability", getName());
 
-        auto distribution = std::binomial_distribution(t, p);
+        auto distribution = std::binomial_distribution<UInt64>(t, p);
         for (auto & elem : container)
             elem = static_cast<UInt64>(distribution(thread_local_rng));
     }
@@ -181,7 +181,7 @@ struct NegativeBinomialDistribution
         if (p < 0.0f || p > 1.0f)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument of function {} should be inside [0, 1] because it is a probability", getName());
 
-        auto distribution = std::negative_binomial_distribution(t, p);
+        auto distribution = std::negative_binomial_distribution<UInt64>(t, p);
         for (auto & elem : container)
             elem = static_cast<UInt64>(distribution(thread_local_rng));
     }
@@ -195,7 +195,7 @@ struct PoissonDistribution
 
     static void generate(UInt64 n, ColumnUInt64::Container & container)
     {
-        auto distribution = std::poisson_distribution(n);
+        auto distribution = std::poisson_distribution<UInt64>(n);
         for (auto & elem : container)
             elem = static_cast<UInt64>(distribution(thread_local_rng));
     }

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -139,6 +139,8 @@ private:
     }
 };
 
+Memory() -> Memory<Allocator<false>>;
+
 
 /** Buffer that could own its working memory.
   * Template parameter: ReadBuffer or WriteBuffer

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -59,7 +59,7 @@ UUID parseUUID(std::span<const UInt8> src)
     const auto size = src.size();
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    const std::reverse_iterator dst(reinterpret_cast<UInt8 *>(&uuid) + sizeof(UUID));
+    const std::reverse_iterator<UInt8 *> dst(reinterpret_cast<UInt8 *>(&uuid) + sizeof(UUID));
 #else
     auto * dst = reinterpret_cast<UInt8 *>(&uuid);
 #endif

--- a/src/IO/WriteHelpers.cpp
+++ b/src/IO/WriteHelpers.cpp
@@ -36,7 +36,7 @@ std::array<char, 36> formatUUID(const UUID & uuid)
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     const auto * src_ptr = reinterpret_cast<const UInt8 *>(&uuid);
-    const std::reverse_iterator src(src_ptr + 16);
+    const std::reverse_iterator<const UInt8 *> src(src_ptr + 16);
 #else
     const auto * src = reinterpret_cast<const UInt8 *>(&uuid);
 #endif

--- a/src/IO/examples/read_buffer_from_hdfs.cpp
+++ b/src/IO/examples/read_buffer_from_hdfs.cpp
@@ -14,7 +14,7 @@ int main()
     setenv("LIBHDFS3_CONF", "/path/to/hdfs-site.xml", true); /// NOLINT
     String hdfs_uri = "hdfs://cluster_name";
     String hdfs_file_path = "/path/to/hdfs/file";
-    ConfigurationPtr config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
+    ConfigurationPtr config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration());
     ReadSettings read_settings;
     ReadBufferFromHDFS read_buffer(hdfs_uri, hdfs_file_path, *config, read_settings, 2097152UL, false);
 

--- a/src/IO/tests/gtest_readbuffer_s3.cpp
+++ b/src/IO/tests/gtest_readbuffer_s3.cpp
@@ -69,7 +69,7 @@ struct ClientFake : DB::S3::Client
         {
             auto response_stream = Aws::Utils::Stream::ResponseStream(
                 Aws::New<DB::SessionAwareIOStream<CountedSessionPtr>>("test response stream", weak_session_ptr.lock(), sb));
-            Aws::AmazonWebServiceResult aws_result(std::move(response_stream), Aws::Http::HeaderValueCollection());
+            Aws::AmazonWebServiceResult<Aws::Utils::Stream::ResponseStream> aws_result(std::move(response_stream), Aws::Http::HeaderValueCollection());
             DB::S3::Model::GetObjectResult result(std::move(aws_result));
             return DB::S3::Model::GetObjectOutcome(std::move(result));
         };

--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -202,7 +202,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
     {
         const auto & date_time64_type = static_cast<const DataTypeDateTime64 &>(type);
         const auto value = date_time64_type.getTimeZone().fromDayNum(DayNum(src.safeGet<UInt16>()));
-        return DecimalField(
+        return DecimalField<DateTime64>(
             DecimalUtils::decimalFromComponentsWithMultiplier<DateTime64>(value, 0, date_time64_type.getScaleMultiplier()),
             date_time64_type.getScale());
     }
@@ -210,7 +210,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
     {
         const auto & date_time64_type = static_cast<const DataTypeDateTime64 &>(type);
         const auto value = date_time64_type.getTimeZone().fromDayNum(ExtendedDayNum(static_cast<Int32>(src.safeGet<Int32>())));
-        return DecimalField(
+        return DecimalField<DateTime64>(
             DecimalUtils::decimalFromComponentsWithMultiplier<DateTime64>(value, 0, date_time64_type.getScaleMultiplier()),
             date_time64_type.getScale());
     }
@@ -235,7 +235,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
     {
         const auto & time64_type = static_cast<const DataTypeTime64 &>(type);
         const auto value = time64_type.getTimeZone().fromDayNum(DayNum(src.safeGet<UInt16>()));
-        return DecimalField(
+        return DecimalField<Time64>(
             DecimalUtils::decimalFromComponentsWithMultiplier<Time64>(value, 0, time64_type.getScaleMultiplier()),
             time64_type.getScale());
     }
@@ -243,7 +243,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
     {
         const auto & time64_type = static_cast<const DataTypeTime64 &>(type);
         const auto value = time64_type.getTimeZone().fromDayNum(ExtendedDayNum(static_cast<Int32>(src.safeGet<Int32>())));
-        return DecimalField(
+        return DecimalField<Time64>(
             DecimalUtils::decimalFromComponentsWithMultiplier<Time64>(value, 0, time64_type.getScaleMultiplier()),
             time64_type.getScale());
     }
@@ -338,7 +338,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
             /// in case if we need to make DateTime64(a) from DateTime64(b), a != b, we need to convert datetime value to the right scale
             const UInt64 value = scale_from > scale_to ? from_type.getValue().value / scale_multiplier_diff
                                                        : from_type.getValue().value * scale_multiplier_diff;
-            return DecimalField(DecimalUtils::decimalFromComponentsWithMultiplier<DateTime64>(value, 0, 1), scale_to);
+            return DecimalField<DateTime64>(DecimalUtils::decimalFromComponentsWithMultiplier<DateTime64>(value, 0, 1), scale_to);
         }
 
         if (which_type.isTime64() && src.getType() == Field::Types::Decimal64)
@@ -357,7 +357,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
             /// in case if we need to make Time64(a) from Time64(b), a != b, we need to convert time value to the right scale
             const UInt64 value = scale_from > scale_to ? from_type.getValue().value / scale_multiplier_diff
                                                        : from_type.getValue().value * scale_multiplier_diff;
-            return DecimalField(DecimalUtils::decimalFromComponentsWithMultiplier<Time64>(value, 0, 1), scale_to);
+            return DecimalField<Time64>(DecimalUtils::decimalFromComponentsWithMultiplier<Time64>(value, 0, 1), scale_to);
         }
 
         /// For toDate('xxx') in 1::Int64, we CAST `src` to UInt64, which may

--- a/src/Interpreters/tests/gtest_convertFieldToType.cpp
+++ b/src/Interpreters/tests/gtest_convertFieldToType.cpp
@@ -66,39 +66,39 @@ INSTANTIATE_TEST_SUITE_P(
             "Date",
             Field(0),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(0), 0)
+            DecimalField<DateTime64>(DateTime64(0), 0)
         },
         // Max value of Date
         {
             "Date",
             Field(std::numeric_limits<UInt16>::max()),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(std::numeric_limits<UInt16>::max() * Day), 0)
+            DecimalField<DateTime64>(DateTime64(std::numeric_limits<UInt16>::max() * Day), 0)
         },
         // check that scale is respected
         {
             "Date",
             Field(123),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(123 * Day), 0)
+            DecimalField<DateTime64>(DateTime64(123 * Day), 0)
         },
         {
             "Date",
             Field(1),
             "DateTime64(1, 'UTC')",
-            DecimalField(DateTime64(Day * 10), 1)
+            DecimalField<DateTime64>(DateTime64(Day * 10), 1)
         },
         {
             "Date",
             Field(123),
             "DateTime64(3, 'UTC')",
-            DecimalField(DateTime64(123 * Day * 1000), 3)
+            DecimalField<DateTime64>(DateTime64(123 * Day * 1000), 3)
         },
         {
             "Date",
             Field(123),
             "DateTime64(6, 'UTC')",
-            DecimalField(DateTime64(123 * Day * 1'000'000), 6)
+            DecimalField<DateTime64>(DateTime64(123 * Day * 1'000'000), 6)
         },
     })
 );
@@ -112,39 +112,39 @@ INSTANTIATE_TEST_SUITE_P(
             "Date32",
             Field(-25'567),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(-25'567 * Day), 0)
+            DecimalField<DateTime64>(DateTime64(-25'567 * Day), 0)
         },
         // max value of Date32: 31 Dec 2299 (see DATE_LUT_MAX_YEAR)
         {
             "Date32",
             Field(120'529),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(120'529 * Day), 0)
+            DecimalField<DateTime64>(DateTime64(120'529 * Day), 0)
         },
         // check that scale is respected
         {
             "Date32",
             Field(123),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(123 * Day), 0)
+            DecimalField<DateTime64>(DateTime64(123 * Day), 0)
         },
         {
             "Date32",
             Field(123),
             "DateTime64(1, 'UTC')",
-            DecimalField(DateTime64(123 * Day * 10), 1)
+            DecimalField<DateTime64>(DateTime64(123 * Day * 10), 1)
         },
         {
             "Date32",
             Field(123),
             "DateTime64(3, 'UTC')",
-            DecimalField(DateTime64(123 * Day * 1000), 3)
+            DecimalField<DateTime64>(DateTime64(123 * Day * 1000), 3)
         },
         {
             "Date32",
             Field(123),
             "DateTime64(6, 'UTC')",
-            DecimalField(DateTime64(123 * Day * 1'000'000), 6)
+            DecimalField<DateTime64>(DateTime64(123 * Day * 1'000'000), 6)
         }
     })
 );
@@ -157,25 +157,25 @@ INSTANTIATE_TEST_SUITE_P(
             "DateTime",
             Field(1),
             "DateTime64(0, 'UTC')",
-            DecimalField(DateTime64(1), 0)
+            DecimalField<DateTime64>(DateTime64(1), 0)
         },
         {
             "DateTime",
             Field(1),
             "DateTime64(1, 'UTC')",
-            DecimalField(DateTime64(1'0), 1)
+            DecimalField<DateTime64>(DateTime64(1'0), 1)
         },
         {
             "DateTime",
             Field(123),
             "DateTime64(3, 'UTC')",
-            DecimalField(DateTime64(123'000), 3)
+            DecimalField<DateTime64>(DateTime64(123'000), 3)
         },
         {
             "DateTime",
             Field(123),
             "DateTime64(6, 'UTC')",
-            DecimalField(DateTime64(123'000'000), 6)
+            DecimalField<DateTime64>(DateTime64(123'000'000), 6)
         },
     })
 );

--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -106,7 +106,7 @@ static FillColumnDescription::StepFunction getStepFunction(const Field & step, c
                     { \
                         auto field_decimal = field.safeGet<DecimalField<DateTime64>>(); \
                         auto res = Add##NAME##sImpl::execute(field_decimal.getValue(), converted_step * jumps_count, time_zone, utc_time_zone, field_decimal.getScale()); \
-                        field = DecimalField(res, field_decimal.getScale()); \
+                        field = DecimalField<decltype(res)>(res, field_decimal.getScale()); \
                     }; \
                     break;
 

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -382,7 +382,7 @@ void RemoteQueryExecutor::sendQueryUnlocked(ClientInfo::QueryKind query_kind, As
         return;
 
     connections = create_connections(async_callback);
-    AsyncCallbackSetter async_callback_setter(connections.get(), async_callback);
+    AsyncCallbackSetter<IConnections> async_callback_setter(connections.get(), async_callback);
 
     const auto & settings = context->getSettingsRef();
     if (isReplicaUnavailable() || needToSkipUnavailableShard())

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -1131,7 +1131,7 @@ void RefreshTask::setRefreshSetHandleUnlock(RefreshSet::Handle && set_handle_)
 
 void RefreshTask::CoordinationZnode::randomize()
 {
-    randomness = std::uniform_int_distribution(Int64(-1e9), Int64(1e9))(thread_local_rng);
+    randomness = std::uniform_int_distribution<Int64>(Int64(-1e9), Int64(1e9))(thread_local_rng);
 }
 
 String RefreshTask::CoordinationZnode::toString() const

--- a/src/Storages/MergeTree/tests/gtest_executor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_executor.cpp
@@ -116,7 +116,7 @@ TEST(Executor, Simple)
 
     String schedule; // mutex is not required because we have a single worker
     String expected_schedule = "ABCDEABCDABCDBCDCDD";
-    std::barrier barrier(2);
+    std::barrier<std::__empty_completion> barrier(2);
     auto task = [&] (const String & name, size_t)
     {
         schedule += name;
@@ -198,7 +198,7 @@ TEST(Executor, RemoveTasksStress)
         CurrentMetrics::BackgroundMergesAndMutationsPoolSize
     );
 
-    std::barrier barrier(schedulers_count + removers_count);
+    std::barrier<std::__empty_completion> barrier(schedulers_count + removers_count);
 
     auto scheduler_routine = [&] ()
     {
@@ -251,7 +251,7 @@ TEST(Executor, UpdatePolicy)
 
     String schedule; // mutex is not required because we have a single worker
     String expected_schedule = "ABCDEDDDDDCCBACBACB";
-    std::barrier barrier(2);
+    std::barrier<std::__empty_completion> barrier(2);
     auto task = [&] (const String & name, size_t)
     {
         schedule += name;

--- a/src/Storages/System/StorageSystemAsyncLoader.cpp
+++ b/src/Storages/System/StorageSystemAsyncLoader.cpp
@@ -33,7 +33,7 @@ namespace
     {
         auto time_us = std::chrono::duration_cast<std::chrono::microseconds>(time_point.time_since_epoch()).count();
         DecimalUtils::DecimalComponents<DateTime64> components{time_us / 1'000'000, time_us % 1'000'000};
-        return DecimalField(DecimalUtils::decimalFromComponents<DateTime64>(components, TIME_SCALE), TIME_SCALE);
+        return DecimalField<DateTime64>(DecimalUtils::decimalFromComponents<DateTime64>(components, TIME_SCALE), TIME_SCALE);
     }
 
     Field optionalTimeInMicroseconds(const TimePoint & time_point)

--- a/src/Storages/System/StorageSystemAsynchronousInserts.cpp
+++ b/src/Storages/System/StorageSystemAsynchronousInserts.cpp
@@ -51,7 +51,7 @@ void StorageSystemAsynchronousInserts::fillData(MutableColumns & res_columns, Co
                 auto time_us = (system_clock::now() - time_diff).time_since_epoch().count();
 
                 DecimalUtils::DecimalComponents<DateTime64> components{time_us / 1'000'000, time_us % 1'000'000};
-                return DecimalField(DecimalUtils::decimalFromComponents<DateTime64>(components, TIME_SCALE), TIME_SCALE);
+                return DecimalField<DateTime64>(DecimalUtils::decimalFromComponents<DateTime64>(components, TIME_SCALE), TIME_SCALE);
             };
 
             const auto & insert_query = key.query->as<const ASTInsertQuery &>();

--- a/src/Storages/TimeSeries/PrometheusRemoteReadProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteReadProtocol.cpp
@@ -64,7 +64,7 @@ namespace
     {
         return makeASTFunction("greaterOrEquals",
                                makeASTColumn(data_table_id, TimeSeriesColumnNames::Timestamp),
-                               std::make_shared<ASTLiteral>(Field{DecimalField{DateTime64{min_timestamp_ms}, 3}}));
+                               std::make_shared<ASTLiteral>(Field{DecimalField<DateTime64>{DateTime64{min_timestamp_ms}, 3}}));
     }
 
     /// Makes an AST for condition `data_table.timestamp <= max_timestamp_ms`
@@ -72,7 +72,7 @@ namespace
     {
         return makeASTFunction("lessOrEquals",
                                makeASTColumn(data_table_id, TimeSeriesColumnNames::Timestamp),
-                               std::make_shared<ASTLiteral>(Field{DecimalField{DateTime64{max_timestamp_ms}, 3}}));
+                               std::make_shared<ASTLiteral>(Field{DecimalField<DateTime64>{DateTime64{max_timestamp_ms}, 3}}));
     }
 
     /// Makes an AST for condition `tags_table.max_time >= min_timestamp_ms`
@@ -80,7 +80,7 @@ namespace
     {
         return makeASTFunction("greaterOrEquals",
                                makeASTColumn(tags_table_id, TimeSeriesColumnNames::MaxTime),
-                               std::make_shared<ASTLiteral>(Field{DecimalField{DateTime64{min_timestamp_ms}, 3}}));
+                               std::make_shared<ASTLiteral>(Field{DecimalField<DateTime64>{DateTime64{min_timestamp_ms}, 3}}));
     }
 
     /// Makes an AST for condition `tags_table.min_time <= max_timestamp_ms`
@@ -88,7 +88,7 @@ namespace
     {
         return makeASTFunction("lessOrEquals",
                                makeASTColumn(tags_table_id, TimeSeriesColumnNames::MinTime),
-                               std::make_shared<ASTLiteral>(Field{DecimalField{DateTime64{max_timestamp_ms}, 3}}));
+                               std::make_shared<ASTLiteral>(Field{DecimalField<DateTime64>{DateTime64{max_timestamp_ms}, 3}}));
     }
 
     /// Makes an AST for the expression referencing a tag value.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Partially clean warnings.cmake

* Added comments to the disabled warnings I've checked. More are pending
* vla-cxx-extension: It's already on by default.
* c++98-compat: Unused.
* ctad-maybe-unsupported: Most of the changes were required in unit test code or in Decimal, where it's better to be explicit about which underlying type you want to use than hope you guessed correctly.


References https://github.com/ClickHouse/ClickHouse/issues/76944

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
