### PR TITLE
Prefetch keys during hash table iteration to minimize cache misses

### DIFF
--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -256,8 +256,8 @@ public:
     template <typename Func>
     void forEachValue(Func && func)
     {
-        for (auto & v : *this)
-            func(v.getKey(), v.getMapped());
+        for (auto it = this->begin(true), end = this->end(); it != end; ++it)
+            func(it->getKey(), it->getMapped());
     }
 
     /// Call func(Mapped &) for each hash map element.

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -256,19 +256,10 @@ public:
     template <typename Func>
     void forEachValue(Func && func)
     {
-        // to small table we can iterate without prefetching
-        if (CouldPrefetchKey<Cell> && this->size() > DB::PrefetchingHelper::iterationsToMeasure() * 2)
-        {
-            auto it = this->prefetchingBegin();
-            auto end = this->prefetchingEnd();
-            for (; it != end; ++it)
-                func(it->getKey(), it->getMapped());
-        }
-        else
-        {
-            for (auto & it : *this)
-                func(it.getKey(), it.getMapped());
-        }
+        auto it = this->begin(false);
+        auto end = this->end();
+        for (; it != end; ++it)
+            func(it->getKey(), it->getMapped());
     }
 
     /// Call func(Mapped &) for each hash map element.

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -257,8 +257,7 @@ public:
     void forEachValue(Func && func)
     {
         // to small table we can iterate without prefetching
-        constexpr size_t prefetch_min_size = 10000;
-        if (CouldPrefetchKey<Cell> && this->size() > prefetch_min_size)
+        if (CouldPrefetchKey<Cell> && this->size() > DB::PrefetchingHelper::iterationsToMeasure() * 2)
         {
             auto it = this->prefetchingBegin();
             auto end = this->prefetchingEnd();

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -256,10 +256,19 @@ public:
     template <typename Func>
     void forEachValue(Func && func)
     {
-        auto it = this->begin(false);
-        auto end = this->end();
-        for (; it != end; ++it)
-            func(it->getKey(), it->getMapped());
+        // to small table we can iterate without prefetching
+        if (CouldPrefetchKey<Cell> && this->size() > DB::PrefetchingHelper::iterationsToMeasure() * 2)
+        {
+            auto it = this->prefetchingBegin();
+            auto end = this->prefetchingEnd();
+            for (; it != end; ++it)
+                func(it->getKey(), it->getMapped());
+        }
+        else
+        {
+            for (auto & it : *this)
+                func(it.getKey(), it.getMapped());
+        }
     }
 
     /// Call func(Mapped &) for each hash map element.

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -259,8 +259,8 @@ public:
         // to small table we can iterate without prefetching
         if (CouldPrefetchKey<Cell> && this->size() > DB::PrefetchingHelper::iterationsToMeasure() * 2)
         {
-            auto it = this->prefetchingBegin();
-            auto end = this->prefetchingEnd();
+            auto it = this->template begin<true>();
+            auto end = this->template end<true>();
             for (; it != end; ++it)
                 func(it->getKey(), it->getMapped());
         }

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -720,7 +720,7 @@ protected:
             if (prefetch_buffer.size() <  prefetch_ahead && next_ptr < buf_end) [[likely]]
             {
                 if (iter_count == DB::PrefetchingHelper::iterationsToMeasure()) [[unlikely]]
-                    prefetch_ahead = std::min(prefetch_buffer.capacity(), prefetching.calcPrefetchLookAhead() + 1);
+                    prefetch_ahead = std::min(prefetch_buffer.capacity(), prefetching.calcPrefetchLookAhead());
 
                 auto n = prefetch_ahead - prefetch_buffer.size();
                 cell_type * last_ptr = nullptr;

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -617,15 +617,18 @@ protected:
         }
     }
 
+    // Prefetching keys will reduce cache misses and improve performance.
+    // Maybe reusing iterator_base is better
     template <typename Derived, bool is_const>
-    class iterator_base /// NOLINT
+    class prefetching_iterator_base
     {
+
         using Container = std::conditional_t<is_const, const Self, Self>;
         using cell_type = std::conditional_t<is_const, const Cell, Cell>;
 
+
         Container * container;
         cell_type * ptr;
-        bool enable_prefetch = false;
         cell_type * prefetch_ptr = nullptr;
         DB::PrefetchingHelper prefetching;
         size_t prefetch_ahead = 2;
@@ -635,19 +638,17 @@ protected:
         friend class HashTable;
 
     public:
-        iterator_base() {} /// NOLINT
-        iterator_base(Container * container_, cell_type * ptr_, bool enable_prefetch_ = false)
-            : container(container_), ptr(ptr_)
-            , enable_prefetch(enable_prefetch_ && container_->size() > DB::PrefetchingHelper::iterationsToMeasure() * 2)
-        {}
+        prefetching_iterator_base() {} /// NOLINT
+        prefetching_iterator_base(Container * container_, cell_type * ptr_) : container(container_), ptr(ptr_) {}
 
-        bool operator== (const iterator_base & rhs) const { return ptr == rhs.ptr; }
-        bool operator!= (const iterator_base & rhs) const { return ptr != rhs.ptr; }
+        bool operator== (const prefetching_iterator_base & rhs) const { return ptr == rhs.ptr; }
+        bool operator!= (const prefetching_iterator_base & rhs) const { return ptr != rhs.ptr; }
 
         Derived & operator++()
         {
-            if (CouldPrefetchKey<cell_type> && enable_prefetch)
+            if (CouldPrefetchKey<cell_type>)
             {
+
                 if (ptr->isZero(*container)) [[unlikely]]
                 {
                     ptr = container->buf;
@@ -662,6 +663,12 @@ protected:
                     ++ptr;
 
                 prefetch();
+
+                /// Skip empty cells in the main buffer.
+                auto * buf_end = container->buf + container->grower.bufSize();
+                while (ptr < buf_end && ptr->isZero(*container))
+                    ++ptr;
+
                 if (prefetched_count > 0)
                     prefetched_count--;
             }
@@ -672,45 +679,22 @@ protected:
                     ptr = container->buf;
                 else
                     ++ptr;
+
+                /// Skip empty cells in the main buffer.
+                auto * buf_end = container->buf + container->grower.bufSize();
+                while (ptr < buf_end && ptr->isZero(*container))
+                    ++ptr;
             }
-
-            /// Skip empty cells in the main buffer.
-            auto * buf_end = container->buf + container->grower.bufSize();
-            while (ptr < buf_end && ptr->isZero(*container))
-                ++ptr;
-
             return static_cast<Derived &>(*this);
         }
 
+
         auto & operator* () const { return *ptr; }
         auto * operator->() const { return ptr; }
-
-        auto getPtr() const { return ptr; }
-        size_t getHash() const { return ptr->getHash(*container); }
-
-        size_t getCollisionChainLength() const
-        {
-            return container->grower.place((ptr - container->buf) - container->grower.place(getHash()));
-        }
-
-        /**
-          * A hack for HashedDictionary.
-          *
-          * The problem: std-like find() returns an iterator, which has to be
-          * compared to end(). On the other hand, HashMap::find() returns
-          * LookupResult, which is compared to nullptr. HashedDictionary has to
-          * support both hash maps with the same code, hence the need for this
-          * hack.
-          *
-          * The proper way would be to remove iterator interface from our
-          * HashMap completely, change all its users to the existing internal
-          * iteration interface, and redefine end() to return LookupResult for
-          * compatibility with std find(). Unfortunately, now is not the time to
-          * do this.
-          */
         operator Cell * () const { return nullptr; } /// NOLINT
 
     private:
+
         void prefetch()
         {
             auto * buf_end = container->buf + container->grower.bufSize();
@@ -747,6 +731,82 @@ protected:
                 }
             }
         }
+    };
+
+    class const_prefetching_iterator
+        : public prefetching_iterator_base<const const_prefetching_iterator, true>
+    {
+    public:
+        using prefetching_iterator_base<const const_prefetching_iterator, true>::prefetching_iterator_base;
+    };
+
+    class prefetching_iterator
+        : public prefetching_iterator_base<prefetching_iterator, false>
+    {
+    public:
+        using prefetching_iterator_base<prefetching_iterator, false>::prefetching_iterator_base;
+    };
+
+    template <typename Derived, bool is_const>
+    class iterator_base /// NOLINT
+    {
+        using Container = std::conditional_t<is_const, const Self, Self>;
+        using cell_type = std::conditional_t<is_const, const Cell, Cell>;
+
+        Container * container;
+        cell_type * ptr;
+
+        friend class HashTable;
+
+    public:
+        iterator_base() {} /// NOLINT
+        iterator_base(Container * container_, cell_type * ptr_) : container(container_), ptr(ptr_) {}
+
+        bool operator== (const iterator_base & rhs) const { return ptr == rhs.ptr; }
+        bool operator!= (const iterator_base & rhs) const { return ptr != rhs.ptr; }
+
+        Derived & operator++()
+        {
+            /// If iterator was pointed to ZeroValueStorage, move it to the beginning of the main buffer.
+            if (unlikely(ptr->isZero(*container)))
+                ptr = container->buf;
+            else
+                ++ptr;
+
+            /// Skip empty cells in the main buffer.
+            auto * buf_end = container->buf + container->grower.bufSize();
+            while (ptr < buf_end && ptr->isZero(*container))
+                ++ptr;
+            return static_cast<Derived &>(*this);
+        }
+
+        auto & operator* () const { return *ptr; }
+        auto * operator->() const { return ptr; }
+
+        auto getPtr() const { return ptr; }
+        size_t getHash() const { return ptr->getHash(*container); }
+
+        size_t getCollisionChainLength() const
+        {
+            return container->grower.place((ptr - container->buf) - container->grower.place(getHash()));
+        }
+
+        /**
+          * A hack for HashedDictionary.
+          *
+          * The problem: std-like find() returns an iterator, which has to be
+          * compared to end(). On the other hand, HashMap::find() returns
+          * LookupResult, which is compared to nullptr. HashedDictionary has to
+          * support both hash maps with the same code, hence the need for this
+          * hack.
+          *
+          * The proper way would be to remove iterator interface from our
+          * HashMap completely, change all its users to the existing internal
+          * iteration interface, and redefine end() to return LookupResult for
+          * compatibility with std find(). Unfortunately, now is not the time to
+          * do this.
+          */
+        operator Cell * () const { return nullptr; } /// NOLINT
     };
 
 
@@ -903,38 +963,74 @@ public:
     };
 
 
-    const_iterator begin(bool enable_prefetch = false) const
+    const_iterator begin() const
     {
         if (!buf)
             return end();
 
         if (this->hasZero())
-            return iteratorToZero(enable_prefetch);
+            return iteratorToZero();
 
         const Cell * ptr = buf;
         auto buf_end = buf + grower.bufSize();
         while (ptr < buf_end && ptr->isZero(*this))
             ++ptr;
 
-        return const_iterator(this, ptr, enable_prefetch);
+        return const_iterator(this, ptr);
     }
 
-    const_iterator cbegin(bool enable_prefetch = false) const { return begin(enable_prefetch); }
+    const_iterator cbegin() const { return begin(); }
 
-    iterator begin(bool enable_prefetch = false)
+    iterator begin()
     {
         if (!buf)
             return end();
 
         if (this->hasZero())
-            return iteratorToZero(enable_prefetch);
+            return iteratorToZero();
 
         Cell * ptr = buf;
         auto * buf_end = buf + grower.bufSize();
         while (ptr < buf_end && ptr->isZero(*this))
             ++ptr;
 
-        return iterator(this, ptr, enable_prefetch);
+        return iterator(this, ptr);
+    }
+
+    const_prefetching_iterator prefetchingBegin() const
+    {
+        if (!buf)
+            return prefetchingEnd();
+        if (this->hasZero())
+            return const_prefetching_iterator(this, this->zeroValue());
+        const Cell * ptr = buf;
+        auto buf_end = buf + grower.bufSize();
+        while (ptr < buf_end && ptr->isZero(*this))
+            ++ptr;
+        return const_prefetching_iterator(this, ptr);
+    }
+
+    prefetching_iterator prefetchingBegin()
+    {
+        if (!buf)
+            return prefetchingEnd();
+        if (this->hasZero())
+            return prefetching_iterator(this, this->zeroValue());
+        Cell * ptr = buf;
+        auto buf_end = buf + grower.bufSize();
+        while (ptr < buf_end && ptr->isZero(*this))
+            ++ptr;
+        return prefetching_iterator(this, ptr);
+    }
+
+    const_prefetching_iterator prefetchingEnd() const
+    {
+        return const_prefetching_iterator(this, buf ? buf + grower.bufSize() : buf);
+    }
+
+    prefetching_iterator prefetchingEnd()
+    {
+        return prefetching_iterator(this, buf ? buf + grower.bufSize() : buf);
     }
 
     const_iterator end() const
@@ -955,10 +1051,10 @@ public:
 
 
 protected:
-    const_iterator iteratorTo(const Cell * ptr, bool enable_prefetch = false) const { return const_iterator(this, ptr, enable_prefetch); }
-    iterator iteratorTo(Cell * ptr, bool enable_prefetch = false)                   { return iterator(this, ptr, enable_prefetch); }
-    const_iterator iteratorToZero(bool enable_prefetch = false) const             { return iteratorTo(this->zeroValue(), enable_prefetch); }
-    iterator iteratorToZero(bool enable_prefetch = false)                         { return iteratorTo(this->zeroValue(), enable_prefetch); }
+    const_iterator iteratorTo(const Cell * ptr) const { return const_iterator(this, ptr); }
+    iterator iteratorTo(Cell * ptr)                   { return iterator(this, ptr); }
+    const_iterator iteratorToZero() const             { return iteratorTo(this->zeroValue()); }
+    iterator iteratorToZero()                         { return iteratorTo(this->zeroValue()); }
 
 
     /// If the key is zero, insert it into a special place and return true.

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -140,12 +140,12 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(DB::SerializedKeyHolder & holder)
 
 inline void KeyPrefetch(const StringRef & key)
 {
-    const size_t CACHE_LINE_SIZE = 64;
-    const size_t MAX_PREFETCH = 256;
-    size_t n = key.size < MAX_PREFETCH ? key.size : MAX_PREFETCH;
+    const size_t cache_line_size = 64;
+    const size_t max_prefetch = 256;
+    const size_t n = key.size < max_prefetch ? key.size : max_prefetch;
     const char * ptr = key.data;
     const char * end = ptr + n;
-    for (; ptr < end; ptr += CACHE_LINE_SIZE)
+    for (; ptr < end; ptr += cache_line_size)
     {
         __builtin_prefetch(ptr);
     }

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -138,3 +138,22 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(DB::SerializedKeyHolder & holder)
     holder.key = std::string_view();
 }
 
+void KeyPrefetch(const StringRef & key);
+{
+    constexpr size_t CACHE_LINE_SIZE = 64;
+    constexpr size_t MAX_PREFETCH = 256; // 最多预取 256 字节
+    size_t n = key.size < MAX_PREFETCH ? key.size : MAX_PREFETCH;
+    const char * ptr = key.data;
+    const char * end = ptr + n;
+    for (; ptr < end; ptr += CACHE_LINE_SIZE)
+    {
+        __builtin_prefetch(ptr);
+    }
+}
+
+template <typename CellType>
+concept CouldPrefetchKey = requires(CellType * cell)
+{
+    { KeyPrefetch(cell->getKey()) };
+}; 
+

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -138,10 +138,10 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(DB::SerializedKeyHolder & holder)
     holder.key = std::string_view();
 }
 
-void KeyPrefetch(const StringRef & key);
+inline void KeyPrefetch(const StringRef & key)
 {
-    constexpr size_t CACHE_LINE_SIZE = 64;
-    constexpr size_t MAX_PREFETCH = 256; // 最多预取 256 字节
+    const size_t CACHE_LINE_SIZE = 64;
+    const size_t MAX_PREFETCH = 256;
     size_t n = key.size < MAX_PREFETCH ? key.size : MAX_PREFETCH;
     const char * ptr = key.data;
     const char * end = ptr + n;
@@ -155,5 +155,4 @@ template <typename CellType>
 concept CouldPrefetchKey = requires(CellType * cell)
 {
     { KeyPrefetch(cell->getKey()) };
-}; 
-
+};

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -144,7 +144,7 @@ inline void KeyPrefetch(const StringRef & key)
     const size_t max_prefetch = 256;
     const size_t n = key.size < max_prefetch ? key.size : max_prefetch;
     const char * ptr = key.data;
-    const char * end = ptr + n - (n % cache_line_size);
+    const char * end = ptr + n;
     for (; ptr < end; ptr += cache_line_size)
     {
         __builtin_prefetch(ptr);

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -144,7 +144,7 @@ inline void KeyPrefetch(const StringRef & key)
     const size_t max_prefetch = 256;
     const size_t n = key.size < max_prefetch ? key.size : max_prefetch;
     const char * ptr = key.data;
-    const char * end = ptr + n;
+    const char * end = ptr + n - (n % cache_line_size);
     for (; ptr < end; ptr += cache_line_size)
     {
         __builtin_prefetch(ptr);

--- a/tests/performance/hash_table_iteration_prefetch.xml
+++ b/tests/performance/hash_table_iteration_prefetch.xml
@@ -1,13 +1,13 @@
 <test>
     <settings>
-        <max_threads>1</max_threads>
+        <max_threads>2</max_threads>
     </settings>
     <create_query>
         create table ht_prefetch (a String, b String, c UInt64) engine=Memory
     </create_query>
 
     <fill_query>
-        insert into ht_prefetch select concat('key', toString(number)), concat('value', toString(rand())), rand() % 1000 from numbers(2e7)
+        insert into ht_prefetch select concat('key', toString(number)), concat('value', toString(rand())), rand() % 1000 from numbers(1e7)
     </fill_query>
 
     <query>

--- a/tests/performance/hash_table_iteration_prefetch.xml
+++ b/tests/performance/hash_table_iteration_prefetch.xml
@@ -1,0 +1,20 @@
+<test>
+    <settings>
+        <max_threads>4</max_threads>
+    </settings>
+    <create_query>
+        create table ht_prefetch (a String, b String, c UInt64) engine=Memory
+    </create_query>
+
+    <fill_query>
+        insert into ht_prefetch select concat('key', toString(number)), concat('value', toString(rand())), rand() % 1000 from numbers(10000000)
+    </fill_query>
+
+    <query>
+        select a, b , avg(c) from ht_prefetch group by a, b  format Null
+    </query>
+
+    <drop_query>
+        drop table if exists ht_prefetch
+    </drop_query>
+</test>

--- a/tests/performance/hash_table_iteration_prefetch.xml
+++ b/tests/performance/hash_table_iteration_prefetch.xml
@@ -7,7 +7,7 @@
     </create_query>
 
     <fill_query>
-        insert into ht_prefetch select concat('key', toString(number)), concat('value', toString(rand())), rand() % 1000 from numbers(10000000)
+        insert into ht_prefetch select concat('key', toString(number)), concat('value', toString(rand())), rand() % 1000 from numbers(2e7)
     </fill_query>
 
     <query>

--- a/tests/performance/hash_table_iteration_prefetch.xml
+++ b/tests/performance/hash_table_iteration_prefetch.xml
@@ -1,6 +1,6 @@
 <test>
     <settings>
-        <max_threads>4</max_threads>
+        <max_threads>1</max_threads>
     </settings>
     <create_query>
         create table ht_prefetch (a String, b String, c UInt64) engine=Memory
@@ -11,7 +11,7 @@
     </fill_query>
 
     <query>
-        select a, b , avg(c) from ht_prefetch group by a, b  format Null
+        select a, b , avg(c) from ht_prefetch group by a, b format Null
     </query>
 
     <drop_query>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Performance Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Prefetch keys during hash table iteration to minimize cache misses.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
