### PR TITLE
Docs: move introspection functions docs to source code

### DIFF
--- a/src/Functions/FunctionsMergeTreePartInfo.cpp
+++ b/src/Functions/FunctionsMergeTreePartInfo.cpp
@@ -249,21 +249,62 @@ public:
 
 REGISTER_FUNCTION(MergeTreePartInfoTools)
 {
-    factory.registerFunction<FunctionMergeTreePartCoverage>(
-        FunctionDocumentation{
-            .description = "Checks if one MergeTree part covers another",
-            .introduced_in = {25, 6},
-            .category = FunctionDocumentation::Category::Introspection,
-        },
-        FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description_coverage = R"(
+Function which checks if the part of the first argument is covered by the part of the second argument.
+    )";
+    FunctionDocumentation::Syntax syntax_coverage = "isMergeTreePartCoveredBy(nested_part, covering_part)";
+    FunctionDocumentation::Arguments arguments_coverage = {
+        {"nested_part", "Name of expected nested part.", {"String"}},
+        {"covering_part", "Name of expected covering part.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_coverage = {"Returns `1` if it covers, `0` otherwise.", {"UInt8"}};
+    FunctionDocumentation::Examples examples_coverage = {
+    {
+        "Basic example",
+        R"(
+WITH 'all_12_25_7_4' AS lhs, 'all_7_100_10_20' AS rhs 
+SELECT isMergeTreePartCoveredBy(rhs, lhs), isMergeTreePartCoveredBy(lhs, rhs);
+        )",
+        R"(
+┌─isMergeTreePartCoveredBy(rhs, lhs)─┬─isMergeTreePartCoveredBy(lhs, rhs)─┐
+│                                  0 │                                  1 │
+└────────────────────────────────────┴────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_coverage = {25, 6};
+    FunctionDocumentation::Category category_coverage = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation_coverage = {description_coverage, syntax_coverage, arguments_coverage, returned_value_coverage, examples_coverage, introduced_in_coverage, category_coverage};
 
-    factory.registerFunction<FunctionMergeTreePartInfo>(
-        FunctionDocumentation{
-            .description = "Represents String value as a MergeTreePartInfo structure",
-            .introduced_in = {25, 6},
-            .category = FunctionDocumentation::Category::Introspection,
-        },
-        FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionMergeTreePartCoverage>(documentation_coverage, FunctionFactory::Case::Insensitive);
+
+    FunctionDocumentation::Description description_info = R"(
+Function that helps to cut the useful values out of the `MergeTree` part name.
+    )";
+    FunctionDocumentation::Syntax syntax_info = "mergeTreePartInfo(part_name)";
+    FunctionDocumentation::Arguments arguments_info = {
+        {"part_name", "Name of part to unpack.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_info = {"Returns a Tuple with subcolumns: `partition_id`, `min_block`, `max_block`, `level`, `mutation`.", {"Tuple"}};
+    FunctionDocumentation::Examples examples_info = {
+    {
+        "Basic example",
+        R"(
+WITH mergeTreePartInfo('all_12_25_7_4') AS info 
+SELECT info.partition_id, info.min_block, info.max_block, info.level, info.mutation;
+        )",
+        R"(
+┌─info.partition_id─┬─info.min_block─┬─info.max_block─┬─info.level─┬─info.mutation─┐
+│ all               │             12 │             25 │          7 │             4 │
+└───────────────────┴────────────────┴────────────────┴────────────┴───────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_info = {25, 6};
+    FunctionDocumentation::Category category_info = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation_info = {description_info, syntax_info, arguments_info, returned_value_info, examples_info, introduced_in_info, category_info};
+
+    factory.registerFunction<FunctionMergeTreePartInfo>(documentation_info, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsMergeTreePartInfo.cpp
+++ b/src/Functions/FunctionsMergeTreePartInfo.cpp
@@ -262,7 +262,7 @@ Function which checks if the part of the first argument is covered by the part o
     {
         "Basic example",
         R"(
-WITH 'all_12_25_7_4' AS lhs, 'all_7_100_10_20' AS rhs 
+WITH 'all_12_25_7_4' AS lhs, 'all_7_100_10_20' AS rhs
 SELECT isMergeTreePartCoveredBy(rhs, lhs), isMergeTreePartCoveredBy(lhs, rhs);
         )",
         R"(
@@ -290,7 +290,7 @@ Function that helps to cut the useful values out of the `MergeTree` part name.
     {
         "Basic example",
         R"(
-WITH mergeTreePartInfo('all_12_25_7_4') AS info 
+WITH mergeTreePartInfo('all_12_25_7_4') AS info
 SELECT info.partition_id, info.min_block, info.max_block, info.level, info.mutation;
         )",
         R"(

--- a/src/Functions/addressToLine.cpp
+++ b/src/Functions/addressToLine.cpp
@@ -63,26 +63,22 @@ protected:
 REGISTER_FUNCTION(AddressToLine)
 {
     FunctionDocumentation::Description description = R"(
-Converts virtual memory address inside ClickHouse server process to the filename and the line number in ClickHouse source code.
-
-If you use official ClickHouse packages, you need to install the `clickhouse-common-static-dbg` package.
+Converts a virtual memory address inside the ClickHouse server process to a filename and line number in ClickHouse's source code.
 
 :::note
-These functions are slow and may impose security considerations.
+This function is slow and may impose security considerations.
 :::
 
-For proper operation of introspection functions:
+To enable this introspection function:
 
 - Install the `clickhouse-common-static-dbg` package.
-- Set the [`allow_introspection_functions`](../../operations/settings/settings.md#allow_introspection_functions) setting to `1`.
-
-For security reasons introspection functions are disabled by default.
+- Set setting [`allow_introspection_functions`](../../operations/settings/settings.md#allow_introspection_functions) to `1`.
     )";
     FunctionDocumentation::Syntax syntax = "addressToLine(address_of_binary_instruction)";
     FunctionDocumentation::Arguments arguments = {
         {"address_of_binary_instruction", "Address of instruction in a running process.", {"UInt64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns the source code filename and the line number in this file delimited by a colon. For example, `/build/obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:199`, where `199` is a line number. Returns the name of a binary, if the function couldn't find the debug information, otherwise an empty string, if the address is not valid.", {"String"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a source code filename and line number delimited by a colon, for example, `/build/obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:199`. Returns the name of a binary, if no debug information could be found, otherwise an empty string, if the address is not valid.", {"String"}};
     FunctionDocumentation::Examples examples = {
     {
         "Selecting the first string from the `trace_log` system table",

--- a/src/Functions/addressToLine.cpp
+++ b/src/Functions/addressToLine.cpp
@@ -62,7 +62,90 @@ protected:
 
 REGISTER_FUNCTION(AddressToLine)
 {
-    factory.registerFunction<FunctionAddressToLine>();
+    FunctionDocumentation::Description description = R"(
+Converts virtual memory address inside ClickHouse server process to the filename and the line number in ClickHouse source code.
+
+If you use official ClickHouse packages, you need to install the `clickhouse-common-static-dbg` package.
+
+:::note
+These functions are slow and may impose security considerations.
+:::
+
+For proper operation of introspection functions:
+
+- Install the `clickhouse-common-static-dbg` package.
+- Set the [`allow_introspection_functions`](../../operations/settings/settings.md#allow_introspection_functions) setting to `1`.
+
+For security reasons introspection functions are disabled by default.
+    )";
+    FunctionDocumentation::Syntax syntax = "addressToLine(address_of_binary_instruction)";
+    FunctionDocumentation::Arguments arguments = {
+        {"address_of_binary_instruction", "Address of instruction in a running process.", {"UInt64"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the source code filename and the line number in this file delimited by a colon. For example, `/build/obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:199`, where `199` is a line number. Returns the name of a binary, if the function couldn't find the debug information, otherwise an empty string, if the address is not valid.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Selecting the first string from the `trace_log` system table",
+        R"(
+SET allow_introspection_functions=1;
+SELECT * FROM system.trace_log LIMIT 1 \G;
+        )",
+        R"(
+-- The `trace` field contains the stack trace at the moment of sampling.
+Row 1:
+──────
+event_date:              2019-11-19
+event_time:              2019-11-19 18:57:23
+revision:                54429
+timer_type:              Real
+thread_number:           48
+query_id:                421b6855-1858-45a5-8f37-f383409d6d72
+trace:                   [140658411141617,94784174532828,94784076370703,94784076372094,94784076361020,94784175007680,140658411116251,140658403895439]
+        )"
+    },
+    {
+        "Getting the source code filename and the line number for a single address",
+        R"(
+SET allow_introspection_functions=1;
+SELECT addressToLine(94784076370703) \G;
+        )",
+        R"(
+Row 1:
+──────
+addressToLine(94784076370703): /build/obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:199
+        )"
+    },
+    {
+        "Applying the function to the whole stack trace",
+        R"(
+-- The arrayMap function in this example processing each individual element of the trace array by the addressToLine function.
+-- The result of this processing is seen in the trace_source_code_lines column of output.
+
+SELECT
+    arrayStringConcat(arrayMap(x -> addressToLine(x), trace), '\n') AS trace_source_code_lines
+FROM system.trace_log
+LIMIT 1
+\G
+        )",
+        R"(
+Row 1:
+──────
+trace_source_code_lines: /lib/x86_64-linux-gnu/libpthread-2.27.so
+/usr/lib/debug/usr/bin/clickhouse
+/build/obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:199
+/build/obj-x86_64-linux-gnu/../src/Common/ThreadPool.h:155
+/usr/include/c++/9/bits/atomic_base.h:551
+/usr/lib/debug/usr/bin/clickhouse
+/lib/x86_64-linux-gnu/libpthread-2.27.so
+/build/glibc-OTsEL5/glibc-2.27/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:97
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionAddressToLine>(documentation);
 }
 
 }

--- a/src/Functions/addressToLineWithInlines.cpp
+++ b/src/Functions/addressToLineWithInlines.cpp
@@ -177,7 +177,7 @@ WHERE
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn = {22, 2};
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 2};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/addressToLineWithInlines.cpp
+++ b/src/Functions/addressToLineWithInlines.cpp
@@ -96,15 +96,16 @@ REGISTER_FUNCTION(AddressToLineWithInlines)
 Similar to `addressToLine`, but returns an Array with all inline functions.
 As a result of this, it is slower than `addressToLine`.
 
-:::note
-If you use official ClickHouse packages, you need to install the `clickhouse-common-static-dbg` package.
-:::
+To enable this introspection function:
+
+- Install the `clickhouse-common-static-dbg` package.
+- Set setting [`allow_introspection_functions`](../../operations/settings/settings.md#allow_introspection_functions) to `1`.
     )";
     FunctionDocumentation::Syntax syntax = "addressToLineWithInlines(address_of_binary_instruction)";
     FunctionDocumentation::Arguments arguments = {
         {"address_of_binary_instruction", "The address of an instruction in a running process.", {"UInt64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns an array whose first element is the source code filename and line number in the file delimited by a colon. From the second element onwards, inline functions' source code filenames, line numbers and function names are listed. If the function couldn't find the debug information, then an array with a single element equal to the name of the binary is returned, otherwise an empty array is returned if the address is not valid.", {"Array(String)"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns an array whose first element is the source code filename and line number delimited by a colon. The second, third, etc. element list inline functions' source code filenames, line numbers and function names. If no debug information could be found, then an array with a single element equal to the name of the binary is returned, otherwise an empty array is returned if the address is not valid.", {"Array(String)"}};
     FunctionDocumentation::Examples examples = {
     {
         "Applying the function to an address",

--- a/src/Functions/addressToLineWithInlines.cpp
+++ b/src/Functions/addressToLineWithInlines.cpp
@@ -92,7 +92,96 @@ private:
 
 REGISTER_FUNCTION(AddressToLineWithInlines)
 {
-    factory.registerFunction<FunctionAddressToLineWithInlines>();
+    FunctionDocumentation::Description description = R"(
+Similar to `addressToLine`, but returns an Array with all inline functions.
+As a result of this, it is slower than `addressToLine`.
+
+:::note
+If you use official ClickHouse packages, you need to install the `clickhouse-common-static-dbg` package.
+:::
+    )";
+    FunctionDocumentation::Syntax syntax = "addressToLineWithInlines(address_of_binary_instruction)";
+    FunctionDocumentation::Arguments arguments = {
+        {"address_of_binary_instruction", "The address of an instruction in a running process.", {"UInt64"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns an array whose first element is the source code filename and line number in the file delimited by a colon. From the second element onwards, inline functions' source code filenames, line numbers and function names are listed. If the function couldn't find the debug information, then an array with a single element equal to the name of the binary is returned, otherwise an empty array is returned if the address is not valid.", {"Array(String)"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Applying the function to an address",
+        R"(
+SET allow_introspection_functions=1;
+SELECT addressToLineWithInlines(531055181::UInt64);
+        )",
+        R"(
+┌─addressToLineWithInlines(CAST('531055181', 'UInt64'))────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ ['./src/Functions/addressToLineWithInlines.cpp:98','./build_normal_debug/./src/Functions/addressToLineWithInlines.cpp:176:DB::(anonymous namespace)::FunctionAddressToLineWithInlines::implCached(unsigned long) const'] │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+        )"
+    },
+    {
+        "Applying the function to the whole stack trace",
+        R"(
+SET allow_introspection_functions=1;
+
+-- The arrayJoin function will split array to rows
+
+SELECT
+    ta, addressToLineWithInlines(arrayJoin(trace) AS ta)
+FROM system.trace_log
+WHERE
+    query_id = '5e173544-2020-45de-b645-5deebe2aae54';
+        )",
+        R"(
+┌────────ta─┬─addressToLineWithInlines(arrayJoin(trace))───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ 365497529 │ ['./build_normal_debug/./contrib/libcxx/include/string_view:252']                                                                                                                                                        │
+│ 365593602 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:191']                                                                                                                                                                      │
+│ 365593866 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365592528 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365591003 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:477']                                                                                                                                                                      │
+│ 365590479 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:442']                                                                                                                                                                      │
+│ 365590600 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:457']                                                                                                                                                                      │
+│ 365598941 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365607098 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365590571 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:451']                                                                                                                                                                      │
+│ 365598941 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365607098 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365590571 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:451']                                                                                                                                                                      │
+│ 365598941 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365607098 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365590571 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:451']                                                                                                                                                                      │
+│ 365598941 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:0']                                                                                                                                                                        │
+│ 365597289 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:807']                                                                                                                                                                      │
+│ 365599840 │ ['./build_normal_debug/./src/Common/Dwarf.cpp:1118']                                                                                                                                                                     │
+│ 531058145 │ ['./build_normal_debug/./src/Functions/addressToLineWithInlines.cpp:152']                                                                                                                                                │
+│ 531055181 │ ['./src/Functions/addressToLineWithInlines.cpp:98','./build_normal_debug/./src/Functions/addressToLineWithInlines.cpp:176:DB::(anonymous namespace)::FunctionAddressToLineWithInlines::implCached(unsigned long) const'] │
+│ 422333613 │ ['./build_normal_debug/./src/Functions/IFunctionAdaptors.h:21']                                                                                                                                                          │
+│ 586866022 │ ['./build_normal_debug/./src/Functions/IFunction.cpp:216']                                                                                                                                                               │
+│ 586869053 │ ['./build_normal_debug/./src/Functions/IFunction.cpp:264']                                                                                                                                                               │
+│ 586873237 │ ['./build_normal_debug/./src/Functions/IFunction.cpp:334']                                                                                                                                                               │
+│ 597901620 │ ['./build_normal_debug/./src/Interpreters/ExpressionActions.cpp:601']                                                                                                                                                    │
+│ 597898534 │ ['./build_normal_debug/./src/Interpreters/ExpressionActions.cpp:718']                                                                                                                                                    │
+│ 630442912 │ ['./build_normal_debug/./src/Processors/Transforms/ExpressionTransform.cpp:23']                                                                                                                                          │
+│ 546354050 │ ['./build_normal_debug/./src/Processors/ISimpleTransform.h:38']                                                                                                                                                          │
+│ 626026993 │ ['./build_normal_debug/./src/Processors/ISimpleTransform.cpp:89']                                                                                                                                                        │
+│ 626294022 │ ['./build_normal_debug/./src/Processors/Executors/ExecutionThreadContext.cpp:45']                                                                                                                                        │
+│ 626293730 │ ['./build_normal_debug/./src/Processors/Executors/ExecutionThreadContext.cpp:63']                                                                                                                                        │
+│ 626169525 │ ['./build_normal_debug/./src/Processors/Executors/PipelineExecutor.cpp:213']                                                                                                                                             │
+│ 626170308 │ ['./build_normal_debug/./src/Processors/Executors/PipelineExecutor.cpp:178']                                                                                                                                             │
+│ 626166348 │ ['./build_normal_debug/./src/Processors/Executors/PipelineExecutor.cpp:329']                                                                                                                                             │
+│ 626163461 │ ['./build_normal_debug/./src/Processors/Executors/PipelineExecutor.cpp:84']                                                                                                                                              │
+│ 626323536 │ ['./build_normal_debug/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:85']                                                                                                                                  │
+│ 626323277 │ ['./build_normal_debug/./src/Processors/Executors/PullingAsyncPipelineExecutor.cpp:112']                                                                                                                                 │
+│ 626323133 │ ['./build_normal_debug/./contrib/libcxx/include/type_traits:3682']                                                                                                                                                       │
+│ 626323041 │ ['./build_normal_debug/./contrib/libcxx/include/tuple:1415']                                                                                                                                                             │
+└───────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn = {22, 2};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionAddressToLineWithInlines>(documentation);
 }
 
 }

--- a/src/Functions/addressToSymbol.cpp
+++ b/src/Functions/addressToSymbol.cpp
@@ -95,7 +95,7 @@ public:
 REGISTER_FUNCTION(AddressToSymbol)
 {
     FunctionDocumentation::Description description = R"(
-Converts virtual memory address inside ClickHouse server process to the symbol from ClickHouse object files.
+Converts virtual memory address inside the ClickHouse server process to a symbol from ClickHouse's object files.
     )";
     FunctionDocumentation::Syntax syntax = "addressToSymbol(address_of_binary_instruction)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/addressToSymbol.cpp
+++ b/src/Functions/addressToSymbol.cpp
@@ -94,7 +94,90 @@ public:
 
 REGISTER_FUNCTION(AddressToSymbol)
 {
-    factory.registerFunction<FunctionAddressToSymbol>();
+    FunctionDocumentation::Description description = R"(
+Converts virtual memory address inside ClickHouse server process to the symbol from ClickHouse object files.
+    )";
+    FunctionDocumentation::Syntax syntax = "addressToSymbol(address_of_binary_instruction)";
+    FunctionDocumentation::Arguments arguments = {
+        {"address_of_binary_instruction", "Address of instruction in a running process.", {"UInt64"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the symbol from ClickHouse object files or an empty string, if the address is not valid.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Selecting the first string from the `trace_log` system table",
+        R"(
+SET allow_introspection_functions=1;
+SELECT * FROM system.trace_log LIMIT 1 \G;
+        )",
+        R"(
+-- The `trace` field contains the stack trace at the moment of sampling.
+Row 1:
+──────
+event_date:    2019-11-20
+event_time:    2019-11-20 16:57:59
+revision:      54429
+timer_type:    Real
+thread_number: 48
+query_id:      724028bf-f550-45aa-910d-2af6212b94ac
+trace:         [94138803686098,94138815010911,94138815096522,94138815101224,94138815102091,94138814222988,94138806823642,94138814457211,94138806823642,94138814457211,94138806823642,94138806795179,94138806796144,94138753770094,94138753771646,94138753760572,94138852407232,140399185266395,140399178045583]
+        )"
+    },
+    {
+        "Getting a symbol for a single address",
+        R"(
+SET allow_introspection_functions=1;
+SELECT addressToSymbol(94138803686098) \G;
+        )",
+        R"(
+Row 1:
+──────
+addressToSymbol(94138803686098): _ZNK2DB24IAggregateFunctionHelperINS_20AggregateFunctionSumImmNS_24AggregateFunctionSumDataImEEEEE19addBatchSinglePlaceEmPcPPKNS_7IColumnEPNS_5ArenaE
+        )"
+    },
+    {
+        "Applying the function to the whole stack trace",
+        R"(
+SET allow_introspection_functions=1;
+
+-- The arrayMap function allows to process each individual element of the trace array by the addressToSymbols function.
+-- The result of this processing is shown in the trace_symbols column of output.
+
+SELECT
+    arrayStringConcat(arrayMap(x -> addressToSymbol(x), trace), '\n') AS trace_symbols
+FROM system.trace_log
+LIMIT 1
+\G
+        )",
+        R"(
+Row 1:
+──────
+trace_symbols: _ZNK2DB24IAggregateFunctionHelperINS_20AggregateFunctionSumImmNS_24AggregateFunctionSumDataImEEEEE19addBatchSinglePlaceEmPcPPKNS_7IColumnEPNS_5ArenaE
+_ZNK2DB10Aggregator21executeWithoutKeyImplERPcmPNS0_28AggregateFunctionInstructionEPNS_5ArenaE
+_ZN2DB10Aggregator14executeOnBlockESt6vectorIN3COWINS_7IColumnEE13immutable_ptrIS3_EESaIS6_EEmRNS_22AggregatedDataVariantsERS1_IPKS3_SaISC_EERS1_ISE_SaISE_EERb
+_ZN2DB10Aggregator14executeOnBlockERKNS_5BlockERNS_22AggregatedDataVariantsERSt6vectorIPKNS_7IColumnESaIS9_EERS6_ISB_SaISB_EERb
+_ZN2DB10Aggregator7executeERKSt10shared_ptrINS_17IBlockInputStreamEERNS_22AggregatedDataVariantsE
+_ZN2DB27AggregatingBlockInputStream8readImplEv
+_ZN2DB17IBlockInputStream4readEv
+_ZN2DB26ExpressionBlockInputStream8readImplEv
+_ZN2DB17IBlockInputStream4readEv
+_ZN2DB26ExpressionBlockInputStream8readImplEv
+_ZN2DB17IBlockInputStream4readEv
+_ZN2DB28AsynchronousBlockInputStream9calculateEv
+_ZNSt17_Function_handlerIFvvEZN2DB28AsynchronousBlockInputStream4nextEvEUlvE_E9_M_invokeERKSt9_Any_data
+_ZN14ThreadPoolImplI20ThreadFromGlobalPoolE6workerESt14_List_iteratorIS0_E
+_ZZN20ThreadFromGlobalPoolC4IZN14ThreadPoolImplIS_E12scheduleImplIvEET_St8functionIFvvEEiSt8optionalImEEUlvE1_JEEEOS4_DpOT0_ENKUlvE_clEv
+_ZN14ThreadPoolImplISt6threadE6workerESt14_List_iteratorIS0_E
+execute_native_thread_routine
+start_thread
+clone
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionAddressToSymbol>(documentation);
 }
 
 }

--- a/src/Functions/demangle.cpp
+++ b/src/Functions/demangle.cpp
@@ -99,7 +99,8 @@ public:
 REGISTER_FUNCTION(Demangle)
 {
     FunctionDocumentation::Description description = R"(
-Converts a symbol that you can get using the [`addressToSymbol`](../../sql-reference/functions/introspection.md#addresstosymbol) function to the C++ function name.
+Converts a symbol to a C++ function name.
+The symbol is usually returned by function [`addressToSymbol`](../../sql-reference/functions/introspection.md#addresstosymbol).
     )";
     FunctionDocumentation::Syntax syntax = "demangle(symbol)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/demangle.cpp
+++ b/src/Functions/demangle.cpp
@@ -98,7 +98,89 @@ public:
 
 REGISTER_FUNCTION(Demangle)
 {
-    factory.registerFunction<FunctionDemangle>();
+    FunctionDocumentation::Description description = R"(
+Converts a symbol that you can get using the [`addressToSymbol`](../../sql-reference/functions/introspection.md#addresstosymbol) function to the C++ function name.
+    )";
+    FunctionDocumentation::Syntax syntax = "demangle(symbol)";
+    FunctionDocumentation::Arguments arguments = {
+        {"symbol", "Symbol from an object file.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the name of the C++ function, or an empty string if the symbol is not valid.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Selecting the first string from the `trace_log` system table",
+        R"(
+SELECT * FROM system.trace_log LIMIT 1 \G;
+        )",
+        R"(
+-- The `trace` field contains the stack trace at the moment of sampling.
+Row 1:
+──────
+event_date:    2019-11-20
+event_time:    2019-11-20 16:57:59
+revision:      54429
+timer_type:    Real
+thread_number: 48
+query_id:      724028bf-f550-45aa-910d-2af6212b94ac
+trace:         [94138803686098,94138815010911,94138815096522,94138815101224,94138815102091,94138814222988,94138806823642,94138814457211,94138806823642,94138814457211,94138806823642,94138806795179,94138806796144,94138753770094,94138753771646,94138753760572,94138852407232,140399185266395,140399178045583]
+        )"
+    },
+    {
+        "Getting a function name for a single address",
+        R"(
+SET allow_introspection_functions=1;
+SELECT demangle(addressToSymbol(94138803686098)) \G;
+        )",
+        R"(
+Row 1:
+──────
+demangle(addressToSymbol(94138803686098)): DB::IAggregateFunctionHelper<DB::AggregateFunctionSum<unsigned long, unsigned long, DB::AggregateFunctionSumData<unsigned long> > >::addBatchSinglePlace(unsigned long, char*, DB::IColumn const**, DB::Arena*) const
+        )"
+    },
+    {
+        "Applying the function to the whole stack trace",
+        R"(
+SET allow_introspection_functions=1;
+
+-- The arrayMap function allows to process each individual element of the trace array by the demangle function.
+-- The result of this processing is shown in the trace_functions column of output.
+
+SELECT
+    arrayStringConcat(arrayMap(x -> demangle(addressToSymbol(x)), trace), '\n') AS trace_functions
+FROM system.trace_log
+LIMIT 1
+\G
+        )",
+        R"(
+Row 1:
+──────
+trace_functions: DB::IAggregateFunctionHelper<DB::AggregateFunctionSum<unsigned long, unsigned long, DB::AggregateFunctionSumData<unsigned long> > >::addBatchSinglePlace(unsigned long, char*, DB::IColumn const**, DB::Arena*) const
+DB::Aggregator::executeWithoutKeyImpl(char*&, unsigned long, DB::Aggregator::AggregateFunctionInstruction*, DB::Arena*) const
+DB::Aggregator::executeOnBlock(std::vector<COW<DB::IColumn>::immutable_ptr<DB::IColumn>, std::allocator<COW<DB::IColumn>::immutable_ptr<DB::IColumn> > >, unsigned long, DB::AggregatedDataVariants&, std::vector<DB::IColumn const*, std::allocator<DB::IColumn const*> >&, std::vector<std::vector<DB::IColumn const*, std::allocator<DB::IColumn const*> >, std::allocator<std::vector<DB::IColumn const*, std::allocator<DB::IColumn const*> > > >&, bool&)
+DB::Aggregator::executeOnBlock(DB::Block const&, DB::AggregatedDataVariants&, std::vector<DB::IColumn const*, std::allocator<DB::IColumn const*> >&, std::vector<std::vector<DB::IColumn const*, std::allocator<DB::IColumn const*> >, std::allocator<std::vector<DB::IColumn const*, std::allocator<DB::IColumn const*> > > >&, bool&)
+DB::Aggregator::execute(std::shared_ptr<DB::IBlockInputStream> const&, DB::AggregatedDataVariants&)
+DB::AggregatingBlockInputStream::readImpl()
+DB::IBlockInputStream::read()
+DB::ExpressionBlockInputStream::readImpl()
+DB::IBlockInputStream::read()
+DB::ExpressionBlockInputStream::readImpl()
+DB::IBlockInputStream::read()
+DB::AsynchronousBlockInputStream::calculate()
+std::_Function_handler<void (), DB::AsynchronousBlockInputStream::next()::{lambda()#1}>::_M_invoke(std::_Any_data const&)
+ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::_List_iterator<ThreadFromGlobalPool>)
+ThreadFromGlobalPool::ThreadFromGlobalPool<ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::function<void ()>, int, std::optional<unsigned long>)::{lambda()#3}>(ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::function<void ()>, int, std::optional<unsigned long>)::{lambda()#3}&&)::{lambda()#1}::operator()() const
+ThreadPoolImpl<std::thread>::worker(std::_List_iterator<std::thread>)
+execute_native_thread_routine
+start_thread
+clone
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionDemangle>(documentation);
 }
 
 }

--- a/src/Functions/logTrace.cpp
+++ b/src/Functions/logTrace.cpp
@@ -57,7 +57,32 @@ namespace
 
 REGISTER_FUNCTION(LogTrace)
 {
-    factory.registerFunction<FunctionLogTrace>();
+    FunctionDocumentation::Description description = R"(
+Emits a trace log message to the server log for each [Block](/development/architecture/#block).
+    )";
+    FunctionDocumentation::Syntax syntax = "logTrace(message)";
+    FunctionDocumentation::Arguments arguments = {
+        {"message", "Message that is emitted to the server log.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0` always.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Basic example",
+        R"(
+SELECT logTrace('logTrace message');
+        )",
+        R"(
+┌─logTrace('logTrace message')─┐
+│                            0 │
+└──────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, {}, category};
+
+    factory.registerFunction<FunctionLogTrace>(documentation);
 }
 
 }

--- a/src/Functions/logTrace.cpp
+++ b/src/Functions/logTrace.cpp
@@ -80,7 +80,7 @@ SELECT logTrace('logTrace message');
     };
     FunctionDocumentation::IntroducedIn introduced_in = {20, 12};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
-    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, {}, category};
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionLogTrace>(documentation);
 }

--- a/src/Functions/logTrace.cpp
+++ b/src/Functions/logTrace.cpp
@@ -62,7 +62,7 @@ Emits a trace log message to the server log for each [Block](/development/archit
     )";
     FunctionDocumentation::Syntax syntax = "logTrace(message)";
     FunctionDocumentation::Arguments arguments = {
-        {"message", "Message that is emitted to the server log.", {"String"}}
+        {"message", "Message that is emitted to the server log.", {"const String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns `0` always.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Functions/tid.cpp
+++ b/src/Functions/tid.cpp
@@ -39,7 +39,30 @@ namespace
 
 REGISTER_FUNCTION(Tid)
 {
-    factory.registerFunction<FunctionTid>();
+    FunctionDocumentation::Description description = R"(
+Returns id of the thread, in which the current [Block](/development/architecture/#block) is processed.
+    )";
+    FunctionDocumentation::Syntax syntax = "tid()";
+    FunctionDocumentation::Arguments arguments = {};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the current thread id.", {"UInt64"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+SELECT tid();
+        )",
+        R"(
+┌─tid()─┐
+│  3878 │
+└───────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Introspection;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionTid>(documentation);
 }
 
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -55,9 +55,6 @@ accurateCastOrDefault
 accurateCastOrNull
 acos
 acosh
-addressToLine
-addressToLineWithInlines
-addressToSymbol
 alphaTokens
 and
 appendTrailingCharIfAbsent
@@ -119,7 +116,6 @@ defaultRoles
 defaultValueOfArgumentType
 defaultValueOfTypeName
 degrees
-demangle
 dotProduct
 dumpColumnStructure
 e
@@ -241,7 +237,6 @@ log
 log10
 log1p
 log2
-logTrace
 lowCardinalityIndices
 lowCardinalityKeys
 lower
@@ -479,7 +474,6 @@ tanh
 tcpPort
 tgamma
 throwIf
-tid
 toBool
 toColumnTypeName
 toDate

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -64,9 +64,6 @@ accurateCastOrDefault
 accurateCastOrNull
 acos
 acosh
-addressToLine
-addressToLineWithInlines
-addressToSymbol
 alphaTokens
 and
 appendTrailingCharIfAbsent
@@ -145,7 +142,6 @@ defaultRoles
 defaultValueOfArgumentType
 defaultValueOfTypeName
 degrees
-demangle
 dictGet
 dictGetAll
 dictGetChildren
@@ -348,7 +344,6 @@ log
 log10
 log1p
 log2
-logTrace
 lowCardinalityIndices
 lowCardinalityKeys
 lower
@@ -635,7 +630,6 @@ tanh
 tcpPort
 tgamma
 throwIf
-tid
 toBFloat16
 toBFloat16OrNull
 toBFloat16OrZero


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Moves docs from introspection.md to source code.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
