### PR TITLE
Do not add result column several times for scalar correlated subquery

### DIFF
--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -479,7 +479,6 @@ void buildRenamingForScalarSubquery(
     {
         new_outputs.push_back(&dag.addAlias(dag.findInOutputs(column_name), fmt::format("{}.{}", correlated_subquery.action_node_name, column_name)));
     }
-    new_outputs.push_back(result_node);
 
     dag.getOutputs() = std::move(new_outputs);
 

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes.reference
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes.reference
@@ -23,7 +23,7 @@ Positions: 2
                COLUMN Const(String) -> \'Nullable(UInt64)\'_String String : 2
                ALIAS __table3.number :: 1 -> __table1.__table3.number UInt64 : 3
                FUNCTION _CAST(count() :: 0, \'Nullable(UInt64)\'_String :: 2) -> __table1 Nullable(UInt64) : 1
-      Positions: 1 3 1
+      Positions: 1 3
         Aggregating
         Keys: __table3.number
         Aggregates:


### PR DESCRIPTION
It's required to support JOIN reordering for a decorrelated plan.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
