### PR TITLE
Fix handling of empty tuple in array() function

### DIFF
--- a/src/Functions/array/array.cpp
+++ b/src/Functions/array/array.cpp
@@ -254,15 +254,22 @@ private:
             return false;
 
         const size_t tuple_size = concrete_out_data->tupleSize();
-        for (size_t i = 0; i < tuple_size; ++i)
+        if (tuple_size == 0)
         {
-            ColumnRawPtrs elem_columns(columns.size(), nullptr);
-            for (size_t j = 0; j < columns.size(); ++j)
+            out_data.insertManyDefaults(columns.size());
+        }
+        else
+        {
+            for (size_t i = 0; i < tuple_size; ++i)
             {
-                const ColumnTuple * concrete_column = assert_cast<const ColumnTuple *>(columns[j]);
-                elem_columns[j] = &concrete_column->getColumn(i);
+                ColumnRawPtrs elem_columns(columns.size(), nullptr);
+                for (size_t j = 0; j < columns.size(); ++j)
+                {
+                    const ColumnTuple * concrete_column = assert_cast<const ColumnTuple *>(columns[j]);
+                    elem_columns[j] = &concrete_column->getColumn(i);
+                }
+                execute(elem_columns, concrete_out_data->getColumn(i), input_rows_count);
             }
-            execute(elem_columns, concrete_out_data->getColumn(i), input_rows_count);
         }
         return true;
     }

--- a/tests/queries/0_stateless/03572_empty_tuple_in_nested_type.reference
+++ b/tests/queries/0_stateless/03572_empty_tuple_in_nested_type.reference
@@ -1,0 +1,9 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (c0 Array(Tuple())) ENGINE = Memory;
+SET max_insert_block_size = 4;
+INSERT INTO TABLE t0 (c0) VALUES ([()]), ([()]), ([()]), ([()]), ([()]), ([()]), ([()]::Array(Tuple())), ([()]), ([(), ()]), ([()]);
+DROP TABLE t0;
+SELECT [(), ()];
+[(),()]

--- a/tests/queries/0_stateless/03572_empty_tuple_in_nested_type.sql
+++ b/tests/queries/0_stateless/03572_empty_tuple_in_nested_type.sql
@@ -1,0 +1,13 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Array(Tuple())) ENGINE = Memory;
+
+SET max_insert_block_size = 4;
+
+INSERT INTO TABLE t0 (c0) VALUES ([()]), ([()]), ([()]), ([()]), ([()]), ([()]), ([()]::Array(Tuple())), ([()]), ([(), ()]), ([()]);
+
+DROP TABLE t0;
+
+SELECT [(), ()];


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed incorrect construction of empty tuples in the `array()` function. This fixes #84202.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
