### PR TITLE
sync changes to `TemporaryReplaceTableName` from private

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2100,7 +2100,7 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
     }
 
     {
-        const String name_hash = getHexUIntLowercase(sipHash64(create.getDatabase() + create.getTable()));
+        const String name_hash = TemporaryReplaceTableName::calculateHash(create.getDatabase(), create.getTable());
         const String random_suffix = [&]()
         {
             if (auto txn = current_context->getZooKeeperMetadataTransaction())

--- a/src/Interpreters/TemporaryReplaceTableName.cpp
+++ b/src/Interpreters/TemporaryReplaceTableName.cpp
@@ -1,6 +1,8 @@
 #include <Interpreters/TemporaryReplaceTableName.h>
 
 #include <Common/re2.h>
+#include <Common/SipHash.h>
+
 
 #include <base/hex.h>
 #include <fmt/core.h>
@@ -22,5 +24,10 @@ namespace DB
             return result;
         }
         return std::nullopt;
+    }
+
+    String TemporaryReplaceTableName::calculateHash(String database, String table)
+    {
+        return getHexUIntLowercase(sipHash64(std::move(database) + std::move(table)));
     }
 }

--- a/src/Interpreters/TemporaryReplaceTableName.h
+++ b/src/Interpreters/TemporaryReplaceTableName.h
@@ -14,5 +14,7 @@ namespace DB
         String toString() const;
 
         static std::optional<TemporaryReplaceTableName> fromString(const String & str);
+
+        static String calculateHash(String database, String table);
     };
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
