### PR TITLE
Disable `00984_parser_stack_overflow` under heavy sanitizers

### DIFF
--- a/tests/queries/0_stateless/00984_parser_stack_overflow.sh
+++ b/tests/queries/0_stateless/00984_parser_stack_overflow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-asan
+# Tags: no-asan, no-msan, no-tsan
 
 # Such a huge timeout mostly for debug build.
 CLICKHOUSE_CURL_TIMEOUT=60


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=84317&sha=780fd89d029ac3fc31a1281019881a4a415e40f0&name_0=PR

curl timeout expired