### PR TITLE
client: sort logs by time (for send_logs_level)

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -7,6 +7,8 @@
 #include <Client/TerminalKeystrokeInterceptor.h>
 #include <Client/TestHint.h>
 #include <Client/TestTags.h>
+#include <Core/SortDescription.h>
+#include <Interpreters/sortBlock.h>
 
 #if USE_CLIENT_AI
 #include <Client/AI/AISQLGenerator.h>
@@ -581,6 +583,12 @@ void ClientBase::onLogData(Block & block)
     {
         std::unique_lock lock(tty_mutex);
         progress_table.clearTableOutput(*tty_buf, lock);
+    }
+    /// Logs can be unsorted, i.e. if they were combined from multiple servers (in case of distributed queries)
+    {
+        SortDescription desc;
+        desc.push_back(SortColumnDescription("event_time_microseconds"));
+        sortBlock(block, desc);
     }
     logs_out_stream->writeLogs(block);
     logs_out_stream->flush();

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -587,6 +587,7 @@ void ClientBase::onLogData(Block & block)
     /// Logs can be unsorted, i.e. if they were combined from multiple servers (in case of distributed queries)
     {
         SortDescription desc;
+        desc.push_back(SortColumnDescription("event_time"));
         desc.push_back(SortColumnDescription("event_time_microseconds"));
         sortBlock(block, desc, 0, IColumn::PermutationSortStability::Stable);
     }

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -588,7 +588,7 @@ void ClientBase::onLogData(Block & block)
     {
         SortDescription desc;
         desc.push_back(SortColumnDescription("event_time_microseconds"));
-        sortBlock(block, desc);
+        sortBlock(block, desc, 0, IColumn::PermutationSortStability::Stable);
     }
     logs_out_stream->writeLogs(block);
     logs_out_stream->flush();

--- a/src/Interpreters/sortBlock.cpp
+++ b/src/Interpreters/sortBlock.cpp
@@ -333,10 +333,10 @@ void checkSortedWithPermutation(const Block & block, const SortDescription & des
 
 }
 
-void sortBlock(Block & block, const SortDescription & description, UInt64 limit)
+void sortBlock(Block & block, const SortDescription & description, UInt64 limit, IColumn::PermutationSortStability stability)
 {
     IColumn::Permutation permutation;
-    getBlockSortPermutationImpl(block, description, IColumn::PermutationSortStability::Unstable, limit, permutation);
+    getBlockSortPermutationImpl(block, description, stability, limit, permutation);
 
 #ifndef NDEBUG
     checkSortedWithPermutation(block, description, limit, permutation);

--- a/src/Interpreters/sortBlock.h
+++ b/src/Interpreters/sortBlock.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Columns/IColumn.h>
 #include <base/types.h>
 #include <Common/PODArray_fwd.h>
 
@@ -11,7 +12,7 @@ class SortDescription;
 using IColumnPermutation = PaddedPODArray<size_t>;
 
 /// Sort one block by `description`. If limit != 0, then the partial sort of the first `limit` rows is produced.
-void sortBlock(Block & block, const SortDescription & description, UInt64 limit = 0);
+void sortBlock(Block & block, const SortDescription & description, UInt64 limit = 0, IColumn::PermutationSortStability stability = IColumn::PermutationSortStability::Unstable);
 
 /** Same as sortBlock, but do not sort the block, but only calculate the permutation of the values,
   *  so that you can rearrange the column values yourself.


### PR DESCRIPTION
Note, that this is likely not enough for all cases, but it help for most of the cases and makes it easier to read the logs while debugging

The test could be:

    chc "select * from remote('127.{1..10}') settings send_logs_level='test'" |& grep '^\[' | tee >(cat -n >&2) | sort --check -k3,3 -n

But, it may not be deterministic, at least because `sort` does not allow duplicated keys during `--check` [1].

  [1]: https://pastila.nl/?01905ada/deba8dd532e7e5a1d4e06dcfa956ccc2#SWsU7h98HEn71nOrGk7aEw==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
client: sort logs by time (for send_logs_level) to make debugging easier