### PR TITLE
Fix reading nested subclumns in StorageLog

### DIFF
--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -198,11 +198,12 @@ Chunk LogSource::generate()
     {
         ColumnPtr column;
         auto name_type_on_disk = getColumnOnDisk(name_type);
+        auto top_level_column_name = Nested::extractTableName(name_type.name);
 
         try
         {
             column = name_type_on_disk.type->createColumn();
-            readData(name_type_on_disk, column, max_rows_to_read, caches[name_type_on_disk.getNameInStorage()]);
+            readData(name_type_on_disk, column, max_rows_to_read, caches[top_level_column_name]);
         }
         catch (Exception & e)
         {

--- a/tests/queries/0_stateless/03756_log_storage_nested_subcolumns.reference
+++ b/tests/queries/0_stateless/03756_log_storage_nested_subcolumns.reference
@@ -1,0 +1,27 @@
+-- { echoOn }
+SELECT c0.c1.null, c0.c2 FROM nested_null_Log;
+[0]	[2]
+SELECT c0.null, c0.c2 FROM null_name_Log;
+[3]	[4]
+SELECT c0.null.null, c0.c2 FROM nested_null_clash_Log;
+[0]	[6]
+SELECT n.c1, n.n2.c2 FROM nested_in_nested_Log;
+[1,3,2]	[[1],[2],[3]]
+-- { echoOn }
+SELECT c0.c1.null, c0.c2 FROM nested_null_TinyLog;
+[0]	[2]
+SELECT c0.null, c0.c2 FROM null_name_TinyLog;
+[3]	[4]
+SELECT c0.null.null, c0.c2 FROM nested_null_clash_TinyLog;
+[0]	[6]
+SELECT n.c1, n.n2.c2 FROM nested_in_nested_TinyLog;
+[1,3,2]	[[1],[2],[3]]
+-- { echoOn }
+SELECT c0.c1.null, c0.c2 FROM nested_null_StripeLog;
+[0]	[2]
+SELECT c0.null, c0.c2 FROM null_name_StripeLog;
+[3]	[4]
+SELECT c0.null.null, c0.c2 FROM nested_null_clash_StripeLog;
+[0]	[6]
+SELECT n.c1, n.n2.c2 FROM nested_in_nested_StripeLog;
+[1,3,2]	[[1],[2],[3]]

--- a/tests/queries/0_stateless/03756_log_storage_nested_subcolumns.sql.j2
+++ b/tests/queries/0_stateless/03756_log_storage_nested_subcolumns.sql.j2
@@ -1,0 +1,24 @@
+SET flatten_nested=1;
+
+{% for engine in ['Log', 'TinyLog', 'StripeLog'] -%}
+
+CREATE TABLE nested_null_{{ engine }} (c0 Nested(c1 Nullable(Int), c2 Int)) ENGINE = {{ engine }};
+INSERT INTO nested_null_{{ engine }} (c0.c1, c0.c2) VALUES ([1], [2]);
+
+CREATE TABLE null_name_{{ engine }} (c0 Nested(null Int, c2 Int)) ENGINE = {{ engine }};
+INSERT INTO null_name_{{ engine }} (c0.null, c0.c2) VALUES ([3], [4]);
+
+CREATE TABLE nested_null_clash_{{ engine }} (c0 Nested(null Nullable(Int), c2 Int)) ENGINE = {{ engine }};
+INSERT INTO nested_null_clash_{{ engine }} (c0.null, c0.c2) VALUES ([5], [6]);
+
+CREATE TABLE nested_in_nested_{{ engine }} (n Nested(c1 Int32, n2 Nested(c2 Int32))) ENGINE = {{ engine }};
+INSERT INTO TABLE nested_in_nested_{{ engine }} (n.c1, n.n2) VALUES ([1, 3, 2], [[(1)],[(2)],[(3)]]);
+
+-- { echoOn }
+SELECT c0.c1.null, c0.c2 FROM nested_null_{{ engine }};
+SELECT c0.null, c0.c2 FROM null_name_{{ engine }};
+SELECT c0.null.null, c0.c2 FROM nested_null_clash_{{ engine }};
+SELECT n.c1, n.n2.c2 FROM nested_in_nested_{{ engine }};
+-- { echoOff }
+
+{% endfor -%}


### PR DESCRIPTION
```sql
CREATE TABLE t (c0 Nested(c1 Nullable(Int), c2 Int)) Engine=Log;
SELECT c0.c1.null, c0.c2 FROM t;
```
In such a select query. After reading the first column, we get a stream for  `c0.size0.bin` EOF, but `c0.c2` can't get sizes from cache because the first column uses `c0.c1` as key instead of `c0`

Closes: #91602
Closes: #91602

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes an error during reading of the subcolumn of a subcolumn in the `Log` engine
