### PR TITLE
Support read_in_order_use_virtual_row for WHERE.

### DIFF
--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -10,6 +10,7 @@
 #include <Processors/Chunk.h>
 #include <Storages/MergeTree/MarkRange.h>
 #include <Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h>
+#include <Processors/Merges/Algorithms/MergeTreeReadInfo.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Functions/IFunction.h>
 
@@ -168,7 +169,7 @@ void FilterTransform::doTransform(Chunk & chunk)
     ColumnPtr filter_column = columns[filter_column_position];
     ConstantFilterDescription constant_filter_description(*filter_column);
 
-    if (constant_filter_description.always_true || on_totals)
+    if (constant_filter_description.always_true || on_totals || isVirtualRow(chunk))
     {
         incrementProfileEvents(num_rows_before_filtration, columns);
         removeFilterIfNeed(columns);

--- a/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.reference
+++ b/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.reference
@@ -1,0 +1,16 @@
+all_1_1_0	0	999999
+all_2_2_0	1000000	1999999
+0
+1024
+2048
+3072
+4096
+5120
+6144
+7168
+8192
+9216
+MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder)	0
+MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder)	57344
+VirtualRowTransform	0
+VirtualRowTransform	57344

--- a/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.sql
+++ b/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.sql
@@ -1,0 +1,24 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings
+
+create table tab (x UInt64, y UInt64) engine = MergeTree order by x;
+
+insert into tab select number, number from numbers(1e6);
+insert into tab select number, number from numbers(1e6, 1e6);
+
+select _part, min(x), max(x) from tab group by _part order by _part ;
+
+select x from tab where bitAnd(y, 1023) == 0 order by x limit 10 settings read_in_order_use_virtual_row=1, log_processors_profiles=1, optimize_move_to_prewhere=0, max_threads=2;
+
+system flush logs;
+
+WITH
+    (
+        SELECT query_id
+        FROM system.query_log
+        WHERE current_database = currentDatabase() AND query like 'select x from tab%' AND event_date >= (today() - 1)
+        ORDER BY event_time DESC
+        LIMIT 1
+    ) AS id
+SELECT name, output_rows from system.processors_profile_log where event_date >= (today() - 1) and query_id = id
+    and (name like '%MergeTreeSelect%' or name like '%VirtualRowTransform%')
+ORDER BY name, output_rows;

--- a/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.sql
+++ b/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.sql
@@ -19,6 +19,8 @@ WITH
         ORDER BY event_time DESC
         LIMIT 1
     ) AS id
-SELECT name, output_rows from system.processors_profile_log where event_date >= (today() - 1) and query_id = id
+SELECT 
+    replace(name, 'ReadPoolParallelReplicasInOrder', 'ReadPoolInOrder') AS name, output_rows
+from system.processors_profile_log where event_date >= (today() - 1) and query_id = id
     and (name like '%MergeTreeSelect%' or name like '%VirtualRowTransform%')
 ORDER BY name, output_rows;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add missing support of `read_in_order_use_virtual_row` for `WHERE`. It allows to skip reading more parts for queries with filters that were not fully pushed to `PREWHERE`.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
