### PR TITLE
Integration tests: add test for detach of replicated table

### DIFF
--- a/tests/integration/test_replicated_detach_table/configs/remote_servers.xml
+++ b/tests/integration/test_replicated_detach_table/configs/remote_servers.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>replica1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>replica2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_replicated_detach_table/test.py
+++ b/tests/integration/test_replicated_detach_table/test.py
@@ -1,0 +1,61 @@
+# Tag no-fasttest: requires S3
+
+import random
+import string
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+replica1 = cluster.add_instance(
+    "replica1",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml"],
+    macros={"shard": "shard1", "replica": "replica1"},
+)
+replica2 = cluster.add_instance(
+    "replica2",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml"],
+    macros={"shard": "shard1", "replica": "replica2"},
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    except Exception as ex:
+        print(ex)
+    finally:
+        cluster.shutdown()
+
+
+def test_replicated_detach_table(start_cluster):
+    replica1.query(
+        "CREATE DATABASE IF NOT EXISTS db ON CLUSTER test_cluster ENGINE=Replicated('/clickhouse/tables/db/test_replicated_table', '{shard}', '{replica}');"
+    )
+
+    replica1.query_with_retry(
+        f"""
+        CREATE TABLE db.test_replicated_table
+        (
+            number UInt64
+        )
+        ENGINE=ReplicatedMergeTree
+        ORDER BY number
+        """
+    )
+    replica1.query(
+        f"INSERT INTO db.test_replicated_table SELECT number FROM system.numbers LIMIT 6;"
+    )
+    replica1.query(
+        f"SYSTEM SYNC REPLICA db.test_replicated_table;",
+        timeout=20,
+    )
+    replica1.query(f"DETACH TABLE db.test_replicated_table PERMANENTLY;")
+
+    replica1.query(f"DROP DATABASE db ON CLUSTER test_cluster SYNC")


### PR DESCRIPTION
Add test for detach of replicated table
Closes https://github.com/ClickHouse/ClickHouse/pull/66092
Closes https://github.com/ClickHouse/ClickHouse/issues/66932

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
