### PR TITLE
Revert "Support DESCRIBE SELECT without parentheses around SELECT"

### DIFF
--- a/docs/en/sql-reference/statements/describe-table.md
+++ b/docs/en/sql-reference/statements/describe-table.md
@@ -65,26 +65,6 @@ The second query additionally shows subcolumns:
 └───────────┴───────────────────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┴──────────────┘
 ```
 
-The DESCRIBE statement can also be used with subqueries or scalar expressions:
-
-``` SQL
-DESCRIBE SELECT 1 FORMAT TSV;
-```
-
-or
-
-``` SQL
-DESCRIBE (SELECT 1) FORMAT TSV;
-```
-
-Result:
-
-``` text
-1       UInt8
-```
-
-This usage returns metadata about the result columns of the specified query or subquery. It is useful for understanding the structure of complex queries before execution.
-
 **See Also**
 
 - [describe_include_subcolumns](../../operations/settings/settings.md#describe_include_subcolumns) setting.

--- a/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -135,7 +135,7 @@ BlockIO InterpreterDescribeQuery::execute()
 void InterpreterDescribeQuery::fillColumnsFromSubquery(const ASTTableExpression & table_expression)
 {
     SharedHeader sample_block;
-    auto select_query = table_expression.subquery;
+    auto select_query = table_expression.subquery->children.at(0);
     auto current_context = getContext();
 
     if (settings[Setting::allow_experimental_analyzer])

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -1,6 +1,4 @@
-#include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
-#include <Parsers/ASTTablesInSelectQuery.h>
 
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserDescribeTableQuery.h>
@@ -21,23 +19,17 @@ bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserSetQuery parser_settings(true);
 
-    ASTPtr select;
+    ASTPtr database;
+    ASTPtr table;
 
     if (!s_describe.ignore(pos, expected) && !s_desc.ignore(pos, expected))
         return false;
 
     auto query = std::make_shared<ASTDescribeQuery>();
+
     s_table.ignore(pos, expected);
 
-    if (ParserSelectWithUnionQuery().parse(pos, select, expected))
-    {
-        auto table_expr = std::make_shared<ASTTableExpression>();
-        table_expr->subquery = select;
-        table_expr->children.push_back(select);
-        query->table_expression = table_expr;
-        query->children.push_back(query->table_expression);
-    }
-    else if (!ParserTableExpression().parse(pos, query->table_expression, expected))
+    if (!ParserTableExpression().parse(pos, query->table_expression, expected))
         return false;
 
     /// For compatibility with SELECTs, where SETTINGS can be in front of FORMAT

--- a/tests/queries/0_stateless/03445_describe_select.reference
+++ b/tests/queries/0_stateless/03445_describe_select.reference
@@ -1,4 +1,0 @@
-1	UInt8					
-1	UInt8					
-number	UInt64					
-example	String					

--- a/tests/queries/0_stateless/03445_describe_select.sql
+++ b/tests/queries/0_stateless/03445_describe_select.sql
@@ -1,6 +1,0 @@
-DESCRIBE SELECT 1 FORMAT TSV;
-DESCRIBE (SELECT 1) FORMAT TSV;
-
-CREATE TABLE test_table (number UInt64, example String) ENGINE = Memory;
-DESCRIBE test_table FORMAT TSV;
-DROP TABLE test_table;


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#82947

Fixes https://github.com/ClickHouse/ClickHouse/issues/84338