### PR TITLE
CI: Allow test rerun for sanitized builds in FTs

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -368,7 +368,14 @@ def main():
         results.append(ft_res_processor.run())
         debug_files += ft_res_processor.debug_files
         test_result = results[-1]
+
+        test_result.set_timing(stopwatch=stop_watch_)
+        if test_result.info:
+            job_info = test_result.info
+            test_result.info = ""
+
         if ft_res_processor.summary and ft_res_processor.summary.retried_tests:
+            print("Retried tests found - add into the report into the separate tab")
             results.append(
                 Result(
                     name="Retried tests",
@@ -391,12 +398,7 @@ def main():
             else:
                 results[-1].set_success()
 
-        results[-1].set_timing(stopwatch=stop_watch_)
-        if results[-1].info:
-            job_info = results[-1].info
-            results[-1].info = ""
-
-        res = results[-1].is_ok()
+        res = test_result.is_ok()
 
     CH.terminate()
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1,9 +1,9 @@
 import argparse
 import os
+import random
 import re
 import time
 from pathlib import Path
-import random
 
 from ci.jobs.scripts.clickhouse_proc import ClickHouseProc
 from ci.jobs.scripts.functional_tests_results import FTResultsProcessor
@@ -139,7 +139,9 @@ def main():
     is_parallel_replicas = False
     runner_options = ""
     # optimal value for most of the jobs
-    nproc = int(Utils.cpu_count() * 0.8)
+    # nproc = int(Utils.cpu_count() * 0.8)
+    # test
+    nproc = int(Utils.cpu_count() * 1.8)
     info = Info()
 
     for to in test_options:
@@ -366,6 +368,15 @@ def main():
         results.append(ft_res_processor.run())
         debug_files += ft_res_processor.debug_files
         test_result = results[-1]
+        if ft_res_processor.summary and ft_res_processor.summary.retried_tests:
+            results.append(
+                Result(
+                    name="Retried tests",
+                    results=ft_res_processor.summary.retried_tests,
+                    status=Result.Status.SUCCESS,
+                    info="test allowed to be retried for sanitizer builds if failed with query timeout",
+                )
+            )
 
         # invert result status for bugfix validation
         if is_bugfix_validation:

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -139,9 +139,7 @@ def main():
     is_parallel_replicas = False
     runner_options = ""
     # optimal value for most of the jobs
-    # nproc = int(Utils.cpu_count() * 0.8)
-    # test
-    nproc = int(Utils.cpu_count() * 1.8)
+    nproc = int(Utils.cpu_count() * 0.8)
     info = Info()
 
     for to in test_options:

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -417,6 +417,8 @@ def main():
         results[-1].results = []
         if not results[-1].is_ok():
             results[-1].set_info("Found errors added into Tests results")
+        if not test_result.is_ok():
+            FTResultsProcessor.sort_by_status(test_result.results)
 
     if JobStages.COLLECT_LOGS in stages:
         print("Collect logs")

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -264,16 +264,18 @@ class FTResultsProcessor:
             with_info_from_results=False,
         )
 
-        if not result.is_ok():
-            order = {
-                "FAIL": 0,
-                "SERVER_DIED": 1,
-                "Timeout": 2,
-                "NOT_FAILED": 3,
-                "BROKEN": 4,
-                "OK": 5,
-                "SKIPPED": 6,
-            }
-            result.results.sort(key=lambda x: order.get(x.status, -1))
-
         return result
+
+    @staticmethod
+    def sort_by_status(results: List[Result]):
+        order = {
+            "FAIL": 0,
+            "SERVER_DIED": 1,
+            "Timeout": 2,
+            "NOT_FAILED": 3,
+            "BROKEN": 4,
+            "OK": 5,
+            "SKIPPED": 6,
+        }
+        results.sort(key=lambda x: order.get(x.status, -1))
+        return results

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -2,9 +2,8 @@ import dataclasses
 import traceback
 from typing import List
 
-from praktika.result import Result
-
 from ci.praktika.info import Info
+from ci.praktika.result import Result
 
 OK_SIGN = "[ OK "
 FAIL_SIGN = "[ FAIL "
@@ -146,6 +145,8 @@ class FTResultsProcessor:
                     info="".join(test[3])[:16384],
                 )
                 if "flaky" not in Info().job_name:
+                    # If a test were rerun in a non-flaky-check run - it's a valid retry.
+                    # Replace old result with a new one.
                     if test_name in test_names:
                         retried_tests.append(test_name)
                         index = next(

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -148,14 +148,13 @@ class FTResultsProcessor:
                     # If a test were rerun in a non-flaky-check run - it's a valid retry.
                     # Replace old result with a new one.
                     if test_name in test_names:
-                        retried_tests.append(test_name)
                         index = next(
                             i
                             for i, x in enumerate(test_results_)
                             if x.name == test_name
                         )
-                        retried_tests.append(test_results_[index])
                         res = test_results_.pop(index)
+                        retried_tests.append(res)
                         assert res.status == Result.StatusExtended.FAIL
                     else:
                         test_names.add(test_name)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -305,7 +305,21 @@ class Runner:
                     result.start_time = start_time
                     result.dump()
 
-            result = Result.from_fs(job.name)
+            try:
+                result = Result.from_fs(job.name)
+            except Exception as e:
+                print(f"ERROR: Failed to load result for job [{job.name}]: {e}")
+                traceback.print_exc()
+                result = Result(
+                    name=job.name,
+                    status=Result.Status.ERROR,
+                    start_time=start_time,
+                    duration=Utils.timestamp() - start_time,
+                    info=f"Failed to load result.json, check result_job_name.json and job.log",
+                    files=[Result.file_name_static(job.name)],
+                )
+                result.dump()
+
             if exit_code != 0:
                 if not result.is_completed():
                     if process.timeout_exceeded:
@@ -324,7 +338,7 @@ class Runner:
                     result.set_info("---").set_info(
                         process.get_latest_log(max_lines=20)
                     ).set_info("---")
-            result.dump()
+                result.dump()
 
         return exit_code
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -23,7 +23,6 @@ import multiprocessing.sharedctypes
 import multiprocessing.synchronize
 import os
 import os.path
-import platform
 import random
 import re
 import shutil
@@ -42,7 +41,6 @@ from ast import literal_eval as make_tuple
 from contextlib import redirect_stdout, contextmanager
 from datetime import datetime, timedelta
 from errno import ESRCH
-from ssl import SSLEOFError
 from subprocess import PIPE, Popen
 from time import sleep, time
 from typing import Dict, List, Optional, Set, Tuple, Union
@@ -1428,7 +1426,7 @@ class TestCase:
                 if max_value and random_settings[setting] > max_value:
                     random_settings[setting] = max_value
 
-    def __init__(self, suite: "TestSuite", case: str, args, is_concurrent: bool):
+    def __init__(self, suite: "TestSuite", case: str, args):
         self.suite = suite
         self.case: str = case  # case file name
         self.args: Namespace = args
@@ -1445,7 +1443,7 @@ class TestCase:
         self.case_file: str = os.path.join(suite.suite_path, case)
         (self.name, self.ext) = os.path.splitext(case)
 
-        file_suffix = f".{os.getpid()}" if is_concurrent and args.test_runs > 1 else ""
+        file_suffix = f".{os.getpid()}"
         self.reference_file = self.get_reference_file(args, suite.suite_path, self.name)
         self.stdout_file = (
             os.path.join(suite.suite_tmp_path, self.name) + file_suffix + ".stdout"
@@ -2490,6 +2488,7 @@ class TestSuite:
         # They will be run, and if they succeed, the status will be changed to FAIL to notify
         # that the changes in PR fixes this test.
         self.blacklist_check: List[str] = []
+        self.tests_with_timeout_queries = None
 
         if args.run_by_hash_num is not None and args.run_by_hash_total is not None:
             if args.run_by_hash_num > args.run_by_hash_total:
@@ -2651,7 +2650,7 @@ class GlobalTimeout(Exception):
 
 def run_tests_array(
     all_tests_with_params: Tuple[
-        List[str],
+        List[Union[str, TestCase]],
         int,
         TestSuite,
         bool,
@@ -2740,7 +2739,12 @@ def run_tests_array(
             stop_tests()
             raise GlobalTimeout("Stop tests run because global time limit is exceeded")
 
-        test_case = TestCase(test_suite, case, args, is_concurrent)
+        if isinstance(case, TestCase):
+            # TestCase object can be used if generated random settings are to be preserver across reruns
+            test_case = case
+        else:
+            # Will generate random test settings on instance creation
+            test_case = TestCase(test_suite, case, args)
 
         try:
             description = ""
@@ -2780,6 +2784,9 @@ def run_tests_array(
                 if not test_result or not test_result.need_retry:
                     break
                 restarted_tests.append(test_result)
+
+            if test_result.status == TestStatus.FAIL and test_result.reason in (FailureReason.STDERR, FailureReason.EXIT_CODE) and "DB::Exception: Timeout exceeded" in test_result.description:
+                test_suite.tests_with_timeout_queries.append(test_case)
 
             # First print the description, than invoke the check result logic
             description += test_result.description
@@ -3043,6 +3050,8 @@ def do_run_tests(
     )
     total_tests = len(test_suite.sequential_tests) + len(test_suite.parallel_tests)
 
+    tests_to_rerun_sequential = []
+
     if test_suite.parallel_tests:
         tests_n = len(test_suite.parallel_tests)
         jobs = min(jobs, tests_n)
@@ -3119,12 +3128,30 @@ def do_run_tests(
                         )
                         runner_process_killed.set()
                     processes.remove(p)
+        if test_suite.tests_with_timeout_queries and any(opt in args.build_flags for opt in (BuildFlags.MEMORY, BuildFlags.ADDRESS, BuildFlags.THREAD, BuildFlags.UNDEFINED)):
+            # allow timeout failures for parallel runs with sanitizers
+            tests_to_rerun_sequential = list(test_suite.tests_with_timeout_queries)
 
     if test_suite.sequential_tests:
         run_tests_array(
             (
                 list(test_suite.sequential_tests),
                 len(test_suite.sequential_tests),
+                test_suite,
+                False,
+                args,
+                exit_code,
+                server_died,
+                restarted_tests,
+            )
+        )
+
+    if tests_to_rerun_sequential:
+        print(f"Sequential rerunning: [{tests_to_rerun_sequential}]")
+        run_tests_array(
+            (
+                tests_to_rerun_sequential,
+                len(tests_to_rerun_sequential),
                 test_suite,
                 False,
                 args,
@@ -3510,6 +3537,7 @@ def main(args):
         test_suite.cloud_skip_list = cloud_skip_list
         test_suite.private_skip_list = private_skip_list
         test_suite.blacklist_check = blacklist_check
+        test_suite.tests_with_timeout_queries = multiprocessing_manager.list()
         total_tests_run += do_run_tests(
             args.jobs,
             test_suite,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

If failed test cases match following conditions:
- sanitized build
- timeout in one of the test case queries, not a test case timeout
- Test cases were run in a parallel batch
They will be restarted at the end of the job sequentially

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

resolves https://github.com/ClickHouse/praktika/issues/104

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
