### PR TITLE
Functional tests: disable test `03208_multiple_joins_with_storage_join` in parallel replicas job

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -67,9 +67,11 @@
 02498_storage_join_key_positions.gen
 03447_storage_join_unsupported_keys
 
-    https://github.com/ClickHouse/ClickHouse/pull/73609
+    https://github.com/ClickHouse/ClickHouse/issues/74360
+    LOGICAL ERROR https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=84536&sha=516c114f38828a2853efa3f0935f19d11b7c0d23&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+ParallelReplicas%2C+s3+storage%2C+parallel%29
+    https://github.com/ClickHouse/ClickHouse/issues/81144
     Cannot parse string
-03208_multiple_joins_with_storage_join
+    03208_multiple_joins_with_storage_join
 
     GLOBAL IN engine set not supported (Method read is not supported by storage Set. (NOT_IMPLEMENTED) (version 25.1.1.1927 (official build)) (from [::1]:42612) (comment: 01231_operator_null_in.sql) (in query: SELECT count() == 1 FROM null_in WHERE i global in test_set)
 01231_operator_null_in

--- a/tests/queries/0_stateless/03208_multiple_joins_with_storage_join.sql
+++ b/tests/queries/0_stateless/03208_multiple_joins_with_storage_join.sql
@@ -1,5 +1,4 @@
-#!/usr/bin/env -S ${HOME}/clickhouse-client --queries-file
-# Tags: no-parallel-replicas
+-- Tags: no-parallel-replicas
 
 DROP TABLE IF EXISTS tab;
 CREATE TABLE tab ( `k` Nullable(UInt32), `k1` Nullable(UInt32), `k2` Nullable(UInt32), `v` String ) ENGINE = MergeTree ORDER BY tuple();

--- a/tests/queries/0_stateless/03208_multiple_joins_with_storage_join.sql
+++ b/tests/queries/0_stateless/03208_multiple_joins_with_storage_join.sql
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S ${HOME}/clickhouse-client --queries-file
+# Tags: no-parallel-replicas
 
 DROP TABLE IF EXISTS tab;
 CREATE TABLE tab ( `k` Nullable(UInt32), `k1` Nullable(UInt32), `k2` Nullable(UInt32), `v` String ) ENGINE = MergeTree ORDER BY tuple();


### PR DESCRIPTION
Disable test `03208_multiple_joins_with_storage_join` because it start throwing LOGICAL ERROR: https://github.com/ClickHouse/ClickHouse/issues/81144#issuecomment-3148705909

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
