### PR TITLE
Fix logger usage in `IAccessStorage`

### DIFF
--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -567,7 +567,7 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
 
             if (skipped_not_allowed_authentication_methods)
             {
-                LOG_INFO(log, "Skipped the check for not allowed authentication methods,"
+                LOG_INFO(getLogger(), "Skipped the check for not allowed authentication methods,"
                               "check allow_no_password and allow_plaintext_password settings in the server configuration");
             }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

```
########## Short fault info ############
(version 25.6.2.5729 (official build), build id: 85E38A1CF53020B4ECDB4F9BE2F16A20141EF8F0, git hash: 90f5769bb4a5f0cdfe987044492b89d374aed6f2, architecture: aarch64) (from thread 111) Received signal 11
Signal description: Segmentation fault
Address: 0x38. Access: <not available>. Address not mapped to object.
Stack trace: 0x000000001075e249 0x00000000107b2288 0x000000001075def8 0x00000000106ca0c8 0x00000000119de41c 0x0000000013200554 0x000000001314931c 0x0000000013149724 0x0000000013150900 0x00000000131f4840 0x000000000dfd10f4 0x0000000016260638 0x0000000016260b54 0x0000000016223ad8 0x0000000016221eb0 0x0000ffffb77fd5b8 0x0000ffffb7865edc
########################################
(version 25.6.2.5729 (official build), build id: 85E38A1CF53020B4ECDB4F9BE2F16A20141EF8F0, git hash: 90f5769bb4a5f0cdfe987044492b89d374aed6f2) (from thread 111) (no query) Received signal Segmentation fault (11)
Address: 0x38. Access: <not available>. Address not mapped to object.
Stack trace: 0x000000001075e249 0x00000000107b2288 0x000000001075def8 0x00000000106ca0c8 0x00000000119de41c 0x0000000013200554 0x000000001314931c 0x0000000013149724 0x0000000013150900 0x00000000131f4840 0x000000000dfd10f4 0x0000000016260638 0x0000000016260b54 0x0000000016223ad8 0x0000000016221eb0 0x0000ffffb77fd5b8 0x0000ffffb7865edc
2.0. inlined from ./contrib/llvm-project/libcxx/include/__atomic/cxx_atomic_impl.h:317: int std::__cxx_atomic_load[abi:ne190107]<int>(std::__cxx_atomic_base_impl<int> const*, std::memory_order)
2.1. inlined from ./contrib/llvm-project/libcxx/include/__atomic/atomic_base.h:59: std::__atomic_base<int, false>::load[abi:ne190107](std::memory_order) const
2.2. inlined from ./contrib/llvm-project/libcxx/include/__atomic/atomic_base.h:62: std::__atomic_base<int, false>::operator int[abi:ne190107]() const
2.3. inlined from ./base/poco/Foundation/include/Poco/Logger.h:2354: Poco::Logger::is(int) const
2. ./ci/tmp/build/./src/Access/IAccessStorage.cpp:570: DB::IAccessStorage::authenticateImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, DB::ClientInfo const&, bool, bool, bool) const @ 0x000000001075e249
3.0. inlined from ./src/Access/IAccessStorage.cpp:528: DB::IAccessStorage::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, DB::ClientInfo const&, bool, bool, bool) const
3. ./ci/tmp/build/./src/Access/MultipleAccessStorage.cpp:452: DB::MultipleAccessStorage::authenticateImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, DB::ClientInfo const&, bool, bool, bool) const @ 0x00000000107b2288
4. ./ci/tmp/build/./src/Access/IAccessStorage.cpp:515: DB::IAccessStorage::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, DB::ClientInfo const&, bool, bool) const @ 0x000000001075def8
5. ./ci/tmp/build/./src/Access/AccessControl.cpp:632: DB::AccessControl::authenticate(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ClientInfo const&) const @ 0x00000000106ca0c8
6. ./ci/tmp/build/./src/Interpreters/Session.cpp:384: DB::Session::authenticate(DB::Credentials const&, Poco::Net::SocketAddress const&, std::vector<String, std::allocator<String>> const&) @ 0x00000000119de41c
7. ./ci/tmp/build/./src/Server/HTTP/authenticateUserByHTTP.cpp:275: DB::authenticateUserByHTTP(DB::HTTPServerRequest const&, DB::HTMLForm const&, DB::HTTPServerResponse&, DB::Session&, std::unique_ptr<DB::Credentials, std::default_delete<DB::Credentials>>&, DB::HTTPHandlerConnectionConfig const&, std::shared_ptr<DB::Context const>, std::shared_ptr<Poco::Logger>) @ 0x0000000013200554
8. ./ci/tmp/build/./src/Server/HTTPHandler.cpp:208: DB::HTTPHandler::authenticateUser(DB::HTTPServerRequest&, DB::HTMLForm&, DB::HTTPServerResponse&) @ 0x000000001314931c
9. ./ci/tmp/build/./src/Server/HTTPHandler.cpp:224: DB::HTTPHandler::processQuery(DB::HTTPServerRequest&, DB::HTMLForm&, DB::HTTPServerResponse&, DB::HTTPHandler::Output&, std::optional<DB::CurrentThread::QueryScope>&, StrongTypedef<unsigned long, ProfileEvents::EventTag> const&) @ 0x0000000013149724
10. ./ci/tmp/build/./src/Server/HTTPHandler.cpp:759: DB::HTTPHandler::handleRequest(DB::HTTPServerRequest&, DB::HTTPServerResponse&, StrongTypedef<unsigned long, ProfileEvents::EventTag> const&) @ 0x0000000013150900
11. ./ci/tmp/build/./src/Server/HTTP/HTTPServerConnection.cpp:71: DB::HTTPServerConnection::run() @ 0x00000000131f4840
12. ./src/Server/TCPProtocolStackHandler.h:38: DB::TCPProtocolStackHandler::run() @ 0x000000000dfd10f4
13. ./ci/tmp/build/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x0000000016260638
14. ./ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x0000000016260b54
15. ./ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x0000000016223ad8
16. ./base/poco/Foundation/src/Thread_POSIX.cpp:335: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000016221eb0
17. ? @ 0x000000000007d5b8
18. ? @ 0x00000000000e5edc
```

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logger usage in `IAccessStorage`.


