### PR TITLE
Reduce logging level for "No blob storage log, not writing blob"

### DIFF
--- a/src/IO/S3/deleteFileFromS3.cpp
+++ b/src/IO/S3/deleteFileFromS3.cpp
@@ -51,7 +51,7 @@ void deleteFileFromS3(
     }
     else
     {
-        LOG_TRACE(log, "No blob storage log, not writing blob {}", key);
+        LOG_TEST(log, "No blob storage log, not writing blob {}", key);
     }
 
     if (outcome.IsSuccess())
@@ -159,7 +159,7 @@ void deleteFilesFromS3(
             }
             else
             {
-                LOG_TRACE(log, "No blob storage log, not writing blobs [{}]", comma_separated_keys);
+                LOG_TEST(log, "No blob storage log, not writing blobs [{}]", comma_separated_keys);
             }
 
             if (outcome.IsSuccess())


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)