### PR TITLE
Data lakes: fix pruning files with virtual columns

### DIFF
--- a/src/Storages/ObjectStorage/IObjectIterator.cpp
+++ b/src/Storages/ObjectStorage/IObjectIterator.cpp
@@ -1,0 +1,64 @@
+#include <Storages/VirtualColumnUtils.h>
+#include <Storages/ObjectStorage/IObjectIterator.h>
+#include <Interpreters/ExpressionActions.h>
+
+namespace DB
+{
+
+static ExpressionActionsPtr getExpressionActions(
+    const DB::ActionsDAG & filter_,
+    const NamesAndTypesList & virtual_columns_,
+    const ContextPtr & context_)
+{
+    auto filter = VirtualColumnUtils::createPathAndFileFilterDAG(filter_.getOutputs().at(0), virtual_columns_);
+    if (filter.has_value())
+    {
+        VirtualColumnUtils::buildSetsForDAG(*filter, context_);
+        return std::make_shared<ExpressionActions>(std::move(*filter));
+    }
+    return nullptr;
+}
+
+ObjectIteratorWithPathAndFileFilter::ObjectIteratorWithPathAndFileFilter(
+    ObjectIterator iterator_,
+    const DB::ActionsDAG & filter_,
+    const NamesAndTypesList & virtual_columns_,
+    const std::string & object_namespace_,
+    const ContextPtr & context_)
+    : WithContext(context_)
+    , iterator(iterator_)
+    , object_namespace(object_namespace_)
+    , virtual_columns(virtual_columns_)
+    , filter_actions(getExpressionActions(filter_, virtual_columns, context_))
+{
+}
+
+ObjectInfoPtr ObjectIteratorWithPathAndFileFilter::next(size_t id)
+{
+    while (true)
+    {
+        auto object = iterator->next(id);
+        if (!object)
+            break;
+
+        if (filter_actions)
+        {
+            const auto key = object->getPath();
+            std::vector<std::string> keys({key});
+
+            auto path = key;
+            if (path.starts_with("/"))
+                path = path.substr(1);
+            path = std::filesystem::path(object_namespace) / path;
+
+            VirtualColumnUtils::filterByPathOrFile(keys, std::vector<std::string>{path}, filter_actions, virtual_columns, getContext());
+            if (keys.empty())
+                continue;
+        }
+
+        return object;
+    }
+    return {};
+}
+
+}

--- a/src/Storages/ObjectStorage/IObjectIterator.h
+++ b/src/Storages/ObjectStorage/IObjectIterator.h
@@ -5,6 +5,7 @@ namespace DB
 {
 using ObjectInfo = RelativePathWithMetadata;
 using ObjectInfoPtr = std::shared_ptr<RelativePathWithMetadata>;
+class ExpressionActions;
 
 struct IObjectIterator
 {
@@ -14,5 +15,25 @@ struct IObjectIterator
 };
 
 using ObjectIterator = std::shared_ptr<IObjectIterator>;
+
+class ObjectIteratorWithPathAndFileFilter : public IObjectIterator, private WithContext
+{
+public:
+    ObjectIteratorWithPathAndFileFilter(
+        ObjectIterator iterator_,
+        const DB::ActionsDAG & filter_,
+        const NamesAndTypesList & virtual_columns_,
+        const std::string & object_namespace_,
+        const ContextPtr & context_);
+
+    ObjectInfoPtr next(size_t) override;
+    size_t estimatedKeysCount() override { return iterator->estimatedKeysCount(); }
+
+private:
+    const ObjectIterator iterator;
+    const std::string object_namespace;
+    const NamesAndTypesList virtual_columns;
+    const std::shared_ptr<ExpressionActions> filter_actions;
+};
 
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -181,11 +181,22 @@ std::shared_ptr<IObjectIterator> StorageObjectStorageSource::createFileIterator(
     }
     else if (configuration->supportsFileIterator())
     {
-        return configuration->iterate(
+        auto iter = configuration->iterate(
             filter_actions_dag,
             file_progress_callback,
             query_settings.list_object_keys_size,
             local_context);
+
+        if (filter_actions_dag)
+        {
+            return std::make_shared<ObjectIteratorWithPathAndFileFilter>(
+                std::move(iter),
+                *filter_actions_dag,
+                virtual_columns,
+                configuration->getNamespace(),
+                local_context);
+        }
+        return iter;
     }
     else
     {

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -2085,7 +2085,6 @@ deltaLakeCluster(cluster_old,
     )
 
 
-
 def test_partition_columns_3(started_cluster):
     instance = started_cluster.instances["node1"]
     spark = started_cluster.spark_session
@@ -2138,4 +2137,74 @@ def test_partition_columns_3(started_cluster):
         "8\tname_8\t32\tUS\t2025\n"
         "9\tname_9\t32\tUS\t2025"
         == instance.query(f"SELECT * FROM {table_function} ORDER BY all").strip()
+    )
+
+
+def test_filtering_by_virtual_columns(started_cluster):
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+    TABLE_NAME = randomize_table_name("test_filtering_by_virtual_columns")
+    result_file = f"{TABLE_NAME}"
+    partition_columns = ["year"]
+
+    schema = StructType(
+        [
+            StructField("id", IntegerType(), nullable=False),
+            StructField("name", StringType(), nullable=False),
+            StructField("age", IntegerType(), nullable=False),
+            StructField("country", StringType(), nullable=False),
+            StructField("year", StringType(), nullable=False),
+        ]
+    )
+
+    num_rows = 10
+    now = datetime.now()
+    data = [(i, f"name_{i}", 32, "US", f"202{i}") for i in range(num_rows)]
+    df = spark.createDataFrame(data=data, schema=schema)
+    df.printSchema()
+    df.write.mode("append").format("delta").partitionBy(partition_columns).save(
+        f"/{TABLE_NAME}"
+    )
+
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+
+    files = upload_directory(minio_client, bucket, f"/{TABLE_NAME}", "")
+    assert len(files) > 0
+    print(f"Uploaded files: {files}")
+
+    table_function = f"deltaLake('http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{result_file}/', 'minio', '{minio_secret_key}', SETTINGS allow_experimental_delta_kernel_rs=0)"
+
+    result = int(instance.query(f"SELECT count() FROM {table_function}"))
+    assert result == num_rows
+
+    assert (
+        "0\tname_0\t32\tUS\t2020\n"
+        "1\tname_1\t32\tUS\t2021\n"
+        "2\tname_2\t32\tUS\t2022\n"
+        "3\tname_3\t32\tUS\t2023\n"
+        "4\tname_4\t32\tUS\t2024\n"
+        "5\tname_5\t32\tUS\t2025\n"
+        "6\tname_6\t32\tUS\t2026\n"
+        "7\tname_7\t32\tUS\t2027\n"
+        "8\tname_8\t32\tUS\t2028\n"
+        "9\tname_9\t32\tUS\t2029"
+        == instance.query(f"SELECT * FROM {table_function} ORDER BY all").strip()
+    )
+
+    query_id = f"query_{TABLE_NAME}_1"
+    result = int(
+        instance.query(
+            f"SELECT count() FROM {table_function} WHERE _path ILIKE '%2024%'",
+            query_id=query_id,
+        )
+    )
+    assert result == 1
+    instance.query("SYSTEM FLUSH LOGS")
+    assert result == int(
+        instance.query(
+            f"SELECT ProfileEvents['EngineFileLikeReadFiles'] FROM system.query_log WHERE query_id = '{query_id}' and type = 'QueryFinish'"
+        )
     )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix pruning files by virtual column in data lakes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
