### PR TITLE
Fix flaky test_disk_checker/test.py::test_disk_readonly_status

### DIFF
--- a/tests/integration/test_disk_checker/config.xml
+++ b/tests/integration/test_disk_checker/config.xml
@@ -7,6 +7,10 @@
                 <type>local</type>
                 <path>/var/lib/clickhouse/path1/</path>
             </test1>
+            <test2>
+                <type>local</type>
+                <path>/var/lib/clickhouse/path2/</path>
+            </test2>
         </disks>
         <policies>
             <test1>
@@ -16,6 +20,13 @@
                     </main>
                 </volumes>
             </test1>
+            <test2>
+                <volumes>
+                    <main>
+                        <disk>test2</disk>
+                    </main>
+                </volumes>
+            </test2>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -12,7 +12,7 @@ def started_cluster():
             "test_disk_checker",
             main_configs=["config.xml"],
             with_minio=False,
-            with_zookeeper=True,
+            with_zookeeper=False,
             with_remote_database_disk=False,
             stay_alive=True,
         )

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -58,7 +58,7 @@ def test_disk_readonly_status(started_cluster):
             func=lambda: get_metric_value(node, "ReadonlyDisks"),
             condition=lambda value: value == 1,
             max_attempts=10,
-            delay=1,
+            delay=5,
         )
 
         # restore the disk to writable state
@@ -69,7 +69,7 @@ def test_disk_readonly_status(started_cluster):
             func=lambda: get_metric_value(node, "ReadonlyDisks"),
             condition=lambda value: value == 0,
             max_attempts=10,
-            delay=1,
+            delay=5,
         )
     finally:
         try:

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -50,9 +50,8 @@ def test_disk_readonly_status(started_cluster):
         node = cluster.instances["test_disk_checker"]
         disk_path = "/var/lib/clickhouse/path1"
 
-        # a hack to make disk readonly
-        node.exec_in_container(["mount", "--bind", disk_path, disk_path])
-        node.exec_in_container(["mount", "-o", "remount,ro,bind", disk_path])
+        # make disk readonly
+        node.exec_in_container(["chmod", "550", disk_path])
 
         # assert for metric with retries
         wait_condition(
@@ -63,7 +62,7 @@ def test_disk_readonly_status(started_cluster):
         )
 
         # restore the disk to writable state
-        node.exec_in_container(["mount", "-o", "remount,rw,bind", disk_path])
+        node.exec_in_container(["chmod", "750", disk_path])
 
         # again assert for metric with retries
         wait_condition(
@@ -74,7 +73,7 @@ def test_disk_readonly_status(started_cluster):
         )
     finally:
         try:
-            node.exec_in_container(["umount", disk_path])
+            node.exec_in_container(["chmod", "750", disk_path])
         except:
             pass
 

--- a/tests/integration/test_disk_checker/test.py
+++ b/tests/integration/test_disk_checker/test.py
@@ -53,7 +53,7 @@ def test_disk_readonly_status(started_cluster):
         disk_path = "/var/lib/clickhouse/path1"
 
         # make disk readonly
-        node.exec_in_container(["chmod", "110", disk_path])
+        node.exec_in_container(["chmod", "555", disk_path])
 
         # assert for metric with retries
         wait_condition(
@@ -64,7 +64,7 @@ def test_disk_readonly_status(started_cluster):
         )
 
         # restore the disk to writable state
-        node.exec_in_container(["chmod", "750", disk_path])
+        node.exec_in_container(["chmod", "755", disk_path])
 
         # again assert for metric with retries
         wait_condition(
@@ -75,7 +75,7 @@ def test_disk_readonly_status(started_cluster):
         )
     finally:
         try:
-            node.exec_in_container(["chmod", "750", disk_path])
+            node.exec_in_container(["chmod", "755", disk_path])
         except:
             pass
 


### PR DESCRIPTION
Add retries of `mount -o ro ...` that can fail with `mount point is busy` due to concurrent write check

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
