### PR TITLE
Support query parameters in TO section of MVs

### DIFF
--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -412,6 +412,15 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
               << (!to_table_id.database_name.empty() ? backQuoteIfNeed(to_table_id.database_name) + "." : "")
               << backQuoteIfNeed(to_table_id.table_name);
     }
+    else if (targets && targets->hasTableASTWithQueryParams(ViewTarget::To))
+    {
+        auto to_table_ast = targets->getTableASTWithQueryParams(ViewTarget::To);
+
+        chassert(to_table_ast);
+
+        ostr << " " << toStringView(Keyword::TO) << " ";
+        to_table_ast->format(ostr, settings, state, frame);
+    }
 
     if (auto to_inner_uuid = getTargetInnerUUID(ViewTarget::To); to_inner_uuid != UUIDHelpers::Nil)
     {

--- a/src/Parsers/ASTViewTargets.cpp
+++ b/src/Parsers/ASTViewTargets.cpp
@@ -311,4 +311,40 @@ void ASTViewTargets::forEachPointerToChild(std::function<void(void**)> f)
     }
 }
 
+void ASTViewTargets::setTableASTWithQueryParams(ViewTarget::Kind kind, const ASTPtr & table_)
+{
+    for (auto & target : targets)
+    {
+        if (target.kind == kind)
+        {
+            target.table_ast = table_;
+            return;
+        }
+    }
+    if (table_)
+        targets.emplace_back(kind).table_ast = table_;
+}
+
+bool ASTViewTargets::hasTableASTWithQueryParams(ViewTarget::Kind kind) const
+{
+    for (const auto & target : targets)
+        if (target.kind == kind)
+            return target.table_ast != nullptr;
+    return false;
+}
+
+ASTPtr ASTViewTargets::getTableASTWithQueryParams(ViewTarget::Kind kind)
+{
+    for (const auto & target : targets)
+        if (target.kind == kind)
+            return target.table_ast;
+    return nullptr;
+}
+
+void ASTViewTargets::resetTableASTWithQueryParams(ViewTarget::Kind kind)
+{
+    for (auto & target : targets)
+        if (target.kind == kind)
+            target.table_ast.reset();
+}
 }

--- a/src/Parsers/ASTViewTargets.h
+++ b/src/Parsers/ASTViewTargets.h
@@ -49,6 +49,9 @@ struct ViewTarget
     /// Table engine of the target table, if it's inner.
     /// That engine can be seen for example after "ENGINE" in a statement like CREATE MATERIALIZED VIEW ... ENGINE ...
     std::shared_ptr<ASTStorage> inner_engine;
+
+    /// Table's AST with query parameters
+    ASTPtr table_ast;
 };
 
 /// Converts ViewTarget::Kind to a string.
@@ -69,6 +72,12 @@ class ASTViewTargets : public IAST
 {
 public:
     std::vector<ViewTarget> targets;
+
+    /// Manipulates AST of the target table which has query parameters in its definition
+    void setTableASTWithQueryParams(ViewTarget::Kind kind, const ASTPtr & table_);
+    bool hasTableASTWithQueryParams(ViewTarget::Kind kind) const;
+    ASTPtr getTableASTWithQueryParams(ViewTarget::Kind kind);
+    void resetTableASTWithQueryParams(ViewTarget::Kind kind);
 
     /// Sets the StorageID of the target table, if it's not inner.
     /// That storage ID can be seen for example after "TO" in a statement like CREATE MATERIALIZED VIEW ... TO ...

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1774,7 +1774,15 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     {
         targets = std::make_shared<ASTViewTargets>();
         if (to_table)
-            targets->setTableID(ViewTarget::To, to_table->as<ASTTableIdentifier>()->getTableId());
+        {
+            if (!to_table->as<ASTTableIdentifier>()->isParam())
+                targets->setTableID(ViewTarget::To, to_table->as<ASTTableIdentifier>()->getTableId());
+            else
+            {
+                chassert(is_materialized_view);
+                targets->setTableASTWithQueryParams(ViewTarget::To, to_table);
+            }
+        }
         if (to_inner_uuid)
             targets->setInnerUUID(ViewTarget::To, parseFromString<UUID>(to_inner_uuid->as<ASTLiteral>()->value.safeGet<String>()));
         if (storage)

--- a/tests/queries/0_stateless/03573_create_query_parameters_in_to_in_materialized_view.reference
+++ b/tests/queries/0_stateless/03573_create_query_parameters_in_to_in_materialized_view.reference
@@ -1,0 +1,8 @@
+CREATE MATERIALIZED VIEW mv_kek TO {db:Identifier}.{target_table:Identifier} AS SELECT * FROM null_kek
+CREATE MATERIALIZED VIEW mv_kek TO {target_table:Identifier} AS SELECT * FROM null_kek
+0
+1
+2
+42
+2
+42

--- a/tests/queries/0_stateless/03573_create_query_parameters_in_to_in_materialized_view.sql
+++ b/tests/queries/0_stateless/03573_create_query_parameters_in_to_in_materialized_view.sql
@@ -1,0 +1,41 @@
+-- formatting
+SELECT formatQuerySingleLine('create materialized view mv_kek to {db:Identifier}.{target_table:Identifier} as select * from null_kek');
+SELECT formatQuerySingleLine('create materialized view mv_kek to {target_table:Identifier} as select * from null_kek');
+
+-- table name substituion
+CREATE TABLE dst_table ENGINE = MergeTree ORDER BY number AS SELECT number FROM numbers(3);
+CREATE TABLE src_table AS dst_table ENGINE = Null;
+
+SET param_dst_table = 'dst_table';
+
+CREATE MATERIALIZED VIEW mv_table TO {dst_table:Identifier} AS SELECT * FROM src_table;
+
+INSERT INTO src_table SELECT 42;
+
+SELECT * FROM dst_table ORDER BY number;
+
+-- strange use case
+
+DROP TABLE mv_table, dst_table, src_table;
+
+CREATE TABLE dst_table (`number` UInt32) ENGINE = MergeTree ORDER BY number;
+CREATE TABLE src_table AS dst_table ENGINE = Null;
+
+SET param_dst_table = 'dst_table';
+SET param_src_table = 'src_table';
+
+CREATE MATERIALIZED VIEW mv_table TO {dst_table:Identifier}
+AS SELECT *
+FROM {src_table:Identifier}
+WHERE number NOT IN (
+    SELECT number
+    FROM {dst_table:Identifier}
+);
+
+INSERT INTO src_table SELECT 42;
+INSERT INTO src_table SELECT 2;
+
+INSERT INTO src_table SELECT 42;
+INSERT INTO src_table SELECT 2;
+
+SELECT * FROM dst_table ORDER BY number ASC;


### PR DESCRIPTION
This PR allows the next query:

```
CREATE MATERIALIZED VIEW mv TO {db:Identifier}.{target_table:Identifier} AS SELECT * FROM src_table
```
Closes: https://github.com/ClickHouse/ClickHouse/issues/62892

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
You can use query parameters after `TO` when creating a materialized view, for example: `CREATE MATERIALIZED VIEW mv TO {to_table:Identifier} AS SELECT * FROM src_table`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
