### PR TITLE
Fix leak in gtest_delta_kernel

### DIFF
--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -1,8 +1,9 @@
-#include <gtest/gtest.h>
 #include "config.h"
 
 #if USE_DELTA_KERNEL_RS
 
+#include <base/scope_guard.h>
+#include <gtest/gtest.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Common/tests/gtest_global_register.h>
 #include <Common/logger_useful.h>
@@ -44,6 +45,7 @@ public:
 TEST_F(DeltaKernelTest, ExpressionVisitor)
 {
     auto * expression = ffi::get_testing_kernel_expression();
+    SCOPE_EXIT(ffi::free_kernel_expression(expression));
     try
     {
         auto dag = DeltaLake::visitExpression(


### PR DESCRIPTION
    ==13==ERROR: LeakSanitizer: detected memory leaks

    Direct leak of 112 byte(s) in 1 object(s) allocated from:
        #0 0x562de572644f in malloc (/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/unit_tests_dbms+0xb7c744f) (BuildId: ece9c88fdfe6a6e98d1a0ed8ab535e80c258c855)
        #1 0x562e12f3f8d7 in get_testing_kernel_expression (/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/unit_tests_dbms+0x38fe08d7) (BuildId: ece9c88fdfe6a6e98d1a0ed8ab535e80c258c855)

CI: https://s3.amazonaws.com/clickhouse-test-reports/PRs/84084/a27e4fcb365a35641c75fc886c90dafc8418b812//unit_tests_asan/job.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
