### PR TITLE
Text index: add internal bloom filter layer

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -41,7 +41,7 @@ CREATE TABLE tab
 (
     `key` UInt64,
     `str` String,
-    INDEX inv_idx(str) TYPE text(tokenizer = 'default|ngram|split|no_op' [, ngram_size = N] [, separators = []] [, segment_digestion_threshold_bytes = B]) [GRANULARITY 64]
+    INDEX inv_idx(str) TYPE text(tokenizer = 'default|ngram|split|no_op' [, ngram_size = N] [, separators = []] [, segment_digestion_threshold_bytes = B] [, bloom_filter_false_positive_rate = R]) [GRANULARITY 64]
 )
 ENGINE = MergeTree
 ORDER BY key
@@ -76,9 +76,9 @@ For example, with separators = `['%21', '%']` string `%21abc` would be tokenized
 
 <details markdown="1">
 
-<summary>Advanced settings</summary>
+<summary>Advanced parameters</summary>
 
-Optional parameter `segment_digestion_threshold_bytes` parameter determines the byte size of index segments.
+Optional parameter `segment_digestion_threshold_bytes` determines the byte size of index segments.
 
 - `segment_digestion_threshold_bytes = 0`: Unlimited size, a single segment is created for each index granule.
 - `segment_digestion_threshold_bytes = B`: A new segment is created every `B` bytes of text input.
@@ -89,6 +89,12 @@ We do not recommend changing `segment_digestion_threshold_bytes`.
 The default value will work well in virtually all situations.
 The presence of more than one segment causes redundant data storage and slower full-text search queries.
 The only reason to provide a non-zero value (e.g. `256MB`) for `segment_digestion_threshold_bytes` is if you get out-of-memory exceptions during index creation.
+
+Optional parameter `bloom_filter_false_positive_rate` determines the false-positive rate of the bloom filter.
+
+- `bloom_filter_false_positive_rate = R`: A double between 0.0 and 1.0.
+
+Default value: `0.001` (0.1%).
 
 </details>
 

--- a/src/Common/FST.cpp
+++ b/src/Common/FST.cpp
@@ -395,6 +395,9 @@ void FiniteStateTransducer::clear()
 
 std::pair<UInt64, bool> FiniteStateTransducer::getOutput(std::string_view term)
 {
+    if (data.empty())
+        return {0, false};
+
     std::pair<UInt64, bool> result(0, false);
 
     /// Read index of initial state

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6848,7 +6848,7 @@ Allows defining columns with [statistics](../../engines/table-engines/mergetree-
 )", EXPERIMENTAL, allow_experimental_statistic) \
     \
     DECLARE(Bool, allow_experimental_full_text_index, false, R"(
-If it is set to true, allow to use experimental text index.
+If set to true, allow using the experimental text index.
 )", EXPERIMENTAL) \
     DECLARE(Bool, allow_experimental_lightweight_update, false, R"(
 Allow to use lightweight updates.

--- a/src/Interpreters/BloomFilterHash.h
+++ b/src/Interpreters/BloomFilterHash.h
@@ -293,7 +293,7 @@ struct BloomFilterHash
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column type was passed to the bloom filter index.");
     }
 
-    static std::pair<size_t, size_t> calculationBestPractices(double max_conflict_probability)
+    static std::pair<size_t, size_t> calculationBestPractices(double false_positive_rate)
     {
         static const size_t MAX_BITS_PER_ROW = 20;
         static const size_t MAX_HASH_FUNCTION_COUNT = 15;
@@ -305,7 +305,7 @@ struct BloomFilterHash
         /// Otherwise, for those rates the loop won't find any possible values in the lookup table
         /// returning bits_per_row = 19 & size_of_hash_functions = 13. Which are the most restrictive values
         /// to be used with the smallest false positive rates.
-        if (max_conflict_probability >= 0.283)
+        if (false_positive_rate >= 0.283)
             return std::pair<size_t, size_t>(MIN_BITS_PER_ROW, MIN_HASH_FUNCTION_COUNT);
 
         /// For the smallest index per level in probability_lookup_table
@@ -338,11 +338,11 @@ struct BloomFilterHash
 
         for (size_t bits_per_row = 1; bits_per_row < MAX_BITS_PER_ROW; ++bits_per_row)
         {
-            if (probability_lookup_table[bits_per_row][min_probability_index_each_bits[bits_per_row]] <= max_conflict_probability)
+            if (probability_lookup_table[bits_per_row][min_probability_index_each_bits[bits_per_row]] <= false_positive_rate)
             {
                 size_t max_size_of_hash_functions = min_probability_index_each_bits[bits_per_row];
                 for (size_t size_of_hash_functions = max_size_of_hash_functions; size_of_hash_functions > 0; --size_of_hash_functions)
-                    if (probability_lookup_table[bits_per_row][size_of_hash_functions] > max_conflict_probability)
+                    if (probability_lookup_table[bits_per_row][size_of_hash_functions] > false_positive_rate)
                         return std::pair<size_t, size_t>(bits_per_row, size_of_hash_functions + 1);
             }
         }

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -19,10 +19,12 @@ namespace DB
 GinFilterParameters::GinFilterParameters(
     String tokenizer_,
     UInt64 segment_digestion_threshold_bytes_,
+    double bloom_filter_false_positive_rate_,
     std::optional<UInt64> ngram_size_,
     std::optional<std::vector<String>> separators_)
     : tokenizer(std::move(tokenizer_))
     , segment_digestion_threshold_bytes(segment_digestion_threshold_bytes_)
+    , bloom_filter_false_positive_rate(bloom_filter_false_positive_rate_)
     , ngram_size(ngram_size_)
     , separators(separators_)
 {

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -8,6 +8,7 @@ namespace DB
 
 static constexpr UInt64 UNLIMITED_ROWS_PER_POSTINGS_LIST = 0;
 static constexpr UInt64 DEFAULT_NGRAM_SIZE = 3;
+static constexpr auto DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE = 0.001; /// 0.1%
 
 static inline constexpr auto TEXT_INDEX_NAME = "text";
 
@@ -22,12 +23,15 @@ struct GinFilterParameters
     GinFilterParameters(
         String tokenizer_,
         UInt64 segment_digestion_threshold_bytes_,
+        double bloom_filter_false_positive_rate_,
         std::optional<UInt64> ngram_size_,
         std::optional<std::vector<String>> separators_);
 
     String tokenizer;
     /// Digestion threshold to split a segment. By default, it is 0 (zero) which means unlimited.
     UInt64 segment_digestion_threshold_bytes;
+    /// Bloom filter false positive rate, by default it's 0.1%.
+    double bloom_filter_false_positive_rate;
     /// for ngram tokenizer
     std::optional<UInt64> ngram_size;
     /// for split tokenizer

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -1,13 +1,16 @@
 // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 
+#include <IO/VarInt.h>
 #include <Storages/MergeTree/GinIndexStore.h>
 #include <Columns/ColumnString.h>
 #include <Common/FST.h>
+#include <Common/HashTable/HashSet.h>
 #include <Compression/CompressionFactory.h>
 #include <Compression/ICompressionCodec.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/BloomFilterHash.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromFile.h>
@@ -154,6 +157,67 @@ GinIndexPostingsListPtr GinIndexPostingsBuilder::deserialize(ReadBuffer & buffer
     }
 }
 
+GinSegmentDictionaryBloomFilter::GinSegmentDictionaryBloomFilter(UInt64 unique_count_, size_t bits_per_rows_, size_t num_hashes_)
+    : unique_count(unique_count_)
+    , bits_per_row(bits_per_rows_)
+    , num_hashes(num_hashes_)
+    , bloom_filter(((bits_per_row * unique_count) + sizeof(BloomFilter::UnderType) - 1) / sizeof(BloomFilter::UnderType), num_hashes, 0)
+{
+}
+
+void GinSegmentDictionaryBloomFilter::add(std::string_view token)
+{
+    bloom_filter.add(token.data(), token.size());
+}
+
+bool GinSegmentDictionaryBloomFilter::contains(std::string_view token)
+{
+    return bloom_filter.find(token.data(), token.size());
+}
+
+UInt64 GinSegmentDictionaryBloomFilter::serialize(WriteBuffer & write_buffer)
+{
+    UInt64 bytes_written = 0;
+    const size_t filter_size_bytes = bloom_filter.getFilter().size() * sizeof(BloomFilter::UnderType);
+
+    writeVarUInt(unique_count, write_buffer);
+    bytes_written += getLengthOfVarUInt(unique_count);
+
+    writeVarUInt(bits_per_row, write_buffer);
+    bytes_written += getLengthOfVarUInt(bits_per_row);
+
+    writeVarUInt(num_hashes, write_buffer);
+    bytes_written += getLengthOfVarUInt(num_hashes);
+
+    writeVarUInt(filter_size_bytes, write_buffer);
+    bytes_written += getLengthOfVarUInt(filter_size_bytes);
+
+    write_buffer.write(reinterpret_cast<const char *>(bloom_filter.getFilter().data()), filter_size_bytes);
+    bytes_written += filter_size_bytes;
+
+    return bytes_written;
+}
+
+std::unique_ptr<GinSegmentDictionaryBloomFilter> GinSegmentDictionaryBloomFilter::deserialize(ReadBuffer & read_buffer)
+{
+    UInt64 unique_count;
+    readVarUInt(unique_count, read_buffer);
+
+    UInt64 bits_per_row = 0;
+    readVarUInt(bits_per_row, read_buffer);
+
+    UInt64 num_hashes = 0;
+    readVarUInt(num_hashes, read_buffer);
+
+    UInt64 filter_size_bytes = 0;
+    readVarUInt(filter_size_bytes, read_buffer);
+
+    auto gin_bloom_filter = std::make_unique<GinSegmentDictionaryBloomFilter>(unique_count, bits_per_row, num_hashes);
+    read_buffer.readStrict(reinterpret_cast<char *>(gin_bloom_filter->bloom_filter.getFilter().data()), filter_size_bytes);
+
+    return gin_bloom_filter;
+}
+
 GinIndexStore::GinIndexStore(const String & name_, DataPartStoragePtr storage_)
     : name(name_)
     , storage(storage_)
@@ -164,11 +228,13 @@ GinIndexStore::GinIndexStore(
     const String & name_,
     DataPartStoragePtr storage_,
     MutableDataPartStoragePtr data_part_storage_builder_,
-    UInt64 segment_digestion_threshold_bytes_)
+    UInt64 segment_digestion_threshold_bytes_,
+    double bloom_filter_false_positive_rate_)
     : name(name_)
     , storage(storage_)
     , data_part_storage_builder(data_part_storage_builder_)
     , segment_digestion_threshold_bytes(segment_digestion_threshold_bytes_)
+    , bloom_filter_false_positive_rate(bloom_filter_false_positive_rate_)
 {
 }
 
@@ -272,6 +338,9 @@ void GinIndexStore::finalize()
     if (metadata_file_stream)
         metadata_file_stream->finalize();
 
+    if (bloom_filter_file_stream)
+        bloom_filter_file_stream->finalize();
+
     if (dict_file_stream)
         dict_file_stream->finalize();
 
@@ -283,6 +352,9 @@ void GinIndexStore::cancel() noexcept
 {
     if (metadata_file_stream)
         metadata_file_stream->cancel();
+
+    if (bloom_filter_file_stream)
+        bloom_filter_file_stream->cancel();
 
     if (dict_file_stream)
         dict_file_stream->cancel();
@@ -316,10 +388,12 @@ void GinIndexStore::initSegmentId()
 void GinIndexStore::initFileStreams()
 {
     String metadata_file_name = getName() + GIN_SEGMENT_METADATA_FILE_TYPE;
+    String bloom_filter_file_name = getName() + GIN_BLOOM_FILTER_FILE_TYPE;
     String dict_file_name = getName() + GIN_DICTIONARY_FILE_TYPE;
     String postings_file_name = getName() + GIN_POSTINGS_FILE_TYPE;
 
     metadata_file_stream = data_part_storage_builder->writeFile(metadata_file_name, 4096, WriteMode::Append, {});
+    bloom_filter_file_stream = data_part_storage_builder->writeFile(bloom_filter_file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
     dict_file_stream = data_part_storage_builder->writeFile(dict_file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
     postings_file_stream = data_part_storage_builder->writeFile(postings_file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
 }
@@ -337,21 +411,39 @@ void GinIndexStore::writeSegmentId()
     ostr->finalize();
 }
 
+namespace
+{
+/// Initialize bloom filter from tokens from the term dictionary
+GinSegmentDictionaryBloomFilter initializeBloomFilter(
+        const GinIndexStore::GinIndexPostingsBuilderContainer & postings,
+        double bloom_filter_false_positive_rate)
+{
+    auto number_of_unique_terms = postings.size(); /// postings is a dictionary
+    const auto [bits_per_rows, num_hashes] = BloomFilterHash::calculationBestPractices(bloom_filter_false_positive_rate);
+    GinSegmentDictionaryBloomFilter bloom_filter(number_of_unique_terms, bits_per_rows, num_hashes);
+    for (const auto & [token, _] : postings)
+        bloom_filter.add(token);
+    return bloom_filter;
+}
+}
+
 void GinIndexStore::writeSegment()
 {
     if (metadata_file_stream == nullptr)
         initFileStreams();
 
+    /// Write segment
+    metadata_file_stream->write(reinterpret_cast<char *>(&current_segment), sizeof(GinIndexSegment));
+
     using TokenPostingsBuilderPair = std::pair<std::string_view, GinIndexPostingsBuilderPtr>;
     using TokenPostingsBuilderPairs = std::vector<TokenPostingsBuilderPair>;
 
-    /// Write segment
-    metadata_file_stream->write(reinterpret_cast<char *>(&current_segment), sizeof(GinIndexSegment));
     TokenPostingsBuilderPairs token_postings_list_pairs;
     token_postings_list_pairs.reserve(current_postings.size());
-
     for (const auto & [token, postings_list] : current_postings)
         token_postings_list_pairs.push_back({token, postings_list});
+
+    GinSegmentDictionaryBloomFilter bloom_filter = initializeBloomFilter(current_postings, bloom_filter_false_positive_rate);
 
     /// Sort token-postings list pairs since all tokens have to be added in FST in sorted order
     std::sort(token_postings_list_pairs.begin(), token_postings_list_pairs.end(),
@@ -371,7 +463,11 @@ void GinIndexStore::writeSegment()
         i++;
         current_segment.postings_start_offset += posting_list_byte_size;
     }
-    ///write item dictionary
+
+    /// Write bloom filter
+    current_segment.bloom_filter_start_offset += bloom_filter.serialize(*bloom_filter_file_stream);
+
+    /// Write item dictionary
     std::vector<UInt8> buffer;
     WriteBufferFromVector<std::vector<UInt8>> write_buf(buffer);
     FST::FstBuilder fst_builder(write_buf);
@@ -423,6 +519,7 @@ void GinIndexStore::writeSegment()
     current_segment.segment_id = getNextSegmentID();
 
     metadata_file_stream->sync();
+    bloom_filter_file_stream->sync();
     dict_file_stream->sync();
     postings_file_stream->sync();
 }
@@ -436,52 +533,74 @@ GinIndexStoreDeserializer::GinIndexStoreDeserializer(const GinIndexStorePtr & st
 void GinIndexStoreDeserializer::initFileStreams()
 {
     String metadata_file_name = store->getName() + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE;
+    String bloom_filter_file_name = store->getName() + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE;
     String dict_file_name = store->getName() + GinIndexStore::GIN_DICTIONARY_FILE_TYPE;
     String postings_file_name = store->getName() + GinIndexStore::GIN_POSTINGS_FILE_TYPE;
 
     metadata_file_stream = store->storage->readFile(metadata_file_name, {}, std::nullopt, std::nullopt);
+    bloom_filter_file_stream = store->storage->readFile(bloom_filter_file_name, {}, std::nullopt, std::nullopt);
     dict_file_stream = store->storage->readFile(dict_file_name, {}, std::nullopt, std::nullopt);
     postings_file_stream = store->storage->readFile(postings_file_name, {}, std::nullopt, std::nullopt);
 }
+
 void GinIndexStoreDeserializer::readSegments()
 {
     UInt32 num_segments = store->getNumOfSegments();
     if (num_segments == 0)
         return;
 
-    using GinIndexSegments = std::vector<GinIndexSegment>;
-    GinIndexSegments segments (num_segments);
-
     assert(metadata_file_stream != nullptr);
 
-    metadata_file_stream->readStrict(reinterpret_cast<char *>(segments.data()), num_segments * sizeof(GinIndexSegment));
-    for (UInt32 i = 0; i < num_segments; ++i)
+    if (store->getVersion() == GinIndexStore::Format::v1)
     {
-        auto seg_id = segments[i].segment_id;
-        auto seg_dict = std::make_shared<GinSegmentDictionary>();
-        seg_dict->postings_start_offset = segments[i].postings_start_offset;
-        seg_dict->dict_start_offset = segments[i].dict_start_offset;
-        store->segment_dictionaries[seg_id] = seg_dict;
+        std::vector<GinIndexSegment> segments(num_segments);
+        metadata_file_stream->readStrict(reinterpret_cast<char *>(segments.data()), num_segments * sizeof(GinIndexSegment));
+        for (UInt32 i = 0; i < num_segments; ++i)
+        {
+            auto seg_dict = std::make_shared<GinSegmentDictionary>();
+            seg_dict->postings_start_offset = segments[i].postings_start_offset;
+            seg_dict->dict_start_offset = segments[i].dict_start_offset;
+            seg_dict->bloom_filter_start_offset = segments[i].bloom_filter_start_offset;
+            store->segment_dictionaries[segments[i].segment_id] = seg_dict;
+        }
     }
 }
 
-void GinIndexStoreDeserializer::readSegmentDictionaries()
+void GinIndexStoreDeserializer::prepareSegmentsForReading()
 {
     for (UInt32 seg_index = 0; seg_index < store->getNumOfSegments(); ++seg_index)
-        readSegmentDictionary(seg_index);
+        prepareSegmentForReading(seg_index);
 }
 
-void GinIndexStoreDeserializer::readSegmentDictionary(UInt32 segment_id)
+void GinIndexStoreDeserializer::prepareSegmentForReading(UInt32 segment_id)
 {
     /// Check validity of segment_id
     auto it = store->segment_dictionaries.find(segment_id);
     if (it == store->segment_dictionaries.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid segment id {}", segment_id);
 
+    const GinSegmentDictionaryPtr & seg_dict = it->second;
+    switch (auto version = store->getVersion(); version)
+    {
+        case GinIndexStore::Format::v1: {
+            /// V1 supports bloom filter, so we can delay reading a segment until it's needed.
+
+            /// Set file pointer of filter file
+            assert(bloom_filter_file_stream != nullptr);
+            bloom_filter_file_stream->seek(it->second->bloom_filter_start_offset, SEEK_SET);
+            seg_dict->bloom_filter = GinSegmentDictionaryBloomFilter::deserialize(*bloom_filter_file_stream);
+            break;
+        }
+    }
+}
+
+void GinIndexStoreDeserializer::readSegmentFST(GinSegmentDictionaryPtr segment_dictionary)
+{
     /// Set file pointer of dictionary file
     assert(dict_file_stream != nullptr);
-    dict_file_stream->seek(it->second->dict_start_offset, SEEK_SET);
+    dict_file_stream->seek(segment_dictionary->dict_start_offset, SEEK_SET);
 
+    segment_dictionary->fst = std::make_unique<FST::FiniteStateTransducer>();
     switch (auto version = store->getVersion(); version)
     {
         case GinIndexStore::Format::v1: {
@@ -490,8 +609,8 @@ void GinIndexStoreDeserializer::readSegmentDictionary(UInt32 segment_id)
             readVarUInt(fst_size_header, *dict_file_stream);
 
             size_t uncompressed_fst_size = fst_size_header >> 1;
-            it->second->offsets.getData().clear();
-            it->second->offsets.getData().resize(uncompressed_fst_size);
+            segment_dictionary->fst->getData().clear();
+            segment_dictionary->fst->getData().resize(uncompressed_fst_size);
             if (fst_size_header & 0x1) /// FST is compressed
             {
                 /// Read compressed FST size
@@ -502,12 +621,14 @@ void GinIndexStoreDeserializer::readSegmentDictionary(UInt32 segment_id)
                 dict_file_stream->readStrict(buf.data(), compressed_fst_size);
                 const auto & codec = DB::GinIndexCompressionFactory::zstdCodec();
                 codec->decompress(
-                    buf.data(), static_cast<UInt32>(compressed_fst_size), reinterpret_cast<char *>(it->second->offsets.getData().data()));
+                    buf.data(),
+                    static_cast<UInt32>(compressed_fst_size),
+                    reinterpret_cast<char *>(segment_dictionary->fst->getData().data()));
             }
             else
             {
                 /// Read uncompressed FST blob
-                dict_file_stream->readStrict(reinterpret_cast<char *>(it->second->offsets.getData().data()), uncompressed_fst_size);
+                dict_file_stream->readStrict(reinterpret_cast<char *>(segment_dictionary->fst->getData().data()), uncompressed_fst_size);
             }
             break;
         }
@@ -523,7 +644,17 @@ GinSegmentedPostingsListContainer GinIndexStoreDeserializer::readSegmentedPostin
     {
         auto segment_id = seg_dict.first;
 
-        auto [offset, found] = seg_dict.second->offsets.getOutput(term);
+        if (seg_dict.second->fst == nullptr)
+        {
+            /// Segment dictionary is not loaded, first check the term in bloom filter
+            if (seg_dict.second->bloom_filter && !seg_dict.second->bloom_filter->contains(term))
+                continue;
+
+            /// Term might be in segment dictionary
+            readSegmentFST(seg_dict.second);
+        }
+
+        auto [offset, found] = seg_dict.second->fst->getOutput(term);
         if (!found)
             continue;
 
@@ -543,7 +674,7 @@ GinPostingsCachePtr GinIndexStoreDeserializer::createPostingsCacheFromTerms(cons
     for (const auto & term : terms)
     {
         // Make sure don't read for duplicated terms
-        if (postings_cache->find(term) != postings_cache->end())
+        if (postings_cache->contains(term))
             continue;
 
         auto container = readSegmentedPostingsLists(term);
@@ -582,7 +713,7 @@ GinIndexStorePtr GinIndexStoreFactory::get(const String & name, DataPartStorageP
 
         GinIndexStoreDeserializer deserializer(store);
         deserializer.readSegments();
-        deserializer.readSegmentDictionaries();
+        deserializer.prepareSegmentsForReading();
 
         stores[key] = store;
 
@@ -605,9 +736,12 @@ void GinIndexStoreFactory::remove(const String & part_path)
 
 bool isGinFile(const String & file_name)
 {
-    return file_name.ends_with(".gin_dict") || file_name.ends_with(".gin_post") || file_name.ends_with(".gin_seg") || file_name.ends_with(".gin_sid");
+    return file_name.ends_with(GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE)
+        || file_name.ends_with(GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE)
+        || file_name.ends_with(GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE)
+        || file_name.ends_with(GinIndexStore::GIN_DICTIONARY_FILE_TYPE)
+        || file_name.ends_with(GinIndexStore::GIN_POSTINGS_FILE_TYPE);
 }
-
 }
 
 // NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -5,6 +5,7 @@
 #include <Disks/IDisk.h>
 #include <IO/ReadBufferFromFileBase.h>
 #include <IO/WriteBufferFromFileBase.h>
+#include <Interpreters/BloomFilter.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 
 #include <roaring.hh>
@@ -36,7 +37,6 @@
 
 namespace DB
 {
-
 static constexpr UInt64 UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES = 0;
 
 /// GinIndexPostingsList which uses 32-bit Roaring
@@ -90,15 +90,52 @@ struct GinIndexSegment
     /// Start row ID for this segment
     UInt32 next_row_id = 1;
 
-    /// .gin_post file offset of this segment's postings lists
-    UInt64 postings_start_offset = 0;
+    /// .gin_bflt file offset of this segment's bloom filter
+    UInt64 bloom_filter_start_offset = 0;
 
     /// .gin_dict file offset of this segment's dictionaries
     UInt64 dict_start_offset = 0;
+
+    /// .gin_post file offset of this segment's postings lists
+    UInt64 postings_start_offset = 0;
+};
+
+/// This class encapsulates an instance of `BloomFilter` class.
+/// The main responsibility is handling the serialization.
+class GinSegmentDictionaryBloomFilter
+{
+public:
+    GinSegmentDictionaryBloomFilter(UInt64 unique_count_, size_t bits_per_rows_, size_t num_hashes_);
+
+    /// Adds token to bloom filter
+    void add(std::string_view token);
+
+    /// Does the token exist according to the bloom filter?
+    bool contains(std::string_view token);
+
+    /// Serialize into WriteBuffer
+    UInt64 serialize(WriteBuffer & write_buffer);
+    /// Deserialize from ReadBuffer
+
+    static std::unique_ptr<GinSegmentDictionaryBloomFilter> deserialize(ReadBuffer & read_buffer);
+
+private:
+    /// Estimated number of entries
+    const UInt64 unique_count;
+    /// Bit size of the bloom filter
+    const UInt64 bits_per_row;
+    /// Number of hash functions used by the bloom filter
+    const UInt64 num_hashes;
+
+    /// Encapsulated BloomFilter instance
+    BloomFilter bloom_filter;
 };
 
 struct GinSegmentDictionary
 {
+    /// .gin_bflt file offset of this segment's bloom filter
+    UInt64 bloom_filter_start_offset;
+
     /// .gin_post file offset of this segment's postings lists
     UInt64 postings_start_offset;
 
@@ -107,7 +144,10 @@ struct GinSegmentDictionary
 
     /// (Minimized) Finite State Transducer, which can be viewed as a map of <term, offset>, where offset is the
     /// offset to the term's posting list in postings list file
-    FST::FiniteStateTransducer offsets;
+    std::unique_ptr<FST::FiniteStateTransducer> fst;
+
+    /// Bloom filter created from the segment's dictionary
+    std::unique_ptr<GinSegmentDictionaryBloomFilter> bloom_filter;
 };
 
 using GinSegmentDictionaryPtr = std::shared_ptr<GinSegmentDictionary>;
@@ -116,6 +156,12 @@ using GinSegmentDictionaryPtr = std::shared_ptr<GinSegmentDictionary>;
 class GinIndexStore
 {
 public:
+    static constexpr auto GIN_SEGMENT_ID_FILE_TYPE = ".gin_sid";
+    static constexpr auto GIN_SEGMENT_METADATA_FILE_TYPE = ".gin_seg";
+    static constexpr auto GIN_BLOOM_FILTER_FILE_TYPE = ".gin_bflt";
+    static constexpr auto GIN_DICTIONARY_FILE_TYPE = ".gin_dict";
+    static constexpr auto GIN_POSTINGS_FILE_TYPE = ".gin_post";
+
     enum class Format : uint8_t
     {
         v1 = 1, /// Initial version, supports adaptive compression
@@ -129,7 +175,8 @@ public:
         const String & name_,
         DataPartStoragePtr storage_,
         MutableDataPartStoragePtr data_part_storage_builder_,
-        UInt64 segment_digestion_threshold_bytes_);
+        UInt64 segment_digestion_threshold_bytes_,
+        double bloom_filter_false_positive_rate_);
 
     /// Check existence by checking the existence of file .gin_sid
     bool exists() const;
@@ -213,16 +260,13 @@ private:
     GinIndexSegment current_segment;
     UInt64 current_size = 0;
     const UInt64 segment_digestion_threshold_bytes = 0;
+    const double bloom_filter_false_positive_rate = 0.0;
 
-    /// File streams for segment, dictionaries and postings lists
+    /// File streams for segment, bloom filter, dictionaries and postings lists
     std::unique_ptr<WriteBufferFromFileBase> metadata_file_stream;
+    std::unique_ptr<WriteBufferFromFileBase> bloom_filter_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> dict_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> postings_file_stream;
-
-    static constexpr auto GIN_SEGMENT_ID_FILE_TYPE = ".gin_sid";
-    static constexpr auto GIN_SEGMENT_METADATA_FILE_TYPE = ".gin_seg";
-    static constexpr auto GIN_DICTIONARY_FILE_TYPE = ".gin_dict";
-    static constexpr auto GIN_POSTINGS_FILE_TYPE = ".gin_post";
 };
 
 using GinIndexStorePtr = std::shared_ptr<GinIndexStore>;
@@ -243,11 +287,14 @@ public:
     /// Read segment information from .gin_seg files
     void readSegments();
 
-    /// Read all dictionaries from .gin_dict files
-    void readSegmentDictionaries();
+    /// Prepare segments for reading
+    void prepareSegmentsForReading();
 
-    /// Read dictionary for given segment id
-    void readSegmentDictionary(UInt32 segment_id);
+    /// Prepare segment for given segment id
+    void prepareSegmentForReading(UInt32 segment_id);
+
+    /// Read FST for given segment dictionary from .gin_dict files
+    void readSegmentFST(GinSegmentDictionaryPtr segment_dictionary);
 
     /// Read postings lists for the term
     GinSegmentedPostingsListContainer readSegmentedPostingsLists(const String & term);
@@ -264,6 +311,7 @@ private:
 
     /// File streams for reading Gin Index
     std::unique_ptr<ReadBufferFromFileBase> metadata_file_stream;
+    std::unique_ptr<ReadBufferFromFileBase> bloom_filter_file_stream;
     std::unique_ptr<ReadBufferFromFileBase> dict_file_stream;
     std::unique_ptr<ReadBufferFromFileBase> postings_file_stream;
 
@@ -309,5 +357,4 @@ private:
 };
 
 bool isGinFile(const String & file_name);
-
 }

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -303,7 +303,11 @@ void MergeTreeDataPartWriterOnDisk::initSkipIndices()
         if (const auto * gin_index = typeid_cast<const MergeTreeIndexGin *>(&*skip_index); gin_index != nullptr)
         {
             store = std::make_shared<GinIndexStore>(
-                stream_name, data_part_storage, data_part_storage, gin_index->gin_filter_params.segment_digestion_threshold_bytes);
+                stream_name,
+                data_part_storage,
+                data_part_storage,
+                gin_index->gin_filter_params.segment_digestion_threshold_bytes,
+                gin_index->gin_filter_params.bloom_filter_false_positive_rate);
             gin_index_stores[stream_name] = store;
         }
 
@@ -496,10 +500,11 @@ void MergeTreeDataPartWriterOnDisk::fillSkipIndicesChecksums(MergeTreeData::Data
         if (typeid_cast<const MergeTreeIndexGin *>(&*skip_indices[i]) != nullptr)
         {
             String filename_without_extension = skip_indices[i]->getFileName();
-            checksums.files[filename_without_extension + ".gin_dict"] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + ".gin_post"] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + ".gin_seg"] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + ".gin_sid"] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + GinIndexStore::GIN_DICTIONARY_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + GinIndexStore::GIN_POSTINGS_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
         }
     }
 

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -892,15 +892,15 @@ static void assertIndexColumnsType(const Block & header)
 MergeTreeIndexPtr bloomFilterIndexCreator(
     const IndexDescription & index)
 {
-    double max_conflict_probability = 0.025;
+    double false_positive_rate = 0.025;
 
     if (!index.arguments.empty())
     {
         const auto & argument = index.arguments[0];
-        max_conflict_probability = std::min<Float64>(1.0, std::max<Float64>(argument.safeGet<Float64>(), 0.0));
+        false_positive_rate = std::min<Float64>(1.0, std::max<Float64>(argument.safeGet<Float64>(), 0.0));
     }
 
-    const auto & bits_per_row_and_size_of_hash_functions = BloomFilterHash::calculationBestPractices(max_conflict_probability);
+    const auto & bits_per_row_and_size_of_hash_functions = BloomFilterHash::calculationBestPractices(false_positive_rate);
 
     return std::make_shared<MergeTreeIndexBloomFilter>(
         index, bits_per_row_and_size_of_hash_functions.first, bits_per_row_and_size_of_hash_functions.second);

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <Common/HashTable/HashSet.h>
 #include <Interpreters/GinFilter.h>
 #include <Interpreters/ITokenExtractor.h>
 #include <Storages/MergeTree/KeyCondition.h>
+#include <Storages/MergeTree/MergeTreeIOSettings.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 
 namespace DB
@@ -146,7 +148,7 @@ public:
 
     MergeTreeIndexGranulePtr createIndexGranule() const override;
     MergeTreeIndexAggregatorPtr createIndexAggregator(const MergeTreeWriterSettings & settings) const override;
-    MergeTreeIndexAggregatorPtr createIndexAggregatorForPart(const GinIndexStorePtr & store, const MergeTreeWriterSettings & /*settings*/) const override;
+    MergeTreeIndexAggregatorPtr createIndexAggregatorForPart(const GinIndexStorePtr & store, const MergeTreeWriterSettings & settings) const override;
     MergeTreeIndexConditionPtr createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
     GinFilterParameters gin_filter_params;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1581,8 +1581,7 @@ namespace ErrorCodes
     of the table.
     )", 0) \
     DECLARE(Bool, add_minmax_index_for_string_columns, false, R"(
-    When enabled, min-max (skipping) indices are added for all string columns of
-    the table.
+    When enabled, min-max (skipping) indices are added for all string columns of the table.
     )", 0) \
     DECLARE(Bool, allow_summing_columns_in_partition_or_order_key, false, R"(
     When enabled, allows summing columns in a SummingMergeTree table to be used in

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -29,6 +29,7 @@
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
 #include <Storages/MergeTree/MergeProjectionPartsTask.h>
 #include <Storages/MutationCommands.h>
+#include <Storages/MergeTree/GinIndexStore.h>
 #include <Storages/MergeTree/MergeTreeDataMergerMutator.h>
 #include <Storages/MergeTree/MergeTreeIndexGin.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
@@ -789,10 +790,11 @@ static NameSet collectFilesToSkip(
         if (dynamic_cast<const MergeTreeIndexGin *>(index.get()))
         {
             auto index_filename = index->getFileName();
-            files_to_skip.insert(index_filename + ".gin_dict");
-            files_to_skip.insert(index_filename + ".gin_post");
-            files_to_skip.insert(index_filename + ".gin_sed");
-            files_to_skip.insert(index_filename + ".gin_sid");
+            files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE);
+            files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE);
+            files_to_skip.insert(index_filename + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE);
+            files_to_skip.insert(index_filename + GinIndexStore::GIN_DICTIONARY_FILE_TYPE);
+            files_to_skip.insert(index_filename + GinIndexStore::GIN_POSTINGS_FILE_TYPE);
         }
     }
 
@@ -871,7 +873,13 @@ static NameToNameVector collectFilesForRenames(
         if (command.type == MutationCommand::Type::DROP_INDEX)
         {
             static const std::array<String, 2> suffixes = {".idx2", ".idx"};
-            static const std::array<String, 4> gin_suffixes = {".gin_dict", ".gin_post", ".gin_seg", ".gin_sid"}; /// .gin_* means generalized inverted index aka. text index
+            static const std::array<String, 5> gin_suffixes = {
+                GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE,
+                GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE,
+                GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE,
+                GinIndexStore::GIN_DICTIONARY_FILE_TYPE,
+                GinIndexStore::GIN_POSTINGS_FILE_TYPE,
+            };
 
             for (const auto & suffix : suffixes)
             {

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -9,6 +9,9 @@ Test separators argument.
 Test segment_digestion_threshold_bytes argument.
 -- segment_digestion_threshold_bytes must be an integer.
 -- segment_digestion_threshold_bytes can be 0 (zero).
+Test bloom_filter_false_positive_rate argument.
+-- bloom_filter_false_positive_rate must be a double.
+-- bloom_filter_false_positive_rate must be between 0.0 and 1.0.
 Parameters are shuffled.
 Types are incorrect.
 Same argument appears >1 times.

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -150,6 +150,53 @@ ENGINE = MergeTree
 ORDER BY tuple();
 DROP TABLE tab;
 
+SELECT 'Test bloom_filter_false_positive_rate argument.';
+
+SELECT '-- bloom_filter_false_positive_rate must be a double.';
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 1)
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = '1024')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 0.5)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+DROP TABLE tab;
+
+SELECT '-- bloom_filter_false_positive_rate must be between 0.0 and 1.0.';
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 0.0)
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 1.0)
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
+
 SELECT 'Parameters are shuffled.';
 
 CREATE TABLE tab
@@ -209,6 +256,14 @@ CREATE TABLE tab
 (
     str String,
     INDEX idx str TYPE text(tokenizer = 'ngram', ngram_size = 3, ngram_size = 4)
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 0.5, bloom_filter_false_positive_rate = 0.5)
 )
 ENGINE = MergeTree
 ORDER BY tuple(); -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/02346_text_index_queries.sql
+++ b/tests/queries/0_stateless/02346_text_index_queries.sql
@@ -120,12 +120,15 @@ SELECT 'Test text(tokenizer = "ngram", ngram_size = 2) on a column with two part
 
 DROP TABLE IF EXISTS tab;
 
-CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE text(tokenizer = 'ngram', ngram_size = 2) GRANULARITY 1)
+CREATE TABLE tab(k UInt64, s String)
     ENGINE = MergeTree() ORDER BY k
     SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
 
 INSERT INTO tab VALUES (101, 'Alick a01'), (102, 'Blick a02'), (103, 'Click a03'), (104, 'Dlick a04'), (105, 'Elick a05'), (106, 'Alick a06'), (107, 'Blick a07'), (108, 'Click a08'), (109, 'Dlick a09'), (110, 'Elick b10'), (111, 'Alick b01'), (112, 'Blick b02'), (113, 'Click b03'), (114, 'Dlick b04'), (115, 'Elick b05'), (116, 'Alick b06'), (117, 'Blick b07'), (118, 'Click b08'), (119, 'Dlick b09'), (120, 'Elick b10');
 INSERT INTO tab VALUES (201, 'rick c01'), (202, 'mick c02'), (203, 'nick c03');
+
+ALTER TABLE tab ADD INDEX af(s) TYPE text(tokenizer = 'ngram', ngram_size = 2) GRANULARITY 1 SETTINGS mutations_sync = 2;
+OPTIMIZE TABLE tab FINAL;
 
 -- check text index was created
 SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND database = currentDatabase() LIMIT 1;


### PR DESCRIPTION
Similar to #83485 but better. Reverts #84977 which reverts #84709.

Adds an additional bloom filter layer on top of text index segments. This prevents loading the segment dictionary into memory when a term does not exist in the dictionary.

The bloom filter is constructed from the segment data on `writeSegment` call.

Introduce a new text index parameter `bloom_filter_false_positive_rate` to control false-positive rate while building the bloom filter. By default it's set to 0.1%.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)