### PR TITLE
Fix cleanup of patch parts in `ReplicatedMergeTree`

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -310,6 +310,36 @@ bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry
     return false;
 }
 
+bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+{
+    if (entry.type != LogEntry::DROP_PART || !storage.supportsLightweightUpdate())
+        return false;
+
+    auto dropped_info = MergeTreePartInfo::fromPartName(entry.new_part_name, format_version);
+
+    if (!dropped_info.isPatch())
+        return false;
+
+    auto original_partition_id = dropped_info.getOriginalPartitionId();
+
+    for (const auto & merge_mutate_entry : queue)
+    {
+        if (merge_mutate_entry->type != LogEntry::MERGE_PARTS && merge_mutate_entry->type != LogEntry::MUTATE_PART)
+            continue;
+
+        auto new_part_info = MergeTreePartInfo::fromPartName(merge_mutate_entry->new_part_name, format_version);
+
+        if (new_part_info.getPartitionId() == original_partition_id && new_part_info.getDataVersion() > dropped_info.getDataVersion())
+        {
+            constexpr auto fmt_string = "Not executing log entry {} for patch part {} because merge or mutation (with result part {}) which triggered drop of patch part is not executed yet.";
+            LOG_DEBUG(LogToStr(out_reason, log), fmt_string, entry.znode_name, entry.new_part_name, merge_mutate_entry->new_part_name);
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool ReplicatedMergeTreeQueue::havePendingPatchPartsForMutation(
     const LogEntry & entry,
     String & out_reason,
@@ -1783,6 +1813,9 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
                 }
             }
         }
+
+        if (isDropOfPatchPartBlocked(entry, out_postpone_reason, state_lock))
+            return false;
     }
 
     return true;

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -331,7 +331,7 @@ bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, 
 
         if (new_part_info.getPartitionId() == original_partition_id && new_part_info.getDataVersion() > dropped_info.getDataVersion())
         {
-            constexpr auto fmt_string = "Not executing log entry {} for patch part {} because merge or mutation (with result part {}) which triggered drop of patch part is not executed yet.";
+            constexpr auto fmt_string = "Not executing log entry {} for patch part {} because the merge or mutation (with result part {}) that triggered the drop of the patch part has not been executed yet.";
             LOG_DEBUG(LogToStr(out_reason, log), fmt_string, entry.znode_name, entry.new_part_name, merge_mutate_entry->new_part_name);
             return true;
         }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -275,6 +275,7 @@ private:
         const String & part_name, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex lock*/) const;
 
     bool isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
+    bool isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
     bool havePendingPatchPartsForMutation(const LogEntry & entry, String & out_reason, const CommittingBlocks & committing_blocks, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
 
     /// Marks the element of the queue as running.

--- a/tests/queries/0_stateless/03100_lwu_40_cleanup_race.reference
+++ b/tests/queries/0_stateless/03100_lwu_40_cleanup_race.reference
@@ -1,0 +1,17 @@
+all_0_0_0	1	v1
+all_0_0_0	2	u2
+all_0_0_0	3	v3
+all_0_0_0_2	1	v1_updated
+all_0_0_0_2	2	u2_updated
+all_0_0_0_2	3	v3_updated
+t_lwu_cleanup_1	all_0_0_0
+t_lwu_cleanup_1	patch-9834becdf7e2e15ad7c410ffd6a5a63c-all_0_0_0_1
+t_lwu_cleanup_2	all_0_0_0_2
+all_0_0_0_2	1	v1_updated
+all_0_0_0_2	2	u2_updated
+all_0_0_0_2	3	v3_updated
+all_0_0_0_2	1	v1_updated
+all_0_0_0_2	2	u2_updated
+all_0_0_0_2	3	v3_updated
+t_lwu_cleanup_1	all_0_0_0_2
+t_lwu_cleanup_2	all_0_0_0_2

--- a/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
+++ b/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# shellcheck source=./mergetree_mutations.lib
+. "$CURDIR"/mergetree_mutations.lib
+
+set -e
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS t_lwu_cleanup_1 SYNC;
+    DROP TABLE IF EXISTS t_lwu_cleanup_2 SYNC;
+
+    CREATE TABLE t_lwu_cleanup_1 (k UInt64, v String)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_lwu_cleanup', '1')
+    ORDER BY k
+    SETTINGS
+        enable_block_number_column = 1,
+        enable_block_offset_column = 1,
+        cleanup_delay_period = 1,
+        max_cleanup_delay_period = 1,
+        cleanup_delay_period_random_add = 0;
+
+    CREATE TABLE t_lwu_cleanup_2 (k UInt64, v String)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_lwu_cleanup', '2')
+    ORDER BY k
+    SETTINGS
+        enable_block_number_column = 1,
+        enable_block_offset_column = 1,
+        cleanup_delay_period = 1,
+        max_cleanup_delay_period = 1,
+        cleanup_delay_period_random_add = 0;
+
+    SET allow_experimental_lightweight_update = 1;
+    SET insert_keeper_fault_injection_probability = 0.0;
+
+    INSERT INTO t_lwu_cleanup_1 VALUES (1, 'v1') (2, 'v2') (3, 'v3');
+    SYSTEM SYNC REPLICA t_lwu_cleanup_1;
+    SYSTEM STOP MERGES t_lwu_cleanup_1;
+
+    UPDATE t_lwu_cleanup_1 SET v = 'u2' WHERE k = 2;
+    SYSTEM SYNC REPLICA t_lwu_cleanup_2;
+
+    ALTER TABLE t_lwu_cleanup_2 UPDATE v = v || '_updated' WHERE 1 SETTINGS mutations_sync = 1;
+    SYSTEM SYNC REPLICA t_lwu_cleanup_1 LIGHTWEIGHT;
+"
+
+for _ in {0..50}; do
+    res=`$CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_cleanup_2' AND active AND startsWith(name, 'patch')"`
+    if [[ $res == "0" ]]; then
+        break
+    fi
+    sleep 1.0
+done
+
+$CLICKHOUSE_CLIENT --query "
+    SET apply_patch_parts =  1;
+
+    SELECT _part, * FROM t_lwu_cleanup_1 ORDER BY k;
+    SELECT _part, * FROM t_lwu_cleanup_2 ORDER BY k;
+
+    SELECT table, name FROM system.parts
+    WHERE database = currentDatabase() AND table IN ('t_lwu_cleanup_1', 't_lwu_cleanup_2') AND active
+    ORDER BY table, name;
+
+    SYSTEM START MERGES t_lwu_cleanup_1;
+"
+
+wait_for_mutation "t_lwu_cleanup_1" "0000000000"
+
+for _ in {0..50}; do
+    res=`$CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_cleanup_1' AND active AND startsWith(name, 'patch')"`
+    if [[ $res == "0" ]]; then
+        break
+    fi
+    sleep 1.0
+done
+
+$CLICKHOUSE_CLIENT --query "
+    SET apply_patch_parts =  0;
+
+    SELECT _part, * FROM t_lwu_cleanup_1 ORDER BY k;
+    SELECT _part, * FROM t_lwu_cleanup_2 ORDER BY k;
+
+    SELECT table, name FROM system.parts
+    WHERE database = currentDatabase() AND table IN ('t_lwu_cleanup_1', 't_lwu_cleanup_2') AND active
+    ORDER BY table, name;
+
+    DROP TABLE IF EXISTS t_lwu_cleanup_1 SYNC;
+    DROP TABLE IF EXISTS t_lwu_cleanup_2 SYNC;
+"

--- a/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
+++ b/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
@@ -44,7 +44,7 @@ $CLICKHOUSE_CLIENT --query "
     SYSTEM SYNC REPLICA t_lwu_cleanup_2;
 
     ALTER TABLE t_lwu_cleanup_2 UPDATE v = v || '_updated' WHERE 1 SETTINGS mutations_sync = 1;
-    SYSTEM SYNC REPLICA t_lwu_cleanup_1 LIGHTWEIGHT;
+    SYSTEM SYNC REPLICA t_lwu_cleanup_1 PULL;
 "
 
 for _ in {0..50}; do

--- a/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
+++ b/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database, no-shared-catalog, no-shared-merge-tree
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed cleanup of patch parts in `ReplicatedMergeTree`. Previously, the result of a lightweight update may temporarily not be visible on the replica until the merged or mutated part that materializes the patch parts is downloaded from another replica.

Fixes #85094.
