### PR TITLE
CI: Disable scrapping of minio_audit_log for TSAN

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -868,6 +868,11 @@ quit
             "minio_audit_logs",
             "minio_server_logs",
         ]
+
+        if "_tasn" in Info.job_name:
+            print("minio_audit_logs scrapping is too slow with tsan - skip")
+            TABLES.remove("minio_audit_logs")
+
         command_args = self.LOGS_SAVER_CLIENT_OPTIONS
         # command_args += f" --config-file={self.ch_config_dir}/config.xml"
         command_args += " --only-system-tables --stacktrace"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Disable scrapping of a slow minio_audit_log table as a workaround
```
Code: 160. DB::Exception: Estimated query execution time (639.25121 seconds) is too long. Maximum: 600. Estimated rows to process: 1485337 (697727 read in 300.28393 seconds).: While executing MergeTreeSelect(pool: ReadPool, algorithm: Thread). (TOO_SLOW), Stack trace (when copying this message, always include the lines below):
```

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
