### PR TITLE
Hold storage in query pipeline for LWU.

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -239,6 +239,7 @@ BlockIO InterpreterAlterQuery::executeToTable(const ASTAlterQuery & alter)
         {
             LOG_DEBUG(getLogger("InterpreterAlterQuery"), "Will execute query '{}' as a lightweight update", query_ptr->formatForErrorMessage());
             res.pipeline = table->updateLightweight(mutation_commands, getContext());
+            res.pipeline.addStorageHolder(table);
             return res;
         }
     }

--- a/src/Interpreters/InterpreterUpdateQuery.cpp
+++ b/src/Interpreters/InterpreterUpdateQuery.cpp
@@ -106,6 +106,7 @@ BlockIO InterpreterUpdateQuery::execute()
 
     BlockIO res;
     res.pipeline = table->updateLightweight(commands, getContext());
+    res.pipeline.addStorageHolder(table);
     return res;
 }
 

--- a/tests/queries/0_stateless/03100_lwu_drop_update_race.sh
+++ b/tests/queries/0_stateless/03100_lwu_drop_update_race.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: long, no-fasttest, no-sanitize-coverage
+
+set -e
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+function thread1()
+{
+    local TIMELIMIT=$((SECONDS+$1))
+    while [ $SECONDS -lt "$TIMELIMIT" ]; do
+        $CLICKHOUSE_CLIENT --query "
+            DROP TABLE IF EXISTS t_lwu_block_number SYNC;
+            SET allow_experimental_lightweight_update = 1;
+
+            CREATE TABLE t_lwu_block_number (id UInt64, c1 UInt64, c2 String)
+            ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_lwu_block_number/', '1')
+            ORDER BY id
+            SETTINGS
+                enable_block_number_column = 1,
+                enable_block_offset_column = 1;
+
+            INSERT INTO t_lwu_block_number VALUES (1, 100, 'aa') (2, 200, 'bb') (3, 300, 'cc');
+            "
+
+    done
+}
+
+function thread2()
+{
+    local TIMELIMIT=$((SECONDS+$1))
+    while [ $SECONDS -lt "$TIMELIMIT" ]; do
+        $CLICKHOUSE_CLIENT --query "
+                SET allow_experimental_lightweight_update = 1;
+                UPDATE t_lwu_block_number SET c2 = 'xx' WHERE id = 1;
+                UPDATE t_lwu_block_number SET c2 = 'aa' WHERE id = 2;
+                " 2> /dev/null || true
+    done
+}
+
+export -f thread1
+export -f thread2
+
+TIMEOUT=10
+
+thread1 $TIMEOUT >/dev/null &
+thread2 $TIMEOUT >/dev/null &
+
+wait

--- a/tests/queries/0_stateless/03100_lwu_drop_update_race.sh
+++ b/tests/queries/0_stateless/03100_lwu_drop_update_race.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-sanitize-coverage
+# Tags: long, no-fasttest, no-sanitize-coverage, no-replicated-database
 
 set -e
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix for https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=51f0b57edd4bd8c26cba96e7f5dac053dda18d60&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20msan%29&name_1=Stress%20test%20%28azure%2C%20msan%29

The storage was dropped before the LWU called dtor in MergeTreeDataPart.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
