### PR TITLE
Ignore UNKNOWN_FUNCTION for UDFs during querying system.functions

### DIFF
--- a/src/Storages/System/StorageSystemFunctions.cpp
+++ b/src/Storages/System/StorageSystemFunctions.cpp
@@ -10,10 +10,18 @@
 #include <Functions/UserDefined/UserDefinedSQLFunctionFactory.h>
 #include <Functions/UserDefined/UserDefinedExecutableFunctionFactory.h>
 #include <Storages/System/StorageSystemFunctions.h>
+#include <Common/ErrorCodes.h>
+#include <Common/Exception.h>
+#include <Common/Logger.h>
 
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_FUNCTION;
+}
 
 enum class FunctionOrigin : int8_t
 {
@@ -140,7 +148,18 @@ void StorageSystemFunctions::fillData(MutableColumns & res_columns, ContextPtr c
     const auto & user_defined_sql_functions_names = user_defined_sql_functions_factory.getAllRegisteredNames();
     for (const auto & function_name : user_defined_sql_functions_names)
     {
-        auto create_query = user_defined_sql_functions_factory.get(function_name)->formatWithSecretsOneLine();
+        String create_query;
+        try
+        {
+            create_query = user_defined_sql_functions_factory.get(function_name)->formatWithSecretsOneLine();
+        }
+        catch (const Exception & e)
+        {
+            if (e.code() == ErrorCodes::UNKNOWN_FUNCTION)
+                tryLogCurrentException(getLogger("system.functions"), fmt::format("Function {} does not exist", function_name), LogsLevel::debug);
+            else
+                throw;
+        }
         fillRow(res_columns, function_name, 0, create_query, FunctionOrigin::SQL_USER_DEFINED, user_defined_sql_functions_factory);
     }
 


### PR DESCRIPTION
Should fix the following error on CI [1] for `00385_storage_file_and_clickhouse-local_app_long`:

    2025-08-02 17:43:52 [79b3342c8ff8] 2025.08.02 16:43:52.513307 [ 112537 ] {dd3ef41d-941b-4d10-bc9b-c182ed564855} <Error> executeQuery: Code: 46. DB::Exception: The object name 'test_sql_udf_duplicate_test_t0brnz0z' is not saved. (UNKNOWN_FUNCTION) (version 25.8.1.1) (from [::1]:36214) (comment: 00385_storage_file_and_clickhouse-local_app_long.sh) (query 1, line 1) (in query: CREATE TABLE buf_00385 ENGINE = Memory AS SELECT name, is_aggregate FROM system.functions), Stack trace (when copying this message, always include the lines below):

Due to race with `03525_sql_udf_names_in_system_query_log`.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/PRs/84946/cc1606deffe54af2acf326c1b76f386fc7efecdb//stateless_tests_amd_tsan_s3_storage_parallel/job.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)