### PR TITLE
Integration tests: setup cluster dependencies in parallel

### DIFF
--- a/tests/integration/helpers/keeper_config3_slow.xml
+++ b/tests/integration/helpers/keeper_config3_slow.xml
@@ -1,0 +1,47 @@
+<clickhouse>
+    <listen_try>true</listen_try>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper/clickhouse-keeper.log</log>
+        <errorlog>/var/log/clickhouse-keeper/clickhouse-keeper.err.log</errorlog>
+    </logger>
+
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>3</server_id>
+
+        <precommit_sleep_ms_for_testing>1000</precommit_sleep_ms_for_testing>
+        <precommit_sleep_probability_for_testing>0.15</precommit_sleep_probability_for_testing>
+        <coordination_settings>
+            <operation_timeout_ms>60000</operation_timeout_ms>
+            <session_timeout_ms>120000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>
+
+            <async_replication>1</async_replication>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>zoo1</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>zoo2</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>zoo3</hostname>
+                <port>9444</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>


### PR DESCRIPTION
1. Setup cluster dependencies in parallel to make setup phase faster
2. Decrease `docker-compose stop` timeout from 20 to 3 
3. Add an option to enable the slow keeper config from the private

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
