### PR TITLE
ci: dump stacktraces in case of unit tests aborted or timed out

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -491,7 +491,7 @@ class JobConfigs:
         name=JobNames.UNITTEST,
         runs_on=[],  # from parametrize()
         command=f"python3 ./ci/jobs/unit_tests_job.py",
-        run_in_docker="clickhouse/fasttest",
+        run_in_docker="clickhouse/fasttest+--privileged",
         digest_config=Job.CacheDigestConfig(
             include_paths=["./ci/jobs/unit_tests_job.py"],
         ),

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -7,11 +7,11 @@ if __name__ == "__main__":
     #
     # Note, LSan does not compatible with debugger, so let's not run binary under gdb for sanitizers
     if "san" not in Info().job_name:
-        command_prefix = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall exit_group' -ex run -ex bt -arg"
+        command_launcher = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall exit_group' -ex run -ex bt -arg"
     else:
-        command_prefix = ""
+        command_launcher = ""
 
     Result.from_gtest_run(
         unit_tests_path="./ci/tmp/unit_tests_dbms",
-        command_prefix=command_prefix,
+        command_launcher=command_launcher,
     ).complete_job()

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -2,12 +2,10 @@ from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 if __name__ == "__main__":
-    # With gdb we will capture stacktrace in case of abnormal termination and timeout (45 mins)
-    # 'catch syscall 231' (exit_group) is a hack to avoid exiting with non-zero exit code when process terminated successfully
-    #
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
-        command_launcher = f"timeout -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'catch syscall 231' -ex run -ex bt -ex 'thread apply all bt' -arg"
+        # With gdb we will capture stacktrace in case of abnormal termination and timeout (45 mins)
+        command_launcher = f"timeout -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'b _Exit' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     #
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
-        command_launcher = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall 231' -ex run -ex bt -arg"
+        command_launcher = f"timeout -v 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall 231' -ex run -ex bt -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -3,11 +3,11 @@ from ci.praktika.result import Result
 
 if __name__ == "__main__":
     # With gdb we will capture stacktrace in case of abnormal termination and timeout (30 mins)
-    # 'catch syscall exit_group' is a hack to avoid exiting with non-zero exit code when process terminated successfully
+    # 'catch syscall 231' (exit_group) is a hack to avoid exiting with non-zero exit code when process terminated successfully
     #
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
-        command_launcher = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall exit_group' -ex run -ex bt -arg"
+        command_launcher = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall 231' -ex run -ex bt -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -5,8 +5,8 @@ if __name__ == "__main__":
     # With gdb we will capture stacktrace in case of abnormal termination and timeout (30 mins)
     # 'catch syscall exit_group' is a hack to avoid exiting with non-zero exit code when process terminated successfully
     #
-    # Note, LSan does not compatible with debugger, so let's not run binary under gdb for sanitizers
-    if "san" not in Info().job_name:
+    # Note, LSan does not compatible with debugger
+    if "asan" not in Info().job_name:
         command_launcher = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall exit_group' -ex run -ex bt -arg"
     else:
         command_launcher = ""

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
         # With gdb we will capture stacktrace in case of abnormal termination and timeout (45 mins)
-        command_launcher = f"timeout -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'b _Exit' -ex run -ex bt -ex 'thread apply all bt' -arg"
+        command_launcher = f"timeout -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -1,3 +1,4 @@
+from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 if __name__ == "__main__":

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     #
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
-        command_launcher = f"timeout -v 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall 231' -ex run -ex bt -ex 'thread apply all bt' -arg"
+        command_launcher = f"timeout -v 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'catch syscall 231' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     #
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
-        command_launcher = f"timeout -v 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall 231' -ex run -ex bt -arg"
+        command_launcher = f"timeout -v 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall 231' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -2,12 +2,12 @@ from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 if __name__ == "__main__":
-    # With gdb we will capture stacktrace in case of abnormal termination and timeout (30 mins)
+    # With gdb we will capture stacktrace in case of abnormal termination and timeout (45 mins)
     # 'catch syscall 231' (exit_group) is a hack to avoid exiting with non-zero exit code when process terminated successfully
     #
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
-        command_launcher = f"timeout -v 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'catch syscall 231' -ex run -ex bt -ex 'thread apply all bt' -arg"
+        command_launcher = f"timeout -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'catch syscall 231' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:
         command_launcher = ""
 

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -1,6 +1,16 @@
 from ci.praktika.result import Result
 
 if __name__ == "__main__":
+    # With gdb we will capture stacktrace in case of abnormal termination and timeout (30 mins)
+    # 'catch syscall exit_group' is a hack to avoid exiting with non-zero exit code when process terminated successfully
+    #
+    # Note, LSan does not compatible with debugger, so let's not run binary under gdb for sanitizers
+    if "san" not in Info().job_name:
+        command_prefix = f"timeout 30m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex 'set pagination off' -ex 'catch syscall exit_group' -ex run -ex bt -arg"
+    else:
+        command_prefix = ""
+
     Result.from_gtest_run(
         unit_tests_path="./ci/tmp/unit_tests_dbms",
+        command_prefix=command_prefix,
     ).complete_job()

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -412,7 +412,7 @@ class Result(MetaClasses.Serializable):
 
     @classmethod
     def from_gtest_run(
-        cls, unit_tests_path, name="", with_log=False, command_prefix=""
+        cls, unit_tests_path, name="", with_log=False, command_launcher=""
     ):
         """
         Runs gtest and generates praktika Result from results
@@ -425,8 +425,8 @@ class Result(MetaClasses.Serializable):
         """
 
         command = f"{unit_tests_path} --gtest_output='json:{ResultTranslator.GTEST_RESULT_FILE}'"
-        if command_prefix:
-            command = f"{command_prefix} {command}"
+        if command_launcher:
+            command = f"{command_launcher} {command}"
 
         Shell.check(f"rm {ResultTranslator.GTEST_RESULT_FILE}")
         result = Result.from_commands_run(
@@ -435,6 +435,7 @@ class Result(MetaClasses.Serializable):
                 f"chmod +x {unit_tests_path}",
                 command,
             ],
+            with_log=with_log,
         )
         is_error = not result.is_ok()
         status, results, info = ResultTranslator.from_gtest()

--- a/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
@@ -942,7 +942,6 @@ struct TestQuery {
 
     SlotAllocationPtr allocateCPUSlots(AllocationType type, ResourceLink master_link, ResourceLink worker_link, const String & workload)
     {
-        std::scoped_lock lock{slots_mutex};
         CPULeaseSettings settings;
         settings.workload = workload;
         settings.preemption_timeout = std::chrono::milliseconds(12); // We use smaller timeout to make tests faster
@@ -979,7 +978,10 @@ struct TestQuery {
             [&, type, workload] (ResourceLink master_link, ResourceLink worker_link)
             {
                 setThreadName(workload.c_str());
-                slots = allocateCPUSlots(type, master_link, worker_link, workload);
+                {
+                    std::unique_lock in_thread_lock{slots_mutex};
+                    slots = allocateCPUSlots(type, master_link, worker_link, workload);
+                }
                 threadFunc(slots->acquire());
 
                 // TODO(serxa): this is not needed any longer. we do pool->wait(). Remove and check tests.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ci: dump stacktraces in case of unit tests aborted or timed out

https://pastila.nl/?00e96eb0/196dff088258a597bd1e6154f2941015#0PHksfOuvvKFoWoL+HvbJg==