### PR TITLE
ci: speed up integration test discovery (10min -> ~10-20sec)

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -333,7 +333,7 @@ class ClickhouseIntegrationTestsRunner:
         report_file = "runner_get_all_tests.jsonl"
         cmd = (
             f"cd {self.repo_path}/tests/integration && "
-            f"timeout --verbose --signal=KILL 1h ./runner {runner_opts} {image_cmd} -- "
+            f"timeout --verbose --signal=KILL 2m ./runner {runner_opts} {image_cmd} -- "
             f"--setup-plan --report-log={report_file}"
         )
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1726,14 +1726,8 @@ class ClickHouseCluster:
             with_remote_database_disk = False
 
         if with_remote_database_disk is None:
-            build_opts = subprocess.check_output(
-                f"""{self.server_bin_path} local -q "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'" """,
-                stderr=subprocess.STDOUT,
-                shell=True,
-            ).decode()
-            with_remote_database_disk = ("NDEBUG" not in build_opts) and (
-                "-fsanitize=address" in build_opts
-            )
+            # Not enabled in public
+            with_remote_database_disk = False
 
         if with_remote_database_disk:
             logging.debug(f"Instance {name}, with_remote_database_disk enabled")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ci: speed up integration test discovery (10min -> ~10-20sec)

Before, with sanitizers it takes 10 minutes, while for release ~2 minutes.

What is funny is that it looks odd and it looks like this code is completelly redundant, because it can never be true, so we can simply remove it, database disk will be fixed separately.

Refs: https://github.com/ClickHouse/ClickHouse/issues/82674
Refs: https://github.com/ClickHouse/ClickHouse/pull/79424