### PR TITLE
Disable skip_binary_checksum_checks and mlock_executable for integration tests

### DIFF
--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -8,6 +8,9 @@
     <!-- For tests which check compatibility with older versions. -->
     <users_config>users.xml</users_config>
 
+    <mlock_executable>false</mlock_executable>
+    <skip_binary_checksum_checks>true</skip_binary_checksum_checks>
+
   <logger>
         <level>test</level>
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>

--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -52,7 +52,7 @@ def test_startup_with_small_bg_pool(started_cluster):
         assert node.query("SELECT * FROM replicated_table") == "20\t30\n"
 
     assert_values()
-    node.restart_clickhouse(stop_start_wait_sec=10)
+    node.restart_clickhouse(stop_start_wait_sec=15)
     assert_values()
 
 


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Apparently, getHashOfLoadedBinary can be slow with sanitizers.
https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/31ba6973264659334b6ed911f254ecfa61689ee5//integration_tests_asan_old_analyzer_5_6/integration_run_parallel3_0.log

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
