### PR TITLE
Allow key-value arguments in s3/s3cluster engine

### DIFF
--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -218,7 +218,7 @@ protected:
                 break;
             if (f->name() == "headers")
                 result.nested_maps.push_back(f->name());
-            else if (f->name() != "extra_credentials")
+            else if (f->name() != "extra_credentials" && f->name() != "equals")
                 break;
             count -= 1;
         }
@@ -236,6 +236,8 @@ protected:
             findSecretNamedArgument("secret_access_key", 1);
             return;
         }
+
+        findSecretNamedArgument("secret_access_key", url_arg_idx);
 
         /// We should check other arguments first because we don't need to do any replacement in case of
         /// s3('url', NOSIGN, 'format' [, 'compression'] [, extra_credentials(..)] [, headers(..)])
@@ -548,6 +550,8 @@ protected:
             findSecretNamedArgument("secret_access_key", 1);
             return;
         }
+
+        findSecretNamedArgument("secret_access_key", 0);
 
         /// We should check other arguments first because we don't need to do any replacement in case of
         /// S3('url', NOSIGN, 'format' [, 'compression'] [, extra_credentials(..)] [, headers(..)])

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -293,17 +293,86 @@ bool StorageS3Configuration::collectCredentials(ASTPtr maybe_credentials, S3::S3
     return true;
 }
 
+template <typename T>
+std::optional<T> getFromPositionOrKeyValue(
+    const std::string & key,
+    const ASTs & args,
+    const std::unordered_map<std::string_view, size_t> & engine_args_to_idx,
+    const std::unordered_map<std::string, Field> & key_value_args)
+{
+    if (auto arg_it = engine_args_to_idx.find(key); arg_it != engine_args_to_idx.end())
+        return checkAndGetLiteralArgument<T>(args[arg_it->second], key);
+
+    if (auto arg_it = key_value_args.find(key); arg_it != key_value_args.end())
+        return arg_it->second.safeGet<T>();
+
+    return std::nullopt;
+};
+
+std::unordered_map<std::string, Field> parseKeyValueArguments(const ASTs & function_args, ContextPtr context)
+{
+    std::unordered_map<std::string, Field> key_value_args;
+    for (const auto & arg : function_args)
+    {
+        const auto * function_ast = arg->as<ASTFunction>();
+        if (!function_ast || function_ast->name != "equals")
+            continue;
+
+        auto * args_expr = assert_cast<ASTExpressionList *>(function_ast->arguments.get());
+        auto & children = args_expr->children;
+        if (children.size() != 2)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Key value argument is incorrect: expected 2 arguments, got {}",
+                children.size());
+        }
+
+        children[0] = evaluateConstantExpressionOrIdentifierAsLiteral(children[0], context);
+        children[1] = evaluateConstantExpressionOrIdentifierAsLiteral(children[1], context);
+
+        auto arg_name_value = children[0]->as<ASTLiteral>()->value;
+        if (arg_name_value.getType() != Field::Types::Which::String)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected string as credential name");
+
+        auto arg_name = arg_name_value.safeGet<String>();
+        auto arg_value = children[1]->as<ASTLiteral>()->value;
+
+        auto inserted = key_value_args.emplace(arg_name, arg_value).second;
+        if (!inserted)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Duplicate key value argument: {}", arg_name);
+    }
+    return key_value_args;
+}
+
 void StorageS3Configuration::fromAST(ASTs & args, ContextPtr context, bool with_structure)
 {
     auto extra_credentials = extractExtraCredentials(args);
 
+    auto * it = std::remove_if(args.begin(), args.end(), [](const ASTPtr & arg)
+    {
+        const auto * function_ast = arg->as<ASTFunction>();
+        return function_ast && function_ast->name == "equals";
+    });
+
     size_t count = StorageURL::evalArgsAndCollectHeaders(args, headers_from_ast, context);
+
+    ASTs key_value_asts;
+    if (it != args.end())
+    {
+        key_value_asts = ASTs(it, args.end());
+        count -= key_value_asts.size();
+    }
 
     if (count == 0 || count > getMaxNumberOfArguments(with_structure))
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
             "Storage S3 requires 1 to {} arguments. All supported signatures:\n{}",
             getMaxNumberOfArguments(with_structure),
             getSignatures(with_structure));
+
+    auto key_value_args = parseKeyValueArguments(key_value_asts, context);
+    if (key_value_args.contains("structure"))
+        with_structure = false;
 
     const auto & config = context->getConfigRef();
     s3_capabilities = std::make_unique<S3Capabilities>(getCapabilitiesFromConfig(config, "s3"));
@@ -531,27 +600,35 @@ void StorageS3Configuration::fromAST(ASTs & args, ContextPtr context, bool with_
         s3_settings->request_settings.updateIfChanged(endpoint_settings->request_settings);
     }
 
-    if (engine_args_to_idx.contains("format"))
+    if (auto format_value = getFromPositionOrKeyValue<String>("format", args, engine_args_to_idx, key_value_args);
+        format_value.has_value())
     {
-        format = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["format"]], "format");
+        format = format_value.value();
         /// Set format to configuration only of it's not 'auto',
         /// because we can have default format set in configuration.
         if (format != "auto")
             format = format;
     }
 
-    if (engine_args_to_idx.contains("structure"))
-        structure = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["structure"]], "structure");
-
-    if (engine_args_to_idx.contains("compression_method"))
-        compression_method = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["compression_method"]], "compression_method");
-
-    if (engine_args_to_idx.contains("partition_strategy"))
+    if (auto structure_value = getFromPositionOrKeyValue<String>("structure", args, engine_args_to_idx, key_value_args);
+        structure_value.has_value())
     {
-        const auto partition_strategy_name = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["partition_strategy"]], "partition_strategy");
+        structure = structure_value.value();
+    }
+
+    if (auto compression_method_value = getFromPositionOrKeyValue<String>("compression_method", args, engine_args_to_idx, key_value_args);
+        compression_method_value.has_value())
+    {
+        compression_method = compression_method_value.value();
+    }
+
+    if (auto partition_strategy_value = getFromPositionOrKeyValue<String>("partition_strategy", args, engine_args_to_idx, key_value_args);
+        partition_strategy_value.has_value())
+    {
+        const auto & partition_strategy_name = partition_strategy_value.value();
         const auto partition_strategy_type_opt = magic_enum::enum_cast<PartitionStrategyFactory::StrategyType>(partition_strategy_name, magic_enum::case_insensitive);
 
-        if (!partition_strategy_type_opt)
+        if (!partition_strategy_type_opt.has_value())
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Partition strategy {} is not supported", partition_strategy_name);
         }
@@ -559,22 +636,41 @@ void StorageS3Configuration::fromAST(ASTs & args, ContextPtr context, bool with_
         partition_strategy_type = partition_strategy_type_opt.value();
     }
 
-    if (engine_args_to_idx.contains("partition_columns_in_data_file"))
-        partition_columns_in_data_file = checkAndGetLiteralArgument<bool>(args[engine_args_to_idx["partition_columns_in_data_file"]], "partition_columns_in_data_file");
+    if (auto partition_columns_in_data_file_value = getFromPositionOrKeyValue<bool>("partition_columns_in_data_file", args, engine_args_to_idx, key_value_args);
+        partition_columns_in_data_file_value.has_value())
+    {
+        partition_columns_in_data_file = partition_columns_in_data_file_value.value();
+    }
     else
         partition_columns_in_data_file = partition_strategy_type != PartitionStrategyFactory::StrategyType::HIVE;
 
-    if (engine_args_to_idx.contains("access_key_id"))
-        s3_settings->auth_settings[S3AuthSetting::access_key_id] = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["access_key_id"]], "access_key_id");
+    if (auto access_key_id_value = getFromPositionOrKeyValue<String>("access_key_id", args, engine_args_to_idx, key_value_args);
+        access_key_id_value.has_value())
+    {
+        s3_settings->auth_settings[S3AuthSetting::access_key_id] = access_key_id_value.value();
+    }
 
-    if (engine_args_to_idx.contains("secret_access_key"))
-        s3_settings->auth_settings[S3AuthSetting::secret_access_key] = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["secret_access_key"]], "secret_access_key");
+    if (auto secret_access_key_value = getFromPositionOrKeyValue<String>("secret_access_key", args, engine_args_to_idx, key_value_args);
+        secret_access_key_value.has_value())
+    {
+        s3_settings->auth_settings[S3AuthSetting::secret_access_key] = secret_access_key_value.value();
+    }
 
-    if (engine_args_to_idx.contains("session_token"))
-        s3_settings->auth_settings[S3AuthSetting::session_token] = checkAndGetLiteralArgument<String>(args[engine_args_to_idx["session_token"]], "session_token");
+    if (auto session_token_value = getFromPositionOrKeyValue<String>("session_token", args, engine_args_to_idx, key_value_args);
+        session_token_value.has_value())
+    {
+        s3_settings->auth_settings[S3AuthSetting::session_token] = session_token_value.value();
+    }
 
     if (no_sign_request)
+    {
         s3_settings->auth_settings[S3AuthSetting::no_sign_request] = no_sign_request;
+    }
+    else if (auto no_sign_value = getFromPositionOrKeyValue<bool>("no_sign", args, {}, key_value_args);
+        no_sign_value.has_value())
+    {
+        s3_settings->auth_settings[S3AuthSetting::no_sign_request] = no_sign_value.value();
+    }
 
     static_configuration = !s3_settings->auth_settings[S3AuthSetting::access_key_id].value.empty() || s3_settings->auth_settings[S3AuthSetting::no_sign_request].changed;
 
@@ -609,13 +705,85 @@ void StorageS3Configuration::addStructureAndFormatToArgsIfNeeded(
         auto extra_credentials = extractExtraCredentials(args);
 
         HTTPHeaderEntries tmp_headers;
+
+        auto * key_value_it = std::remove_if(args.begin(), args.end(), [](const ASTPtr & arg)
+        {
+            const auto * function_ast = arg->as<ASTFunction>();
+            return function_ast && function_ast->name == "equals";
+        });
+
         size_t count = StorageURL::evalArgsAndCollectHeaders(args, tmp_headers, context);
+
+        ASTs key_value_asts;
+        if (key_value_it != args.end())
+        {
+            key_value_asts = ASTs(key_value_it, args.end());
+            count -= key_value_asts.size();
+        }
 
         if (count == 0 || count > getMaxNumberOfArguments())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected 1 to {} arguments in table function s3, got {}", getMaxNumberOfArguments(), count);
 
         auto format_literal = std::make_shared<ASTLiteral>(format_);
         auto structure_literal = std::make_shared<ASTLiteral>(structure_);
+
+        bool format_in_key_value = false;
+        bool structure_in_key_value = false;
+        for (auto * it = key_value_it; it != args.end(); ++it)
+        {
+            const auto & arg = *it;
+            const auto * function_ast = arg->as<ASTFunction>();
+            if (!function_ast || function_ast->name != "equals")
+                continue;
+
+            auto * args_expr = assert_cast<ASTExpressionList *>(function_ast->arguments.get());
+            auto & children = args_expr->children;
+            if (children.size() != 2)
+            {
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Key value argument is incorrect: expected 2 arguments, got {}",
+                    children.size());
+            }
+
+            children[0] = evaluateConstantExpressionOrIdentifierAsLiteral(children[0], context);
+
+            auto arg_name_value = children[0]->as<ASTLiteral>()->value;
+            if (arg_name_value.getType() != Field::Types::Which::String)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected string as credential name");
+            auto arg_name = arg_name_value.safeGet<String>();
+
+            if (arg_name == "format")
+            {
+                children[1] = format_literal;
+                format_in_key_value = true;
+            }
+            else if (arg_name == "structure")
+            {
+                children[1] = structure_literal;
+                structure_in_key_value = true;
+            }
+        }
+
+        if (format_in_key_value && structure_in_key_value)
+        {
+            /// Add extracted extra credentials to the end of the args.
+            if (extra_credentials)
+                args.push_back(extra_credentials);
+            return;
+        }
+        else if (format_in_key_value && with_structure)
+        {
+            /// Structure goes right after format, so if format is in key-value,
+            /// then structure is required to be key-value.
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected positional arguments to go before key-value arguments");
+        }
+        else if (structure_in_key_value)
+        {
+            with_structure = false;
+        }
+
+        args.erase(key_value_it, args.end());
 
         /// s3(s3_url)
         if (count == 1)
@@ -775,6 +943,9 @@ void StorageS3Configuration::addStructureAndFormatToArgsIfNeeded(
                 args[5] = structure_literal;
         }
 
+        if (!key_value_asts.empty())
+            args.insert(args.end(), std::make_move_iterator(key_value_asts.begin()), std::make_move_iterator(key_value_asts.end()));
+
         /// Add extracted extra credentials to the end of the args.
         if (extra_credentials)
             args.push_back(extra_credentials);
@@ -784,3 +955,4 @@ void StorageS3Configuration::addStructureAndFormatToArgsIfNeeded(
 }
 
 #endif
+

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -328,15 +328,15 @@ static std::unordered_map<std::string, Field> parseKeyValueArguments(const ASTs 
                 children.size());
         }
 
-        children[0] = evaluateConstantExpressionOrIdentifierAsLiteral(children[0], context);
-        children[1] = evaluateConstantExpressionOrIdentifierAsLiteral(children[1], context);
+        auto key_literal = evaluateConstantExpressionOrIdentifierAsLiteral(children[0], context);
+        auto value_literal = evaluateConstantExpressionOrIdentifierAsLiteral(children[1], context);
 
-        auto arg_name_value = children[0]->as<ASTLiteral>()->value;
+        auto arg_name_value = key_literal->as<ASTLiteral>()->value;
         if (arg_name_value.getType() != Field::Types::Which::String)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected string as credential name");
 
         auto arg_name = arg_name_value.safeGet<String>();
-        auto arg_value = children[1]->as<ASTLiteral>()->value;
+        auto arg_value = value_literal->as<ASTLiteral>()->value;
 
         auto inserted = key_value_args.emplace(arg_name, arg_value).second;
         if (!inserted)

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -762,9 +762,9 @@ void StorageS3Configuration::addStructureAndFormatToArgsIfNeeded(
                     children.size());
             }
 
-            children[0] = evaluateConstantExpressionOrIdentifierAsLiteral(children[0], context);
+            auto literal = evaluateConstantExpressionOrIdentifierAsLiteral(children[0], context);
 
-            auto arg_name_value = children[0]->as<ASTLiteral>()->value;
+            auto arg_name_value = literal->as<ASTLiteral>()->value;
             if (arg_name_value.getType() != Field::Types::Which::String)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected string as credential name");
             auto arg_name = arg_name_value.safeGet<String>();

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -288,7 +288,7 @@ def test_create_table():
         ),
         f"Kafka() SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '{password}', format_avro_schema_registry_url = 'http://schema_user:{password}@'",
         f"Kafka() SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '{password}', format_avro_schema_registry_url = 'http://schema_user:{password}@domain.com'",
-
+        f"S3('http://minio1:9001/root/data/test5.csv.gz', 'CSV', access_key_id = 'minio', secret_access_key = '{password}', compression_method = 'gzip')",
     ]
 
     def make_test_case(i):
@@ -367,6 +367,7 @@ def test_create_table():
             f"CREATE TABLE table32 (`x` int) ENGINE = AzureBlobStorage('{masked_sas_conn_string}', 'exampledatasets', 'example.csv')",
             "CREATE TABLE table33 (`x` int) ENGINE = Kafka SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '[HIDDEN]', format_avro_schema_registry_url = 'http://schema_user:[HIDDEN]@'",
             "CREATE TABLE table34 (`x` int) ENGINE = Kafka SETTINGS kafka_broker_list = '127.0.0.1', kafka_topic_list = 'topic', kafka_group_name = 'group', kafka_format = 'JSONEachRow', kafka_security_protocol = 'sasl_ssl', kafka_sasl_mechanism = 'PLAIN', kafka_sasl_username = 'user', kafka_sasl_password = '[HIDDEN]', format_avro_schema_registry_url = 'http://schema_user:[HIDDEN]@domain.com'",
+            "CREATE TABLE table35 (`x` int) ENGINE = S3('http://minio1:9001/root/data/test5.csv.gz', 'CSV', access_key_id = 'minio', secret_access_key = '[HIDDEN]', compression_method = 'gzip')",
         ],
         must_not_contain=[password],
     )

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2758,6 +2758,14 @@ def test_key_value_args(started_cluster):
         f"insert into function s3('{url}', format = TSVRaw, structure = 'a Int32, b String', partition_strategy='hive') partition by b select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
     )
 
+    # Check order - positional args before key-value
+    assert (
+        "Expected positional arguments to go before key-value arguments"
+        in node.query_and_get_error(
+            f"insert into function s3('{url}', structure = 'a Int32, b String', partition_strategy='hive', TSV) partition by b select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+        )
+    )
+
     # Check s3Cluster
     # TODO: fix with new analyzer enabled
     assert 2 == int(

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2771,19 +2771,16 @@ def test_key_value_args(started_cluster):
     assert 2 == int(
         node.query(
             f"select a from s3Cluster(cluster, '{url}', TSVRaw, structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'",
-            settings={"allow_experimental_analyzer": 0},
         )
     )
     assert 2 == int(
         node.query(
             f"select a from s3Cluster(cluster, '{url}', format = TSVRaw, structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'",
-            settings={"allow_experimental_analyzer": 0},
         )
     )
     assert 2 == int(
         node.query(
             f"select a from s3Cluster(cluster, '{url}', structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'",
-            settings={"allow_experimental_analyzer": 0},
         )
     )
 

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2582,9 +2582,17 @@ def test_filesystem_cache(started_cluster):
     )
     instance.query("SYSTEM FLUSH LOGS")
 
-    total_count = int(instance.query(f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' and message ilike '%Boundary alignment:%'"))
+    total_count = int(
+        instance.query(
+            f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' and message ilike '%Boundary alignment:%'"
+        )
+    )
     assert total_count > 0
-    count = int(instance.query(f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' and message ilike '%Boundary alignment: 0%'"))
+    count = int(
+        instance.query(
+            f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' and message ilike '%Boundary alignment: 0%'"
+        )
+    )
     assert count == total_count
 
 
@@ -2599,8 +2607,18 @@ def test_archive(started_cluster):
     node2 = started_cluster.instances["dummy2"]
     node_old = started_cluster.instances["dummy_old"]
 
-    assert "false" == node2.query("SELECT getSetting('cluster_function_process_archive_on_multiple_nodes')").strip()
-    assert "true" == node.query("SELECT getSetting('cluster_function_process_archive_on_multiple_nodes')").strip()
+    assert (
+        "false"
+        == node2.query(
+            "SELECT getSetting('cluster_function_process_archive_on_multiple_nodes')"
+        ).strip()
+    )
+    assert (
+        "true"
+        == node.query(
+            "SELECT getSetting('cluster_function_process_archive_on_multiple_nodes')"
+        ).strip()
+    )
 
     function = f"s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/minio_data/archive* :: example*.csv', 'minio', '{minio_secret_key}')"
 
@@ -2610,7 +2628,9 @@ def test_archive(started_cluster):
     cluster_function_old = f"s3Cluster(cluster_with_old_server, 'http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/minio_data/archive* :: example*.csv', 'minio', '{minio_secret_key}')"
     cluster_function_new = f"s3Cluster(cluster, 'http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/minio_data/archive* :: example*.csv', 'minio', '{minio_secret_key}')"
 
-    paths_list_new = node.query(f"SELECT distinct(_path) FROM {cluster_function_new} SETTINGS cluster_function_process_archive_on_multiple_nodes = 1")
+    paths_list_new = node.query(
+        f"SELECT distinct(_path) FROM {cluster_function_new} SETTINGS cluster_function_process_archive_on_multiple_nodes = 1"
+    )
     assert "Failed to get object info" in node.query_and_get_error(
         f"SELECT distinct(_path) FROM {cluster_function_old} SETTINGS max_threads=1"
     )
@@ -2643,13 +2663,126 @@ def test_archive(started_cluster):
     # Implementation with whole archive sending can have duplicates,
     # this is was a mistake in implementation.
     assert expected_count <= int(
-        node2.query(
-            f"SELECT count() FROM {cluster_function_old}", query_id = query_id
-        )
+        node2.query(f"SELECT count() FROM {cluster_function_old}", query_id=query_id)
     )
     node2.query("SYSTEM FLUSH LOGS")
-    assert 7 == int(node2.query(f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' AND message ilike '%send over the whole%'"))
+    assert 7 == int(
+        node2.query(
+            f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' AND message ilike '%send over the whole%'"
+        )
+    )
 
     assert expected_count == int(
-        node.query(f"SELECT count() FROM {cluster_function_new} SETTINGS cluster_function_process_archive_on_multiple_nodes = 1")
+        node.query(
+            f"SELECT count() FROM {cluster_function_new} SETTINGS cluster_function_process_archive_on_multiple_nodes = 1"
+        )
+    )
+
+
+def test_key_value_args(started_cluster):
+    node = started_cluster.instances["dummy"]
+    restricted_node = started_cluster.instances["restricted_dummy"]
+    table_name = f"test_key_value_args_{uuid.uuid4()}"
+    bucket = started_cluster.minio_bucket
+
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/file"
+
+    # Check format.
+    assert (
+        "The data format cannot be detected by the contents"
+        in node.query_and_get_error(
+            f"insert into function s3('{url}', structure = 'a Int32, b String') select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+        )
+    )
+    node.query(
+        f"insert into function s3('{url}', format = TSVRaw, structure = 'a Int32, b String') select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+    )
+    node.query(
+        f"insert into function s3('{url}', 'TSVRaw', structure = 'a Int32, b String') select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+    )
+
+    # Check structure.
+    assert (
+        "a\tInt32\t\t\t\t\t\nb\tString"
+        in node.query(
+            f"describe table s3('{url}', format = TSVRaw, structure = 'a Int32, b String')"
+        ).strip()
+    )
+    assert 2 == int(
+        node.query(
+            f"select a from s3('{url}', format = TSVRaw, structure = 'a Int32, b String') where b = '2'"
+        )
+    )
+
+    # Check access_key_id, secret_access_key
+    assert (
+        "The request signature we calculated does not match the signature you provided"
+        in node.query_and_get_error(
+            f"insert into function s3('{url}', structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = 'keko', format = 'TSVRaw') select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+        )
+    )
+    node.query(
+        f"insert into function s3('{url}', structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', format = 'TSVRaw') select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+    )
+    assert 2 == int(
+        node.query(
+            f"select a from s3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', structure = 'a Int32, b String') where b = '2'"
+        )
+    )
+
+    # Check session_token
+    assert "Failed to get object info" in node.query_and_get_error(
+        f"select a from s3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', structure = 'a Int32, b String', session_token = 'kek') where b = '2'"
+    )
+
+    # Check structure
+    assert "Cannot parse DateTime" in node.query_and_get_error(
+        f"select a from s3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', structure = 'a Int32, b DateTime') where b = '2'"
+    )
+
+    # Check compression_method
+    assert "inflate failed" in node.query_and_get_error(
+        f"select a from s3('{url}', format = TSVRaw, structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'gzip') where b = '2'"
+    )
+    assert 2 == int(
+        node.query(
+            f"select a from s3('{url}', format = TSVRaw, structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'"
+        )
+    )
+
+    # Check partition strategy
+    assert "is not supported" in node.query_and_get_error(
+        f"insert into function s3('{url}', format = TSVRaw, structure = 'a Int32, b String', partition_strategy='hivy') partition by b select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+    )
+    node.query(
+        f"insert into function s3('{url}', format = TSVRaw, structure = 'a Int32, b String', partition_strategy='hive') partition by b select number, toString(number) from numbers(10) settings s3_truncate_on_insert=1"
+    )
+
+    # Check s3Cluster
+    # TODO: fix with new analyzer enabled
+    assert 2 == int(
+        node.query(
+            f"select a from s3Cluster(cluster, '{url}', TSVRaw, structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'",
+            settings={"allow_experimental_analyzer": 0},
+        )
+    )
+    assert 2 == int(
+        node.query(
+            f"select a from s3Cluster(cluster, '{url}', format = TSVRaw, structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'",
+            settings={"allow_experimental_analyzer": 0},
+        )
+    )
+    assert 2 == int(
+        node.query(
+            f"select a from s3Cluster(cluster, '{url}', structure = 'a Int32, b String', access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'none') where b = '2'",
+            settings={"allow_experimental_analyzer": 0},
+        )
+    )
+
+    node.query(
+        f"CREATE TABLE test (a Int32, b String) engine = S3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'gzip')"
+    )
+    assert (
+        "S3(\\'http://minio1:9001/root/file\\', \\'TSVRaw\\', \\'format\\' = \\'TSVRaw\\', \\'access_key_id\\' = \\'minio\\', \\'secret_access_key\\' = \\'[HIDDEN]\\', \\'compression_method\\' = \\'gzip\\')"
+        in node.query("SHOW CREATE TABLE test")
     )

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2685,7 +2685,7 @@ def test_key_value_args(started_cluster):
     table_name = f"test_key_value_args_{uuid.uuid4()}"
     bucket = started_cluster.minio_bucket
 
-    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/file"
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_name}_data"
 
     # Check format.
     assert (
@@ -2785,9 +2785,9 @@ def test_key_value_args(started_cluster):
     )
 
     node.query(
-        f"CREATE TABLE test (a Int32, b String) engine = S3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'gzip')"
+        f"CREATE TABLE {table_name} (a Int32, b String) engine = S3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'gzip')"
     )
     assert (
         "S3(\\'http://minio1:9001/root/file\\', \\'TSVRaw\\', \\'format\\' = \\'TSVRaw\\', \\'access_key_id\\' = \\'minio\\', \\'secret_access_key\\' = \\'[HIDDEN]\\', \\'compression_method\\' = \\'gzip\\')"
-        in node.query("SHOW CREATE TABLE test")
+        in node.query(f"SHOW CREATE TABLE {table_name}")
     )

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2788,6 +2788,6 @@ def test_key_value_args(started_cluster):
         f"CREATE TABLE {table_name} (a Int32, b String) engine = S3('{url}', format = TSVRaw, access_key_id = 'minio', secret_access_key = '{minio_secret_key}', compression_method = 'gzip')"
     )
     assert (
-        f"S3(\\'{url}\\', \\'TSVRaw\\', \\'format\\' = \\'TSVRaw\\', \\'access_key_id\\' = \\'minio\\', \\'secret_access_key\\' = \\'[HIDDEN]\\', \\'compression_method\\' = \\'gzip\\')"
+        f"S3(\\'{url}\\', \\'TSVRaw\\', format = \\'TSVRaw\\', access_key_id = \\'minio\\', secret_access_key = \\'[HIDDEN]\\', compression_method = \\'gzip\\')"
         in node.query(f"SHOW CREATE TABLE {table_name}")
     )

--- a/tests/integration/test_storage_s3/test_invalid_env_credentials.py
+++ b/tests/integration/test_storage_s3/test_invalid_env_credentials.py
@@ -118,6 +118,7 @@ def test_with_invalid_environment_credentials(started_cluster):
     for bucket, auth in [
         (started_cluster.minio_restricted_bucket, f"'minio', '{minio_secret_key}'"),
         (started_cluster.minio_bucket, "NOSIGN"),
+        (started_cluster.minio_bucket, "no_sign = 1"),
     ]:
         instance.query(
             f"insert into function s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', {auth}) select * from numbers(100) settings s3_truncate_on_insert=1"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow key value arguments in `s3` or `s3Cluster` table engine/function, e.g. for example `s3('url', CSV,  structure = 'a Int32', compression_method = 'gzip')`. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
