### PR TITLE
Hopefully fix flaky test_refreshable_mv/test.py::test_backup_outer_table

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -414,11 +414,11 @@ def test_pause(started_cluster, cleanup):
         "create table re.src (x Int64) engine ReplicatedMergeTree order by x;"
         "insert into re.src values (1);"
     )
+    node2.query("system sync database replica re")
+    node2.query_with_retry("system sync replica re.src")
     node2.query(
-        "system sync database replica re;"
-        "system sync replica re.src;"
         "create materialized view re.a refresh every 1 second (x Int64) engine ReplicatedMergeTree order by x as select x from re.src;"
-        "system wait view re.a"
+        "system wait view re.a;"
     )
     assert node2.query("select * from re.a") == "1\n"
     node2.query("system stop replicated view re.a")
@@ -472,11 +472,13 @@ def do_test_backup(to_table):
         "create table re.src (x Int64) engine ReplicatedMergeTree order by x;"
         "insert into re.src values (1);"
     )
+    node2.query("system sync database replica re")
+    # Retry because this sometimes fails with "Table is in readonly mode" because the table wasn't
+    # fully initialized yet. Apparently `system sync database replica` doesn't prevent that.
+    node2.query_with_retry("system sync replica re.src")
     node2.query(
-        "system sync database replica re;"
-        "system sync replica re.src;"
         f"create materialized view re.rmv refresh every 1 second {'TO re.tgt' if to_table else '(x Int64) engine ReplicatedMergeTree order by x'} as select x from re.src;"
-        "system wait view re.rmv"
+        "system wait view re.rmv;"
     )
     assert node2.query(f"select * from re.{target}") == "1\n"
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

The test does:
```sql
system sync database replica re;
system sync replica re.src;
```
(`re` is DatabaseReplicated, `src` is StorageReplicatedMergeTree.) And apparently the second query can fail with "Table is in readonly mode": https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=82821&sha=0f0839a268862a5fa5c34db746836dbc0482f857&name_0=PR&name_1=Integration%20tests%20%28asan%2C%20old%20analyzer%2C%206%2F6%29

I didn't figure out what is going on. Relevant part of server log: https://pastila.nl/?002d33be/d7839309707c02b60217743d349c49b6#zSSVeWXc2wclJGIeckVWrg== . So, CREATE TABLE started (in DDLWorker), then `system sync database replica` started and finished (!), then `Table started successfully` was logged (which happens after setting `is_readonly` to false), then the CREATE TABLE finished, then 100ms later (!) the `Table is in readonly mode` exception was logged. I don't get it.
 * Why didn't `system sync database replica` wait for the CREATE TABLE to finish?
 * How could the `Table is in readonly mode` exception happen after `Table started successfully`? Maybe it took >100ms to throw+catch+log the exception (maybe stack unwinding+symbolizing is this slow in asan?)?

This PR doesn't grapple with any of that and just adds retries to the test.