### PR TITLE
Distinguish between `*Cluster` and `Distributed` for object storage

### DIFF
--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -200,12 +200,12 @@ StoragePtr TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::
 
     /// NOTE: Automatic cluster functions are implemented at the wrong level of abstraction.
     /// We should replace ordinary "function" with "functionCluster" at AST level. For some reason
-    /// we don't do it and implement some parts "functionCluster" logic inside ordinary "function".
+    /// we don't do it and implement some parts of "functionCluster" logic inside ordinary "function".
     /// And now we have a problem because we cannot distinguish two cases:
     /// 1. Is it really a query which was initiated by clusterFunction?
     /// 2. Is it just an ordinary Distributed/remote which reads from object storage function?
     /// It's important to distinguish these cases because they use different packets in their protocols.
-    /// Distributed/remote initiator expect one protocol and functionCluster expect other protocol.
+    /// Distributed/remote initiator expect one protocol and "functionCluster" expect other protocol.
     ///
     /// HACK Fortunately distributed_depth is incremented only from Distributed/remote and that is the way
     /// how we can distinguish these cases.

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -198,6 +198,19 @@ StoragePtr TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::
         return storage;
     }
 
+    /// NOTE: Automatic cluster functions are implemented at the wrong level of abstraction.
+    /// We should replace ordinary "function" with "functionCluster" at AST level. For some reason
+    /// we don't do it and implement some parts "functionCluster" logic inside ordinary "function".
+    /// And now we have a problem because we cannot distinguish two cases:
+    /// 1. Is it really a query which was initiated by clusterFunction?
+    /// 2. Is it just an ordinary Distributed/remote which reads from object storage function?
+    /// It's important to distinguish these cases because they use different packets in their protocols.
+    /// Distributed/remote initiator expect one protocol and functionCluster expect other protocol.
+    ///
+    /// HACK Fortunately distributed_depth is incremented only from Distributed/remote and that is the way
+    /// how we can distinguish these cases.
+    bool is_initiated_by_cluster_function = context->getClientInfo().distributed_depth == 0;
+
     storage = std::make_shared<StorageObjectStorage>(
         configuration,
         getObjectStorage(context, !is_insert_query),
@@ -211,7 +224,7 @@ StoragePtr TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::
         /* catalog*/nullptr,
         /* if_not_exists*/false,
         /* is_datalake_query*/ false,
-        /* distributed_processing */ is_secondary_query,
+        /* distributed_processing */ is_secondary_query && is_initiated_by_cluster_function,
         /* partition_by */ partition_by,
         /* is_table_function */true);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error while reading from object storage functions through Distributed table or remote table function. Fixes: #84658, Fixes #85173, Fixes #52022.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
