### PR TITLE
Support iceberg writes to read from pyiceberg

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6918,7 +6918,7 @@ Allow experimental delta-kernel-rs implementation.
     DECLARE(Bool, allow_experimental_insert_into_iceberg, false, R"(
 Allow to execute `insert` queries into iceberg.
 )", EXPERIMENTAL) \
-    DECLARE(Bool, write_full_path_insert_iceberg, false, R"(
+    DECLARE(Bool, write_full_path_in_iceberg_metadata, false, R"(
 Write full paths (including s3://) into iceberg metadata files.
 )", EXPERIMENTAL) \
     DECLARE(Bool, make_distributed_plan, false, R"(

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6918,6 +6918,9 @@ Allow experimental delta-kernel-rs implementation.
     DECLARE(Bool, allow_experimental_insert_into_iceberg, false, R"(
 Allow to execute `insert` queries into iceberg.
 )", EXPERIMENTAL) \
+    DECLARE(Bool, write_full_path_insert_iceberg, false, R"(
+Write full paths (including s3://) into iceberg metadata files.
+)", EXPERIMENTAL) \
     DECLARE(Bool, make_distributed_plan, false, R"(
 Make distributed query plan.
 )", EXPERIMENTAL) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -59,7 +59,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"opentelemetry_trace_cpu_scheduling", false, false, "New setting to trace `cpu_slot_preemption` feature."},
             {"vector_search_with_rescoring", true, true, "New setting."},
             {"delta_lake_enable_expression_visitor_logging", false, false, "New setting"},
-            {"write_full_path_insert_iceberg", false, false, "New setting."},
+            {"write_full_path_in_iceberg_metadata", false, false, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.7",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -59,6 +59,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"opentelemetry_trace_cpu_scheduling", false, false, "New setting to trace `cpu_slot_preemption` feature."},
             {"vector_search_with_rescoring", true, true, "New setting."},
             {"delta_lake_enable_expression_visitor_logging", false, false, "New setting"},
+            {"write_full_path_insert_iceberg", false, false, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.7",
         {
@@ -81,7 +82,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"distributed_plan_force_shuffle_aggregation", 0, 0, "New experimental setting"},
             {"allow_experimental_insert_into_iceberg", false, false, "New setting."},
             /// RELEASE CLOSED
-            {"write_full_path_insert_iceberg", false, false, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.6",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -81,6 +81,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"distributed_plan_force_shuffle_aggregation", 0, 0, "New experimental setting"},
             {"allow_experimental_insert_into_iceberg", false, false, "New setting."},
             /// RELEASE CLOSED
+            {"write_full_path_insert_iceberg", false, false, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.6",
         {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -59,6 +59,7 @@ namespace Setting
 {
 extern const SettingsUInt64 output_format_compression_level;
 extern const SettingsUInt64 output_format_compression_zstd_window_log;
+extern const SettingsBool write_full_path_insert_iceberg;
 }
 
 namespace DataLakeStorageSetting
@@ -71,31 +72,76 @@ namespace ErrorCodes
 extern const int BAD_ARGUMENTS;
 }
 
-FileNamesGenerator::FileNamesGenerator(const String & table_dir)
-    : data_dir(table_dir + "data/")
+FileNamesGenerator::FileNamesGenerator(const String & table_dir_, const String & storage_dir_)
+    : table_dir(table_dir_)
+    , storage_dir(storage_dir_)
+    , data_dir(table_dir + "data/")
     , metadata_dir(table_dir + "metadata/")
+    , storage_data_dir(storage_dir + "data/")
+    , storage_metadata_dir(storage_dir + "metadata/")
 {
 }
 
-String FileNamesGenerator::generateDataFileName()
+FileNamesGenerator & FileNamesGenerator::operator=(const FileNamesGenerator & other)
 {
-    return fmt::format("{}data-{}.parquet", data_dir, uuid_generator.createRandom().toString());
+    if (this == &other)
+        return *this;
+
+    data_dir = other.data_dir;
+    metadata_dir = other.metadata_dir;
+    storage_data_dir = other.storage_data_dir;
+    storage_metadata_dir = other.storage_metadata_dir;
+    initial_version = other.initial_version;
+
+    table_dir = other.table_dir;
+    storage_dir = other.storage_dir;
+    return *this;
 }
 
-String FileNamesGenerator::generateManifestEntryName()
+FileNamesGenerator::Result FileNamesGenerator::generateDataFileName()
 {
-    return fmt::format("{}{}.avro", metadata_dir, uuid_generator.createRandom().toString());
+    auto uuid_str = uuid_generator.createRandom().toString();
+
+    return Result{
+        .path_in_metadata = fmt::format("{}data-{}.parquet", data_dir, uuid_str),
+        .path_in_storage = fmt::format("{}data-{}.parquet", storage_data_dir, uuid_str)
+    };
 }
 
-String FileNamesGenerator::generateManifestListName(Int64 snapshot_id, Int32 format_version)
+FileNamesGenerator::Result FileNamesGenerator::generateManifestEntryName()
 {
-    return fmt::format("{}snap-{}-{}-{}.avro", metadata_dir, snapshot_id, format_version, uuid_generator.createRandom().toString());
+    auto uuid_str = uuid_generator.createRandom().toString();
+
+    return Result{
+        .path_in_metadata = fmt::format("{}{}.avro", metadata_dir, uuid_str),
+        .path_in_storage = fmt::format("{}{}.avro", storage_metadata_dir, uuid_str),
+    };
 }
 
-String FileNamesGenerator::generateMetadataName()
+FileNamesGenerator::Result FileNamesGenerator::generateManifestListName(Int64 snapshot_id, Int32 format_version)
 {
-    return fmt::format("{}v{}.metadata.json", metadata_dir, initial_version);
+    auto uuid_str = uuid_generator.createRandom().toString();
+
+    return Result{
+        .path_in_metadata = fmt::format("{}snap-{}-{}-{}.avro", metadata_dir, snapshot_id, format_version, uuid_str),
+        .path_in_storage = fmt::format("{}snap-{}-{}-{}.avro", storage_metadata_dir, snapshot_id, format_version, uuid_str),
+    };
 }
+
+FileNamesGenerator::Result FileNamesGenerator::generateMetadataName()
+{
+    return Result{
+        .path_in_metadata = fmt::format("{}v{}.metadata.json", metadata_dir, initial_version),
+        .path_in_storage = fmt::format("{}v{}.metadata.json", storage_metadata_dir, initial_version),
+    };
+}
+
+String FileNamesGenerator::convertMetadataPathToStoragePath(const String & metadata_path) const
+{
+    std::cerr << "result to read " << storage_dir + metadata_path.substr(table_dir.size()) << '\n';
+    return storage_dir + metadata_path.substr(table_dir.size());
+}
+
 
 String removeEscapedSlashes(const String & json_str)
 {
@@ -241,6 +287,7 @@ void generateManifestFile(
 }
 
 void generateManifestList(
+    const FileNamesGenerator & filename_generator,
     Poco::JSON::Object::Ptr metadata,
     ObjectStoragePtr object_storage,
     ContextPtr context,
@@ -333,7 +380,7 @@ void generateManifestList(
             {
                 auto manifest_list = snapshots->getObject(static_cast<UInt32>(i))->getValue<String>(Iceberg::f_manifest_list);
 
-                StorageObjectStorage::ObjectInfo object_info(manifest_list);
+                StorageObjectStorage::ObjectInfo object_info(filename_generator.convertMetadataPathToStoragePath(manifest_list));
                 auto manifest_list_buf = StorageObjectStorageSource::createReadBuffer(object_info, object_storage, context, getLogger("IcebergWrites"));
 
                 auto input_stream = std::make_unique<AvroInputStreamReadBufferAdapter>(*manifest_list_buf);
@@ -389,7 +436,7 @@ Poco::JSON::Object::Ptr MetadataGenerator::getParentSnapshot(Int64 parent_snapsh
     return nullptr;
 }
 
-std::pair<Poco::JSON::Object::Ptr, String> MetadataGenerator::generateNextMetadata(
+MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
     FileNamesGenerator & generator,
     const String & metadata_filename,
     Int64 parent_snapshot_id,
@@ -408,7 +455,7 @@ std::pair<Poco::JSON::Object::Ptr, String> MetadataGenerator::generateNextMetada
     }
     Int32 snapshot_id = dis(gen);
 
-    auto manifest_list_name = generator.generateManifestListName(snapshot_id, format_version);
+    auto [manifest_list_name, storage_manifest_list_name] = generator.generateManifestListName(snapshot_id, format_version);
     new_snapshot->set(Iceberg::f_metadata_snapshot_id, snapshot_id);
     new_snapshot->set(Iceberg::f_parent_snapshot_id, parent_snapshot_id);
 
@@ -470,7 +517,7 @@ std::pair<Poco::JSON::Object::Ptr, String> MetadataGenerator::generateNextMetada
         new_snapshot_item->set(Iceberg::f_timestamp_ms, ms.count());
         metadata_object->getArray(Iceberg::f_snapshot_log)->add(new_snapshot_item);
     }
-    return {new_snapshot, manifest_list_name};
+    return {new_snapshot, manifest_list_name, storage_manifest_list_name};
 }
 
 ChunkPartitioner::ChunkPartitioner(
@@ -608,15 +655,30 @@ IcebergStorageSink::IcebergStorageSink(
     , context(context_)
     , configuration(configuration_)
     , format_settings(format_settings_)
-    , filename_generator(configuration_->getPath())
 {
     configuration->update(object_storage, context, true, false);
     auto log = getLogger("IcebergWrites");
     auto [last_version, metadata_path, compression_method]
         = getLatestOrExplicitMetadataFileAndVersion(object_storage, configuration_, nullptr, context_, log.get());
 
-    filename_generator.setVersion(last_version + 1);
     metadata = getMetadataJSONObject(metadata_path, object_storage, configuration, nullptr, context, log, compression_method);
+
+    auto config_path = configuration_->getPath();
+    if (config_path.empty() || config_path.back() != '/')
+        config_path += "/";
+    if (!context_->getSettingsRef()[Setting::write_full_path_insert_iceberg])
+    {
+        filename_generator = FileNamesGenerator(config_path, config_path);
+    }
+    else
+    {
+        auto bucket = metadata->getValue<String>(Iceberg::f_location);
+        if (bucket.empty() || bucket.back() != '/')
+            bucket += "/";
+        filename_generator = FileNamesGenerator(bucket, config_path);
+    }
+
+    filename_generator.setVersion(last_version + 1);
 
     partition_spec_id = metadata->getValue<Int64>(Iceberg::f_default_spec_id);
     auto partitions_specs = metadata->getArray(Iceberg::f_partition_specs);
@@ -660,11 +722,11 @@ void IcebergStorageSink::consume(Chunk & chunk)
     {
         if (!data_filenames.contains(partition_key))
         {
-            auto data_filename = filename_generator.generateDataFileName();
+            auto [data_filename, data_filename_in_storage] = filename_generator.generateDataFileName();
             data_filenames[partition_key] = data_filename;
 
             auto buffer = object_storage->writeObject(
-                StoredObject(data_filename), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+                StoredObject(data_filename_in_storage), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
 
             write_buffers[partition_key] = std::move(buffer);
             if (format_settings)
@@ -738,21 +800,26 @@ void IcebergStorageSink::cancelBuffers()
 
 bool IcebergStorageSink::initializeMetadata()
 {
-    auto metadata_name = filename_generator.generateMetadataName();
+    auto [metadata_name, storage_metadata_name] = filename_generator.generateMetadataName();
 
-    Int64 parent_snapshot = metadata->getValue<Int64>(Iceberg::f_current_snapshot_id);
-    auto [new_snapshot, manifest_list_name] = MetadataGenerator(metadata).generateNextMetadata(
+    Int64 parent_snapshot = -1;
+    if (metadata->has(Iceberg::f_current_snapshot_id))
+        parent_snapshot = metadata->getValue<Int64>(Iceberg::f_current_snapshot_id);
+
+    auto [new_snapshot, manifest_list_name, storage_manifest_list_name] = MetadataGenerator(metadata).generateNextMetadata(
         filename_generator, metadata_name, parent_snapshot, write_buffers.size(), total_rows, total_chunks_size, static_cast<Int32>(data_filenames.size()));
 
+    Strings manifest_entries_in_storage;
     Strings manifest_entries;
     Int32 manifest_lengths = 0;
     for (const auto & [partition_key, data_filename] : data_filenames)
     {
-        auto manifest_entry_name = filename_generator.generateManifestEntryName();
+        auto [manifest_entry_name, storage_manifest_entry_name] = filename_generator.generateManifestEntryName();
+        manifest_entries_in_storage.push_back(storage_manifest_entry_name);
         manifest_entries.push_back(manifest_entry_name);
 
         auto buffer_manifest_entry = object_storage->writeObject(
-            StoredObject(manifest_entry_name), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+            StoredObject(storage_manifest_entry_name), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
         generateManifestFile(metadata, partitioner ? partitioner->getColumns() : std::vector<String>{}, partition_key, data_filename, new_snapshot, configuration->format, partititon_spec, partition_spec_id, *buffer_manifest_entry);
         buffer_manifest_entry->finalize();
         manifest_lengths += buffer_manifest_entry->count();
@@ -760,10 +827,10 @@ bool IcebergStorageSink::initializeMetadata()
 
     {
         auto buffer_manifest_list = object_storage->writeObject(
-            StoredObject(manifest_list_name), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+            StoredObject(storage_manifest_list_name), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
 
         generateManifestList(
-            metadata, object_storage, context, manifest_entries, new_snapshot, manifest_lengths, *buffer_manifest_list);
+            filename_generator, metadata, object_storage, context, manifest_entries, new_snapshot, manifest_lengths, *buffer_manifest_list);
         buffer_manifest_list->finalize();
     }
 
@@ -772,17 +839,17 @@ bool IcebergStorageSink::initializeMetadata()
         Poco::JSON::Stringifier::stringify(metadata, oss, 4);
         std::string json_representation = removeEscapedSlashes(oss.str());
 
-        if (object_storage->exists(StoredObject(metadata_name)))
+        if (object_storage->exists(StoredObject(storage_metadata_name)))
         {
-            for (const auto & manifest_filename : manifest_entries)
-                object_storage->removeObjectIfExists(StoredObject(manifest_filename));
+            for (const auto & manifest_filename_in_storage : manifest_entries_in_storage)
+                object_storage->removeObjectIfExists(StoredObject(manifest_filename_in_storage));
 
-            object_storage->removeObjectIfExists(StoredObject(manifest_list_name));
+            object_storage->removeObjectIfExists(StoredObject(storage_manifest_list_name));
             return false;
         }
 
         auto buffer_metadata = object_storage->writeObject(
-            StoredObject(metadata_name), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+            StoredObject(storage_metadata_name), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
         buffer_metadata->write(json_representation.data(), json_representation.size());
         buffer_metadata->finalize();
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -138,7 +138,6 @@ FileNamesGenerator::Result FileNamesGenerator::generateMetadataName()
 
 String FileNamesGenerator::convertMetadataPathToStoragePath(const String & metadata_path) const
 {
-    std::cerr << "result to read " << storage_dir + metadata_path.substr(table_dir.size()) << '\n';
     return storage_dir + metadata_path.substr(table_dir.size());
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -59,7 +59,7 @@ namespace Setting
 {
 extern const SettingsUInt64 output_format_compression_level;
 extern const SettingsUInt64 output_format_compression_zstd_window_log;
-extern const SettingsBool write_full_path_insert_iceberg;
+extern const SettingsBool write_full_path_in_iceberg_metadata;
 }
 
 namespace DataLakeStorageSetting
@@ -665,7 +665,7 @@ IcebergStorageSink::IcebergStorageSink(
     auto config_path = configuration_->getPath();
     if (config_path.empty() || config_path.back() != '/')
         config_path += "/";
-    if (!context_->getSettingsRef()[Setting::write_full_path_insert_iceberg])
+    if (!context_->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata])
     {
         filename_generator = FileNamesGenerator(config_path, config_path);
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -35,7 +35,12 @@ class FileNamesGenerator
 public:
     struct Result
     {
+        /// Path recorded in the Iceberg metadata files.
+        /// If `write_full_path_in_iceberg_metadata` is disabled, it will be a simple relative path (e.g., /a/b/c.avro).
+        /// Otherwise, it will include a prefix indicating the file system type (e.g., s3://a/b/c.avro).
         String path_in_metadata;
+
+        /// Actual path to the object in the storage (e.g., /a/b/c.avro).
         String path_in_storage;
     };
 


### PR DESCRIPTION
Same as https://github.com/ClickHouse/ClickHouse/pull/84465 but in master

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support iceberg writes to read from pyiceberg

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

