### PR TITLE
Use bloom filters for has/hasAny with const array in the left argument

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -387,7 +387,8 @@ bool MergeTreeIndexConditionBloomFilter::traverseFunction(const RPNBuilderTreeNo
             if (traverseTreeEquals(function_name, lhs_argument, const_type, const_value, out, parent))
                 return true;
         }
-        else if (lhs_argument.tryGetConstant(const_value, const_type) && (function_name == "equals" || function_name == "notEquals"))
+        else if (lhs_argument.tryGetConstant(const_value, const_type) &&
+            (function_name == "equals" || function_name == "has" || function_name == "hasAny" || function_name == "notEquals"))
         {
             if (traverseTreeEquals(function_name, rhs_argument, const_type, const_value, out, parent))
                 return true;
@@ -530,6 +531,30 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
 }
 
 
+static ColumnPtr createColumnFromConstantArray(const Field & value_field, const DataTypePtr & actual_type)
+{
+    if (value_field.getType() != Field::Types::Array)
+        return nullptr;
+
+    const bool is_nullable = actual_type->isNullable();
+    auto mutable_column = actual_type->createColumn();
+
+    for (const auto & f : value_field.safeGet<Array>())
+    {
+        if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
+            return nullptr;
+
+        auto converted = convertFieldToType(f, *actual_type);
+        if (converted.isNull())
+            return nullptr;
+
+        mutable_column->insert(converted);
+    }
+
+    return std::move(mutable_column);
+}
+
+
 static bool indexOfCanUseBloomFilter(const RPNBuilderTreeNode * parent)
 {
     if (!parent)
@@ -626,21 +651,32 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
 
         if (function_name == "has" || function_name == "indexOf")
         {
-            if (!array_type)
-                return false;
-
-            /// We can treat `indexOf` function similar to `has`.
-            /// But it is little more cumbersome, compare: `has(arr, elem)` and `indexOf(arr, elem) != 0`.
-            /// The `parent` in this context is expected to be function `!=` (`notEquals`).
-            if (function_name == "has" || indexOfCanUseBloomFilter(parent))
+            if (array_type)
             {
-                out.function = RPNElement::FUNCTION_HAS;
-                const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-                auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
-                if (converted_field.isNull())
+                /// We can treat `indexOf` function similar to `has`.
+                /// But it is little more cumbersome, compare: `has(arr, elem)` and `indexOf(arr, elem) != 0`.
+                /// The `parent` in this context is expected to be function `!=` (`notEquals`).
+                if (function_name == "has" || indexOfCanUseBloomFilter(parent))
+                {
+                    out.function = RPNElement::FUNCTION_HAS;
+                    const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
+                    auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
+                    if (converted_field.isNull())
+                        return false;
+
+                    out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithField(actual_type.get(), converted_field)));
+                }
+            }
+            else if (function_name == "has")
+            {
+                const DataTypePtr actual_type = BloomFilter::getPrimitiveType(index_type);
+                ColumnPtr column = createColumnFromConstantArray(value_field, actual_type);
+
+                if (!column)
                     return false;
 
-                out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithField(actual_type.get(), converted_field)));
+                out.function = RPNElement::FUNCTION_HAS_ANY;
+                out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithColumn(actual_type, column, 0, column->size())));
             }
         }
         else if (function_name == "hasAny" || function_name == "hasAll")
@@ -648,29 +684,11 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
             if (!array_type)
                 return false;
 
-            if (value_field.getType() != Field::Types::Array)
-                return false;
-
             const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-            ColumnPtr column;
-            {
-                const bool is_nullable = actual_type->isNullable();
-                auto mutable_column = actual_type->createColumn();
+            ColumnPtr column = createColumnFromConstantArray(value_field, actual_type);
 
-                for (const auto & f : value_field.safeGet<Array>())
-                {
-                    if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
-                        return false;
-
-                    auto converted = convertFieldToType(f, *actual_type);
-                    if (converted.isNull())
-                        return false;
-
-                    mutable_column->insert(converted);
-                }
-
-                column = std::move(mutable_column);
-            }
+            if (!column)
+                return false;
 
             out.function = function_name == "hasAny" ?
                 RPNElement::FUNCTION_HAS_ANY :

--- a/tests/queries/0_stateless/03375_bloom_filter_has_hasAny_const_array.reference
+++ b/tests/queries/0_stateless/03375_bloom_filter_has_hasAny_const_array.reference
@@ -1,0 +1,5 @@
+Description: bloom_filter GRANULARITY 1
+Granules: 3/4
+Description: bloom_filter GRANULARITY 1
+Granules: 2/4
+d

--- a/tests/queries/0_stateless/03375_bloom_filter_has_hasAny_const_array.sql
+++ b/tests/queries/0_stateless/03375_bloom_filter_has_hasAny_const_array.sql
@@ -1,0 +1,40 @@
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+
+CREATE TABLE bloom_filter_has_const_array
+(
+    `bf` String,
+    `abf` Array(String),
+    INDEX idx_bf bf TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_abf abf TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity=1;
+
+INSERT INTO bloom_filter_has_const_array
+VALUES ('a', ['a','a']), ('b', ['b','b']), ('c', ['c','c']), ('d',['d','e']);
+
+SET parallel_replicas_local_plan=1;
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT bf
+    FROM bloom_filter_has_const_array
+    WHERE hasAny(['a','c','d'], abf)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT bf
+    FROM bloom_filter_has_const_array
+    WHERE has(['a','d'], bf)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
+
+SELECT bf
+FROM bloom_filter_has_const_array
+WHERE hasAny(['a','c','d'], abf) and has(['a','d'], bf) and hasAll(['d','e'], abf);
+
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+

--- a/tests/queries/0_stateless/03375_bloom_filter_has_hasAny_const_array.sql
+++ b/tests/queries/0_stateless/03375_bloom_filter_has_hasAny_const_array.sql
@@ -1,3 +1,5 @@
+SET parallel_replicas_local_plan=1;
+
 DROP TABLE IF EXISTS bloom_filter_has_const_array;
 
 CREATE TABLE bloom_filter_has_const_array
@@ -13,8 +15,6 @@ SETTINGS index_granularity=1;
 
 INSERT INTO bloom_filter_has_const_array
 VALUES ('a', ['a','a']), ('b', ['b','b']), ('c', ['c','c']), ('d',['d','e']);
-
-SET parallel_replicas_local_plan=1;
 
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1

--- a/tests/queries/0_stateless/03375_bloom_filter_ngram_has_hasAny_const_array.reference
+++ b/tests/queries/0_stateless/03375_bloom_filter_ngram_has_hasAny_const_array.reference
@@ -1,0 +1,5 @@
+Description: ngrambf_v1 GRANULARITY 1
+Granules: 3/4
+Description: ngrambf_v1 GRANULARITY 1
+Granules: 2/4
+d

--- a/tests/queries/0_stateless/03375_bloom_filter_ngram_has_hasAny_const_array.sql
+++ b/tests/queries/0_stateless/03375_bloom_filter_ngram_has_hasAny_const_array.sql
@@ -1,0 +1,40 @@
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+
+CREATE TABLE bloom_filter_has_const_array
+(
+    `bf` String,
+    `abf` Array(String),
+    INDEX idx_bf bf TYPE ngrambf_v1(1, 512, 3, 0) GRANULARITY 1,
+    INDEX idx_abf abf TYPE ngrambf_v1(1, 512, 3, 0) GRANULARITY 1,
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity=1;
+
+INSERT INTO bloom_filter_has_const_array
+VALUES ('a', ['a','a']), ('b', ['b','b']), ('c', ['c','c']), ('d',['d','e']);
+
+SET parallel_replicas_local_plan=1;
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT bf
+    FROM bloom_filter_has_const_array
+    WHERE hasAny(['a','c','d'], abf)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT bf
+    FROM bloom_filter_has_const_array
+    WHERE has(['a','d'], bf)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
+
+SELECT bf
+FROM bloom_filter_has_const_array
+WHERE hasAny(['a','c','d'], abf) and has(['a','d'], bf) and hasAll(['d','e'], abf);
+
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+

--- a/tests/queries/0_stateless/03375_bloom_filter_ngram_has_hasAny_const_array.sql
+++ b/tests/queries/0_stateless/03375_bloom_filter_ngram_has_hasAny_const_array.sql
@@ -1,3 +1,5 @@
+SET parallel_replicas_local_plan=1;
+
 DROP TABLE IF EXISTS bloom_filter_has_const_array;
 
 CREATE TABLE bloom_filter_has_const_array
@@ -13,8 +15,6 @@ SETTINGS index_granularity=1;
 
 INSERT INTO bloom_filter_has_const_array
 VALUES ('a', ['a','a']), ('b', ['b','b']), ('c', ['c','c']), ('d',['d','e']);
-
-SET parallel_replicas_local_plan=1;
 
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1

--- a/tests/queries/0_stateless/03375_bloom_filter_token_has_hasAny_const_array.reference
+++ b/tests/queries/0_stateless/03375_bloom_filter_token_has_hasAny_const_array.reference
@@ -1,0 +1,5 @@
+Description: tokenbf_v1 GRANULARITY 1
+Granules: 3/4
+Description: tokenbf_v1 GRANULARITY 1
+Granules: 2/4
+d

--- a/tests/queries/0_stateless/03375_bloom_filter_token_has_hasAny_const_array.sql
+++ b/tests/queries/0_stateless/03375_bloom_filter_token_has_hasAny_const_array.sql
@@ -1,0 +1,40 @@
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+
+CREATE TABLE bloom_filter_has_const_array
+(
+    `bf` String,
+    `abf` Array(String),
+    INDEX idx_bf bf TYPE tokenbf_v1(512,3,0) GRANULARITY 1,
+    INDEX idx_abf abf TYPE tokenbf_v1(512,3,0) GRANULARITY 1,
+)
+ENGINE = MergeTree
+ORDER BY ()
+SETTINGS index_granularity=1;
+
+INSERT INTO bloom_filter_has_const_array
+VALUES ('a', ['a','a']), ('b', ['b','b']), ('c', ['c','c']), ('d',['d','e']);
+
+SET parallel_replicas_local_plan=1;
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT bf
+    FROM bloom_filter_has_const_array
+    WHERE hasAny(['a','c','d'], abf)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT bf
+    FROM bloom_filter_has_const_array
+    WHERE has(['a','d'], bf)
+)
+WHERE explain LIKE 'Description%' or explain LIKE 'Granules%';
+
+SELECT bf
+FROM bloom_filter_has_const_array
+WHERE hasAny(['a','c','d'], abf) and has(['a','d'], bf) and hasAll(['d','e'], abf);
+
+DROP TABLE IF EXISTS bloom_filter_has_const_array;
+

--- a/tests/queries/0_stateless/03375_bloom_filter_token_has_hasAny_const_array.sql
+++ b/tests/queries/0_stateless/03375_bloom_filter_token_has_hasAny_const_array.sql
@@ -1,3 +1,5 @@
+SET parallel_replicas_local_plan=1;
+
 DROP TABLE IF EXISTS bloom_filter_has_const_array;
 
 CREATE TABLE bloom_filter_has_const_array
@@ -13,8 +15,6 @@ SETTINGS index_granularity=1;
 
 INSERT INTO bloom_filter_has_const_array
 VALUES ('a', ['a','a']), ('b', ['b','b']), ('c', ['c','c']), ('d',['d','e']);
-
-SET parallel_replicas_local_plan=1;
 
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement  

### Changelog entry:
Improved support for bloom filter indexes (regular, ngram, and token) to be utilized when the first argument is a constant array (the set) and the second is the indexed column (the subset), enabling more efficient query execution.

### Motivation:
Previously, bloom filter indexes were only applied when the indexed column appeared as the first argument in membership functions. This limitation prevented optimization in queries where a constant array was the first argument and the indexed column was second.

### Example use
Given a table with a bloom filter index on a non-Array column:

```sql
CREATE TABLE users (
    user_id UInt64,
    name String,
    INDEX bf_idx user_id TYPE bloom_filter
) ENGINE = MergeTree ORDER BY user_id;
```
  The following query will now efficiently use the bf_idx index to filter granules, whereas previously it would have resulted in a full table scan:
  
```sql  
SELECT name FROM users WHERE has([123, 456, 789], user_id);
```