### PR TITLE
add dimensional metric for the size of `ConcurrentBoundedQueue`

### DIFF
--- a/src/Common/DimensionalMetrics.cpp
+++ b/src/Common/DimensionalMetrics.cpp
@@ -64,6 +64,12 @@ namespace DB::DimensionalMetrics
         return *it->second;
     }
 
+    void MetricFamily::unregister(LabelValues label_values) noexcept
+    {
+        std::lock_guard lock(mutex);
+        metrics.erase(label_values);
+    }
+
     MetricFamily::MetricsMap MetricFamily::getMetrics() const
     {
         std::shared_lock lock(mutex);

--- a/src/Common/DimensionalMetrics.h
+++ b/src/Common/DimensionalMetrics.h
@@ -40,6 +40,7 @@ namespace DB::DimensionalMetrics
     public:
         explicit MetricFamily(Labels labels_, std::vector<LabelValues> initial_label_values = {});
         Metric & withLabels(LabelValues label_values);
+        void unregister(LabelValues label_values) noexcept;
         MetricsMap getMetrics() const;
         const Labels & getLabels() const;
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -269,7 +269,7 @@ private:
 
     using RequestsQueue = ConcurrentBoundedQueue<RequestInfo>;
 
-    RequestsQueue requests_queue{131072, "zookeeper-client"};
+    RequestsQueue requests_queue{1024, "zookeeper-client"};
     void pushRequest(RequestInfo && info);
 
     using Operations = std::map<XID, RequestInfo>;

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -269,7 +269,7 @@ private:
 
     using RequestsQueue = ConcurrentBoundedQueue<RequestInfo>;
 
-    RequestsQueue requests_queue{1024};
+    RequestsQueue requests_queue{131072, "zookeeper-client"};
     void pushRequest(RequestInfo && info);
 
     using Operations = std::map<XID, RequestInfo>;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This change adds a dimensional metric for the size of `ConcurrentBoundedQueue`, labelled by the queue type (i.e. what the queue is there for) and queue id (i.e. randomly generated id for the current instance of the queue).

This metric is primarily needed to verify if the keeper response time spikes are related to the queue being too long.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
