### PR TITLE
Fix bad function call in cache policy

### DIFF
--- a/src/Common/LRUCachePolicy.h
+++ b/src/Common/LRUCachePolicy.h
@@ -243,7 +243,9 @@ private:
 
             current_size_in_bytes -= cell.size;
             current_weight_lost += cell.size;
-            on_remove_entry_function(cell.size, cell.value);
+            /// Update cache-specific metrics.
+            if (on_remove_entry_function)
+                on_remove_entry_function(cell.size, cell.value);
 
             cells.erase(it);
             queue.pop_front();

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -329,7 +329,9 @@ private:
 
                 /// We cannot have protected cells in non-protected queue
                 chassert(!is_protected);
-                on_remove_entry_function(cell.size, cell.value);
+                /// Update cache-specific metrics.
+                if (on_remove_entry_function)
+                    on_remove_entry_function(cell.size, cell.value);
 
                 cells.erase(it);
                 queue.pop_front();

--- a/src/Common/tests/gtest_lru_cache.cpp
+++ b/src/Common/tests/gtest_lru_cache.cpp
@@ -105,3 +105,18 @@ TEST(LRUCache, getOrSet)
     ASSERT_TRUE(*value == 10);
 }
 
+
+TEST(LRUCache, noOnRemoveEntryCallback)
+{
+    DB::LRUCachePolicy<std::string, size_t> lru_cache = {CurrentMetrics::end(), CurrentMetrics::end(), 10, 1, {}};
+    lru_cache.set("key1", std::make_shared<size_t>(10));
+    auto value = lru_cache.get("key1");
+    ASSERT_TRUE(value != nullptr);
+    ASSERT_TRUE(*value == 10);
+    lru_cache.set("key2", std::make_shared<size_t>(20));
+    value = lru_cache.get("key1");
+    ASSERT_TRUE(value == nullptr);
+    value = lru_cache.get("key2");
+    ASSERT_TRUE(value != nullptr);
+    ASSERT_TRUE(*value == 20);
+}

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -240,3 +240,14 @@ TEST(SLRUCache, MaxCount)
         }
     }
 }
+
+TEST(SLRUCache, noOnRemoveEntryCallback)
+{
+    DB::SLRUCachePolicy<std::string, size_t> slru_cache = {CurrentMetrics::end(), CurrentMetrics::end(), 20, 1, 0.5, {}};
+    slru_cache.set("key1", std::make_shared<size_t>(10));
+    slru_cache.set("key2", std::make_shared<size_t>(20));
+    auto value = slru_cache.get("key2");
+    ASSERT_TRUE(value != nullptr);
+    value = slru_cache.get("key1");
+    ASSERT_TRUE(value == nullptr);
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not for changelog, because it does not affect public repository.

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
