### PR TITLE
Fix flaky test_backup_restore_new/test_cancel_backup.py

### DIFF
--- a/tests/integration/test_backup_restore_new/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_new/test_cancel_backup.py
@@ -6,6 +6,11 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV, assert_eq_with_retry
 
+# We expect backup/restore query cancellation to be fast enough,
+# though in CI cancellation may occasionally take slightly more
+# then 2 seconds (2000 - 2500 ms).
+kill_duration_ms_threshold = 4000
+
 cluster = ClickHouseCluster(__file__)
 
 main_configs = [
@@ -105,13 +110,7 @@ def cancel_backup(backup_id):
             f"SELECT query_duration_ms FROM system.query_log WHERE query_kind='KillQuery' AND query LIKE '%{backup_id}%' AND type='QueryFinish'"
         )
     )
-    # Common failures in CI with 2000:
-    # E       assert 2520 < 2000
-    # E       assert 2210 < 2000
-    # E       assert 2160 < 2000
-    # E       assert 2143 < 2000
-    # E       assert 2495 < 2000
-    assert kill_duration_ms < 4000  # Query must be cancelled quickly
+    assert kill_duration_ms < kill_duration_ms_threshold
 
 
 # Start restoring from a backup.
@@ -177,7 +176,7 @@ def cancel_restore(restore_id):
             f"SELECT query_duration_ms FROM system.query_log WHERE query_kind='KillQuery' AND query LIKE '%{restore_id}%' AND type='QueryFinish'"
         )
     )
-    assert kill_duration_ms < 2000  # Query must be cancelled quickly
+    assert kill_duration_ms < kill_duration_ms_threshold
 
 
 # Test that BACKUP and RESTORE operations can be cancelled with KILL QUERY.


### PR DESCRIPTION
There is a dozen of [failures](https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IHRvRGF0ZSgnMjAyNS0wOC0wNCcpIC0gSU5URVJWQUwgMzAgREFZCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgKHRlc3Rfc3RhdHVzIExJS0UgJ0YlJyBPUiB0ZXN0X3N0YXR1cyBMSUtFICdFJScpIAogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCB0ZXN0X25hbWUgPSAndGVzdF9iYWNrdXBfcmVzdG9yZV9uZXcvdGVzdF9jYW5jZWxfYmFja3VwLnB5Ojp0ZXN0X2NhbmNlbF9iYWNrdXAnCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWU=) during the last 30 days, and all of them related to restore cancellation taking slightly more than 2sec (2000 - 2300 ms). Increasing this threshold (like it was done for backups cancellation in #77421) should fix these failures.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)