### PR TITLE
S3Queue fix logical error "table is already registered"

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -67,6 +67,7 @@ static struct InitFiu
     REGULAR(distributed_cache_fail_connect_non_retriable) \
     REGULAR(distributed_cache_fail_connect_retriable) \
     REGULAR(object_storage_queue_fail_commit) \
+    REGULAR(object_storage_queue_fail_startup) \
     REGULAR(smt_dont_merge_first_part) \
     REGULAR(smt_mutate_only_second_part) \
     REGULAR(smt_sleep_in_schedule_data_processing_job) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -559,14 +559,6 @@ namespace
     };
 }
 
-void ObjectStorageQueueMetadata::registerIfNot(const StorageID & storage_id, bool active)
-{
-    if (active)
-        registerActive(storage_id);
-    else
-        registerNonActive(storage_id);
-}
-
 void ObjectStorageQueueMetadata::registerActive(const StorageID & storage_id)
 {
     const auto id = getProcessorID(storage_id);
@@ -586,7 +578,7 @@ void ObjectStorageQueueMetadata::registerActive(const StorageID & storage_id)
     LOG_TRACE(log, "Added {} to active registry ({})", self.table_id, id);
 }
 
-void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id)
+void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id, bool & created_new_metadata)
 {
     const auto registry_path = zookeeper_path / "registry";
     const auto self = Info::create(storage_id);
@@ -605,6 +597,8 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id)
 
         if (zk_client->tryGet(registry_path, registry_str, &stat))
         {
+            created_new_metadata = false;
+
             Strings registered;
             splitInto<','>(registered, registry_str);
 
@@ -626,6 +620,8 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id)
         }
         else
         {
+            created_new_metadata = true;
+
             requests.push_back(zkutil::makeCreateRequest(
                 registry_path,
                 self.serialize(),
@@ -672,42 +668,34 @@ Strings ObjectStorageQueueMetadata::getRegistered(bool active)
     return registered;
 }
 
-size_t ObjectStorageQueueMetadata::unregister(const StorageID & storage_id, bool active, bool remove_metadata_if_no_registered)
-{
-    if (active)
-        return unregisterActive(storage_id);
-    else
-        return unregisterNonActive(storage_id, remove_metadata_if_no_registered);
-}
-
-size_t ObjectStorageQueueMetadata::unregisterActive(const StorageID & storage_id)
+void ObjectStorageQueueMetadata::unregisterActive(const StorageID & storage_id)
 {
     const auto zk_client = getZooKeeper();
     const auto registry_path = zookeeper_path / "registry";
     const auto table_path = registry_path / getProcessorID(storage_id);
 
     auto code = zk_client->tryRemove(table_path);
-    const size_t remaining_nodes_num = zk_client->getChildren(registry_path).size();
 
-    const auto self = Info::create(storage_id);
     if (code == Coordination::Error::ZOK)
     {
-        LOG_TRACE(log, "Table '{}' has been removed from the active registry (remaining nodes: {})", self.table_id, remaining_nodes_num);
+        LOG_TRACE(
+            log, "Table '{}' has been removed from the active registry "
+            "(table path: {})",
+            storage_id.getNameForLogs(), table_path);
     }
     else
     {
         LOG_DEBUG(
             log,
-            "Cannot remove table '{}' from the active registry, reason: {} (remaining nodes: {})",
-            self.table_id,
+            "Cannot remove table '{}' from the active registry, reason: {} "
+            "(table path: {})",
+            storage_id.getNameForLogs(),
             Coordination::errorMessage(code),
-            remaining_nodes_num);
+            table_path);
     }
-
-    return remaining_nodes_num;
 }
 
-size_t ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage_id, bool remove_metadata_if_no_registered)
+void ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage_id, bool remove_metadata_if_no_registered)
 {
     const auto registry_path = zookeeper_path / "registry";
     const auto drop_lock_path = zookeeper_path / "drop";
@@ -736,7 +724,7 @@ size_t ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage
             {
                 LOG_WARNING(log, "Cannot unregister: registry does not exist");
                 chassert(false);
-                return 0;
+                return;
             }
 
             Strings registered;
@@ -760,8 +748,11 @@ size_t ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage
                     count += 1;
                 }
             }
+
             if (!found)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot unregister: table '{}' is not registered", self.table_id);
+
+            LOG_TRACE(log, "Registered count: {}, remove metadata: {}", count, remove_metadata_if_no_registered);
 
             if (remove_metadata_if_no_registered && count == 0)
             {
@@ -835,7 +826,7 @@ size_t ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage
                     throw;
                 }
             }
-            return count;
+            return;
         }
 
         if (Coordination::isHardwareError(code)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -639,13 +639,11 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
             return;
         }
 
-        if (code == Coordination::Error::ZBADVERSION
+        if ((code == Coordination::Error::ZBADVERSION
             || code == Coordination::Error::ZNODEEXISTS
             || code == Coordination::Error::ZNONODE
-            || code == Coordination::Error::ZSESSIONEXPIRED)
+            || code == Coordination::Error::ZSESSIONEXPIRED) && (i < max_tries - 1))
         {
-            if (i == max_tries - 1)
-                zkutil::KeeperMultiException::check(code, requests, responses);
             continue;
         }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -121,10 +121,13 @@ public:
     /// active = true:
     ///     We also want to register nodes only for a period when they are active.
     ///     For this we create ephemeral nodes in "zookeeper_path / registry / <node_info>"
-    void registerIfNot(const StorageID & storage_id, bool active);
+    void registerNonActive(const StorageID & storage_id, bool & created_new_metadata);
+    void registerActive(const StorageID & storage_id);
+
     /// Unregister table.
     /// Return the number of remaining (after unregistering) registered tables.
-    size_t unregister(const StorageID & storage_id, bool active, bool remove_metadata_if_no_registered);
+    void unregisterActive(const StorageID & storage_id);
+    void unregisterNonActive(const StorageID & storage_id, bool remove_metadata_if_no_registered);
     Strings getRegistered(bool active);
 
     /// According to current *active* registered tables,
@@ -150,12 +153,6 @@ private:
     void cleanupThreadFuncImpl();
 
     void migrateToBucketsInKeeper(size_t value);
-
-    void registerNonActive(const StorageID & storage_id);
-    void registerActive(const StorageID & storage_id);
-
-    size_t unregisterNonActive(const StorageID & storage_id, bool remove_metadata_if_no_registered);
-    size_t unregisterActive(const StorageID & storage_id);
 
     void updateRegistryFunc();
     void updateRegistry(const DB::Strings & registered_);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -82,10 +82,13 @@ void ObjectStorageQueueFactory::renameTable(const StorageID & from, const Storag
     if (to_it == storages.end())
     {
         storages.emplace(to);
-        LOG_TRACE(log, "Unregistered table: {}, table {} was already registered", from.getNameForLogs(), to.getNameForLogs());
+        LOG_TRACE(log, "Unregistered table: {}, registered table: {}", from.getNameForLogs(), to.getNameForLogs());
     }
     else
-        LOG_TRACE(log, "Unregistered table: {}, registered table: {}", from.getNameForLogs(), to.getNameForLogs());
+    {
+        /// This could happen because of exchange/replace tables.
+        LOG_TRACE(log, "Unregistered table: {}, table {} was already registered", from.getNameForLogs(), to.getNameForLogs());
+    }
 }
 
 void ObjectStorageQueueFactory::shutdown()

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -44,7 +44,10 @@ void ObjectStorageQueueFactory::unregisterTable(const StorageID & storage, bool 
     std::lock_guard lock(mutex);
 
     if (shutdown_called)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Shutdown was called");
+    {
+        /// We can call unregisterTable from table shutdown.
+        return;
+    }
 
     auto it = storages.find(storage);
     if (it == storages.end())

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -35,6 +35,11 @@ private:
     std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> storages;
 };
 
+/*
+ * A class which storages objects of ObjectStorageQueueMetadata
+ * because they can be shared between different Queue tables on the same server
+ * in case they share the same keeper path.
+ */
 class ObjectStorageQueueMetadataFactory final : private boost::noncopyable
 {
 public:
@@ -42,12 +47,22 @@ public:
 
     static ObjectStorageQueueMetadataFactory & instance();
 
+    /// Get a metadata instance if exists, otherwise create a new one.
+    /// Registers table in keeper in persistent node.
     FilesMetadataPtr getOrCreate(
         const std::string & zookeeper_path,
         ObjectStorageQueueMetadataPtr metadata,
-        const StorageID & storage_id);
+        const StorageID & storage_id,
+        bool & created_new_metadata);
 
-    void remove(const std::string & zookeeper_path, const StorageID & storage_id, bool remove_metadata_if_no_registered);
+    /// Reduce ref count for the metadata instance.
+    /// Metadata will be removed when ref count becomes zero.
+    /// Unregisters table in keeper from persistent node.
+    void remove(
+        const std::string & zookeeper_path,
+        const StorageID & storage_id,
+        bool is_drop,
+        bool keep_data_in_keeper);
 
     std::unordered_map<std::string, FilesMetadataPtr> getAll();
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -30,6 +30,7 @@ public:
     void shutdown();
 
 private:
+    const LoggerPtr log = getLogger("ObjectStorageQueueFactory");
     bool shutdown_called = false;
     std::mutex mutex;
     std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> storages;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -64,6 +64,7 @@ namespace Setting
 namespace FailPoints
 {
     extern const char object_storage_queue_fail_commit[];
+    extern const char object_storage_queue_fail_startup[];
 }
 
 namespace ServerSetting
@@ -107,8 +108,8 @@ namespace ErrorCodes
     extern const int BAD_QUERY_PARAMETER;
     extern const int QUERY_NOT_ALLOWED;
     extern const int SUPPORT_IS_DISABLED;
-    extern const int UNKNOWN_EXCEPTION;
     extern const int NOT_IMPLEMENTED;
+    extern const int FAULT_INJECTED;
 }
 
 namespace
@@ -260,22 +261,57 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
 
 void StorageObjectStorageQueue::startup()
 {
+    if (startup_finished)
+    {
+        LOG_TRACE(log, "Startup was already successfully called");
+        return;
+    }
+
+    /// Create metadata in keeper if it does not exits yet.
+    /// Create a persistent node for the table under /registry node.
+    bool created_new_metadata = false;
+    files_metadata = ObjectStorageQueueMetadataFactory::instance().getOrCreate(
+        zk_path,
+        std::move(temp_metadata),
+        getStorageID(),
+        created_new_metadata);
+
     /// Register the metadata in startup(), unregister in shutdown.
     /// (If startup is never called, shutdown also won't be called.)
-    files_metadata = ObjectStorageQueueMetadataFactory::instance().getOrCreate(zk_path, std::move(temp_metadata), getStorageID());
-    try
-    {
-        ObjectStorageQueueFactory::instance().registerTable(getStorageID());
-        files_metadata->startup();
-        for (auto & task : streaming_tasks)
-            task->activateAndSchedule();
-    }
-    catch (...)
-    {
-        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID(), /*remove_metadata_if_no_registered=*/true);
-        files_metadata.reset();
-        throw;
-    }
+    SCOPE_EXIT_SAFE({
+        if (!startup_finished)
+        {
+            /// Unregister table metadata from keeper and remove metadata from keeper,
+            /// if it was just created by us (created_new_metadata == true)
+            /// and if /registry is empty (no table was concurrently created).
+            ObjectStorageQueueMetadataFactory::instance().remove(
+                zk_path,
+                getStorageID(),
+                /* is_drop */created_new_metadata,
+                /* keep_data_in_keeper */false);
+
+            files_metadata.reset();
+        }
+    });
+
+    /// Register table as a Queue table on this server.
+    /// This will allow to execute shutdown of Queue tables
+    /// before shutting down all other tables on server shutdown.
+    ObjectStorageQueueFactory::instance().registerTable(getStorageID());
+    SCOPE_EXIT_SAFE({
+        if (!startup_finished)
+            ObjectStorageQueueFactory::instance().unregisterTable(getStorageID(), /* if_exists */true);
+    });
+
+    fiu_do_on(FailPoints::object_storage_queue_fail_startup, {
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Failed to startup");
+    });
+
+    /// Start background tasks.
+    files_metadata->startup();
+    for (auto & task : streaming_tasks)
+        task->activateAndSchedule();
+
     startup_finished = true;
 }
 
@@ -284,30 +320,39 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
     if (shutdown_called)
         return;
 
-    if (is_drop)
-        ObjectStorageQueueFactory::instance().unregisterTable(getStorageID());
+    /// Unregister table from local Queue storages factory.
+    /// (which allows to  to execute shutdown of Queue tables
+    /// before shutting down all other tables on server shutdown).
+    ObjectStorageQueueFactory::instance().unregisterTable(getStorageID(), /* if_exists */true);
 
     table_is_being_dropped = is_drop;
     shutdown_called = true;
 
-    Stopwatch watch;
-    LOG_TRACE(log, "Waiting for streaming to finish...");
-    for (auto & task : streaming_tasks)
-        task->deactivate();
-    LOG_TRACE(log, "Streaming finished (took: {} ms)", watch.elapsedMilliseconds());
+    {
+        Stopwatch watch;
+        LOG_DEBUG(log, "Waiting for streaming to finish...");
+
+        for (auto & task : streaming_tasks)
+            task->deactivate();
+
+        LOG_DEBUG(
+            log, "Finished {} streaming tasks (took: {} ms)",
+            streaming_tasks.size(), watch.elapsedMilliseconds());
+    }
 
     if (files_metadata)
     {
         try
         {
-            files_metadata->unregister(getStorageID(), /* active */true, /* remove_metadata_if_no_registered */false);
+            files_metadata->unregisterActive(getStorageID());
         }
         catch (...)
         {
             tryLogCurrentException(log);
         }
 
-        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID(), is_drop && !keep_data_in_keeper);
+        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID(), is_drop, keep_data_in_keeper);
+
         files_metadata.reset();
     }
     LOG_TRACE(log, "Shut down storage");
@@ -536,7 +581,7 @@ void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
 
                 LOG_DEBUG(log, "Started streaming to {} attached views", dependencies_count);
 
-                files_metadata->registerIfNot(storage_id, /* active */true);
+                files_metadata->registerActive(storage_id);
 
                 if (streamToViews(streaming_tasks_index))
                 {
@@ -581,7 +626,7 @@ void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
         {
             try
             {
-                files_metadata->unregister(storage_id, /* active */true, /* remove_metadata_if_no_registered */false);
+                files_metadata->unregisterActive(storage_id);
             }
             catch (...)
             {
@@ -769,7 +814,7 @@ void StorageObjectStorageQueue::commit(
     Coordination::Responses responses;
 
     fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Failed to commit processed files");
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Failed to commit processed files");
     });
 
     auto code = zk_client->tryMulti(requests, responses);

--- a/tests/integration/helpers/s3_queue_common.py
+++ b/tests/integration/helpers/s3_queue_common.py
@@ -108,6 +108,7 @@ def create_table(
     bucket=None,
     expect_error=False,
     database_name="default",
+    replace=False,
     no_settings=False,
 ):
     auth_params = ",".join(auth)
@@ -131,15 +132,17 @@ def create_table(
     else:
         engine_def = f"{engine_name}('{started_cluster.env_variables['AZURITE_CONNECTION_STRING']}', '{started_cluster.azurite_container}', '{files_path}/', 'CSV')"
 
-    node.query(f"DROP TABLE IF EXISTS {database_name}.{table_name}")
+    create = "REPLACE" if replace else "CREATE"
+    if not replace:
+        node.query(f"DROP TABLE IF EXISTS {database_name}.{table_name}")
     if no_settings:
         create_query = f"""
-            CREATE TABLE {database_name}.{table_name} ({format})
+            {create} TABLE {database_name}.{table_name} ({format})
             ENGINE = {engine_def}
             """
     else:
         create_query = f"""
-            CREATE TABLE {database_name}.{table_name} ({format})
+            {create} TABLE {database_name}.{table_name} ({format})
             ENGINE = {engine_def}
             SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
             """

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -1035,3 +1035,114 @@ def test_mv_settings(started_cluster, mode, limit):
             f"SELECT count() FROM system.parts WHERE table = '{dst_table_name}' AND level = 0"
         )
     )
+
+
+def test_detach_attach_table(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = f"test_detach_attach_table_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    mv_table_name = f"{table_name}_mv"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+
+    format = "column1 Int32, column2 String"
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        format=format,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "s3queue_processing_threads_num": 1,
+            "polling_max_timeout_ms": 0,
+            "polling_min_timeout_ms": 0,
+        }
+    )
+
+    node.query(f"DETACH TABLE {table_name}")
+    node.query(f"ATTACH TABLE {table_name}")
+
+    num_rows = 10000
+    file_count = [0]
+    def insert():
+        table_name_suffix = f"{uuid.uuid4()}"
+        file_count[0] += 1
+        file_name = f"file_{table_name}_{table_name_suffix}_{file_count[0]}.csv"
+        s3_function = f"s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/{files_path}/{file_name}', 'minio', '{minio_secret_key}')"
+        node.query(
+            f"INSERT INTO FUNCTION {s3_function} select number, randomString(100) FROM numbers({num_rows})"
+        )
+
+    insert()
+
+    create_mv(
+        node,
+        table_name,
+        dst_table_name,
+        mv_name=mv_table_name,
+        format=format,
+    )
+
+    def get_count():
+        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+    for _ in range(20):
+        if num_rows == get_count():
+            break
+        time.sleep(1)
+
+    assert num_rows == get_count()
+
+
+def test_failed_startup(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = f"test_failed_startup_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    mv_table_name = f"{table_name}_mv"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+
+    format = "column1 Int32, column2 String"
+    node.query(f"SYSTEM ENABLE FAILPOINT object_storage_queue_fail_startup")
+    assert "Failed to startup" in create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        format=format,
+        expect_error=True,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "s3queue_processing_threads_num": 1,
+            "polling_max_timeout_ms": 0,
+            "polling_min_timeout_ms": 0,
+        }
+    )
+    node.query(f"SYSTEM DISABLE FAILPOINT object_storage_queue_fail_startup")
+
+    zk = started_cluster.get_kazoo_client("zoo1")
+    try:
+        zk.get(f"{keeper_path}")
+        assert False
+    except NoNodeError:
+        pass
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        format=format,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "s3queue_processing_threads_num": 1,
+            "polling_max_timeout_ms": 0,
+            "polling_min_timeout_ms": 0,
+        }
+    )
+
+    assert len(zk.get(f"{keeper_path}")) > 0

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -545,7 +545,7 @@ def test_failed_commit(started_cluster):
 
     def check_failpoint():
         return node.contains_in_log(
-            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 1002. DB::Exception: Failed to commit processed files. (UNKNOWN_EXCEPTION)"
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 710. DB::Exception: Failed to commit processed files."
         )
 
     for _ in range(100):
@@ -567,7 +567,7 @@ def test_failed_commit(started_cluster):
 
     count_failed = int(
         node.count_in_log(
-            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 1002. DB::Exception: Failed to commit processed files. (UNKNOWN_EXCEPTION)"
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 710. DB::Exception: Failed to commit processed files."
         )
     )
     count = get_count()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error from S3Queue "Table is already registered". Closes https://github.com/ClickHouse/ClickHouse/issues/84433. Broken after https://github.com/ClickHouse/ClickHouse/pull/83530.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
