### PR TITLE
Fix condition not being moved to prewhere in case there is a row policy

### DIFF
--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -136,8 +136,8 @@ public:
     std::string dumpDAG() const;
 
     void serialize(WriteBuffer & out, SerializedSetsRegistry & registry) const;
+    
     static ActionsDAG deserialize(ReadBuffer & in, DeserializedSetsRegistry & registry, const ContextPtr & context);
-
     const Node & addInput(std::string name, DataTypePtr type);
     const Node & addInput(ColumnWithTypeAndName column);
     const Node & addColumn(ColumnWithTypeAndName column);

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -2339,7 +2339,7 @@ void ExpressionAnalysisResult::checkActions() const
                     throw Exception(ErrorCodes::ILLEGAL_PREWHERE, "PREWHERE cannot contain ARRAY JOIN action");
         };
 
-        check_actions(prewhere_info->prewhere_actions);
+        check_actions(prewhere_info->prewhere_actions.value());
     }
 }
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1074,6 +1074,7 @@ bool InterpreterSelectQuery::adjustParallelReplicasAfterAnalysis()
     ActionDAGNodes added_filter_nodes = MergeTreeData::getFiltersForPrimaryKeyAnalysis(*this);
     if (query_info_copy.prewhere_info)
     {
+        if (!query_info_copy.prewhere_info->prewhere_actions.getOutputs().empty())
         {
             const auto & node
                 = query_info_copy.prewhere_info->prewhere_actions.findInOutputs(query_info_copy.prewhere_info->prewhere_column_name);
@@ -2481,7 +2482,9 @@ std::optional<UInt64> InterpreterSelectQuery::getTrivialCount(UInt64 allow_exper
     if (analysis_result.hasPrewhere())
     {
         auto & prewhere_info = analysis_result.prewhere_info;
-        filter_nodes.push_back(&prewhere_info->prewhere_actions.findInOutputs(prewhere_info->prewhere_column_name));
+
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+            filter_nodes.push_back(&prewhere_info->prewhere_actions.findInOutputs(prewhere_info->prewhere_column_name));
 
         if (prewhere_info->row_level_filter)
             filter_nodes.push_back(&prewhere_info->row_level_filter->findInOutputs(prewhere_info->row_level_column_name));

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1074,10 +1074,10 @@ bool InterpreterSelectQuery::adjustParallelReplicasAfterAnalysis()
     ActionDAGNodes added_filter_nodes = MergeTreeData::getFiltersForPrimaryKeyAnalysis(*this);
     if (query_info_copy.prewhere_info)
     {
-        if (!query_info_copy.prewhere_info->prewhere_actions.getOutputs().empty())
+        if (query_info_copy.prewhere_info->prewhere_actions)
         {
             const auto & node
-                = query_info_copy.prewhere_info->prewhere_actions.findInOutputs(query_info_copy.prewhere_info->prewhere_column_name);
+                = query_info_copy.prewhere_info->prewhere_actions->findInOutputs(query_info_copy.prewhere_info->prewhere_column_name);
             added_filter_nodes.nodes.push_back(&node);
         }
 
@@ -1195,9 +1195,9 @@ Block InterpreterSelectQuery::getSampleBlockImpl()
     {
         auto header = *source_header;
 
-        if (analysis_result.prewhere_info)
+        if (analysis_result.prewhere_info && analysis_result.prewhere_info->prewhere_actions)
         {
-            header = analysis_result.prewhere_info->prewhere_actions.updateHeader(header);
+            header = analysis_result.prewhere_info->prewhere_actions->updateHeader(header);
             if (analysis_result.prewhere_info->remove_prewhere_column)
                 header.erase(analysis_result.prewhere_info->prewhere_column_name);
         }
@@ -1658,14 +1658,17 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                 query_plan.addStep(std::move(row_level_filter_step));
             }
 
-            auto prewhere_step = std::make_unique<FilterStep>(
-                query_plan.getCurrentHeader(),
-                expressions.prewhere_info->prewhere_actions.clone(),
-                expressions.prewhere_info->prewhere_column_name,
-                expressions.prewhere_info->remove_prewhere_column);
+            if (expressions.prewhere_info->prewhere_actions)
+            {
+                auto prewhere_step = std::make_unique<FilterStep>(
+                    query_plan.getCurrentHeader(),
+                    expressions.prewhere_info->prewhere_actions->clone(),
+                    expressions.prewhere_info->prewhere_column_name,
+                    expressions.prewhere_info->remove_prewhere_column);
 
-            prewhere_step->setStepDescription("PREWHERE");
-            query_plan.addStep(std::move(prewhere_step));
+                prewhere_step->setStepDescription("PREWHERE");
+                query_plan.addStep(std::move(prewhere_step));
+            }
         }
     }
     else
@@ -2220,13 +2223,16 @@ void InterpreterSelectQuery::addEmptySourceToQueryPlan(QueryPlan & query_plan, c
             });
         }
 
-        auto filter_actions = std::make_shared<ExpressionActions>(prewhere_info.prewhere_actions.clone());
-        pipe.addSimpleTransform([&](const SharedHeader & header)
+        if (prewhere_info.prewhere_actions)
         {
-            return std::make_shared<FilterTransform>(
-                header, filter_actions,
-                prewhere_info.prewhere_column_name, prewhere_info.remove_prewhere_column);
-        });
+            auto filter_actions = std::make_shared<ExpressionActions>(prewhere_info.prewhere_actions->clone());
+            pipe.addSimpleTransform([&](const SharedHeader & header)
+            {
+                return std::make_shared<FilterTransform>(
+                    header, filter_actions,
+                    prewhere_info.prewhere_column_name, prewhere_info.remove_prewhere_column);
+            });
+        }
     }
 
     auto read_from_pipe = std::make_unique<ReadFromPreparedSource>(std::move(pipe));
@@ -2311,10 +2317,10 @@ void InterpreterSelectQuery::addPrewhereAliasActions()
     {
         NameSet columns;
 
-        if (prewhere_info)
+        if (prewhere_info && prewhere_info->prewhere_actions)
         {
             /// Get some columns directly from PREWHERE expression actions
-            auto prewhere_required_columns = prewhere_info->prewhere_actions.getRequiredColumns().getNames();
+            auto prewhere_required_columns = prewhere_info->prewhere_actions->getRequiredColumns().getNames();
             columns.insert(prewhere_required_columns.begin(), prewhere_required_columns.end());
 
             if (prewhere_info->row_level_filter)
@@ -2383,10 +2389,10 @@ void InterpreterSelectQuery::addPrewhereAliasActions()
         NameSet required_columns_after_prewhere_set;
 
         /// Collect required columns from prewhere expression actions.
-        if (prewhere_info)
+        if (prewhere_info && prewhere_info->prewhere_actions)
         {
             NameSet columns_to_remove(columns_to_remove_after_prewhere.begin(), columns_to_remove_after_prewhere.end());
-            Block prewhere_actions_result = prewhere_info->prewhere_actions.getResultColumns();
+            Block prewhere_actions_result = prewhere_info->prewhere_actions->getResultColumns();
 
             /// Populate required columns with the columns, added by PREWHERE actions and not removed afterwards.
             /// XXX: looks hacky that we already know which columns after PREWHERE we won't need for sure.
@@ -2421,11 +2427,11 @@ void InterpreterSelectQuery::addPrewhereAliasActions()
         /// Remove columns which will be added by prewhere.
         std::erase_if(required_columns, [&](const String & name) { return required_columns_after_prewhere_set.contains(name); });
 
-        if (prewhere_info)
+        if (prewhere_info && prewhere_info->prewhere_actions)
         {
             /// Don't remove columns which are needed to be aliased.
             for (const auto & name : required_columns)
-                prewhere_info->prewhere_actions.tryRestoreColumn(name);
+                prewhere_info->prewhere_actions->tryRestoreColumn(name);
 
             /// Add physical columns required by prewhere actions.
             for (const auto & column : required_columns_from_prewhere)
@@ -2483,8 +2489,8 @@ std::optional<UInt64> InterpreterSelectQuery::getTrivialCount(UInt64 allow_exper
     {
         auto & prewhere_info = analysis_result.prewhere_info;
 
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
-            filter_nodes.push_back(&prewhere_info->prewhere_actions.findInOutputs(prewhere_info->prewhere_column_name));
+        if (prewhere_info->prewhere_actions)
+            filter_nodes.push_back(&prewhere_info->prewhere_actions->findInOutputs(prewhere_info->prewhere_column_name));
 
         if (prewhere_info->row_level_filter)
             filter_nodes.push_back(&prewhere_info->row_level_filter->findInOutputs(prewhere_info->row_level_column_name));

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -923,7 +923,6 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                         }
                         else if (prewhere_info->prewhere_actions.getOutputs().empty())
                         {
-                            prewhere_info = std::make_shared<PrewhereInfo>();
                             prewhere_info->prewhere_actions = std::move(filter_info.actions);
                             prewhere_info->prewhere_column_name = filter_info.column_name;
                             prewhere_info->remove_prewhere_column = filter_info.do_remove_column;

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -1062,6 +1062,8 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                     }
                 }
 
+                [[maybe_unused]] auto some_header = query_plan.getCurrentHeader();
+
                 auto parallel_replicas_enabled_for_storage = [](const StoragePtr & table, const Settings & query_settings)
                 {
                     if (!table->isMergeTree())

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -461,7 +461,10 @@ void updatePrewhereOutputsIfNeeded(SelectQueryInfo & table_expression_query_info
     if (!table_expression_query_info.prewhere_info)
         return;
 
-    auto & prewhere_actions = table_expression_query_info.prewhere_info->prewhere_actions;
+    if (!table_expression_query_info.prewhere_info->prewhere_actions)
+        return;
+
+    auto & prewhere_actions = *table_expression_query_info.prewhere_info->prewhere_actions;
 
     NameSet required_columns;
     if (column_names.size() == 1)
@@ -921,7 +924,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                             prewhere_info->row_level_column_name = filter_info.column_name;
                             prewhere_info->need_filter = true;
                         }
-                        else if (prewhere_info->prewhere_actions.getOutputs().empty())
+                        else if (!prewhere_info->prewhere_actions)
                         {
                             prewhere_info->prewhere_actions = std::move(filter_info.actions);
                             prewhere_info->prewhere_column_name = filter_info.column_name;

--- a/src/Processors/QueryPlan/Optimizations/calculateHashTableCacheKeys.cpp
+++ b/src/Processors/QueryPlan/Optimizations/calculateHashTableCacheKeys.cpp
@@ -32,7 +32,8 @@ UInt64 calculateHashFromStep(const SourceStepWithFilter & read)
     if (const auto & snapshot = read.getStorageSnapshot())
         hash.update(snapshot->storage.getStorageID().getFullTableName());
     if (const auto & dag = read.getPrewhereInfo())
-        dag->prewhere_actions.updateHash(hash);
+        if (dag->prewhere_actions)
+            dag->prewhere_actions->updateHash(hash);
     return hash.get64();
 }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoinByShards.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoinByShards.cpp
@@ -39,7 +39,8 @@ ReadFromMergeTree * findReadingStep(const QueryPlan::Node & node)
 ActionsDAG makeSourceDAG(ReadFromMergeTree & source)
 {
     if (const auto & prewhere_info = source.getPrewhereInfo())
-        return prewhere_info->prewhere_actions.clone();
+        if (prewhere_info->prewhere_actions)
+            return prewhere_info->prewhere_actions->clone();
 
     return ActionsDAG(source.getOutputHeader()->getColumnsWithTypeAndName());
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -136,7 +136,7 @@ static void collectLazilyReadColumnNames(
         if (prewhere_info->row_level_filter)
             removeUsedColumnNames(*prewhere_info->row_level_filter, lazily_read_column_name_set, alias_index, prewhere_info->row_level_column_name);
 
-        removeUsedColumnNames(prewhere_info->prewhere_actions, lazily_read_column_name_set, alias_index, prewhere_info->prewhere_column_name);
+        removeUsedColumnNames(prewhere_info->prewhere_actions.value(), lazily_read_column_name_set, alias_index, prewhere_info->prewhere_column_name);
     }
 
     for (auto step_it = steps.rbegin(); step_it != steps.rend(); ++step_it)

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -48,9 +48,8 @@ ActionsDAG splitAndFillPrewhereInfo(
     const std::list<const ActionsDAG::Node *> & prewhere_nodes_list)
 {
     prewhere_info->need_filter = true;
-    prewhere_info->remove_prewhere_column = remove_prewhere_column;
 
-    if (prewhere_info->remove_prewhere_column)
+    if (remove_prewhere_column)
     {
         removeFromOutput(filter_expression, filter_column_name);
         auto & outputs = filter_expression.getOutputs();
@@ -95,19 +94,42 @@ ActionsDAG splitAndFillPrewhereInfo(
         conditions.push_back(split_result.split_nodes_mapping.at(condition));
 
     /// Is it possible that prewhere_info->prewhere_actions was not empty?
-    /// Not sure, but just in case let's merge it    
+    /// Not sure, but just in case let's merge it
     if (prewhere_info->prewhere_actions)
     {
         split_result.first.mergeInplace(std::move(*prewhere_info->prewhere_actions));
 
         const auto * existing_prewhere_node = &split_result.first.findInOutputs(prewhere_info->prewhere_column_name);
-        conditions.insert(conditions.begin(), existing_prewhere_node);
+        conditions.push_back(existing_prewhere_node);
+
+        /// Should this be done after or before the mergeInPlace?
+        if (prewhere_info->remove_prewhere_column)
+        {
+            removeFromOutput(split_result.first, prewhere_info->prewhere_column_name);
+            // split_result.first.removeUnusedActions();
+        }
+    }
+
+        {
+        std::unordered_set<const ActionsDAG::Node *> first_outputs(
+            split_result.first.getOutputs().begin(), split_result.first.getOutputs().end());
+        for (const auto * input : split_result.first.getInputs())
+        {
+            if (!first_outputs.contains(input))
+            {
+                split_result.first.getOutputs().push_back(input);
+                /// Add column to second actions as input.
+                /// Do not add it to result, so it would be removed.
+                split_result.second.addInput(input->result_name, input->result_type);
+            }
+        }
     }
 
     prewhere_info->prewhere_actions = std::move(split_result.first);
 
     if (conditions.size() == 1)
     {
+        prewhere_info->remove_prewhere_column = remove_prewhere_column;
         prewhere_info->prewhere_column_name = conditions.front()->result_name;
         if (prewhere_info->remove_prewhere_column)
             prewhere_info->prewhere_actions->getOutputs().push_back(conditions.front());
@@ -185,8 +207,10 @@ void optimizePrewhere(Stack & stack, QueryPlan::Nodes &)
 
     Names queried_columns = source_step_with_filter->requiredSourceColumns();
 
+    const auto & storage_prewhere_info = source_step_with_filter->getPrewhereInfo();
+
     const auto & source_filter_actions_dag = source_step_with_filter->getFilterActionsDAG();
-    MergeTreeWhereOptimizer where_optimizer{
+    MergeTreeWhereOptimizer where_optimizer{ 
         std::move(column_compressed_sizes),
         storage_metadata,
         storage.getConditionSelectivityEstimatorByPredicate(storage_snapshot, source_filter_actions_dag ? &*source_filter_actions_dag : nullptr, context),
@@ -202,7 +226,6 @@ void optimizePrewhere(Stack & stack, QueryPlan::Nodes &)
     if (optimize_result.prewhere_nodes.empty())
         return;
 
-    const auto & storage_prewhere_info = source_step_with_filter->getPrewhereInfo();
     PrewhereInfoPtr prewhere_info;
     if (storage_prewhere_info)
         prewhere_info = storage_prewhere_info->clone();

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -94,9 +94,9 @@ ActionsDAG splitAndFillPrewhereInfo(
     for (const auto * condition : prewhere_nodes_list)
         conditions.push_back(split_result.split_nodes_mapping.at(condition));
 
-    /// There is a chance prewhere_info was already populated (row policies are an example, see PlannerJoinTree)
-    /// We need to preserve it, hence the below merge
-    bool has_existing_prewhere = !prewhere_info->prewhere_column_name.empty();
+    /// Is it possible that prewhere_info->prewhere_actions was not empty?
+    /// Not sure, but just in case let's merge it
+    bool has_existing_prewhere = !prewhere_info->prewhere_actions.getOutputs().empty();
     
     if (has_existing_prewhere)
     {

--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
@@ -18,8 +18,8 @@ void optimizePrimaryKeyConditionAndLimit(const Stack & stack)
     const auto & storage_prewhere_info = source_step_with_filter->getPrewhereInfo();
     if (storage_prewhere_info)
     {
-        if (!storage_prewhere_info->prewhere_actions.getOutputs().empty())
-            source_step_with_filter->addFilter(storage_prewhere_info->prewhere_actions.clone(), storage_prewhere_info->prewhere_column_name);
+        if (storage_prewhere_info->prewhere_actions)
+            source_step_with_filter->addFilter(storage_prewhere_info->prewhere_actions->clone(), storage_prewhere_info->prewhere_column_name);
         if (storage_prewhere_info->row_level_filter)
             source_step_with_filter->addFilter(storage_prewhere_info->row_level_filter->clone(), storage_prewhere_info->row_level_column_name);
     }

--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
@@ -18,7 +18,8 @@ void optimizePrimaryKeyConditionAndLimit(const Stack & stack)
     const auto & storage_prewhere_info = source_step_with_filter->getPrewhereInfo();
     if (storage_prewhere_info)
     {
-        source_step_with_filter->addFilter(storage_prewhere_info->prewhere_actions.clone(), storage_prewhere_info->prewhere_column_name);
+        if (!storage_prewhere_info->prewhere_actions.getOutputs().empty())
+            source_step_with_filter->addFilter(storage_prewhere_info->prewhere_actions.clone(), storage_prewhere_info->prewhere_column_name);
         if (storage_prewhere_info->row_level_filter)
             source_step_with_filter->addFilter(storage_prewhere_info->row_level_filter->clone(), storage_prewhere_info->row_level_column_name);
     }

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -179,13 +179,13 @@ void buildSortingDAG(QueryPlan::Node & node, std::optional<ActionsDAG> & dag, Fi
     IQueryPlanStep * step = node.step.get();
     if (auto * reading = typeid_cast<ReadFromMergeTree *>(step))
     {
-        if (const auto prewhere_info = reading->getPrewhereInfo())
+        if (const auto prewhere_info = reading->getPrewhereInfo(); prewhere_info && prewhere_info->prewhere_actions)
         {
             /// Should ignore limit if there is filtering.
             limit = 0;
 
             //std::cerr << "====== Adding prewhere " << std::endl;
-            appendExpression(dag, prewhere_info->prewhere_actions);
+            appendExpression(dag, prewhere_info->prewhere_actions.value());
             if (const auto * filter_expression = dag->tryFindInOutputs(prewhere_info->prewhere_column_name))
                 appendFixedColumnsFromFilterExpression(*filter_expression, fixed_columns);
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -351,7 +351,7 @@ std::optional<String> optimizeUseNormalProjections(Stack & stack, QueryPlan::Nod
         Pipe pipe(std::make_shared<NullSource>(std::make_shared<const Block>(proj_snapshot->getSampleBlockForColumns(required_columns))));
         if (projection_query_info.prewhere_info)
         {
-            auto filter_actions = std::make_shared<ExpressionActions>(std::move(projection_query_info.prewhere_info->prewhere_actions));
+            auto filter_actions = std::make_shared<ExpressionActions>(std::move(projection_query_info.prewhere_info->prewhere_actions.value()));
             pipe.addSimpleTransform(
                 [&](const SharedHeader & header)
                 {

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -147,12 +147,15 @@ bool QueryDAG::buildImpl(QueryPlan::Node & node, ActionsDAG::NodeRawConstPtrs & 
                     return false;
             }
 
-            appendExpression(prewhere_info->prewhere_actions);
-            if (const auto * filter_expression
-                = findInOutputs(*dag, prewhere_info->prewhere_column_name, prewhere_info->remove_prewhere_column))
-                filter_nodes.push_back(filter_expression);
-            else
-                return false;
+            if (prewhere_info->prewhere_actions)
+            {
+                appendExpression(prewhere_info->prewhere_actions.value());
+                if (const auto * filter_expression
+                    = findInOutputs(*dag, prewhere_info->prewhere_column_name, prewhere_info->remove_prewhere_column))
+                    filter_nodes.push_back(filter_expression);
+                else
+                    return false;
+            }
         }
         return true;
     }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -112,7 +112,8 @@ bool restorePrewhereInputs(PrewhereInfo & info, const NameSet & inputs)
     if (info.row_level_filter)
         added = added || restoreDAGInputs(*info.row_level_filter, inputs);
 
-    added = added || restoreDAGInputs(info.prewhere_actions, inputs);
+    if (info.prewhere_actions)
+        added = added || restoreDAGInputs(*info.prewhere_actions, inputs);
 
     return added;
 }
@@ -254,9 +255,9 @@ static SortDescription getSortDescriptionForOutputHeader(
     Block original_header = output_header->cloneEmpty();
     if (prewhere_info)
     {
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+        if (prewhere_info->prewhere_actions)
         {
-            FindOriginalNodeForOutputName original_column_finder(prewhere_info->prewhere_actions);
+            FindOriginalNodeForOutputName original_column_finder(*prewhere_info->prewhere_actions);
             for (auto & column : original_header)
             {
                 const auto * original_node = original_column_finder.find(column.name);
@@ -2606,7 +2607,7 @@ void ReadFromMergeTree::describeActions(FormatSettings & format_settings) const
         prefix.push_back(format_settings.indent_char);
         prefix.push_back(format_settings.indent_char);
 
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+        if (prewhere_info->prewhere_actions)
         {
             format_settings.out << prefix << "Prewhere filter" << '\n';
             format_settings.out << prefix << "Prewhere filter column: " << prewhere_info->prewhere_column_name;
@@ -2614,7 +2615,7 @@ void ReadFromMergeTree::describeActions(FormatSettings & format_settings) const
                format_settings.out << " (removed)";
             format_settings.out << '\n';
 
-            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions.clone());
+            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions->clone());
             expression->describeActions(format_settings.out, prefix);
         }
 
@@ -2650,12 +2651,12 @@ void ReadFromMergeTree::describeActions(JSONBuilder::JSONMap & map) const
         std::unique_ptr<JSONBuilder::JSONMap> prewhere_info_map = std::make_unique<JSONBuilder::JSONMap>();
         prewhere_info_map->add("Need filter", prewhere_info->need_filter);
 
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+        if (prewhere_info->prewhere_actions)
         {
             std::unique_ptr<JSONBuilder::JSONMap> prewhere_filter_map = std::make_unique<JSONBuilder::JSONMap>();
             prewhere_filter_map->add("Prewhere filter column", prewhere_info->prewhere_column_name);
             prewhere_filter_map->add("Prewhere filter remove filter column", prewhere_info->remove_prewhere_column);
-            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions.clone());
+            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions->clone());
             prewhere_filter_map->add("Prewhere filter expression", expression->toTree());
 
             prewhere_info_map->add("Prewhere filter", std::move(prewhere_filter_map));

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -254,6 +254,7 @@ static SortDescription getSortDescriptionForOutputHeader(
     Block original_header = output_header->cloneEmpty();
     if (prewhere_info)
     {
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
         {
             FindOriginalNodeForOutputName original_column_finder(prewhere_info->prewhere_actions);
             for (auto & column : original_header)
@@ -2605,6 +2606,7 @@ void ReadFromMergeTree::describeActions(FormatSettings & format_settings) const
         prefix.push_back(format_settings.indent_char);
         prefix.push_back(format_settings.indent_char);
 
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
         {
             format_settings.out << prefix << "Prewhere filter" << '\n';
             format_settings.out << prefix << "Prewhere filter column: " << prewhere_info->prewhere_column_name;
@@ -2648,6 +2650,7 @@ void ReadFromMergeTree::describeActions(JSONBuilder::JSONMap & map) const
         std::unique_ptr<JSONBuilder::JSONMap> prewhere_info_map = std::make_unique<JSONBuilder::JSONMap>();
         prewhere_info_map->add("Need filter", prewhere_info->need_filter);
 
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
         {
             std::unique_ptr<JSONBuilder::JSONMap> prewhere_filter_map = std::make_unique<JSONBuilder::JSONMap>();
             prewhere_filter_map->add("Prewhere filter column", prewhere_info->prewhere_column_name);

--- a/src/Processors/QueryPlan/SourceStepWithFilter.cpp
+++ b/src/Processors/QueryPlan/SourceStepWithFilter.cpp
@@ -35,6 +35,7 @@ Block SourceStepWithFilter::applyPrewhereActions(Block block, const PrewhereInfo
             block.erase(prewhere_info->row_level_column_name);
         }
 
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
         {
             block = prewhere_info->prewhere_actions.updateHeader(block);
 
@@ -109,6 +110,7 @@ void SourceStepWithFilter::describeActions(FormatSettings & format_settings) con
         prefix.push_back(format_settings.indent_char);
         prefix.push_back(format_settings.indent_char);
 
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
         {
             format_settings.out << prefix << "Prewhere filter" << '\n';
             format_settings.out << prefix << "Prewhere filter column: " << prewhere_info->prewhere_column_name;
@@ -138,6 +140,7 @@ void SourceStepWithFilter::describeActions(JSONBuilder::JSONMap & map) const
         std::unique_ptr<JSONBuilder::JSONMap> prewhere_info_map = std::make_unique<JSONBuilder::JSONMap>();
         prewhere_info_map->add("Need filter", prewhere_info->need_filter);
 
+        if (!prewhere_info->prewhere_actions.getOutputs().empty())
         {
             std::unique_ptr<JSONBuilder::JSONMap> prewhere_filter_map = std::make_unique<JSONBuilder::JSONMap>();
             prewhere_filter_map->add("Prewhere filter column", prewhere_info->prewhere_column_name);

--- a/src/Processors/QueryPlan/SourceStepWithFilter.cpp
+++ b/src/Processors/QueryPlan/SourceStepWithFilter.cpp
@@ -35,9 +35,9 @@ Block SourceStepWithFilter::applyPrewhereActions(Block block, const PrewhereInfo
             block.erase(prewhere_info->row_level_column_name);
         }
 
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+        if (prewhere_info->prewhere_actions)
         {
-            block = prewhere_info->prewhere_actions.updateHeader(block);
+            block = prewhere_info->prewhere_actions->updateHeader(block);
 
             auto & prewhere_column = block.getByName(prewhere_info->prewhere_column_name);
             if (!prewhere_column.type->canBeUsedInBooleanContext())
@@ -110,7 +110,7 @@ void SourceStepWithFilter::describeActions(FormatSettings & format_settings) con
         prefix.push_back(format_settings.indent_char);
         prefix.push_back(format_settings.indent_char);
 
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+        if (prewhere_info->prewhere_actions)
         {
             format_settings.out << prefix << "Prewhere filter" << '\n';
             format_settings.out << prefix << "Prewhere filter column: " << prewhere_info->prewhere_column_name;
@@ -118,7 +118,7 @@ void SourceStepWithFilter::describeActions(FormatSettings & format_settings) con
                 format_settings.out << " (removed)";
             format_settings.out << '\n';
 
-            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions.clone());
+            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions->clone());
             expression->describeActions(format_settings.out, prefix);
         }
 
@@ -140,12 +140,12 @@ void SourceStepWithFilter::describeActions(JSONBuilder::JSONMap & map) const
         std::unique_ptr<JSONBuilder::JSONMap> prewhere_info_map = std::make_unique<JSONBuilder::JSONMap>();
         prewhere_info_map->add("Need filter", prewhere_info->need_filter);
 
-        if (!prewhere_info->prewhere_actions.getOutputs().empty())
+        if (prewhere_info->prewhere_actions)
         {
             std::unique_ptr<JSONBuilder::JSONMap> prewhere_filter_map = std::make_unique<JSONBuilder::JSONMap>();
             prewhere_filter_map->add("Prewhere filter column", prewhere_info->prewhere_column_name);
             prewhere_filter_map->add("Prewhere filter remove filter column", prewhere_info->remove_prewhere_column);
-            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions.clone());
+            auto expression = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions->clone());
             prewhere_filter_map->add("Prewhere filter expression", expression->toTree());
 
             prewhere_info_map->add("Prewhere filter", std::move(prewhere_filter_map));

--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -415,8 +415,9 @@ std::string PrewhereInfo::dump() const
         ss << "row_level_filter " << row_level_filter->dumpDAG() << "\n";
     }
 
+    if (prewhere_actions)
     {
-        ss << "prewhere_actions " << prewhere_actions.dumpDAG() << "\n";
+        ss << "prewhere_actions " << prewhere_actions->dumpDAG() << "\n";
     }
 
     ss << "remove_prewhere_column " << remove_prewhere_column

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1138,17 +1138,20 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 
     if (const auto & prewhere_info = select_query_info.prewhere_info)
     {
-        for (const auto * outputs : prewhere_info->prewhere_actions.getOutputs())
+        if (prewhere_info->prewhere_actions)
         {
-            if (outputs->result_name == prewhere_info->prewhere_column_name)
+            for (const auto * outputs : prewhere_info->prewhere_actions->getOutputs())
             {
-                auto stats = drop_mark_ranges(outputs);
-                LOG_DEBUG(log,
-                        "Query condition cache has dropped {}/{} granules for PREWHERE condition {}.",
-                        stats.granules_dropped,
-                        stats.total_granules,
-                        prewhere_info->prewhere_column_name);
-                break;
+                if (outputs->result_name == prewhere_info->prewhere_column_name)
+                {
+                    auto stats = drop_mark_ranges(outputs);
+                    LOG_DEBUG(log,
+                            "Query condition cache has dropped {}/{} granules for PREWHERE condition {}.",
+                            stats.granules_dropped,
+                            stats.total_granules,
+                            prewhere_info->prewhere_column_name);
+                    break;
+                }
             }
         }
     }

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -116,7 +116,7 @@ MergeTreeSelectProcessor::MergeTreeSelectProcessor(
     if (prewhere_info || has_prewhere_actions_steps)
         LOG_TEST(log, "PREWHERE conditions: {}, Original PREWHERE DAG:\n{}\nPREWHERE actions:\n{}",
             has_prewhere_actions_steps ? prewhere_actions.dumpConditions() : std::string("<nullptr>"),
-            prewhere_info ? prewhere_info->prewhere_actions.dumpDAG() : std::string("<nullptr>"),
+            prewhere_info && prewhere_info->prewhere_actions ? prewhere_info->prewhere_actions->dumpDAG() : std::string("<nullptr>"),
             has_prewhere_actions_steps ? prewhere_actions.dump() : std::string("<nullptr>"));
 }
 
@@ -148,13 +148,13 @@ PrewhereExprInfo MergeTreeSelectProcessor::getPrewhereActions(PrewhereInfoPtr pr
             prewhere_actions.steps.emplace_back(std::make_shared<PrewhereExprStep>(std::move(row_level_filter_step)));
         }
 
-        if (!enable_multiple_prewhere_read_steps ||
-            !tryBuildPrewhereSteps(prewhere_info, actions_settings, prewhere_actions, force_short_circuit_execution))
+        if (prewhere_info->prewhere_actions && (!enable_multiple_prewhere_read_steps ||
+            !tryBuildPrewhereSteps(prewhere_info, actions_settings, prewhere_actions, force_short_circuit_execution)))
         {
             PrewhereExprStep prewhere_step
             {
                 .type = PrewhereExprStep::Filter,
-                .actions = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions.clone(), actions_settings),
+                .actions = std::make_shared<ExpressionActions>(prewhere_info->prewhere_actions->clone(), actions_settings),
                 .filter_column_name = prewhere_info->prewhere_column_name,
                 .remove_filter_column = prewhere_info->remove_prewhere_column,
                 .need_filter = prewhere_info->need_filter,
@@ -178,9 +178,9 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
             if (!task || algorithm->needNewTask(*task))
             {
                 /// Update the query condition cache for filters in PREWHERE stage
-                if (reader_settings.use_query_condition_cache && task && prewhere_info)
+                if (reader_settings.use_query_condition_cache && task && prewhere_info && prewhere_info->prewhere_actions)
                 {
-                    for (const auto * output : prewhere_info->prewhere_actions.getOutputs())
+                    for (const auto * output : prewhere_info->prewhere_actions->getOutputs())
                     {
                         if (output->result_name == prewhere_info->prewhere_column_name)
                         {
@@ -198,7 +198,7 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                                 part_name,
                                 output->getHash(),
                                 reader_settings.query_condition_cache_store_conditions_as_plaintext
-                                    ? prewhere_info->prewhere_actions.getNames()[0]
+                                    ? prewhere_info->prewhere_actions->getNames()[0]
                                     : "",
                                 task->getPrewhereUnmatchedMarks(),
                                 data_part->index_granularity->getMarksCount(),

--- a/src/Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.cpp
+++ b/src/Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.cpp
@@ -212,7 +212,7 @@ bool tryBuildPrewhereSteps(
     PrewhereExprInfo & prewhere,
     bool force_short_circuit_execution)
 {
-    if (!prewhere_info)
+    if (!prewhere_info || prewhere_info->prewhere_actions.getOutputs().empty())
         return true;
 
     /// 1. List all condition nodes that are combined with AND into PREWHERE condition

--- a/src/Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.cpp
+++ b/src/Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.cpp
@@ -212,11 +212,11 @@ bool tryBuildPrewhereSteps(
     PrewhereExprInfo & prewhere,
     bool force_short_circuit_execution)
 {
-    if (!prewhere_info || prewhere_info->prewhere_actions.getOutputs().empty())
+    if (!prewhere_info || !prewhere_info->prewhere_actions)
         return true;
 
     /// 1. List all condition nodes that are combined with AND into PREWHERE condition
-    const auto & condition_root = prewhere_info->prewhere_actions.findInOutputs(prewhere_info->prewhere_column_name);
+    const auto & condition_root = prewhere_info->prewhere_actions->findInOutputs(prewhere_info->prewhere_column_name);
     const bool is_conjunction = (condition_root.type == ActionsDAG::ActionType::FUNCTION && condition_root.function_base->getName() == "and");
     if (!is_conjunction)
         return false;
@@ -294,7 +294,7 @@ bool tryBuildPrewhereSteps(
     }
 
     /// 6. Find all outputs of the original DAG
-    auto original_outputs = prewhere_info->prewhere_actions.getOutputs();
+    auto original_outputs = prewhere_info->prewhere_actions->getOutputs();
     steps.back().actions->getOutputs().clear();
     /// 7. Find all outputs that were computed in the already built DAGs, mark these nodes as outputs in the steps where they were computed
     /// 8. Add computation of the remaining outputs to the last step with the procedure similar to 4

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -45,7 +45,7 @@ struct PrewhereInfo
     /// This actions are separate because prewhere condition should not be executed over filtered rows.
     std::optional<ActionsDAG> row_level_filter;
     /// Actions which are executed on block in order to get filter column for prewhere step.
-    ActionsDAG prewhere_actions;
+    std::optional<ActionsDAG> prewhere_actions;
     String row_level_column_name;
     String prewhere_column_name;
     bool remove_prewhere_column = false;
@@ -65,7 +65,8 @@ struct PrewhereInfo
         if (row_level_filter)
             prewhere_info->row_level_filter = row_level_filter->clone();
 
-        prewhere_info->prewhere_actions = prewhere_actions.clone();
+        if (prewhere_actions)
+            prewhere_info->prewhere_actions = prewhere_actions->clone();
 
         prewhere_info->row_level_column_name = row_level_column_name;
         prewhere_info->prewhere_column_name = prewhere_column_name;

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -364,12 +364,13 @@ void StorageBuffer::read(
                         src_table_query_info.prewhere_info->row_level_filter->removeUnusedActions();
                     }
 
+                    if (src_table_query_info.prewhere_info->prewhere_actions)
                     {
                         src_table_query_info.prewhere_info->prewhere_actions = ActionsDAG::merge(
                             actions_dag.clone(),
-                            std::move(src_table_query_info.prewhere_info->prewhere_actions));
+                            std::move(*src_table_query_info.prewhere_info->prewhere_actions));
 
-                        src_table_query_info.prewhere_info->prewhere_actions.removeUnusedActions();
+                        src_table_query_info.prewhere_info->prewhere_actions->removeUnusedActions();
                     }
                 }
 
@@ -488,9 +489,9 @@ void StorageBuffer::read(
                 });
             }
 
-            if (!query_info.prewhere_info->prewhere_actions.getOutputs().empty())
+            if (query_info.prewhere_info->prewhere_actions)
             {
-                auto actions = std::make_shared<ExpressionActions>(query_info.prewhere_info->prewhere_actions.clone(), actions_settings);
+                auto actions = std::make_shared<ExpressionActions>(query_info.prewhere_info->prewhere_actions->clone(), actions_settings);
                 pipe_from_buffers.addSimpleTransform([&](const SharedHeader & header)
                 {
                     return std::make_shared<FilterTransform>(

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -488,15 +488,18 @@ void StorageBuffer::read(
                 });
             }
 
-            auto actions = std::make_shared<ExpressionActions>(query_info.prewhere_info->prewhere_actions.clone(), actions_settings);
-            pipe_from_buffers.addSimpleTransform([&](const SharedHeader & header)
+            if (!query_info.prewhere_info->prewhere_actions.getOutputs().empty())
             {
-                return std::make_shared<FilterTransform>(
-                        header,
-                        actions,
-                        query_info.prewhere_info->prewhere_column_name,
-                        query_info.prewhere_info->remove_prewhere_column);
-            });
+                auto actions = std::make_shared<ExpressionActions>(query_info.prewhere_info->prewhere_actions.clone(), actions_settings);
+                pipe_from_buffers.addSimpleTransform([&](const SharedHeader & header)
+                {
+                    return std::make_shared<FilterTransform>(
+                            header,
+                            actions,
+                            query_info.prewhere_info->prewhere_column_name,
+                            query_info.prewhere_info->remove_prewhere_column);
+                });
+            }
         }
 
         for (const auto & processor : pipe_from_buffers.getProcessors())

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
@@ -1,0 +1,28 @@
+Expression ((Project names + Projection))
+Actions: INPUT : 0 -> __table1.a Int32 : 0
+         INPUT : 1 -> __table1.b Int32 : 1
+         ALIAS __table1.a :: 0 -> a Int32 : 2
+         ALIAS __table1.b :: 1 -> b Int32 : 0
+Positions: 2 0
+  Expression ((WHERE + Change column names to column identifiers))
+  Actions: INPUT : 0 -> a Int32 : 0
+           INPUT : 1 -> b Int32 : 1
+           ALIAS a :: 0 -> __table1.a Int32 : 2
+           ALIAS b :: 1 -> __table1.b Int32 : 0
+  Positions: 2 0
+    ReadFromMergeTree (default.03591_test)
+    ReadType: Default
+    Parts: 1
+    Granules: 1
+    Prewhere info
+    Need filter: 1
+      Prewhere filter
+      Prewhere filter column: and(equals(a, 1_UInt8), equals(__table1.b, 2_UInt8)) (removed)
+      Actions: INPUT : 0 -> b Int32 : 0
+               COLUMN Const(UInt8) -> 2_UInt8 UInt8 : 1
+               INPUT : 1 -> a Int32 : 2
+               COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 3
+               FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(__table1.b, 2_UInt8) UInt8 : 4
+               FUNCTION equals(a : 2, 1_UInt8 :: 3) -> equals(a, 1_UInt8) UInt8 : 1
+               FUNCTION and(equals(a, 1_UInt8) : 1, equals(__table1.b, 2_UInt8) :: 4) -> and(equals(a, 1_UInt8), equals(__table1.b, 2_UInt8)) UInt8 : 3
+      Positions: 1 2 0 3

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
@@ -1,15 +1,18 @@
+1	1
+2	2
+1	1
 Expression ((Project names + Projection))
-Actions: INPUT : 0 -> __table1.a Int32 : 0
-         INPUT : 1 -> __table1.b Int32 : 1
-         ALIAS __table1.a :: 0 -> a Int32 : 2
-         ALIAS __table1.b :: 1 -> b Int32 : 0
-Positions: 2 0
+Actions: INPUT : 0 -> __table1.b Int32 : 0
+         INPUT : 1 -> __table1.a Int32 : 1
+         ALIAS __table1.b :: 0 -> b Int32 : 2
+         ALIAS __table1.a :: 1 -> a Int32 : 0
+Positions: 0 2
   Expression ((WHERE + Change column names to column identifiers))
-  Actions: INPUT : 0 -> a Int32 : 0
-           INPUT : 1 -> b Int32 : 1
+  Actions: INPUT : 1 -> a Int32 : 0
+           INPUT : 0 -> b Int32 : 1
            ALIAS a :: 0 -> __table1.a Int32 : 2
            ALIAS b :: 1 -> __table1.b Int32 : 0
-  Positions: 2 0
+  Positions: 0 2
     ReadFromMergeTree (default.03591_test)
     ReadType: Default
     Parts: 1
@@ -23,8 +26,8 @@ Positions: 2 0
                FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(__table1.b, 2_UInt8) UInt8 : 2
       Positions: 0 2
       Row level filter
-      Row level filter column: equals(a, 1_UInt8)
-      Actions: INPUT : 0 -> a Int32 : 0
+      Row level filter column: equals(b, 1_UInt8)
+      Actions: INPUT : 0 -> b Int32 : 0
                COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
-               FUNCTION equals(a : 0, 1_UInt8 :: 1) -> equals(a, 1_UInt8) UInt8 : 2
+               FUNCTION equals(b : 0, 1_UInt8 :: 1) -> equals(b, 1_UInt8) UInt8 : 2
       Positions: 2 0

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
@@ -1,6 +1,21 @@
-1	1
+-- {echoOn}
+
+SET use_query_condition_cache=0;
+DROP TABLE IF EXISTS 03591_test;
+DROP ROW POLICY IF EXISTS 03591_rp ON 03591_test;
+CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple();
+INSERT INTO 03591_test VALUES (3, 1), (2, 2), (3, 2);
+SELECT * FROM 03591_test;
+3	1
 2	2
-1	1
+3	2
+SELECT * FROM 03591_test WHERE throwIf(b=1, 'Should throw') SETTINGS optimize_move_to_prewhere = 1; -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}
+CREATE ROW POLICY 03591_rp ON 03591_test USING b=2 TO CURRENT_USER;
+SELECT * FROM 03591_test;
+2	2
+3	2
+-- Print plan with actions to make sure both a > 0 and b=2 are present in the prewhere section
+EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE a > 0 SETTINGS optimize_move_to_prewhere = 1;
 Expression ((Project names + Projection))
 Actions: INPUT : 0 -> __table1.b Int32 : 0
          INPUT : 1 -> __table1.a Int32 : 1
@@ -8,10 +23,43 @@ Actions: INPUT : 0 -> __table1.b Int32 : 0
          ALIAS __table1.a :: 1 -> a Int32 : 0
 Positions: 0 2
   Expression ((WHERE + Change column names to column identifiers))
-  Actions: INPUT : 1 -> a Int32 : 0
-           INPUT : 0 -> b Int32 : 1
-           ALIAS a :: 0 -> __table1.a Int32 : 2
-           ALIAS b :: 1 -> __table1.b Int32 : 0
+  Actions: INPUT : 0 -> b Int32 : 0
+           INPUT : 1 -> a Int32 : 1
+           ALIAS b :: 0 -> __table1.b Int32 : 2
+           ALIAS a :: 1 -> __table1.a Int32 : 0
+  Positions: 2 0
+    ReadFromMergeTree (default.03591_test)
+    ReadType: Default
+    Parts: 1
+    Granules: 1
+    Prewhere info
+    Need filter: 1
+      Prewhere filter
+      Prewhere filter column: greater(__table1.a, 0_UInt8) (removed)
+      Actions: INPUT : 0 -> a Int32 : 0
+               COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
+               FUNCTION greater(a : 0, 0_UInt8 :: 1) -> greater(__table1.a, 0_UInt8) UInt8 : 2
+      Positions: 0 2
+      Row level filter
+      Row level filter column: equals(b, 2_UInt8)
+      Actions: INPUT : 0 -> b Int32 : 0
+               COLUMN Const(UInt8) -> 2_UInt8 UInt8 : 1
+               FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(b, 2_UInt8) UInt8 : 2
+      Positions: 2 0
+SELECT * FROM 03591_test WHERE throwIf(b=1, 'Should not throw because b=1 is not visible to this user due to the b=2 row policy') SETTINGS optimize_move_to_prewhere = 1;
+-- Print plan with actions to make sure a > 0, b = 2 and a = 3 are present in the prewhere section
+EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE a > 0 SETTINGS optimize_move_to_prewhere = 1, additional_table_filters={'03591_test': 'a=3'};
+Expression ((Project names + Projection))
+Actions: INPUT : 0 -> __table1.a Int32 : 0
+         INPUT : 1 -> __table1.b Int32 : 1
+         ALIAS __table1.a :: 0 -> a Int32 : 2
+         ALIAS __table1.b :: 1 -> b Int32 : 0
+Positions: 2 0
+  Expression ((WHERE + Change column names to column identifiers))
+  Actions: INPUT : 1 -> b Int32 : 0
+           INPUT : 0 -> a Int32 : 1
+           ALIAS b :: 0 -> __table1.b Int32 : 2
+           ALIAS a :: 1 -> __table1.a Int32 : 0
   Positions: 0 2
     ReadFromMergeTree (default.03591_test)
     ReadType: Default
@@ -20,14 +68,20 @@ Positions: 0 2
     Prewhere info
     Need filter: 1
       Prewhere filter
-      Prewhere filter column: equals(__table1.b, 2_UInt8) (removed)
+      Prewhere filter column: and(equals(a, 3_UInt8), greater(__table1.a, 0_UInt8)) (removed)
+      Actions: INPUT : 0 -> a Int32 : 0
+               COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 1
+               INPUT :: 0 -> a Int32 : 2
+               COLUMN Const(UInt8) -> 3_UInt8 UInt8 : 3
+               FUNCTION greater(a : 0, 0_UInt8 :: 1) -> greater(__table1.a, 0_UInt8) UInt8 : 4
+               FUNCTION equals(a : 0, 3_UInt8 :: 3) -> equals(a, 3_UInt8) UInt8 : 1
+               FUNCTION and(equals(a, 3_UInt8) : 1, greater(__table1.a, 0_UInt8) :: 4) -> and(equals(a, 3_UInt8), greater(__table1.a, 0_UInt8)) UInt8 : 3
+      Positions: 1 0 3
+      Row level filter
+      Row level filter column: equals(b, 2_UInt8)
       Actions: INPUT : 0 -> b Int32 : 0
                COLUMN Const(UInt8) -> 2_UInt8 UInt8 : 1
-               FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(__table1.b, 2_UInt8) UInt8 : 2
-      Positions: 0 2
-      Row level filter
-      Row level filter column: equals(b, 1_UInt8)
-      Actions: INPUT : 0 -> b Int32 : 0
-               COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
-               FUNCTION equals(b : 0, 1_UInt8 :: 1) -> equals(b, 1_UInt8) UInt8 : 2
+               FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(b, 2_UInt8) UInt8 : 2
       Positions: 2 0
+DROP ROW POLICY 03591_rp ON 03591_test;
+SELECT * FROM 03591_test WHERE throwIf(b=2, 'Should throw') SETTINGS optimize_move_to_prewhere = 1; -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
@@ -17,12 +17,14 @@ Positions: 2 0
     Prewhere info
     Need filter: 1
       Prewhere filter
-      Prewhere filter column: and(equals(a, 1_UInt8), equals(__table1.b, 2_UInt8)) (removed)
+      Prewhere filter column: equals(__table1.b, 2_UInt8) (removed)
       Actions: INPUT : 0 -> b Int32 : 0
                COLUMN Const(UInt8) -> 2_UInt8 UInt8 : 1
-               INPUT : 1 -> a Int32 : 2
-               COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 3
-               FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(__table1.b, 2_UInt8) UInt8 : 4
-               FUNCTION equals(a : 2, 1_UInt8 :: 3) -> equals(a, 1_UInt8) UInt8 : 1
-               FUNCTION and(equals(a, 1_UInt8) : 1, equals(__table1.b, 2_UInt8) :: 4) -> and(equals(a, 1_UInt8), equals(__table1.b, 2_UInt8)) UInt8 : 3
-      Positions: 1 2 0 3
+               FUNCTION equals(b : 0, 2_UInt8 :: 1) -> equals(__table1.b, 2_UInt8) UInt8 : 2
+      Positions: 0 2
+      Row level filter
+      Row level filter column: equals(a, 1_UInt8)
+      Actions: INPUT : 0 -> a Int32 : 0
+               COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
+               FUNCTION equals(a : 0, 1_UInt8 :: 1) -> equals(a, 1_UInt8) UInt8 : 2
+      Positions: 2 0

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS 03591_test;
+
+DROP ROW POLICY IF EXISTS 03591_rp ON 03591_test;
+
+CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple();
+
+INSERT INTO 03591_test VALUES (1, 2);
+
+CREATE ROW POLICY 03591_rp ON 03591_test USING a=1 TO CURRENT_USER;
+
+-- Print plan with actions to make sure both a=1 and b=2 are present in the prewhere section
+EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE b=2 SETTINGS optimize_move_to_prewhere = 1;

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
@@ -1,12 +1,26 @@
+SET use_query_condition_cache=0;
+
 DROP TABLE IF EXISTS 03591_test;
 
 DROP ROW POLICY IF EXISTS 03591_rp ON 03591_test;
 
 CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple();
 
-INSERT INTO 03591_test VALUES (1, 2);
+INSERT INTO 03591_test VALUES (1, 1), (2, 2);
 
-CREATE ROW POLICY 03591_rp ON 03591_test USING a=1 TO CURRENT_USER;
+SELECT * FROM 03591_test;
 
--- Print plan with actions to make sure both a=1 and b=2 are present in the prewhere section
+SELECT * FROM 03591_test WHERE throwIf(b=2, 'Should throw') SETTINGS optimize_move_to_prewhere = 1; -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}
+
+CREATE ROW POLICY 03591_rp ON 03591_test USING b=1 TO CURRENT_USER;
+
+SELECT * FROM 03591_test;
+
+-- Print plan with actions to make sure both b=1 and b=2 are present in the prewhere section
 EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE b=2 SETTINGS optimize_move_to_prewhere = 1;
+
+SELECT * FROM 03591_test WHERE throwIf(b=2, 'Should not throw because b=2 is not visible to this user due to the b=1 row policy') SETTINGS optimize_move_to_prewhere = 1;
+
+DROP ROW POLICY 03591_rp ON 03591_test;
+
+SELECT * FROM 03591_test WHERE throwIf(b=2, 'Should throw') SETTINGS optimize_move_to_prewhere = 1; -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
@@ -1,3 +1,5 @@
+-- {echoOn}
+
 SET use_query_condition_cache=0;
 
 DROP TABLE IF EXISTS 03591_test;
@@ -6,20 +8,23 @@ DROP ROW POLICY IF EXISTS 03591_rp ON 03591_test;
 
 CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple();
 
-INSERT INTO 03591_test VALUES (1, 1), (2, 2);
+INSERT INTO 03591_test VALUES (3, 1), (2, 2), (3, 2);
 
 SELECT * FROM 03591_test;
 
-SELECT * FROM 03591_test WHERE throwIf(b=2, 'Should throw') SETTINGS optimize_move_to_prewhere = 1; -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}
+SELECT * FROM 03591_test WHERE throwIf(b=1, 'Should throw') SETTINGS optimize_move_to_prewhere = 1; -- {serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO}
 
-CREATE ROW POLICY 03591_rp ON 03591_test USING b=1 TO CURRENT_USER;
+CREATE ROW POLICY 03591_rp ON 03591_test USING b=2 TO CURRENT_USER;
 
 SELECT * FROM 03591_test;
 
--- Print plan with actions to make sure both b=1 and b=2 are present in the prewhere section
-EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE b=2 SETTINGS optimize_move_to_prewhere = 1;
+-- Print plan with actions to make sure both a > 0 and b=2 are present in the prewhere section
+EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE a > 0 SETTINGS optimize_move_to_prewhere = 1;
 
-SELECT * FROM 03591_test WHERE throwIf(b=2, 'Should not throw because b=2 is not visible to this user due to the b=1 row policy') SETTINGS optimize_move_to_prewhere = 1;
+SELECT * FROM 03591_test WHERE throwIf(b=1, 'Should not throw because b=1 is not visible to this user due to the b=2 row policy') SETTINGS optimize_move_to_prewhere = 1;
+
+-- Print plan with actions to make sure a > 0, b = 2 and a = 3 are present in the prewhere section
+EXPLAIN PLAN actions=1 SELECT * FROM 03591_test WHERE a > 0 SETTINGS optimize_move_to_prewhere = 1, additional_table_filters={'03591_test': 'a=3'};
 
 DROP ROW POLICY 03591_rp ON 03591_test;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes https://github.com/ClickHouse/ClickHouse/issues/69777 and https://github.com/ClickHouse/ClickHouse/issues/83748

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
