### PR TITLE
tests: optimize 03300_merge_parts_metric

### DIFF
--- a/tests/queries/0_stateless/03300_merge_parts_metric.sh
+++ b/tests/queries/0_stateless/03300_merge_parts_metric.sh
@@ -5,9 +5,9 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# Among 1000 invocations, the values are equal most of the time
+# Among 1000 invocations, the values are equal most of the time, but let's expect at least 10% of equality to avoid flakiness
 # Note: they could be non-equal due to timing differences.
 
-$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test; CREATE TABLE test (x Bool) ENGINE = Memory;"
-yes "INSERT INTO test SELECT sum(length(source_part_names)) = (SELECT value FROM system.metrics WHERE name = 'MergeParts') FROM system.merges;" | head -n1000 | $CLICKHOUSE_CLIENT
-$CLICKHOUSE_CLIENT --query "SELECT sum(x) > 500 FROM test; DROP TABLE test;"
+yes "SELECT sum(length(source_part_names)) = (SELECT value FROM system.metrics WHERE name = 'MergeParts') FROM system.merges;" | head -n1000 | $CLICKHOUSE_CLIENT | {
+  sort | uniq -cd | awk '$1 > 100 && $NF == "1" { print $NF }'
+}


### PR DESCRIPTION
Sometimes it fails on CI [1], so let's decrease the threshold, and also simplify (and now it is 25% faster, 4.2s -> 3s).

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0c9a45081425e47c1e6c30f9a28efe34575389c7&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
