### PR TITLE
Fix starting superfluous internal backups after connection problems

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -82,7 +82,8 @@ The BACKUP and RESTORE statements take a list of DATABASE and TABLE names, a des
 - ASYNC: backup or restore asynchronously
 - PARTITIONS: a list of partitions to restore
 - SETTINGS:
-  - `id`: id of backup or restore operation, randomly generated UUID is used, if not specified manually. If there is already running operation with the same `id` exception is thrown.
+  - `id`: the identifier of a backup or restore operation. If it's unset or empty then a randomly generated UUID will be used.
+  If it's explicitly set to a nonempty string then it should be different each time. This `id` is used to find rows in table `system.backups` related to a specific backup or restore operation.
   - [`compression_method`](/sql-reference/statements/create/table#column_compression_codec) and compression_level
   - `password` for the file on disk
   - `base_backup`: the destination of the previous backup of this source.  For example, `Disk('backups', '1.zip')`

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -30,6 +30,7 @@
 #include <Common/Macros.h>
 #include <Common/logger_useful.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/quoteString.h>
 #include <Common/setThreadName.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/ThreadPool.h>
@@ -393,16 +394,14 @@ struct BackupsWorker::BackupStarter
             backup_settings.backup_uuid = UUIDHelpers::generateV4();
 
         /// `backup_id` will be used as a key to the `infos` map, so it should be unique.
-        if (is_internal_backup)
-            backup_id = "internal-" + toString(UUIDHelpers::generateV4()); /// Always generate `backup_id` for internal backup to avoid collision if both internal and non-internal backups are on the same host
-        else if (!backup_settings.id.empty())
+        if (!backup_settings.id.empty())
             backup_id = backup_settings.id;
         else
             backup_id = toString(*backup_settings.backup_uuid);
 
-        String base_backup_name;
-        if (backup_settings.base_backup_info)
-            base_backup_name = backup_settings.base_backup_info->toStringForLogging();
+        /// We should avoid a collision if both internal and non-internal backups are on the same host.
+        if (is_internal_backup)
+            backup_id += "-internal-" + backup_settings.host_id;
 
         /// process_list_element_holder is used to make an element in ProcessList live while BACKUP is working asynchronously.
         auto process_list_element = backup_context->getProcessListElement();
@@ -425,8 +424,17 @@ struct BackupsWorker::BackupStarter
                 "To mitigate this, either disable checksum (SET s3_disable_checksum = 1) or increase max_backup_bandwidth.",
                 formatReadableSizeWithBinarySuffix(static_cast<double>(queryMaxSpeed), 0));
         }
+    }
 
-        backups_worker.addInfo(backup_id,
+    std::pair<bool, BackupStatus> addInfo()
+    {
+        String base_backup_name;
+        if (backup_settings.base_backup_info)
+            base_backup_name = backup_settings.base_backup_info->toStringForLogging();
+
+        auto process_list_element = backup_context->getProcessListElement();
+
+        return backups_worker.addInfo(backup_id,
             backup_name_for_logging,
             base_backup_name,
             backup_context->getCurrentQueryId(),
@@ -525,6 +533,10 @@ std::pair<BackupOperationID, BackupStatus> BackupsWorker::startMakingBackup(cons
 {
     auto starter = std::make_shared<BackupStarter>(*this, query, context);
 
+    auto [info_added, current_status] = starter->addInfo();
+    if (!info_added)
+        return {starter->backup_id, current_status};
+
     try
     {
         auto thread_pool_id = starter->is_internal_backup ? ThreadPoolId::ASYNC_BACKGROUND_INTERNAL_BACKUP: ThreadPoolId::ASYNC_BACKGROUND_BACKUP;
@@ -544,7 +556,7 @@ std::pair<BackupOperationID, BackupStatus> BackupsWorker::startMakingBackup(cons
             },
             Priority{});
 
-        return {starter->backup_id, BackupStatus::CREATING_BACKUP};
+        return {starter->backup_id, current_status};
     }
     catch (...)
     {
@@ -830,16 +842,21 @@ struct BackupsWorker::RestoreStarter
         else
             restore_id = toString(*restore_settings.restore_uuid);
 
-        String base_backup_name;
-        if (restore_settings.base_backup_info)
-            base_backup_name = restore_settings.base_backup_info->toStringForLogging();
-
         /// process_list_element_holder is used to make an element in ProcessList live while BACKUP is working asynchronously.
         auto process_list_element = restore_context->getProcessListElement();
         if (process_list_element)
             process_list_element_holder = process_list_element->getProcessListEntry();
+    }
 
-        backups_worker.addInfo(restore_id,
+    std::pair<bool, BackupStatus> addInfo()
+    {
+        String base_backup_name;
+        if (restore_settings.base_backup_info)
+            base_backup_name = restore_settings.base_backup_info->toStringForLogging();
+
+        auto process_list_element = restore_context->getProcessListElement();
+
+        return backups_worker.addInfo(restore_id,
             backup_name_for_logging,
             base_backup_name,
             restore_context->getCurrentQueryId(),
@@ -919,6 +936,10 @@ std::pair<BackupOperationID, BackupStatus> BackupsWorker::startRestoring(const A
 {
     auto starter = std::make_shared<RestoreStarter>(*this, query, context);
 
+    auto [info_added, current_status] = starter->addInfo();
+    if (!info_added)
+        return {starter->restore_id, current_status};
+
     try
     {
         auto thread_pool_id = starter->is_internal_restore ? ThreadPoolId::ASYNC_BACKGROUND_INTERNAL_RESTORE : ThreadPoolId::ASYNC_BACKGROUND_RESTORE;
@@ -938,7 +959,7 @@ std::pair<BackupOperationID, BackupStatus> BackupsWorker::startRestoring(const A
             },
             Priority{});
 
-        return {starter->restore_id, BackupStatus::RESTORING};
+        return {starter->restore_id, current_status};
     }
     catch (...)
     {
@@ -1142,8 +1163,9 @@ BackupsWorker::makeRestoreCoordination(bool on_cluster, const RestoreSettings & 
 }
 
 
-void BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name, const String & query_id,
-                            bool internal, QueryStatusPtr process_list_element, BackupStatus status)
+std::pair<bool, BackupStatus> BackupsWorker::addInfo(const OperationID & id, const String & name, const String & base_backup_name,
+                                                     const String & query_id, bool internal, QueryStatusPtr process_list_element,
+                                                     BackupStatus status)
 {
     ExtendedOperationInfo extended_info;
     auto & info = extended_info.info;
@@ -1172,10 +1194,21 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
     auto it = infos.find(id);
     if (it != infos.end())
     {
-        /// It's better not allow to overwrite the current status if it's in progress.
         auto current_status = it->second.info.status;
-        if (!isFinalStatus(current_status))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot start a backup or restore: ID {} is already in use", id);
+        if (internal && it->second.info.internal && (name == it->second.info.name) && (base_backup_name == it->second.info.base_backup_name) &&
+            (isBackupStatus(status) == isBackupStatus(current_status)))
+        {
+            /// In case of connection problems DDLWorker may enqueue multiple internal backup or restore queries
+            /// causing the same internal backup or restore to be started on the same host multiple times.
+            /// We need to handle that and ignore superfluous internal backups or restores.
+            return {false, current_status};
+        }
+
+        /// Normally we don't allow using the same ID for another backup or restore again.
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot start {} with ID {} because there is another {} with the same ID",
+            isBackupStatus(status) ? "backup" : "restore",
+            quoteString(id),
+            isBackupStatus(current_status) ? "backup" : "restore");
     }
 
     if (backup_log)
@@ -1185,6 +1218,7 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, const S
 
     num_active_backups += getNumActiveBackupsChange(status);
     num_active_restores += getNumActiveRestoresChange(status);
+    return {true, status};
 }
 
 

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -126,8 +126,9 @@ private:
     /// Run data restoring tasks which insert data to tables.
     void restoreTablesData(const BackupOperationID & restore_id, BackupPtr backup, DataRestoreTasks && tasks, ThreadPool & thread_pool, QueryStatusPtr process_list_element);
 
-    void addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, const String & query_id,
-                bool internal, QueryStatusPtr process_list_element, BackupStatus status);
+    std::pair<bool, BackupStatus> addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, const String & query_id,
+                                          bool internal, QueryStatusPtr process_list_element, BackupStatus status);
+
     void setStatus(const BackupOperationID & id, BackupStatus status, bool throw_if_error = true);
     void setStatusSafe(const String & id, BackupStatus status) { setStatus(id, status, false); }
     void setNumFilesAndSize(const BackupOperationID & id, size_t num_files, UInt64 total_size, size_t num_entries,


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix starting superfluous internal backups after connection problems.

This PR also disables using the same ID for different backups or restores. So the following is no longer allowed:
```
BACKUP TABLE tbl TO ... SETTINGS id='1';
BACKUP TABLE tbl2 TO ... SETTINGS id='1';
RESTORE TABLE tbl FROM ... SETTINGS id='1';
```
If the `id` of an operation is specified it must be different each time.

### Details:

Some `test_backup_restore_on_cluster` tests fail sometimes because of this issue ([see](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=83986&sha=1354f6053aa04c8ff46e9e00becc2b5c0511a2b7&name_0=PR&name_1=Integration%20tests%20%28tsan%2C%206%2F6%29)).

When an `ON CLUSTER` backup or restore starts it uses retries in DDLWorker to create nodes `/clickhouse/task_queue/ddl/query-` to send the backup query to other hosts. However when the connection to Keeper is unstable it's possible that such a node is created but reported as a connection loss, and then it's created again, making DDLWorker to execute multiple internal backup queries on the same host, leading to strange failures like `Coordination::Exception: Transaction failed (Node exists)`:

```
2025.07.18 18:46:45.270694 [ 16 ] {58c1e622-a82f-474e-9d6b-c78774bcb7b9} <Debug> executeQuery: (from 172.16.1.1:60518) (query 1, line 1) BACKUP TABLE tbl ON CLUSTER 'cluster' TO Disk('backups', '07426decd3584266b20cc3b029005268') SETTINGS id='07426decd3584266b20cc3b029005268' ASYNC (stage: Complete)

2025.07.18 18:46:47.395424 [ 687 ] {} <Error> ZooKeeperClient: Code: 999. Coordination::Exception: Operation timeout (deadline of 1000 ms already expired) for path: /clickhouse/task_queue/ddl/query-. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):

2025.07.18 18:46:47.395917 [ 688 ] {58c1e622-a82f-474e-9d6b-c78774bcb7b9} <Trace> DDLWorker: ZooKeeperRetriesControl: DDLWorker::enqueueQuery: setKeeperError: error=Operation timeout message=Coordination error: Operation timeout, path /clickhouse/task_queue/ddl/query-
2025.07.18 18:46:47.396031 [ 688 ] {58c1e622-a82f-474e-9d6b-c78774bcb7b9} <Debug> DDLWorker: ZooKeeperRetriesControl: DDLWorker::enqueueQuery: will retry due to error: retry_count=1/10 timeout=100ms error=Operation timeout message=Coordination error: Operation timeout, path /clickhouse/task_queue/ddl/query-

2025.07.18 18:46:47.848965 [ 688 ] {58c1e622-a82f-474e-9d6b-c78774bcb7b9} <Debug> DDLWorker: ZooKeeperRetriesControl: DDLWorker::enqueueQuery: succeeded after: Iterations=2 Total keeper failures=1/10

2025.07.18 18:46:47.851497 [ 679 ] {} <Debug> DDLWorker: Processing task query-0000000015 (query: BACKUP TABLE tbl TO Disk('backups', '07426decd3584266b20cc3b029005268') SETTINGS id = '07426decd3584266b20cc3b029005268', backup_uuid = '9b086662-b3f6-48a8-90e0-798c66be165a', internal = true, async = true, host_id = 'node1:9000', cluster_host_ids = [['node1:9000', 'node2:9000']], backup restore: false)

2025.07.18 18:46:48.012334 [ 679 ] {} <Debug> DDLWorker: Processing task query-0000000016 (query: BACKUP TABLE tbl TO Disk('backups', '07426decd3584266b20cc3b029005268') SETTINGS id = '07426decd3584266b20cc3b029005268', backup_uuid = '9b086662-b3f6-48a8-90e0-798c66be165a', internal = true, async = true, host_id = 'node1:9000', cluster_host_ids = [['node1:9000', 'node2:9000']], backup restore: false)

2025.07.18 18:46:48.124201 [ 685 ] {ed14b285-db69-4565-93de-7915fca7f6c4} <Error> BackupsWorker: Failed to make internal backup Disk('backups', '07426decd3584266b20cc3b029005268'): Code: 999. Coordination::Exception: Transaction failed (Node exists): Op #2, path: /clickhouse/backups/backup-9b086662-b3f6-48a8-90e0-798c66be165a/stage/started|node1:9000. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:113: Poco::Exception::Exception(String const&, int) @ 0x00000000294ef700
1. ./ci/tmp/build/./src/Common/Exception.cpp:115: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000012a9ee54
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000008f30520
3. ./src/Common/Exception.h:137: DB::Exception::Exception<Coordination::Error&, unsigned long&>(int, FormatStringHelperImpl<std::type_identity<Coordination::Error&>::type, std::type_identity<unsigned long&>::type>, Coordination::Error&, unsigned long&) @ 0x0000000021578066
4. ./src/Common/ZooKeeper/KeeperException.h:37: zkutil::KeeperMultiException::KeeperMultiException(Coordination::Error, unsigned long, std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>> const&) @ 0x00000000215615e1
5. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:1617: zkutil::KeeperMultiException::KeeperMultiException(Coordination::Error, std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>> const&) @ 0x0000000021561b3f
6. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:1634: zkutil::KeeperMultiException::check(Coordination::Error, std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>> const&) @ 0x0000000021554b5d
7. ./ci/tmp/build/./src/Backups/BackupCoordinationStageSync.cpp:377: DB::BackupCoordinationStageSync::createStartAndAliveNodesAndCheckConcurrency(std::shared_ptr<DB::ZooKeeperWithFaultInjection>) @ 0x00000000192f8645
8. ./ci/tmp/build/./src/Backups/BackupCoordinationStageSync.cpp:239: DB::BackupCoordinationStageSync::createStartAndAliveNodesAndCheckConcurrency(DB::BackupConcurrencyCounters&) @ 0x00000000192f50ef
9. ./ci/tmp/build/./src/Backups/BackupCoordinationStageSync.cpp:135: DB::BackupCoordinationStageSync::BackupCoordinationStageSync(bool, String const&, String const&, std::vector<String, std::allocator<String>> const&, bool, DB::BackupConcurrencyCounters&, DB::WithRetries const&, std::function<std::future<void> (std::function<void ()>&&, Priority)>, std::shared_ptr<DB::QueryStatus>, std::shared_ptr<Poco::Logger>) @ 0x00000000192f33c1
10. ./ci/tmp/build/./src/Backups/BackupCoordinationOnCluster.cpp:189: DB::BackupCoordinationOnCluster::BackupCoordinationOnCluster(StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag> const&, bool, String const&, std::function<std::shared_ptr<zkutil::ZooKeeper> ()>, DB::BackupKeeperSettings const&, String const&, std::vector<String, std::allocator<String>> const&, bool, DB::BackupConcurrencyCounters&, std::function<std::future<void> (std::function<void ()>&&, Priority)>, std::shared_ptr<DB::QueryStatus>) @ 0x00000000192d0e11
11. ./contrib/llvm-project/libcxx/include/__memory/construct_at.h:41: DB::BackupsWorker::makeBackupCoordination(bool, DB::BackupSettings const&, std::shared_ptr<DB::Context const> const&) const @ 0x000000001926f0c1
12. ./ci/tmp/build/./src/Backups/BackupsWorker.cpp:437: DB::BackupsWorker::BackupStarter::doBackup() @ 0x000000001927b2d0
```
This PR fixes that.