### PR TITLE
Hopefully fix flaky test_refreshable_mat_view/test.py::test_simple_append

### DIFF
--- a/tests/integration/test_refreshable_mat_view/test.py
+++ b/tests/integration/test_refreshable_mat_view/test.py
@@ -466,9 +466,9 @@ def test_long_query_cancel(fn_setup_tables):
 
 @pytest.fixture(scope="function")
 def fn3_setup_tables():
+    node.query("DROP TABLE IF EXISTS test_rmv ON CLUSTER default SYNC")
+    node.query("DROP TABLE IF EXISTS test_db.test_rmv ON CLUSTER default SYNC")
     node.query("DROP TABLE IF EXISTS tgt1 ON CLUSTER default")
-    node.query("DROP TABLE IF EXISTS test_rmv ON CLUSTER default")
-    node.query("DROP TABLE IF EXISTS test_db.test_rmv ON CLUSTER default")
 
     node.query(f"CREATE TABLE tgt1 ON CLUSTER default (a DateTime) ENGINE = Memory")
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Error: "Table default.tgt1 already exists"
Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=da64f0a8074601d84ff057cf7c1fb82fe340eb04&name_0=MasterCI&name_1=Integration%20tests%20%28release%2C%205%2F6%29&name_1=Integration%20tests%20%28release%2C%205%2F6%29

I guess what's happening is `fn_setup_tables` drops `tgt1`, then `test_rmv` (refreshable MV with `TO tgt1`) does a refresh and creates `tgt1` again, then `fn_setup_tables` tries to create `tgt1` and makes a surprised pikachu face when it already exists. The fix is to drop the RMV before dropping its target table.