### PR TITLE
delta lake: move expression visitor logs under setting

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6421,6 +6421,9 @@ Query Iceberg table using the snapshot that was current at a specific timestamp.
     DECLARE(Int64, iceberg_snapshot_id, 0, R"(
 Query Iceberg table using the specific snapshot id.
 )", 0) \
+    DECLARE(Bool, delta_lake_enable_expression_visitor_logging, false, R"(
+Enables Test level logs of DeltaLake expression visitor. These logs can be too verbose even for test logging.
+)", 0) \
     DECLARE(Bool, allow_deprecated_error_prone_window_functions, false, R"(
 Allow usage of deprecated error prone window functions (neighbor, runningAccumulate, runningDifferenceStartingWithFirstValue, runningDifference)
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -54,6 +54,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"azure_sdk_use_native_client", false, true, "New setting"},
             {"opentelemetry_trace_cpu_scheduling", false, false, "New setting to trace `cpu_slot_preemption` feature."},
             {"vector_search_with_rescoring", true, true, "New setting."},
+            {"delta_lake_enable_expression_visitor_logging", false, false, "New setting"},
         });
         addSettingsChanges(settings_changes_history, "25.7",
         {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/ExpressionVisitor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/ExpressionVisitor.cpp
@@ -93,6 +93,8 @@ private:
     /// Result expression schema.
     const DB::NamesAndTypesList & schema;
 
+    const bool enable_logging;
+
     /// Final parsing result.
     std::shared_ptr<DB::ActionsDAG> dag;
     /// Intermediate parsing result.
@@ -104,12 +106,15 @@ private:
 
 public:
     /// `schema` is the expression schema of result expression.
-    explicit ExpressionVisitorData(const DB::NamesAndTypesList & schema_)
+    explicit ExpressionVisitorData(const DB::NamesAndTypesList & schema_, bool enable_logging_)
         : schema(schema_)
+        , enable_logging(enable_logging_)
         , dag(std::make_shared<DB::ActionsDAG>())
         , context(DB::Context::getGlobalContextInstance())
     {
     }
+
+    bool enableLogging() const { return enable_logging; }
 
     DB::ContextPtr getContext() const { return context; }
 
@@ -151,7 +156,8 @@ public:
         /// Finalize the result in result_dag with requested schema.
         for (const auto & node : nodes)
         {
-            LOG_TEST(log, "Node type: {}, result name: {}", node->type, node->result_name);
+            if (enable_logging)
+                LOG_TEST(log, "Node type: {}, result name: {}", node->type, node->result_name);
 
             /// During parsing we assigned temporary const_{i} names
             /// to constant expressions,
@@ -183,9 +189,10 @@ public:
                 column_with_type_and_name = DB::ColumnWithTypeAndName(node->column, node->result_type, node->result_name);
             }
 
-            LOG_TEST(
-                log, "Added output: {}, type: {}",
-                column_with_type_and_name.name, column_with_type_and_name.type->getTypeId());
+            if (enable_logging)
+                LOG_TEST(
+                    log, "Added output: {}, type: {}",
+                    column_with_type_and_name.name, column_with_type_and_name.type->getTypeId());
 
             result_columns.push_back(column_with_type_and_name);
             ++schema_it;
@@ -237,7 +244,9 @@ public:
         const auto & node = dag->addColumn(std::move(column));
 
         node_lists[list_id].push_back(&node);
-        LOG_TEST(log, "Added list id {}", list_id);
+
+        if (enable_logging)
+            LOG_TEST(log, "Added list id {}", list_id);
     }
 
     /// Add identifier (column name) node to the list by `list_id`.
@@ -266,7 +275,9 @@ public:
         const auto & node = dag->addInput(std::move(column));
 
         node_lists[list_id].push_back(&node);
-        LOG_TEST(log, "Added list id {}", list_id);
+
+        if (enable_logging)
+            LOG_TEST(log, "Added list id {}", list_id);
     }
 
     /// Add function node to the list by `list_id`.
@@ -286,10 +297,14 @@ public:
         const auto & node = dag->addFunction(function, std::move(it->second), {});
 
         node_lists.erase(child_list_id);
-        LOG_TEST(log, "Removed list id {}", child_list_id);
+
+        if (enable_logging)
+            LOG_TEST(log, "Removed list id {}", child_list_id);
 
         node_lists[list_id].push_back(&node);
-        LOG_TEST(log, "Added list id {}", list_id);
+
+        if (enable_logging)
+            LOG_TEST(log, "Added list id {}", list_id);
     }
 
     /// Once a list by id `list_id` is fully formed
@@ -331,7 +346,9 @@ public:
         }
 
         node_lists.erase(it);
-        LOG_TEST(log, "Removed list id {}", list_id);
+
+        if (enable_logging)
+            LOG_TEST(log, "Removed list id {}", list_id);
 
         return std::pair(values, types);
     }
@@ -479,10 +496,11 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(
-                state->logger(),
-                "List id: {}, child list id: {}, type: Function {}",
-                sibling_list_id, child_list_id, Func::name);
+            if (state->enableLogging())
+                LOG_TEST(
+                    state->logger(),
+                    "List id: {}, child list id: {}, type: Function {}",
+                    sibling_list_id, child_list_id, Func::name);
 
             DB::FunctionOverloadResolverPtr function = DB::FunctionFactory::instance().get(Func::name, state->getContext());
             state->addFunction(sibling_list_id, child_list_id, std::move(function));
@@ -495,7 +513,9 @@ private:
         visitorImpl(*state, [&]()
         {
             const auto name_str = KernelUtils::fromDeltaString(name);
-            LOG_TEST(state->logger(), "List id: {}, name: {}, type: Column", sibling_list_id, name_str);
+
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, name: {}, type: Column", sibling_list_id, name_str);
 
             state->addIdentifier(sibling_list_id, name_str);
         });
@@ -509,10 +529,11 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(
-                state->logger(),
-                "List id: {}, child list id: {}, type: StructExpression",
-                sibling_list_id, child_list_id);
+            if (state->enableLogging())
+                LOG_TEST(
+                    state->logger(),
+                    "List id: {}, child list id: {}, type: StructExpression",
+                    sibling_list_id, child_list_id);
 
 
             DB::FunctionOverloadResolverPtr function =
@@ -529,7 +550,9 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, type: {}", sibling_list_id, DataType::type_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: {}", sibling_list_id, DataType::type_id);
+
             state->addLiteral(sibling_list_id, value, std::make_shared<DataType>());
         });
     }
@@ -579,7 +602,8 @@ private:
                 state->addLiteral(sibling_list_id, value, std::make_shared<DB::DataTypeDecimal128>(precision, scale));
             }
 
-            LOG_TEST(state->logger(), "List id: {}, type: Decimal", sibling_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: Decimal", sibling_list_id);
         });
     }
 
@@ -588,7 +612,8 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, type: Date", sibling_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: Date", sibling_list_id);
 
             const ExtendedDayNum daynum{value};
             state->addLiteral(sibling_list_id, value, std::make_shared<DB::DataTypeDate32>());
@@ -600,7 +625,8 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, type: Timestamp", sibling_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: Timestamp", sibling_list_id);
 
             const auto datetime_value = DB::DecimalField<DB::Decimal64>(value, 6);
             state->addLiteral(sibling_list_id, datetime_value, std::make_shared<DB::DataTypeDateTime64>(6));
@@ -612,7 +638,8 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, type: TimestampNtz", sibling_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: TimestampNtz", sibling_list_id);
 
             const auto datetime_value = DB::DecimalField<DB::Decimal64>(value, 6);
             state->addLiteral(sibling_list_id, datetime_value, std::make_shared<DB::DataTypeDateTime64>(6));
@@ -625,7 +652,8 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, type: Binary", sibling_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: Binary", sibling_list_id);
 
             std::string value(reinterpret_cast<const char *>(buffer), len);
             state->addLiteral(sibling_list_id, value, std::make_shared<DB::DataTypeFixedString>(len));
@@ -637,7 +665,9 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, type: Null", sibling_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, type: Null", sibling_list_id);
+
             state->addLiteral(
                 sibling_list_id,
                 DB::Null(),
@@ -650,7 +680,8 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(state->logger(), "List id: {}, child list id: {}, type: Array", sibling_list_id, child_list_id);
+            if (state->enableLogging())
+                LOG_TEST(state->logger(), "List id: {}, child list id: {}, type: Array", sibling_list_id, child_list_id);
 
             auto [values, types] = state->extractLiteralList<DB::Array>(child_list_id);
             state->addLiteral(
@@ -669,10 +700,11 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(
-                state->logger(),
-                "List id: {}, child field list id: {}, child value list id: {}, type: Struct",
-                sibling_list_id, child_field_list_id, child_value_list_id);
+            if (state->enableLogging())
+                LOG_TEST(
+                    state->logger(),
+                    "List id: {}, child field list id: {}, child value list id: {}, type: Struct",
+                    sibling_list_id, child_field_list_id, child_value_list_id);
 
             auto [values, types] = state->extractLiteralList<DB::Tuple>(child_value_list_id);
             state->addLiteral(sibling_list_id, values, std::make_shared<DB::DataTypeTuple>(types));
@@ -688,10 +720,11 @@ private:
         ExpressionVisitorData * state = static_cast<ExpressionVisitorData *>(data);
         visitorImpl(*state, [&]()
         {
-            LOG_TEST(
-                state->logger(),
-                "List id: {}, key list id: {}, value list id: {}, type: Map",
-                sibling_list_id, key_list_id, value_list_id);
+            if (state->enableLogging())
+                LOG_TEST(
+                    state->logger(),
+                    "List id: {}, key list id: {}, value list id: {}, type: Map",
+                    sibling_list_id, key_list_id, value_list_id);
 
             auto [keys, key_types] = state->extractLiteralList<DB::Tuple>(key_list_id);
             chassert(keys.size() == key_types.size());
@@ -745,9 +778,10 @@ std::vector<DB::Field> getConstValuesFromExpression(const DB::Names & columns, c
 
 std::shared_ptr<DB::ActionsDAG> visitScanCallbackExpression(
     const ffi::Expression * expression,
-    const DB::NamesAndTypesList & expression_schema)
+    const DB::NamesAndTypesList & expression_schema,
+    bool enable_logging)
 {
-    ExpressionVisitorData data(expression_schema);
+    ExpressionVisitorData data(expression_schema, enable_logging);
     ExpressionVisitor::visit(expression, data);
     return data.getScanCallbackExpressionResult();
 }
@@ -756,7 +790,7 @@ std::shared_ptr<DB::ActionsDAG> visitExpression(
     ffi::SharedExpression * expression,
     const DB::NamesAndTypesList & expression_schema)
 {
-    ExpressionVisitorData data(expression_schema);
+    ExpressionVisitorData data(expression_schema, /* enable_logging */true);
     ExpressionVisitor::visit(expression, data);
     return data.getScanCallbackExpressionResult();
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/ExpressionVisitor.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/ExpressionVisitor.h
@@ -30,7 +30,8 @@ std::vector<DB::Field> getConstValuesFromExpression(
 /// Visit exception for scanCallback.
 std::shared_ptr<DB::ActionsDAG> visitScanCallbackExpression(
     const ffi::Expression * expression,
-    const DB::NamesAndTypesList & expression_schema);
+    const DB::NamesAndTypesList & expression_schema,
+    bool enable_logging);
 
 /// A method used in unit test.
 std::shared_ptr<DB::ActionsDAG> visitExpression(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -8,6 +8,7 @@
 #include <Core/Types.h>
 #include <Core/NamesAndTypes.h>
 #include <Core/Field.h>
+#include <Core/Settings.h>
 
 #include <Columns/IColumn.h>
 #include <Common/Exception.h>
@@ -33,6 +34,11 @@ namespace fs = std::filesystem;
 namespace DB::ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+}
+
+namespace DB::Setting
+{
+    extern const SettingsBool delta_lake_enable_expression_visitor_logging;
 }
 
 namespace ProfileEvents
@@ -82,6 +88,7 @@ public:
         const DB::ActionsDAG * filter_dag_,
         DB::IDataLakeMetadata::FileProgressCallback callback_,
         size_t list_batch_size_,
+        bool enable_expression_visitor_logging_,
         LoggerPtr log_)
         : engine(engine_)
         , snapshot(snapshot_)
@@ -93,6 +100,7 @@ public:
         , callback(callback_)
         , list_batch_size(list_batch_size_)
         , log(log_)
+        , enable_expression_visitor_logging(enable_expression_visitor_logging_)
         , thread([&, thread_group = DB::CurrentThread::getGroup()] {
             /// Attach to current query thread group, to be able to
             /// have query id in logs and metrics from scanDataFunc.
@@ -279,7 +287,7 @@ public:
 
         if (transform && !context->partition_columns.empty())
         {
-            auto parsed_transform = visitScanCallbackExpression(transform, context->expression_schema);
+            auto parsed_transform = visitScanCallbackExpression(transform, context->expression_schema, context->enable_expression_visitor_logging);
             object->data_lake_metadata = DB::DataLakeObjectMetadata{ .transform = parsed_transform };
 
             LOG_TEST(
@@ -318,6 +326,7 @@ private:
     const DB::IDataLakeMetadata::FileProgressCallback callback;
     const size_t list_batch_size;
     const LoggerPtr log;
+    const bool enable_expression_visitor_logging;
 
     std::exception_ptr scan_exception;
 
@@ -345,10 +354,12 @@ private:
 TableSnapshot::TableSnapshot(
     KernelHelperPtr helper_,
     DB::ObjectStoragePtr object_storage_,
+    DB::ContextPtr context_,
     LoggerPtr log_)
     : helper(helper_)
     , object_storage(object_storage_)
     , log(log_)
+    , enable_expression_visitor_logging(context_->getSettingsRef()[DB::Setting::delta_lake_enable_expression_visitor_logging])
 {
 }
 
@@ -420,6 +431,7 @@ DB::ObjectIterator TableSnapshot::iterate(
         filter_dag,
         callback,
         list_batch_size,
+        enable_expression_visitor_logging,
         log);
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -28,6 +28,7 @@ public:
     explicit TableSnapshot(
         KernelHelperPtr helper_,
         DB::ObjectStoragePtr object_storage_,
+        DB::ContextPtr context_,
         LoggerPtr log_);
 
     /// Get snapshot version.
@@ -63,6 +64,7 @@ private:
     const KernelHelperPtr helper;
     const DB::ObjectStoragePtr object_storage;
     const LoggerPtr log;
+    const bool enable_expression_visitor_logging;
 
     mutable KernelExternEngine engine;
     mutable KernelSnapshot snapshot;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -631,7 +631,7 @@ DataLakeMetadataPtr DeltaLakeMetadata::create(
     bool enable_delta_kernel = query_settings_ref[Setting::allow_experimental_delta_kernel_rs];
     if (supports_delta_kernel && enable_delta_kernel)
     {
-        return std::make_unique<DeltaLakeMetadataDeltaKernel>(object_storage, configuration);
+        return std::make_unique<DeltaLakeMetadataDeltaKernel>(object_storage, configuration, local_context);
     }
     else
         return std::make_unique<DeltaLakeMetadata>(object_storage, configuration, local_context);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -11,12 +11,14 @@ namespace DB
 
 DeltaLakeMetadataDeltaKernel::DeltaLakeMetadataDeltaKernel(
     ObjectStoragePtr object_storage,
-    StorageObjectStorageConfigurationWeakPtr configuration_)
+    StorageObjectStorageConfigurationWeakPtr configuration_,
+    ContextPtr context)
     : log(getLogger("DeltaLakeMetadata"))
     , table_snapshot(
         std::make_shared<DeltaLake::TableSnapshot>(
             getKernelHelper(configuration_.lock(), object_storage),
             object_storage,
+            context,
             log))
 {
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
@@ -26,7 +26,8 @@ public:
 
     DeltaLakeMetadataDeltaKernel(
         ObjectStoragePtr object_storage_,
-        StorageObjectStorageConfigurationWeakPtr configuration_);
+        StorageObjectStorageConfigurationWeakPtr configuration_,
+        ContextPtr context);
 
     bool supportsUpdate() const override { return true; }
 
@@ -47,10 +48,10 @@ public:
     static DataLakeMetadataPtr create(
         ObjectStoragePtr object_storage,
         StorageObjectStorageConfigurationWeakPtr configuration,
-        ContextPtr /* context */)
+        ContextPtr context)
     {
         auto configuration_ptr = configuration.lock();
-        return std::make_unique<DeltaLakeMetadataDeltaKernel>(object_storage, configuration);
+        return std::make_unique<DeltaLakeMetadataDeltaKernel>(object_storage, configuration, context);
     }
 
     ObjectIterator iterate(

--- a/tests/integration/test_storage_delta/configs/users.d/users.xml
+++ b/tests/integration/test_storage_delta/configs/users.d/users.xml
@@ -4,6 +4,7 @@
             <password></password>
             <profile>default</profile>
             <named_collection_control>1</named_collection_control>
+            <delta_lake_enable_expression_visitor_logging>1</delta_lake_enable_expression_visitor_logging>
         </default>
     </users>
 </clickhouse>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a setting `delta_lake_enable_expression_visitor_logging` to turn off expression visitor logs as they can be too verbose even for test log level when debugging something.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
