### PR TITLE
Skip creating and renaming the temp inner table of non-append Refreshable MV DDLs in Replicated DBs

### DIFF
--- a/src/Databases/DatabaseReplicatedSettings.cpp
+++ b/src/Databases/DatabaseReplicatedSettings.cpp
@@ -14,6 +14,7 @@ namespace DB
     DECLARE(String, collection_name, "", "A name of a collection defined in server's config where all info for cluster authentication is defined", 0) \
     DECLARE(Bool, check_consistency, true, "Check consistency of local metadata and metadata in Keeper, do replica recovery on inconsistency", 0) \
     DECLARE(UInt64, max_retries_before_automatic_recovery, 10, "Max number of attempts to execute a queue entry before marking replica as lost recovering it from snapshot (0 means infinite)", 0) \
+    DECLARE(Bool, allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views, false, "If enabled, when processing DDLs in Replicated databases, it skips creating and exchanging DDLs of the temporary tables of refreshable materialized views if possible", 0) \
 
 DECLARE_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -7,11 +7,13 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/DDLTask.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Storages/StorageMaterializedView.h>
 #include <base/sleep.h>
 #include <Common/FailPoint.h>
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/thread_local_rng.h>
+#include <Parsers/ASTRenameQuery.h>
 
 namespace fs = std::filesystem;
 
@@ -28,6 +30,7 @@ namespace DatabaseReplicatedSetting
     extern const DatabaseReplicatedSettingsUInt64 max_replication_lag_to_enqueue;
     extern const DatabaseReplicatedSettingsUInt64 max_retries_before_automatic_recovery;
     extern const DatabaseReplicatedSettingsUInt64 wait_entry_commited_timeout_sec;
+    extern const DatabaseReplicatedSettingsBool allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views;
 }
 
 namespace ErrorCodes
@@ -59,6 +62,10 @@ DatabaseReplicatedDDLWorker::DatabaseReplicatedDDLWorker(DatabaseReplicated * db
           fmt::format("DDLWorker({})", db->getDatabaseName()))
     , database(db)
 {
+    LOG_INFO(
+        log,
+        "allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views {}",
+        database->db_settings[DatabaseReplicatedSetting::allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views].value);
     /// Pool size must be 1 to avoid reordering of log entries.
     /// TODO Make a dependency graph of DDL queries. It will allow to execute independent entries in parallel.
     /// We also need similar graph to load tables on server startup in order of topsort.
@@ -473,6 +480,82 @@ String DatabaseReplicatedDDLWorker::tryEnqueueAndExecuteEntry(DDLLogEntry & entr
     return entry_path;
 }
 
+static bool getRMVCoordinationInfo(
+    LoggerPtr log,
+    const ZooKeeperPtr & zookeeper,
+    UUID parent_uuid,
+    Coordination::Stat & stats,
+    RefreshTask::CoordinationZnode & coordination_znode)
+{
+    if (parent_uuid == UUIDHelpers::Nil)
+        return false;
+
+    const auto storage = DatabaseCatalog::instance().tryGetByUUID(parent_uuid).second;
+    if (!storage)
+        return false;
+    auto in_memory_metadata = storage->getInMemoryMetadataPtr();
+    const auto * refresh = in_memory_metadata->refresh->as<ASTRefreshStrategy>();
+    if (!refresh || refresh->append)
+        return false;
+    const auto * mv = dynamic_cast<const StorageMaterializedView *>(storage.get());
+    if (!mv)
+        return false;
+
+    const auto coordination_path = mv->getCoordinationPath();
+
+    if (!coordination_path.has_value() || (*coordination_path).empty())
+        return false;
+    try
+    {
+        String data;
+        if (!zookeeper->tryGet(*coordination_path, data, &stats))
+            return false;
+        coordination_znode.parse(data);
+        return true;
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Unable to get coordination information: " + *coordination_path);
+        return false;
+    }
+}
+
+bool DatabaseReplicatedDDLWorker::shouldSkipCreatingRMVTempTable(
+    const ZooKeeperPtr & zookeeper, UUID parent_uuid, UUID create_uuid, int64_t ddl_log_ctime)
+{
+    if (create_uuid == UUIDHelpers::Nil)
+        return false;
+
+    Coordination::Stat stats;
+    RefreshTask::CoordinationZnode coordination_znode;
+
+    if (!getRMVCoordinationInfo(log, zookeeper, parent_uuid, stats, coordination_znode))
+        return false;
+
+    LOG_TEST(log, "MV {}, coordination info: {}", parent_uuid, coordination_znode.toString());
+    if (coordination_znode.last_success_table_uuid == create_uuid)
+        return false;
+
+    LOG_TEST(log, "ddl_log_ctime {}, stats.mtime {}", ddl_log_ctime, stats.mtime);
+    // It is possible the the temporary table is created and replciated before the the coordiation info is updated.
+    // So if ddl_log_ctime >= stats.mtime, the table is new and should not be skip.
+    return ddl_log_ctime < stats.mtime;
+}
+
+bool DatabaseReplicatedDDLWorker::shouldSkipRenamingRMVTempTable(
+    const ZooKeeperPtr & zookeeper, UUID parent_uuid, const QualifiedTableName & rename_from_table)
+{
+    Coordination::Stat stats;
+    RefreshTask::CoordinationZnode coordination_znode;
+
+    if (!getRMVCoordinationInfo(log, zookeeper, parent_uuid, stats, coordination_znode))
+        return false;
+
+    StorageID storage_id{rename_from_table};
+    // If the temporary table creating DDL is skipped, there is no table, we skip renaming
+    return !DatabaseCatalog::instance().isTableExist(storage_id, context);
+}
+
 DDLTaskPtr DatabaseReplicatedDDLWorker::initAndCheckTask(const String & entry_name, String & out_reason, const ZooKeeperPtr & zookeeper, bool dry_run)
 {
     if (!dry_run)
@@ -577,7 +660,8 @@ DDLTaskPtr DatabaseReplicatedDDLWorker::initAndCheckTask(const String & entry_na
         return {};
     }
 
-    String node_data = zookeeper->get(entry_path);
+    Coordination::Stat stats;
+    String node_data = zookeeper->get(entry_path, &stats);
     task->entry.parse(node_data);
 
     if (task->entry.query.empty())
@@ -602,6 +686,63 @@ DDLTaskPtr DatabaseReplicatedDDLWorker::initAndCheckTask(const String & entry_na
     {
         out_reason = fmt::format("Parent table {} doesn't exist", task->entry.parent_table_uuid.value());
         return {};
+    }
+    if (database->db_settings[DatabaseReplicatedSetting::allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views]
+        && task->entry.parent_table_uuid)
+    {
+        // Refreshing in non-append Refreshable Materialized Views:
+        // 1. Create a temporary table: .tmp_inner.<uuid of the parent MV>
+        // 2. Fill in the data from the SELECT clause
+        // 3. Rename (with exchange) the temporary table to the target table name. The target table name can be the inner table of the view, or the table specified in the view create query.
+        // 4. Drop the temporary table after exchanging. Note that the temporary table after exchanging is not the table created in step 1. It is the one exchanged in step 3.
+        // 5. Update the coordination info in Keeper
+
+        // Queries created in steps 1, 3, and 4 are replicated through the DDL logs.
+        // If a replica is woken up after a long sleep, there are lots of creating, renaming and dropping DDLs generated by the RMVs.
+        // To speed up the DDL processing, these old create DDLs are skipped.
+        // Once the creating DDL is skipped, there is no table to rename in the renaming DDL, so the renaming DDL is skipped if the table name does not exist.
+        // For the dropping DDLs, as the query contains `IF EXISTS`, we don't need to skip.
+        const auto & parent_table_uuid = *task->entry.parent_table_uuid;
+        LOG_DEBUG(log, "Entry {}, parent_uuid {}", entry_name, parent_table_uuid);
+        if (const auto * create_query = task->query->as<ASTCreateQuery>())
+        {
+            if (create_query->uuid != UUIDHelpers::Nil
+                && shouldSkipCreatingRMVTempTable(zookeeper, *task->entry.parent_table_uuid, create_query->uuid, stats.ctime))
+            {
+                LOG_INFO(
+                    log,
+                    "Skip DDL {} as creating the old temp table of RMV '{}', query {}",
+                    entry_name,
+                    parent_table_uuid,
+                    create_query->formatForLogging());
+                out_reason = fmt::format(
+                    "Creating the old temp table '{}' of Refreshable Materialized View '{}'", create_query->uuid, parent_table_uuid);
+                return {};
+            }
+        }
+        else if (const auto * rename_query = task->query->as<ASTRenameQuery>())
+        {
+            if (rename_query->getElements().size() == 1)
+            {
+                const auto & element = rename_query->getElements().front();
+                QualifiedTableName from_table{.database = element.from.getDatabase(), .table = element.from.getTable()};
+                if (shouldSkipRenamingRMVTempTable(zookeeper, *task->entry.parent_table_uuid, from_table))
+                {
+                    LOG_INFO(
+                        log,
+                        "Skip DDL {} as renaming the old temp table of RMV '{}', query {}",
+                        entry_name,
+                        parent_table_uuid,
+                        rename_query->formatForLogging());
+
+                    out_reason = fmt::format(
+                        "Renaming the old temp table '{}' of Refreshable Materialized View '{}'",
+                        from_table.getFullName(),
+                        parent_table_uuid);
+                    return {};
+                }
+            }
+        }
     }
 
     return task;

--- a/src/Databases/DatabaseReplicatedWorker.h
+++ b/src/Databases/DatabaseReplicatedWorker.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Interpreters/DDLWorker.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
+#include <Core/QualifiedTableName.h>
 
 namespace DB
 {
@@ -54,6 +55,9 @@ private:
     bool canRemoveQueueEntry(const String & entry_name, const Coordination::Stat & stat) override;
 
     bool checkParentTableExists(const UUID & uuid) const;
+
+    bool shouldSkipCreatingRMVTempTable(const ZooKeeperPtr & zookeeper, UUID parent_uuid, UUID create_uuid, int64_t ddl_log_ctime);
+    bool shouldSkipRenamingRMVTempTable(const ZooKeeperPtr & zookeeper, UUID parent_uuid, const QualifiedTableName & rename_from_table);
 
     DatabaseReplicated * const database;
     mutable std::mutex mutex;

--- a/src/Storages/MaterializedView/RefreshTask.h
+++ b/src/Storages/MaterializedView/RefreshTask.h
@@ -68,6 +68,7 @@ public:
     void alterRefreshParams(const DB::ASTRefreshStrategy & new_strategy);
 
     Info getInfo() const;
+    String getCoordinationPath() const { return coordination.path; }
 
     bool canCreateOrDropOtherTables() const;
 

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <Parsers/IAST_fwd.h>
 
 #include <Common/CurrentThread.h>
@@ -109,6 +110,13 @@ public:
     std::optional<UInt64> totalRows(ContextPtr query_context) const override;
     std::optional<UInt64> totalBytes(ContextPtr query_context) const override;
     std::optional<UInt64> totalBytesUncompressed(const Settings & settings) const override;
+
+    std::optional<String> getCoordinationPath() const
+    {
+        if (!refresher.ptr)
+            return std::nullopt;
+        return refresher.ptr->getCoordinationPath();
+    }
 
 private:
     mutable std::mutex target_table_id_mutex;

--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/configs/config.xml
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/configs/config.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+    <remote_servers>
+        <default>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+    <async_load_databases>true</async_load_databases>
+    <fail_points_active>
+        <database_replicated_startup_pause>false</database_replicated_startup_pause>
+    </fail_points_active>
+</clickhouse>

--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/configs/read_only.xml
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/configs/read_only.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <disable_insertion_and_mutation>true</disable_insertion_and_mutation>
+    <text_log><flush_interval_milliseconds>1000000000000</flush_interval_milliseconds></text_log>
+</clickhouse>

--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/configs/users.xml
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/configs/users.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
+            <allow_experimental_alter_materialized_view_structure>1</allow_experimental_alter_materialized_view_structure>
+            <allow_ddl>1</allow_ddl>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
@@ -1,0 +1,151 @@
+import datetime
+import logging
+import random
+import string
+import time
+from random import randint
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster, QueryRuntimeException
+from helpers.network import PartitionManager
+from helpers.test_tools import TSV, assert_eq_with_retry, assert_logs_contain
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.xml"],
+    user_configs=["configs/users.xml"],
+    with_zookeeper=True,
+    with_minio=True,
+    keeper_required_feature_flags=["multi_read", "create_if_not_exists"],
+    macros={"shard": "shard1", "replica": "1"},
+    stay_alive=True,
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.xml"],
+    user_configs=["configs/users.xml"],
+    with_zookeeper=True,
+    keeper_required_feature_flags=["multi_read", "create_if_not_exists"],
+    macros={"shard": "shard1", "replica": "2"},
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def count_skip_ddls(node, db_name, since_ts):
+    node.query("SYSTEM FLUSH LOGS")
+    result = node.query(
+        f"SELECT count() FROM system.text_log WHERE logger_name='DDLWorker({db_name})' AND position(message, 'Skip DDL query') > 0 AND event_time_microseconds > '{since_ts}'"
+    ).strip()
+    return int(result)
+
+def get_random_string(string_length=8):
+    alphabet = string.ascii_letters + string.digits
+    return "".join((random.choice(alphabet) for _ in range(string_length)))
+
+def get_last_ddl_worker_log_ts(node, db_name):
+    node.query("SYSTEM FLUSH LOGS")
+    result = node.query(
+        f"SELECT max(event_time_microseconds) FROM system.text_log WHERE logger_name='DDLWorker({db_name})' "
+    ).strip()
+
+    if len(result) == 0:
+        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    return result
+
+
+@pytest.mark.parametrize("append", [True, False])
+@pytest.mark.parametrize("with_inner_table", [True, False])
+@pytest.mark.parametrize("allow_skipping", [1, 0])
+def test_refreshable_mv_skip_old_temp_tables_ddls(
+    started_cluster,
+    append: bool,
+    with_inner_table: bool,
+    allow_skipping: int,
+):
+    db_name = "test_" + get_random_string()
+    node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    node2.query(f"DROP DATABASE IF EXISTS {db_name}  SYNC")
+
+    node1.query(
+        f"CREATE DATABASE {db_name} ENGINE=Replicated('/test/{db_name}', "
+        + r"'{shard}', '{replica}') "
+        + f" SETTINGS allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views={allow_skipping}"
+    )
+
+    append_clause = "APPEND" if append else ""
+
+    if(with_inner_table):
+        node1.query(
+            f"CREATE TABLE {db_name}.target (x DateTime) ENGINE ReplicatedMergeTree ORDER BY x"
+        )
+        node1.query(
+        f"CREATE MATERIALIZED VIEW {db_name}.mv REFRESH EVERY 2 SECOND {append_clause} TO {db_name}.target AS SELECT now() AS x"
+    )
+    else:
+        node1.query(
+            f"CREATE MATERIALIZED VIEW {db_name}.mv REFRESH EVERY 2 SECOND {append_clause} (x DateTime) ENGINE ReplicatedMergeTree ORDER BY x AS SELECT now() AS x"
+        )
+
+    node2.query(
+        f"CREATE DATABASE {db_name} ENGINE=Replicated('/test/{db_name}', "
+        + r"'{shard}', '{replica}')"
+        + f" SETTINGS allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views={allow_skipping}"
+    )
+
+    # Make sure that tables are replicated on node2
+    assert (
+        node2.query_with_retry(
+            f"SELECT count() FROM system.tables WHERE database='{db_name}'",
+            check_callback=lambda x: x.strip() == "2",
+        ).strip()
+        == "2"
+    )
+
+    last_log_ts = get_last_ddl_worker_log_ts(node2, db_name)
+    node2.stop_clickhouse()
+
+    # Wait for node1 to refresh the view several times
+    time.sleep(5)
+
+    node2.start_clickhouse()
+
+    node1.query(f"ALTER TABLE {db_name}.mv MODIFY REFRESH EVERY 1 HOUR {append_clause}")
+
+    # Make sure that the view is not refreshing, and it is scheduled to be refreshed in at least 10 minutes
+    node1.query_with_retry(
+        f"SELECT next_refresh_time FROM system.view_refreshes WHERE view='mv' AND database='{db_name}'",
+        check_callback=lambda x: datetime.now()
+        - datetime.strptime(x.strip(), "%Y-%m-%d %H:%M:%S")
+        > datetime.timedelta(minutes=10),
+    )
+
+    table_info1 = node1.query(f"SELECT uuid, name FROM system.tables WHERE database='{db_name}'")
+    assert table_info1 == node2.query_with_retry(
+        f"SELECT uuid, name FROM system.tables WHERE database='{db_name}'",
+        check_callback=lambda x: x == table_info1,
+    )
+    data1 = TSV(node1.query(f"SELECT x FROM {db_name}.mv ORDER BY x"))
+    data2 = TSV(node2.query(f"SELECT x FROM {db_name}.mv ORDER BY x"))
+    assert data1 == data2
+
+    if append or allow_skipping == 0:
+        assert count_skip_ddls(node2, db_name, last_log_ts) == 0
+    else:
+        assert count_skip_ddls(node2, db_name, last_log_ts) > 0
+
+    node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    node2.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")


### PR DESCRIPTION
…

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Skip creating and renaming the old temp table of non-append RMV DDLs in Replicated DBs.

Refreshing in non-append Refreshable Materialized Views:
1. Create a temporary table: .tmp_inner.<uuid of the parent MV>
2. Fill in the data from the SELECT clause
3. Rename (with exchange) the temporary table to the target table name. The target table name can be the inner table of the view, or the table specified in the view create query.
4. Drop the temporary table after exchanging. Note that the temporary table after exchanging is not the table created in step 1. It is the one exchanged in step 3.
5. Update the coordination info in Keeper

Queries created in steps 1, 3, and 4 are replicated through the DDL logs.
If a replica is woken up after a long sleep, there are lots of creating, renaming and dropping DDLs generated by the RMVs.
To speed up the DDL processing, these old create DDLs are skipped.
Once the creating DDL is skipped, there is no table to rename in the renaming DDL, so the renaming DDL is skipped if the table name does not exist.
For the dropping DDLs, as the query contains `IF EXISTS`, we don't need to skip.

Enable this logic with DB replicated setting `allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
