### PR TITLE
Fix Keeper watches count again

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -3323,8 +3323,8 @@ KeeperResponsesForSessions KeeperStorage<Container>::processRequest(
             if (std::holds_alternative<RemoveNodeDelta>(delta.operation))
             {
                 auto responses = processWatchesImpl(delta.path, watches, list_watches, sessions_and_watchers, Coordination::Event::DELETED);
+                total_watches_count -= responses.size();
                 results.insert(results.end(), responses.begin(), responses.end());
-                total_watches_count -= results.size();
             }
         }
 

--- a/tests/integration/test_keeper_watches/test.py
+++ b/tests/integration/test_keeper_watches/test.py
@@ -112,7 +112,9 @@ def test_ephemeral_watch_session_close(started_cluster):
         pass
     try:
         zk.create("/ephemeral_test_node", b"data", ephemeral=True)
+        zk.create("/ephemeral_test_node_the_second", b"data", ephemeral=True)
         zk.exists("/ephemeral_test_node", watch=watch_callback)
+        zk.exists("/ephemeral_test_node_the_second", watch=watch_callback)
     finally:
         destroy_zk_client(zk)
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix total watches count returned by Keeper.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
