### PR TITLE
Disable test `01961_roaring_memory_tracking` for coverage build

### DIFF
--- a/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
+++ b/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
@@ -1,4 +1,4 @@
--- Tags: no-replicated-database, no-asan, no-tsan, no-msan, no-ubsan
+-- Tags: no-replicated-database, no-asan, no-tsan, no-msan, no-ubsan, no-coverage
 
 SET max_bytes_before_external_group_by = 0;
 SET max_bytes_ratio_before_external_group_by = 0;

--- a/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
+++ b/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
@@ -1,4 +1,5 @@
 -- Tags: no-replicated-database, no-asan, no-tsan, no-msan, no-ubsan, no-coverage
+-- Sanitizers have their own mechanism of tracking the allocation/deallocations and it doesn't work with our MemoryTracker. 
 
 SET max_bytes_before_external_group_by = 0;
 SET max_bytes_ratio_before_external_group_by = 0;


### PR DESCRIPTION
`malloc`/`free` interceptions are disabled for coverage builds (as well as for all sanitizers). 


### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This closes: https://github.com/ClickHouse/ClickHouse/issues/85183

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
