### PR TITLE
Use default `distributed_ddl_task_timeout` in tests

### DIFF
--- a/tests/config/users.d/database_replicated.xml
+++ b/tests/config/users.d/database_replicated.xml
@@ -3,7 +3,6 @@
         <default>
             <distributed_ddl_output_mode>none</distributed_ddl_output_mode>
             <database_replicated_initial_query_timeout_sec>120</database_replicated_initial_query_timeout_sec>
-            <distributed_ddl_task_timeout>120</distributed_ddl_task_timeout>
             <database_replicated_always_detach_permanently>1</database_replicated_always_detach_permanently>
             <database_replicated_enforce_synchronous_settings>1</database_replicated_enforce_synchronous_settings>
             <database_replicated_allow_replicated_engine_arguments>3</database_replicated_allow_replicated_engine_arguments>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Sometimes we're getting failures like these:
* [one](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=83884&sha=3247de614555e702c95ac975829fc73b6eb9b427&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29)
* [two](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=82355&sha=29ae7b4e3dd11cdd4100fcf7c9c5d20540360ac5&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%201%2F2%29)
* [three](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79982&sha=393d98b777e1c42f7a5b0ec15992cea7c2fd965f&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%201%2F2%29)

And I'm not sure if there is any benefit from having this timeout lower than the default (180). 
