### PR TITLE
Threadpool readers configuration as server settings

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1134,6 +1134,11 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(Bool, skip_binary_checksum_checks, false, R"(Skips ClickHouse binary checksum integrity checks)", 0) \
     DECLARE(UInt64, jemalloc_flush_profile_interval_bytes, 0, R"(Flushing jemalloc profile will be done after global peak memory usage increased by jemalloc_flush_profile_interval_bytes)", 0) \
     DECLARE(Bool, jemalloc_flush_profile_on_memory_exceeded, 0, R"(Flushing jemalloc profile will be done on total memory exceeded errors)", 0) \
+    DECLARE(NonZeroUInt64, threadpool_local_fs_reader_pool_size, 100, R"(The number of threads in the thread pool for reading from local filesystem when `local_filesystem_read_method = 'pread_threadpool'`.)", 0) \
+    DECLARE(UInt64, threadpool_local_fs_reader_queue_size, 1000000, R"(The maximum number of jobs that can be scheduled on the thread pool for reading from local filesystem.)", 0) \
+    DECLARE(NonZeroUInt64, threadpool_remote_fs_reader_pool_size, 250, R"(Number of threads in the Thread pool used for reading from remote filesystem when `remote_filesystem_read_method = 'threadpool'`.)", 0) \
+    DECLARE(UInt64, threadpool_remote_fs_reader_queue_size, 1000000, R"(The maximum number of jobs that can be scheduled on the thread pool for reading from remote filesystem.)", 0) \
+
 
 // clang-format on
 

--- a/src/Disks/IO/getThreadPoolReader.h
+++ b/src/Disks/IO/getThreadPoolReader.h
@@ -1,11 +1,12 @@
 #pragma once
 
-namespace Poco::Util { class AbstractConfiguration; }
+#include <memory>
 
 namespace DB
 {
 
 class IAsynchronousReader;
+struct ServerSettings;
 
 enum class FilesystemReaderType : uint8_t
 {
@@ -16,8 +17,6 @@ enum class FilesystemReaderType : uint8_t
 
 IAsynchronousReader & getThreadPoolReader(FilesystemReaderType type);
 
-std::unique_ptr<IAsynchronousReader> createThreadPoolReader(
-    FilesystemReaderType type,
-    const Poco::Util::AbstractConfiguration & config);
+std::unique_ptr<IAsynchronousReader> createThreadPoolReader(FilesystemReaderType type, const ServerSettings & server_settings);
 
 }

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -6397,12 +6397,18 @@ OrdinaryBackgroundExecutorPtr Context::getCommonExecutor() const
 
 IAsynchronousReader & Context::getThreadPoolReader(FilesystemReaderType type) const
 {
-    callOnce(shared->readers_initialized, [&] {
-        const auto & config = getConfigRef();
-        shared->asynchronous_remote_fs_reader = createThreadPoolReader(FilesystemReaderType::ASYNCHRONOUS_REMOTE_FS_READER, config);
-        shared->asynchronous_local_fs_reader = createThreadPoolReader(FilesystemReaderType::ASYNCHRONOUS_LOCAL_FS_READER, config);
-        shared->synchronous_local_fs_reader = createThreadPoolReader(FilesystemReaderType::SYNCHRONOUS_LOCAL_FS_READER, config);
-    });
+    callOnce(
+        shared->readers_initialized,
+        [&]
+        {
+            const auto & server_settings = getServerSettings();
+            shared->asynchronous_remote_fs_reader
+                = createThreadPoolReader(FilesystemReaderType::ASYNCHRONOUS_REMOTE_FS_READER, server_settings);
+            shared->asynchronous_local_fs_reader
+                = createThreadPoolReader(FilesystemReaderType::ASYNCHRONOUS_LOCAL_FS_READER, server_settings);
+            shared->synchronous_local_fs_reader
+                = createThreadPoolReader(FilesystemReaderType::SYNCHRONOUS_LOCAL_FS_READER, server_settings);
+        });
 
     switch (type)
     {

--- a/tests/integration/test_threadpool_readers/configs/overrides.yaml
+++ b/tests/integration/test_threadpool_readers/configs/overrides.yaml
@@ -1,0 +1,17 @@
+---
+threadpool_local_fs_reader_pool_size: 2
+threadpool_remote_fs_reader_pool_size: 2
+
+storage_configuration:
+  disks:
+    disk_s3:
+      type: s3
+      endpoint: http://minio1:9001/root/data/
+      access_key_id: minio
+      secret_access_key: ClickHouse_Minio_P@ssw0rd
+  policies:
+    s3_policy:
+      volumes:
+        main:
+          disk:
+          - disk_s3

--- a/tests/integration/test_threadpool_readers/test.py
+++ b/tests/integration/test_threadpool_readers/test.py
@@ -1,0 +1,120 @@
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/overrides.yaml"],
+    with_minio=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_local_fs_threadpool_reader(start_cluster):
+    init_script = """
+        drop table if exists default.test_local;
+
+        create table default.test_local
+        (key UInt32, value1 UInt32, value2 UInt32)
+        engine = MergeTree
+        order by key;
+
+        insert into default.test_local
+        select number, number + 1, number + 2
+        from numbers(2000000);
+
+        optimize table default.test_local final;
+    """
+
+    for stmt in [s.strip() for s in init_script.split(";") if s.strip() != ""]:
+        node.query(stmt)
+
+    query_id = uuid.uuid4().hex
+
+    node.query(
+        sql="""
+            select * from default.test_local
+            format Null
+            settings
+                local_filesystem_read_method = 'pread_threadpool',
+                min_bytes_to_use_direct_io = 1,
+                max_threads = 8,
+                log_query_threads = 1;
+        """,
+        query_id=query_id,
+    )
+
+    node.query("system flush logs query_thread_log")
+
+    threads_used = node.query(f"""
+        select uniqExact(thread_id)
+        from system.query_thread_log
+        where query_id = '{query_id}'
+          and thread_name = 'ThreadPoolRead'
+    """)
+
+    # For local FS one of the pool threads may be busy with background tasks
+    assert 0 < int(threads_used) and int(threads_used) <= 2
+
+    node.query("drop table if exists default.test_local")
+
+
+def test_remote_fs_threadpool_reader(start_cluster):
+    init_script = """
+        drop table if exists default.test_remote;
+
+        create table default.test_remote
+        (key UInt32, value1 UInt32, value2 UInt32)
+        engine = MergeTree
+        order by key
+        settings storage_policy = 's3_policy';
+
+        insert into default.test_remote
+        select number, number + 1, number + 2
+        from numbers(2000000);
+
+        optimize table default.test_remote final;
+    """
+
+    for stmt in [s.strip() for s in init_script.split(";") if s.strip() != ""]:
+        node.query(stmt)
+
+    query_id = uuid.uuid4().hex
+
+    node.query(
+        sql="""
+            select * from default.test_remote
+            format Null
+            settings
+                remote_filesystem_read_method = 'threadpool',
+                max_threads = 8,
+                log_query_threads = 1;
+        """,
+        query_id=query_id,
+    )
+
+    node.query("system flush logs query_thread_log")
+
+    threads_used = node.query(f"""
+        select uniqExact(thread_id)
+        from system.query_thread_log
+        where query_id = '{query_id}'
+          and thread_name = 'VFSRead'
+    """)
+
+    assert int(threads_used) == 2
+
+    node.query("drop table if exists default.test_remote")


### PR DESCRIPTION
By default local/remote fs are read via thread pool readers, but configuration settings for those pools are not present in documentation.

This patch switches configuration of thread pool readers from plain config to server settings and adds the test to verify that those settings are respected.

(Not sure about the PR category though -- it doesn't look like as documentation but in fact it is)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
