### PR TITLE
Fix test_store_db_replica, restarting instances after restoring

### DIFF
--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -248,9 +248,6 @@ def test_query_after_restore_db_replica(
         node_2, exclusive_database_name
     )
 
-    if need_restart:
-        node_1.restart_clickhouse()
-
     assert (
         zk.exists(f"/clickhouse/{exclusive_database_name}/metadata/{exists_table_name}")
         is None
@@ -261,6 +258,9 @@ def test_query_after_restore_db_replica(
     )
 
     node_1.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
+
+    if need_restart:
+        node_1.restart_clickhouse()
 
     assert (
         zk.exists(f"/clickhouse/{exclusive_database_name}/metadata/{process_table}")
@@ -335,9 +335,6 @@ def test_query_after_restore_db_replica(
         f"{exclusive_database_name}.{changed_table}",
     )
 
-    if need_restart:
-        node_1.restart_clickhouse()
-
     assert (
         zk.exists(f"/clickhouse/{exclusive_database_name}/metadata/{exists_table_name}")
         is None
@@ -349,6 +346,9 @@ def test_query_after_restore_db_replica(
 
     node_1.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
     node_2.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
+
+    if need_restart:
+        node_1.restart_clickhouse()
 
     if exists_table:
         assert zk.exists(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

CIDB [link](https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=9815ee852cba6ea1e945fd5e7599c5f8eb0f07dd&name_0=MasterCI&name_1=Integration%20tests%20%28tsan%2C%204%2F6%29&name_1=Integration%20tests%20%28tsan%2C%204%2F6%29)

After restarting the instance, the tables which do not have metadata in Keeper are marked as broken, so it cannot be restored with `SYSTEM RESTORE DATABASE REPLICA <db_name>`.
This PR restarts the instance after the restoring query.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
