### PR TITLE
Allow to change tracing level in delta-kernel-rs per query

### DIFF
--- a/contrib/delta-kernel-rs-cmake/CMakeLists.txt
+++ b/contrib/delta-kernel-rs-cmake/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 # * default-engine: Needed for its s3 client (we can't pass our own s3 client via ffi)
 clickhouse_import_crate(
     MANIFEST_PATH "${DELTA_KERNEL_RS_SOURCE_DIR}/ffi/Cargo.toml"
-    FEATURES "default-engine, test-ffi"
+    FEATURES "default-engine, test-ffi, tracing"
 )
 clickhouse_config_crate_flags(delta_kernel_ffi)
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6434,6 +6434,9 @@ Query Iceberg table using the specific snapshot id.
     DECLARE(Bool, delta_lake_enable_expression_visitor_logging, false, R"(
 Enables Test level logs of DeltaLake expression visitor. These logs can be too verbose even for test logging.
 )", 0) \
+    DECLARE(DeltaLakeTracingLevel, delta_lake_tracing_level, DeltaLakeTracingLevel::NONE, R"(
+Turns on delta-kernel-rs tracing to a specified log level.
+)", 0) \
     DECLARE(Bool, allow_deprecated_error_prone_window_functions, false, R"(
 Allow usage of deprecated error prone window functions (neighbor, runningAccumulate, runningDifferenceStartingWithFirstValue, runningDifference)
 )", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -105,6 +105,7 @@ class WriteBuffer;
     M(CLASS_NAME, UInt64Auto) \
     M(CLASS_NAME, URI) \
     M(CLASS_NAME, VectorSearchFilterStrategy) \
+    M(CLASS_NAME, DeltaLakeTracingLevel) \
     M(CLASS_NAME, GeoToH3ArgumentOrder)
 
 

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -327,4 +327,14 @@ IMPLEMENT_SETTING_ENUM(
     {{"lat_lon", GeoToH3ArgumentOrder::LAT_LON},
      {"lon_lat", GeoToH3ArgumentOrder::LON_LAT}})
 
+IMPLEMENT_SETTING_ENUM(
+    DeltaLakeTracingLevel,
+    ErrorCodes::BAD_ARGUMENTS,
+    {{"none", DeltaLakeTracingLevel::NONE},
+     {"error", DeltaLakeTracingLevel::ERROR},
+     {"warning", DeltaLakeTracingLevel::WARN},
+     {"info", DeltaLakeTracingLevel::INFO},
+     {"debug", DeltaLakeTracingLevel::DEBUG},
+     {"trace", DeltaLakeTracingLevel::TRACE}})
+
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -421,4 +421,16 @@ enum class GeoToH3ArgumentOrder : uint8_t
 
 DECLARE_SETTING_ENUM(GeoToH3ArgumentOrder)
 
+enum class DeltaLakeTracingLevel : uint8_t
+{
+    NONE,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE,
+};
+
+DECLARE_SETTING_ENUM(DeltaLakeTracingLevel)
+
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -65,6 +65,7 @@ private:
     const DB::ObjectStoragePtr object_storage;
     const LoggerPtr log;
     const bool enable_expression_visitor_logging;
+    DB::DeltaLakeTracingLevel tracing_level;
 
     mutable KernelExternEngine engine;
     mutable KernelSnapshot snapshot;


### PR DESCRIPTION
Depends on https://github.com/delta-io/delta-kernel-rs/pull/1111

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a setting `delta_lake_tracing_level` to allow to change delta-kernel-rs tracing level per query.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
