### PR TITLE
Fix calculating min marks per task for parallel replicas

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.cpp
@@ -74,6 +74,8 @@ size_t getMinMarksPerTask(size_t min_marks_per_task, const std::vector<DB::Merge
 {
     /// For each part the value of `min_marks_per_task` is capped by `sum_marks / (threads * total_query_nodes) / 2` (see calculateMinMarksPerTask()),
     /// unless `merge_tree_min_read_task_size` or `min_*_for_concurrent_read` settings are set too high. So, we can safely take the maximum of all parts.
+    /// On the flip side, it is not safe to take the minimum, because e.g. for compact parts we don't know individual column sizes, so we use whole part size as approximation,
+    /// and as the result we might end up with a very small `min_marks_per_task` that will cause too many requests to the coordinator.
     const auto max_across_parts = std::ranges::max(
         per_part_infos, [](const auto & lhs, const auto & rhs) { return lhs->min_marks_per_task < rhs->min_marks_per_task; });
     min_marks_per_task = std::max(min_marks_per_task, max_across_parts->min_marks_per_task);

--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -95,6 +95,7 @@ extern const Event ParallelReplicasUsedCount;
 extern const Event ParallelReplicasUnavailableCount;
 
 extern const Event ParallelReplicasQueryCount;
+extern const Event ParallelReplicasNumRequests;
 }
 
 namespace DB
@@ -1093,6 +1094,7 @@ ParallelReadResponse InOrderCoordinator<mode>::handleRequest(ParallelReadRequest
 
 void ParallelReplicasReadingCoordinator::handleInitialAllRangesAnnouncement(InitialAllRangesAnnouncement announcement)
 {
+    ProfileEvents::increment(ProfileEvents::ParallelReplicasNumRequests);
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::ParallelReplicasHandleAnnouncementMicroseconds);
 
     if (is_reading_completed)
@@ -1119,6 +1121,7 @@ ParallelReadResponse ParallelReplicasReadingCoordinator::handleRequest(ParallelR
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS, "Chosen number of marks to read is zero (likely because of weird interference of settings)");
 
+    ProfileEvents::increment(ProfileEvents::ParallelReplicasNumRequests);
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::ParallelReplicasHandleRequestMicroseconds);
 
     ParallelReadResponse response;

--- a/tests/queries/0_stateless/03581_parallel_replicas_task_size.sql
+++ b/tests/queries/0_stateless/03581_parallel_replicas_task_size.sql
@@ -1,0 +1,38 @@
+-- Tags: no-random-settings
+-- no-random-settings: a lot of settings influence task sizes, so it is simple to disable randomization completely
+
+CREATE TABLE t(a UInt64, s String) ENGINE = MergeTree ORDER BY a SETTINGS storage_policy = 's3_cache', min_rows_for_wide_part = 10000, min_bytes_for_wide_part = 0;
+
+SYSTEM STOP MERGES t;
+
+INSERT INTO t SELECT *, randomString(100) FROM numbers_mt(3_000_000);
+INSERT INTO t SELECT *, randomString(100) FROM numbers(1_000);
+INSERT INTO t SELECT *, randomString(100) FROM numbers(1_000);
+INSERT INTO t SELECT *, randomString(100) FROM numbers(1_000);
+INSERT INTO t SELECT *, randomString(100) FROM numbers(1_000);
+
+-- The problem with too small task sizes specifically happens when we have compact parts.
+-- Because for them we don't know individual column sizes, see `calculateMinMarksPerTask()` function.
+SELECT
+    throwIf(countIf(part_type = 'Compact') = 0),
+    throwIf(countIf(part_type = 'Wide') = 0)
+FROM system.parts
+WHERE (database = currentDatabase()) AND (table = 't')
+FORMAT Null;
+
+-- If ClickHouse will choose too small task size, we don't want to artificially correct it's decision.
+SET max_threads = 3, merge_tree_min_read_task_size = 1;
+
+SET enable_parallel_replicas = 2, max_parallel_replicas = 3, parallel_replicas_for_non_replicated_merge_tree = 1, cluster_for_parallel_replicas = 'parallel_replicas';
+
+SELECT * FROM t FORMAT Null SETTINGS log_comment = 'parallel_replicas_task_size_82982938';
+
+SYSTEM FLUSH LOGS query_log;
+
+-- The objective is to check that we request enough marks with each request. Obviously, the more we request, the less requests we will have.
+-- Before the fix, in this particular case we made ~ 70 requests, now it should be <= 15 (25 is used to ensure no flakyness).
+SELECT throwIf(ProfileEvents['ParallelReplicasNumRequests'] > 25)
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = 'parallel_replicas_task_size_82982938' AND type = 'QueryFinish'
+SETTINGS enable_parallel_replicas = 0
+FORMAT Null;

--- a/tests/queries/0_stateless/03581_parallel_replicas_task_size.sql
+++ b/tests/queries/0_stateless/03581_parallel_replicas_task_size.sql
@@ -1,4 +1,5 @@
--- Tags: no-random-settings
+-- Tags: no-fasttest, no-random-settings
+-- no-fasttest: requires s3 storage
 -- no-random-settings: a lot of settings influence task sizes, so it is simple to disable randomization completely
 
 CREATE TABLE t(a UInt64, s String) ENGINE = MergeTree ORDER BY a SETTINGS storage_policy = 's3_cache', min_rows_for_wide_part = 10000, min_bytes_for_wide_part = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the calculation of the minimal task size for parallel replicas.