### PR TITLE
Fix leaks for keeper with rocksdb storage (iterators was not destroyed)

### DIFF
--- a/src/Coordination/RocksDBContainer.h
+++ b/src/Coordination/RocksDBContainer.h
@@ -11,6 +11,7 @@
 #include <rocksdb/table.h>
 #include <rocksdb/snapshot.h>
 #include <rocksdb/write_batch.h>
+#include <Common/logger_useful.h>
 
 namespace DB
 {
@@ -179,7 +180,11 @@ public:
     {
         if (initialized)
         {
-            rocksdb_ptr->Close();
+            auto status = rocksdb_ptr->Close();
+            if (!status.ok())
+            {
+                LOG_ERROR(getLogger("RocksDB"), "Close failed (the error will be ignored): {}", status.ToString());
+            }
             rocksdb_ptr = nullptr;
 
             std::filesystem::remove_all(rocksdb_dir);

--- a/src/Coordination/RocksDBContainer.h
+++ b/src/Coordination/RocksDBContainer.h
@@ -70,7 +70,7 @@ public:
 
         explicit const_iterator(std::shared_ptr<KVPair> pair_) : pair(std::move(pair_)) {}
 
-        explicit const_iterator(rocksdb::Iterator * iter_) : iter(iter_)
+        explicit const_iterator(std::shared_ptr<rocksdb::Iterator> iter_) : iter(iter_)
         {
             updatePairFromIter();
         }
@@ -362,7 +362,7 @@ public:
         }
         rocksdb_ptr = std::unique_ptr<rocksdb::DB>(db);
 
-        auto * it = rocksdb_ptr->NewIterator(rocksdb::ReadOptions{});
+        std::unique_ptr<rocksdb::Iterator> it(rocksdb_ptr->NewIterator(rocksdb::ReadOptions{}));
         counter = 0;
         for (it->SeekToFirst(); it->Valid(); it->Next())
         {
@@ -479,7 +479,7 @@ public:
         read_options.total_order_seek = true;
         if (snapshot_mode)
             read_options.snapshot = snapshot;
-        auto * iter = rocksdb_ptr->NewIterator(read_options);
+        std::shared_ptr<rocksdb::Iterator> iter(rocksdb_ptr->NewIterator(read_options));
         iter->SeekToFirst();
         return const_iterator(iter);
     }

--- a/src/Coordination/RocksDBContainer.h
+++ b/src/Coordination/RocksDBContainer.h
@@ -147,8 +147,6 @@ public:
         }
     };
 
-    bool initialized = false;
-
     const const_iterator end_ptr;
 
     void initialize(const KeeperContextPtr & context)
@@ -173,12 +171,11 @@ public:
         }
         rocksdb_ptr = std::unique_ptr<rocksdb::DB>(db);
         write_options.disableWAL = true;
-        initialized = true;
     }
 
     ~RocksDBContainer()
     {
-        if (initialized)
+        if (rocksdb_ptr)
         {
             auto status = rocksdb_ptr->Close();
             if (!status.ok())


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix leaks for keeper with rocksdb storage (iterators was not destroyed)

CI: https://s3.amazonaws.com/clickhouse-test-reports/PRs/84084/a27e4fcb365a35641c75fc886c90dafc8418b812//unit_tests_asan/job.log