### PR TITLE
docs: typo in table_engines.md

### DIFF
--- a/docs/en/operations/system-tables/table_engines.md
+++ b/docs/en/operations/system-tables/table_engines.md
@@ -3,10 +3,10 @@ description: 'System table containing descriptions of table engines supported by
   server and the features they support.'
 keywords: ['system table', 'table_engines']
 slug: /operations/system-tables/table_engines
-title: 'system.table_engine'
+title: 'system.table_engines'
 ---
 
-# system.table_engine
+# system.table_engines
 
 Contains description of table engines supported by server and their feature support information.
 


### PR DESCRIPTION
### Changelog category:
- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

fix: typo in `system.table_engines` title (was `system.table_engine`, should be `system.table_engines`)