### PR TITLE
Vector search docs: Remove beta badge

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/annindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/annindexes.md
@@ -6,8 +6,6 @@ slug: /engines/table-engines/mergetree-family/annindexes
 title: 'Exact and Approximate Vector Search'
 ---
 
-import BetaBadge from '@theme/badges/BetaBadge';
-
 # Exact and approximate vector search
 
 The problem of finding the N closest points in a multi-dimensional (vector) space for a given point is known as [nearest neighbor search](https://en.wikipedia.org/wiki/Nearest_neighbor_search) or, shorter, vector search.
@@ -68,8 +66,6 @@ returns
 ```
 
 ## Approximate vector search {#approximate-nearest-neighbor-search}
-
-<BetaBadge/>
 
 ClickHouse provides a special "vector similarity" index to perform approximate vector search.
 


### PR DESCRIPTION
Do not merge before GA.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The vector similarity index and vector search are now GA.