### PR TITLE
Stricter checks for replacing table functions with cluster alternatives

### DIFF
--- a/src/Analyzer/Resolve/TableFunctionsWithClusterAlternativesVisitor.h
+++ b/src/Analyzer/Resolve/TableFunctionsWithClusterAlternativesVisitor.h
@@ -17,14 +17,24 @@ public:
             ++table_function_count;
         else if (node->getNodeType() == QueryTreeNodeType::TABLE)
             ++table_count;
+        else if (node->getNodeType() == QueryTreeNodeType::QUERY && node->as<QueryNode>()->isSubquery())
+            has_subquery = true;
+        else if (node->getNodeType() == QueryTreeNodeType::JOIN)
+            has_join = true;
     }
 
     bool needChildVisit(const QueryTreeNodePtr &, const QueryTreeNodePtr &) { return true; }
-    bool shouldReplaceWithClusterAlternatives() const { return (table_count + table_function_count) == 1; }
+    bool shouldReplaceWithClusterAlternatives() const
+    {
+        return !has_subquery && !has_join && (table_count + table_function_count) == 1;
+    }
 
 private:
     size_t table_count = 0;
     size_t table_function_count = 0;
+
+    bool has_subquery = false;
+    bool has_join = false;
 };
 
 }

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -13,10 +13,10 @@ Expression ((Project names + Projection))
   Expression
     Join
       Expression
-      Expression
         Expression (Change column names to column identifiers)
-        Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
           ReadFromSystemNumbers
+      Expression
+        Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
           ReadFromObjectStorage
 Expression ((Project names + (Projection + Change column names to column identifiers)))
   ReadFromURL

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -20,6 +20,15 @@ Expression ((Project names + Projection))
         Expression (Change column names to column identifiers)
           ReadFromSystemNumbers
       Expression
+        Expression (Change column names to column identifiers)
+          ReadFromObjectStorage
+Expression ((Project names + Projection))
+  Expression
+    Join
+      Expression
+        Expression (Change column names to column identifiers)
+          ReadFromSystemNumbers
+      Expression
         Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
           ReadFromObjectStorage
 Expression ((Project names + (Projection + Change column names to column identifiers)))

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -9,6 +9,15 @@ CreatingSets (Create sets before main query execution)
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromObjectStorage
+Expression ((Project names + Projection))
+  Expression
+    Join
+      Expression
+      Expression
+        Expression (Change column names to column identifiers)
+        Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
+          ReadFromSystemNumbers
+          ReadFromObjectStorage
 Expression ((Project names + (Projection + Change column names to column identifiers)))
   ReadFromURL
 Expression ((Project names + (Projection + Change column names to column identifiers)))

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -10,6 +10,10 @@ CreatingSets (Create sets before main query execution)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromObjectStorage
 Expression ((Project names + Projection))
+  Aggregating
+    Expression ((Before GROUP BY + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers)))))
+      ReadFromObjectStorage
+Expression ((Project names + Projection))
   Expression
     Join
       Expression

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -10,6 +10,7 @@ SET parallel_replicas_for_cluster_engines=true;
 EXPLAIN SELECT * FROM url('http://localhost:8123');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV') where c1 in (SELECT c1 FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
+EXPLAIN SELECT number FROM system.numbers n INNER JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = s.c1) LIMIT 10
 
 SET parallel_replicas_for_cluster_engines=false;
 

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -12,6 +12,7 @@ EXPLAIN SELECT * FROM url('http://localhost:8123');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV') where c1 in (SELECT c1 FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
 EXPLAIN SELECT sum(c1) FROM (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
+EXPLAIN SELECT number FROM system.numbers n JOIN s3('http://localhost:11111/test/a.tsv', 'TSV') s ON (toInt64(n.number) = toInt64(s.c1));
 EXPLAIN SELECT number FROM system.numbers n JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = toInt64(s.c1));
 
 SET parallel_replicas_for_cluster_engines=false;

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -6,11 +6,12 @@ SET enable_parallel_replicas=1;
 SET max_parallel_replicas=4;
 SET cluster_for_parallel_replicas='test_cluster_two_shards';
 SET parallel_replicas_for_cluster_engines=true;
+SET query_plan_join_swap_table=0;
 
 EXPLAIN SELECT * FROM url('http://localhost:8123');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV') where c1 in (SELECT c1 FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
-SELECT explain FROM (EXPLAIN SELECT number FROM system.numbers n JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = toInt64(s.c1))) ORDER BY explain DESC;
+EXPLAIN SELECT number FROM system.numbers n JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = toInt64(s.c1));
 
 SET parallel_replicas_for_cluster_engines=false;
 

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -10,7 +10,7 @@ SET parallel_replicas_for_cluster_engines=true;
 EXPLAIN SELECT * FROM url('http://localhost:8123');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV') where c1 in (SELECT c1 FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
-EXPLAIN SELECT number FROM system.numbers n INNER JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = s.c1) LIMIT 10
+SELECT explain FROM (EXPLAIN SELECT number FROM system.numbers n JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = toInt64(s.c1))) ORDER BY explain DESC;
 
 SET parallel_replicas_for_cluster_engines=false;
 

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -11,6 +11,7 @@ SET query_plan_join_swap_table=0;
 EXPLAIN SELECT * FROM url('http://localhost:8123');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV') where c1 in (SELECT c1 FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
+EXPLAIN SELECT sum(c1) FROM (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV'));
 EXPLAIN SELECT number FROM system.numbers n JOIN (SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV')) s ON (toInt64(n.number) = toInt64(s.c1));
 
 SET parallel_replicas_for_cluster_engines=false;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not try to substitute table functions to its cluster alternative in presence of a JOIN or subquery.
