### PR TITLE
Slightly better test `test_restore_replica`

### DIFF
--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -43,6 +43,10 @@ def fill_table():
     node_1.query("INSERT INTO test SELECT number + 800 FROM numbers(200)")
     check_data(499500, 1000)
 
+def drop_tables():
+    for node in nodes:
+        node.query("DROP TABLE IF EXISTS test SYNC")
+
 
 # kazoo.delete may throw NotEmptyError on concurrent modifications of the path
 def zk_rmr_with_retries(zk, path):
@@ -124,6 +128,7 @@ def test_restore_replica_sequential(start_cluster):
     node_3.query("SYSTEM SYNC REPLICA test")
 
     check_after_restoration()
+    drop_tables()
 
 
 def test_restore_replica_parallel(start_cluster):
@@ -152,6 +157,7 @@ def test_restore_replica_parallel(start_cluster):
     node_1.query("INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
 
     check_after_restoration()
+    drop_tables()
 
 
 def test_restore_replica_alive_replicas(start_cluster):
@@ -181,6 +187,7 @@ def test_restore_replica_alive_replicas(start_cluster):
     node_3.query("SYSTEM SYNC REPLICA test")
 
     check_after_restoration()
+    drop_tables()
 
 
 def test_fix_metadata_version_on_attach_part_after_restore(start_cluster):
@@ -227,3 +234,6 @@ def test_fix_metadata_version_on_attach_part_after_restore(start_cluster):
     assert_eq_with_retry(
         node_2, "SELECT count() FROM test_ttl", "0\n", retry_count=60, sleep_time=1
     )
+
+    for node in [node_1, node_2]:
+        node.query("DROP TABLE IF EXISTS test_ttl")

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -236,4 +236,4 @@ def test_fix_metadata_version_on_attach_part_after_restore(start_cluster):
     )
 
     for node in [node_1, node_2]:
-        node.query("DROP TABLE IF EXISTS test_ttl")
+        node.query("DROP TABLE IF EXISTS test_ttl SYNC")


### PR DESCRIPTION
This test is flaky in master: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IEhPVVIKICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKSAKICAgIEFORCBjaGVja19zdGF0dXMgIT0gJ3N1Y2Nlc3MnCiAgICBBTkQgdGVzdF9uYW1lIElMSUtFICcldGVzdF9yZXN0b3JlX3JlcGxpY2EvdGVzdC5weSUnCk9SREVSIEJZIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgY2hlY2tfc3RhcnRfdGltZQ==

During the investigation I found that this test has overridden settings for the backoff in the background pool and logs are polluted with: 

```
2025.07.31 17:56:33.659021 [ 219 ] {BgSchPool::0fbf0b09-b5e9-43ea-8039-ea3550d71ad2} <Debug> default.test_ttl (ReplicatedMergeTreeQueue): Not executing log entry queue-0000000001 for part 1_0_0_1 because merges with TTL are cancelled now.
2025.07.31 17:56:33.661289 [ 194 ] {BgSchPool::1367969d-aaec-4d8c-9e61-6a4f34ff0ce7} <Debug> default.test_ttl (ReplicatedMergeTreeQueue): Not executing log entry queue-0000000001 for part 1_0_0_1 because merges with TTL are cancelled now.
2025.07.31 17:56:33.661792 [ 269 ] {BgSchPool::8211470d-18ff-464a-8ac8-231d25eb40a6} <Debug> default.test_ttl (ReplicatedMergeTreeQueue): Not executing log entry queue-0000000001 for part 1_0_0_1 because merges with TTL are cancelled now.
2025.07.31 17:56:33.662205 [ 33 ] {BgSchPool::2002fea4-becf-44c3-a71a-05c773279307} <Debug> default.test_ttl (ReplicatedMergeTreeQueue): Not executing log entry queue-0000000001 for part 1_0_0_1 because merges with TTL are cancelled now.
```

I have a suspicion that it might overload the CPU in a tiny container.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
