### PR TITLE
We should retry starting sccache server before cmake

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -153,6 +153,10 @@ def main():
             Shell.check(
                 f"ln -sf /build/cmake/toolchain/darwin-x86_64 {current_directory}/cmake/toolchain/darwin-aarch64"
             )
+        elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
+            run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
+        run_shell("sccache start server", "sccache --start-server", retries=3)
+        run_shell("sccache stats", "sccache --show-stats")
         results.append(
             Result.from_commands_run(
                 name="Cmake configuration",
@@ -167,15 +171,12 @@ def main():
 
     files = []
     if res and JobStages.BUILD in stages:
-        run_shell("sccache start server", "sccache --start-server", retries=3)
-        run_shell("sccache stats", "sccache --show-stats")
         if build_type == BuildTypes.AMD_DEBUG:
             targets = "-k0 all"
         elif build_type == BuildTypes.FUZZERS:
             targets = "fuzzers"
         elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             targets = "-k0 all"
-            run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
         else:
             targets = "clickhouse-bundle"
         results.append(

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -155,7 +155,14 @@ def main():
             )
         elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
-        run_shell("sccache start server", "sccache --start-server", retries=3)
+        # The sccache server sometimes fails to start because of issues with S3
+        # It should start before cmake, since cmake can precompile binaries during
+        # configuration stage
+        results.append(
+            Result.from_commands_run(
+                name="Start sccache server", command="sccache --start-server", retries=3
+            )
+        )
         run_shell("sccache stats", "sccache --show-stats")
         results.append(
             Result.from_commands_run(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`sccache` sometimes could start during `cmake` configuration, and fail to start. This change starts the server before cmake.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
