### PR TITLE
Revert "Text index: add internal bloom filter layer"

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -41,7 +41,7 @@ CREATE TABLE tab
 (
     `key` UInt64,
     `str` String,
-    INDEX inv_idx(str) TYPE text(tokenizer = 'default|ngram|split|no_op' [, ngram_size = N] [, separators = []] [, segment_digestion_threshold_bytes = B] [, bloom_filter_false_positive_rate = R]) [GRANULARITY 64]
+    INDEX inv_idx(str) TYPE text(tokenizer = 'default|ngram|split|no_op' [, ngram_size = N] [, separators = []] [, segment_digestion_threshold_bytes = B]) [GRANULARITY 64]
 )
 ENGINE = MergeTree
 ORDER BY key
@@ -76,9 +76,9 @@ For example, with separators = `['%21', '%']` string `%21abc` would be tokenized
 
 <details markdown="1">
 
-<summary>Advanced parameters</summary>
+<summary>Advanced settings</summary>
 
-Optional parameter `segment_digestion_threshold_bytes` determines the byte size of index segments.
+Optional parameter `segment_digestion_threshold_bytes` parameter determines the byte size of index segments.
 
 - `segment_digestion_threshold_bytes = 0`: Unlimited size, a single segment is created for each index granule.
 - `segment_digestion_threshold_bytes = B`: A new segment is created every `B` bytes of text input.
@@ -89,12 +89,6 @@ We do not recommend changing `segment_digestion_threshold_bytes`.
 The default value will work well in virtually all situations.
 The presence of more than one segment causes redundant data storage and slower full-text search queries.
 The only reason to provide a non-zero value (e.g. `256MB`) for `segment_digestion_threshold_bytes` is if you get out-of-memory exceptions during index creation.
-
-Optional parameter `bloom_filter_false_positive_rate` determines the false-positive rate of the bloom filter.
-
-- `bloom_filter_false_positive_rate = R`: A double between 0.0 and 1.0.
-
-Default value: `0.001` (0.1%).
 
 </details>
 

--- a/programs/fst-dump-tree/FstDumpTree.cpp
+++ b/programs/fst-dump-tree/FstDumpTree.cpp
@@ -25,6 +25,14 @@
 
 namespace
 {
+    constexpr const std::string_view GIN_SEGMENT_ID_FILE_TYPE = ".gin_sid";
+    constexpr const std::string_view GIN_SEGMENT_METADATA_FILE_TYPE = ".gin_seg";
+    constexpr const std::string_view GIN_DICTIONARY_FILE_TYPE = ".gin_dict";
+    constexpr const std::string_view GIN_POSTINGS_FILE_TYPE = ".gin_post";
+}
+
+namespace
+{
 std::pair<UInt64, UInt64> readNextStateIdAndArcOutput(DB::ReadBuffer & read_buffer)
 {
     UInt64 next_state_id = 0;
@@ -96,39 +104,32 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
         std::unique_ptr<DB::ReadBufferFromFile> segment_metadata_read_buffer;
         std::unique_ptr<DB::ReadBufferFromFile> dictionary_read_buffer;
         std::unique_ptr<DB::ReadBufferFromFile> postings_read_buffer;
-        std::unique_ptr<DB::ReadBufferFromFile> bloom_filter_read_buffer;
         for (const auto & dir_entry : std::filesystem::directory_iterator(input_path))
         {
             const auto& path_as_string = dir_entry.path().string();
-            if (path_as_string.ends_with(DB::GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE))
+            if (path_as_string.ends_with(GIN_SEGMENT_ID_FILE_TYPE))
             {
                 if (segment_id_read_buffer != nullptr)
                     printAndExit("Segment id file are already initialized at '{}', trying to initialized again at '{}'", segment_id_read_buffer->getFileName(), path_as_string);
                 segment_id_read_buffer = std::make_unique<DB::ReadBufferFromFile>(dir_entry.path().string());
             }
-            if (path_as_string.ends_with(DB::GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE))
+            if (path_as_string.ends_with(GIN_SEGMENT_METADATA_FILE_TYPE))
             {
                 if (segment_metadata_read_buffer != nullptr)
                     printAndExit("Segment metadata file are already initialized at '{}', trying to initialized again at '{}'", segment_metadata_read_buffer->getFileName(), path_as_string);
                 segment_metadata_read_buffer = std::make_unique<DB::ReadBufferFromFile>(dir_entry.path().string());
             }
-            if (path_as_string.ends_with(DB::GinIndexStore::GIN_DICTIONARY_FILE_TYPE))
+            if (path_as_string.ends_with(GIN_DICTIONARY_FILE_TYPE))
             {
                 if (dictionary_read_buffer != nullptr)
                     printAndExit("Segment dictionary file are already initialized at '{}', trying to initialized again at '{}'", dictionary_read_buffer->getFileName(), path_as_string);
                 dictionary_read_buffer = std::make_unique<DB::ReadBufferFromFile>(dir_entry.path().string());
             }
-            if (path_as_string.ends_with(DB::GinIndexStore::GIN_POSTINGS_FILE_TYPE))
+            if (path_as_string.ends_with(GIN_POSTINGS_FILE_TYPE))
             {
                 if (postings_read_buffer != nullptr)
                     printAndExit("Segment postings file are already initialized at '{}', trying to initialized again at '{}'", postings_read_buffer->getFileName(), path_as_string);
                 postings_read_buffer = std::make_unique<DB::ReadBufferFromFile>(dir_entry.path().string());
-            }
-            if (path_as_string.ends_with(DB::GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE))
-            {
-                if (bloom_filter_read_buffer != nullptr)
-                    printAndExit("Segment bloom filter file are already initialized at '{}', trying to initialized again at '{}'", bloom_filter_read_buffer->getFileName(), path_as_string);
-                bloom_filter_read_buffer = std::make_unique<DB::ReadBufferFromFile>(dir_entry.path().string());
             }
         }
         if (segment_id_read_buffer == nullptr)
@@ -139,8 +140,6 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
             printAndExit("Cannot find segment dictionary file.");
         if (postings_read_buffer == nullptr)
             printAndExit("Cannot find segment postings file.");
-        if (bloom_filter_read_buffer == nullptr)
-            printAndExit("Cannot find segment bloom filter file.");
 
         DB::GinIndexStore::Format version;
         uint64_t number_of_segments = 0;
@@ -168,17 +167,16 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
         /// Read segment metadata
         using GinSegmentDictionaries = std::unordered_map<UInt32, DB::GinSegmentDictionaryPtr>;
         GinSegmentDictionaries segment_dictionaries(number_of_segments);
-        if (version == DB::GinIndexStore::Format::v1)
         {
             std::vector<DB::GinIndexSegment> segments(number_of_segments);
             segment_metadata_read_buffer->readStrict(reinterpret_cast<char *>(segments.data()), number_of_segments * sizeof(DB::GinIndexSegment));
             for (UInt32 i = 0; i < number_of_segments; ++i)
             {
+                auto seg_id = segments[i].segment_id;
                 auto seg_dict = std::make_shared<DB::GinSegmentDictionary>();
                 seg_dict->postings_start_offset = segments[i].postings_start_offset;
                 seg_dict->dict_start_offset = segments[i].dict_start_offset;
-                seg_dict->bloom_filter_start_offset = segments[i].bloom_filter_start_offset;
-                segment_dictionaries[segments[i].segment_id] = seg_dict;
+                segment_dictionaries[seg_id] = seg_dict;
             }
         }
 
@@ -194,26 +192,15 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                 }
 
                 const auto & segment_dict = it->second;
+                fmt::println(
+                    "[Segment {}]: dictionary data offset = {}, postings offset = {}",
+                    segment_id,
+                    segment_dict->dict_start_offset,
+                    segment_dict->postings_start_offset);
+
                 dictionary_read_buffer->seek(segment_dict->dict_start_offset, SEEK_SET);
                 if (version == DB::GinIndexStore::Format::v1)
                 {
-                    fmt::println(
-                        "[Segment {}]: term dictionary (FST) offset = {}, bloom filter offset = {}, postings offset = {}",
-                        segment_id,
-                        segment_dict->dict_start_offset,
-                        segment_dict->bloom_filter_start_offset,
-                        segment_dict->postings_start_offset);
-
-                    /// Read bloom filter
-                    bloom_filter_read_buffer->seek(segment_dict->bloom_filter_start_offset, SEEK_SET);
-                    segment_dict->bloom_filter = DB::GinSegmentDictionaryBloomFilter::deserialize(*bloom_filter_read_buffer);
-
-                    fmt::println(
-                        "[Segment {}]: bloom filter size = {}",
-                        segment_id,
-                        formatReadableSizeWithBinarySuffix(bloom_filter_read_buffer->getPosition() - segment_dict->bloom_filter_start_offset));
-
-
                     /// Read FST size header
                     UInt64 fst_size_header = 0;
                     readVarUInt(fst_size_header, *dictionary_read_buffer);
@@ -221,9 +208,8 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                     /// Get uncompressed FST size
                     size_t uncompressed_fst_size = fst_size_header >> 1;
 
-                    segment_dict->fst = std::make_unique<DB::FST::FiniteStateTransducer>();
-                    segment_dict->fst->getData().clear();
-                    segment_dict->fst->getData().resize(uncompressed_fst_size);
+                    segment_dict->offsets.getData().clear();
+                    segment_dict->offsets.getData().resize(uncompressed_fst_size);
                     if (fst_size_header & 0x1) /// FST is compressed
                     {
                         /// Read compressed FST size
@@ -238,7 +224,7 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                         codec->decompress(
                             buf.get(),
                             static_cast<UInt32>(compressed_fst_size),
-                            reinterpret_cast<char *>(segment_dict->fst->getData().data()));
+                            reinterpret_cast<char *>(segment_dict->offsets.getData().data()));
                         fmt::println(
                             "[Segment {}]: FST uncompressed size = {} | compressed size = {}",
                             segment_id,
@@ -248,7 +234,7 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                     else
                     {
                         dictionary_read_buffer->readStrict(
-                            reinterpret_cast<char *>(segment_dict->fst->getData().data()), uncompressed_fst_size);
+                            reinterpret_cast<char *>(segment_dict->offsets.getData().data()), uncompressed_fst_size);
                         fmt::println(
                             "[Segment {}]: FST uncompressed size = {}",
                             segment_id,
@@ -321,7 +307,7 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
 
             for (const auto & [segment_id, segment_dict] : segment_dictionaries)
             {
-                const auto data = segment_dict->fst->getData();
+                const auto data = segment_dict->offsets.getData();
 
                 DB::ReadBufferFromMemory read_buffer(data.data(), data.size());
                 read_buffer.seek(data.size() - 1, SEEK_SET);

--- a/src/Common/FST.cpp
+++ b/src/Common/FST.cpp
@@ -395,9 +395,6 @@ void FiniteStateTransducer::clear()
 
 std::pair<UInt64, bool> FiniteStateTransducer::getOutput(std::string_view term)
 {
-    if (data.empty())
-        return {0, false};
-
     std::pair<UInt64, bool> result(0, false);
 
     /// Read index of initial state

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6853,7 +6853,7 @@ Allows defining columns with [statistics](../../engines/table-engines/mergetree-
 )", EXPERIMENTAL, allow_experimental_statistic) \
     \
     DECLARE(Bool, allow_experimental_full_text_index, false, R"(
-If set to true, allow using the experimental text index.
+If it is set to true, allow to use experimental text index.
 )", EXPERIMENTAL) \
     DECLARE(Bool, allow_experimental_lightweight_update, false, R"(
 Allow to use lightweight updates.

--- a/src/Interpreters/BloomFilterHash.h
+++ b/src/Interpreters/BloomFilterHash.h
@@ -293,7 +293,7 @@ struct BloomFilterHash
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column type was passed to the bloom filter index.");
     }
 
-    static std::pair<size_t, size_t> calculationBestPractices(double false_positive_rate)
+    static std::pair<size_t, size_t> calculationBestPractices(double max_conflict_probability)
     {
         static const size_t MAX_BITS_PER_ROW = 20;
         static const size_t MAX_HASH_FUNCTION_COUNT = 15;
@@ -305,7 +305,7 @@ struct BloomFilterHash
         /// Otherwise, for those rates the loop won't find any possible values in the lookup table
         /// returning bits_per_row = 19 & size_of_hash_functions = 13. Which are the most restrictive values
         /// to be used with the smallest false positive rates.
-        if (false_positive_rate >= 0.283)
+        if (max_conflict_probability >= 0.283)
             return std::pair<size_t, size_t>(MIN_BITS_PER_ROW, MIN_HASH_FUNCTION_COUNT);
 
         /// For the smallest index per level in probability_lookup_table
@@ -338,11 +338,11 @@ struct BloomFilterHash
 
         for (size_t bits_per_row = 1; bits_per_row < MAX_BITS_PER_ROW; ++bits_per_row)
         {
-            if (probability_lookup_table[bits_per_row][min_probability_index_each_bits[bits_per_row]] <= false_positive_rate)
+            if (probability_lookup_table[bits_per_row][min_probability_index_each_bits[bits_per_row]] <= max_conflict_probability)
             {
                 size_t max_size_of_hash_functions = min_probability_index_each_bits[bits_per_row];
                 for (size_t size_of_hash_functions = max_size_of_hash_functions; size_of_hash_functions > 0; --size_of_hash_functions)
-                    if (probability_lookup_table[bits_per_row][size_of_hash_functions] > false_positive_rate)
+                    if (probability_lookup_table[bits_per_row][size_of_hash_functions] > max_conflict_probability)
                         return std::pair<size_t, size_t>(bits_per_row, size_of_hash_functions + 1);
             }
         }

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -19,12 +19,10 @@ namespace DB
 GinFilterParameters::GinFilterParameters(
     String tokenizer_,
     UInt64 segment_digestion_threshold_bytes_,
-    double bloom_filter_false_positive_rate_,
     std::optional<UInt64> ngram_size_,
     std::optional<std::vector<String>> separators_)
     : tokenizer(std::move(tokenizer_))
     , segment_digestion_threshold_bytes(segment_digestion_threshold_bytes_)
-    , bloom_filter_false_positive_rate(bloom_filter_false_positive_rate_)
     , ngram_size(ngram_size_)
     , separators(separators_)
 {

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -8,7 +8,6 @@ namespace DB
 
 static constexpr UInt64 UNLIMITED_ROWS_PER_POSTINGS_LIST = 0;
 static constexpr UInt64 DEFAULT_NGRAM_SIZE = 3;
-static constexpr auto DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE = 0.001; /// 0.1%
 
 static inline constexpr auto TEXT_INDEX_NAME = "text";
 
@@ -23,15 +22,12 @@ struct GinFilterParameters
     GinFilterParameters(
         String tokenizer_,
         UInt64 segment_digestion_threshold_bytes_,
-        double bloom_filter_false_positive_rate_,
         std::optional<UInt64> ngram_size_,
         std::optional<std::vector<String>> separators_);
 
     String tokenizer;
     /// Digestion threshold to split a segment. By default, it is 0 (zero) which means unlimited.
     UInt64 segment_digestion_threshold_bytes;
-    /// Bloom filter false positive rate, by default it's 0.1%.
-    double bloom_filter_false_positive_rate;
     /// for ngram tokenizer
     std::optional<UInt64> ngram_size;
     /// for split tokenizer

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -1,16 +1,13 @@
 // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 
-#include <IO/VarInt.h>
 #include <Storages/MergeTree/GinIndexStore.h>
 #include <Columns/ColumnString.h>
 #include <Common/FST.h>
-#include <Common/HashTable/HashSet.h>
 #include <Compression/CompressionFactory.h>
 #include <Compression/ICompressionCodec.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Interpreters/BloomFilterHash.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromFile.h>
@@ -157,67 +154,6 @@ GinIndexPostingsListPtr GinIndexPostingsBuilder::deserialize(ReadBuffer & buffer
     }
 }
 
-GinSegmentDictionaryBloomFilter::GinSegmentDictionaryBloomFilter(UInt64 unique_count_, size_t bits_per_rows_, size_t num_hashes_)
-    : unique_count(unique_count_)
-    , bits_per_row(bits_per_rows_)
-    , num_hashes(num_hashes_)
-    , bloom_filter(((bits_per_row * unique_count) + sizeof(BloomFilter::UnderType) - 1) / sizeof(BloomFilter::UnderType), num_hashes, 0)
-{
-}
-
-void GinSegmentDictionaryBloomFilter::add(std::string_view token)
-{
-    bloom_filter.add(token.data(), token.size());
-}
-
-bool GinSegmentDictionaryBloomFilter::contains(std::string_view token)
-{
-    return bloom_filter.find(token.data(), token.size());
-}
-
-UInt64 GinSegmentDictionaryBloomFilter::serialize(WriteBuffer & write_buffer)
-{
-    UInt64 bytes_written = 0;
-    const size_t filter_size_bytes = bloom_filter.getFilter().size() * sizeof(BloomFilter::UnderType);
-
-    writeVarUInt(unique_count, write_buffer);
-    bytes_written += getLengthOfVarUInt(unique_count);
-
-    writeVarUInt(bits_per_row, write_buffer);
-    bytes_written += getLengthOfVarUInt(bits_per_row);
-
-    writeVarUInt(num_hashes, write_buffer);
-    bytes_written += getLengthOfVarUInt(num_hashes);
-
-    writeVarUInt(filter_size_bytes, write_buffer);
-    bytes_written += getLengthOfVarUInt(filter_size_bytes);
-
-    write_buffer.write(reinterpret_cast<const char *>(bloom_filter.getFilter().data()), filter_size_bytes);
-    bytes_written += filter_size_bytes;
-
-    return bytes_written;
-}
-
-std::unique_ptr<GinSegmentDictionaryBloomFilter> GinSegmentDictionaryBloomFilter::deserialize(ReadBuffer & read_buffer)
-{
-    UInt64 unique_count;
-    readVarUInt(unique_count, read_buffer);
-
-    UInt64 bits_per_row = 0;
-    readVarUInt(bits_per_row, read_buffer);
-
-    UInt64 num_hashes = 0;
-    readVarUInt(num_hashes, read_buffer);
-
-    UInt64 filter_size_bytes = 0;
-    readVarUInt(filter_size_bytes, read_buffer);
-
-    auto gin_bloom_filter = std::make_unique<GinSegmentDictionaryBloomFilter>(unique_count, bits_per_row, num_hashes);
-    read_buffer.readStrict(reinterpret_cast<char *>(gin_bloom_filter->bloom_filter.getFilter().data()), filter_size_bytes);
-
-    return gin_bloom_filter;
-}
-
 GinIndexStore::GinIndexStore(const String & name_, DataPartStoragePtr storage_)
     : name(name_)
     , storage(storage_)
@@ -228,13 +164,11 @@ GinIndexStore::GinIndexStore(
     const String & name_,
     DataPartStoragePtr storage_,
     MutableDataPartStoragePtr data_part_storage_builder_,
-    UInt64 segment_digestion_threshold_bytes_,
-    double bloom_filter_false_positive_rate_)
+    UInt64 segment_digestion_threshold_bytes_)
     : name(name_)
     , storage(storage_)
     , data_part_storage_builder(data_part_storage_builder_)
     , segment_digestion_threshold_bytes(segment_digestion_threshold_bytes_)
-    , bloom_filter_false_positive_rate(bloom_filter_false_positive_rate_)
 {
 }
 
@@ -338,9 +272,6 @@ void GinIndexStore::finalize()
     if (metadata_file_stream)
         metadata_file_stream->finalize();
 
-    if (bloom_filter_file_stream)
-        bloom_filter_file_stream->finalize();
-
     if (dict_file_stream)
         dict_file_stream->finalize();
 
@@ -352,9 +283,6 @@ void GinIndexStore::cancel() noexcept
 {
     if (metadata_file_stream)
         metadata_file_stream->cancel();
-
-    if (bloom_filter_file_stream)
-        bloom_filter_file_stream->cancel();
 
     if (dict_file_stream)
         dict_file_stream->cancel();
@@ -388,12 +316,10 @@ void GinIndexStore::initSegmentId()
 void GinIndexStore::initFileStreams()
 {
     String metadata_file_name = getName() + GIN_SEGMENT_METADATA_FILE_TYPE;
-    String bloom_filter_file_name = getName() + GIN_BLOOM_FILTER_FILE_TYPE;
     String dict_file_name = getName() + GIN_DICTIONARY_FILE_TYPE;
     String postings_file_name = getName() + GIN_POSTINGS_FILE_TYPE;
 
     metadata_file_stream = data_part_storage_builder->writeFile(metadata_file_name, 4096, WriteMode::Append, {});
-    bloom_filter_file_stream = data_part_storage_builder->writeFile(bloom_filter_file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
     dict_file_stream = data_part_storage_builder->writeFile(dict_file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
     postings_file_stream = data_part_storage_builder->writeFile(postings_file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append, {});
 }
@@ -411,39 +337,21 @@ void GinIndexStore::writeSegmentId()
     ostr->finalize();
 }
 
-namespace
-{
-/// Initialize bloom filter from tokens from the term dictionary
-GinSegmentDictionaryBloomFilter initializeBloomFilter(
-        const GinIndexStore::GinIndexPostingsBuilderContainer & postings,
-        double bloom_filter_false_positive_rate)
-{
-    auto number_of_unique_terms = postings.size(); /// postings is a dictionary
-    const auto [bits_per_rows, num_hashes] = BloomFilterHash::calculationBestPractices(bloom_filter_false_positive_rate);
-    GinSegmentDictionaryBloomFilter bloom_filter(number_of_unique_terms, bits_per_rows, num_hashes);
-    for (const auto & [token, _] : postings)
-        bloom_filter.add(token);
-    return bloom_filter;
-}
-}
-
 void GinIndexStore::writeSegment()
 {
     if (metadata_file_stream == nullptr)
         initFileStreams();
 
-    /// Write segment
-    metadata_file_stream->write(reinterpret_cast<char *>(&current_segment), sizeof(GinIndexSegment));
-
     using TokenPostingsBuilderPair = std::pair<std::string_view, GinIndexPostingsBuilderPtr>;
     using TokenPostingsBuilderPairs = std::vector<TokenPostingsBuilderPair>;
 
+    /// Write segment
+    metadata_file_stream->write(reinterpret_cast<char *>(&current_segment), sizeof(GinIndexSegment));
     TokenPostingsBuilderPairs token_postings_list_pairs;
     token_postings_list_pairs.reserve(current_postings.size());
+
     for (const auto & [token, postings_list] : current_postings)
         token_postings_list_pairs.push_back({token, postings_list});
-
-    GinSegmentDictionaryBloomFilter bloom_filter = initializeBloomFilter(current_postings, bloom_filter_false_positive_rate);
 
     /// Sort token-postings list pairs since all tokens have to be added in FST in sorted order
     std::sort(token_postings_list_pairs.begin(), token_postings_list_pairs.end(),
@@ -463,11 +371,7 @@ void GinIndexStore::writeSegment()
         i++;
         current_segment.postings_start_offset += posting_list_byte_size;
     }
-
-    /// Write bloom filter
-    current_segment.bloom_filter_start_offset += bloom_filter.serialize(*bloom_filter_file_stream);
-
-    /// Write item dictionary
+    ///write item dictionary
     std::vector<UInt8> buffer;
     WriteBufferFromVector<std::vector<UInt8>> write_buf(buffer);
     FST::FstBuilder fst_builder(write_buf);
@@ -519,7 +423,6 @@ void GinIndexStore::writeSegment()
     current_segment.segment_id = getNextSegmentID();
 
     metadata_file_stream->sync();
-    bloom_filter_file_stream->sync();
     dict_file_stream->sync();
     postings_file_stream->sync();
 }
@@ -533,74 +436,52 @@ GinIndexStoreDeserializer::GinIndexStoreDeserializer(const GinIndexStorePtr & st
 void GinIndexStoreDeserializer::initFileStreams()
 {
     String metadata_file_name = store->getName() + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE;
-    String bloom_filter_file_name = store->getName() + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE;
     String dict_file_name = store->getName() + GinIndexStore::GIN_DICTIONARY_FILE_TYPE;
     String postings_file_name = store->getName() + GinIndexStore::GIN_POSTINGS_FILE_TYPE;
 
     metadata_file_stream = store->storage->readFile(metadata_file_name, {}, std::nullopt, std::nullopt);
-    bloom_filter_file_stream = store->storage->readFile(bloom_filter_file_name, {}, std::nullopt, std::nullopt);
     dict_file_stream = store->storage->readFile(dict_file_name, {}, std::nullopt, std::nullopt);
     postings_file_stream = store->storage->readFile(postings_file_name, {}, std::nullopt, std::nullopt);
 }
-
 void GinIndexStoreDeserializer::readSegments()
 {
     UInt32 num_segments = store->getNumOfSegments();
     if (num_segments == 0)
         return;
 
+    using GinIndexSegments = std::vector<GinIndexSegment>;
+    GinIndexSegments segments (num_segments);
+
     assert(metadata_file_stream != nullptr);
 
-    if (store->getVersion() == GinIndexStore::Format::v1)
+    metadata_file_stream->readStrict(reinterpret_cast<char *>(segments.data()), num_segments * sizeof(GinIndexSegment));
+    for (UInt32 i = 0; i < num_segments; ++i)
     {
-        std::vector<GinIndexSegment> segments(num_segments);
-        metadata_file_stream->readStrict(reinterpret_cast<char *>(segments.data()), num_segments * sizeof(GinIndexSegment));
-        for (UInt32 i = 0; i < num_segments; ++i)
-        {
-            auto seg_dict = std::make_shared<GinSegmentDictionary>();
-            seg_dict->postings_start_offset = segments[i].postings_start_offset;
-            seg_dict->dict_start_offset = segments[i].dict_start_offset;
-            seg_dict->bloom_filter_start_offset = segments[i].bloom_filter_start_offset;
-            store->segment_dictionaries[segments[i].segment_id] = seg_dict;
-        }
+        auto seg_id = segments[i].segment_id;
+        auto seg_dict = std::make_shared<GinSegmentDictionary>();
+        seg_dict->postings_start_offset = segments[i].postings_start_offset;
+        seg_dict->dict_start_offset = segments[i].dict_start_offset;
+        store->segment_dictionaries[seg_id] = seg_dict;
     }
 }
 
-void GinIndexStoreDeserializer::prepareSegmentsForReading()
+void GinIndexStoreDeserializer::readSegmentDictionaries()
 {
     for (UInt32 seg_index = 0; seg_index < store->getNumOfSegments(); ++seg_index)
-        prepareSegmentForReading(seg_index);
+        readSegmentDictionary(seg_index);
 }
 
-void GinIndexStoreDeserializer::prepareSegmentForReading(UInt32 segment_id)
+void GinIndexStoreDeserializer::readSegmentDictionary(UInt32 segment_id)
 {
     /// Check validity of segment_id
     auto it = store->segment_dictionaries.find(segment_id);
     if (it == store->segment_dictionaries.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid segment id {}", segment_id);
 
-    const GinSegmentDictionaryPtr & seg_dict = it->second;
-    switch (auto version = store->getVersion(); version)
-    {
-        case GinIndexStore::Format::v1: {
-            /// V1 supports bloom filter, so we can delay reading a segment until it's needed.
-
-            /// Set file pointer of filter file
-            assert(bloom_filter_file_stream != nullptr);
-            bloom_filter_file_stream->seek(it->second->bloom_filter_start_offset, SEEK_SET);
-            seg_dict->bloom_filter = GinSegmentDictionaryBloomFilter::deserialize(*bloom_filter_file_stream);
-            break;
-        }
-    }
-}
-
-void GinIndexStoreDeserializer::readSegmentFST(GinSegmentDictionaryPtr segment_dictionary)
-{
     /// Set file pointer of dictionary file
     assert(dict_file_stream != nullptr);
-    dict_file_stream->seek(segment_dictionary->dict_start_offset, SEEK_SET);
+    dict_file_stream->seek(it->second->dict_start_offset, SEEK_SET);
 
-    segment_dictionary->fst = std::make_unique<FST::FiniteStateTransducer>();
     switch (auto version = store->getVersion(); version)
     {
         case GinIndexStore::Format::v1: {
@@ -609,8 +490,8 @@ void GinIndexStoreDeserializer::readSegmentFST(GinSegmentDictionaryPtr segment_d
             readVarUInt(fst_size_header, *dict_file_stream);
 
             size_t uncompressed_fst_size = fst_size_header >> 1;
-            segment_dictionary->fst->getData().clear();
-            segment_dictionary->fst->getData().resize(uncompressed_fst_size);
+            it->second->offsets.getData().clear();
+            it->second->offsets.getData().resize(uncompressed_fst_size);
             if (fst_size_header & 0x1) /// FST is compressed
             {
                 /// Read compressed FST size
@@ -621,14 +502,12 @@ void GinIndexStoreDeserializer::readSegmentFST(GinSegmentDictionaryPtr segment_d
                 dict_file_stream->readStrict(buf.data(), compressed_fst_size);
                 const auto & codec = DB::GinIndexCompressionFactory::zstdCodec();
                 codec->decompress(
-                    buf.data(),
-                    static_cast<UInt32>(compressed_fst_size),
-                    reinterpret_cast<char *>(segment_dictionary->fst->getData().data()));
+                    buf.data(), static_cast<UInt32>(compressed_fst_size), reinterpret_cast<char *>(it->second->offsets.getData().data()));
             }
             else
             {
                 /// Read uncompressed FST blob
-                dict_file_stream->readStrict(reinterpret_cast<char *>(segment_dictionary->fst->getData().data()), uncompressed_fst_size);
+                dict_file_stream->readStrict(reinterpret_cast<char *>(it->second->offsets.getData().data()), uncompressed_fst_size);
             }
             break;
         }
@@ -644,17 +523,7 @@ GinSegmentedPostingsListContainer GinIndexStoreDeserializer::readSegmentedPostin
     {
         auto segment_id = seg_dict.first;
 
-        if (seg_dict.second->fst == nullptr)
-        {
-            /// Segment dictionary is not loaded, first check the term in bloom filter
-            if (seg_dict.second->bloom_filter && !seg_dict.second->bloom_filter->contains(term))
-                continue;
-
-            /// Term might be in segment dictionary
-            readSegmentFST(seg_dict.second);
-        }
-
-        auto [offset, found] = seg_dict.second->fst->getOutput(term);
+        auto [offset, found] = seg_dict.second->offsets.getOutput(term);
         if (!found)
             continue;
 
@@ -674,7 +543,7 @@ GinPostingsCachePtr GinIndexStoreDeserializer::createPostingsCacheFromTerms(cons
     for (const auto & term : terms)
     {
         // Make sure don't read for duplicated terms
-        if (postings_cache->contains(term))
+        if (postings_cache->find(term) != postings_cache->end())
             continue;
 
         auto container = readSegmentedPostingsLists(term);
@@ -713,7 +582,7 @@ GinIndexStorePtr GinIndexStoreFactory::get(const String & name, DataPartStorageP
 
         GinIndexStoreDeserializer deserializer(store);
         deserializer.readSegments();
-        deserializer.prepareSegmentsForReading();
+        deserializer.readSegmentDictionaries();
 
         stores[key] = store;
 
@@ -736,12 +605,9 @@ void GinIndexStoreFactory::remove(const String & part_path)
 
 bool isGinFile(const String & file_name)
 {
-    return file_name.ends_with(GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE)
-        || file_name.ends_with(GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE)
-        || file_name.ends_with(GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE)
-        || file_name.ends_with(GinIndexStore::GIN_DICTIONARY_FILE_TYPE)
-        || file_name.ends_with(GinIndexStore::GIN_POSTINGS_FILE_TYPE);
+    return file_name.ends_with(".gin_dict") || file_name.ends_with(".gin_post") || file_name.ends_with(".gin_seg") || file_name.ends_with(".gin_sid");
 }
+
 }
 
 // NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -303,11 +303,7 @@ void MergeTreeDataPartWriterOnDisk::initSkipIndices()
         if (const auto * gin_index = typeid_cast<const MergeTreeIndexGin *>(&*skip_index); gin_index != nullptr)
         {
             store = std::make_shared<GinIndexStore>(
-                stream_name,
-                data_part_storage,
-                data_part_storage,
-                gin_index->gin_filter_params.segment_digestion_threshold_bytes,
-                gin_index->gin_filter_params.bloom_filter_false_positive_rate);
+                stream_name, data_part_storage, data_part_storage, gin_index->gin_filter_params.segment_digestion_threshold_bytes);
             gin_index_stores[stream_name] = store;
         }
 
@@ -500,11 +496,10 @@ void MergeTreeDataPartWriterOnDisk::fillSkipIndicesChecksums(MergeTreeData::Data
         if (typeid_cast<const MergeTreeIndexGin *>(&*skip_indices[i]) != nullptr)
         {
             String filename_without_extension = skip_indices[i]->getFileName();
-            checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + GinIndexStore::GIN_DICTIONARY_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + GinIndexStore::GIN_POSTINGS_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + ".gin_dict"] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + ".gin_post"] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + ".gin_seg"] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + ".gin_sid"] = MergeTreeDataPartChecksums::Checksum();
         }
     }
 

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -892,15 +892,15 @@ static void assertIndexColumnsType(const Block & header)
 MergeTreeIndexPtr bloomFilterIndexCreator(
     const IndexDescription & index)
 {
-    double false_positive_rate = 0.025;
+    double max_conflict_probability = 0.025;
 
     if (!index.arguments.empty())
     {
         const auto & argument = index.arguments[0];
-        false_positive_rate = std::min<Float64>(1.0, std::max<Float64>(argument.safeGet<Float64>(), 0.0));
+        max_conflict_probability = std::min<Float64>(1.0, std::max<Float64>(argument.safeGet<Float64>(), 0.0));
     }
 
-    const auto & bits_per_row_and_size_of_hash_functions = BloomFilterHash::calculationBestPractices(false_positive_rate);
+    const auto & bits_per_row_and_size_of_hash_functions = BloomFilterHash::calculationBestPractices(max_conflict_probability);
 
     return std::make_shared<MergeTreeIndexBloomFilter>(
         index, bits_per_row_and_size_of_hash_functions.first, bits_per_row_and_size_of_hash_functions.second);

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -37,7 +37,6 @@ static const String ARGUMENT_TOKENIZER = "tokenizer";
 static const String ARGUMENT_NGRAM_SIZE = "ngram_size";
 static const String ARGUMENT_SEPARATORS = "separators";
 static const String ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES = "segment_digestion_threshold_bytes";
-static const String ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE = "bloom_filter_false_positive_rate";
 
 MergeTreeIndexGranuleGin::MergeTreeIndexGranuleGin(const String & index_name_)
     : index_name(index_name_)
@@ -124,14 +123,14 @@ void MergeTreeIndexAggregatorGin::update(const Block & block, size_t * pos, size
         return;
 
     const auto & index_column_name = index_columns[0];
-    const auto & index_column = block.getByName(index_column_name);
+    const auto & column = block.getByName(index_column_name).column;
 
     auto start_row_id = store->getNextRowIDRange(rows_read);
 
     size_t current_position = *pos;
     for (size_t i = 0; i < rows_read; ++i)
     {
-        auto ref = index_column.column->getDataAt(current_position + i);
+        auto ref = column->getDataAt(current_position + i);
         addToGinFilter(start_row_id + i, ref.data, ref.size, granule->gin_filter);
         store->incrementCurrentSizeBy(ref.size);
     }
@@ -670,7 +669,7 @@ MergeTreeIndexGranulePtr MergeTreeIndexGin::createIndexGranule() const
 MergeTreeIndexAggregatorPtr MergeTreeIndexGin::createIndexAggregator(const MergeTreeWriterSettings & /*settings*/) const
 {
     /// should not be called: createIndexAggregatorForPart should be used
-    chassert(false);
+    assert(false);
     return nullptr;
 }
 
@@ -709,7 +708,7 @@ std::optional<Type> getOption(const std::unordered_map<String, Field> & options,
     if (auto it = options.find(option); it != options.end())
     {
         const Field & value = it->second;
-        Field::Types::Which expected_type = Field::TypeToEnum<NearestFieldType<Type>>::value;
+        Field::Types::Which expected_type = Field::TypeToEnum<Type>::value;
         if (value.getType() != expected_type)
             throw Exception(
                 ErrorCodes::INCORRECT_QUERY,
@@ -763,13 +762,10 @@ MergeTreeIndexPtr ginIndexCreator(const IndexDescription & index)
     else
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Tokenizer {} not supported", tokenizer);
 
-    UInt64 segment_digestion_threshold_bytes
+    const UInt64 segment_digestion_threshold_bytes
         = getOption<UInt64>(options, ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES).value_or(UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES);
 
-    double bloom_filter_false_positive_rate
-        = getOption<double>(options, ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE).value_or(DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE);
-
-    GinFilterParameters params(tokenizer, segment_digestion_threshold_bytes, bloom_filter_false_positive_rate, ngram_size, separators);
+    GinFilterParameters params(tokenizer, segment_digestion_threshold_bytes, ngram_size, separators);
     return std::make_shared<MergeTreeIndexGin>(index, params, std::move(token_extractor));
 }
 
@@ -789,7 +785,7 @@ void ginIndexValidator(const IndexDescription & index, bool /*attach*/)
     if (!is_supported_tokenizer)
         throw Exception(
             ErrorCodes::INCORRECT_QUERY,
-            "Text index argument '{}' supports only 'default', 'ngram', 'split', and 'no_op', but got {}",
+            "Text index '{}' argument supports only 'default', 'ngram', 'split', and 'no_op', but got {}",
             ARGUMENT_TOKENIZER,
             tokenizer.value());
 
@@ -800,7 +796,7 @@ void ginIndexValidator(const IndexDescription & index, bool /*attach*/)
         if (ngram_size.has_value() && (*ngram_size < 2 || *ngram_size > 8))
             throw Exception(
                 ErrorCodes::INCORRECT_QUERY,
-                "Text index argument '{}' must be between 2 and 8, but got {}",
+                "Text index '{}' argument must be between 2 and 8, but got {}",
                 ARGUMENT_NGRAM_SIZE,
                 *ngram_size);
     }
@@ -813,30 +809,18 @@ void ginIndexValidator(const IndexDescription & index, bool /*attach*/)
                 if (separator.getType() != Field::Types::String)
                     throw Exception(
                         ErrorCodes::INCORRECT_QUERY,
-                        "Element of text index argument '{}' expected to be String, but got {}",
+                        "Element of text index argument {} expected to be String, but got {}",
                         ARGUMENT_SEPARATORS,
                         separator.getTypeName());
         }
     }
 
-    UInt64 segment_digestion_threshold_bytes
+    const UInt64 segment_digestion_threshold_bytes
         = getOption<UInt64>(options, ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES).value_or(UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES);
-
-    double bloom_filter_false_positive_rate
-        = getOption<double>(options, ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE).value_or(DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE);
-
-    if (!std::isfinite(bloom_filter_false_positive_rate)
-            || bloom_filter_false_positive_rate <= 0.0 || bloom_filter_false_positive_rate >= 1.0)
-        throw Exception(
-            ErrorCodes::INCORRECT_QUERY,
-            "Text index argument '{}' must be between 0.0 and 1.0, but got {}",
-            ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE,
-            bloom_filter_false_positive_rate);
 
     GinFilterParameters gin_filter_params(
         tokenizer.value(),
         segment_digestion_threshold_bytes,
-        bloom_filter_false_positive_rate,
         ngram_size,
         getOptionAsStringArray(options, ARGUMENT_SEPARATORS).value_or(std::vector<String>{" "})); /// Just validate
 
@@ -855,7 +839,7 @@ void ginIndexValidator(const IndexDescription & index, bool /*attach*/)
     if (!data_type.isString() && !data_type.isFixedString())
         throw Exception(
             ErrorCodes::INCORRECT_QUERY,
-            "Text index must be created on columns of type `String`, `FixedString`, `LowCardinality(String)`, `LowCardinality(FixedString)`");
+            "Text index can be created on columns of type `String`, `FixedString`, `LowCardinality(String)`, `LowCardinality(FixedString)`");
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <Common/HashTable/HashSet.h>
 #include <Interpreters/GinFilter.h>
 #include <Interpreters/ITokenExtractor.h>
 #include <Storages/MergeTree/KeyCondition.h>
-#include <Storages/MergeTree/MergeTreeIOSettings.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 
 namespace DB
@@ -148,7 +146,7 @@ public:
 
     MergeTreeIndexGranulePtr createIndexGranule() const override;
     MergeTreeIndexAggregatorPtr createIndexAggregator(const MergeTreeWriterSettings & settings) const override;
-    MergeTreeIndexAggregatorPtr createIndexAggregatorForPart(const GinIndexStorePtr & store, const MergeTreeWriterSettings & settings) const override;
+    MergeTreeIndexAggregatorPtr createIndexAggregatorForPart(const GinIndexStorePtr & store, const MergeTreeWriterSettings & /*settings*/) const override;
     MergeTreeIndexConditionPtr createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
     GinFilterParameters gin_filter_params;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1581,7 +1581,8 @@ namespace ErrorCodes
     of the table.
     )", 0) \
     DECLARE(Bool, add_minmax_index_for_string_columns, false, R"(
-    When enabled, min-max (skipping) indices are added for all string columns of the table.
+    When enabled, min-max (skipping) indices are added for all string columns of
+    the table.
     )", 0) \
     DECLARE(Bool, allow_summing_columns_in_partition_or_order_key, false, R"(
     When enabled, allows summing columns in a SummingMergeTree table to be used in

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -29,7 +29,6 @@
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
 #include <Storages/MergeTree/MergeProjectionPartsTask.h>
 #include <Storages/MutationCommands.h>
-#include <Storages/MergeTree/GinIndexStore.h>
 #include <Storages/MergeTree/MergeTreeDataMergerMutator.h>
 #include <Storages/MergeTree/MergeTreeIndexGin.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
@@ -790,11 +789,10 @@ static NameSet collectFilesToSkip(
         if (dynamic_cast<const MergeTreeIndexGin *>(index.get()))
         {
             auto index_filename = index->getFileName();
-            files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE);
-            files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE);
-            files_to_skip.insert(index_filename + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE);
-            files_to_skip.insert(index_filename + GinIndexStore::GIN_DICTIONARY_FILE_TYPE);
-            files_to_skip.insert(index_filename + GinIndexStore::GIN_POSTINGS_FILE_TYPE);
+            files_to_skip.insert(index_filename + ".gin_dict");
+            files_to_skip.insert(index_filename + ".gin_post");
+            files_to_skip.insert(index_filename + ".gin_sed");
+            files_to_skip.insert(index_filename + ".gin_sid");
         }
     }
 
@@ -873,13 +871,7 @@ static NameToNameVector collectFilesForRenames(
         if (command.type == MutationCommand::Type::DROP_INDEX)
         {
             static const std::array<String, 2> suffixes = {".idx2", ".idx"};
-            static const std::array<String, 5> gin_suffixes = {
-                GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE,
-                GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE,
-                GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE,
-                GinIndexStore::GIN_DICTIONARY_FILE_TYPE,
-                GinIndexStore::GIN_POSTINGS_FILE_TYPE,
-            };
+            static const std::array<String, 4> gin_suffixes = {".gin_dict", ".gin_post", ".gin_seg", ".gin_sid"}; /// .gin_* means generalized inverted index aka. text index
 
             for (const auto & suffix : suffixes)
             {

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -9,9 +9,6 @@ Test separators argument.
 Test segment_digestion_threshold_bytes argument.
 -- segment_digestion_threshold_bytes must be an integer.
 -- segment_digestion_threshold_bytes can be 0 (zero).
-Test bloom_filter_false_positive_rate argument.
--- bloom_filter_false_positive_rate must be a double.
--- bloom_filter_false_positive_rate must be between 0.0 and 1.0.
 Parameters are shuffled.
 Types are incorrect.
 Same argument appears >1 times.

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -150,53 +150,6 @@ ENGINE = MergeTree
 ORDER BY tuple();
 DROP TABLE tab;
 
-SELECT 'Test bloom_filter_false_positive_rate argument.';
-
-SELECT '-- bloom_filter_false_positive_rate must be a double.';
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 1)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = '1024')
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 0.5)
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-DROP TABLE tab;
-
-SELECT '-- bloom_filter_false_positive_rate must be between 0.0 and 1.0.';
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 0.0)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 1.0)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
 SELECT 'Parameters are shuffled.';
 
 CREATE TABLE tab
@@ -256,14 +209,6 @@ CREATE TABLE tab
 (
     str String,
     INDEX idx str TYPE text(tokenizer = 'ngram', ngram_size = 3, ngram_size = 4)
-)
-ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = 'default', bloom_filter_false_positive_rate = 0.5, bloom_filter_false_positive_rate = 0.5)
 )
 ENGINE = MergeTree
 ORDER BY tuple(); -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/02346_text_index_queries.sql
+++ b/tests/queries/0_stateless/02346_text_index_queries.sql
@@ -120,15 +120,12 @@ SELECT 'Test text(tokenizer = "ngram", ngram_size = 2) on a column with two part
 
 DROP TABLE IF EXISTS tab;
 
-CREATE TABLE tab(k UInt64, s String)
+CREATE TABLE tab(k UInt64, s String, INDEX af(s) TYPE text(tokenizer = 'ngram', ngram_size = 2) GRANULARITY 1)
     ENGINE = MergeTree() ORDER BY k
     SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
 
 INSERT INTO tab VALUES (101, 'Alick a01'), (102, 'Blick a02'), (103, 'Click a03'), (104, 'Dlick a04'), (105, 'Elick a05'), (106, 'Alick a06'), (107, 'Blick a07'), (108, 'Click a08'), (109, 'Dlick a09'), (110, 'Elick b10'), (111, 'Alick b01'), (112, 'Blick b02'), (113, 'Click b03'), (114, 'Dlick b04'), (115, 'Elick b05'), (116, 'Alick b06'), (117, 'Blick b07'), (118, 'Click b08'), (119, 'Dlick b09'), (120, 'Elick b10');
 INSERT INTO tab VALUES (201, 'rick c01'), (202, 'mick c02'), (203, 'nick c03');
-
-ALTER TABLE tab ADD INDEX af(s) TYPE text(tokenizer = 'ngram', ngram_size = 2) GRANULARITY 1 SETTINGS mutations_sync = 2;
-OPTIMIZE TABLE tab FINAL;
 
 -- check text index was created
 SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND database = currentDatabase() LIMIT 1;


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#85054 because it causes [tsan failures](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85207&sha=latest&name_0=PR&name_1=Stress+test+%28amd_tsan%29).