### PR TITLE
Integration tests: Split tests into batches based on historical test execution time

### DIFF
--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -38,6 +38,7 @@ def get_json_params_dict(
     docker_images: List[DockerImage],
     run_by_hash_total: int,
     run_by_hash_num: int,
+    job_configuration: str
 ) -> dict:
     return {
         "context_name": check_name,
@@ -50,6 +51,8 @@ def get_json_params_dict(
         "disable_net_host": True,
         "run_by_hash_total": run_by_hash_total,
         "run_by_hash_num": run_by_hash_num,
+        "pr_updated_at": pr_info.updated_at,
+        "job_configuration": job_configuration,
     }
 
 
@@ -166,6 +169,8 @@ def main():
             run_by_hash_total = int(option.split("/")[1])
             break
 
+    job_configuration = options[0].strip()
+
     is_flaky_check = "flaky" in check_name
 
     assert (
@@ -211,6 +216,7 @@ def main():
                 images,
                 run_by_hash_total,
                 run_by_hash_num,
+                job_configuration
             )
         )
         json_params.write(params_text)

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -916,6 +916,8 @@ class ClickhouseIntegrationTestsRunner:
                 parallel_files_list.append(file)
 
         tests_execution_times = self.get_tests_execution_time()
+        assert len(tests_execution_times) > 400, \
+            f"Number of tests should be more than 400. Actual {len(tests_execution_times)}"
         known_db_modules_set = set(tests_execution_times.keys())
 
         parallel_tests_with_known_time: Dict[str, float] = {
@@ -932,9 +934,11 @@ class ClickhouseIntegrationTestsRunner:
         ]
 
         logging.info("Found %s parallel modules with known execution time.", len(parallel_tests_with_known_time))
-        logging.info("Found %s new parallel modules.", len(new_parallel_tests))
+        logging.info("Found %s new parallel modules:", len(new_parallel_tests))
+        logging.info("%s", str(new_parallel_tests))
         logging.info("Found %s sequential modules with known execution time.", len(sequential_tests_with_known_time))
-        logging.info("Found %s new sequential modules.", len(new_sequential_tests))
+        logging.info("Found %s new sequential modules:", len(new_sequential_tests))
+        logging.info("%s", str(new_sequential_tests))
 
         # balance parallel tests
         parallel_heap = [(0, i, []) for i in range(num_groups)]

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -558,7 +558,7 @@ class ClickhouseIntegrationTestsRunner:
                 print("Timeout expired - break test group execution")
                 break
             logging.info("Running test group %s for the %s retry", test_group, i)
-            # clear_ip_tables_and_restart_daemons()
+            clear_ip_tables_and_restart_daemons()
 
             test_names = set([])
             for test_name in tests_in_group:
@@ -595,80 +595,80 @@ class ClickhouseIntegrationTestsRunner:
             log_path = os.path.join(self.repo_path, "tests/integration", log_basename)
             logging.info("Executing cmd: %s", cmd)
             # ignore retcode, since it meaningful due to pipe to tee
-            # with TeePopen(cmd, log_path) as proc:
-            #     global runner_subprocess  # pylint:disable=global-statement
-            #     runner_subprocess = proc
-            #     proc.wait()
+            with TeePopen(cmd, log_path) as proc:
+                global runner_subprocess  # pylint:disable=global-statement
+                runner_subprocess = proc
+                proc.wait()
 
-            # extra_logs_names = [log_basename]
-            # log_result_path = os.path.join(
-            #     self.path(), "integration_run_" + log_basename
-            # )
-            # shutil.copy(log_path, log_result_path)
-            # log_paths.append(log_result_path)
-            #
-            # for pytest_log_path in glob.glob(
-            #     os.path.join(self.repo_path, "tests/integration/pytest*.log")
-            # ):
-            #     new_name = f"{test_group_str}_{i}_{os.path.basename(pytest_log_path)}"
-            #     os.rename(
-            #         pytest_log_path,
-            #         os.path.join(self.repo_path, "tests/integration", new_name),
-            #     )
-            #     extra_logs_names.append(new_name)
-            #
-            # dockerd_log_path = os.path.join(
-            #     self.repo_path, "tests/integration/dockerd.log"
-            # )
-            # if os.path.exists(dockerd_log_path):
-            #     new_name = f"{test_group_str}_{i}_{os.path.basename(dockerd_log_path)}"
-            #     os.rename(
-            #         dockerd_log_path,
-            #         os.path.join(self.repo_path, "tests/integration", new_name),
-            #     )
-            #     extra_logs_names.append(new_name)
-            #
-            # if os.path.exists(report_path):
-            #     extra_logs_names.append(report_name)
-            #     new_counters, new_tests_times = self._parse_report(report_path)
-            #     for state, tests in new_counters.items():
-            #         logging.info(
-            #             "Tests with %s state (%s): %s", state, len(tests), tests
-            #         )
-            #     self._update_counters(counters, new_counters)
-            #     for test_name, test_time in new_tests_times.items():
-            #         tests_times[test_name] = test_time
-            #
-            # test_data_dirs_new = self._find_test_data_dirs(self.repo_path, test_names)
-            # test_data_dirs_diff = self._get_test_data_dirs_difference(
-            #     test_data_dirs_new, test_data_dirs
-            # )
-            # test_data_dirs = test_data_dirs_new
-            #
-            # if extra_logs_names or test_data_dirs_diff:
-            #     extras_result_path = os.path.join(
-            #         self.path(), f"integration_run_{test_group_str}_{i}.tar.zst"
-            #     )
-            #     self._compress_logs(
-            #         os.path.join(self.repo_path, "tests/integration"),
-            #         extra_logs_names + list(test_data_dirs_diff),
-            #         extras_result_path,
-            #     )
-            #     log_paths.append(extras_result_path)
-            #
-            # if len(counters["PASSED"]) == len(tests_in_group):
-            #     logging.info("All tests from group %s passed", test_group)
-            #     break
-            # if (
-            #     len(counters["PASSED"]) >= 0
-            #     and len(counters["FAILED"]) == 0
-            #     and len(counters["ERROR"]) == 0
-            # ):
-            #     logging.info(
-            #         "Seems like all tests passed but some of them are skipped or "
-            #         "deselected. Ignoring them and finishing group."
-            #     )
-            #     break
+            extra_logs_names = [log_basename]
+            log_result_path = os.path.join(
+                self.path(), "integration_run_" + log_basename
+            )
+            shutil.copy(log_path, log_result_path)
+            log_paths.append(log_result_path)
+
+            for pytest_log_path in glob.glob(
+                os.path.join(self.repo_path, "tests/integration/pytest*.log")
+            ):
+                new_name = f"{test_group_str}_{i}_{os.path.basename(pytest_log_path)}"
+                os.rename(
+                    pytest_log_path,
+                    os.path.join(self.repo_path, "tests/integration", new_name),
+                )
+                extra_logs_names.append(new_name)
+
+            dockerd_log_path = os.path.join(
+                self.repo_path, "tests/integration/dockerd.log"
+            )
+            if os.path.exists(dockerd_log_path):
+                new_name = f"{test_group_str}_{i}_{os.path.basename(dockerd_log_path)}"
+                os.rename(
+                    dockerd_log_path,
+                    os.path.join(self.repo_path, "tests/integration", new_name),
+                )
+                extra_logs_names.append(new_name)
+
+            if os.path.exists(report_path):
+                extra_logs_names.append(report_name)
+                new_counters, new_tests_times = self._parse_report(report_path)
+                for state, tests in new_counters.items():
+                    logging.info(
+                        "Tests with %s state (%s): %s", state, len(tests), tests
+                    )
+                self._update_counters(counters, new_counters)
+                for test_name, test_time in new_tests_times.items():
+                    tests_times[test_name] = test_time
+
+            test_data_dirs_new = self._find_test_data_dirs(self.repo_path, test_names)
+            test_data_dirs_diff = self._get_test_data_dirs_difference(
+                test_data_dirs_new, test_data_dirs
+            )
+            test_data_dirs = test_data_dirs_new
+
+            if extra_logs_names or test_data_dirs_diff:
+                extras_result_path = os.path.join(
+                    self.path(), f"integration_run_{test_group_str}_{i}.tar.zst"
+                )
+                self._compress_logs(
+                    os.path.join(self.repo_path, "tests/integration"),
+                    extra_logs_names + list(test_data_dirs_diff),
+                    extras_result_path,
+                )
+                log_paths.append(extras_result_path)
+
+            if len(counters["PASSED"]) == len(tests_in_group):
+                logging.info("All tests from group %s passed", test_group)
+                break
+            if (
+                len(counters["PASSED"]) >= 0
+                and len(counters["FAILED"]) == 0
+                and len(counters["ERROR"]) == 0
+            ):
+                logging.info(
+                    "Seems like all tests passed but some of them are skipped or "
+                    "deselected. Ignoring them and finishing group."
+                )
+                break
         else:
             # Mark all non tried tests as errors, with '::' in name
             # (example test_partition/test.py::test_partition_simple). For flaky check
@@ -1038,11 +1038,11 @@ class ClickhouseIntegrationTestsRunner:
 
     def run_normal_check(self):
         logging.info("Pulling images")
-        # self._pre_pull_images()
-        # logging.info(
-        #     "Dump iptables before run %s",
-        #     subprocess.check_output("sudo iptables -nvL", shell=True),
-        # )
+        self._pre_pull_images()
+        logging.info(
+            "Dump iptables before run %s",
+            subprocess.check_output("sudo iptables -nvL", shell=True),
+        )
         parallel_skip_tests = self._get_parallel_tests_skip_list(self.repo_path)
         logging.info(
             "Found %s tests first 3 %s",
@@ -1127,9 +1127,9 @@ class ClickhouseIntegrationTestsRunner:
             for test_name, test_time in group_test_times.items():
                 tests_times[test_name] = test_time
 
-            # if len(counters["FAILED"]) + len(counters["ERROR"]) >= 20:
-            #     logging.info("Collected more than 20 failed/error tests, stopping")
-            #     break
+            if len(counters["FAILED"]) + len(counters["ERROR"]) >= 20:
+                logging.info("Collected more than 20 failed/error tests, stopping")
+                break
         if counters["FAILED"] or counters["ERROR"]:
             logging.info(
                 "Overall status failure, because we have tests in FAILED or ERROR state"

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -146,6 +146,7 @@ class PRInfo:
         self.head_ref = ""  # type: str
         self.head_name = ""  # type: str
         self.number = 0  # type: int
+        self.updated_at = None
 
         # workflow completed event, used for PRs only
         if "action" in github_event and github_event["action"] == "completed":
@@ -194,6 +195,7 @@ class PRInfo:
             self.labels = {
                 label["name"] for label in github_event["pull_request"]["labels"]
             }
+            self.updated_at = github_event["pull_request"]["updated_at"]
 
             self.user_login = github_event["pull_request"]["user"]["login"]  # type: str
             self.user_orgs = set()  # type: Set[str]


### PR DESCRIPTION
1. Split tests into deterministic CI batches based on execution time. This solves the problem of uneven total execution time for each batch.
2. Remove parallel test subgroups. This feature was problematic because it split tests individually instead of by file. As a result, tests from a single file could be separated into different subgroups, forcing setup and teardown to run multiple times. Also removing this improves parallelization as single pool of workers is used for all parallel tests.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
