### PR TITLE
Docs: register documentation for toStartOfMillisecond and fromDaysSinceYearZero

### DIFF
--- a/src/Functions/fromDaysSinceYearZero.cpp
+++ b/src/Functions/fromDaysSinceYearZero.cpp
@@ -169,7 +169,7 @@ fromDaysSinceYearZero32(toDaysSinceYearZero(toDate('2023-09-08'))) AS date2
     FunctionDocumentation::IntroducedIn introduced_in_fromDaysSinceYearZero32 = {23, 11};
     FunctionDocumentation::Category category_fromDaysSinceYearZero32 = FunctionDocumentation::Category::DateAndTime;
     FunctionDocumentation documentation_fromDaysSinceYearZero32 = {description_fromDaysSinceYearZero32, syntax_fromDaysSinceYearZero32, arguments_fromDaysSinceYearZero32, returned_value_fromDaysSinceYearZero32, examples_fromDaysSinceYearZero32, introduced_in_fromDaysSinceYearZero32, category_fromDaysSinceYearZero32};
-    factory.registerFunction<FunctionFromDaysSinceYearZero<DateTraits32>>();
+    factory.registerFunction<FunctionFromDaysSinceYearZero<DateTraits32>>(documentation_fromDaysSinceYearZero32);
 
     factory.registerAlias("FROM_DAYS", FunctionFromDaysSinceYearZero<DateTraits>::name, FunctionFactory::Case::Insensitive);
 }

--- a/src/Functions/toStartOfSubsecond.cpp
+++ b/src/Functions/toStartOfSubsecond.cpp
@@ -43,7 +43,7 @@ SELECT toStartOfMillisecond(dt64, 'Asia/Istanbul');
     FunctionDocumentation::Category category = FunctionDocumentation::Category::DateAndTime;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToStartOfMillisecond>();
+    factory.registerFunction<FunctionToStartOfMillisecond>(documentation);
 }
 
 using FunctionToStartOfMicrosecond = FunctionDateOrDateTimeToSomething<DataTypeDateTime64, ToStartOfMicrosecondImpl>;

--- a/src/Functions/today.cpp
+++ b/src/Functions/today.cpp
@@ -91,13 +91,13 @@ REGISTER_FUNCTION(Today)
         {
             "Usage example",
             "SELECT today() AS today, curdate() AS curdate, current_date() AS current_date FORMAT Pretty",
-            R"(
+R"(
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃      today ┃    curdate ┃ current_date ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
 │ 2024-03-03 │ 2024-03-03 │   2024-03-03 │
 └────────────┴────────────┴──────────────┘    
-            )"
+)"
         }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};

--- a/src/Functions/today.cpp
+++ b/src/Functions/today.cpp
@@ -83,10 +83,10 @@ public:
 
 REGISTER_FUNCTION(Today)
 {
-    FunctionDocumentation::Description description = "Returns the current date at moment of query analysis. It is the same as `toDate(now())`.";
+    FunctionDocumentation::Description description = "Returns the current date at moment of query analysis. Same as `toDate(now())`.";
     FunctionDocumentation::Syntax syntax = "today()";
     FunctionDocumentation::Arguments arguments = {};
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns the current date", {"DateTime"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the current date", {"Date"}};
     FunctionDocumentation::Examples example = {
         {
             "Usage example",
@@ -95,7 +95,7 @@ R"(
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃      today ┃    curdate ┃ current_date ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
-│ 2024-03-03 │ 2024-03-03 │   2024-03-03 │
+│ 2025-03-03 │ 2025-03-03 │   2025-03-03 │
 └────────────┴────────────┴──────────────┘
 )"
         }

--- a/src/Functions/today.cpp
+++ b/src/Functions/today.cpp
@@ -83,7 +83,28 @@ public:
 
 REGISTER_FUNCTION(Today)
 {
-    factory.registerFunction<TodayOverloadResolver>();
+    FunctionDocumentation::Description description = "Returns the current date at moment of query analysis. It is the same as `toDate(now())`.";
+    FunctionDocumentation::Syntax syntax = "today()";
+    FunctionDocumentation::Arguments arguments = {};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the current date", {"DateTime"}};
+    FunctionDocumentation::Examples example = {
+        {
+            "Usage example",
+            "SELECT today() AS today, curdate() AS curdate, current_date() AS current_date FORMAT Pretty",
+            R"(
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃      today ┃    curdate ┃ current_date ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 2024-03-03 │ 2024-03-03 │   2024-03-03 │
+└────────────┴────────────┴──────────────┘    
+            )"
+        }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::DateAndTime;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<TodayOverloadResolver>(documentation);
     factory.registerAlias("current_date", TodayOverloadResolver::name, FunctionFactory::Case::Insensitive);
     factory.registerAlias("curdate", TodayOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }

--- a/src/Functions/today.cpp
+++ b/src/Functions/today.cpp
@@ -96,14 +96,14 @@ R"(
 ┃      today ┃    curdate ┃ current_date ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
 │ 2024-03-03 │ 2024-03-03 │   2024-03-03 │
-└────────────┴────────────┴──────────────┘    
+└────────────┴────────────┴──────────────┘
 )"
         }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::DateAndTime;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<TodayOverloadResolver>(documentation);
     factory.registerAlias("current_date", TodayOverloadResolver::name, FunctionFactory::Case::Insensitive);
     factory.registerAlias("curdate", TodayOverloadResolver::name, FunctionFactory::Case::Insensitive);

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -163,7 +163,6 @@ formatReadableTimeDelta
 formatRow
 formatRowNoNewline
 fragment
-fromDaysSinceYearZero32
 fromUnixTimestamp64Micro
 fromUnixTimestamp64Milli
 fromUnixTimestamp64Nano
@@ -580,7 +579,6 @@ toIntervalYear
 toJSONString
 toLowCardinality
 toNullable
-toStartOfMillisecond
 toString
 toStringCutToZero
 toTime
@@ -622,7 +620,6 @@ toUnixTimestamp64Milli
 toUnixTimestamp64Nano
 toUnixTimestamp64Second
 toValidUTF8
-today
 transactionID
 transactionLatestSnapshot
 transactionOldestSnapshot

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -251,7 +251,6 @@ formatReadableTimeDelta
 formatRow
 formatRowNoNewline
 fragment
-fromDaysSinceYearZero32
 fromUnixTimestamp64Micro
 fromUnixTimestamp64Milli
 fromUnixTimestamp64Nano
@@ -741,7 +740,6 @@ toIntervalYear
 toJSONString
 toLowCardinality
 toNullable
-toStartOfMillisecond
 toString
 toStringCutToZero
 toTime
@@ -784,7 +782,6 @@ toUnixTimestamp64Milli
 toUnixTimestamp64Nano
 toUnixTimestamp64Second
 toValidUTF8
-today
 tokens
 topLevelDomain
 topLevelDomainRFC


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Registers documentation for source code documentation which was written but not registered, and adds documentation for one function which I missed.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
