### PR TITLE
Add `column` as an alias of `name` in `system.columns`

### DIFF
--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -36,8 +36,7 @@ StorageSystemColumns::StorageSystemColumns(const StorageID & table_id_)
 
     /// NOTE: when changing the list of columns, take care of the ColumnsSource::generate method,
     /// when they are referenced by their numeric positions.
-    storage_metadata.setColumns(ColumnsDescription(
-    {
+    auto description = ColumnsDescription({
         { "database",           std::make_shared<DataTypeString>(), "Database name."},
         { "table",              std::make_shared<DataTypeString>(), "Table name."},
         { "name",               std::make_shared<DataTypeString>(), "Column name."},
@@ -65,7 +64,13 @@ StorageSystemColumns::StorageSystemColumns(const StorageID & table_id_)
         { "datetime_precision",         std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()),
             "Decimal precision of DateTime64 data type. For other data types, the NULL value is returned."},
         { "serialization_hint",         std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()), "A hint for column to choose serialization on inserts according to statistics."},
-    }));
+    });
+
+    description.setAliases({
+        {"column", std::make_shared<DataTypeString>(), "name"}
+    });
+
+    storage_metadata.setColumns(description);
     setInMemoryMetadata(storage_metadata);
 }
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -91,7 +91,8 @@ CREATE TABLE system.columns
     `numeric_precision_radix` Nullable(UInt64),
     `numeric_scale` Nullable(UInt64),
     `datetime_precision` Nullable(UInt64),
-    `serialization_hint` Nullable(String)
+    `serialization_hint` Nullable(String),
+    `column` String ALIAS name
 )
 ENGINE = SystemColumns
 COMMENT 'Lists all columns from all tables of the current server.'

--- a/tests/queries/0_stateless/03579_system_columns_column_alias.reference
+++ b/tests/queries/0_stateless/03579_system_columns_column_alias.reference
@@ -1,0 +1,3 @@
+database
+database
+database	database	1

--- a/tests/queries/0_stateless/03579_system_columns_column_alias.sql
+++ b/tests/queries/0_stateless/03579_system_columns_column_alias.sql
@@ -1,0 +1,11 @@
+-- Test that system.columns has 'column' as an alias for 'name'
+
+-- Query using the original 'name' column
+SELECT name FROM system.columns WHERE database = 'system' AND table = 'columns' LIMIT 1;
+
+-- Query using the new 'column' alias - should return identical results  
+SELECT column FROM system.columns WHERE database = 'system' AND table = 'columns' LIMIT 1;
+
+-- Test that both column names work in the same query
+SELECT name, column, name = column as alias_works FROM system.columns 
+WHERE database = 'system' AND table = 'columns' LIMIT 1;


### PR DESCRIPTION
closes #84340

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The `system.columns` table now provides `column` as an alias for the existing `name` column.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
