### PR TITLE
fix server constants folding in analyzer

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolveScope.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolveScope.cpp
@@ -34,10 +34,16 @@ IdentifierResolveScope::IdentifierResolveScope(QueryTreeNodePtr scope_node_, Ide
 
     if (auto * union_node = scope_node->as<UnionNode>())
     {
+        if (parent_scope && parent_scope->context)
+            union_node->getMutableContext()->setDistributed(parent_scope->context->isDistributed());
+
         context = union_node->getContext();
     }
     else if (auto * query_node = scope_node->as<QueryNode>())
     {
+        if (parent_scope && parent_scope->context)
+            query_node->getMutableContext()->setDistributed(parent_scope->context->isDistributed());
+
         context = query_node->getContext();
         group_by_use_nulls = context->getSettingsRef()[Setting::group_by_use_nulls]
             && (query_node->isGroupByWithGroupingSets() || query_node->isGroupByWithRollup() || query_node->isGroupByWithCube());

--- a/tests/queries/0_stateless/03577_server_constant_folding.reference
+++ b/tests/queries/0_stateless/03577_server_constant_folding.reference
@@ -1,0 +1,82 @@
+-- IN subquery
+1	1
+2	2
+3	3
+-- GLOBAL IN subquery
+1	0
+2	0
+3	0
+-- IN union
+1	1
+1	2
+2	2
+2	4
+3	3
+3	6
+-- GLOBAL IN union
+1	0
+2	0
+3	0
+-- IN CTE subquery
+1	1
+2	2
+3	3
+-- GLOBAL IN CTE subquery
+1	0
+2	0
+3	0
+-- IN CTE union
+1	1
+1	2
+2	2
+2	4
+3	3
+3	6
+-- GLOBAL IN CTE union
+1	0
+2	0
+3	0
+-- JOIN subquery, analyzer
+1	1
+2	2
+3	3
+-- JOIN subquery, w/o analyzer
+1	1
+2	2
+3	3
+-- GLOBAL JOIN subquery, analyzer
+1	0
+2	0
+3	0
+-- GLOBAL JOIN subquery, w/o analyzer
+1	0
+2	0
+3	0
+-- JOIN union, analyzer
+1	1
+1	2
+2	2
+2	4
+3	3
+3	6
+-- JOIN union, w/o analyzer
+1	1
+1	2
+2	2
+2	4
+3	3
+3	6
+-- GLOBAL JOIN union, analyzer
+1	0
+1	0
+2	0
+2	0
+3	0
+3	0
+-- GLOBAL JOIN union, w/o analyzer
+1	0
+1	0
+2	0
+2	0
+3	0
+3	0

--- a/tests/queries/0_stateless/03577_server_constant_folding.sql
+++ b/tests/queries/0_stateless/03577_server_constant_folding.sql
@@ -1,0 +1,177 @@
+SET prefer_localhost_replica = 0;
+
+SELECT '-- IN subquery';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number IN (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+)
+ORDER BY 1, 2;
+
+SELECT '-- GLOBAL IN subquery';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number GLOBAL IN (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+)
+ORDER BY 1, 2;
+
+SELECT '-- IN union';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number IN (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+    UNION ALL
+    SELECT number FROM numbers(10) WHERE number = shardNum() * 2
+)
+ORDER BY 1, 2;
+
+SELECT '-- GLOBAL IN union';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number GLOBAL IN (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+    UNION ALL
+    SELECT number FROM numbers(10) WHERE number = shardNum() * 2
+)
+ORDER BY 1, 2;
+
+SELECT '-- IN CTE subquery';
+
+WITH flt AS (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+)
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number IN (flt)
+ORDER BY 1, 2;
+
+SELECT '-- GLOBAL IN CTE subquery';
+
+WITH flt AS (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+)
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number GLOBAL IN (flt)
+ORDER BY 1, 2;
+
+SELECT '-- IN CTE union';
+
+WITH flt AS (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+    UNION ALL
+    SELECT number FROM numbers(10) WHERE number = shardNum() * 2
+)
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number IN (flt)
+ORDER BY 1, 2;
+
+SELECT '-- GLOBAL IN CTE union';
+
+WITH flt AS (
+    SELECT number FROM numbers(10) WHERE number = shardNum()
+    UNION ALL
+    SELECT number FROM numbers(10) WHERE number = shardNum() * 2
+)
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+WHERE number GLOBAL IN (flt)
+ORDER BY 1, 2;
+
+-- Old analyzer has some issues with aliases for `remote()`, so the queries
+-- executed w/o are slightly different, and required mostly to confirm the
+-- same behavior for resolving shardNum() result value.
+
+SELECT '-- JOIN subquery, analyzer';
+
+SELECT shardNum(), tab.number
+FROM remote('127.0.0.{1..3}', numbers(100)) tab
+    ALL JOIN (
+        SELECT number FROM numbers(10) WHERE number = shardNum()
+    ) flt ON tab.number = flt.number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 1;
+
+SELECT '-- JOIN subquery, w/o analyzer';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+    ALL JOIN (
+        SELECT number AS flt_number FROM numbers(10) WHERE number = shardNum()
+    ) flt ON number = flt_number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 0, joined_subquery_requires_alias = 0;
+
+SELECT '-- GLOBAL JOIN subquery, analyzer';
+
+SELECT shardNum(), tab.number
+FROM remote('127.0.0.{1..3}', numbers(100)) tab
+    GLOBAL ALL JOIN (
+        SELECT number FROM numbers(10) WHERE number = shardNum()
+    ) flt ON tab.number = flt.number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 1;
+
+SELECT '-- GLOBAL JOIN subquery, w/o analyzer';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+    GLOBAL ALL JOIN (
+        SELECT number AS flt_number FROM numbers(10) WHERE number = shardNum()
+    ) flt ON number = flt_number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 0, joined_subquery_requires_alias = 0;
+
+SELECT '-- JOIN union, analyzer';
+
+SELECT shardNum(), tab.number
+FROM remote('127.0.0.{1..3}', numbers(100)) tab
+    ALL JOIN (
+        SELECT number FROM numbers(10) WHERE number = shardNum()
+        UNION ALL
+        SELECT number FROM numbers(10) WHERE number = shardNum() * 2
+    ) flt ON tab.number = flt.number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 1;
+
+SELECT '-- JOIN union, w/o analyzer';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+    ALL JOIN (
+        SELECT number AS flt_number FROM numbers(10) WHERE number = shardNum()
+        UNION ALL
+        SELECT number AS flt_number FROM numbers(10) WHERE number = shardNum() * 2
+    ) flt ON number = flt_number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 0, joined_subquery_requires_alias = 0;
+
+SELECT '-- GLOBAL JOIN union, analyzer';
+
+SELECT shardNum(), tab.number
+FROM remote('127.0.0.{1..3}', numbers(100)) tab
+    GLOBAL ALL JOIN (
+        SELECT number FROM numbers(10) WHERE number = shardNum()
+        UNION ALL
+        SELECT number FROM numbers(10) WHERE number = shardNum() * 2
+    ) flt ON tab.number = flt.number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 1;
+
+SELECT '-- GLOBAL JOIN union, w/o analyzer';
+
+SELECT shardNum(), number
+FROM remote('127.0.0.{1..3}', numbers(100))
+    GLOBAL ALL JOIN (
+        SELECT number AS flt_number FROM numbers(10) WHERE number = shardNum()
+        UNION ALL
+        SELECT number AS flt_number FROM numbers(10) WHERE number = shardNum() * 2
+    ) flt ON number = flt_number
+ORDER BY 1, 2
+SETTINGS enable_analyzer = 0, joined_subquery_requires_alias = 0;


### PR DESCRIPTION
Some functions allow constant folding depending on if current context is distributed or not (e.g. server constants like hostName() or scalars like shardNum()), but the analyzer don't propagate `is_distributed` property of the context, when constructing new resolve scopes for subqueries. This leads to server constant functions in subqueries being replaced with their values on initiator node while running QueryAnalysisPass.

This patch updates the behavior of building `IdentifierResolveScope`s for subqueries, by always propagating `is_distributed` property of the parent's context.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix resolving host-dependent functions like shardNum() in subqueries on initiator node.