### PR TITLE
Add missing checks for table name length

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -709,7 +709,11 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
     {
         std::lock_guard lock(mutex);
         for (auto & table : tables)
+        {
+            checkTableNameLengthUnlocked(new_name, table.first, getContext());
+
             DatabaseCatalog::instance().checkTableCanBeRemovedOrRenamed({database_name, table.first}, check_ref_deps, check_loading_deps);
+        }
     }
 
 

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -928,15 +928,15 @@ void DatabaseOnDisk::checkTableNameLength(const String & table_name) const
     checkTableNameLengthUnlocked(database_name, table_name, getContext());
 }
 
-void DatabaseOnDisk::checkTableNameLengthUnlocked(const String & the_database_name, const String & table_name, ContextPtr the_context)
+void DatabaseOnDisk::checkTableNameLengthUnlocked(const String & database_name_, const String & table_name, ContextPtr context_)
 {
-    const size_t allowed_max_length = computeMaxTableNameLength(the_database_name, the_context);
+    const size_t allowed_max_length = computeMaxTableNameLength(database_name_, context_);
     const size_t escaped_name_length = escapeForFileName(table_name).length();
     if (escaped_name_length > allowed_max_length)
     {
         throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
             "The max length of table name for database {} is {}, current length is {}",
-            the_database_name, allowed_max_length, escaped_name_length);
+            database_name_, allowed_max_length, escaped_name_length);
     }
 }
 

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -925,18 +925,18 @@ void DatabaseOnDisk::alterDatabaseComment(const AlterCommand & command)
 void DatabaseOnDisk::checkTableNameLength(const String & table_name) const
 {
     std::lock_guard lock(mutex);
-    checkTableNameLengthUnlocked(table_name);
+    checkTableNameLengthUnlocked(database_name, table_name, getContext());
 }
 
-void DatabaseOnDisk::checkTableNameLengthUnlocked(const String & table_name) const TSA_REQUIRES(mutex)
+void DatabaseOnDisk::checkTableNameLengthUnlocked(const String & the_database_name, const String & table_name, ContextPtr the_context)
 {
-    const size_t allowed_max_length = computeMaxTableNameLength(database_name, getContext());
+    const size_t allowed_max_length = computeMaxTableNameLength(the_database_name, the_context);
     const size_t escaped_name_length = escapeForFileName(table_name).length();
     if (escaped_name_length > allowed_max_length)
     {
         throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
             "The max length of table name for database {} is {}, current length is {}",
-            database_name, allowed_max_length, escaped_name_length);
+            the_database_name, allowed_max_length, escaped_name_length);
     }
 }
 

--- a/src/Databases/DatabaseOnDisk.h
+++ b/src/Databases/DatabaseOnDisk.h
@@ -87,7 +87,7 @@ public:
     void checkMetadataFilenameAvailabilityUnlocked(const String & to_table_name) const TSA_REQUIRES(mutex);
 
     void checkTableNameLength(const String & table_name) const override;
-    static void checkTableNameLengthUnlocked(const String & the_database_name, const String & table_name, ContextPtr the_context);
+    static void checkTableNameLengthUnlocked(const String & database_name_, const String & table_name, ContextPtr context_);
 
     void modifySettingsMetadata(const SettingsChanges & settings_changes, ContextPtr query_context);
 

--- a/src/Databases/DatabaseOnDisk.h
+++ b/src/Databases/DatabaseOnDisk.h
@@ -87,7 +87,7 @@ public:
     void checkMetadataFilenameAvailabilityUnlocked(const String & to_table_name) const TSA_REQUIRES(mutex);
 
     void checkTableNameLength(const String & table_name) const override;
-    void checkTableNameLengthUnlocked(const String & table_name) const TSA_REQUIRES(mutex);
+    static void checkTableNameLengthUnlocked(const String & the_database_name, const String & table_name, ContextPtr the_context);
 
     void modifySettingsMetadata(const SettingsChanges & settings_changes, ContextPtr query_context);
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2097,6 +2097,9 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
             throw Exception(ErrorCodes::INCORRECT_QUERY,
                             "{} query is supported only for Atomic databases",
                             create.create_or_replace ? "CREATE OR REPLACE TABLE" : "REPLACE TABLE");
+
+        if (mode <= LoadingStrictnessLevel::CREATE)
+            database->checkTableNameLength(table_to_replace_name);
     }
 
     {

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -146,6 +146,8 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
         }
         else
         {
+            database->checkTableNameLength(to_table_id.table_name);
+
             DatabaseCatalog::instance().checkTableCanBeRenamedWithNoCyclicDependencies(from_table_id, to_table_id);
             bool check_ref_deps = getContext()->getSettingsRef()[Setting::check_referential_table_dependencies];
             bool check_loading_deps = !check_ref_deps && getContext()->getSettingsRef()[Setting::check_table_dependencies];

--- a/tests/integration/test_check_table_name_length_2/configs/remote_servers.xml
+++ b/tests/integration/test_check_table_name_length_2/configs/remote_servers.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <two_replicas>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </two_replicas>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_check_table_name_length_2/test.py
+++ b/tests/integration/test_check_table_name_length_2/test.py
@@ -1,0 +1,52 @@
+import pytest
+from helpers.cluster import ClickHouseCluster, QueryRuntimeException
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance("node1", with_zookeeper=True, main_configs=["configs/remote_servers.xml"])
+node2 = cluster.add_instance("node2", with_zookeeper=True, main_configs=["configs/remote_servers.xml"])
+nodes = [node1, node2]
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_check_table_name_length_2(started_cluster):
+    for (i, node) in enumerate(nodes):
+        node.query("create database atomic engine Atomic;"
+                   f"create database replic engine Replicated('/replic' , 's0', 'r{i}');")
+
+    # (For simplicity we assume that filesystem's file name limit is 255. If we ever need to run
+    #  this test in environments where the limit is different, these numbers can be replaced with
+    #  something based on getMaxTableNameLengthForDatabase.)
+    ok_name = 'a'*200
+    long_name = 'a'*250
+    long_db = 'd'*100
+
+    node1.query(f"create table atomic.{ok_name} (x Int64) engine MergeTree order by x")
+    node1.query(f"create table replic.{ok_name} (x Int64) engine MergeTree order by x")
+    node2.query(f"create or replace table atomic.{ok_name} on cluster 'two_replicas' (x Int64) engine MergeTree order by x")
+
+    for (node, db, on_cluster) in [(node1, "atomic", ""), (node2, "replic", ""), (node1, "atomic", "on cluster 'two_replicas'")]:
+        # CREATE TABLE
+        with pytest.raises(QueryRuntimeException, match="ARGUMENT_OUT_OF_BOUND"):
+            node.query(f"create table {db}.{long_name} {on_cluster} (x Int64) engine MergeTree order by x")
+        # CREATE OR REPLACE TABLE
+        with pytest.raises(QueryRuntimeException, match="ARGUMENT_OUT_OF_BOUND"):
+            node.query(f"create or replace table {db}.{long_name} {on_cluster} (x Int64) engine MergeTree order by x")
+        # RENAME TABLE
+        with pytest.raises(QueryRuntimeException, match="ARGUMENT_OUT_OF_BOUND"):
+            node.query(f"rename table {db}.{ok_name} to atomic.{long_name} {on_cluster}")
+        # RENAME DATABASE
+        with pytest.raises(QueryRuntimeException, match="ARGUMENT_OUT_OF_BOUND"):
+            node.query(f"rename database {db} to f{long_db} {on_cluster}")
+
+    for node in nodes:
+        node.query(
+            "drop database atomic;"
+            "drop database replic;")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added missing table name length checks in CREATE OR REPLACE and RENAME queries.

Closes https://github.com/ClickHouse/ClickHouse/issues/36485

Without this, it's possible to accidentally CREATE or RENAME a table with a name that's too long for the filesystem, and get stuck with a broken table that keeps throwing `filesystem_error`. There was already a check for this, but it missed some code paths.

(There's at least one remaining loophole: if the table is moved to `<db>_broken[_replicated]_tables`, its name may become too long. But probably a RENAME TABLE would work on such table to give it a shorter name. That's because a slightly-too-long name probably doesn't cause trouble until the table is dropped; the longest file name format (`<db>.<table>.<uuid>.sql`) is used only for dropped tables.)