### PR TITLE
http_authentication_servers: case-insensitive forward_headers

### DIFF
--- a/docs/en/operations/external-authenticators/http.md
+++ b/docs/en/operations/external-authenticators/http.md
@@ -55,7 +55,7 @@ Retry parameters:
 
 Forward headers:
 
-The part defines which headers will be forwarded from client request headers to external HTTP authenticator
+The part defines which headers will be forwarded from client request headers to external HTTP authenticator. Note that headers will be matched against config ones in case-insensitive way, but forwarded as-is i.e. unmodified.
 
 ### Enabling HTTP authentication in `users.xml` {#enabling-http-auth-in-users-xml}
 

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -258,7 +258,7 @@ HTTPAuthClientParams parseHTTPAuthParams(const Poco::Util::AbstractConfiguration
     for (const auto & header : forward_headers)
     {
         String name = config.getString(prefix + ".forward_headers." + header);
-        http_auth_params.forward_headers.insert(Poco::toLower(name));
+        http_auth_params.forward_headers.insert(name);
     }
 
     return http_auth_params;

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -258,7 +258,7 @@ HTTPAuthClientParams parseHTTPAuthParams(const Poco::Util::AbstractConfiguration
     for (const auto & header : forward_headers)
     {
         String name = config.getString(prefix + ".forward_headers." + header);
-        http_auth_params.forward_headers.push_back(name);
+        http_auth_params.forward_headers.insert(Poco::toLower(name));
     }
 
     return http_auth_params;

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -258,7 +258,7 @@ HTTPAuthClientParams parseHTTPAuthParams(const Poco::Util::AbstractConfiguration
     for (const auto & header : forward_headers)
     {
         String name = config.getString(prefix + ".forward_headers." + header);
-        http_auth_params.forward_headers.insert(name);
+        http_auth_params.forward_headers.push_back(name);
     }
 
     return http_auth_params;

--- a/src/Access/HTTPAuthClient.h
+++ b/src/Access/HTTPAuthClient.h
@@ -10,17 +10,6 @@
 namespace DB
 {
 
-struct ci_less {
-    bool operator()(const std::string& a, const std::string& b) const {
-        return std::lexicographical_compare(
-            a.begin(), a.end(),
-            b.begin(), b.end(),
-            [](unsigned char ac, unsigned char bc) {
-                return std::tolower(ac) < std::tolower(bc);
-            });
-    }
-};
-
 struct HTTPAuthClientParams
 {
     Poco::URI uri;
@@ -28,7 +17,7 @@ struct HTTPAuthClientParams
     size_t max_tries;
     size_t retry_initial_backoff_ms;
     size_t retry_max_backoff_ms;
-    std::set<String, ci_less> forward_headers;
+    std::vector<String> forward_headers;
 };
 
 template <typename TResponseParser>
@@ -42,7 +31,7 @@ public:
         , max_tries{params.max_tries}
         , retry_initial_backoff_ms{params.retry_initial_backoff_ms}
         , retry_max_backoff_ms{params.retry_max_backoff_ms}
-        , forward_headers{params.forward_headers}
+        , forward_headers{params.forward_headers.begin(), params.forward_headers.end()}
         , uri{params.uri}
         , parser{parser_}
     {
@@ -76,6 +65,20 @@ public:
     }
 
     const Poco::URI & getURI() const { return uri; }
+
+    struct ci_less
+    {
+        bool operator()(const std::string & a, const std::string & b) const
+        {
+            return std::lexicographical_compare(
+                a.begin(), a.end(),
+                b.begin(), b.end(),
+                [](unsigned char ac, unsigned char bc) {
+                    return std::tolower(ac) < std::tolower(bc);
+                });
+        }
+    };
+
     const std::set<String, ci_less> & getForwardHeaders() const { return forward_headers; }
 
 private:

--- a/src/Access/HTTPAuthClient.h
+++ b/src/Access/HTTPAuthClient.h
@@ -73,7 +73,8 @@ public:
             return std::lexicographical_compare(
                 a.begin(), a.end(),
                 b.begin(), b.end(),
-                [](unsigned char ac, unsigned char bc) {
+                [](unsigned char ac, unsigned char bc)
+                {
                     return std::tolower(ac) < std::tolower(bc);
                 });
         }
@@ -104,7 +105,8 @@ public:
         Poco::Net::HTTPRequest request{
             Poco::Net::HTTPRequest::HTTP_GET, this->getURI().getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1};
 
-        for (const auto & k : headers) {
+        for (const auto & k : headers)
+        {
             if (this->getForwardHeaders().contains(k.first))
                 request.add(k.first, k.second);
         }

--- a/tests/integration/test_external_http_authenticator/test.py
+++ b/tests/integration/test_external_http_authenticator/test.py
@@ -94,11 +94,12 @@ def test_basic_auth_failed(started_cluster):
     )
 
 def test_header_failed(started_cluster):
-    ping_response = instance.exec_in_container(
-        ["curl", "-s", "-u", "good_user:bad_password", "-H", "Custom-Header: ok",  "--data", f"SELECT 2+2", f"http://localhost:8123"],
-        nothrow=True,
-    )
-    assert ping_response == "4\n"
+    for header_name in ["Custom-Header", "CUSTOM-HEADER", "custom-header"]:
+        ping_response = instance.exec_in_container(
+            ["curl", "-s", "-u", "good_user:bad_password", "-H", f"{header_name}: ok",  "--data", f"SELECT 2+2", f"http://localhost:8123"],
+            nothrow=True,
+        )
+        assert ping_response == "4\n"
 
 def test_session_settings_from_auth_response(started_cluster):
     for user, response in USER_RESPONSES.items():


### PR DESCRIPTION
HTTP header names are case-insensitive, so let's interpret them like this to avoid applying hacks like:

```yaml
    http_authentication_servers:
      auth_backend:
        forward_headers:
          name:
          - x-auth-token
          - X-Auth-Token
          - X-AUTH-TOKEN
```
in ClickHouse config.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Match external auth forward_headers in case-insensitive way

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
