### PR TITLE
Text index: remove multi format versions handling

### DIFF
--- a/programs/fst-dump-tree/FstDumpTree.cpp
+++ b/programs/fst-dump-tree/FstDumpTree.cpp
@@ -153,9 +153,6 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                 case static_cast<FormatAsInt>(DB::GinIndexStore::Format::v1):
                     version = DB::GinIndexStore::Format::v1;
                     break;
-                case static_cast<FormatAsInt>(DB::GinIndexStore::Format::v2):
-                    version = DB::GinIndexStore::Format::v2;
-                    break;
                 default:
                     printAndExit("Segment id file is corrupted: unsupported version '{}'", DB::GinIndexStore::Format::v0);
             }
@@ -203,18 +200,6 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
 
                 dictionary_read_buffer->seek(segment_dict->dict_start_offset, SEEK_SET);
                 if (version == DB::GinIndexStore::Format::v1)
-                {
-                    /// Read uncompressed FST size
-                    size_t fst_size = 0;
-                    readVarUInt(fst_size, *dictionary_read_buffer);
-
-                    /// Read uncompressed FST blob
-                    segment_dict->offsets.getData().clear();
-                    segment_dict->offsets.getData().resize(fst_size);
-                    dictionary_read_buffer->readStrict(reinterpret_cast<char *>(segment_dict->offsets.getData().data()), fst_size);
-                    fmt::println("[Segment {}]: FST size = {}", segment_id, formatReadableSizeWithBinarySuffix(fst_size));
-                }
-                else if (version == DB::GinIndexStore::Format::v2)
                 {
                     /// Read FST size header
                     UInt64 fst_size_header = 0;

--- a/programs/fst-dump-tree/FstDumpTree.cpp
+++ b/programs/fst-dump-tree/FstDumpTree.cpp
@@ -154,7 +154,7 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                     version = DB::GinIndexStore::Format::v1;
                     break;
                 default:
-                    printAndExit("Segment id file is corrupted: unsupported version '{}'", DB::GinIndexStore::Format::v0);
+                    printAndExit("Segment id file is corrupted: unsupported version '{}'", ver);
             }
 
             readVarUInt(number_of_segments, *segment_id_read_buffer);

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -22,8 +22,8 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int CORRUPTED_DATA;
     extern const int LOGICAL_ERROR;
-    extern const int UNKNOWN_FORMAT_VERSION;
 };
 
 const CompressionCodecPtr & GinIndexCompressionFactory::zstdCodec()
@@ -208,18 +208,8 @@ GinIndexStore::Format getFormatVersion(uint8_t version)
         case static_cast<FormatAsInt>(GinIndexStore::Format::v1):
             return GinIndexStore::Format::v1;
         default:
-            return GinIndexStore::Format::v0;
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "Text Index: segment ID file contains an unsupported version '{}'", version);
     }
-}
-
-void verifyFormatVersionIsSupported(GinIndexStore::Format version)
-{
-    if (version != GinIndexStore::Format::v1)
-        throw Exception(
-            ErrorCodes::UNKNOWN_FORMAT_VERSION,
-            "Unsupported text index version: currently supported version {}, but got {}",
-            GinIndexStore::Format::v1,
-            version);
 }
 }
 
@@ -239,7 +229,7 @@ UInt32 GinIndexStore::getNumOfSegments()
         uint8_t version = 0;
         readBinary(version, *istr);
 
-        verifyFormatVersionIsSupported(getFormatVersion(version));
+        getFormatVersion(version);
 
         readVarUInt(result, *istr);
     }
@@ -252,7 +242,7 @@ GinIndexStore::Format GinIndexStore::getVersion()
 {
     String segment_id_file_name = getName() + GIN_SEGMENT_ID_FILE_TYPE;
     if (!storage->existsFile(segment_id_file_name))
-        return GinIndexStore::Format::v0;
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Text Index: segment ID file does not exist");
 
     std::unique_ptr<DB::ReadBufferFromFileBase> istr = this->storage->readFile(segment_id_file_name, {}, std::nullopt, std::nullopt);
     uint8_t version = 0;
@@ -308,7 +298,7 @@ void GinIndexStore::initSegmentId()
         uint8_t version = 0;
         readBinary(version, *istr);
 
-        verifyFormatVersionIsSupported(getFormatVersion(version));
+        getFormatVersion(version);
 
         readVarUInt(segment_id, *istr);
     }
@@ -516,8 +506,6 @@ void GinIndexStoreDeserializer::readSegmentDictionary(UInt32 segment_id)
             }
             break;
         }
-        default:
-            verifyFormatVersionIsSupported(version);
     }
 }
 

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -207,8 +207,6 @@ GinIndexStore::Format getFormatVersion(uint8_t version)
     {
         case static_cast<FormatAsInt>(GinIndexStore::Format::v1):
             return GinIndexStore::Format::v1;
-        case static_cast<FormatAsInt>(GinIndexStore::Format::v2):
-            return GinIndexStore::Format::v2;
         default:
             return GinIndexStore::Format::v0;
     }
@@ -216,12 +214,11 @@ GinIndexStore::Format getFormatVersion(uint8_t version)
 
 void verifyFormatVersionIsSupported(GinIndexStore::Format version)
 {
-    if ((version < GinIndexStore::Format::v1) || (version > GinIndexStore::Format::v2))
+    if (version != GinIndexStore::Format::v1)
         throw Exception(
             ErrorCodes::UNKNOWN_FORMAT_VERSION,
-            "Unsupported text index version: supported versions {} and {}, but got {}",
+            "Unsupported text index version: currently supported version {}, but got {}",
             GinIndexStore::Format::v1,
-            GinIndexStore::Format::v2,
             version);
 }
 }
@@ -493,17 +490,6 @@ void GinIndexStoreDeserializer::readSegmentDictionary(UInt32 segment_id)
     switch (auto version = store->getVersion(); version)
     {
         case GinIndexStore::Format::v1: {
-            /// Read FST size
-            size_t fst_size = 0;
-            readVarUInt(fst_size, *dict_file_stream);
-
-            /// Read FST blob
-            it->second->offsets.getData().clear();
-            it->second->offsets.getData().resize(fst_size);
-            dict_file_stream->readStrict(reinterpret_cast<char *>(it->second->offsets.getData().data()), fst_size);
-            break;
-        }
-        case GinIndexStore::Format::v2: {
             /// Read FST size header
             UInt64 fst_size_header;
             readVarUInt(fst_size_header, *dict_file_stream);

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -116,8 +116,7 @@ class GinIndexStore
 public:
     enum class Format : uint8_t
     {
-        v0 = 0,
-        v1 = 1, /// Initial version
+        v1 = 1, /// Initial version, supports adaptive compression
     };
 
     /// Container for all term's Gin Index Postings List Builder

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -114,12 +114,10 @@ using GinSegmentDictionaryPtr = std::shared_ptr<GinSegmentDictionary>;
 class GinIndexStore
 {
 public:
-    /// TODO(ahmadov): clean up versions when full-text search is not experimental feature anymore.
     enum class Format : uint8_t
     {
         v0 = 0,
         v1 = 1, /// Initial version
-        v2 = 2, /// Supports adaptive compression
     };
 
     /// Container for all term's Gin Index Postings List Builder
@@ -170,7 +168,7 @@ private:
     /// FST size less than 100KiB does not worth to compress.
     static constexpr auto FST_SIZE_COMPRESSION_THRESHOLD = 100_KiB;
     /// Current version of GinIndex to store FST
-    static constexpr auto CURRENT_GIN_FILE_FORMAT_VERSION = Format::v2;
+    static constexpr auto CURRENT_GIN_FILE_FORMAT_VERSION = Format::v1;
 
     friend class GinIndexStoreDeserializer;
 


### PR DESCRIPTION
Removes text index `Format::v2` and moves the improvements from `v2` into `v1`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)