### PR TITLE
Limit Keeper log entry cache size by number of entries

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -713,8 +713,8 @@ void PrefetchedCacheEntry::resolve(LogEntryPtr log_entry_)
 }
 
 LogEntryStorage::LogEntryStorage(const LogFileSettings & log_settings, KeeperContextPtr keeper_context_)
-    : latest_logs_cache(log_settings.latest_logs_cache_size_threshold)
-    , commit_logs_cache(log_settings.commit_logs_cache_size_threshold)
+    : latest_logs_cache(log_settings.latest_logs_cache_size_threshold, log_settings.latest_logs_cache_entry_count_threshold)
+    , commit_logs_cache(log_settings.commit_logs_cache_size_threshold, log_settings.commit_logs_cache_entry_count_threshold)
     , prefetch_queue(std::numeric_limits<uint64_t>::max())
     , keeper_context(std::move(keeper_context_))
     , log(getLogger("Changelog"))
@@ -809,7 +809,7 @@ void LogEntryStorage::startCommitLogsPrefetch(uint64_t last_committed_index) con
         return;
 
     /// we don't start prefetch if there is no limit on latest logs cache
-    if (latest_logs_cache.size_threshold == 0)
+    if (latest_logs_cache.hasUnlimitedSpace())
         return;
 
     /// commit logs is not empty and it's not next log
@@ -833,6 +833,7 @@ void LogEntryStorage::startCommitLogsPrefetch(uint64_t last_committed_index) con
     prefetch_from = current_index;
 
     size_t total_size = 0;
+    size_t total_entries = 0;
     std::vector<FileReadInfo> file_infos;
     FileReadInfo * current_file_info = nullptr;
     size_t next_position = 0;
@@ -855,7 +856,7 @@ void LogEntryStorage::startCommitLogsPrefetch(uint64_t last_committed_index) con
             current_file_info = &file_infos.emplace_back(changelog_description, position, /* count */ 1);
             next_position = position + size_in_file;
         }
-        else if (total_size + entry_size > commit_logs_cache.size_threshold)
+        else if (total_size + entry_size > commit_logs_cache.size_threshold || total_entries > commit_logs_cache.count_threshold)
             break;
         else if (changelog_description == current_file_info->file_description && position == next_position)
         {
@@ -869,6 +870,7 @@ void LogEntryStorage::startCommitLogsPrefetch(uint64_t last_committed_index) con
         }
 
         total_size += entry_size;
+        ++total_entries;
         commit_logs_cache.addEntry(current_index, entry_size, std::make_shared<PrefetchedCacheEntry>());
     }
 
@@ -884,8 +886,9 @@ void LogEntryStorage::startCommitLogsPrefetch(uint64_t last_committed_index) con
     }
 }
 
-LogEntryStorage::InMemoryCache::InMemoryCache(size_t size_threshold_)
+LogEntryStorage::InMemoryCache::InMemoryCache(size_t size_threshold_, size_t count_threshold_)
     : size_threshold(size_threshold_)
+    , count_threshold(count_threshold_)
 {}
 
 void LogEntryStorage::InMemoryCache::updateStatsWithNewEntry(uint64_t index, size_t size)
@@ -1031,6 +1034,11 @@ void LogEntryStorage::InMemoryCache::clear()
     cache_size = 0;
 }
 
+bool LogEntryStorage::InMemoryCache::hasUnlimitedSpace() const
+{
+    return size_threshold == 0 && count_threshold == 0;
+}
+
 bool LogEntryStorage::InMemoryCache::empty() const
 {
     return cache.empty();
@@ -1043,7 +1051,8 @@ size_t LogEntryStorage::InMemoryCache::numberOfEntries() const
 
 bool LogEntryStorage::InMemoryCache::hasSpaceAvailable(size_t log_entry_size) const
 {
-    return size_threshold == 0 || empty() || cache_size + log_entry_size < size_threshold;
+    return empty() || (size_threshold != 0 && (cache_size + log_entry_size < size_threshold))
+        || (count_threshold != 0 && (numberOfEntries() + 1 < count_threshold));
 }
 
 void LogEntryStorage::addEntry(uint64_t index, const LogEntryPtr & log_entry)
@@ -1389,7 +1398,7 @@ uint64_t LogEntryStorage::termAt(uint64_t index) const
 void LogEntryStorage::addLogLocations(std::vector<std::pair<uint64_t, LogLocation>> && indices_with_log_locations)
 {
     /// if we have unlimited space in latest logs cache we don't need log location
-    if (latest_logs_cache.size_threshold == 0)
+    if (latest_logs_cache.hasUnlimitedSpace())
         return;
 
     if (indices_with_log_locations.empty())
@@ -1405,7 +1414,7 @@ void LogEntryStorage::addLogLocations(std::vector<std::pair<uint64_t, LogLocatio
 void LogEntryStorage::refreshCache()
 {
     /// if we have unlimited space in latest logs cache we don't need log location
-    if (latest_logs_cache.size_threshold == 0)
+    if (latest_logs_cache.hasUnlimitedSpace())
         return;
 
     std::vector<IndexWithLogLocation> new_unapplied_indices_with_log_locations;
@@ -1428,7 +1437,8 @@ void LogEntryStorage::refreshCache()
 
     std::lock_guard lock(commit_logs_cache_mutex);
     while (latest_logs_cache.numberOfEntries() > 1 && latest_logs_cache.min_index_in_cache <= max_index_with_location
-           && latest_logs_cache.cache_size > latest_logs_cache.size_threshold)
+           && (latest_logs_cache.cache_size > latest_logs_cache.size_threshold
+               || latest_logs_cache.numberOfEntries() > latest_logs_cache.count_threshold))
     {
         auto node = latest_logs_cache.popOldestEntry();
         auto log_entry_size = logEntrySize(getLogEntry(node.mapped()));

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -122,7 +122,9 @@ struct LogFileSettings
     uint64_t max_size = 0;
     uint64_t overallocate_size = 0;
     uint64_t latest_logs_cache_size_threshold = 0;
+    uint64_t latest_logs_cache_entry_count_threshold = 0;
     uint64_t commit_logs_cache_size_threshold = 0;
+    uint64_t commit_logs_cache_entry_count_threshold = 0;
 };
 
 struct FlushSettings
@@ -229,7 +231,7 @@ private:
 
     struct InMemoryCache
     {
-        explicit InMemoryCache(size_t size_threshold_);
+        explicit InMemoryCache(size_t size_threshold_, size_t count_threshold_);
 
         void addEntry(uint64_t index, size_t size, CacheEntry log_entry);
         void addEntry(IndexToCacheEntryNode && node);
@@ -254,6 +256,8 @@ private:
         bool hasSpaceAvailable(size_t log_entry_size) const;
         void clear();
 
+        bool hasUnlimitedSpace() const;
+
         /// Mapping log_id -> log_entry
         mutable IndexToCacheEntry cache;
         size_t cache_size = 0;
@@ -261,6 +265,7 @@ private:
         size_t max_index_in_cache = 0;
 
         const size_t size_threshold;
+        const size_t count_threshold;
     };
 
     InMemoryCache latest_logs_cache;

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -60,8 +60,10 @@ namespace ErrorCodes
     DECLARE(Bool, async_replication, false, "Enable async replication. All write and read guarantees are preserved while better performance is achieved. Settings is disabled by default to not break backwards compatibility.", 0) \
     DECLARE(Bool, experimental_use_rocksdb, false, "Use rocksdb as backend storage", 0) \
     DECLARE(UInt64, rocksdb_load_batch_size, 1000, "Size of write batch used during snapshot loading", 0) \
-    DECLARE(UInt64, latest_logs_cache_size_threshold, 1 * 1024 * 1024 * 1024, "Maximum total size of in-memory cache of latest log entries.", 0) \
-    DECLARE(UInt64, commit_logs_cache_size_threshold, 500 * 1024 * 1024, "Maximum total size of in-memory cache of log entries needed next for commit.", 0) \
+    DECLARE(UInt64, latest_logs_cache_size_threshold, 1_GiB, "Maximum total size of in-memory cache of latest log entries.", 0) \
+    DECLARE(UInt64, latest_logs_cache_entry_count_threshold, 200'000, "Maximum number of entries in in-memory cache of latest log entries.", 0) \
+    DECLARE(UInt64, commit_logs_cache_size_threshold, 500_MiB, "Maximum total size of in-memory cache of log entries needed next for commit.", 0) \
+    DECLARE(UInt64, commit_logs_cache_entry_count_threshold, 100'000, "Maximum number of entries in in-memory cache of log entries needed next for commit.", 0) \
     DECLARE(UInt64, disk_move_retries_wait_ms, 1000, "How long to wait between retries after a failure which happened while a file was being moved between disks.", 0) \
     DECLARE(UInt64, disk_move_retries_during_init, 100, "The amount of retries after a failure which happened while a file was being moved between disks during initialization.", 0) \
     DECLARE(UInt64, log_slow_total_threshold_ms, 5000, "Requests for which the total latency is larger than this settings will be logged", 0) \

--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -21,9 +21,11 @@ namespace CoordinationSetting
 {
     extern const CoordinationSettingsBool async_replication;
     extern const CoordinationSettingsUInt64 commit_logs_cache_size_threshold;
+    extern const CoordinationSettingsUInt64 commit_logs_cache_entry_count_threshold;
     extern const CoordinationSettingsBool compress_logs;
     extern const CoordinationSettingsBool force_sync;
     extern const CoordinationSettingsUInt64 latest_logs_cache_size_threshold;
+    extern const CoordinationSettingsUInt64 latest_logs_cache_entry_count_threshold;
     extern const CoordinationSettingsUInt64 log_file_overallocate_size;
     extern const CoordinationSettingsUInt64 max_flush_batch_size;
     extern const CoordinationSettingsUInt64 max_log_file_size;
@@ -311,7 +313,9 @@ KeeperStateManager::KeeperStateManager(
               .max_size = keeper_context_->getCoordinationSettings()[CoordinationSetting::max_log_file_size],
               .overallocate_size = keeper_context_->getCoordinationSettings()[CoordinationSetting::log_file_overallocate_size],
               .latest_logs_cache_size_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::latest_logs_cache_size_threshold],
-              .commit_logs_cache_size_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::commit_logs_cache_size_threshold]
+              .latest_logs_cache_entry_count_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::latest_logs_cache_entry_count_threshold],
+              .commit_logs_cache_size_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::commit_logs_cache_size_threshold],
+              .commit_logs_cache_entry_count_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::commit_logs_cache_entry_count_threshold],
           },
           FlushSettings
           {

--- a/src/Coordination/tests/gtest_coordination_changelog.cpp
+++ b/src/Coordination/tests/gtest_coordination_changelog.cpp
@@ -97,7 +97,6 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestFile)
 
 TYPED_TEST(CoordinationChangelogTest, ChangelogReadWrite)
 {
-
     ChangelogDirTest test("./logs");
     this->setLogDirectory("./logs");
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Limit Keeper log entry cache size by number of entries using `keeper_server.coordination_settings.latest_logs_cache_entry_count_threshold` and `keeper_server.coordination_settings.commit_logs_cache_entry_count_threshold`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
