### PR TITLE
Exclude two tests for vector search from tsan

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_expansion_search.sql
+++ b/tests/queries/0_stateless/02354_vector_search_expansion_search.sql
@@ -1,11 +1,10 @@
--- Tags: no-fasttest, long, no-asan, no-ubsan, no-debug
+-- Tags: no-fasttest, long, no-asan, no-ubsan, no-tsan, no-debug
 -- ^^ Disable test for slow builds: generating data takes time but a sufficiently large data set
 -- is necessary for different hnsw_candidate_list_size_for_search settings to make a difference
 
 -- Tests vector search with setting 'hnsw_candidate_list_size_for_search'
 
 SET enable_vector_similarity_index = 1;
-SET max_execution_time = 600;
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02354_vector_search_multiple_marks.sql
+++ b/tests/queries/0_stateless/02354_vector_search_multiple_marks.sql
@@ -1,9 +1,9 @@
--- Tags: no-fasttest, no-ordinary-database
+-- Tags: no-fasttest, no-ordinary-database, no-tsan
+-- no-tsan: generating data takes too long
 
 -- Tests correctness of vector similarity index with > 1 mark
 
 SET enable_vector_similarity_index = 1;
-SET max_execution_time = 600;
 
 DROP TABLE IF EXISTS tab;
 


### PR DESCRIPTION
Multiple timeouts for two vector search tests were seen recently.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)