### PR TITLE
Write port numbers in HTTP server log of integration tests

### DIFF
--- a/tests/integration/helpers/http_server.py
+++ b/tests/integration/helpers/http_server.py
@@ -3,6 +3,7 @@ import argparse
 import csv
 import socket
 import ssl
+import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
@@ -26,6 +27,17 @@ def check_auth(fn):
 
 def start_server(server_address, data_path, schema, cert_path, address_family):
     class TSVHTTPHandler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            sys.stderr.write(
+                "%s:%s - - [%s] %s\n"
+                % (
+                    self.address_string(),
+                    self.server.server_port,
+                    self.log_date_time_string(),
+                    format % args,
+                )
+            )
+
         @check_auth
         def do_GET(self):
             self.__send_headers()


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Display port numbers of connections in HTTP server log of integration tests. This makes debugging flaky tests easier when the problems are with network.

### Documentation entry for user-facing changes
Example `http_server.py.log` before this change:

```
172.16.3.3 - - [14/Jul/2025 19:31:29] "POST / HTTP/1.1" 200 -
172.16.3.3 - - [14/Jul/2025 19:31:29] "POST / HTTP/1.1" 200 -
172.16.3.3 - - [14/Jul/2025 19:31:33] "POST / HTTP/1.1" 200 -
172.16.3.3 - - [14/Jul/2025 19:31:35] "POST / HTTP/1.1" 200 -
172.16.3.3 - - [14/Jul/2025 19:31:37] "POST / HTTP/1.1" 200 -
172.16.3.3 - - [14/Jul/2025 19:31:37] "POST / HTTP/1.1" 200 -
```

After:
```
172.16.3.3:5555 - - [14/Jul/2025 19:31:29] "POST / HTTP/1.1" 200 -
172.16.3.3:5555 - - [14/Jul/2025 19:31:29] "POST / HTTP/1.1" 200 -
172.16.3.3:5555 - - [14/Jul/2025 19:31:33] "POST / HTTP/1.1" 200 -
172.16.3.3:5555 - - [14/Jul/2025 19:31:35] "POST / HTTP/1.1" 200 -
172.16.3.3:5555 - - [14/Jul/2025 19:31:37] "POST / HTTP/1.1" 200 -
172.16.3.3:5555 - - [14/Jul/2025 19:31:37] "POST / HTTP/1.1" 200 -
```