### PR TITLE
docs: clarify logger.console not disabling file logging

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -820,7 +820,7 @@ The location and format of log messages.
 | `size`              | Rotation policy: Maximum size of the log files in bytes. Once the log file size exceeds this threshold, it is renamed and archived, and a new log file is created.                  |
 | `count`             | Rotation policy: How many historical log files Clickhouse are kept at most.                                                                                                         |
 | `stream_compress`   | Compress log messages using LZ4. Set to `1` or `true` to enable.                                                                                                                    |
-| `console`           | Do not write log messages to log files, instead print them in the console. Set to `1` or `true` to enable. Default is `1` if Clickhouse does not run in daemon mode, `0` otherwise. |
+| `console`           | Enable logging to the console. Set to `1` or `true` to enable. Default is `1` if Clickhouse does not run in daemon mode, `0` otherwise.                                             |
 | `console_log_level` | Log level for console output. Defaults to `level`.                                                                                                                                  |
 | `formatting`        | Log format for console output. Currently, only `json` is supported                                                                                                                  |
 | `use_syslog`        | Also forward log output to syslog.                                                                                                                                                  |


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Fixes ClickHouse/clickhouse-docs#4255