### PR TITLE
Support deferring HTTP 100 Continue to after quota checks

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -994,7 +994,8 @@ static BlockIO executeQueryImpl(
     QueryProcessingStage::Enum stage,
     ReadBufferUniquePtr & istr,
     ASTPtr & out_ast,
-    ImplicitTransactionControlExecutorPtr implicit_tcl_executor)
+    ImplicitTransactionControlExecutorPtr implicit_tcl_executor,
+    HTTPContinueCallback http_continue_callback = {})
 {
     const bool internal = flags.internal;
 
@@ -1407,6 +1408,10 @@ static BlockIO executeQueryImpl(
                 quota->checkExceeded(QuotaType::ERRORS);
             }
 
+            /// Invoke HTTP 100-Continue callback after async insert quota checks are completed
+            if (http_continue_callback && !internal)
+                http_continue_callback();
+
             auto result = queue->pushQueryWithInlinedData(out_ast, context);
 
             if (result.status == AsynchronousInsertQueue::PushResult::OK)
@@ -1547,6 +1552,10 @@ static BlockIO executeQueryImpl(
                         quota->checkExceeded(QuotaType::ERRORS);
                     }
                 }
+
+                /// Invoke HTTP 100-Continue callback after quota checks are completed
+                if (http_continue_callback && !internal)
+                    http_continue_callback();
 
                 if (interpreter)
                 {
@@ -1810,11 +1819,12 @@ void executeQuery(
     QueryFlags flags,
     const std::optional<FormatSettings> & output_format_settings,
     HandleExceptionInOutputFormatFunc handle_exception_in_output_format,
-    QueryFinishCallback query_finish_callback)
+    QueryFinishCallback query_finish_callback,
+    HTTPContinueCallback http_continue_callback)
 {
     executeQuery(
         wrapReadBufferReference(istr), ostr, allow_into_outfile, context, std::move(set_result_details), flags,
-        output_format_settings, std::move(handle_exception_in_output_format), std::move(query_finish_callback));
+        output_format_settings, std::move(handle_exception_in_output_format), std::move(query_finish_callback), std::move(http_continue_callback));
 }
 
 void executeQuery(
@@ -1826,7 +1836,8 @@ void executeQuery(
     QueryFlags flags,
     const std::optional<FormatSettings> & output_format_settings,
     HandleExceptionInOutputFormatFunc handle_exception_in_output_format,
-    QueryFinishCallback query_finish_callback)
+    QueryFinishCallback query_finish_callback,
+    HTTPContinueCallback http_continue_callback)
 {
     PODArray<char> parse_buf;
     const char * begin;
@@ -1850,9 +1861,12 @@ void executeQuery(
             context->getSettingsRef()[Setting::max_os_cpu_wait_time_ratio_to_throw],
             /*should_throw*/ true);
 
-    if (istr->available() > max_query_size)
+    if (istr->available() > max_query_size || http_continue_callback)
     {
         /// If remaining buffer space in 'istr' is enough to parse query up to 'max_query_size' bytes, then parse inplace.
+        /// Also, if the HTTP 100 Continue response is deferred (which is the case if http_continue_callback is set),
+        /// we should not attempt to read anything from the body. We expect the query (without insert data) to be present
+        /// in the buffer already because it should have been extracted from the query parameter.
         begin = istr->position();
         end = istr->buffer().end();
         istr->position() += end - begin;
@@ -1945,7 +1959,7 @@ void executeQuery(
     auto implicit_tcl_executor = std::make_shared<ImplicitTransactionControlExecutor>();
     try
     {
-        streams = executeQueryImpl(begin, end, context, flags, QueryProcessingStage::Complete, istr, ast, implicit_tcl_executor);
+        streams = executeQueryImpl(begin, end, context, flags, QueryProcessingStage::Complete, istr, ast, implicit_tcl_executor, http_continue_callback);
     }
     catch (...)
     {

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -33,6 +33,7 @@ struct QueryResultDetails
 using SetResultDetailsFunc = std::function<void(const QueryResultDetails &)>;
 using HandleExceptionInOutputFormatFunc = std::function<void(IOutputFormat & output_format, const String & format_name, const ContextPtr & context, const std::optional<FormatSettings> & format_settings)>;
 using QueryFinishCallback = std::function<void()>;
+using HTTPContinueCallback = std::function<void()>;
 
 
 /// Parse and execute a query.
@@ -45,8 +46,9 @@ void executeQuery(
     QueryFlags flags = {},
     const std::optional<FormatSettings> & output_format_settings = std::nullopt, /// Format settings for output format, will be calculated from the context if not set.
     HandleExceptionInOutputFormatFunc handle_exception_in_output_format = {}, /// If a non-empty callback is passed, it will be called on exception with created output format.
-    QueryFinishCallback query_finish_callback = {} /// Use it to do everything you need to before the QueryFinish entry will be dumped to query_log
+    QueryFinishCallback query_finish_callback = {}, /// Use it to do everything you need to before the QueryFinish entry will be dumped to query_log
                                                    /// NOTE: It will not be called in case of exception (i.e. ExceptionWhileProcessing)
+    HTTPContinueCallback http_continue_callback = {} /// If a non-empty callback is passed, it will be called after quota checks to send HTTP 100 Continue.
 );
 
 void executeQuery(
@@ -58,8 +60,9 @@ void executeQuery(
     QueryFlags flags = {},
     const std::optional<FormatSettings> & output_format_settings = std::nullopt, /// Format settings for output format, will be calculated from the context if not set.
     HandleExceptionInOutputFormatFunc handle_exception_in_output_format = {}, /// If a non-empty callback is passed, it will be called on exception with created output format.
-    QueryFinishCallback query_finish_callback = {} /// Use it to do everything you need to before the QueryFinish entry will be dumped to query_log
-                                                   /// NOTE: It will not be called in case of exception (i.e. ExceptionWhileProcessing)
+    QueryFinishCallback query_finish_callback = {}, /// Use it to do everything you need to before the QueryFinish entry will be dumped to query_log
+                                                    /// NOTE: It will not be called in case of exception (i.e. ExceptionWhileProcessing)
+    HTTPContinueCallback http_continue_callback = {} /// If a non-empty callback is passed, it will be called after quota checks to send HTTP 100 Continue.
 );
 
 

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -1,3 +1,4 @@
+#include <Server/HTTP/deferHTTP100Continue.h>
 #include <Server/HTTP/HTTPServerConnection.h>
 #include <Server/TCPServer.h>
 
@@ -98,7 +99,7 @@ void HTTPServerConnection::run()
 
                     if (handler)
                     {
-                        if (request.getExpectContinue() && response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
+                        if (!shouldDeferHTTP100Continue(request) && request.getExpectContinue() && response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
                             response.sendContinue();
 
                         handler->handleRequest(request, response, write_event);

--- a/src/Server/HTTP/HTTPServerResponse.cpp
+++ b/src/Server/HTTP/HTTPServerResponse.cpp
@@ -146,7 +146,7 @@ void HTTPServerResponse::allowKeepAliveIFFRequestIsFullyRead()
     /// Connection can only be reused if we've fully read the previous request and all its POST data.
     /// Otherwise we'd misinterpret the leftover data as part of the next request's header.
     /// HTTPServerRequest::canKeepAlive() checks that request stream is bounded and is fully read.
-    if (!request || !request->canKeepAlive())
+    if (!request || (request->getExpectContinue() && getStatus() != Poco::Net::HTTPResponse::HTTP_CONTINUE) || !request->canKeepAlive())
         setKeepAlive(false);
 }
 }

--- a/src/Server/HTTP/deferHTTP100Continue.cpp
+++ b/src/Server/HTTP/deferHTTP100Continue.cpp
@@ -1,0 +1,13 @@
+#include <Server/HTTP/deferHTTP100Continue.h>
+
+
+namespace DB
+{
+
+bool shouldDeferHTTP100Continue(const HTTPRequest & request)
+{
+    const std::string& header_value = request.get("X-ClickHouse-100-Continue", Poco::Net::HTTPMessage::EMPTY);
+    return !header_value.empty() && Poco::icompare(header_value, "defer") == 0;
+}
+
+}

--- a/src/Server/HTTP/deferHTTP100Continue.h
+++ b/src/Server/HTTP/deferHTTP100Continue.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Server/HTTP/HTTPRequest.h>
+
+
+namespace DB
+{
+
+/// Checks whether we should defer the HTTP 100 Continue response to after quota checks.
+bool shouldDeferHTTP100Continue(const HTTPRequest & request);
+
+}

--- a/tests/queries/0_stateless/03353_http_100_continue.reference
+++ b/tests/queries/0_stateless/03353_http_100_continue.reference
@@ -1,0 +1,27 @@
+=== Test: Basic Expect 100-Continue (not deferred) ===
+✓ Received 100 Continue response
+✓ Received 200 OK response
+=== Test: Without Expect header ===
+✓ No 100 Continue response (expected)
+✓ Received 200 OK response
+=== Test: Deferred 100 Continue (query in body) ===
+✓ No 100 Continue response (expected)
+✓ Timed out (expected)
+=== Test: Deferred 100 Continue (query in URL) ===
+✓ Received 100 Continue response
+✓ Received 200 OK response
+=== Test: Deferred 100 Continue (INSERT data in body) ===
+✓ Received 100 Continue response
+✓ Received 200 OK response
+=== Test: Deferred 100 Continue with TOO_MANY_SIMULTANEOUS_QUERIES ===
+✓ No 100 Continue response (expected)
+✓ No body uploaded (expected)
+✓ Received TOO_MANY_SIMULTANEOUS_QUERIES
+=== Test: Deferred 100 Continue with AUTHENTICATION_FAILED ===
+✓ No 100 Continue response (expected)
+✓ No body uploaded (expected)
+✓ Received AUTHENTICATION_FAILED
+=== Test: Deferred 100 Continue with QUOTA_EXCEEDED ===
+✓ No 100 Continue response (expected)
+✓ No body uploaded (expected)
+✓ Received QUOTA_EXCEEDED

--- a/tests/queries/0_stateless/03353_http_100_continue.sh
+++ b/tests/queries/0_stateless/03353_http_100_continue.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+checkForMissing100ContinueResponse() {
+    if echo "$result" | grep -q "HTTP/1.1 100 Continue"; then
+        echo "✗ Unexpected 100 Continue response"
+        echo "$result"
+    else
+        echo "✓ No 100 Continue response (expected)"
+    fi
+}
+
+checkFor100ContinueResponse() {
+    if echo "$result" | grep -q "HTTP/1.1 100 Continue"; then
+        echo "✓ Received 100 Continue response"
+    else
+        echo "✗ Missing 100 Continue response"
+        echo "$result"
+    fi
+}
+
+checkFor200OkResponse() {
+    if echo "$result" | grep -q "HTTP/1.1 200 OK"; then
+        echo "✓ Received 200 OK response"
+    else
+        echo "✗ Missing 200 OK response"
+        echo "$result"
+    fi
+}
+
+checkForTimeout() {
+    if echo "$result" | grep -q "Operation timed out"; then
+        echo "✓ Timed out (expected)"
+    else
+        echo "✗ Missing timeout"
+        echo "$result"
+    fi
+}
+
+checkForMissingBodyUpload() {
+    if echo "$result" | grep -q "We are completely uploaded and fine"; then
+        echo "✗ Unexpected body upload"
+        echo "$result"
+    else
+        echo "✓ No body uploaded (expected)"
+    fi
+}
+
+checkForError() {
+    if echo "$result" | grep -q "$1"; then
+        echo "✓ Received $1"
+    else
+        echo "✗ Missing $1"
+        echo "$result"
+    fi
+}
+
+# Note: The combination of expect100-timeout and max-time (overall timeout) for curl is there to ensure that we fail with a timeout if 
+# we don't receive a 100 Continue response, instead of silently continuing with sending the body, which could hide bugs.
+
+echo "=== Test: Basic Expect 100-Continue (not deferred) ==="
+result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" -H "Expect: 100-continue" --expect100-timeout 300 --max-time 60 -d "SELECT 1" 2>&1)
+checkFor100ContinueResponse
+checkFor200OkResponse
+
+echo "=== Test: Without Expect header ==="
+result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" -d "SELECT 1" 2>&1)
+checkForMissing100ContinueResponse
+checkFor200OkResponse
+
+echo "=== Test: Deferred 100 Continue (query in body) ==="
+result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" -H "Expect: 100-continue" -H "X-ClickHouse-100-Continue: defer" --expect100-timeout 300 --max-time 5 -d "SELECT 1" 2>&1)
+checkForMissing100ContinueResponse
+checkForTimeout
+
+echo "=== Test: Deferred 100 Continue (query in URL) ==="
+result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&query=SELECT%201" -H "Expect: 100-continue" -H "X-ClickHouse-100-Continue: defer" --expect100-timeout 300 --max-time 60 2>&1)
+checkFor100ContinueResponse
+checkFor200OkResponse
+
+echo "=== Test: Deferred 100 Continue (INSERT data in body) ==="
+$CLICKHOUSE_CLIENT -n --query "
+DROP TABLE IF EXISTS expect_100_continue;
+CREATE OR REPLACE TABLE expect_100_continue (a UInt8) ENGINE = Memory;
+"
+result=$(echo -ne '10\n11\n12\n' | ${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20expect_100_continue%20FORMAT%20TabSeparated" -H "Expect: 100-continue" -H "X-ClickHouse-100-Continue: defer" --expect100-timeout 300 --max-time 60 -d @- 2>&1)
+checkFor100ContinueResponse
+checkFor200OkResponse
+
+echo "=== Test: Deferred 100 Continue with TOO_MANY_SIMULTANEOUS_QUERIES ==="
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d 'SELECT sleep(300) SETTINGS function_sleep_max_microseconds_per_block=300000000' &
+pid=$!
+sleep 5
+result=$(echo -ne '10\n11\n12\n' | ${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20expect_100_continue%20FORMAT%20TabSeparated&max_concurrent_queries_for_all_users=1" -H "Expect: 100-continue" -H "X-ClickHouse-100-Continue: defer" --expect100-timeout 300 --max-time 60 -d @- 2>&1)
+checkForMissing100ContinueResponse
+checkForMissingBodyUpload
+checkForError TOO_MANY_SIMULTANEOUS_QUERIES
+kill $pid
+
+echo "=== Test: Deferred 100 Continue with AUTHENTICATION_FAILED ==="
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS expect_100_continue"
+result=$(echo -ne '10\n11\n12\n' | ${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20expect_100_continue%20FORMAT%20TabSeparated&user=expect_100_continue" -H "Expect: 100-continue" -H "X-ClickHouse-100-Continue: defer" --expect100-timeout 300 --max-time 60 -d @- 2>&1)
+checkForMissing100ContinueResponse
+checkForMissingBodyUpload
+checkForError AUTHENTICATION_FAILED
+
+echo "=== Test: Deferred 100 Continue with QUOTA_EXCEEDED ==="
+$CLICKHOUSE_CLIENT -n --query "
+CREATE USER expect_100_continue;
+GRANT INSERT ON expect_100_continue TO expect_100_continue;
+DROP QUOTA IF EXISTS quota_expect_100_continue;
+CREATE QUOTA quota_expect_100_continue KEYED BY user_name FOR INTERVAL 1 month MAX query_inserts = 1 TO expect_100_continue;
+"
+# use up quota
+$CLICKHOUSE_CLIENT --user expect_100_continue --query "INSERT INTO expect_100_continue VALUES (1)" >/dev/null
+result=$(echo -ne '10\n11\n12\n' | ${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20expect_100_continue%20FORMAT%20TabSeparated&user=expect_100_continue" -H "Expect: 100-continue" -H "X-ClickHouse-100-Continue: defer" --expect100-timeout 300 --max-time 60 -d @- 2>&1)
+checkForMissing100ContinueResponse
+checkForMissingBodyUpload
+checkForError QUOTA_EXCEEDED


### PR DESCRIPTION

### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

When HTTP clients set the header `X-ClickHouse-100-Continue: defer` in addition to `Expect: 100-continue`, ClickHouse doesn't send send a `100 Continue` response to the client until after quota validation passes, preventing waste of network bandwidth from transmitting request bodies that will be thrown away anyways. This is relevant for INSERT queries where the query can be sent in the URL query string and the data is sent in the request body.
Aborting a request without sending the full body prevents connection reuse with HTTP/1.1, but the additional latency introduced by opening new connections is usually insignificant compared to total INSERT duration with large amounts of data.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
