### PR TITLE
Fix Not-ready Set for IN (subquery) inside additional_table_filters expression.

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -703,6 +703,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
     QueryPlan query_plan;
     std::unordered_map<const QueryNode *, const QueryPlan::Node *> query_node_to_plan_step_mapping;
     std::set<std::string> used_row_policies;
+    UsefulSets useful_sets;
 
     if (table_node || table_function_node)
     {
@@ -930,7 +931,10 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 
                 const auto & table_expression_alias = table_expression->getOriginalAlias();
                 if (auto additional_filters_info = buildAdditionalFiltersIfNeeded(storage, table_expression_alias, table_expression_query_info, planner_context))
+                {
+                    appendSetsFromActionsDAG(additional_filters_info->actions, useful_sets);
                     add_filter(*additional_filters_info, "additional filter");
+                }
 
                 if (!select_query_options.build_logical_plan)
                     from_stage = storage->getQueryProcessingStage(
@@ -1357,6 +1361,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
         .query_plan = std::move(query_plan),
         .from_stage = from_stage,
         .used_row_policies = std::move(used_row_policies),
+        .useful_sets = std::move(useful_sets),
         .query_node_to_plan_step_mapping = std::move(query_node_to_plan_step_mapping),
     };
 }

--- a/tests/queries/0_stateless/02346_additional_filters.reference
+++ b/tests/queries/0_stateless/02346_additional_filters.reference
@@ -110,6 +110,8 @@ select number, x, y from (select number from system.numbers limit 5) f any left 
 select b + 1 as c from (select a + 1 as b from (select x + 1 as a from table_1)) settings additional_table_filters={'table_1' : 'x != 2 and x != 3'};
 4
 7
+select dummy from system.one SETTINGS additional_table_filters = {'system.one':'dummy in (select number from numbers(2))'};
+0
 -- { echoOn }
 select * from v_numbers;
 1

--- a/tests/queries/0_stateless/02346_additional_filters.sql
+++ b/tests/queries/0_stateless/02346_additional_filters.sql
@@ -44,6 +44,7 @@ select * from system.numbers limit 5 settings additional_table_filters={'system.
 select * from (select number from system.numbers limit 5 union all select x from table_1) order by number settings additional_table_filters={'system.numbers':'number != 3','table_1':'x!=2'};
 select number, x, y from (select number from system.numbers limit 5) f any left join (select x, y from table_1) s on f.number = s.x order by all settings additional_table_filters={'system.numbers' : 'number != 3', 'table_1' : 'x != 2'};
 select b + 1 as c from (select a + 1 as b from (select x + 1 as a from table_1)) settings additional_table_filters={'table_1' : 'x != 2 and x != 3'};
+select dummy from system.one SETTINGS additional_table_filters = {'system.one':'dummy in (select number from numbers(2))'};
 
 -- { echoOff }
 


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
<!-- End of fixes issue link part, do not remove -->


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Not-ready Set` for `IN (subquery)` inside `additional_table_filters expression` setting.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
