### PR TITLE
Fix missing nullable tuple support in getLeastSupertype

### DIFF
--- a/src/DataTypes/getLeastSupertype.cpp
+++ b/src/DataTypes/getLeastSupertype.cpp
@@ -271,71 +271,6 @@ DataTypePtr findSmallestIntervalSuperType(const DataTypes &types, TypeIndexSet &
 }
 
 template <LeastSupertypeOnError on_error>
-DataTypePtr getLeastSuperTypeForTuple(const DataTypes & types)
-{
-    Strings element_names;
-    size_t element_size = 0;
-    std::vector<DataTypes> element_types;
-    for (const auto & type : types)
-    {
-        if (const auto * type_tuple = typeid_cast<const DataTypeTuple *>(type.get()))
-        {
-            const auto & current_elements = type_tuple->getElements();
-            if (element_types.empty())
-            {
-                element_size = current_elements.size();
-                element_types.resize(element_size);
-                for (size_t i = 0; i < element_size; ++i)
-                    element_types[i].reserve(types.size());
-                if (type_tuple->hasExplicitNames())
-                    element_names = type_tuple->getElementNames();
-            }
-
-            if (element_size != type_tuple->getElements().size())
-                return throwOrReturn<on_error>(types, "because Tuples have different sizes", ErrorCodes::NO_COMMON_TYPE);
-            for (size_t i = 0; i < element_size; ++i)
-                element_types[i].emplace_back(current_elements[i]);
-
-            // If there are different names, drop all names. The result will be an unnamed tuple.
-            if (element_names.empty() == type_tuple->hasExplicitNames())
-                element_names.clear();
-            if (!element_names.empty())
-            {
-                const auto & current_element_names = type_tuple->getElementNames();
-                for (size_t i = 0; i < element_size; ++i)
-                {
-                    if (element_names[i] != current_element_names[i])
-                    {
-                        element_names.clear();
-                        break;
-                    }
-                }
-            }
-        }
-        else
-            return throwOrReturn<on_error>(types, "because some of them are Tuple and some of them are not", ErrorCodes::NO_COMMON_TYPE);
-    }
-
-
-    DataTypes commont_element_types(element_size);
-    for (size_t i = 0; i < element_size; ++i)
-    {
-        auto common_type = getLeastSupertype<on_error>(element_types[i]);
-        /// When on_error == LeastSupertypeOnError::Null and we cannot get least supertype,
-        /// common_type will be nullptr, we should return nullptr in this case.
-        if (!common_type)
-            return nullptr;
-        commont_element_types[i] = common_type;
-    }
-
-    if (element_names.empty())
-        return std::make_shared<DataTypeTuple>(commont_element_types);
-    else
-        return std::make_shared<DataTypeTuple>(commont_element_types, element_names);
-
-}
-
-template <LeastSupertypeOnError on_error>
 DataTypePtr getLeastSupertype(const DataTypes & types)
 {
     /// Trivial cases
@@ -430,10 +365,81 @@ DataTypePtr getLeastSupertype(const DataTypes & types)
     }
 
     /// For tuples
-    for (const auto & type : types)
     {
-        if (typeid_cast<const DataTypeTuple *>(type.get()))
-            return getLeastSuperTypeForTuple<on_error>(types);
+        bool have_tuple = false;
+        bool have_nullable_tuple = false;
+        bool all_tuples = true;
+        size_t tuple_size = 0;
+
+        std::vector<DataTypes> nested_types;
+        Strings element_names;
+        for (const auto & type : types)
+        {
+            auto type_not_nullable = removeNullable(type);
+            if (const DataTypeTuple * type_tuple = typeid_cast<const DataTypeTuple *>(type_not_nullable.get()))
+            {
+                if (!have_tuple)
+                {
+                    tuple_size = type_tuple->getElements().size();
+                    nested_types.resize(tuple_size);
+                    for (size_t elem_idx = 0; elem_idx < tuple_size; ++elem_idx)
+                        nested_types[elem_idx].reserve(types.size());
+                    if (type_tuple->hasExplicitNames())
+                        element_names = type_tuple->getElementNames();
+                }
+                else if (tuple_size != type_tuple->getElements().size())
+                    return throwOrReturn<on_error>(types, "because Tuples have different sizes", ErrorCodes::NO_COMMON_TYPE);
+
+                have_tuple = true;
+                if (!type->equals(*type_not_nullable))
+                    have_nullable_tuple = true;
+
+                for (size_t elem_idx = 0; elem_idx < tuple_size; ++elem_idx)
+                    nested_types[elem_idx].emplace_back(type_tuple->getElements()[elem_idx]);
+
+                // If there are different names, drop all names. The result will be an unnamed tuple.
+                if (element_names.empty() == type_tuple->hasExplicitNames())
+                    element_names.clear();
+                if (!element_names.empty())
+                {
+                    const auto & current_element_names = type_tuple->getElementNames();
+                    for (size_t i = 0; i < tuple_size; ++i)
+                    {
+                        if (element_names[i] != current_element_names[i])
+                        {
+                            element_names.clear();
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+                all_tuples = false;
+        }
+
+        if (have_tuple)
+        {
+            if (!all_tuples)
+                return throwOrReturn<on_error>(types, "because some of them are Tuple and some of them are not", ErrorCodes::NO_COMMON_TYPE);
+
+            DataTypes common_tuple_types(tuple_size);
+            for (size_t elem_idx = 0; elem_idx < tuple_size; ++elem_idx)
+            {
+                auto common_type = getLeastSupertype<on_error>(nested_types[elem_idx]);
+                /// When on_error == LeastSupertypeOnError::Null and we cannot get least supertype,
+                /// common_type will be nullptr, we should return nullptr in this case.
+                if (!common_type)
+                    return nullptr;
+                common_tuple_types[elem_idx] = common_type;
+            }
+
+            DataTypePtr res;
+            if (element_names.empty())
+                res = std::make_shared<DataTypeTuple>(common_tuple_types);
+            else
+                res = std::make_shared<DataTypeTuple>(common_tuple_types, element_names);
+            return have_nullable_tuple ? makeNullable(res) : res;
+        }
     }
 
     /// For maps


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
(https://github.com/ClickHouse/ClickHouse/pull/81345) missing nullable tuple support in getLeastSupertype, try fix it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
