### PR TITLE
Replace error with warning during object storage table attaching

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -111,15 +111,6 @@ StorageObjectStorage::StorageObjectStorage(
         && !configuration->isDataLakeConfiguration();
     const bool do_lazy_init = lazy_init && !need_resolve_columns_or_format && !need_resolve_sample_path;
 
-    LOG_DEBUG(
-        &Poco::Logger::get("StorageObjectStorage"),
-        "Creating storage {} need_resolve_columns_or_format: {}, need_resolve_sample_path: {}, do_lazy_init: {}",
-        configuration->getEngineName(),
-        need_resolve_columns_or_format,
-        need_resolve_sample_path,
-        do_lazy_init);
-
-
     bool updated_configuration = false;
     try
     {

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -111,6 +111,15 @@ StorageObjectStorage::StorageObjectStorage(
         && !configuration->isDataLakeConfiguration();
     const bool do_lazy_init = lazy_init && !need_resolve_columns_or_format && !need_resolve_sample_path;
 
+    LOG_DEBUG(
+        &Poco::Logger::get("StorageObjectStorage"),
+        "Creating storage {} need_resolve_columns_or_format: {}, need_resolve_sample_path: {}, do_lazy_init: {}",
+        configuration->getEngineName(),
+        need_resolve_columns_or_format,
+        need_resolve_sample_path,
+        do_lazy_init);
+
+
     bool updated_configuration = false;
     try
     {
@@ -132,7 +141,7 @@ StorageObjectStorage::StorageObjectStorage(
         {
             throw;
         }
-        tryLogCurrentException(log);
+        tryLogCurrentException(log, /*start of message = */ "", LogsLevel::warning);
     }
 
     /// We always update configuration on read for table engine,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
