### PR TITLE
Set all caches to 128MB in CI

### DIFF
--- a/tests/config/config.d/small_caches.xml
+++ b/tests/config/config.d/small_caches.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <!-- Setup all caches to 128MB to consume less memory and test eviction -->
+    <uncompressed_cache_size>134217728</uncompressed_cache_size>
+    <mark_cache_size>134217728</mark_cache_size>
+    <primary_index_cache_size>134217728</primary_index_cache_size>
+    <iceberg_metadata_files_cache_size>134217728</iceberg_metadata_files_cache_size>
+    <vector_similarity_index_cache_size>134217728</vector_similarity_index_cache_size>
+    <index_uncompressed_cache_size>134217728</index_uncompressed_cache_size>
+    <index_mark_cache_size>134217728</index_mark_cache_size>
+</clickhouse>

--- a/tests/config/config.d/small_caches.xml
+++ b/tests/config/config.d/small_caches.xml
@@ -7,4 +7,8 @@
     <vector_similarity_index_cache_size>134217728</vector_similarity_index_cache_size>
     <index_uncompressed_cache_size>134217728</index_uncompressed_cache_size>
     <index_mark_cache_size>134217728</index_mark_cache_size>
+    <query_cache>
+      <max_size_in_bytes>134217728</max_size_in_bytes>
+    </query_cache>
+    <compiled_expression_cache_size>134217728</compiled_expression_cache_size>
 </clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -119,6 +119,9 @@ fi
 ln -sf $SRC_PATH/config.d/encryption.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/zookeeper_log.xml $DEST_SERVER_PATH/config.d/
 
+# Lower all caches size to 128MB
+ln -sf $SRC_PATH/config.d/small_caches.xml $DEST_SERVER_PATH/config.d/
+
 # Randomize which logger is used (until sync logger is removed, if that ever happens)
 ln -sf $SRC_PATH/config.d/logger_trace.xml $DEST_SERVER_PATH/config.d/
 value=$((RANDOM % 2))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now we use less memory for caches in CI and have better tests for eviction.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
