### PR TITLE
Extend `SharedLockGuard` with lock/unlock methods

### DIFF
--- a/src/Common/SharedLockGuard.h
+++ b/src/Common/SharedLockGuard.h
@@ -25,7 +25,7 @@ template <typename Mutex>
 class TSA_SCOPED_LOCKABLE SharedLockGuard
 {
 public:
-    explicit SharedLockGuard(Mutex & mutex_) TSA_ACQUIRE_SHARED(mutex_) : shared_lock(mutex_) { locked = true; }
+    explicit SharedLockGuard(Mutex & mutex_) TSA_ACQUIRE_SHARED(mutex_) : shared_lock(mutex_) {}
     ~SharedLockGuard() TSA_RELEASE() = default;
 
     void lock() TSA_ACQUIRE_SHARED()

--- a/src/Common/SharedLockGuard.h
+++ b/src/Common/SharedLockGuard.h
@@ -1,9 +1,18 @@
 #pragma once
 
+#include <Common/Exception.h>
+
 #include <base/defines.h>
+
+#include <shared_mutex>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+};
 
 /** SharedLockGuard provides RAII-style locking mechanism for acquiring shared ownership of the implementation
   * of the SharedLockable concept (for example std::shared_mutex or ContextSharedMutex) supplied as the
@@ -16,12 +25,30 @@ template <typename Mutex>
 class TSA_SCOPED_LOCKABLE SharedLockGuard
 {
 public:
-    explicit SharedLockGuard(Mutex & mutex_) TSA_ACQUIRE_SHARED(mutex_) : mutex(mutex_) { mutex_.lock_shared(); }
+    explicit SharedLockGuard(Mutex & mutex_) TSA_ACQUIRE_SHARED(mutex_) : shared_lock(mutex_) { locked = true; }
+    ~SharedLockGuard() TSA_RELEASE() = default;
 
-    ~SharedLockGuard() TSA_RELEASE() { mutex.unlock_shared(); }
+    void lock() TSA_ACQUIRE_SHARED()
+    {
+        if (locked)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't lock twice the same mutex");
+
+        shared_lock.lock();
+        locked = true;
+    }
+
+    void unlock() TSA_RELEASE()
+    {
+        if (!locked)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't unlock the mutex without locking it first");
+
+        shared_lock.unlock();
+        locked = false;
+    }
 
 private:
-    Mutex & mutex;
+    std::shared_lock<Mutex> shared_lock;
+    bool locked = true;
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(SharedLockGuard);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ability to lock/unlock `SharedLockGuard` explicitly.
