### PR TITLE
Drop support for `multiSearchAny` from text index

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -116,7 +116,6 @@ INSERT INTO tab(key, str) VALUES (1, 'Hello World');
 SELECT * from tab WHERE str == 'Hello World';
 SELECT * from tab WHERE str IN ('Hello', 'World');
 SELECT * from tab WHERE str LIKE '%Hello%';
-SELECT * from tab WHERE multiSearchAny(str, ['Hello', 'World']);
 SELECT * from tab WHERE hasToken(str, 'Hello');
 ```
 
@@ -177,18 +176,6 @@ Similarly, if you like to search a column value ending with `olap engine`, use s
 :::note
 Index lookups for functions `startsWith` and `endWidth` are generally less efficient than for functions `like`/`notLike`/`match`.
 :::
-
-#### `multiSearchAny` {#functions-example-multisearchany}
-
-Function [multiSearchAny](/sql-reference/functions/string-search-functions.md/#multisearchany) searches the provided search term as a substring in the column value.
-As a result, search term should be a complete token to use with the `text` index.
-This can be achieved by putting a space before and after the input needle.
-
-Example:
-
-```sql
-SELECT count() FROM hackernews WHERE multiSearchAny(lower(comment), [' clickhouse ', ' chdb ']);
-```
 
 #### `hasToken` and `hasTokenOrNull` {#functions-example-hastoken-hastokenornull}
 
@@ -322,7 +309,7 @@ We can also search for one or all of multiple terms, i.e., disjunctions or conju
 -- multiple OR'ed terms
 SELECT count(*)
 FROM hackernews
-WHERE multiSearchAny(lower(comment), ['oltp', 'olap']);
+WHERE hasToken(lower(comment), 'avx') OR hasToken(lower(comment), 'sve');
 
 -- multiple AND'ed terms
 SELECT count(*)

--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -455,7 +455,7 @@ Indexes of type `set` can be utilized by all functions. The other index types ar
 | [match](/sql-reference/functions/string-search-functions.md/#match)                                                            | ✗           | ✗      | ✔          | ✔          | ✗            | ✔    |
 | [startsWith](/sql-reference/functions/string-functions.md/#startswith)                                                         | ✔           | ✔      | ✔          | ✔          | ✗            | ✔    |
 | [endsWith](/sql-reference/functions/string-functions.md/#endswith)                                                             | ✗           | ✗      | ✔          | ✔          | ✗            | ✔    |
-| [multiSearchAny](/sql-reference/functions/string-search-functions.md/#multisearchany)                                          | ✗           | ✗      | ✔          | ✗          | ✗            | ✔    |
+| [multiSearchAny](/sql-reference/functions/string-search-functions.md/#multisearchany)                                          | ✗           | ✗      | ✔          | ✗          | ✗            | ✗    |
 | [in](/sql-reference/functions/in-functions)                                                                                    | ✔           | ✔      | ✔          | ✔          | ✔            | ✔    |
 | [notIn](/sql-reference/functions/in-functions)                                                                                 | ✔           | ✔      | ✔          | ✔          | ✔            | ✔    |
 | [less (`<`)](/sql-reference/functions/comparison-functions.md/#less)                                                           | ✔           | ✔      | ✗          | ✗          | ✗            | ✗    |

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -181,7 +181,6 @@ bool MergeTreeIndexConditionGin::alwaysUnknownOrTrue() const
          RPNElement::FUNCTION_SEARCH_ALL,
          RPNElement::FUNCTION_IN,
          RPNElement::FUNCTION_NOT_IN,
-         RPNElement::FUNCTION_MULTI_SEARCH,
          RPNElement::FUNCTION_MATCH});
 }
 
@@ -259,17 +258,6 @@ bool MergeTreeIndexConditionGin::mayBeTrueOnGranuleInPart(MergeTreeIndexGranuleP
             rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
             if (element.function == RPNElement::FUNCTION_NOT_IN)
                 rpn_stack.back() = !rpn_stack.back();
-        }
-        else if (element.function == RPNElement::FUNCTION_MULTI_SEARCH)
-        {
-            std::vector<bool> result(element.set_gin_filters.back().size(), true);
-
-            const auto & gin_filters = element.set_gin_filters[0];
-
-            for (size_t row = 0; row < gin_filters.size(); ++row)
-                result[row] = granule->gin_filter.contains(gin_filters[row], cache_store);
-
-            rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
         }
         else if (element.function == RPNElement::FUNCTION_MATCH)
         {
@@ -392,7 +380,6 @@ bool MergeTreeIndexConditionGin::traverseAtomAST(const RPNBuilderTreeNode & node
                  function_name == "hasTokenOrNull" ||
                  function_name == "startsWith" ||
                  function_name == "endsWith" ||
-                 function_name == "multiSearchAny" ||
                  function_name == "searchAny" ||
                  function_name == "searchAll" ||
                  function_name == "match")
@@ -507,25 +494,6 @@ bool MergeTreeIndexConditionGin::traverseASTEquals(
         out.gin_filter = std::make_unique<GinFilter>();
         const auto & value = const_value.safeGet<String>();
         token_extractor->substringToGinFilter(value.data(), value.size(), *out.gin_filter, false, true);
-        return true;
-    }
-    if (function_name == "multiSearchAny")
-    {
-        out.function = RPNElement::FUNCTION_MULTI_SEARCH;
-
-        /// 2d vector is not needed here but is used because already exists for FUNCTION_IN
-        std::vector<GinFilters> gin_filters;
-        gin_filters.emplace_back();
-        for (const auto & element : const_value.safeGet<Array>())
-        {
-            if (element.getType() != Field::Types::String)
-                return false;
-
-            gin_filters.back().emplace_back();
-            const auto & value = element.safeGet<String>();
-            token_extractor->substringToGinFilter(value.data(), value.size(), gin_filters.back().back(), false, false);
-        }
-        out.set_gin_filters = std::move(gin_filters);
         return true;
     }
     /// Currently, not all token extractors support LIKE-style matching.

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -87,7 +87,6 @@ private:
             FUNCTION_NOT_EQUALS,
             FUNCTION_IN,
             FUNCTION_NOT_IN,
-            FUNCTION_MULTI_SEARCH,
             FUNCTION_MATCH,
             FUNCTION_SEARCH_ANY,
             FUNCTION_SEARCH_ALL,
@@ -110,7 +109,7 @@ private:
         /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS
         std::unique_ptr<GinFilter> gin_filter;
 
-        /// For FUNCTION_IN, FUNCTION_NOT_IN and FUNCTION_MULTI_SEARCH
+        /// For FUNCTION_IN and FUNCTION_NOT_IN
         std::vector<GinFilters> set_gin_filters;
 
         /// For FUNCTION_IN and FUNCTION_NOT_IN

--- a/tests/queries/0_stateless/02346_text_index_queries.reference
+++ b/tests/queries/0_stateless/02346_text_index_queries.reference
@@ -20,9 +20,6 @@ af	text
 101	x Alick a01 y
 106	x Alick a06 y
 1
-101	x Alick a01 y
-111	x Alick b01 y
-1
 Test text(tokenizer = "ngram", ngram_size = 2) on a column with two parts
 af	text
 101	Alick a01

--- a/tests/queries/0_stateless/02346_text_index_queries.sql
+++ b/tests/queries/0_stateless/02346_text_index_queries.sql
@@ -101,19 +101,6 @@ SELECT read_rows==4 from system.query_log
         AND result_rows==2
     LIMIT 1;
 
--- search text index with multiSearch
-SELECT * FROM tab_x WHERE multiSearchAny(s, [' a01 ', ' b01 ']) ORDER BY k;
-
--- check the query only read 2 granules (4 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==4 from system.query_log
-    WHERE query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab_x WHERE multiSearchAny(s, [\' a01 \', \' b01 \']) ORDER BY k;')
-        AND type='QueryFinish'
-        AND result_rows==2
-    LIMIT 1;
-
 ----------------------------------------------------
 SELECT 'Test text(tokenizer = "ngram", ngram_size = 2) on a column with two parts';
 

--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.reference
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.reference
@@ -68,16 +68,3 @@ Parts: 1/1
 -- Skip for substring with complete token
 Parts: 1/1
 Parts: 0/1
-
--- No skip for multiple substrings
-Parts: 1/1
-Parts: 1/1
-1	Service is not ready
-
--- Skip for multiple substrings with complete tokens
-Parts: 1/1
-Parts: 0/1
-
--- No skip for multiple non-existsing substrings, only one with complete token
-Parts: 1/1
-Parts: 1/1

--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
@@ -195,35 +195,3 @@ FROM (
 WHERE explain LIKE '%Parts:%';
 
 SELECT * FROM 03165_token_ft WHERE match(message, ' xyz ');
-
-SELECT '';
-SELECT '-- No skip for multiple substrings';
-
-SELECT trim(explain)
-FROM (
-    EXPLAIN indexes = 1 SELECT * FROM 03165_token_ft WHERE multiSearchAny(message, ['ce', 'no'])
-)
-WHERE explain LIKE '%Parts:%';
-
-SELECT * FROM 03165_token_ft WHERE multiSearchAny(message, ['ce', 'no']);
-
-SELECT '';
-SELECT '-- Skip for multiple substrings with complete tokens';
-
-SELECT trim(explain)
-FROM (
-    EXPLAIN indexes = 1 SELECT * FROM 03165_token_ft WHERE multiSearchAny(message, [' wx ', ' yz '])
-)
-WHERE explain LIKE '%Parts:%';
-
-SELECT * FROM 03165_token_ft WHERE multiSearchAny(message, [' wx ', ' yz ']);
-
-SELECT '';
-SELECT '-- No skip for multiple non-existsing substrings, only one with complete token';
-SELECT trim(explain)
-FROM (
-    EXPLAIN indexes = 1 SELECT * FROM 03165_token_ft WHERE multiSearchAny(message, [' wx ', 'yz'])
-)
-WHERE explain LIKE '%Parts:%';
-
-SELECT * FROM 03165_token_ft WHERE multiSearchAny(message, [' wx ', 'yz']);


### PR DESCRIPTION
Supporting a single out of 22 `multi*` functions by the text index is kind of arbitary. Besides that, usage required the slightly awkward space prefix/suffix which (likely) is incompatible with `split` tokenizers.

If someone _really_ _really_ wants `multiSearchAny` support back, we can add it again later (but then in a more systematic way).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)