### PR TITLE
CI: Checkout submodules with xargs

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -131,7 +131,7 @@ def main():
                 f"mkdir -p {build_dir} && git submodule sync && git submodule init"
             )
             res = res and Shell.check(
-                f"git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\\n||' | xargs --max-procs=20 --null --no-run-if-empty --max-args=1 git submodule update --depth=1 --single-branch",
+                f"git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\\n||' | xargs --max-procs=40 --null --no-run-if-empty --max-args=1 git submodule update --depth=1 --single-branch",
                 retries=3,
                 strict=True,
             )

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -131,7 +131,7 @@ def main():
                 f"mkdir -p {build_dir} && git submodule sync && git submodule init"
             )
             res = res and Shell.check(
-                f"git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\\n||' | xargs --max-procs=15 --null --no-run-if-empty --max-args=1 git submodule update --depth=1 --single-branch",
+                f"git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\\n||' | xargs --max-procs=10 --null --no-run-if-empty --max-args=1 git submodule update --depth=1 --single-branch",
                 retries=3,
             )
             return res

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -131,9 +131,8 @@ def main():
                 f"mkdir -p {build_dir} && git submodule sync && git submodule init"
             )
             res = res and Shell.check(
-                f"git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\\n||' | xargs --max-procs=40 --null --no-run-if-empty --max-args=1 git submodule update --depth=1 --single-branch",
+                f"git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\\n||' | xargs --max-procs=15 --null --no-run-if-empty --max-args=1 git submodule update --depth=1 --single-branch",
                 retries=3,
-                strict=True,
             )
             return res
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

[After being checked out with two reties](https://s3.amazonaws.com/clickhouse-test-reports/PRs/85042/1e8b71763ebb25a8d44e5110abdfeac1a9dd8168//build_arm_binary/job.log), cmake still complains that submodules are not updated. try a different approach for submodule checkout

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
