### PR TITLE
Add name of the broken file to log exception message on failed parse while reading from system.remote_data_path

### DIFF
--- a/src/Storages/System/StorageSystemRemoteDataPaths.cpp
+++ b/src/Storages/System/StorageSystemRemoteDataPaths.cpp
@@ -373,7 +373,7 @@ Chunk SystemRemoteDataPathsSource::generate()
         {
             storage_objects = disk->getMetadataStorage()->getStorageObjects(local_path);
         }
-        catch (const Exception & e)
+        catch (Exception & e)
         {
             /// Unfortunately in rare cases it can happen when files disappear
             /// or can be empty in case of operation interruption (like cancelled metadata fetch)
@@ -383,6 +383,7 @@ Chunk SystemRemoteDataPathsSource::generate()
                 e.code() == ErrorCodes::CANNOT_READ_ALL_DATA)
                 continue;
 
+            e.addMessage("While parsing file {}", local_path);
             throw;
         }
 


### PR DESCRIPTION
Add name of the broken file to log exception message on failed parse while reading from system.remote_data_paths.

```
2025.08.06 12:36:17.582965 [ 14 ] {} <Error> TCPHandler: Code: 27. DB::Exception: Cannot parse input: expected '\n' before: 'broken\n': while parsing: 'broken
': While parsing file store/3aa/3aaa4b9b-cc7a-4021-be98-1835262c2885/all_1_1_0/data.bin: While executing SystemRemoteDataPaths. (CANNOT_PARSE_INPUT_ASSERTION_FAILED), Stack trace (when copying this message, always include the lines below):

```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
