### PR TITLE
fix SQL example for composite key type definition to match with XML

### DIFF
--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -2026,7 +2026,7 @@ or
 ```sql
 CREATE DICTIONARY (
     field1 String,
-    field2 String
+    field2 UInt32
     ...
 )
 PRIMARY KEY field1, field2


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


Fixed type of dictionary key to match with other examples