### PR TITLE
Lock 'mutex' when getting zookeeper from 'view' in RefreshTask

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -326,7 +326,15 @@ void RefreshTask::startReplicated()
 {
     if (!coordination.coordinated)
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Refreshable materialized view is not coordinated.");
-    const auto zookeeper = view->getContext()->getZooKeeper();
+
+    const auto zookeeper = [this]()
+    {
+        std::lock_guard guard(mutex);
+        if (!view)
+            throw Exception(ErrorCodes::TABLE_IS_DROPPED, "The table was dropped or detached");
+        return view->getContext()->getZooKeeper();
+    }();
+
     String path = coordination.path + "/paused";
     auto code = zookeeper->tryRemove(path);
     if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
@@ -337,7 +345,15 @@ void RefreshTask::stopReplicated(const String & reason)
 {
     if (!coordination.coordinated)
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Refreshable materialized view is not coordinated.");
-    const auto zookeeper = view->getContext()->getZooKeeper();
+
+    const auto zookeeper = [this]()
+    {
+        std::lock_guard guard(mutex);
+        if (!view)
+            throw Exception(ErrorCodes::TABLE_IS_DROPPED, "The table was dropped or detached");
+        return view->getContext()->getZooKeeper();
+    }();
+
     String path = coordination.path + "/paused";
     auto code = zookeeper->tryCreate(path, reason, zkutil::CreateMode::Persistent);
     if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNODEEXISTS)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Lock 'mutex' when getting zookeeper from 'view' in RefreshTask

In `RefreshTask::startReplicated` and `Refresh::stopReplicated`, `view` may be used after the task is shut down. To avoid a data race, we put that logic under `mutex`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
