### PR TITLE
Support type casts for IN and GLOBAL IN over KV storages

### DIFF
--- a/tests/queries/0_stateless/03578_distributed_kv_global_in.reference
+++ b/tests/queries/0_stateless/03578_distributed_kv_global_in.reference
@@ -1,0 +1,34 @@
+-- RocksDB: set
+0	val-0
+0	val-0
+1	val-1
+1	val-1
+2	val-2
+2	val-2
+-- RocksDB: subquery
+0	val-0
+0	val-0
+1	val-1
+1	val-1
+2	val-2
+2	val-2
+-- Rows read:
+6
+15
+-- KeeperMap: set
+0	val-0
+0	val-0
+1	val-1
+1	val-1
+2	val-2
+2	val-2
+-- KeeperMap: subquery
+0	val-0
+0	val-0
+1	val-1
+1	val-1
+2	val-2
+2	val-2
+-- Rows read:
+6
+15

--- a/tests/queries/0_stateless/03578_distributed_kv_global_in.sql
+++ b/tests/queries/0_stateless/03578_distributed_kv_global_in.sql
@@ -1,0 +1,101 @@
+-- Tags: no-fasttest
+
+SET prefer_localhost_replica = 0;
+
+DROP TABLE IF EXISTS 03578_rocksdb_local, 03578_rocksdb_dist;
+
+CREATE TABLE IF NOT EXISTS 03578_rocksdb_local
+(
+    key UInt64,
+    val String
+)
+ENGINE = EmbeddedRocksDB()
+PRIMARY KEY key;
+
+CREATE TABLE IF NOT EXISTS 03578_rocksdb_dist
+(
+    key UInt64,
+    val String
+)
+ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), 03578_rocksdb_local);
+
+INSERT INTO 03578_rocksdb_local SELECT number, 'val-' || number FROM numbers(1000);
+
+SELECT '-- RocksDB: set';
+
+SELECT *
+FROM 03578_rocksdb_dist
+WHERE key GLOBAL IN (0, 1, 2)
+ORDER BY 1, 2;
+
+SELECT '-- RocksDB: subquery';
+
+SELECT *
+FROM 03578_rocksdb_dist
+WHERE key GLOBAL IN (
+    SELECT number FROM numbers(3)
+)
+ORDER BY 1, 2;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- Rows read:';
+
+SELECT read_rows
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE '%FROM 03578_rocksdb_dist%'
+  AND is_initial_query
+ORDER BY event_time_microseconds;
+
+DROP TABLE 03578_rocksdb_local, 03578_rocksdb_dist;
+
+DROP TABLE IF EXISTS 03578_keepermap_local, 03578_keepermap_dist;
+
+CREATE TABLE IF NOT EXISTS 03578_keepermap_local
+(
+    key UInt64,
+    val String
+)
+ENGINE = KeeperMap('/' || currentDatabase() || '/test_03578_global_in')
+PRIMARY KEY (key);
+
+CREATE TABLE IF NOT EXISTS 03578_keepermap_dist
+(
+    key UInt64,
+    val String
+)
+ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), 03578_keepermap_local);
+
+INSERT INTO 03578_keepermap_local SELECT number, 'val-' || number FROM numbers(1000);
+
+SELECT '-- KeeperMap: set';
+
+SELECT *
+FROM 03578_keepermap_dist
+WHERE key GLOBAL IN (0, 1, 2)
+ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: subquery';
+
+SELECT *
+FROM 03578_keepermap_dist
+WHERE key GLOBAL IN (
+    SELECT number FROM numbers(3)
+)
+ORDER BY 1, 2;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- Rows read:';
+
+SELECT read_rows
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE '%FROM 03578_keepermap_dist%'
+  AND is_initial_query
+ORDER BY event_time_microseconds;
+
+DROP TABLE IF EXISTS 03578_keepermap_local, 03578_keepermap_dist;

--- a/tests/queries/0_stateless/03578_kv_in_type_casts.reference
+++ b/tests/queries/0_stateless/03578_kv_in_type_casts.reference
@@ -1,0 +1,91 @@
+-- RocksDB: set safe to cast
+0	val-0
+1	val-1
+-- RocksDB: set not safe to cast
+0	val-0
+1	val-1
+-- RocksDB: set with overflow
+0	val-0
+-- RocksDB: set with cast failure
+-- RocksDB: subquery safe to cast
+0	val-0
+1	val-1
+-- RocksDB: subquery not safe to cast
+0	val-0
+1	val-1
+-- RocksDB: subquery with overflow
+0	val-0
+-- RocksDB: subquery with cast failure
+0	val-0
+-- Rows read:
+2
+2
+1
+4
+4
+102
+102
+
+-- RocksDB null: set without null
+0	val-0
+1	val-1
+-- RocksDB null: set with null
+1	val-1
+\N	val-null
+-- RocksDB null: subquery without null
+0	val-0
+1	val-1
+-- RocksDB null: subquery with null
+1	val-1
+\N	val-null
+-- Rows read:
+2
+100
+4
+102
+
+-- KeeperMap: set safe to cast
+0	val-0
+1	val-1
+-- KeeperMap: set not safe to cast
+0	val-0
+1	val-1
+-- KeeperMap: set with overflow
+0	val-0
+-- KeeperMap: set with cast failure
+-- KeeperMap: subquery safe to cast
+0	val-0
+1	val-1
+-- KeeperMap: subquery not safe to cast
+0	val-0
+1	val-1
+-- KeeperMap: subquery with overflow
+0	val-0
+-- KeeperMap: subquery with cast failure
+0	val-0
+-- Rows read:
+2
+2
+1
+4
+4
+102
+102
+
+-- KeeperMap null: set without null
+0	val-0
+1	val-1
+-- KeeperMap null: set with null
+1	val-1
+\N	val-null
+-- KeeperMap null: subquery without null
+0	val-0
+1	val-1
+-- KeeperMap null: subquery with null
+1	val-1
+\N	val-null
+-- Rows read:
+2
+100
+4
+102

--- a/tests/queries/0_stateless/03578_kv_in_type_casts.sql
+++ b/tests/queries/0_stateless/03578_kv_in_type_casts.sql
@@ -1,0 +1,185 @@
+-- Tags: no-fasttest
+
+DROP TABLE IF EXISTS 03578_rocksdb;
+
+CREATE TABLE IF NOT EXISTS 03578_rocksdb
+(
+    key UInt16,
+    val String
+)
+ENGINE = EmbeddedRocksDB()
+PRIMARY KEY key;
+
+INSERT INTO 03578_rocksdb SELECT number, 'val-' || number FROM numbers(100);
+
+SELECT '-- RocksDB: set safe to cast';
+SELECT * FROM 03578_rocksdb WHERE key IN (0::UInt8, 1::UInt8) ORDER BY 1, 2;
+
+SELECT '-- RocksDB: set not safe to cast';
+SELECT * FROM 03578_rocksdb WHERE key IN (0::UInt32, 1::UInt32) ORDER BY 1, 2;
+
+SELECT '-- RocksDB: set with overflow';
+SELECT * FROM 03578_rocksdb WHERE key IN (0::UInt32, 1000000::UInt32) ORDER BY 1, 2;
+
+SELECT '-- RocksDB: set with cast failure';
+SELECT * FROM 03578_rocksdb WHERE key IN ('0', 'non-number') ORDER BY 1, 2; -- { serverError TYPE_MISMATCH }
+
+SELECT '-- RocksDB: subquery safe to cast';
+SELECT * FROM 03578_rocksdb WHERE key IN (SELECT 0::UInt8 UNION ALL SELECT 1::UInt8) ORDER BY 1, 2;
+
+SELECT '-- RocksDB: subquery not safe to cast';
+SELECT * FROM 03578_rocksdb WHERE key IN (SELECT 0::UInt32 UNION ALL SELECT 1::UInt32) ORDER BY 1, 2;
+
+SELECT '-- RocksDB: subquery with overflow';
+SELECT * FROM 03578_rocksdb WHERE key IN (SELECT 0::UInt32 UNION ALL SELECT 1000000::UInt32) ORDER BY 1, 2;
+
+SELECT '-- RocksDB: subquery with cast failure';
+SELECT * FROM 03578_rocksdb WHERE key IN (SELECT '0' UNION ALL SELECT 'non-number') ORDER BY 1, 2;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- Rows read:';
+
+SELECT read_rows
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE '%FROM 03578_rocksdb%'
+  AND is_initial_query
+ORDER BY event_time_microseconds;
+
+DROP TABLE 03578_rocksdb;
+
+SELECT '';
+
+DROP TABLE IF EXISTS 03578_rocksdb_nullable;
+
+CREATE TABLE IF NOT EXISTS 03578_rocksdb_nullable
+(
+    key Nullable(UInt16),
+    val String
+)
+ENGINE = EmbeddedRocksDB()
+PRIMARY KEY key;
+
+INSERT INTO 03578_rocksdb_nullable SELECT null, 'val-null';
+INSERT INTO 03578_rocksdb_nullable SELECT number, 'val-' || number FROM numbers(99);
+
+SELECT '-- RocksDB null: set without null';
+SELECT * FROM 03578_rocksdb_nullable WHERE key IN (0, 1) ORDER BY 1, 2;
+
+SELECT '-- RocksDB null: set with null';
+SELECT * FROM 03578_rocksdb_nullable WHERE key IN (null, 1) ORDER BY 1, 2 SETTINGS transform_null_in = 1;
+
+SELECT '-- RocksDB null: subquery without null';
+SELECT * FROM 03578_rocksdb_nullable WHERE key IN (SELECT 0 UNION ALL SELECT 1) ORDER BY 1, 2;
+
+SELECT '-- RocksDB null: subquery with null';
+SELECT * FROM 03578_rocksdb_nullable WHERE key IN (SELECT null UNION ALL SELECT 1) ORDER BY 1, 2 SETTINGS transform_null_in = 1;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- Rows read:';
+
+SELECT read_rows
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE '%FROM 03578_rocksdb_nullable%'
+  AND is_initial_query
+ORDER BY event_time_microseconds;
+
+DROP TABLE 03578_rocksdb_nullable;
+
+SELECT '';
+
+DROP TABLE IF EXISTS 03578_keepermap;
+
+CREATE TABLE IF NOT EXISTS 03578_keepermap
+(
+    key UInt16,
+    val String
+)
+ENGINE = KeeperMap('/' || currentDatabase() || '/test_03578_type_cast')
+PRIMARY KEY key;
+
+INSERT INTO 03578_keepermap SELECT number, 'val-' || number FROM numbers(100);
+
+SELECT '-- KeeperMap: set safe to cast';
+SELECT * FROM 03578_keepermap WHERE key IN (0::UInt8, 1::UInt8) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: set not safe to cast';
+SELECT * FROM 03578_keepermap WHERE key IN (0::UInt32, 1::UInt32) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: set with overflow';
+SELECT * FROM 03578_keepermap WHERE key IN (0::UInt32, 1000000::UInt32) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: set with cast failure';
+SELECT * FROM 03578_keepermap WHERE key IN ('0', 'non-number') ORDER BY 1, 2; -- { serverError TYPE_MISMATCH }
+
+SELECT '-- KeeperMap: subquery safe to cast';
+SELECT * FROM 03578_keepermap WHERE key IN (SELECT 0::UInt8 UNION ALL SELECT 1::UInt8) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: subquery not safe to cast';
+SELECT * FROM 03578_keepermap WHERE key IN (SELECT 0::UInt32 UNION ALL SELECT 1::UInt32) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: subquery with overflow';
+SELECT * FROM 03578_keepermap WHERE key IN (SELECT 0::UInt32 UNION ALL SELECT 1000000::UInt32) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap: subquery with cast failure';
+SELECT * FROM 03578_keepermap WHERE key IN (SELECT '0' UNION ALL SELECT 'non-number') ORDER BY 1, 2;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- Rows read:';
+
+SELECT read_rows
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE '%FROM 03578_keepermap%'
+  AND is_initial_query
+ORDER BY event_time_microseconds;
+
+DROP TABLE 03578_keepermap;
+
+SELECT '';
+
+DROP TABLE IF EXISTS 03578_keepermap_nullable;
+
+CREATE TABLE IF NOT EXISTS 03578_keepermap_nullable
+(
+    key Nullable(UInt16),
+    val String
+)
+ENGINE = KeeperMap('/' || currentDatabase() || '/test_03578_type_cast_null')
+PRIMARY KEY key;
+
+INSERT INTO 03578_keepermap_nullable SELECT null, 'val-null';
+INSERT INTO 03578_keepermap_nullable SELECT number, 'val-' || number FROM numbers(99);
+
+SELECT '-- KeeperMap null: set without null';
+SELECT * FROM 03578_keepermap_nullable WHERE key IN (0, 1) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap null: set with null';
+SELECT * FROM 03578_keepermap_nullable WHERE key IN (null, 1) ORDER BY 1, 2 SETTINGS transform_null_in = 1;
+
+SELECT '-- KeeperMap null: subquery without null';
+SELECT * FROM 03578_keepermap_nullable WHERE key IN (SELECT 0 UNION ALL SELECT 1) ORDER BY 1, 2;
+
+SELECT '-- KeeperMap null: subquery with null';
+SELECT * FROM 03578_keepermap_nullable WHERE key IN (SELECT null UNION ALL SELECT 1) ORDER BY 1, 2 SETTINGS transform_null_in = 1;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- Rows read:';
+
+SELECT read_rows
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE '%FROM 03578_keepermap_nullable%'
+  AND is_initial_query
+ORDER BY event_time_microseconds;
+
+DROP TABLE 03578_keepermap_nullable;


### PR DESCRIPTION
Related #83099 (its part regarding GLOBAL IN)

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow set values type casting when pushing down `IN` / `GLOBAL IN` filters over KeyValue storage primary keys (e.g., EmbeddedRocksDB, KeeperMap).