### PR TITLE
Fix memory tracking drift from background schedule pool and executor

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -349,6 +349,8 @@ void BackgroundSchedulePool::threadFunction()
     {
         TaskInfoPtr task;
 
+        current_thread->flushUntrackedMemory();
+
         {
             UniqueLock tasks_lock(tasks_mutex);
 
@@ -370,6 +372,8 @@ void BackgroundSchedulePool::threadFunction()
 
         if (task)
             task->execute(*this);
+
+        current_thread->flushUntrackedMemory();
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -347,6 +347,8 @@ void MergeTreeBackgroundExecutor<Queue>::threadFunction()
 {
     setThreadName(name.c_str());
 
+    current_thread->flushUntrackedMemory();
+
     DENY_ALLOCATIONS_IN_SCOPE;
 
     while (true)
@@ -374,6 +376,8 @@ void MergeTreeBackgroundExecutor<Queue>::threadFunction()
                 tryLogCurrentException(__PRETTY_FUNCTION__);
             });
         }
+
+        current_thread->flushUntrackedMemory();
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix memory tracking drift from background schedule pool and executor

It has been [reported](https://github.com/ClickHouse/ClickHouse/pull/83607#issuecomment-3083835465) (and I also noticed it few months ago) that it is possible to see negative MemoryTracking metric, while this should never be possible after bunch of fixes. It is not big, ~100MiB per 1 hour, but it still annoying.

But, huge thread pools, that reserve all threads at start may lead to this, since each of them will have a drift up to 4MiB (it is not depends on the `max_untracked_memory`, since we do not apply it for all threads at start).

And indeed I've tested this and with
background_schedule_pool_size=10000, and I see that MemoryTracking can go down, while after this patch, it is almost constant.

**And I hope this is the final bits of memory tracking drift!**

_Note: workaround to mitigate this drift is to decrease background pool sizes, i.e. `background_schedule_pool_size=10`, but this is not recommended for production usage_

<details>

<summary>screenshots</summary>

#### memory-tracking-before-docker-vanilla

<img width="950" height="626" alt="memory-tracking-before-docker-vanilla" src="https://github.com/user-attachments/assets/ff798c8b-871e-4989-904a-cb9bdd4a008c" />

#### memory-tracking-before-patch-10k-1h

<img width="946" height="622" alt="memory-tracking-before-patch-10k-1h" src="https://github.com/user-attachments/assets/363466ab-75e2-4abe-b7b5-7ec2793af6ce" />

#### memory-tracking-after-patch-10k-2h

<img width="955" height="632" alt="memory-tracking-after-patch-10k-2h" src="https://github.com/user-attachments/assets/944d2cc8-673b-4fc6-a7fd-c2088ba63a03" />

</details>

Fixes: #82036
Cc: @filimonov 