### PR TITLE
Fix data race in ReplicatedMergeTreeQueue and using TSA

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h
@@ -117,6 +117,7 @@ public:
 
         if (mutations_state_ptr)
         {
+            std::lock_guard lock(mutations_state_ptr->state_mutex);
             Int64 left_mutation_version = mutations_state_ptr->getCurrentMutationVersion(
                 left.info.getOriginalPartitionId(), left.info.getDataVersion());
 
@@ -178,7 +179,12 @@ public:
         if (it == patches_by_partition.end() || it->second.empty())
             return {};
 
-        Int64 next_version = mutations_state_ptr->getNextMutationVersion(partition_id, first_part.getDataVersion());
+        Int64 next_version{};
+        {
+            std::lock_guard lock(mutations_state_ptr->state_mutex);
+            next_version = mutations_state_ptr->getNextMutationVersion(partition_id, first_part.getDataVersion());
+        }
+
         return DB::getPatchesToApplyOnMerge(it->second, range, next_version);
     }
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
@@ -4,7 +4,7 @@
 namespace DB
 {
 
-int ReplicatedMergeTreeAltersSequence::getHeadAlterVersion(std::unique_lock<std::mutex> & /*state_lock*/) const
+int ReplicatedMergeTreeAltersSequence::getHeadAlterVersion() const
 {
     /// If queue empty, than we don't have version
     if (!queue_state.empty())
@@ -12,7 +12,7 @@ int ReplicatedMergeTreeAltersSequence::getHeadAlterVersion(std::unique_lock<std:
     return -1;
 }
 
-void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
+void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version)
 {
     /// Metadata alter can be added before, or
     /// maybe already finished if we startup after metadata alter was finished.
@@ -23,7 +23,7 @@ void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version, s
 }
 
 void ReplicatedMergeTreeAltersSequence::addMetadataAlter(
-    int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
+    int alter_version)
 {
     /// Data alter (mutation) always added before. See ReplicatedMergeTreeQueue::pullLogsToQueue.
     /// So mutation already added to this sequence or doesn't exist.
@@ -33,7 +33,7 @@ void ReplicatedMergeTreeAltersSequence::addMetadataAlter(
         queue_state[alter_version].metadata_finished = false;
 }
 
-void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/)
+void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version)
 {
     /// Sequence must not be empty
     assert(!queue_state.empty());
@@ -47,7 +47,7 @@ void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, s
         queue_state[alter_version].metadata_finished = true;
 }
 
-void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
+void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version)
 {
     /// Queue can be empty after load of finished mutation without move of mutation pointer
     if (queue_state.empty())
@@ -66,7 +66,7 @@ void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::
     }
 }
 
-bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const
+bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version) const
 {
     /// Queue maybe empty when we start after server shutdown
     /// and have some MUTATE_PART records in queue
@@ -80,7 +80,7 @@ bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version, s
     return queue_state.at(alter_version).metadata_finished;
 }
 
-bool ReplicatedMergeTreeAltersSequence::canExecuteMetaAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const
+bool ReplicatedMergeTreeAltersSequence::canExecuteMetaAlter(int alter_version) const
 {
     assert(!queue_state.empty());
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
@@ -35,27 +35,27 @@ private:
 public:
 
     /// Add mutation for alter (alter data stage).
-    void addMutationForAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
+    void addMutationForAlter(int alter_version);
 
     /// Add metadata for alter (alter metadata stage).
-    void addMetadataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
+    void addMetadataAlter(int alter_version);
 
     /// Finish metadata alter. If corresponding data alter finished, than we can remove
     /// alter from sequence.
-    void finishMetadataAlter(int alter_version, std::unique_lock <std::mutex> & /*state_lock*/);
+    void finishMetadataAlter(int alter_version);
 
     /// Finish data alter. If corresponding metadata alter finished, than we can remove
     /// alter from sequence.
-    void finishDataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
+    void finishDataAlter(int alter_version);
 
     /// Check that we can execute this data alter. If it's metadata stage finished.
-    bool canExecuteDataAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const;
+    bool canExecuteDataAlter(int alter_version) const;
 
     /// Check that we can execute metadata alter with version.
-    bool canExecuteMetaAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const;
+    bool canExecuteMetaAlter(int alter_version) const;
 
     /// Just returns smallest alter version in sequence (first entry)
-    int getHeadAlterVersion(std::unique_lock<std::mutex> & /*state_lock*/) const;
+    int getHeadAlterVersion() const;
 };
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <deque>
-#include <mutex>
 #include <map>
 
 namespace DB

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1,3 +1,4 @@
+#include <Common/UniqueLock.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeQueue.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
@@ -60,7 +61,7 @@ ReplicatedMergeTreeQueue::ReplicatedMergeTreeQueue(StorageReplicatedMergeTree & 
     log = getLogger(logger_name);
 }
 
-void ReplicatedMergeTreeQueue::clear()
+void ReplicatedMergeTreeQueue::clear() TSA_NO_THREAD_SAFETY_ANALYSIS
 {
     auto locks = lockQueue();
     chassert(future_parts.empty());
@@ -116,6 +117,7 @@ bool ReplicatedMergeTreeQueue::isGoingToBeDropped(const MergeTreePartInfo & part
 }
 
 bool ReplicatedMergeTreeQueue::isGoingToBeDroppedImpl(const MergeTreePartInfo & part_info, MergeTreePartInfo * out_drop_range_info) const
+    TSA_REQUIRES(state_mutex)
 {
     String covering_virtual = virtual_parts.getContainingPart(part_info);
     if (!covering_virtual.empty())
@@ -199,7 +201,7 @@ bool ReplicatedMergeTreeQueue::load(zkutil::ZooKeeperPtr zookeeper)
 
             std::lock_guard lock(state_mutex);
 
-            insertUnlocked(entry, min_unprocessed_insert_time_changed, lock);
+            insertUnlocked(entry, min_unprocessed_insert_time_changed);
 
             updated = true;
         }
@@ -256,7 +258,7 @@ void ReplicatedMergeTreeQueue::removeDropReplaceIntent(const MergeTreePartInfo &
 }
 
 bool ReplicatedMergeTreeQueue::isIntersectingWithDropReplaceIntent(
-    const LogEntry & entry, const String & part_name, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex lock*/) const
+    const LogEntry & entry, const String & part_name, String & out_reason) const TSA_REQUIRES(state_mutex)
 {
     const auto part_info = MergeTreePartInfo::fromPartName(part_name, format_version);
     for (const auto & intent : drop_replace_range_intents)
@@ -279,7 +281,7 @@ bool ReplicatedMergeTreeQueue::isIntersectingWithDropReplaceIntent(
     return false;
 }
 
-bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason) const TSA_REQUIRES(state_mutex)
 {
     if (entry.type != LogEntry::MERGE_PARTS || !storage.supportsLightweightUpdate())
         return false;
@@ -310,7 +312,7 @@ bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry
     return false;
 }
 
-bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason) const
 {
     if (entry.type != LogEntry::DROP_PART || !storage.supportsLightweightUpdate())
         return false;
@@ -343,8 +345,7 @@ bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, 
 bool ReplicatedMergeTreeQueue::havePendingPatchPartsForMutation(
     const LogEntry & entry,
     String & out_reason,
-    const CommittingBlocks & committing_blocks,
-    std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+    const CommittingBlocks & committing_blocks) const TSA_REQUIRES(state_mutex)
 {
     if (entry.type != LogEntry::MUTATE_PART || !storage.supportsLightweightUpdate())
         return false;
@@ -387,9 +388,8 @@ bool ReplicatedMergeTreeQueue::havePendingPatchPartsForMutation(
     return false;
 }
 
-void ReplicatedMergeTreeQueue::insertUnlocked(
-    const LogEntryPtr & entry, std::optional<time_t> & min_unprocessed_insert_time_changed,
-    std::lock_guard<std::mutex> & state_lock)
+void ReplicatedMergeTreeQueue::insertUnlocked(const LogEntryPtr & entry, std::optional<time_t> & min_unprocessed_insert_time_changed)
+    TSA_REQUIRES(state_mutex)
 {
     auto entry_virtual_parts = entry->getVirtualPartNames(format_version);
 
@@ -440,7 +440,7 @@ void ReplicatedMergeTreeQueue::insertUnlocked(
     if (entry->type == LogEntry::ALTER_METADATA)
     {
         LOG_TRACE(log, "Adding alter metadata version {} to the queue", entry->alter_version);
-        alter_sequence.addMetadataAlter(entry->alter_version, state_lock);
+        alter_sequence.addMetadataAlter(entry->alter_version);
     }
 }
 
@@ -451,7 +451,7 @@ void ReplicatedMergeTreeQueue::insert(zkutil::ZooKeeperPtr zookeeper, LogEntryPt
 
     {
         std::lock_guard lock(state_mutex);
-        insertUnlocked(entry, min_unprocessed_insert_time_changed, lock);
+        insertUnlocked(entry, min_unprocessed_insert_time_changed);
     }
 
     updateTimesInZooKeeper(zookeeper, min_unprocessed_insert_time_changed, {});
@@ -462,8 +462,7 @@ void ReplicatedMergeTreeQueue::updateStateOnQueueEntryRemoval(
     const LogEntryPtr & entry,
     bool is_successful,
     std::optional<time_t> & min_unprocessed_insert_time_changed,
-    std::optional<time_t> & max_processed_insert_time_changed,
-    std::unique_lock<std::mutex> & state_lock)
+    std::optional<time_t> & max_processed_insert_time_changed) TSA_REQUIRES(state_mutex)
 {
 
     auto entry_virtual_parts = entry->getVirtualPartNames(format_version);
@@ -549,7 +548,7 @@ void ReplicatedMergeTreeQueue::updateStateOnQueueEntryRemoval(
         if (entry->type == LogEntry::ALTER_METADATA)
         {
             LOG_TRACE(log, "Finishing metadata alter with version {}", entry->alter_version);
-            alter_sequence.finishMetadataAlter(entry->alter_version, state_lock);
+            alter_sequence.finishMetadataAlter(entry->alter_version);
         }
     }
     else
@@ -576,6 +575,7 @@ void ReplicatedMergeTreeQueue::updateStateOnQueueEntryRemoval(
 
 
 void ReplicatedMergeTreeQueue::removeCoveredPartsFromMutations(const String & part_name, bool remove_part, bool remove_covered_parts)
+    TSA_REQUIRES(state_mutex)
 {
     auto part_info = MergeTreePartInfo::fromPartName(part_name, format_version);
 
@@ -617,7 +617,7 @@ void ReplicatedMergeTreeQueue::removeCoveredPartsFromMutations(const String & pa
         storage.mutations_finalizing_task->schedule();
 }
 
-void ReplicatedMergeTreeQueue::addPartToMutations(const String & part_name, const MergeTreePartInfo & part_info)
+void ReplicatedMergeTreeQueue::addPartToMutations(const String & part_name, const MergeTreePartInfo & part_info) TSA_REQUIRES(state_mutex)
 {
     LOG_TEST(log, "Adding part {} to mutations", part_name);
     assert(!part_info.isFakeDropRangePart());
@@ -677,7 +677,7 @@ void ReplicatedMergeTreeQueue::removeProcessedEntry(zkutil::ZooKeeperPtr zookeep
 
     /// First remove from memory then from ZooKeeper
     {
-        std::unique_lock lock(state_mutex);
+        std::lock_guard lock(state_mutex);
         if (entry->removed_by_other_entry)
         {
             need_remove_from_zk = false;
@@ -697,8 +697,7 @@ void ReplicatedMergeTreeQueue::removeProcessedEntry(zkutil::ZooKeeperPtr zookeep
                 {
                     found = true;
                     updateStateOnQueueEntryRemoval(
-                            entry, /* is_successful = */ true,
-                            min_unprocessed_insert_time_changed, max_processed_insert_time_changed, lock);
+                        entry, /* is_successful = */ true, min_unprocessed_insert_time_changed, max_processed_insert_time_changed);
 
                     queue.erase(it);
                     queue_size = queue.size();
@@ -868,7 +867,7 @@ std::pair<int32_t, int32_t> ReplicatedMergeTreeQueue::pullLogsToQueue(zkutil::Zo
                     copied_entries[copied_entry_idx]->znode_name = path_created.substr(path_created.find_last_of('/') + 1);
 
                     std::optional<time_t> unused = false;
-                    insertUnlocked(copied_entries[copied_entry_idx], unused, state_lock);
+                    insertUnlocked(copied_entries[copied_entry_idx], unused);
                 }
 
                 last_queue_update = time(nullptr);
@@ -1059,7 +1058,7 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
                     if (entry.isAlterMutation())
                     {
                         LOG_DEBUG(log, "Removed alter {} because mutation {} were killed.", entry.alter_version, entry.znode_name);
-                        alter_sequence.finishDataAlter(entry.alter_version, state_lock);
+                        alter_sequence.finishDataAlter(entry.alter_version);
                     }
                 }
                 else
@@ -1156,7 +1155,7 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
                 if (entry->isAlterMutation() && entry->znode_name > mutation_pointer)
                 {
                     LOG_TRACE(log, "Adding mutation {} with alter version {} to the queue", entry->znode_name, entry->alter_version);
-                    alter_sequence.addMutationForAlter(entry->alter_version, state_lock);
+                    alter_sequence.addMutationForAlter(entry->alter_version);
                 }
             }
         }
@@ -1202,7 +1201,7 @@ ReplicatedMergeTreeMutationEntryPtr ReplicatedMergeTreeQueue::removeMutation(
         if (entry->isAlterMutation())
         {
             LOG_DEBUG(log, "Removed alter {} because mutation {} were killed.", entry->alter_version, entry->znode_name);
-            alter_sequence.finishDataAlter(entry->alter_version, state_lock);
+            alter_sequence.finishDataAlter(entry->alter_version);
         }
 
         if (mutation_was_active)
@@ -1309,7 +1308,7 @@ void ReplicatedMergeTreeQueue::removePartProducingOpsInRange(
     std::optional<time_t> max_processed_insert_time_changed;
 
     /// Remove operations with parts, contained in the range to be deleted, from the queue.
-    std::unique_lock lock(state_mutex);
+    UniqueLock lock(state_mutex);
 
     [[maybe_unused]] bool called_from_alter_query_directly = covering_entry && covering_entry->replace_range_entry
         && covering_entry->replace_range_entry->columns_version < 0;
@@ -1338,7 +1337,7 @@ void ReplicatedMergeTreeQueue::removePartProducingOpsInRange(
 
             updateStateOnQueueEntryRemoval(
                 *it, /* is_successful = */ false,
-                min_unprocessed_insert_time_changed, max_processed_insert_time_changed, lock);
+                min_unprocessed_insert_time_changed, max_processed_insert_time_changed);
 
             LogEntryPtr removing_entry = std::move(*it);   /// Make it live a bit longer
             removing_entry->removed_by_other_entry = true;
@@ -1356,14 +1355,14 @@ void ReplicatedMergeTreeQueue::removePartProducingOpsInRange(
 
     /// Let's wait for the operations with the parts contained in the range to be deleted.
     for (LogEntryPtr & entry : to_wait)
-        entry->execution_complete.wait(lock, [&entry] { return !entry->currently_executing; });
+        entry->execution_complete.wait(lock.getUnderlyingLock(), [&entry] { return !entry->currently_executing; });
 }
 
 void ReplicatedMergeTreeQueue::waitForCurrentlyExecutingOpsInRange(const MergeTreePartInfo & part_info) const
 {
     Queue to_wait;
 
-    std::unique_lock lock(state_mutex);
+    UniqueLock lock(state_mutex);
 
     for (const auto& entry : queue)
     {
@@ -1384,12 +1383,12 @@ void ReplicatedMergeTreeQueue::waitForCurrentlyExecutingOpsInRange(const MergeTr
     LOG_DEBUG(log, "Waiting for {} entries that are currently executing.", to_wait.size());
 
     for (LogEntryPtr & entry : to_wait)
-        entry->execution_complete.wait(lock, [&entry] { return !entry->currently_executing; });
+        entry->execution_complete.wait(lock.getUnderlyingLock(), [&entry] { return !entry->currently_executing; });
 }
 
 bool ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(const LogEntry & entry, const String & new_part_name,
-                                                          String & out_reason, std::unique_lock<std::mutex> & /* queue_lock */,
-                                                          std::vector<LogEntryPtr> * covered_entries_to_wait) const
+                                                          String & out_reason,
+                                                          std::vector<LogEntryPtr> * covered_entries_to_wait) const TSA_REQUIRES(state_mutex)
 {
     /// Let's check if the same part is now being created by another action.
     auto entry_for_same_part_it = future_parts.find(new_part_name);
@@ -1466,7 +1465,7 @@ bool ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(const LogEntry & entry
 bool ReplicatedMergeTreeQueue::addFuturePartIfNotCoveredByThem(const String & part_name, LogEntry & entry, String & reject_reason)
 {
     /// We have found `part_name` on some replica and are going to fetch it instead of covered `entry->new_part_name`.
-    std::unique_lock lock(state_mutex);
+    UniqueLock lock(state_mutex);
 
     String covering_part = virtual_parts.getContainingPart(part_name);
     if (covering_part.empty())
@@ -1490,7 +1489,8 @@ bool ReplicatedMergeTreeQueue::addFuturePartIfNotCoveredByThem(const String & pa
         return false;
 
     std::vector<LogEntryPtr> covered_entries_to_wait;
-    if (isCoveredByFuturePartsImpl(entry, part_name, reject_reason, lock, &covered_entries_to_wait))
+
+    if (isCoveredByFuturePartsImpl(entry, part_name, reject_reason, &covered_entries_to_wait))
         return false;
 
     CurrentlyExecuting::setActualPartName(entry, part_name, *this, lock, covered_entries_to_wait);
@@ -1534,8 +1534,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
     String & out_postpone_reason,
     MergeTreeDataMergerMutator & merger_mutator,
     MergeTreeData & data,
-    const CommittingBlocks & committing_blocks,
-    std::unique_lock<std::mutex> & state_lock) const
+    const CommittingBlocks & committing_blocks) const TSA_REQUIRES(state_mutex)
 {
     if (auto postpone_time = getPostponeTimeMsForEntry(entry, data))
     {
@@ -1552,10 +1551,10 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
     {
         /// Do not wait for any entries here, because we have only one thread that scheduling queue entries.
         /// We can wait in worker threads, but not in scheduler.
-        if (isCoveredByFuturePartsImpl(entry, new_part_name, out_postpone_reason, state_lock, /* covered_entries_to_wait */ nullptr))
+        if (isCoveredByFuturePartsImpl(entry, new_part_name, out_postpone_reason, /* covered_entries_to_wait */ nullptr))
             return false;
 
-        if (isIntersectingWithDropReplaceIntent(entry, new_part_name, out_postpone_reason, state_lock))
+        if (isIntersectingWithDropReplaceIntent(entry, new_part_name, out_postpone_reason))
             return false;
     }
 
@@ -1669,7 +1668,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
             }
         }
 
-        if (havePendingPatchPartsForMutation(entry, out_postpone_reason, committing_blocks, state_lock))
+        if (havePendingPatchPartsForMutation(entry, out_postpone_reason, committing_blocks))
             return false;
 
         UInt64 max_source_parts_size = entry.type == LogEntry::MERGE_PARTS ? CompactionStatistics::getMaxSourcePartsSizeForMerge(data)
@@ -1703,7 +1702,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
                 }
             }
 
-            if (isMergeOfPatchPartsBlocked(entry, out_postpone_reason, state_lock))
+            if (isMergeOfPatchPartsBlocked(entry, out_postpone_reason))
                 return false;
         }
 
@@ -1722,9 +1721,9 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
     /// corresponding alter_version.
     if (entry.type == LogEntry::ALTER_METADATA)
     {
-        if (!alter_sequence.canExecuteMetaAlter(entry.alter_version, state_lock))
+        if (!alter_sequence.canExecuteMetaAlter(entry.alter_version))
         {
-            int head_alter = alter_sequence.getHeadAlterVersion(state_lock);
+            int head_alter = alter_sequence.getHeadAlterVersion();
             constexpr auto fmt_string = "Cannot execute alter metadata {} with version {} because another alter {} must be executed before";
             LOG_TRACE(LogToStr(out_postpone_reason, log), fmt_string, entry.znode_name, entry.alter_version, head_alter);
             return false;
@@ -1743,9 +1742,9 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
     /// If this MUTATE_PART is part of alter modify/drop query, than we have to execute them one by one
     if (entry.isAlterMutation())
     {
-        if (!alter_sequence.canExecuteDataAlter(entry.alter_version, state_lock))
+        if (!alter_sequence.canExecuteDataAlter(entry.alter_version))
         {
-            int head_alter = alter_sequence.getHeadAlterVersion(state_lock);
+            int head_alter = alter_sequence.getHeadAlterVersion();
             if (head_alter == entry.alter_version)
             {
                 constexpr auto fmt_string = "Cannot execute alter data {} with version {} because metadata still not altered";
@@ -1814,7 +1813,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
             }
         }
 
-        if (isDropOfPatchPartBlocked(entry, out_postpone_reason, state_lock))
+        if (isDropOfPatchPartBlocked(entry, out_postpone_reason))
             return false;
     }
 
@@ -1823,7 +1822,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
 
 
 Int64 ReplicatedMergeTreeQueue::getCurrentMutationVersion(
-    const String & partition_id, Int64 data_version) const
+    const String & partition_id, Int64 data_version) const TSA_REQUIRES(state_mutex)
 {
     auto in_partition = mutations_by_partition.find(partition_id);
     if (in_partition == mutations_by_partition.end())
@@ -1838,7 +1837,7 @@ Int64 ReplicatedMergeTreeQueue::getCurrentMutationVersion(
 }
 
 Int64 ReplicatedMergeTreeQueue::getNextMutationVersion(
-    const String & partition_id, Int64 data_version) const
+    const String & partition_id, Int64 data_version) const TSA_REQUIRES(state_mutex)
 {
     auto in_partition = mutations_by_partition.find(partition_id);
     if (in_partition == mutations_by_partition.end())
@@ -1852,7 +1851,7 @@ Int64 ReplicatedMergeTreeQueue::getNextMutationVersion(
 }
 
 ReplicatedMergeTreeQueue::CurrentlyExecuting::CurrentlyExecuting(
-    const ReplicatedMergeTreeQueue::LogEntryPtr & entry_, ReplicatedMergeTreeQueue & queue_, std::unique_lock<std::mutex> & /* state_lock */)
+    const ReplicatedMergeTreeQueue::LogEntryPtr & entry_, ReplicatedMergeTreeQueue & queue_)
     : entry(entry_), queue(queue_)
 {
     if (auto drop_range = entry->getDropRange(queue.format_version))
@@ -1879,7 +1878,7 @@ void ReplicatedMergeTreeQueue::CurrentlyExecuting::setActualPartName(
     ReplicatedMergeTreeQueue::LogEntry & entry,
     const String & actual_part_name,
     ReplicatedMergeTreeQueue & queue,
-    std::unique_lock<std::mutex> & state_lock,
+    UniqueLock<std::mutex> & state_lock,
     std::vector<LogEntryPtr> & covered_entries_to_wait)
 {
     if (actual_part_name.empty())
@@ -1899,7 +1898,7 @@ void ReplicatedMergeTreeQueue::CurrentlyExecuting::setActualPartName(
     if (actual_part_name == entry.new_part_name)
         return;
 
-    if (!queue.future_parts.emplace(actual_part_name, entry.shared_from_this()).second)
+    if (!queue.emplaceFuturePart(actual_part_name, entry.shared_from_this()))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Attaching already existing future part {}. This is a bug. "
                                                    "It happened on attempt to execute {}: {}",
                                                    actual_part_name, entry.znode_name, entry.toString());
@@ -1915,7 +1914,7 @@ void ReplicatedMergeTreeQueue::CurrentlyExecuting::setActualPartName(
             continue;
         LOG_TRACE(queue.log, "Waiting for {} producing {} to finish before executing {} producing not disjoint part {} (actual part {})",
                   covered_entry->znode_name, covered_entry->new_part_name, entry.znode_name, entry.new_part_name, actual_part_name);
-        covered_entry->execution_complete.wait(state_lock, [&covered_entry] { return !covered_entry->currently_executing; });
+        covered_entry->execution_complete.wait(state_lock.getUnderlyingLock(), [&covered_entry] { return !covered_entry->currently_executing; });
     }
 }
 
@@ -1935,7 +1934,7 @@ ReplicatedMergeTreeQueue::CurrentlyExecuting::~CurrentlyExecuting()
 
     auto erase_and_check = [this](const String & part_name)
     {
-        if (!queue.future_parts.erase(part_name))
+        if (!queue.eraseFuturePart(part_name))
         {
             LOG_ERROR(queue.log, "Untagging already untagged future part {}. This is a bug.", part_name);
             assert(false);
@@ -1969,14 +1968,14 @@ ReplicatedMergeTreeQueue::SelectedEntryPtr ReplicatedMergeTreeQueue::selectEntry
         committing_blocks = getCommittingBlocks(zookeeper, zookeeper_path, partition_ids_hint, /*with_data=*/ true);
     }
 
-    std::unique_lock lock(state_mutex);
+    std::lock_guard lock(state_mutex);
 
     for (auto it = queue.begin(); it != queue.end(); ++it)
     {
         if ((*it)->currently_executing)
             continue;
 
-        if (shouldExecuteLogEntry(**it, (*it)->postpone_reason, merger_mutator, data, committing_blocks, lock))
+        if (shouldExecuteLogEntry(**it, (*it)->postpone_reason, merger_mutator, data, committing_blocks))
         {
             entry = *it;
             /// We gave a chance for the entry, move it to the tail of the queue, after that
@@ -1990,7 +1989,7 @@ ReplicatedMergeTreeQueue::SelectedEntryPtr ReplicatedMergeTreeQueue::selectEntry
     }
 
     if (entry)
-        return std::make_shared<SelectedEntry>(entry, std::unique_ptr<CurrentlyExecuting>{new CurrentlyExecuting(entry, *this, lock)});
+        return std::make_shared<SelectedEntry>(entry, std::unique_ptr<CurrentlyExecuting>{new CurrentlyExecuting(entry, *this)});
     return {};
 }
 
@@ -2323,7 +2322,7 @@ bool ReplicatedMergeTreeQueue::tryFinalizeMutations(zkutil::ZooKeeperPtr zookeep
                 mutation.is_done = true;
                 mutation.latest_fail_reason.clear();
                 mutation.latest_fail_error_code_name.clear();
-                alter_sequence.finishDataAlter(mutation.entry->alter_version, lock);
+                alter_sequence.finishDataAlter(mutation.entry->alter_version);
                 if (mutation.parts_to_do.size() != 0)
                 {
                     LOG_INFO(log, "Seems like we jumped over mutation {} when downloaded part with bigger mutation number. "
@@ -2387,7 +2386,7 @@ bool ReplicatedMergeTreeQueue::tryFinalizeMutations(zkutil::ZooKeeperPtr zookeep
                 if (entry->isAlterMutation())
                 {
                     LOG_TRACE(log, "Finishing data alter with version {} for entry {}", entry->alter_version, entry->znode_name);
-                    alter_sequence.finishDataAlter(entry->alter_version, lock);
+                    alter_sequence.finishDataAlter(entry->alter_version);
                 }
                 decrementMutationsCounters(mutation_counters, entry->commands);
             }
@@ -2568,7 +2567,7 @@ ReplicatedMergeTreeQueue::QueueLocks ReplicatedMergeTreeQueue::lockQueue()
 ReplicatedMergeTreeQueue::SubscriberHandler
 ReplicatedMergeTreeQueue::addSubscriber(ReplicatedMergeTreeQueue::SubscriberCallBack && callback,
                                         std::unordered_set<String> & out_entry_names, SyncReplicaMode sync_mode,
-                                        std::unordered_set<String> src_replicas)
+                                        std::unordered_set<String> && src_replicas)
 {
     std::lock_guard<std::mutex> lock(state_mutex);
     std::lock_guard lock_subscribers(subscribers_mutex);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -109,16 +109,9 @@ private:
     using FuturePartsSet = std::map<String, LogEntryPtr>;
     FuturePartsSet TSA_GUARDED_BY(state_mutex) future_parts;
 
-    bool emplaceFuturePart(const String & actual_part_name, LogEntryPtr entry)
-    {
-        std::lock_guard lock(state_mutex);
-        return future_parts.emplace(actual_part_name, entry).second;
-    }
-    bool eraseFuturePart(const String & part_name)
-    {
-        std::lock_guard lock(state_mutex);
-        return future_parts.erase(part_name);
-    }
+    bool emplaceFuturePart(const String & actual_part_name, LogEntryPtr entry);
+
+    bool eraseFuturePart(const String & part_name);
 
     /// Avoid parallel execution of queue enties, which may remove other entries from the queue.
     std::set<MergeTreePartInfo> currently_executing_drop_replace_ranges;
@@ -328,6 +321,7 @@ public:
     ~ReplicatedMergeTreeQueue() = default;
 
     /// Clears queue state
+    // The reason for no analysis is TSA doesn't work with QueueLocks.
     void clear() TSA_NO_THREAD_SAFETY_ANALYSIS;
 
     /// Get set of parts from zookeeper

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -3,8 +3,10 @@
 #include <cstdint>
 #include <optional>
 #include <expected>
+#include <mutex>
 
 #include <Common/ActionBlocker.h>
+#include <Common/UniqueLock.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Parsers/SyncReplicaMode.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeLogEntry.h>
@@ -94,18 +96,29 @@ private:
       * In ZK records in chronological order. Here they are executed in parallel and reorder after entry execution.
       * Order of execution is not "queue" at all. Look at selectEntryToProcess.
       */
-    Queue queue;
+    Queue TSA_GUARDED_BY(state_mutex) queue;
 
-    InsertsByTime inserts_by_time;
+    InsertsByTime TSA_GUARDED_BY(state_mutex) inserts_by_time;
     std::atomic<time_t> min_unprocessed_insert_time = 0;
     std::atomic<time_t> max_processed_insert_time = 0;
 
-    time_t last_queue_update = 0;
+    time_t TSA_GUARDED_BY(state_mutex) last_queue_update = 0;
 
     /// parts that will appear as a result of actions performed right now by background threads (these actions are not in the queue).
     /// Used to block other actions on parts in the range covered by future_parts.
     using FuturePartsSet = std::map<String, LogEntryPtr>;
-    FuturePartsSet future_parts;
+    FuturePartsSet TSA_GUARDED_BY(state_mutex) future_parts;
+
+    bool emplaceFuturePart(const String & actual_part_name, LogEntryPtr entry)
+    {
+        std::lock_guard lock(state_mutex);
+        return future_parts.emplace(actual_part_name, entry).second;
+    }
+    bool eraseFuturePart(const String & part_name)
+    {
+        std::lock_guard lock(state_mutex);
+        return future_parts.erase(part_name);
+    }
 
     /// Avoid parallel execution of queue enties, which may remove other entries from the queue.
     std::set<MergeTreePartInfo> currently_executing_drop_replace_ranges;
@@ -113,14 +126,14 @@ private:
     /** What will be the set of active parts after executing all log entries up to log_pointer.
       * Used to determine which merges can be assigned (see ReplicatedMergeTreeZooKeeperMergePredicate)
       */
-    ActiveDataPartSet virtual_parts;
+    ActiveDataPartSet TSA_GUARDED_BY(state_mutex) virtual_parts;
 
     /// Used to prevent operations to start in ranges which will be affected by DROP_RANGE/REPLACE_RANGE
-    std::vector<MergeTreePartInfo> drop_replace_range_intents;
+    std::vector<MergeTreePartInfo> TSA_GUARDED_BY(state_mutex) drop_replace_range_intents;
 
     /// We do not add DROP_PARTs to virtual_parts because they can intersect,
     /// so we store them separately in this structure.
-    DropPartsRanges drop_parts;
+    DropPartsRanges TSA_GUARDED_BY(state_mutex) drop_parts;
 
     /// A set of mutations loaded from ZooKeeper.
     /// mutations_by_partition is an index partition ID -> block ID -> mutation into this set.
@@ -159,24 +172,24 @@ private:
     };
 
     /// Mapping from znode path to Mutations Status
-    std::map<String, MutationStatus> mutations_by_znode;
+    std::map<String, MutationStatus> TSA_GUARDED_BY(state_mutex) mutations_by_znode;
 
     /// Unfinished mutations that are required for AlterConversions.
-    MutationCounters mutation_counters;
+    MutationCounters TSA_GUARDED_BY(state_mutex) mutation_counters;
 
     /// Partition -> (block_number -> MutationStatus)
-    std::unordered_map<String, std::map<Int64, MutationStatus *>> mutations_by_partition;
+    std::unordered_map<String, std::map<Int64, MutationStatus *>> TSA_GUARDED_BY(state_mutex) mutations_by_partition;
     /// Znode ID of the latest mutation that is done.
-    String mutation_pointer;
+    String TSA_GUARDED_BY(state_mutex) mutation_pointer;
 
     /// Provides only one simultaneous call to pullLogsToQueue.
     std::mutex pull_logs_to_queue_mutex;
 
     /// This sequence control ALTERs execution in replication queue.
     /// We need it because alters have to be executed sequentially (one by one).
-    ReplicatedMergeTreeAltersSequence alter_sequence;
+    ReplicatedMergeTreeAltersSequence TSA_GUARDED_BY(state_mutex) alter_sequence;
 
-    Strings broken_parts_to_enqueue_fetches_on_loading;
+    Strings TSA_GUARDED_BY(state_mutex) broken_parts_to_enqueue_fetches_on_loading;
 
     /// List of subscribers
     /// A subscriber callback is called when an entry queue is deleted
@@ -197,7 +210,7 @@ private:
         ReplicatedMergeTreeQueue & queue;
     };
 
-    Subscribers subscribers;
+    Subscribers TSA_GUARDED_BY(subscribers_mutex) subscribers;
 
     /// Notify subscribers about queue change (new queue size and entry that was removed)
     void notifySubscribers(size_t new_queue_size, const String * removed_log_entry_id);
@@ -210,9 +223,7 @@ private:
     std::mutex update_mutations_mutex;
 
     /// Insert new entry from log into queue
-    void insertUnlocked(
-        const LogEntryPtr & entry, std::optional<time_t> & min_unprocessed_insert_time_changed,
-        std::lock_guard<std::mutex> & state_lock);
+    void insertUnlocked(const LogEntryPtr & entry, std::optional<time_t> & min_unprocessed_insert_time_changed) TSA_REQUIRES(state_mutex);
 
     void removeProcessedEntry(zkutil::ZooKeeperPtr zookeeper, LogEntryPtr & entry);
 
@@ -224,35 +235,32 @@ private:
         String & out_postpone_reason,
         MergeTreeDataMergerMutator & merger_mutator,
         MergeTreeData & data,
-        const CommittingBlocks & committing_blocks,
-        std::unique_lock<std::mutex> & state_lock) const;
+        const CommittingBlocks & committing_blocks) const TSA_REQUIRES(state_mutex);
 
     /// Return the version (block number) of the last mutation that we don't need to apply to the part
     /// with getDataVersion() == data_version. (Either this mutation was already applied or the part
     /// was created after the mutation).
     /// If there is no such mutation or it has already been executed and deleted, return 0.
-    Int64 getCurrentMutationVersion(const String & partition_id, Int64 data_version) const;
-    Int64 getNextMutationVersion(const String & partition_id, int64_t data_version) const;
+    Int64 getCurrentMutationVersion(const String & partition_id, Int64 data_version) const TSA_REQUIRES(state_mutex);
+    Int64 getNextMutationVersion(const String & partition_id, int64_t data_version) const TSA_REQUIRES(state_mutex);
 
     /** Check that part isn't in currently generating parts and isn't covered by them.
       * Should be called under state_mutex.
       */
     bool isCoveredByFuturePartsImpl(
-        const LogEntry & entry,
-        const String & new_part_name, String & out_reason,
-        std::unique_lock<std::mutex> & state_lock,
-        std::vector<LogEntryPtr> * covered_entries_to_wait) const;
+        const LogEntry & entry, const String & new_part_name, String & out_reason, std::vector<LogEntryPtr> * covered_entries_to_wait) const
+        TSA_REQUIRES(state_mutex);
 
     /// After removing the queue element, update the insertion times in the RAM. Running under state_mutex.
     /// Returns information about what times have changed - this information can be passed to updateTimesInZooKeeper.
-    void updateStateOnQueueEntryRemoval(const LogEntryPtr & entry,
+    void updateStateOnQueueEntryRemoval(
+        const LogEntryPtr & entry,
         bool is_successful,
         std::optional<time_t> & min_unprocessed_insert_time_changed,
-        std::optional<time_t> & max_processed_insert_time_changed,
-        std::unique_lock<std::mutex> & state_lock);
+        std::optional<time_t> & max_processed_insert_time_changed) TSA_REQUIRES(state_mutex);
 
     /// Add part for mutations with block_number > part.getDataVersion()
-    void addPartToMutations(const String & part_name, const MergeTreePartInfo & part_info);
+    void addPartToMutations(const String & part_name, const MergeTreePartInfo & part_info) TSA_REQUIRES(state_mutex);
 
     /// Remove covered parts from mutations (parts_to_do) which were assigned
     /// for mutation. If remove_covered_parts = true, than remove parts covered
@@ -263,20 +271,19 @@ private:
     /// block_number > part.getDataVersion()
     /// or block_number == part.getDataVersion()
     ///    ^ (this may happen if we downloaded mutated part from other replica)
-    void removeCoveredPartsFromMutations(const String & part_name, bool remove_part, bool remove_covered_parts);
+    void removeCoveredPartsFromMutations(const String & part_name, bool remove_part, bool remove_covered_parts) TSA_REQUIRES(state_mutex);
 
     /// Update the insertion times in ZooKeeper.
     void updateTimesInZooKeeper(zkutil::ZooKeeperPtr zookeeper,
         std::optional<time_t> min_unprocessed_insert_time_changed,
         std::optional<time_t> max_processed_insert_time_changed) const;
 
-    bool isIntersectingWithDropReplaceIntent(
-        const LogEntry & entry,
-        const String & part_name, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex lock*/) const;
+    bool isIntersectingWithDropReplaceIntent(const LogEntry & entry, const String & part_name, String & out_reason) const
+        TSA_REQUIRES(state_mutex);
 
-    bool isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
-    bool isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
-    bool havePendingPatchPartsForMutation(const LogEntry & entry, String & out_reason, const CommittingBlocks & committing_blocks, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
+    bool isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason) const TSA_REQUIRES(state_mutex);
+    bool isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason) const TSA_REQUIRES(state_mutex);
+    bool havePendingPatchPartsForMutation(const LogEntry & entry, String & out_reason, const CommittingBlocks & committing_blocks) const TSA_REQUIRES(state_mutex);
 
     /// Marks the element of the queue as running.
     class CurrentlyExecuting
@@ -288,17 +295,14 @@ private:
         friend class ReplicatedMergeTreeQueue;
 
         /// Created only in the selectEntryToProcess function. It is called under mutex.
-        CurrentlyExecuting(
-            const ReplicatedMergeTreeQueue::LogEntryPtr & entry_,
-            ReplicatedMergeTreeQueue & queue_,
-            std::unique_lock<std::mutex> & state_lock);
+        CurrentlyExecuting(const ReplicatedMergeTreeQueue::LogEntryPtr & entry_, ReplicatedMergeTreeQueue & queue_);
 
         /// In case of fetch, we determine actual part during the execution, so we need to update entry. It is called under state_mutex.
         static void setActualPartName(
             ReplicatedMergeTreeQueue::LogEntry & entry,
             const String & actual_part_name,
             ReplicatedMergeTreeQueue & queue,
-            std::unique_lock<std::mutex> & state_lock,
+            UniqueLock<std::mutex> & state_lock,
             std::vector<LogEntryPtr> & covered_entries_to_wait);
 
     public:
@@ -324,7 +328,7 @@ public:
     ~ReplicatedMergeTreeQueue() = default;
 
     /// Clears queue state
-    void clear();
+    void clear() TSA_NO_THREAD_SAFETY_ANALYSIS;
 
     /// Get set of parts from zookeeper
     void initialize(zkutil::ZooKeeperPtr zookeeper);
@@ -458,7 +462,8 @@ public:
 
     /// Returns true if part_info is covered by some DROP_RANGE or DROP_PART
     bool isGoingToBeDropped(const MergeTreePartInfo & part_info, MergeTreePartInfo * out_drop_range_info = nullptr) const;
-    bool isGoingToBeDroppedImpl(const MergeTreePartInfo & part_info, MergeTreePartInfo * out_drop_range_info) const;
+    bool isGoingToBeDroppedImpl(const MergeTreePartInfo & part_info, MergeTreePartInfo * out_drop_range_info) const
+        TSA_REQUIRES(state_mutex);
 
     /// Check that part produced by some entry in queue and get source parts for it.
     /// If there are several entries return largest source_parts set. This rarely possible
@@ -476,7 +481,11 @@ public:
     ActionBlocker pull_log_blocker;
 
     /// Adds a subscriber
-    SubscriberHandler addSubscriber(SubscriberCallBack && callback, std::unordered_set<String> & out_entry_names, SyncReplicaMode sync_mode, std::unordered_set<String> src_replicas);
+    SubscriberHandler addSubscriber(
+        SubscriberCallBack && callback,
+        std::unordered_set<String> & out_entry_names,
+        SyncReplicaMode sync_mode,
+        std::unordered_set<String> && src_replicas);
 
     void notifySubscribersOnPartialShutdown();
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9418,7 +9418,7 @@ bool StorageReplicatedMergeTree::waitForProcessingQueue(UInt64 max_wait_millisec
             target_entry_event.set();
     };
 
-    const auto handler = queue.addSubscriber(std::move(callback), wait_for_ids, sync_mode, source_replicas);
+    const auto handler = queue.addSubscriber(std::move(callback), wait_for_ids, sync_mode, std::move(source_replicas));
 
     if (!target_entry_event.tryWait(max_wait_milliseconds))
         return false;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

- Improved thread-safety in `ReplicatedMergeTreeQueue` by adding internal thread safety analysis annotations

Many methods in in `ReplicatedMergeTreeQueue` accept a `std::lock_guard` or `std::unique_lock` params. I suggest using clang's TSA to detect data races. 

For example, I found a data race with using `getCurrentMutationVersion`.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
