### PR TITLE
Handle NULLs in ALTER MODIFY COLUMN

### DIFF
--- a/src/Interpreters/inplaceBlockConversions.h
+++ b/src/Interpreters/inplaceBlockConversions.h
@@ -3,6 +3,7 @@
 #include <Core/Names.h>
 #include <Interpreters/Context_fwd.h>
 #include <Common/COW.h>
+#include <Storages/ColumnDefault.h>
 
 #include <memory>
 
@@ -34,7 +35,8 @@ std::optional<ActionsDAG> evaluateMissingDefaults(
     bool null_as_default = false);
 
 /// Tries to convert columns in block to required_columns
-void performRequiredConversions(Block & block, const NamesAndTypesList & required_columns, ContextPtr context);
+void performRequiredConversions(Block & block, const NamesAndTypesList & required_columns, ContextPtr context,
+    const ColumnDefaults & column_defaults, bool forbid_default_defaults = false);
 
 void fillMissingColumns(
     Columns & res_columns,

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1301,7 +1301,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
                 throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "Cannot ALTER column");
             /// Check if new metadata is convertible from old metadata for projection.
             Block old_projection_block = projection.sample_block;
-            performRequiredConversions(old_projection_block, new_projection.sample_block.getNamesAndTypesList(), context);
+            performRequiredConversions(old_projection_block, new_projection.sample_block.getNamesAndTypesList(), context, metadata_copy.getColumns().getDefaults());
             new_projections.add(std::move(new_projection));
         }
         catch (Exception & exception)

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -361,7 +361,9 @@ void IMergeTreeReader::performRequiredConversions(Columns & res_columns) const
         if (copy_block.empty())
             return;
 
-        DB::performRequiredConversions(copy_block, getColumns(), data_part_info_for_read->getContext());
+        DB::performRequiredConversions(copy_block, getColumns(),
+            data_part_info_for_read->getContext(),
+            storage_snapshot->metadata->getColumns().getDefaults());
 
         /// Move columns from block.
         name_and_type = getColumns().begin();

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4452,7 +4452,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
     if (!columns_to_check_conversion.empty())
     {
         auto old_header = old_metadata.getSampleBlock();
-        performRequiredConversions(old_header, columns_to_check_conversion, local_context);
+        performRequiredConversions(old_header, columns_to_check_conversion, local_context, new_metadata.getColumns().getDefaults(), true);
     }
 
     if (old_metadata.hasSettingsChanges())

--- a/tests/queries/0_stateless/02662_sparse_columns_mutations_1.sql
+++ b/tests/queries/0_stateless/02662_sparse_columns_mutations_1.sql
@@ -30,7 +30,7 @@ ORDER BY name;
 
 SELECT countIf(s = 'foo'), arraySort(groupUniqArray(s)) FROM t_sparse_mutations_1;
 
-ALTER TABLE t_sparse_mutations_1 MODIFY COLUMN s String;
+ALTER TABLE t_sparse_mutations_1 MODIFY COLUMN s String DEFAULT '';
 
 SELECT name, type, serialization_kind FROM system.parts_columns
 WHERE database = currentDatabase() AND table = 't_sparse_mutations_1' AND column = 's' AND active

--- a/tests/queries/0_stateless/03575_modify_column_null_to_default.reference
+++ b/tests/queries/0_stateless/03575_modify_column_null_to_default.reference
@@ -1,0 +1,38 @@
+-- { echoOn }
+
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+\N	\N	\N	\N
+SYSTEM STOP MERGES nullable_test;
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable UInt64 SETTINGS mutations_sync = 0, alter_sync = 0; -- { serverError BAD_ARGUMENTS }
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable UInt64 DEFAULT 42 SETTINGS mutations_sync = 0, alter_sync = 0;
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	\N	\N	\N
+SYSTEM START MERGES nullable_test;
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	\N	\N	\N
+OPTIMIZE TABLE nullable_test FINAL;
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	\N	\N	\N
+ALTER TABLE nullable_test MODIFY COLUMN my_text_lc_nullable String DEFAULT 'empty';
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	\N	\N	empty
+-- Previouly existing DEFAULT NULL does not allow to modify
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable_with_default UInt64 SETTINGS mutations_sync = 0, alter_sync = 0; -- { serverError CANNOT_CONVERT_TYPE }
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	\N	\N	empty
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable_with_default UInt64 DEFAULT 43 SETTINGS mutations_sync = 0, alter_sync = 0;
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	43	\N	empty
+-- But when we have DEFAULT which is non NULL we can keep it
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable_with_default2 UInt64 SETTINGS mutations_sync = 0, alter_sync = 0;
+SELECT * from nullable_test ORDER BY ALL;
+1	1	1	A
+42	43	11	empty
+DROP TABLE IF EXISTS nullable_test;

--- a/tests/queries/0_stateless/03575_modify_column_null_to_default.sql
+++ b/tests/queries/0_stateless/03575_modify_column_null_to_default.sql
@@ -1,0 +1,46 @@
+DROP TABLE IF EXISTS nullable_test;
+
+CREATE TABLE nullable_test(
+    my_int_nullable Nullable(UInt32),
+    my_int_nullable_with_default Nullable(UInt32) DEFAULT NULL,
+    my_int_nullable_with_default2 Nullable(UInt32) DEFAULT 11,
+    my_text_lc_nullable LowCardinality(Nullable(String)),
+) ORDER BY tuple();
+
+INSERT INTO nullable_test VALUES (NULL, NULL, NULL, NULL), (1, 1, 1, 'A');
+
+-- { echoOn }
+
+SELECT * from nullable_test ORDER BY ALL;
+
+SYSTEM STOP MERGES nullable_test;
+
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable UInt64 SETTINGS mutations_sync = 0, alter_sync = 0; -- { serverError BAD_ARGUMENTS }
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable UInt64 DEFAULT 42 SETTINGS mutations_sync = 0, alter_sync = 0;
+
+SELECT * from nullable_test ORDER BY ALL;
+
+SYSTEM START MERGES nullable_test;
+
+SELECT * from nullable_test ORDER BY ALL;
+
+OPTIMIZE TABLE nullable_test FINAL;
+SELECT * from nullable_test ORDER BY ALL;
+
+ALTER TABLE nullable_test MODIFY COLUMN my_text_lc_nullable String DEFAULT 'empty';
+SELECT * from nullable_test ORDER BY ALL;
+
+-- Previouly existing DEFAULT NULL does not allow to modify
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable_with_default UInt64 SETTINGS mutations_sync = 0, alter_sync = 0; -- { serverError CANNOT_CONVERT_TYPE }
+
+SELECT * from nullable_test ORDER BY ALL;
+
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable_with_default UInt64 DEFAULT 43 SETTINGS mutations_sync = 0, alter_sync = 0;
+SELECT * from nullable_test ORDER BY ALL;
+
+-- But when we have DEFAULT which is non NULL we can keep it
+ALTER TABLE nullable_test MODIFY COLUMN my_int_nullable_with_default2 UInt64 SETTINGS mutations_sync = 0, alter_sync = 0;
+
+SELECT * from nullable_test ORDER BY ALL;
+
+DROP TABLE IF EXISTS nullable_test;

--- a/tests/queries/0_stateless/03721_statistics_alter_type_bug.sql
+++ b/tests/queries/0_stateless/03721_statistics_alter_type_bug.sql
@@ -14,7 +14,7 @@ DROP TABLE column_modify_test;
 CREATE TABLE column_modify_test (id UInt64, val Nullable(String), other_col UInt64) engine=MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part=0, auto_statistics_types='uniq,countmin';
 INSERT INTO column_modify_test VALUES (1,'one',0);
 
-ALTER TABLE column_modify_test MODIFY COLUMN val String;
+ALTER TABLE column_modify_test MODIFY COLUMN val String DEFAULT '';
 
 alter table column_modify_test update other_col=1 where id = 1 SETTINGS mutations_sync=1;
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):

- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

ALTER MODIFY COLUMN now requires explicit DEFAULT when converting nullable columns to non-nullable types. Previously such ALTERs could get stuck with cannot convert null to not null errors, now NULLs are replaced with column's default expression. Resolves #5985

### Details

Close https://github.com/ClickHouse/ClickHouse/issues/5985
