### PR TITLE
Docs: move docs for Null functions to source code

### DIFF
--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -36,9 +36,9 @@ String mapTypesToTypesWithLinks(const std::vector<std::string> & types)
 
         if (type == "NULL")
             result += "`](/sql-reference/syntax#null)";
-        if (type == "Any")
+        else if (type == "Any")
             result += "`](/sql-reference/data-types)";
-        if (type == "String" || type == "String literal")
+        else if (type == "String" || type == "String literal")
             result += "`](/sql-reference/data-types/string)";
         else if (type.starts_with("FixedString"))
             result += "`](/sql-reference/data-types/fixedstring)";

--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -34,6 +34,10 @@ String mapTypesToTypesWithLinks(const std::vector<std::string> & types)
         if (type.starts_with("const "))
             type = type.substr(6); // Remove "const " prefix
 
+        if (type == "NULL")
+            result += "`](/sql-reference/syntax#null)";
+        if (type == "Any")
+            result += "`](/sql-reference/data-types)";
         if (type == "String" || type == "String literal")
             result += "`](/sql-reference/data-types/string)";
         else if (type.starts_with("FixedString"))
@@ -211,7 +215,7 @@ String FunctionDocumentation::categoryAsString() const
         {Category::Map, "Map"},
         {Category::Mathematical, "Mathematical"},
         {Category::NLP, "Natural Language Processing"},
-        {Category::Nullable, "Nullable"},
+        {Category::Null, "Null"},
         {Category::NumericIndexedVector, "NumericIndexedVector"},
         {Category::Other, "Other"},
         {Category::RandomNumber, "Random Number"},

--- a/src/Common/FunctionDocumentation.h
+++ b/src/Common/FunctionDocumentation.h
@@ -104,7 +104,7 @@ struct FunctionDocumentation
         Map,
         Mathematical,
         NLP,
-        Nullable,
+        Null,
         NumericIndexedVector,
         Other,
         RandomNumber,

--- a/src/Functions/assumeNotNull.cpp
+++ b/src/Functions/assumeNotNull.cpp
@@ -64,7 +64,45 @@ public:
 
 REGISTER_FUNCTION(AssumeNotNull)
 {
-    factory.registerFunction<FunctionAssumeNotNull>();
+    FunctionDocumentation::Description description = R"(
+Returns the corresponding non-`Nullable` value for a value of type [`Nullable`](../data-types/nullable.md).
+If the original value is `NULL`, an arbitrary result can be returned.
+
+See also: functions [`ifNull`](#ifNull) and [`coalesce`](#coalesce).
+    )";
+    FunctionDocumentation::Syntax syntax = "assumeNotNull(x)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "The original value of any nullable type.", {"Nullable(T)"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the non-nullable value, if the original value was not `NULL`, otherwise an arbitrary value, if the input value is `NULL`.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
+        {"Usage example",
+         R"(
+CREATE TABLE t_null (x Int8, y Nullable(Int8))
+ENGINE=MergeTree()
+ORDER BY x;
+
+INSERT INTO t_null VALUES (1, NULL), (2, 3);
+
+SELECT assumeNotNull(y) FROM table;
+SELECT toTypeName(assumeNotNull(y)) FROM t_null;
+        )",
+         R"(
+┌─assumeNotNull(y)─┐
+│                0 │
+│                3 │
+└──────────────────┘
+┌─toTypeName(assumeNotNull(y))─┐
+│ Int8                         │
+│ Int8                         │
+└──────────────────────────────┘
+        )"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in{1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionAssumeNotNull>(documentation);
 }
 
 }

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -195,10 +195,10 @@ Returns the leftmost non-`NULL` argument.
 
 CREATE TABLE aBook
 (
-  name String,
-  mail Nullable(String),
-  phone Nullable(String),
-  telegram Nullable(UInt32)
+    name String,
+    mail Nullable(String),
+    phone Nullable(String),
+    telegram Nullable(UInt32)
 )
 ENGINE = MergeTree
 ORDER BY tuple();

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -180,7 +180,49 @@ private:
 
 REGISTER_FUNCTION(Coalesce)
 {
-    factory.registerFunction<FunctionCoalesce>({}, FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description = R"(
+Returns the leftmost non-`NULL` argument.
+    )";
+    FunctionDocumentation::Syntax syntax = "coalesce(x[, y, ...])";
+    FunctionDocumentation::Arguments arguments = {
+        {"x[, y, ...]", "Any number of parameters of non-compound type. All parameters must be of mutually compatible data types.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the first non-`NULL` argument, otherwise `NULL`, if all arguments are `NULL`.", {"Any", "NULL"}};
+    FunctionDocumentation::Examples examples = {
+        {"Usage example",
+         R"(
+-- Consider a list of contacts that may specify multiple ways to contact a customer.
+
+CREATE TABLE aBook
+(
+  name String,
+  mail Nullable(String),
+  phone Nullable(String),
+  telegram Nullable(UInt32)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO aBook VALUES ('client 1', NULL, '123-45-67', 123), ('client 2', NULL, NULL, NULL);
+
+-- The mail and phone fields are of type String, but the telegram field is UInt32 so it needs to be converted to String.
+
+-- Get the first available contact method for the customer from the contact list
+
+SELECT name, coalesce(mail, phone, CAST(telegram,'Nullable(String)')) FROM aBook;
+        )",
+         R"(
+┌─name─────┬─coalesce(mail, phone, CAST(telegram, 'Nullable(String)'))─┐
+│ client 1 │ 123-45-67                                                 │
+│ client 2 │ ᴺᵁᴸᴸ                                                      │
+└──────────┴───────────────────────────────────────────────────────────┘
+        )"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionCoalesce>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/ifNull.cpp
+++ b/src/Functions/ifNull.cpp
@@ -91,7 +91,31 @@ private:
 
 REGISTER_FUNCTION(IfNull)
 {
-    factory.registerFunction<FunctionIfNull>({}, FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description = R"(
+Returns an alternative value if the first argument is `NULL`.
+    )";
+    FunctionDocumentation::Syntax syntax = "ifNull(x, alt)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "The value to check for `NULL`.", {"Any"}},
+        {"alt", "The value that the function returns if `x` is `NULL`.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the value of `x` if it is not `NULL`, otherwise `alt`.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
+        {"Usage example",
+         R"(
+SELECT ifNull('a', 'b'), ifNull(NULL, 'b');
+        )",
+         R"(
+┌─ifNull('a', 'b')─┬─ifNull(NULL, 'b')─┐
+│ a                │ b                 │
+└──────────────────┴───────────────────┘
+        )"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in{1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionIfNull>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/isNotDistinctFrom.cpp
+++ b/src/Functions/isNotDistinctFrom.cpp
@@ -6,22 +6,30 @@ namespace DB
 
 REGISTER_FUNCTION(IsNotDistinctFrom)
 {
-    factory.registerFunction<FunctionIsNotDistinctFrom>(
-        FunctionDocumentation{
-        .description = R"(
-Performs a null-safe comparison between two values. This function will consider
+    FunctionDocumentation::Description description = R"(
+Performs a null-safe comparison between two `JOIN` keys. This function will consider
 two `NULL` values as identical and will return `true`, which is distinct from the usual
 equals behavior where comparing two `NULL` values would return `NULL`.
 
-Currently, this function can only be used in the `JOIN ON` section of a query.
-[example:join_on_is_not_distinct_from]
-)",
-        .examples{
-            {"join_on_is_not_distinct_from", "SELECT * FROM (SELECT NULL AS a) AS t1 JOIN (SELECT NULL AS b) AS t2 ON isNotDistinctFrom(t1.a, t2.b)", "NULL\tNULL"},
-        },
-        .category = FunctionDocumentation::Category::Nullable,
-    });
+:::info
+This function is an internal function used by the implementation of `JOIN ON`.
+Please do not use it manually in queries.
+:::
 
+For a complete example see: [`NULL` values in `JOIN` keys](/sql-reference/statements/select/join#null-values-in-join-keys).
+    )";
+    FunctionDocumentation::Syntax syntax = "isNotDistinctFrom(x, y)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "First `JOIN` key to compare.", {"Any"}},
+        {"y", "Second `JOIN` key to compare.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `true` when `x` and `y` are both `NULL`, otherwise `false`.", {"Bool"}};
+    FunctionDocumentation::Examples examples = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionIsNotDistinctFrom>(documentation);
 }
 
 }

--- a/src/Functions/isNotNull.cpp
+++ b/src/Functions/isNotNull.cpp
@@ -144,7 +144,44 @@ private:
 
 REGISTER_FUNCTION(IsNotNull)
 {
-    factory.registerFunction<FunctionIsNotNull>();
+    FunctionDocumentation::Description description = R"(
+Checks if the argument is not `NULL`.
+
+Also see: operator [`IS NOT NULL`](/sql-reference/operators#is_not_null).
+    )";
+    FunctionDocumentation::Syntax syntax = "isNotNull(x)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "A value of non-compound data type.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if `x` is not `NULL`, otherwise `0`.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE t_null
+(
+  x Int32,
+  y Nullable(Int32)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO t_null VALUES (1, NULL), (2, 3);
+
+SELECT x FROM t_null WHERE isNotNull(y);
+        )",
+        R"(
+┌─x─┐
+│ 2 │
+└───┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionIsNotNull>(documentation);
 }
 
 }

--- a/src/Functions/isNull.cpp
+++ b/src/Functions/isNull.cpp
@@ -80,7 +80,44 @@ ColumnPtr FunctionIsNull::executeImpl(const ColumnsWithTypeAndName & arguments, 
 
 REGISTER_FUNCTION(IsNull)
 {
-    factory.registerFunction<FunctionIsNull>({}, FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description = R"(
+Checks if the argument is `NULL`.
+
+Also see: operator [`IS NULL`](/sql-reference/operators#is_null).
+    )";
+    FunctionDocumentation::Syntax syntax = "isNull(x)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "A value of non-compound data type.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if `x` is `NULL`, otherwise `0`.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE t_null
+(
+  x Int32,
+  y Nullable(Int32)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO t_null VALUES (1, NULL), (2, 3);
+
+SELECT x FROM t_null WHERE isNull(y);
+        )",
+        R"(
+┌─x─┐
+│ 1 │
+└───┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionIsNull>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/isNullable.cpp
+++ b/src/Functions/isNullable.cpp
@@ -82,7 +82,41 @@ private:
 
 REGISTER_FUNCTION(IsNullable)
 {
-    factory.registerFunction<FunctionIsNullable>();
+    FunctionDocumentation::Description description = R"(
+Checks whether the argument's data type is `Nullable` (i.e it allows `NULL` values).
+    )";
+    FunctionDocumentation::Syntax syntax = "isNullable(x)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "A value of any data type.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if `x` is of a `Nullable` data type, otherwise `0`.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE tab(
+  ordinary_col UInt32,
+  nullable_col Nullable(UInt32)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+INSERT INTO tab (ordinary_col, nullable_col) VALUES (1,1), (2, 2), (3,3);
+SELECT isNullable(ordinary_col), isNullable(nullable_col) FROM tab;
+        )",
+        R"(
+┌───isNullable(ordinary_col)──┬───isNullable(nullable_col)──┐
+│                           0 │                           1 │
+│                           0 │                           1 │
+│                           0 │                           1 │
+└─────────────────────────────┴─────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 7};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionIsNullable>(documentation);
 }
 
 }

--- a/src/Functions/isNullable.cpp
+++ b/src/Functions/isNullable.cpp
@@ -94,9 +94,9 @@ Checks whether the argument's data type is `Nullable` (i.e it allows `NULL` valu
     {
         "Usage example",
         R"(
-CREATE TABLE tab(
-  ordinary_col UInt32,
-  nullable_col Nullable(UInt32)
+CREATE TABLE tab (
+    ordinary_col UInt32,
+    nullable_col Nullable(UInt32)
 )
 ENGINE = MergeTree
 ORDER BY tuple();

--- a/src/Functions/isZeroOrNull.cpp
+++ b/src/Functions/isZeroOrNull.cpp
@@ -132,9 +132,9 @@ Checks if the argument is either zero (`0`) or `NULL`.
     )";
     FunctionDocumentation::Syntax syntax = "isZeroOrNull(x)";
     FunctionDocumentation::Arguments arguments = {
-        {"x", "A numeric value.", {"Number"}}
+        {"x", "A numeric value.", {"UInt"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if `x` is `NULL` or equal to zero, otherwise `0`.", {"UInt8"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if `x` is `NULL` or equal to zero, otherwise `0`.", {"UInt8/16/32/64", "Float32/Float64"}};
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",

--- a/src/Functions/isZeroOrNull.cpp
+++ b/src/Functions/isZeroOrNull.cpp
@@ -127,7 +127,43 @@ private:
 
 REGISTER_FUNCTION(IsZeroOrNull)
 {
-    factory.registerFunction<FunctionIsZeroOrNull>();
+    FunctionDocumentation::Description description = R"(
+Checks if the argument is either zero (`0`) or `NULL`.
+    )";
+    FunctionDocumentation::Syntax syntax = "isZeroOrNull(x)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "A numeric value.", {"Number"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if `x` is `NULL` or equal to zero, otherwise `0`.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE t_null
+(
+  x Int32,
+  y Nullable(Int32)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO t_null VALUES (1, NULL), (2, 0), (3, 3);
+
+SELECT x FROM t_null WHERE isZeroOrNull(y);
+        )",
+        R"(
+┌─x─┐
+│ 1 │
+│ 2 │
+└───┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 3};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionIsZeroOrNull>(documentation);
 }
 
 }

--- a/src/Functions/nullIf.cpp
+++ b/src/Functions/nullIf.cpp
@@ -69,7 +69,31 @@ public:
 
 REGISTER_FUNCTION(NullIf)
 {
-    factory.registerFunction<FunctionNullIf>({}, FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description = R"(
+Returns `NULL` if both arguments are equal.
+    )";
+    FunctionDocumentation::Syntax syntax = "nullIf(x, y)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "The first value.", {"Any"}},
+        {"y", "The second value.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `NULL` if both arguments are equal, otherwise returns the first argument.", {"NULL", "Nullable(x)"}};
+    FunctionDocumentation::Examples examples = {
+        {"Usage example",
+         R"(
+SELECT nullIf(1, 1), nullIf(1, 2);
+        )",
+         R"(
+┌─nullIf(1, 1)─┬─nullIf(1, 2)─┐
+│         ᴺᵁᴸᴸ │            1 │
+└──────────────┴──────────────┘
+        )"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in{1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionNullIf>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toNullable.cpp
+++ b/src/Functions/toNullable.cpp
@@ -47,7 +47,30 @@ public:
 
 REGISTER_FUNCTION(ToNullable)
 {
-    factory.registerFunction<FunctionToNullable>();
+    FunctionDocumentation::Description description = R"(
+Converts the provided argument type to `Nullable`.
+    )";
+    FunctionDocumentation::Syntax syntax = "toNullable(x)";
+    FunctionDocumentation::Arguments arguments = {
+        {"x", "A value of any non-compound type.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the input value but of `Nullable` type.", {"Nullable(Any)"}};
+    FunctionDocumentation::Examples examples = {
+        {"Usage example",
+         R"(
+SELECT toTypeName(10), toTypeName(toNullable(10));
+        )",
+         R"(
+┌─toTypeName(10)─┬─toTypeName(toNullable(10))─┐
+│ UInt8          │ Nullable(UInt8)            │
+└────────────────┴────────────────────────────┘
+        )"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in{1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Null;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionToNullable>(documentation);
 }
 
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -62,7 +62,6 @@ alphaTokens
 and
 appendTrailingCharIfAbsent
 asinh
-assumeNotNull
 atan
 atan2
 atanh
@@ -85,7 +84,6 @@ cbrt
 ceil
 char
 cityHash64
-coalesce
 concat
 concatAssumeInjective
 connectionId
@@ -198,7 +196,6 @@ hopStart
 hostName
 hypot
 identity
-ifNull
 ignore
 ilike
 in
@@ -217,12 +214,8 @@ isDecimalOverflow
 isIPAddressInRange
 isIPv4String
 isIPv6String
-isNotNull
-isNull
-isNullable
 isValidJSON
 isValidUTF8
-isZeroOrNull
 javaHash
 javaHashUTF16LE
 joinGet
@@ -317,7 +310,6 @@ notInIgnoreSet
 notLike
 notNullIn
 notNullInIgnoreSet
-nullIf
 nullIn
 nullInIgnoreSet
 or
@@ -570,7 +562,6 @@ toIntervalWeek
 toIntervalYear
 toJSONString
 toLowCardinality
-toNullable
 toString
 toStringCutToZero
 toTime

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -73,7 +73,6 @@ appendTrailingCharIfAbsent
 ascii
 asin
 asinh
-assumeNotNull
 atan
 atan2
 atanh
@@ -97,7 +96,6 @@ cbrt
 ceil
 char
 cityHash64
-coalesce
 compareSubstrings
 concat
 concatAssumeInjective
@@ -300,7 +298,6 @@ hopStart
 hostName
 hypot
 identity
-ifNull
 ignore
 ilike
 in
@@ -321,13 +318,8 @@ isDynamicElementInSharedData
 isIPAddressInRange
 isIPv4String
 isIPv6String
-isNotDistinctFrom
-isNotNull
-isNull
-isNullable
 isValidJSON
 isValidUTF8
-isZeroOrNull
 jaroSimilarity
 jaroWinklerSimilarity
 javaHash
@@ -428,7 +420,6 @@ notInIgnoreSet
 notLike
 notNullIn
 notNullInIgnoreSet
-nullIf
 nullIn
 nullInIgnoreSet
 or
@@ -731,7 +722,6 @@ toIntervalWeek
 toIntervalYear
 toJSONString
 toLowCardinality
-toNullable
 toString
 toStringCutToZero
 toTime


### PR DESCRIPTION
Moves the documentation for https://clickhouse.com/docs/sql-reference/functions/functions-for-nulls into the source code for generating this page automatically from system tables.
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
