### PR TITLE
Test index: Fix fuzzer crash with empty inputs

### DIFF
--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -36,6 +36,9 @@ std::vector<String> ITokenExtractor::getTokens(const char * data, size_t length)
 
 std::vector<String> NgramTokenExtractor::getTokens(const char * data, size_t length) const
 {
+    if (length == 0)
+        return {};
+
     if (length < n)
         return std::vector<String>{String(data, length)};
 
@@ -351,6 +354,9 @@ bool SplitTokenExtractor::nextInStringLike(const char * /*data*/, size_t /*lengt
 
 std::vector<String> NoOpTokenExtractor::getTokens(const char * data, size_t length) const
 {
+    if (length == 0)
+        return {};
+
     return {String(data, length)};
 }
 

--- a/tests/queries/0_stateless/02346_text_index_bug84805.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug84805.reference
@@ -1,0 +1,2 @@
+Test no_op tokenizer
+Test ngram tokenizer

--- a/tests/queries/0_stateless/02346_text_index_bug84805.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug84805.sql
@@ -20,7 +20,7 @@ SELECT 'Test ngram tokenizer';
 
 CREATE TABLE tab (
     str String,
-    INDEX idx str TYPE text(tokenizer = 'no_op') )
+    INDEX idx str TYPE text(tokenizer = 'ngram') )
 ENGINE = MergeTree()
 ORDER BY tuple();
 

--- a/tests/queries/0_stateless/02346_text_index_bug84805.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug84805.sql
@@ -1,0 +1,29 @@
+SET allow_experimental_full_text_index = 1;
+
+-- Issue 84805: the no-op and ngram tokenizers crash for empty inputs
+
+SELECT 'Test no_op tokenizer';
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab (
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'no_op') )
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+INSERT INTO TABLE tab (str) VALUES ('');
+
+DROP TABLE tab;
+
+SELECT 'Test ngram tokenizer';
+
+CREATE TABLE tab (
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'no_op') )
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+INSERT INTO TABLE tab (str) VALUES ('');
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/03403_function_tokens.reference
+++ b/tests/queries/0_stateless/03403_function_tokens.reference
@@ -4,7 +4,7 @@ Default tokenizer
 ['abc','def','foo','bar','baz','code','hello','world','xäöüx']
 ['abc','def','foo','bar','baz','code','hello','world','xäöüx']
 Ngram tokenizer
-['']
+[]
 ['abc','bc ','c d',' de','def']
 ['abc','bc ','c d',' de','def']
 ['abc def']
@@ -16,7 +16,7 @@ Split tokenizer
 ['a','bc','d']
 ['a','bc','d']
 No-op tokenizer
-['']
+[]
 ['abc def']
 Special cases (not systematically tested)
 -- FixedString inputs


### PR DESCRIPTION
Resolves #84805

CC: @ahmadov @Ergus @george-larionov 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `ngram` and `no_op` tokenizers no longer crash the (experimental) text index for empty input tokens.