### PR TITLE
Improve docs for 'format' field of UDF config

### DIFF
--- a/docs/en/sql-reference/functions/udf.md
+++ b/docs/en/sql-reference/functions/udf.md
@@ -26,7 +26,7 @@ A function configuration contains the following settings:
 - `name` - a function name.
 - `command` - script name to execute or command if `execute_direct` is false.
 - `argument` - argument description with the `type`, and optional `name` of an argument. Each argument is described in a separate setting. Specifying name is necessary if argument names are part of serialization for user defined function format like [Native](/interfaces/formats/Native) or [JSONEachRow](/interfaces/formats/JSONEachRow). Default argument name value is `c` + argument_number.
-- `format` - a [format](../../interfaces/formats.md) in which arguments are passed to the command.
+- `format` - a [format](../../interfaces/formats.md) in which arguments are passed to the command. The command output is expected to use the same format too.
 - `return_type` - the type of a returned value.
 - `return_name` - name of returned value. Specifying return name is necessary if return name is part of serialization for user defined function format like [Native](../../interfaces/formats.md#native) or [JSONEachRow](/interfaces/formats/JSONEachRow). Optional. Default value is `result`.
 - `type` - an executable type. If `type` is set to `executable` then single command is started. If it is set to `executable_pool` then a pool of commands is created.


### PR DESCRIPTION
The [doc](https://clickhouse.com/docs/sql-reference/functions/udf) says:
```
format - a format in which arguments are passed to the command.
```

But looks like this applies to the output of the command too.

### Changelog category (leave one):

- Documentation (changelog entry is not required)


