### PR TITLE
ParallelReplicas: avoid full scan with empty ranges to read

### DIFF
--- a/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
+++ b/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
@@ -99,7 +99,7 @@ std::pair<QueryPlanPtr, bool> createLocalPlanForParallelReplicas(
     { return coordinator->handleRequest(std::move(req)); };
 
     auto read_from_merge_tree_parallel_replicas = reading->createLocalParallelReplicasReadingStep(
-        analyzed_result_ptr, std::move(all_ranges_cb), std::move(read_task_cb), replica_number);
+        context, analyzed_result_ptr, std::move(all_ranges_cb), std::move(read_task_cb), replica_number);
     node->step = std::move(read_from_merge_tree_parallel_replicas);
 
     addConvertingActions(*query_plan, header, /*has_missing_objects=*/false);

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -416,6 +416,7 @@ ReadFromMergeTree::ReadFromMergeTree(
 }
 
 std::unique_ptr<ReadFromMergeTree> ReadFromMergeTree::createLocalParallelReplicasReadingStep(
+    ContextPtr & context_,
     AnalysisResultPtr analyzed_result_ptr_,
     MergeTreeAllRangesCallback all_ranges_callback_,
     MergeTreeReadTaskCallback read_task_callback_,
@@ -429,7 +430,7 @@ std::unique_ptr<ReadFromMergeTree> ReadFromMergeTree::createLocalParallelReplica
         data,
         getQueryInfo(),
         getStorageSnapshot(),
-        getContext(),
+        context_,
         block_size.max_block_size_rows,
         requested_num_streams,
         max_block_numbers_to_read,

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -157,6 +157,7 @@ public:
     ReadFromMergeTree(ReadFromMergeTree &&) noexcept = default;
 
     std::unique_ptr<ReadFromMergeTree> createLocalParallelReplicasReadingStep(
+        ContextPtr & context_,
         AnalysisResultPtr analyzed_result_ptr_,
         MergeTreeAllRangesCallback all_ranges_callback_,
         MergeTreeReadTaskCallback read_task_callback_,

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -326,6 +326,8 @@ private:
     int getSortDirection() const;
     void updateSortDescription();
 
+    bool isParallelReplicasLocalPlanForInitiator() const;
+
     mutable AnalysisResultPtr analyzed_result_ptr;
     VirtualFields shared_virtual_fields;
 

--- a/tests/queries/0_stateless/03581_parallel_replicas_read_empty_ranges.reference
+++ b/tests/queries/0_stateless/03581_parallel_replicas_read_empty_ranges.reference
@@ -1,0 +1,8 @@
+Primary key:	0
+Skip index MinMax:	0
+Skip index Set:	0
+
+Rows read:
+0
+0
+0

--- a/tests/queries/0_stateless/03581_parallel_replicas_read_empty_ranges.sql
+++ b/tests/queries/0_stateless/03581_parallel_replicas_read_empty_ranges.sql
@@ -1,0 +1,38 @@
+set allow_experimental_parallel_reading_from_replicas = 1,
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+
+drop table if exists 03581_data;
+
+create table 03581_data (
+    key UInt32,
+
+    val_minmax UInt32,
+    val_set UInt32,
+
+    index skip_minmax val_minmax type set(0) granularity 1,
+    index skip_set val_set type set(0) granularity 1,
+)
+engine = MergeTree
+order by key
+settings index_granularity = 10;
+
+insert into 03581_data select number, number, number from numbers(1000);
+
+select 'Primary key:', count() from 03581_data where key = 2000;
+select 'Skip index MinMax:', count() from 03581_data where val_minmax = 2000;
+select 'Skip index Set:', count() from 03581_data where val_set = 2000;
+
+select '';
+select 'Rows read:';
+
+system flush logs query_log;
+
+select read_rows
+from system.query_log
+where current_database = currentDatabase()
+  and type = 'QueryFinish'
+  and query ilike '% from 03581_data where %'
+order by event_time_microseconds desc;
+
+drop table 03581_data;


### PR DESCRIPTION
Closes #80789.

When reading from parallel replicas, by default local plan is enabled, and index analysis happens only during building local plan at initiator. In case index analysis results in empty set of ranges, local plan initialization returns NullSource, without any notice of parallel replicas coordinator (which normally happens during construction of MergeTree pipe).

Fixing it by explicit initialization of coordinator reading state in case of empty ranges to read.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Eliminated full scans for the cases when index analysis results in empty ranges for parallel replicas reading

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)