### PR TITLE
CI: Fix long output truncation in ci report

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -510,7 +510,7 @@ class Result(MetaClasses.Serializable):
                         with open(
                             log_file, "r", encoding="utf-8", errors="ignore"
                         ) as f:
-                            error_infos.append(f.read().strip())
+                            error_infos.append(f.read().strip().splitlines())
                     res = exit_code == 0
 
                 # If fail_fast is enabled, stop on first failure
@@ -519,7 +519,7 @@ class Result(MetaClasses.Serializable):
                     break
 
         # Create and return the result object with status and log file (if any)
-        MAX_LINES_IN_INFO = 100
+        MAX_LINES_IN_INFO = 500
         return Result.create_from(
             name=name,
             status=res,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
