### PR TITLE
Fix flaky 03552_filesystem_read_prefetches_log

### DIFF
--- a/tests/queries/0_stateless/03552_filesystem_read_prefetches_log.sql.j2
+++ b/tests/queries/0_stateless/03552_filesystem_read_prefetches_log.sql.j2
@@ -8,10 +8,27 @@ drop table if exists test;
 -- Need wide parts to enable prefetch
 create table test (key Int) engine=MergeTree() order by () settings min_bytes_for_wide_part=0, disk = '{{ disk }}';
 -- Need at least 2 parts
+system stop merges test;
 insert into test values (1);
 insert into test values (2);
 select * from test settings local_filesystem_read_prefetch=1, enable_filesystem_read_prefetches_log=1, allow_prefetched_read_pool_for_local_filesystem=1, local_filesystem_read_method='pread_threadpool' format Null settings log_comment = '{{ disk }}';
 system flush logs filesystem_read_prefetches_log, query_log;
-with (select query_id from system.query_log where current_database = currentDatabase() and log_comment = '{{ disk }}' and type != 'QueryStart') as query_id_ select '{{ disk }}', count()>0 from system.filesystem_read_prefetches_log where query_id = query_id_;
+with (
+    select query_id
+    from system.query_log
+    where current_database = currentDatabase()
+      and log_comment = '{{ disk }}'
+      and type != 'QueryStart'
+) as initial_query_id_,
+query_ids_ as (
+    select query_id
+    from system.query_log
+    where initial_query_id = initial_query_id_
+      and log_comment = '{{ disk }}'
+      and type != 'QueryStart'
+)
+select '{{ disk }}', count()>0
+from system.filesystem_read_prefetches_log
+where query_id in (query_ids_);
 drop table test;
 {% endfor %}


### PR DESCRIPTION
Fix for this [failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85319&sha=b336a2d8cec93e7e8d08ad71e6b30cbaf4c8f8f8&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+ParallelReplicas%2C+s3+storage%2C+parallel%29&name_2=Tests) (and probably couple of others).

Current version may fail in case of enabled parallel replicas, when the actual reading is performed not by initiator local pipeline.

The fix is to check prefetches for all initiated queries (also note that current_database will be 'default' on replicas so previously only a single query was returned as query_id_).

Also disabling merges for test table just in case, to keep 2 parts.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
