### PR TITLE
Fix lightweight updates after upgrade

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -925,6 +925,10 @@ void StorageReplicatedMergeTree::createNewZooKeeperNodesAttempt() const
             zookeeper_path + "/temp/" + EphemeralLockInZooKeeper::LEGACY_LOCK_OTHER, String(), zkutil::CreateMode::Persistent));
     }
 
+    /// For synchronization of lightweight updates (see PatchPartsLock.h)
+    futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/lightweight_updates", String(), zkutil::CreateMode::Persistent));
+    futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/lightweight_updates/in_progress", String(), zkutil::CreateMode::Persistent));
+
     for (auto & future : futures)
     {
         auto res = future.get();
@@ -1041,10 +1045,6 @@ bool StorageReplicatedMergeTree::createTableIfNotExistsAttempt(const StorageMeta
         ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/quorum/failed_parts", "",
             zkutil::CreateMode::Persistent));
         ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/mutations", "",
-            zkutil::CreateMode::Persistent));
-        ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/lightweight_updates", "",
-            zkutil::CreateMode::Persistent));
-        ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/lightweight_updates/in_progress", "",
             zkutil::CreateMode::Persistent));
 
         /// And create first replica atomically. See also "createReplica" method that is used to create not the first replicas.

--- a/tests/integration/test_lightweight_updates/test.py
+++ b/tests/integration/test_lightweight_updates/test.py
@@ -112,7 +112,10 @@ def test_lwu_replicated_database(started_cluster, db_engine, table_engine):
 
 @pytest.mark.parametrize("table_engine", ["ReplicatedMergeTree"])
 def test_lwu_upgrade(started_cluster, table_engine):
-    node3.query("DROP TABLE IF EXISTS lwu_table_upgrade")
+    node3.query("DROP TABLE IF EXISTS lwu_table_upgrade SYNC")
+
+    if CLICKHOUSE_CI_MIN_TESTED_VERSION not in node3.query("select version()").strip():
+        node3.restart_with_original_version(clear_data_dir=True)
 
     node3.query(
         f"CREATE TABLE lwu_table_upgrade (x Int32, y String) ENGINE = {table_engine}('/test/clickhouse/default/lwu_table_upgrade', '1') ORDER BY x"

--- a/tests/integration/test_lightweight_updates/test.py
+++ b/tests/integration/test_lightweight_updates/test.py
@@ -1,10 +1,10 @@
 import pytest
 import random
 
-import helpers.cluster
+from helpers.cluster import CLICKHOUSE_CI_MIN_TESTED_VERSION, ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = helpers.cluster.ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance(
     "node1",
@@ -14,6 +14,15 @@ node1 = cluster.add_instance(
 node2 = cluster.add_instance(
     "node2",
     with_zookeeper=True,
+)
+
+node3 = cluster.add_instance(
+    "node3",
+    with_zookeeper=True,
+    image="clickhouse/clickhouse-server",
+    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    stay_alive=True,
+    with_installed_binary=True,
 )
 
 
@@ -98,4 +107,76 @@ def test_lwu_replicated_database(started_cluster, db_engine, table_engine):
     """
         )
         == ""
+    )
+
+
+@pytest.mark.parametrize("table_engine", ["ReplicatedMergeTree"])
+def test_lwu_upgrade(started_cluster, table_engine):
+    node3.query("DROP TABLE IF EXISTS lwu_table_upgrade")
+
+    node3.query(
+        f"CREATE TABLE lwu_table_upgrade (x Int32, y String) ENGINE = {table_engine}('/test/clickhouse/default/lwu_table_upgrade', '1') ORDER BY x"
+    )
+    node3.query(
+        "INSERT INTO lwu_table_upgrade SELECT number, 'v' || toString(number) FROM numbers(100000)"
+    )
+    node3.query(
+        "INSERT INTO lwu_table_upgrade SELECT number, 'v' || toString(number) FROM numbers(100000, 100000)"
+    )
+
+    node3.query("OPTIMIZE TABLE lwu_table_upgrade FINAL")
+
+    with pytest.raises(Exception) as e:
+        node3.query(
+            "UPDATE lwu_table_upgrade SET y = 'updated' WHERE x >= 50000 AND x < 150000"
+        )
+    assert "SYNTAX_ERROR" in str(e.value)
+
+    node3.restart_with_latest_version()
+
+    with pytest.raises(Exception) as e:
+        node3.query(
+            "UPDATE lwu_table_upgrade SET y = 'updated' WHERE x >= 50000 AND x < 150000",
+            settings={
+                "allow_experimental_lightweight_update": 1,
+                "update_parallel_mode": "auto",
+            },
+        )
+    assert "NOT_IMPLEMENTED" in str(e.value)
+
+    node3.query(
+        "ALTER TABLE lwu_table_upgrade MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1, apply_patches_on_merge = 0"
+    )
+    node3.query(
+        "UPDATE lwu_table_upgrade SET y = 'updated' WHERE x >= 50000 AND x < 150000",
+        settings={
+            "allow_experimental_lightweight_update": 1,
+            "update_parallel_mode": "auto",
+        },
+    )
+
+    assert (
+        node3.query("SELECT count() FROM lwu_table_upgrade WHERE y = 'updated'")
+        == "100000\n"
+    )
+
+    node3.query("OPTIMIZE TABLE lwu_table_upgrade FINAL")
+
+    assert (
+        node3.query("SELECT count() FROM lwu_table_upgrade WHERE y = 'updated'")
+        == "100000\n"
+    )
+
+    node3.query(
+        "ALTER TABLE lwu_table_upgrade MODIFY SETTING apply_patches_on_merge = 1"
+    )
+
+    node3.query("OPTIMIZE TABLE lwu_table_upgrade FINAL")
+
+    assert (
+        node3.query(
+            "SELECT count() FROM lwu_table_upgrade WHERE y = 'updated'",
+            settings={"apply_patch_parts": 0},
+        )
+        == "100000\n"
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed lightweight updates for tables with `ReplicatedMergeTree` engine created on servers with a version lower than 25.7.

