### PR TITLE
Add `database_replicated` settings

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1586,6 +1586,18 @@
         <max_replicated_fetches_network_bandwidth>1000000000</max_replicated_fetches_network_bandwidth>
     </replicated_merge_tree>
     -->
+    
+    <!-- Settings to fine-tune DatabaseReplicatedSettings. See documentation in source code, in DatabaseReplicatedSettings.h -->
+    <!--
+    <database_replicated>
+        <max_broken_tables_ratio>1</max_broken_tables_ratio>
+        <max_replication_lag_to_enqueue>50</max_replication_lag_to_enqueue>
+        <wait_entry_commited_timeout_sec>3600</wait_entry_commited_timeout_sec>
+        <collection_name>default_collection</collection_name>
+        <check_consistency>true</check_consistency>
+        <max_retries_before_automatic_recovery>10</max_retries_before_automatic_recovery>
+    </database_replicated>
+    -->
 
     <!-- Settings to fine-tune Distributed tables. See documentation in source code, in DistributedSettings.h -->
     <!--

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -151,6 +151,8 @@ DatabaseReplicated::DatabaseReplicated(
     , db_settings(std::move(db_settings_))
     , tables_metadata_digest(0)
 {
+    LOG_INFO(log, "DatabaseReplicatedSettings {}", db_settings.toString());
+
     if (zookeeper_path.empty() || shard_name.empty() || replica_name.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path, shard and replica names must be non-empty");
     if (shard_name.contains('/') || replica_name.contains('/'))
@@ -2302,7 +2304,8 @@ void registerDatabaseReplicated(DatabaseFactory & factory)
         info.level = 0;
         replica_name = args.context->getMacros()->expand(replica_name, info);
 
-        DatabaseReplicatedSettings database_replicated_settings{};
+        const auto & initial_storage_settings = args.context->getDatabaseReplicatedSettings();
+        DatabaseReplicatedSettings database_replicated_settings{initial_storage_settings};
         if (engine_define->settings)
             database_replicated_settings.loadFromQuery(*engine_define);
 

--- a/src/Databases/DatabaseReplicatedSettings.h
+++ b/src/Databases/DatabaseReplicatedSettings.h
@@ -3,6 +3,14 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsFields.h>
 
+
+namespace Poco
+{
+namespace Util
+{
+class AbstractConfiguration;
+}
+}
 namespace DB
 {
 class ASTStorage;
@@ -27,6 +35,9 @@ struct DatabaseReplicatedSettings
     DATABASE_REPLICATED_SETTINGS_SUPPORTED_TYPES(DatabaseReplicatedSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)
 
     void loadFromQuery(ASTStorage & storage_def);
+    void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
+
+    String toString() const;
 
 private:
     std::unique_ptr<DatabaseReplicatedSettingsImpl> impl;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -137,6 +137,7 @@ class DeadLetterQueue;
 class IAsynchronousReader;
 class IOUringReader;
 struct MergeTreeSettings;
+struct DatabaseReplicatedSettings;
 struct DistributedSettings;
 struct InitialAllRangesAnnouncement;
 struct ParallelReadRequest;
@@ -1365,6 +1366,7 @@ public:
 
     const MergeTreeSettings & getMergeTreeSettings() const;
     const MergeTreeSettings & getReplicatedMergeTreeSettings() const;
+    const DatabaseReplicatedSettings & getDatabaseReplicatedSettings() const;
     const DistributedSettings & getDistributedSettings() const;
     const S3SettingsByEndpoint & getStorageS3Settings() const;
     const AzureSettingsByEndpoint & getStorageAzureSettings() const;

--- a/tests/integration/test_database_replicated_settings/configs/config.xml
+++ b/tests/integration/test_database_replicated_settings/configs/config.xml
@@ -1,0 +1,26 @@
+<clickhouse>
+    <database_atomic_delay_before_drop_table_sec>10</database_atomic_delay_before_drop_table_sec>
+    <allow_moving_table_directory_to_trash>1</allow_moving_table_directory_to_trash>
+    <merge_tree>
+        <initialization_retry_period>10</initialization_retry_period>
+    </merge_tree>
+    <max_database_replicated_create_table_thread_pool_size>50</max_database_replicated_create_table_thread_pool_size>
+    <allow_experimental_transactions>42</allow_experimental_transactions>
+    <async_load_databases>false</async_load_databases>
+    <named_collections>
+        <postgres1>
+            <user>postgres</user>
+            <password>ClickHouse_PostgreSQL_P@ssw0rd</password>
+            <host>postgres1</host>
+            <port>5432</port>
+            <database>postgres_database</database>
+        </postgres1>
+        <postgres2>
+            <user>postgres</user>
+            <password>ClickHouse_PostgreSQL_P@ssw0rd</password>
+            <host>postgres1</host>
+            <port>1111</port>
+            <database>postgres_database</database>
+        </postgres2>
+    </named_collections>
+</clickhouse>

--- a/tests/integration/test_database_replicated_settings/configs/database_replicated_settings.xml
+++ b/tests/integration/test_database_replicated_settings/configs/database_replicated_settings.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <database_replicated>
+        <max_broken_tables_ratio>0.75</max_broken_tables_ratio>
+        <max_replication_lag_to_enqueue>100</max_replication_lag_to_enqueue>
+        <wait_entry_commited_timeout_sec>1800</wait_entry_commited_timeout_sec>
+        <collection_name>postgres1</collection_name>
+        <check_consistency>false</check_consistency>
+        <max_retries_before_automatic_recovery>5</max_retries_before_automatic_recovery>
+    </database_replicated>
+</clickhouse>

--- a/tests/integration/test_database_replicated_settings/configs/users.xml
+++ b/tests/integration/test_database_replicated_settings/configs/users.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
+            <allow_experimental_alter_materialized_view_structure>1</allow_experimental_alter_materialized_view_structure>
+            <allow_ddl>1</allow_ddl>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_database_replicated_settings/test.py
+++ b/tests/integration/test_database_replicated_settings/test.py
@@ -1,0 +1,166 @@
+import logging
+import os
+import random
+import re
+import shutil
+import string
+import threading
+import time
+from typing import Any, Dict
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+from helpers.test_tools import assert_eq_with_retry, assert_logs_contain
+from helpers.database_disk import get_database_disk_name, replace_text_in_metadata
+
+
+cluster = ClickHouseCluster(__file__)
+
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.xml", "configs/database_replicated_settings.xml"],
+    user_configs=["configs/users.xml"],
+    keeper_required_feature_flags=["multi_read", "create_if_not_exists"],
+    macros={"shard": "shard1", "replica": "1"},
+    stay_alive=True,
+    with_zookeeper=True,
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.xml"],
+    user_configs=["configs/users.xml"],
+    keeper_required_feature_flags=["multi_read", "create_if_not_exists"],
+    macros={"shard": "shard1", "replica": "2"},
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def get_random_string(string_length=8):
+    alphabet = string.ascii_letters + string.digits
+    return "".join((random.choice(alphabet) for _ in range(string_length)))
+
+def convert_setting(key : str, value: str):
+    match key:
+        case "node_with_database_replicated_settings" | "check_consistency":
+            if value.lower() == "false":
+                value = False
+            elif value.lower() == "true":
+                value = True
+            else:
+                raise Exception(f"Invalid settings {key}: {value}")
+            return key, value
+        case "max_broken_tables_ratio":
+            value = float(value)
+            return key, value
+        case "max_replication_lag_to_enqueue" | "wait_entry_commited_timeout_sec" | "max_retries_before_automatic_recovery":
+            value = int(value)
+            return key, value
+        case "collection_name":
+            return key, value
+    
+    raise Exception(f"Unknown settings {key}: {value}")
+
+def get_settings_from_logs(node, db_name) ->Dict[str, Any]:
+    node.query("SYSTEM FLUSH LOGS")
+    result = str(node.query(
+        f"SELECT message FROM system.text_log WHERE logger_name='DatabaseReplicated ({db_name})' AND position(message, 'DatabaseReplicatedSettings') = 1"
+    ).strip())
+    assert result.startswith("DatabaseReplicatedSettings")
+    settings = result.removeprefix("DatabaseReplicatedSettings").strip()
+    
+    if settings == "":
+        return {}
+
+    config_dict = {}
+    # Split into key-value pairs
+    pairs = settings.split(",")
+    for pair in pairs:
+        key, value = pair.strip().split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if(value.startswith(r"\'")):
+            value = value.strip(r"\'")
+        
+        key, value = convert_setting(key, value)
+        config_dict[key] = value
+        
+    return config_dict
+    
+@pytest.mark.parametrize("node_with_database_replicated_settings", [True, False])
+@pytest.mark.parametrize("max_broken_tables_ratio", [None, 0.5])
+@pytest.mark.parametrize("max_replication_lag_to_enqueue", [None, 10])
+@pytest.mark.parametrize("wait_entry_commited_timeout_sec", [None, 900])
+@pytest.mark.parametrize("collection_name", [None, "postgres2"])
+@pytest.mark.parametrize("check_consistency", [None, True, False])
+@pytest.mark.parametrize("max_retries_before_automatic_recovery", [None, 1])
+def test_database_replicated_settings(
+    started_cluster,
+    node_with_database_replicated_settings: bool, # default config from database_replicated_settings.xml
+    max_broken_tables_ratio,
+    max_replication_lag_to_enqueue,
+    wait_entry_commited_timeout_sec,
+    collection_name,
+    check_consistency,
+    max_retries_before_automatic_recovery,
+):
+    db_name = "test_" + get_random_string()
+
+    node = node1 if node_with_database_replicated_settings else node2
+    
+    node.query(f"DROP DATABASE IF EXISTS {db_name}")
+
+    settings_in_query = ""
+    setting_dict : Dict[str, Any]= {}
+
+    def add_setting(key, val, default):
+        nonlocal settings_in_query
+        nonlocal setting_dict
+        nonlocal node_with_database_replicated_settings
+        if val == None:
+            if node_with_database_replicated_settings:
+                setting_dict[key] = default
+            return
+        
+        setting_dict[key] = val
+        
+        if isinstance(val, str):
+            val = f"'{val}'"
+        if settings_in_query != "":
+            settings_in_query += f", {key}={val}"
+        else :
+            settings_in_query += f"{key}={val}"
+
+    add_setting("max_broken_tables_ratio", max_broken_tables_ratio, float(0.75) if node_with_database_replicated_settings else float(1.0))
+    add_setting("max_replication_lag_to_enqueue", max_replication_lag_to_enqueue, int(100) if node_with_database_replicated_settings else int(50))
+    add_setting("wait_entry_commited_timeout_sec", wait_entry_commited_timeout_sec, int(1800) if node_with_database_replicated_settings else int(3600))
+    add_setting("collection_name", collection_name, "postgres1" if node_with_database_replicated_settings else "")
+    add_setting("check_consistency", check_consistency, False if node_with_database_replicated_settings else True)
+    add_setting(
+        "max_retries_before_automatic_recovery", max_retries_before_automatic_recovery, int(5) if node_with_database_replicated_settings else int(10)
+    )
+
+    if settings_in_query != "":
+        settings_in_query = f"SETTINGS {settings_in_query}"
+    node.query(
+        f"CREATE DATABASE {db_name} ENGINE=Replicated('/test/{db_name}', "
+        + r"'{shard}', '{replica}') "
+        + settings_in_query
+    )
+    
+    settings_dict_from_logs = get_settings_from_logs(node, db_name)
+    assert setting_dict == settings_dict_from_logs
+    node.query(f"DROP DATABASE IF EXISTS {db_name}")
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add `database_replicated` settings defining the default values of DatabaseReplicatedSettings. If the setting is not present in the Replicated DB create query, the value from this setting is used.

Example:
````
<clickhouse>
    <database_replicated>
        <max_broken_tables_ratio>0.75</max_broken_tables_ratio>
        <max_replication_lag_to_enqueue>100</max_replication_lag_to_enqueue>
        <wait_entry_commited_timeout_sec>1800</wait_entry_commited_timeout_sec>
        <collection_name>postgres1</collection_name>
        <check_consistency>false</check_consistency>
        <max_retries_before_automatic_recovery>5</max_retries_before_automatic_recovery>
    </database_replicated>
</clickhouse>
````

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
