### PR TITLE
Try breaking `01576_alter_low_cardinality_and_select` even more

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -361,7 +361,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskLocal::readFile(const String & path,
     if (file_size && file_size3 && file_size3.value() != file_size.value())
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
-            "File size mismatch for file {}: expected {}, got {}",
+            "File size mismatch for file after creating read buffer {}: expected {}, got {}",
             backQuote(path),
             file_size.value_or(0),
             file_size3.value_or(0));

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -344,7 +344,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskLocal::readFile(const String & path,
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     auto file_size2 = fileSizeSafe(fs::path(disk_path) / path);
-    if (file_size.value() != file_size2.value())
+    if (file_size && file_size2 && file_size.value() != file_size2.value())
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "File size mismatch for file {}: expected {}, got {}",
@@ -358,13 +358,13 @@ std::unique_ptr<ReadBufferFromFileBase> DiskLocal::readFile(const String & path,
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     auto file_size3 = fileSizeSafe(fs::path(disk_path) / path);
-    if (file_size3.value() != file_size.value())
+    if (file_size && file_size3 && file_size3.value() != file_size.value())
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "File size mismatch for file {}: expected {}, got {}",
             backQuote(path),
-            file_size3.value_or(0),
-            file_size.value_or(0));
+            file_size.value_or(0),
+            file_size3.value_or(0));
 
     return r;
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Towards https://github.com/ClickHouse/ClickHouse/issues/83699
