### PR TITLE
Fix optional params in table function `mergeTreeIndex`

### DIFF
--- a/docs/en/sql-reference/table-functions/mergeTreeIndex.md
+++ b/docs/en/sql-reference/table-functions/mergeTreeIndex.md
@@ -14,7 +14,7 @@ Represents the contents of index and marks files of MergeTree tables. It can be 
 ## Syntax {#syntax}
 
 ```sql
-mergeTreeIndex(database, table [, with_marks = true | with_minmax = true])
+mergeTreeIndex(database, table [, with_marks = true] [, with_minmax = true])
 ```
 
 ## Arguments {#arguments}
@@ -25,10 +25,6 @@ mergeTreeIndex(database, table [, with_marks = true | with_minmax = true])
 | `table`       | The table name to read index and marks from.      |
 | `with_marks`  | Whether include columns with marks to the result. |
 | `with_minmax` | Whether include min-max index to the result.      |
-
-:::note
-This function takes either 2 or 3 arguments
-:::
 
 ## Returned value {#returned_value}
 

--- a/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
@@ -54,9 +54,9 @@ void TableFunctionMergeTreeIndex::parseArguments(const ASTPtr & ast_function, Co
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Table function ({}) must have arguments.", quoteString(getName()));
 
     ASTs & args = args_func.at(0)->children;
-    if (args.size() < 2 || args.size() > 3)
+    if (args.size() < 2)
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-            "Table function '{}' must have 2 or 3 arguments, got: {}", getName(), args.size());
+            "Table function '{}' must have at least 2 arguments, got: {}", getName(), args.size());
 
     args[0] = evaluateConstantExpressionForDatabaseName(args[0], context);
     args[1] = evaluateConstantExpressionOrIdentifierAsLiteral(args[1], context);

--- a/tests/queries/0_stateless/03579_mergeTreeIndex_params.reference
+++ b/tests/queries/0_stateless/03579_mergeTreeIndex_params.reference
@@ -1,0 +1,20 @@
+part_name	mark_number	rows_in_granule	s
+0_2_2_0	0	2	b
+0_2_2_0	1	0	d
+1_1_1_0	0	3	a
+1_1_1_0	1	0	e
+part_name	mark_number	rows_in_granule	s	s.mark	n.mark
+0_2_2_0	0	2	b	(0,0)	(0,0)
+0_2_2_0	1	0	d	(0,4)	(0,16)
+1_1_1_0	0	3	a	(0,0)	(0,0)
+1_1_1_0	1	0	e	(0,6)	(0,24)
+part_name	mark_number	rows_in_granule	minmax_n	s
+0_2_2_0	0	2	(2,4)	b
+0_2_2_0	1	0	(2,4)	d
+1_1_1_0	0	3	(1,5)	a
+1_1_1_0	1	0	(1,5)	e
+part_name	mark_number	rows_in_granule	minmax_n	s	s.mark	n.mark
+0_2_2_0	0	2	(2,4)	b	(0,0)	(0,0)
+0_2_2_0	1	0	(2,4)	d	(0,4)	(0,16)
+1_1_1_0	0	3	(1,5)	a	(0,0)	(0,0)
+1_1_1_0	1	0	(1,5)	e	(0,6)	(0,24)

--- a/tests/queries/0_stateless/03579_mergeTreeIndex_params.sql
+++ b/tests/queries/0_stateless/03579_mergeTreeIndex_params.sql
@@ -7,14 +7,14 @@ SETTINGS index_granularity = 3, min_bytes_for_wide_part = 0, min_rows_for_wide_p
 INSERT INTO t_mt_params VALUES ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5);
 
 SELECT * FROM mergeTreeIndex(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT * FROM mergeTreeIndex('default'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT * FROM mergeTreeIndex('default', 't_mt_params', non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
-SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1, non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
-SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1, with_minmax = 1, non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeIndex(currentDatabase()); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params', non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params', with_marks = 1, non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params', with_marks = 1, with_minmax = 1, non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
 
-SELECT * FROM mergeTreeIndex('default', 't_mt_params') ORDER BY ALL FORMAT TSVWithNames;
-SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1) ORDER BY ALL FORMAT TSVWithNames;
-SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_minmax = 1) ORDER BY ALL FORMAT TSVWithNames;
-SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1, with_minmax = 1) ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params') ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params', with_marks = 1) ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params', with_minmax = 1) ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex(currentDatabase(), 't_mt_params', with_marks = 1, with_minmax = 1) ORDER BY ALL FORMAT TSVWithNames;
 
 DROP TABLE t_mt_params;

--- a/tests/queries/0_stateless/03579_mergeTreeIndex_params.sql
+++ b/tests/queries/0_stateless/03579_mergeTreeIndex_params.sql
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS t_mt_params;
+
+CREATE TABLE t_mt_params (s String, n UInt64)
+ENGINE = MergeTree ORDER BY s PARTITION BY n % 2
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_mt_params VALUES ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5);
+
+SELECT * FROM mergeTreeIndex(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeIndex('default'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeIndex('default', 't_mt_params', non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1, non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1, with_minmax = 1, non_existing_param = 1); -- { serverError BAD_ARGUMENTS }
+
+SELECT * FROM mergeTreeIndex('default', 't_mt_params') ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1) ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_minmax = 1) ORDER BY ALL FORMAT TSVWithNames;
+SELECT * FROM mergeTreeIndex('default', 't_mt_params', with_marks = 1, with_minmax = 1) ORDER BY ALL FORMAT TSVWithNames;
+
+DROP TABLE t_mt_params;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
