### PR TITLE
Update stddevpopstable.md

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/stddevpopstable.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/stddevpopstable.md
@@ -22,7 +22,7 @@ stddevPopStable(x)
 
 **Returned value**
 
-Square root of standard deviation of `x`. [Float64](../../data-types/float.md).
+Square root of the variance of `x`. [Float64](../../data-types/float.md).
 
 **Example**
 


### PR DESCRIPTION
The standard deviation of data `x` equals to the square root of the variance of data `x`.
### Changelog category:
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes
- The standard deviation of data `x` equals to the square root of the variance of data `x`.
- Motivation: This corrects the description that standard deviation is the square root of x
