### PR TITLE
Allow to use any storage policy for external aggregation/sorting

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -370,6 +370,8 @@ void LocalServer::tryInitPath()
         LOG_DEBUG(log, "Working directory will be created as needed: {}", path);
     }
 
+    fs::create_directories(path);
+
     global_context->setPath(fs::path(path) / "");
 
     global_context->setTemporaryStoragePath(fs::path(path) / "tmp" / "", 0);

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -571,6 +571,7 @@
     -->
 
     <!-- Path to temporary data for processing heavy queries. -->
+    <!-- NOTE: all files with `tmp` prefix will be removed at server startup -->
     <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
 
     <!-- Disable AuthType plaintext_password and no_password for ACL. -->
@@ -620,6 +621,8 @@
          - keep_free_space_bytes    is ignored
          - max_data_part_size_bytes is ignored
          - you must have exactly one volume in that policy
+
+         NOTE: all files with `tmp` prefix will be removed at server startup
     -->
     <!-- <tmp_policy>tmp</tmp_policy> -->
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -163,12 +163,21 @@ namespace DB
     DECLARE(UInt32, asynchronous_heavy_metrics_update_period_s, 120, R"(Period in seconds for updating heavy asynchronous metrics.)", 0) \
     DECLARE(String, default_database, "default", R"(The default database name.)", 0) \
     DECLARE(String, tmp_policy, "", R"(
-    Policy for storage with temporary data. For more information see the [MergeTree Table Engine](/engines/table-engines/mergetree-family/mergetree) documentation.
+    Policy for storage with temporary data. All files with `tmp` prefix will be removed at start.
+
+    :::note
+    Recommendations for using object storage as `tmp_policy`:
+    - Use separate `bucket:path` on each server
+    - Use `metadata_type=plain`
+    - You may also want to set TTL for this bucket
+    :::
 
     :::note
     - Only one option can be used to configure temporary data storage: `tmp_path` ,`tmp_policy`, `temporary_data_in_cache`.
     - `move_factor`, `keep_free_space_bytes`,`max_data_part_size_bytes` and are ignored.
-    - Policy should have exactly *one volume* with *local* disks.
+    - Policy should have exactly *one volume*
+
+    For more information see the [MergeTree Table Engine](/engines/table-engines/mergetree-family/mergetree) documentation.
     :::
 
     **Example**

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1407,40 +1407,38 @@ void Context::setFilesystemCacheUser(const String & user)
     shared->filesystem_cache_user = user;
 }
 
-static void setupTmpPath(LoggerPtr log, const std::string & path)
+static void setupTmpPath(LoggerPtr log, const DiskPtr & disk)
 try
 {
-    LOG_DEBUG(log, "Setting up {} to store temporary data in it", path);
+    LOG_DEBUG(log, "Setting up {}:{} to store temporary data in it", disk->getName(), disk->getPath());
 
-    if (fs::exists(path))
+    if (disk->existsDirectory(""))
     {
-        /// Clearing old temporary files.
-        fs::directory_iterator dir_end;
-        for (fs::directory_iterator it(path); it != dir_end; ++it)
+        for (auto it = disk->iterateDirectory(""); it->isValid(); it->next())
         {
-            if (it->is_regular_file())
+            /// existsFile() checks for is_regular_file() for local disk
+            if (it->path().starts_with("tmp") && disk->existsFile(it->path()))
             {
-                if (startsWith(it->path().filename(), "tmp"))
-                {
-                    LOG_DEBUG(log, "Removing old temporary file {}", it->path().string());
-                    fs::remove(it->path());
-                }
-                else
-                    LOG_DEBUG(log, "Found unknown file in temporary path {}", it->path().string());
+                LOG_DEBUG(log, "Removing old temporary file {}", it->path());
+                disk->removeFile(it->path());
             }
-            /// We skip directories (for example, 'http_buffers' - it's used for buffering of the results) and all other file types.
+            else
+            {
+                LOG_DEBUG(log, "Found unknown file in temporary path {}", it->path());
+            }
         }
     }
     else
     {
-        fs::create_directories(path);
+        disk->createDirectory("");
     }
 }
 catch (...)
 {
     DB::tryLogCurrentException(log, fmt::format(
-        "Caught exception while setting up temporary path: {}. "
-        "It is ok to skip this exception as cleaning old temporary files is not necessary", path));
+        "Caught exception while setting up temporary disk {}:{}. "
+        "It is ok to skip this exception as cleaning old temporary files is not necessary",
+        disk->getName(), disk->getPath()));
 }
 
 static VolumePtr createLocalSingleDiskVolume(const std::string & path, const Poco::Util::AbstractConfiguration & config_)
@@ -1464,7 +1462,7 @@ void Context::setTemporaryStoragePath(const String & path, size_t max_size)
     VolumePtr volume = createLocalSingleDiskVolume(shared->tmp_path, shared->getConfigRefWithLock(lock));
 
     for (const auto & disk : volume->getDisks())
-        setupTmpPath(shared->log, disk->getPath());
+        setupTmpPath(shared->log, disk);
 
     TemporaryDataOnDiskSettings temporary_data_on_disk_settings;
     temporary_data_on_disk_settings.max_size_on_disk = max_size;
@@ -1498,16 +1496,7 @@ void Context::setTemporaryStoragePolicy(const String & policy_name, size_t max_s
 
         /// Check that underlying disk is local (can be wrapped in decorator)
         DiskPtr disk_ptr = disk;
-
-        if (dynamic_cast<const DiskLocal *>(disk_ptr.get()) == nullptr)
-        {
-            const auto * disk_raw_ptr = disk_ptr.get();
-            throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG,
-                "Disk '{}' ({}) is not local and can't be used for temporary files",
-                disk_ptr->getName(), typeid(*disk_raw_ptr).name());
-        }
-
-        setupTmpPath(shared->log, disk->getPath());
+        setupTmpPath(shared->log, disk);
     }
 
     std::lock_guard lock(shared->mutex);

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -155,7 +155,7 @@ public:
             if (disk->existsFile(path_to_file))
             {
                 LOG_TRACE(getLogger("TemporaryFileOnLocalDisk"), "Removing temporary file '{}'", path_to_file);
-                disk->removeRecursive(path_to_file);
+                disk->removeFile(path_to_file);
             }
             else
             {

--- a/tests/integration/test_tmp_policy/configs/config.d/remote_storage_configuration.xml
+++ b/tests/integration/test_tmp_policy/configs/config.d/remote_storage_configuration.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk_s3_plain>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/disks/mtp/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </disk_s3_plain>
+        </disks>
+
+        <policies>
+            <tmp>
+                <volumes>
+                    <main>
+                        <disk>disk_s3_plain</disk>
+                    </main>
+                </volumes>
+            </tmp>
+        </policies>
+    </storage_configuration>
+
+    <tmp_policy>tmp</tmp_policy>
+</clickhouse>

--- a/tests/integration/test_tmp_policy/test.py
+++ b/tests/integration/test_tmp_policy/test.py
@@ -7,14 +7,22 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
-node = cluster.add_instance(
-    "node",
+node_local = cluster.add_instance(
+    "node_local",
     main_configs=["configs/config.d/storage_configuration.xml"],
     tmpfs=["/disk1:size=100M", "/disk2:size=100M"],
+    stay_alive=True,
+)
+
+node_remote = cluster.add_instance(
+    "node_remote",
+    main_configs=["configs/config.d/remote_storage_configuration.xml"],
+    with_minio=True,
+    stay_alive=True,
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def start_cluster():
     try:
         cluster.start()
@@ -23,7 +31,7 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_disk_selection(start_cluster):
+def test_multiple_local_disk():
     query = "SELECT count(ignore(*)) FROM (SELECT * FROM system.numbers LIMIT 1e7) GROUP BY number"
     settings = {
         "max_bytes_ratio_before_external_group_by": 0,
@@ -32,13 +40,93 @@ def test_disk_selection(start_cluster):
         "max_bytes_before_external_sort": 1 << 20,
     }
 
-    assert node.contains_in_log("Setting up /disk1/ to store temporary data in it")
-    assert node.contains_in_log("Setting up /disk2/ to store temporary data in it")
+    assert node_local.contains_in_log(
+        "Setting up .*disk1.* to store temporary data in it"
+    )
+    assert node_local.contains_in_log(
+        "Setting up .*disk2.* to store temporary data in it"
+    )
 
-    node.query(query, settings=settings)
-    assert node.contains_in_log(
+    node_local.query(query, settings=settings)
+    assert node_local.contains_in_log(
         "Writing part of aggregation data into temporary file.*/disk1/"
     )
-    assert node.contains_in_log(
+    assert node_local.contains_in_log(
         "Writing part of aggregation data into temporary file.*/disk2/"
     )
+
+
+def test_remote_disk():
+    query = "SELECT count(ignore(*)) FROM (SELECT * FROM system.numbers LIMIT 1e7) GROUP BY number"
+    settings = {
+        "max_bytes_ratio_before_external_group_by": 0,
+        "max_bytes_ratio_before_external_sort": 0,
+        "max_bytes_before_external_group_by": 1 << 20,
+        "max_bytes_before_external_sort": 1 << 20,
+    }
+
+    node_remote.query(query, settings=settings)
+    assert node_remote.contains_in_log(
+        "Writing part of aggregation data into temporary file.*disk_s3_plain"
+    )
+    assert node_remote.contains_in_log(
+        "Writing part of aggregation data into temporary file.*disk_s3_plain"
+    )
+
+
+@pytest.mark.parametrize(
+    "node, config, disk",
+    [
+        pytest.param(
+            node_local,
+            "storage_configuration.xml",
+            "disk1",
+            id="local_disk1",
+        ),
+        pytest.param(
+            node_local,
+            "storage_configuration.xml",
+            "disk2",
+            id="local_disk2",
+        ),
+        pytest.param(
+            node_remote,
+            "remote_storage_configuration.xml",
+            "disk_s3_plain",
+            id="remote",
+        ),
+    ],
+)
+def test_cleanup_temporary_disk_at_server_start(node, config, disk):
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse disks -C /etc/clickhouse-server/config.d/{config} --disk {disk} -q 'write --path-to foo' <<<foo",
+        ]
+    )
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse disks -C /etc/clickhouse-server/config.d/{config} --disk {disk} -q 'write --path-to tmpfoo' <<<foo",
+        ]
+    )
+    assert node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse disks -C /etc/clickhouse-server/config.d/{config} --disk {disk} -q 'ls'",
+        ]
+    ).strip().split("\n") == ["foo", "tmpfoo"]
+
+    # Now restart the server to cleanup the tmp disk on start
+    node.restart_clickhouse()
+
+    assert node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse disks -C /etc/clickhouse-server/config.d/{config} --disk {disk} -q 'ls'",
+        ]
+    ).strip().split("\n") == ["foo"]


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow to use any storage policy (i.e. object storage, such as S3) for external aggregation/sorting

Fixes: https://github.com/ClickHouse/ClickHouse/issues/42157