### PR TITLE
Virtual column for `DeltaLake` table version

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
@@ -59,6 +59,8 @@ public:
         size_t list_batch_size,
         ContextPtr context) const override;
 
+    std::shared_ptr<DeltaLake::TableSnapshot> getTableSnapshot() const { return table_snapshot; }
+
 private:
     const LoggerPtr log;
     const std::shared_ptr<DeltaLake::TableSnapshot> table_snapshot;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 #if USE_PARQUET && USE_DELTA_KERNEL_RS
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h>
+#include <Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h>
 #endif
 #include <Common/SipHash.h>
 #include <Core/Settings.h>
@@ -275,7 +276,7 @@ Chunk StorageObjectStorageSource::generate()
 #if USE_PARQUET && USE_DELTA_KERNEL_RS
             if (configuration->isDataLakeConfiguration())
             {
-                if (auto * delta_metadata = dynamic_cast<const DeltaLakeMetadataDeltaKernel*>(configuration->getExternalMetadata()))
+                if (const auto * delta_metadata = dynamic_cast<const DeltaLakeMetadataDeltaKernel*>(configuration->getExternalMetadata()))
                 {
                     if (auto table_snapshot = delta_metadata->getTableSnapshot())
                         delta_lake_version = table_snapshot->getVersion();

--- a/src/Storages/VirtualColumnUtils.h
+++ b/src/Storages/VirtualColumnUtils.h
@@ -77,7 +77,8 @@ VirtualColumnsDescription getVirtualsForFileLikeStorage(
     const ContextPtr & context,
     const std::string & sample_path = "",
     std::optional<FormatSettings> format_settings_ = std::nullopt,
-    bool is_data_lake = false);
+    bool is_data_lake = false,
+    bool is_delta_lake = false);
 
 std::optional<ActionsDAG> createPathAndFileFilterDAG(const ActionsDAG::Node * predicate, const NamesAndTypesList & virtual_columns);
 
@@ -105,6 +106,7 @@ struct VirtualsForFileLikeStorage
     const String * filename { nullptr };
     std::optional<Poco::Timestamp> last_modified { std::nullopt };
     const String * etag { nullptr };
+    std::optional<UInt64> delta_lake_version { std::nullopt };
 };
 
 void addRequestedFileLikeStorageVirtualsToChunk(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Adds `_delta_lake_version` virtual field to delta lake table query

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

```SQL
SELECT
    *,
    'snapshot',
    _file,
    _delta_lake_version
FROM deltaLake('s3://pjhampton/deltalake2', '[HIDDEN]', '[HIDDEN]')
LIMIT 1
FORMAT Vertical

Query id: ce16c644-4e3c-4134-a5bd-fd983e89554a

Row 1:
──────
id:                  416b1f47-4485-4ec3-b0e0-c00b2f31c184
name:                ROVTJ
age:                 32
created_at:          2025-07-22 18:41:01.127915
now():               2025-07-25 14:53:58
_file:               part-00001-2c8063b1-fce3-403a-8a7a-a14156f2d0d8-c000.snappy.parquet
_delta_lake_version: 28252

1 row in set. Elapsed: 9.408 sec. 
```
