### PR TITLE
Update wait condition for system flush logs

### DIFF
--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -160,7 +160,7 @@ void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index exp
     auto result = confirm_event.wait_for(lock, std::chrono::seconds(timeout_seconds), [&]
     {
         if (should_prepare_tables_anyway)
-            return (flushed_index >= expected_flushed_index && prepared_tables >= requested_prepare_tables) || is_shutdown;
+            return (flushed_index >= expected_flushed_index && prepared_tables >= expected_flushed_index) || is_shutdown;
         return (flushed_index >= expected_flushed_index) || is_shutdown;
     });
 

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -159,8 +159,6 @@ void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index exp
 
     auto result = confirm_event.wait_for(lock, std::chrono::seconds(timeout_seconds), [&]
     {
-        if (should_prepare_tables_anyway)
-            return (flushed_index >= expected_flushed_index && prepared_tables >= expected_flushed_index) || is_shutdown;
         return (flushed_index >= expected_flushed_index) || is_shutdown;
     });
 

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -609,8 +609,6 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
 
         block.setColumns(std::move(columns));
 
-        LOG_TRACE(log, "Filled block with, {} entries", block.rows());
-
         /// We write to table indirectly, using InterpreterInsertQuery.
         /// This is needed to support DEFAULT-columns in table.
 
@@ -632,15 +630,11 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
             /* async_isnert */ false);
         BlockIO io = interpreter.execute();
 
-        LOG_TRACE(log, "Build pipeline");
-
         PushingPipelineExecutor executor(io.pipeline);
 
         executor.start();
         executor.push(block);
         executor.finish();
-
-        LOG_TRACE(log, "Inserted");
     }
     catch (...)
     {

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -609,6 +609,8 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
 
         block.setColumns(std::move(columns));
 
+        LOG_TRACE(log, "Filled block with, {} entries", block.rows());
+
         /// We write to table indirectly, using InterpreterInsertQuery.
         /// This is needed to support DEFAULT-columns in table.
 
@@ -630,11 +632,15 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
             /* async_isnert */ false);
         BlockIO io = interpreter.execute();
 
+        LOG_TRACE(log, "Build pipeline");
+
         PushingPipelineExecutor executor(io.pipeline);
 
         executor.start();
         executor.push(block);
         executor.finish();
+
+        LOG_TRACE(log, "Inserted");
     }
     catch (...)
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


From [ci run](https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/6dd40b76f70cb152410bc22e95e9f5d8a42d65d6//stateless_tests_amd_msan_parallel_2_2/job.log)

[Logs](https://pastila.clickhouse.com/?0025e7c8/df08bd35609eb9111f27621383aafd5f#9tTdd6PVPcaWpMR7tQIW4g==)

```
2025.08.04 19:15:48.500545 [ 6331 ] {7e682e98-daab-4db6-98a3-81a2bdf30663} <Debug> executeQuery: (from [::1]:55292) (comment: 03568_mutation_affected_rows_counter.sql) (query 7, line 11) SYSTEM FLUSH LOGS; (stage: Complete)
2025.08.04 19:15:48.509304 [ 6331 ] {7e682e98-daab-4db6-98a3-81a2bdf30663} <Debug> SystemLogQueue (system.query_log): Requested flush up to offset 152867  <----- required offset

2025.08.04 19:17:15.349468 [ 4713 ] {dd3566bd-4ca0-4bea-95bd-74630ad7a111} <Debug> executeQuery: (from [::1]:53586) (comment: 02306_part_types_profile_events) (query 14, line 26) SYSTEM FLUSH LOGS query_log, part_log; (stage: Complete)  <----- other flush query which bumps requested_prepare_tables

2025.08.04 19:17:15.753825 [ 2362 ] {} <Trace> SystemLog (system.query_log): Flushed system log up to offset 155733  <----- should trigger
```

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
