### PR TITLE
tests: avoid possible "Bind for 0.0.0.0:2181 failed: port is already allocated" in kafka tests (2)

### DIFF
--- a/tests/integration/compose/docker_compose_kafka.yml
+++ b/tests/integration/compose/docker_compose_kafka.yml
@@ -2,7 +2,7 @@ services:
   kafka_zookeeper:
     image: zookeeper:3.4.9
     hostname: kafka_zookeeper
-    ports:
+    expose:
       - 2181
     environment:
       ZOO_MY_ID: 1


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Hopefully addresses https://github.com/ClickHouse/ClickHouse/issues/83694