### PR TITLE
Reduce FormatSettings constructors calls (micro optimization)

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.cpp
@@ -176,14 +176,16 @@ public:
                             "Too large array size (maximum: {})", AGGREGATE_FUNCTION_GROUP_ARRAY_INSERT_AT_MAX_SIZE);
 
         Array & arr = data(place).value;
-
         arr.resize(size);
+
+        FormatSettings format_settings;
+
         for (size_t i = 0; i < size; ++i)
         {
             UInt8 is_null = 0;
             readBinary(is_null, buf);
             if (!is_null)
-                serialization->deserializeBinary(arr[i], buf, {});
+                serialization->deserializeBinary(arr[i], buf, format_settings);
         }
     }
 

--- a/src/AggregateFunctions/AggregateFunctionSumMap.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSumMap.cpp
@@ -334,6 +334,7 @@ public:
         size_t size = 0;
         readVarUInt(size, buf);
 
+        FormatSettings format_settings;
         std::function<void(size_t, Array &)> deserialize;
         switch (*version)
         {
@@ -341,7 +342,7 @@ public:
             {
                 deserialize = [&](size_t col_idx, Array & values)
                 {
-                    values_serializations[col_idx]->deserializeBinary(values[col_idx], buf, {});
+                    values_serializations[col_idx]->deserializeBinary(values[col_idx], buf, format_settings);
                 };
                 break;
             }
@@ -350,7 +351,7 @@ public:
                 deserialize = [&](size_t col_idx, Array & values)
                 {
                     Field & value = values[col_idx];
-                    promoted_values_serializations[col_idx]->deserializeBinary(value, buf, {});
+                    promoted_values_serializations[col_idx]->deserializeBinary(value, buf, format_settings);
 
                     /// Compatibility with previous versions.
                     if (value.getType() == Field::Types::Decimal128)
@@ -376,7 +377,7 @@ public:
         for (size_t i = 0; i < size; ++i)
         {
             Field key;
-            keys_serialization->deserializeBinary(key, buf, {});
+            keys_serialization->deserializeBinary(key, buf, format_settings);
 
             Array values;
             values.resize(values_types.size());

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -1338,6 +1338,8 @@ Field getFieldFromColumnForASTLiteralImpl(const ColumnPtr & column, size_t row, 
             size_t end = shared_data_offsets[row];
             auto dynamic_type = std::make_shared<DataTypeDynamic>();
             auto dynamic_serialization = dynamic_type->getDefaultSerialization();
+
+            FormatSettings format_settings;
             for (size_t i = start; i != end; ++i)
             {
                 String path = shared_paths->getDataAt(i).toString();
@@ -1345,7 +1347,7 @@ Field getFieldFromColumnForASTLiteralImpl(const ColumnPtr & column, size_t row, 
                 ReadBufferFromMemory buf(value_data.data, value_data.size);
                 auto tmp_column = dynamic_type->createColumn();
                 tmp_column->reserve(1);
-                dynamic_serialization->deserializeBinary(*tmp_column, buf, {});
+                dynamic_serialization->deserializeBinary(*tmp_column, buf, format_settings);
                 object[path] = getFieldFromColumnForASTLiteralImpl(std::move(tmp_column), 0, dynamic_type, true);
             }
 

--- a/src/Storages/KVStorageUtils.h
+++ b/src/Storages/KVStorageUtils.h
@@ -29,10 +29,12 @@ void fillColumns(const K & key, const V & value, size_t key_pos, const Block & h
 {
     ReadBufferFromString key_buffer(key);
     ReadBufferFromString value_buffer(value);
+
+    FormatSettings format_settings;
     for (size_t i = 0; i < header.columns(); ++i)
     {
         const auto & serialization = header.getByPosition(i).type->getDefaultSerialization();
-        serialization->deserializeBinary(*columns[i], i == key_pos ? key_buffer : value_buffer, {});
+        serialization->deserializeBinary(*columns[i], i == key_pos ? key_buffer : value_buffer, format_settings);
     }
 }
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -132,6 +132,7 @@ void IMergeTreeDataPart::MinMaxIndex::load(const IMergeTreeDataPart & part)
     size_t minmax_idx_size = minmax_column_types.size();
 
     hyperrectangle.reserve(minmax_idx_size);
+    FormatSettings format_settings;
     for (size_t i = 0; i < minmax_idx_size; ++i)
     {
         String file_name = "minmax_" + getFileColumnName(minmax_column_names[i], part.checksums) + ".idx";
@@ -139,9 +140,9 @@ void IMergeTreeDataPart::MinMaxIndex::load(const IMergeTreeDataPart & part)
         auto serialization = minmax_column_types[i]->getDefaultSerialization();
 
         Field min_val;
-        serialization->deserializeBinary(min_val, *file, {});
+        serialization->deserializeBinary(min_val, *file, format_settings);
         Field max_val;
-        serialization->deserializeBinary(max_val, *file, {});
+        serialization->deserializeBinary(max_val, *file, format_settings);
 
         // NULL_LAST
         if (min_val.isNull())
@@ -1101,10 +1102,11 @@ std::shared_ptr<IMergeTreeDataPart::Index> IMergeTreeDataPart::loadIndex() const
     for (size_t j = 0; j < key_size; ++j)
         key_serializations[j] = primary_key.data_types[j]->getDefaultSerialization();
 
+    FormatSettings format_settings;
     for (size_t i = 0; i < marks_count; ++i)
     {
         for (size_t j = 0; j < key_size; ++j)
-            key_serializations[j]->deserializeBinary(*loaded_index[j], *index_file, {});
+            key_serializations[j]->deserializeBinary(*loaded_index[j], *index_file, format_settings);
     }
 
     optimizeIndexColumns(marks_count, loaded_index);

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -56,6 +56,7 @@ void MergeTreeIndexGranuleMinMax::deserializeBinary(ReadBuffer & istr, MergeTree
     Field min_val;
     Field max_val;
 
+    FormatSettings format_settings;
     for (size_t i = 0; i < index_sample_block.columns(); ++i)
     {
         const DataTypePtr & type = index_sample_block.getByPosition(i).type;
@@ -66,8 +67,8 @@ void MergeTreeIndexGranuleMinMax::deserializeBinary(ReadBuffer & istr, MergeTree
             case 1:
                 if (!type->isNullable())
                 {
-                    serialization->deserializeBinary(min_val, istr, {});
-                    serialization->deserializeBinary(max_val, istr, {});
+                    serialization->deserializeBinary(min_val, istr, format_settings);
+                    serialization->deserializeBinary(max_val, istr, format_settings);
                 }
                 else
                 {
@@ -81,8 +82,8 @@ void MergeTreeIndexGranuleMinMax::deserializeBinary(ReadBuffer & istr, MergeTree
                     readBinary(is_null, istr);
                     if (!is_null)
                     {
-                        serialization->deserializeBinary(min_val, istr, {});
-                        serialization->deserializeBinary(max_val, istr, {});
+                        serialization->deserializeBinary(min_val, istr, format_settings);
+                        serialization->deserializeBinary(max_val, istr, format_settings);
                     }
                     else
                     {
@@ -94,8 +95,8 @@ void MergeTreeIndexGranuleMinMax::deserializeBinary(ReadBuffer & istr, MergeTree
 
             /// New format with proper Nullable support for values that includes Null values
             case 2:
-                serialization->deserializeBinary(min_val, istr, {});
-                serialization->deserializeBinary(max_val, istr, {});
+                serialization->deserializeBinary(min_val, istr, format_settings);
+                serialization->deserializeBinary(max_val, istr, format_settings);
 
                 // NULL_LAST
                 if (min_val.isNull())


### PR DESCRIPTION
This structure is 1704 bytes in size, pretty heavy

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)