### PR TITLE
Fix formatting of CREATE USER with query parameters

### DIFF
--- a/src/Parsers/Access/ASTCreateUserQuery.cpp
+++ b/src/Parsers/Access/ASTCreateUserQuery.cpp
@@ -214,14 +214,9 @@ ASTPtr ASTCreateUserQuery::clone() const
 void ASTCreateUserQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, FormatState &, FormatStateStacked) const
 {
     if (attach)
-    {
         ostr << "ATTACH USER";
-    }
     else
-    {
-        ostr << (alter ? "ALTER USER" : "CREATE USER")
-                   ;
-    }
+        ostr << (alter ? "ALTER USER" : "CREATE USER");
 
     if (if_exists)
         ostr << " IF EXISTS";
@@ -234,9 +229,7 @@ void ASTCreateUserQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
     names->format(ostr, format);
 
     if (!storage_name.empty())
-        ostr
-                    << " IN "
-                    << backQuoteIfNeed(storage_name);
+        ostr << " IN " << backQuoteIfNeed(storage_name);
 
     formatOnCluster(ostr, format);
 
@@ -247,25 +240,19 @@ void ASTCreateUserQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
     {
         // If identification (auth method) is missing from query, we should serialize it in the form of `NO_PASSWORD` unless it is alter query
         if (!alter)
-        {
             ostr << " IDENTIFIED WITH no_password";
-        }
     }
     else
     {
         if (add_identified_with)
-        {
             ostr << " ADD";
-        }
 
         ostr << " IDENTIFIED";
         formatAuthenticationData(authentication_methods, ostr, format);
     }
 
     if (global_valid_until)
-    {
         formatValidUntil(*global_valid_until, ostr, format);
-    }
 
     if (hosts)
         formatHosts(nullptr, *hosts, ostr, format);

--- a/src/Parsers/Access/ASTUserNameWithHost.cpp
+++ b/src/Parsers/Access/ASTUserNameWithHost.cpp
@@ -16,11 +16,14 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-void ASTUserNameWithHost::formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const
+void ASTUserNameWithHost::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
-    ostr << backQuoteIfNeed(getBaseName());
-    if (auto pattern = getHostPattern(); !pattern.empty())
-        ostr << "@" << backQuoteIfNeed(pattern);
+    username->format(ostr, settings);
+    if (host_pattern)
+    {
+        ostr << "@";
+        host_pattern->format(ostr, settings);
+    }
 }
 
 String ASTUserNameWithHost::toString() const
@@ -65,11 +68,9 @@ ASTUserNameWithHost::ASTUserNameWithHost(ASTPtr && name_, String && host_pattern
 
 String ASTUserNameWithHost::getBaseName() const
 {
-    if (children.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "ASTUserNameWithHost is empty");
-
-    chassert(username);
-
+    chassert(!children.empty());
+    if (!username)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Username is not set");
     return getStringFromAST(username);
 }
 

--- a/src/Parsers/Access/ASTUserNameWithHost.h
+++ b/src/Parsers/Access/ASTUserNameWithHost.h
@@ -18,9 +18,7 @@ public:
     explicit ASTUserNameWithHost(const String & name_);
     explicit ASTUserNameWithHost(ASTPtr && name_ast_, String && host_pattern_ = "");
 
-    String getBaseName() const;
     String getHostPattern() const;
-
     String toString() const;
 
     String getID(char) const override { return "UserNameWithHost"; }
@@ -28,10 +26,11 @@ public:
     void replace(String name_);
 
 protected:
-    void formatImpl(WriteBuffer & ostr, const FormatSettings &, FormatState &, FormatStateStacked) const override;
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 
 private:
     String getStringFromAST(const ASTPtr & ast) const;
+    String getBaseName() const;
 
     ASTPtr username;
     ASTPtr host_pattern;

--- a/tests/queries/0_stateless/03573_create_user_query_parameters_format.reference
+++ b/tests/queries/0_stateless/03573_create_user_query_parameters_format.reference
@@ -1,0 +1,5 @@
+CREATE USER {username:Identifier} IDENTIFIED WITH no_password
+CREATE USER {username:Identifier}@'clickhouse.com' IDENTIFIED WITH no_password HOST LIKE 'clickhouse.com'
+CREATE USER {username:Identifier}@'127.0.0.1' IDENTIFIED WITH no_password HOST LOCAL
+CREATE USER {username:Identifier}@'192.168.0.1' IDENTIFIED WITH no_password HOST LIKE '192.168.0.1'
+CREATE USER foo@'127.0.0.1' IDENTIFIED WITH no_password HOST LOCAL

--- a/tests/queries/0_stateless/03573_create_user_query_parameters_format.sh
+++ b/tests/queries/0_stateless/03573_create_user_query_parameters_format.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_FORMAT <<<"CREATE USER {username:Identifier} IDENTIFIED WITH no_password"
+$CLICKHOUSE_FORMAT <<<"CREATE USER {username:Identifier}@'clickhouse.com' IDENTIFIED WITH no_password"
+$CLICKHOUSE_FORMAT <<<"CREATE USER {username:Identifier}@'127.0.0.1' IDENTIFIED WITH no_password"
+$CLICKHOUSE_FORMAT <<<"CREATE USER {username:Identifier}@'192.168.0.1' IDENTIFIED WITH no_password"
+$CLICKHOUSE_FORMAT <<<"CREATE USER foo@'127.0.0.1' IDENTIFIED WITH no_password"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix formatting of CREATE USER with query parameters (i.e. `CREATE USER {username:Identifier} IDENTIFIED WITH no_password`)

Fixes: #81387 (cc @Diskein )