### PR TITLE
Doccs: clarify `mergeTreeIndex` takes 2 or 3 arguments but not 4

### DIFF
--- a/docs/en/sql-reference/table-functions/mergeTreeIndex.md
+++ b/docs/en/sql-reference/table-functions/mergeTreeIndex.md
@@ -14,7 +14,7 @@ Represents the contents of index and marks files of MergeTree tables. It can be 
 ## Syntax {#syntax}
 
 ```sql
-mergeTreeIndex(database, table [, with_marks = true] [, with_minmax = true])
+mergeTreeIndex(database, table [, with_marks = true | with_minmax = true])
 ```
 
 ## Arguments {#arguments}
@@ -25,6 +25,10 @@ mergeTreeIndex(database, table [, with_marks = true] [, with_minmax = true])
 | `table`       | The table name to read index and marks from.      |
 | `with_marks`  | Whether include columns with marks to the result. |
 | `with_minmax` | Whether include min-max index to the result.      |
+
+:::note
+This function takes either 2 or 3 arguments
+:::
 
 ## Returned value {#returned_value}
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Repro: https://fiddle.clickhouse.com/95bb4476-a4f6-4d86-8165-6968395901fe
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
