### PR TITLE
Check if correlated subquery is used in distributed context

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -232,6 +232,8 @@ void QueryAnalyzer::resolve(QueryTreeNodePtr & node, const QueryTreeNodePtr & ta
                             node->getNodeTypeName());
         }
     }
+
+    validateCorrelatedSubqueries(node);
 }
 
 void QueryAnalyzer::resolveConstantExpression(QueryTreeNodePtr & node, const QueryTreeNodePtr & table_expression, ContextPtr context)
@@ -260,6 +262,8 @@ void QueryAnalyzer::resolveConstantExpression(QueryTreeNodePtr & node, const Que
         resolveExpressionNodeList(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
     else
         resolveExpressionNode(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+
+    validateCorrelatedSubqueries(node);
 }
 
 bool isFromJoinTree(const IQueryTreeNode * node_source, const IQueryTreeNode * tree_node)

--- a/src/Analyzer/ValidationUtils.cpp
+++ b/src/Analyzer/ValidationUtils.cpp
@@ -1,13 +1,14 @@
 #include <Analyzer/ValidationUtils.h>
 
+#include <Analyzer/AggregationUtils.h>
+#include <Analyzer/ColumnNode.h>
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
-#include <Analyzer/ColumnNode.h>
-#include <Analyzer/TableNode.h>
-#include <Analyzer/QueryNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
-#include <Analyzer/AggregationUtils.h>
+#include <Analyzer/QueryNode.h>
+#include <Analyzer/TableNode.h>
 #include <Analyzer/WindowFunctionsUtils.h>
+#include <Storages/IStorage.h>
 
 namespace DB
 {
@@ -478,6 +479,66 @@ void validateTreeSize(const QueryTreeNodePtr & node,
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "Query tree is too big. Maximum: {}",
             max_size);
+}
+
+void validateCorrelatedSubqueries(const QueryTreeNodePtr & node)
+{
+    bool has_remote = false;
+    bool has_correlated_subquery = false;
+    QueryTreeNodes nodes_to_process = { node };
+
+    while (!nodes_to_process.empty())
+    {
+        auto current_node = nodes_to_process.back();
+        nodes_to_process.pop_back();
+
+        switch (current_node->getNodeType())
+        {
+            case QueryTreeNodeType::QUERY:
+            {
+                auto & query_node = current_node->as<QueryNode &>();
+                if (query_node.isCorrelated())
+                    has_correlated_subquery = true;
+                break;
+            }
+            case QueryTreeNodeType::UNION:
+            {
+                auto & union_node = current_node->as<UnionNode &>();
+                if (union_node.isCorrelated())
+                    has_correlated_subquery = true;
+                break;
+            }
+            case QueryTreeNodeType::TABLE:
+            {
+                auto & table_node = current_node->as<TableNode &>();
+                const auto & storage = table_node.getStorage();
+                if (storage->isRemote())
+                    has_remote = true;
+                break;
+            }
+            case QueryTreeNodeType::TABLE_FUNCTION:
+            {
+                auto & table_function_node = current_node->as<TableFunctionNode &>();
+                const auto & storage = table_function_node.getStorage();
+                if (storage->isRemote())
+                    has_remote = true;
+                break;
+            }
+            default:
+                break;
+        }
+
+        if (has_remote && has_correlated_subquery)
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+                "Correlated subqueries are not supported with remote tables. In query {}",
+                node->formatASTForErrorMessage());
+
+        for (const auto & child : current_node->getChildren())
+        {
+            if (child)
+                nodes_to_process.push_back(child);
+        }
+    }
 }
 
 }

--- a/src/Analyzer/ValidationUtils.cpp
+++ b/src/Analyzer/ValidationUtils.cpp
@@ -512,7 +512,7 @@ void validateCorrelatedSubqueries(const QueryTreeNodePtr & node)
             {
                 auto & table_node = current_node->as<TableNode &>();
                 const auto & storage = table_node.getStorage();
-                if (storage->isRemote())
+                if (storage && storage->isRemote())
                     has_remote = true;
                 break;
             }
@@ -520,7 +520,7 @@ void validateCorrelatedSubqueries(const QueryTreeNodePtr & node)
             {
                 auto & table_function_node = current_node->as<TableFunctionNode &>();
                 const auto & storage = table_function_node.getStorage();
-                if (storage->isRemote())
+                if (storage && storage->isRemote())
                     has_remote = true;
                 break;
             }

--- a/src/Analyzer/ValidationUtils.h
+++ b/src/Analyzer/ValidationUtils.h
@@ -41,6 +41,7 @@ void validateTreeSize(const QueryTreeNodePtr & node,
     size_t max_size,
     std::unordered_map<QueryTreeNodePtr, size_t> & node_to_tree_size);
 
+void validateCorrelatedSubqueries(const QueryTreeNodePtr & node);
 
 /** Compare node with group by key node.
   * Such comparison does not take into account aliases, but checks types and column sources.

--- a/tests/queries/0_stateless/03576_analyzer_distributed_correlated_subquery.sql
+++ b/tests/queries/0_stateless/03576_analyzer_distributed_correlated_subquery.sql
@@ -1,5 +1,5 @@
 SET enable_analyzer = 1;
 
 CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
-CREATE TABLE t1 (c0 Int) ENGINE = Distributed('default', default, t0);
+CREATE TABLE t1 (c0 Int) ENGINE = Distributed('test_cluster_two_shards', default, t0);
 SELECT (SELECT _shard_num) FROM t1 GROUP BY _shard_num SETTINGS allow_experimental_correlated_subqueries = 1; -- { serverError NOT_IMPLEMENTED }

--- a/tests/queries/0_stateless/03576_analyzer_distributed_correlated_subquery.sql
+++ b/tests/queries/0_stateless/03576_analyzer_distributed_correlated_subquery.sql
@@ -1,0 +1,5 @@
+SET enable_analyzer = 1;
+
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE t1 (c0 Int) ENGINE = Distributed('default', default, t0);
+SELECT (SELECT _shard_num) FROM t1 GROUP BY _shard_num SETTINGS allow_experimental_correlated_subqueries = 1; -- { serverError NOT_IMPLEMENTED }


### PR DESCRIPTION
### Changelog category (leave one):

- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add a check if a correlated subquery is used in a distributed context to avoid a crash. Fixes #82205.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
