### PR TITLE
Fix recovering replicated databases with long moving metadata file

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -40,7 +40,8 @@
 #include <boost/range/adaptor/map.hpp>
 #include <fmt/ranges.h>
 
-#include "config.h"
+#include <config.h>
+#include <base/sleep.h>
 
 #if USE_LIBPQXX
 #    include <Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.h>
@@ -78,6 +79,7 @@ namespace ErrorCodes
     extern const int UNFINISHED;
     extern const int INFINITE_LOOP;
     extern const int THERE_IS_NO_QUERY;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace Setting
@@ -2039,12 +2041,31 @@ DDLGuard::DDLGuard(Map & map_, SharedMutex & db_mutex_, std::unique_lock<std::mu
     is_database_guard = elem.empty();
     if (!is_database_guard)
     {
+        static constexpr int MAX_TRY = 10;
+        static constexpr int INTERVAL_MS = 100;
+        bool acquired_db_mutex_lock = false;
+        for (int i = 0; i < MAX_TRY; ++i)
+        {
+            acquired_db_mutex_lock = db_mutex.try_lock_shared();
+            if (acquired_db_mutex_lock)
+                break;
 
-        bool locked_database_for_read = db_mutex.try_lock_shared();
-        if (!locked_database_for_read)
+            if (DatabaseCatalog::instance().isDatabaseExist(database_name))
+            {
+                releaseTableLock();
+                throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} is currently dropped or renamed", database_name);
+            }
+
+            sleepForMilliseconds(INTERVAL_MS);
+        }
+        if (!acquired_db_mutex_lock)
         {
             releaseTableLock();
-            throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} is currently dropped or renamed", database_name);
+            throw Exception(
+                ErrorCodes::TIMEOUT_EXCEEDED,
+                "Unable to acquire the database lock of {} after {} ms",
+                database_name,
+                MAX_TRY * INTERVAL_MS);
         }
     }
 }

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -2042,7 +2042,7 @@ DDLGuard::DDLGuard(Map & map_, SharedMutex & db_mutex_, std::unique_lock<std::mu
     if (!is_database_guard)
     {
         static constexpr int MAX_TRY = 10;
-        static constexpr int INTERVAL_MS = 100;
+        static constexpr UInt64 INTERVAL_MS = 100;
         bool acquired_db_mutex_lock = false;
         for (int i = 0; i < MAX_TRY; ++i)
         {
@@ -2050,7 +2050,7 @@ DDLGuard::DDLGuard(Map & map_, SharedMutex & db_mutex_, std::unique_lock<std::mu
             if (acquired_db_mutex_lock)
                 break;
 
-            if (DatabaseCatalog::instance().isDatabaseExist(database_name))
+            if (!DatabaseCatalog::instance().isDatabaseExist(database_name))
             {
                 releaseTableLock();
                 throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} is currently dropped or renamed", database_name);

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -376,6 +376,13 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         DatabaseCatalog::instance().attachDatabase(database_name, database);
         added = true;
 
+        if (need_write_metadata)
+        {
+            /// Prevents from overwriting metadata of detached database
+            default_db_disk->moveFile(metadata_file_tmp_path, metadata_file_path);
+            renamed = true;
+        }
+
         if (!load_database_without_tables)
         {
             /// We use global context here, because storages lifetime is bigger than query context lifetime
@@ -386,14 +393,6 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
             waitLoad(currentPoolOr(TablesLoaderForegroundPoolId), load_tasks);
             /// Only then prioritize, schedule and wait all the startup tasks
             waitLoad(currentPoolOr(TablesLoaderForegroundPoolId), startup_tasks);
-        }
-
-
-        if (need_write_metadata)
-        {
-            /// Prevents from overwriting metadata of detached database
-            default_db_disk->moveFile(metadata_file_tmp_path, metadata_file_path);
-            renamed = true;
         }
     }
     catch (...)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix recovering replicated databases when moving the metadata file takes a long time.

When creating a Replicated DB, at this [point](https://github.com/ClickHouse/ClickHouse/blob/97243e8d319f190d594b0c8c73f76ec629209fdc/src/Interpreters/InterpreterCreateQuery.cpp#L389), the DB is considered started because the loading tasks are finished.
The DDLWorker can process the DDLs. If there is a create table DDL, it needs to acquire the table `ddl_guard` [here](https://github.com/ClickHouse/ClickHouse/blob/97243e8d319f190d594b0c8c73f76ec629209fdc/src/Interpreters/InterpreterCreateQuery.cpp#L1793). The `ddl_guard` requires the shared db mutex [here](https://github.com/ClickHouse/ClickHouse/blob/97243e8d319f190d594b0c8c73f76ec629209fdc/src/Interpreters/DatabaseCatalog.cpp#L2018).

If moving the metadata file takes a long time, the DB `ddl_guard` is still on hold. When DDLWorker is creating a table, it cannot acquire the DB shared mutex and [throws an exception](https://github.com/ClickHouse/ClickHouse/blob/97243e8d319f190d594b0c8c73f76ec629209fdc/src/Interpreters/DatabaseCatalog.cpp#L2022):
```
throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} is currently dropped or renamed", database_name);
```

This PR:
- When acquiring the DB lock fails, if the DB exists, retry with a timeout.
- Moves the moving file before checking if the table loading tasks are finished

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
