### PR TITLE
Mask S3 credentials in logs when using ENGINE = Backup with S3 storage

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -699,7 +699,14 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                     }
                     if (!secret_arguments.replacement.empty())
                     {
-                        ostr << "'" << secret_arguments.replacement << "'";
+                        if (secret_arguments.quote_replacement)
+                        {
+                            ostr << "'" << secret_arguments.replacement << "'";
+                        }
+                        else
+                        {
+                            ostr << secret_arguments.replacement;
+                        }
                     }
                     else
                     {

--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -56,6 +56,8 @@ public:
         /// `azureBlobStorage('DefaultEndpointsProtocol=https;AccountKey=secretkey;...', ...)` should be replaced with
         /// `azureBlobStorage('DefaultEndpointsProtocol=https;AccountKey=[HIDDEN];...', ...)`.
         std::string replacement;
+        /// Whether to wrap a result using full argument replacement in quotes.
+        bool quote_replacement = true;
 
         bool hasSecrets() const
         {
@@ -710,6 +712,7 @@ protected:
             result.start = 1;
             result.count = 1;
             result.replacement = std::move(replacement);
+            result.quote_replacement = false;
         }
     }
 

--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -698,14 +698,11 @@ protected:
                 else
                 {
                     String arg_value;
-                    if (storage_function->arguments->at(i)->tryGetString(&arg_value, true))
+                    if (!storage_function->arguments->at(i)->tryGetString(&arg_value, true))
                     {
-                        replacement += "'" + arg_value + "'";
+                        return;
                     }
-                    else
-                    {
-                        replacement += "[ARG]";
-                    }
+                    replacement += "'" + arg_value + "'";
                 }
             }
             replacement += ")";

--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -679,41 +679,118 @@ protected:
         auto storage_arg = function->arguments->at(1);
         auto storage_function = storage_arg->getFunction();
 
-        /// Backup('', S3('url', 'access_key_id', 'secret_access_key'))
-        if (storage_function && storage_function->name() == "S3" && storage_function->arguments->size() >= 3)
+        if (!storage_function)
+            return;
+
+        if (storage_function->name() == "S3")
         {
-            std::string replacement = "S3(";
+            /// Backup('', S3(...))
+            findBackupS3SecretArguments(storage_function.get());
+        }
+    }
 
-            for (size_t i = 0; i < storage_function->arguments->size(); ++i)
+    void findBackupS3SecretArguments(const AbstractFunction * s3_function)
+    {
+        if (s3_function->arguments->size() == 0)
+            return;
+
+        if (s3_function->arguments->at(0)->isIdentifier())
+        {
+            /// Backup('', S3(named_collection, ..., secret_access_key = 'secret', ...))
+            findBackupS3NamedCollectionSecretArguments(s3_function);
+        }
+        else
+        {
+            /// Backup('', S3('url', 'access_key_id', 'secret_access_key'))
+            findBackupS3PositionalSecretArguments(s3_function);
+        }
+    }
+
+    void findBackupS3NamedCollectionSecretArguments(const AbstractFunction * s3_function)
+    {
+        String replacement = "S3(";
+
+        for (size_t i = 0; i < s3_function->arguments->size(); ++i)
+        {
+            if (i > 0)
+                replacement += ", ";
+
+            auto arg = s3_function->arguments->at(i);
+            auto equals_func = arg->getFunction();
+
+            if (equals_func && equals_func->name() == "equals" && equals_func->arguments->size() == 2)
             {
-                if (i > 0)
+                // Named parameter: key = value
+                String param_name;
+                if (!equals_func->arguments->at(0)->tryGetString(&param_name, true))
                 {
-                    replacement += ", ";
+                    return;
                 }
+                replacement += param_name + " = ";
 
-                if (i == 2) // Secret key position
+                if (param_name == "secret_access_key")
                 {
                     replacement += "'[HIDDEN]'";
                 }
                 else
                 {
-                    String arg_value;
-                    if (storage_function->arguments->at(i)->tryGetString(&arg_value, true))
+                    String param_value;
+                    if (!equals_func->arguments->at(1)->tryGetString(&param_value, true))
                     {
-                        replacement += "'" + arg_value + "'";
+                        return;
                     }
-                    else
-                    {
-                        replacement += "[ARG]";
-                    }
+                    replacement += "'" + param_value + "'";
                 }
             }
-            replacement += ")";
-
-            result.start = 1;
-            result.count = 1;
-            result.replacement = std::move(replacement);
+            else
+            {
+                // Positional argument (like named_collection name)
+                String arg_value;
+                if (!arg->tryGetString(&arg_value, true))
+                {
+                    return;
+                }
+                replacement += arg_value;
+            }
         }
+        replacement += ")";
+
+        result.start = 1;
+        result.count = 1;
+        result.replacement = std::move(replacement);
+    }
+
+    void findBackupS3PositionalSecretArguments(const AbstractFunction * s3_function)
+    {
+        if (s3_function->arguments->size() < 3)
+            return;
+
+        String replacement = "S3(";
+
+        for (size_t i = 0; i < s3_function->arguments->size(); ++i)
+        {
+            if (i > 0)
+                replacement += ", ";
+
+            if (i == 2) // Secret key position
+            {
+                replacement += "'[HIDDEN]'";
+            }
+            else
+            {
+                String arg_value;
+                if (!s3_function->arguments->at(i)->tryGetString(&arg_value, true))
+                {
+                    return;
+                }
+                replacement += "'" + arg_value + "'";
+            }
+        }
+        replacement += ")";
+
+        result.start = 1;
+        result.count = 1;
+        result.replacement = std::move(replacement);
     }
 
     void findBackupNameSecretArguments()

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -393,6 +393,10 @@ def test_create_database():
         f"S3('http://minio1:9001/root/data', 'minio', '{password}')",
         f"S3(named_collection_2, secret_access_key = '{password}', access_key_id = 'minio')",
         # f"PostgreSQL('localhost:5432', 'postgres_db', 'postgres_user', '{password}')",
+        (
+            f"Backup('', S3('http://minio1:9001/root/data/backup', 'minio', '{password}'))",
+            "DNS_ERROR",
+        ),
     ]
 
     def make_test_case(i):
@@ -420,6 +424,7 @@ def test_create_database():
             "CREATE DATABASE database2 ENGINE = S3('http://minio1:9001/root/data', 'minio', '[HIDDEN]')",
             "CREATE DATABASE database3 ENGINE = S3(named_collection_2, secret_access_key = '[HIDDEN]', access_key_id = 'minio')",
             # "CREATE DATABASE database4 ENGINE = PostgreSQL('localhost:5432', 'postgres_db', 'postgres_user', '[HIDDEN]')",
+            "CREATE DATABASE database4 ENGINE = Backup('', 'S3('http://minio1:9001/root/data/backup', 'minio', '[HIDDEN]')')",
         ],
         must_not_contain=[password],
     )

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -397,6 +397,10 @@ def test_create_database():
             f"Backup('', S3('http://minio1:9001/root/data/backup', 'minio', '{password}'))",
             "DNS_ERROR",
         ),
+        (
+            f"Backup('', S3(named_collection_3, secret_access_key = '{password}', access_key_id = 'minio'))",
+            "DNS_ERROR",
+        ),
     ]
 
     def make_test_case(i):
@@ -425,6 +429,7 @@ def test_create_database():
             "CREATE DATABASE database3 ENGINE = S3(named_collection_2, secret_access_key = '[HIDDEN]', access_key_id = 'minio')",
             # "CREATE DATABASE database4 ENGINE = PostgreSQL('localhost:5432', 'postgres_db', 'postgres_user', '[HIDDEN]')",
             "CREATE DATABASE database4 ENGINE = Backup('', 'S3('http://minio1:9001/root/data/backup', 'minio', '[HIDDEN]')')",
+            "CREATE DATABASE database5 ENGINE = Backup('', 'S3(named_collection_2, secret_access_key = '[HIDDEN]', access_key_id = 'minio')')",
         ],
         must_not_contain=[password],
     )

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -397,10 +397,6 @@ def test_create_database():
             f"Backup('', S3('http://minio1:9001/root/data/backup', 'minio', '{password}'))",
             "DNS_ERROR",
         ),
-        (
-            f"Backup('', S3(named_collection_3, secret_access_key = '{password}', access_key_id = 'minio'))",
-            "DNS_ERROR",
-        ),
     ]
 
     def make_test_case(i):
@@ -429,7 +425,6 @@ def test_create_database():
             "CREATE DATABASE database3 ENGINE = S3(named_collection_2, secret_access_key = '[HIDDEN]', access_key_id = 'minio')",
             # "CREATE DATABASE database4 ENGINE = PostgreSQL('localhost:5432', 'postgres_db', 'postgres_user', '[HIDDEN]')",
             "CREATE DATABASE database4 ENGINE = Backup('', 'S3('http://minio1:9001/root/data/backup', 'minio', '[HIDDEN]')')",
-            "CREATE DATABASE database5 ENGINE = Backup('', 'S3(named_collection_2, secret_access_key = '[HIDDEN]', access_key_id = 'minio')')",
         ],
         must_not_contain=[password],
     )

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -424,7 +424,7 @@ def test_create_database():
             "CREATE DATABASE database2 ENGINE = S3('http://minio1:9001/root/data', 'minio', '[HIDDEN]')",
             "CREATE DATABASE database3 ENGINE = S3(named_collection_2, secret_access_key = '[HIDDEN]', access_key_id = 'minio')",
             # "CREATE DATABASE database4 ENGINE = PostgreSQL('localhost:5432', 'postgres_db', 'postgres_user', '[HIDDEN]')",
-            "CREATE DATABASE database4 ENGINE = Backup('', 'S3('http://minio1:9001/root/data/backup', 'minio', '[HIDDEN]')')",
+            "CREATE DATABASE database4 ENGINE = Backup('', S3('http://minio1:9001/root/data/backup', 'minio', '[HIDDEN]'))",
         ],
         must_not_contain=[password],
     )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Closes https://github.com/ClickHouse/ClickHouse/issues/83001

Note that this PR only handles positional args since named collections for this does not work in ClickHouse (yet, e.g. `CREATE DATABASE test_backup_named ENGINE = Backup('', S3('https://example.com/bucket', access_key_id = 'access_key', secret_access_key = 'secret_key'));` doesn't work)

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Mask S3 credentials in logs when using DATABASE ENGINE = Backup with S3 storage

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
