### PR TITLE
Don't do anything with TTL if it doesn't exists anymore

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1624,26 +1624,30 @@ UInt64 IMergeTreeDataPart::readExistingRowsCount()
 
 void IMergeTreeDataPart::loadTTLInfos()
 {
-    if (auto in = readFileIfExists("ttl.txt"))
+    auto metadata_snapshot = getMetadataSnapshot();
+    if (metadata_snapshot->hasAnyTTL())
     {
-        assertString("ttl format version: ", *in);
-        size_t format_version;
-        readText(format_version, *in);
-        assertChar('\n', *in);
-
-        if (format_version == 1)
+        if (auto in = readFileIfExists("ttl.txt"))
         {
-            try
+            assertString("ttl format version: ", *in);
+            size_t format_version;
+            readText(format_version, *in);
+            assertChar('\n', *in);
+
+            if (format_version == 1)
             {
-                ttl_infos.read(*in);
+                try
+                {
+                    ttl_infos.read(*in);
+                }
+                catch (const JSONException &)
+                {
+                    throw Exception(ErrorCodes::BAD_TTL_FILE, "Error while parsing file ttl.txt in part: {}", name);
+                }
             }
-            catch (const JSONException &)
-            {
-                throw Exception(ErrorCodes::BAD_TTL_FILE, "Error while parsing file ttl.txt in part: {}", name);
-            }
+            else
+                throw Exception(ErrorCodes::BAD_TTL_FILE, "Unknown ttl format version: {}", toString(format_version));
         }
-        else
-            throw Exception(ErrorCodes::BAD_TTL_FILE, "Unknown ttl format version: {}", toString(format_version));
     }
 }
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -469,7 +469,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     }
 
     const auto & local_part_min_ttl = global_ctx->new_data_part->ttl_infos.part_min_ttl;
-    if (local_part_min_ttl && local_part_min_ttl <= global_ctx->time_of_merge)
+    if (global_ctx->metadata_snapshot->hasAnyTTL() && local_part_min_ttl && local_part_min_ttl <= global_ctx->time_of_merge)
         ctx->need_remove_expired_values = true;
 
     if (ctx->need_remove_expired_values && global_ctx->ttl_merges_blocker->isCancelled())

--- a/tests/queries/0_stateless/03578_merges_with_and_without_ttl.reference
+++ b/tests/queries/0_stateless/03578_merges_with_and_without_ttl.reference
@@ -1,0 +1,1 @@
+Got merge algorithm Vertical

--- a/tests/queries/0_stateless/03578_merges_with_and_without_ttl.sh
+++ b/tests/queries/0_stateless/03578_merges_with_and_without_ttl.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-random-merge-tree-settings
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_with_ttl"
+
+$CLICKHOUSE_CLIENT --query "CREATE TABLE test_with_ttl (d DateTime, a Int) engine = MergeTree order by tuple() TTL d + INTERVAL 1 SECOND settings min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage=0, vertical_merge_algorithm_min_columns_to_activate=1, vertical_merge_algorithm_min_rows_to_activate=1"
+
+$CLICKHOUSE_CLIENT --query "SYSTEM STOP MERGES test_with_ttl"
+
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 1)"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 2)"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 3)"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 4)"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 5)"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 6)"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_with_ttl VALUES (now(), 7)"
+
+$CLICKHOUSE_CLIENT --query "ALTER TABLE test_with_ttl REMOVE TTL"
+
+# to trigger TTL
+# NOTE: it doesn't make test flaky, if TTL is not ready than merge will be Vertical by default
+sleep 3
+
+$CLICKHOUSE_CLIENT --query "SYSTEM START MERGES test_with_ttl"
+
+iterations=30
+for _ in $(seq 1 $iterations); do
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+    merge_type=$($CLICKHOUSE_CLIENT --query "SELECT merge_algorithm FROM system.part_log WHERE table = 'test_with_ttl' and database='${CLICKHOUSE_DATABASE}' and event_type = 'MergeParts' LIMIT 1")
+    if [[ "$merge_type" != "" && "$merge_type" != "Undecided" ]]; then
+        break;
+    fi
+    sleep 1
+done
+
+echo "Got merge algorithm $merge_type"
+
+$CLICKHOUSE_CLIENT --query "DETACH TABLE test_with_ttl"
+$CLICKHOUSE_CLIENT --query "ATTACH TABLE test_with_ttl"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_with_ttl"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now if all TTL are removed from table MergeTree will do nothing related to TTL.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
