### PR TITLE
Make HTTPHandler's logger protected, enable use in subclasses

### DIFF
--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -60,6 +60,9 @@ public:
 
     virtual std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) = 0;
 
+protected:
+    LoggerPtr log;
+
 private:
     struct Output
     {
@@ -118,7 +121,6 @@ private:
     };
 
     IServer & server;
-    LoggerPtr log;
 
     /// It is the name of the server that will be sent in an http-header X-ClickHouse-Server-Display-Name.
     String server_display_name;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Simply changing `HTTPHandler.log` from `private` to `protected` so subclasses can use it directly.  Since it's built with `name`, that's already set up to make the log entries intuitive.

Without this change, my custom HTTP handler needs to make its own `getLogger(name)` call, which seems like a waste since `log` is right there, ready to roll.