### PR TITLE
Docs: transfer JSON functions documentation to source (part 1)

### DIFF
--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -1132,7 +1132,7 @@ Checks for the existence of the provided value(s) in the JSON document.
         FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the value exists in `json`, otherwise `0`", {"(U)Int8/16/32/64"}};
         FunctionDocumentation::Examples example = {
         {
-            "Usage example", 
+            "Usage example",
             R"(
 SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 'b') = 1;
 SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 4) = 0;
@@ -1146,19 +1146,17 @@ SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 4) = 0;
         FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-        
+
         factory.registerFunction<JSONOverloadResolver<NameJSONHas, JSONHasImpl>>(documentation);
     }
-    
+
     // isValidJSON
     {
         FunctionDocumentation::Description description = R"(
 Checks that the string passed is valid JSON.
 )";
         FunctionDocumentation::Syntax syntax = "isValidJSON(json)";
-        FunctionDocumentation::Arguments arguments = {
-            {"json", "JSON string to validate", {"String"}}
-        };
+        FunctionDocumentation::Arguments argument = {{"json", "JSON string to validate", {"String"}}};
         FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the string is valid JSON, otherwise `0`.", {"UInt8"}};
         FunctionDocumentation::Examples example = {
         {
@@ -1175,7 +1173,7 @@ SELECT isValidJSON('not JSON') = 0;
         {
             "Using integers to access both JSON arrays and JSON objects",
             R"(
-SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 0);            
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 0);
 SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 1);
 SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 2);
 SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', -1);
@@ -1190,17 +1188,17 @@ SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 3);
 1
 1
 0
-         
+
             )"
         }
         };
         FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
-        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-        
+        FunctionDocumentation documentation = {description, syntax, argument, returned_value, example, introduced_in, category};
+
         factory.registerFunction<JSONOverloadResolver<NameIsValidJSON, IsValidJSONImpl>>(documentation);
     }
-    
+
     // JSONLength
     {
         FunctionDocumentation::Description description = R"(
@@ -1229,11 +1227,11 @@ SELECT JSONLength('{"a": "hello", "b": [-100, 200.0, 300]}') = 2;
         FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-        
+
         factory.registerFunction<JSONOverloadResolver<NameJSONLength, JSONLengthImpl>>(documentation);
     }
     factory.registerFunction<JSONOverloadResolver<NameJSONKey, JSONKeyImpl>>();
-    
+
     // JSONType
     {
         FunctionDocumentation::Description description = R"(
@@ -1263,7 +1261,7 @@ SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}', 'b') = 'Array';
         FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-        
+	
         factory.registerFunction<JSONOverloadResolver<NameJSONType, JSONTypeImpl>>(documentation);
     }
     factory.registerFunction<JSONOverloadResolver<NameJSONExtractInt, JSONExtractInt64Impl>>();
@@ -1291,10 +1289,7 @@ Parses JSON and extracts a value of Int type using case-insensitive key matching
             {"json", "JSON string to parse", {"String"}},
             {"indices_or_keys", "Optional. Indices or keys to navigate to the field. Keys use case-insensitive matching", {"String", "(U)Int*"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {
-            "Returns the extracted Int value, 0 if not found or cannot be converted.",
-            {"Int64"}
-        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns the extracted Int value, 0 if not found or cannot be converted.", {"Int64"}};
         FunctionDocumentation::Examples examples = {
             {"basic", R"(SELECT JSONExtractIntCaseInsensitive('{"Value": 123}', 'value'))", "123"},
             {"nested", R"(SELECT JSONExtractIntCaseInsensitive('{"DATA": {"COUNT": 42}}', 'data', 'Count'))", "42"}
@@ -1414,10 +1409,7 @@ Parses JSON and extracts a value of the given ClickHouse data type using case-in
             {"indices_or_keys", "Optional. Indices or keys to navigate to the field. Keys use case-insensitive matching", {"String", "(U)Int*"}},
             {"return_type", "The ClickHouse data type to extract", {"String"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {
-            "Returns the extracted value in the specified data type.",
-            {}
-        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns the extracted value in the specified data type.", {"Any"}};
         FunctionDocumentation::Examples examples = {
             {"int_type", R"(SELECT JSONExtractCaseInsensitive('{"Number": 123}', 'number', 'Int32'))", "123"},
             {"array_type", R"(SELECT JSONExtractCaseInsensitive('{"List": [1, 2, 3]}', 'list', 'Array(Int32)'))", "[1,2,3]"}
@@ -1440,10 +1432,7 @@ Parses key-value pairs from JSON using case-insensitive key matching. This funct
             {"indices_or_keys", "Optional. Indices or keys to navigate to the object. Keys use case-insensitive matching", {"String", "(U)Int*"}},
             {"value_type", "The ClickHouse data type of the values", {"String"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {
-            "Returns an array of tuples containing key-value pairs.",
-            {"Array(Tuple(String, T))"}
-        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns an array of tuples containing key-value pairs.", {"Array(Tuple(String, T))"}};
         FunctionDocumentation::Examples examples = {
             {"basic", R"(SELECT JSONExtractKeysAndValuesCaseInsensitive('{"Name": "Alice", "AGE": 30}', 'String'))", "[('Name','Alice'),('AGE','30')]"}
         };

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -1123,7 +1123,7 @@ REGISTER_FUNCTION(JSON)
     {
         FunctionDocumentation::Description description = R"(
 Checks for the existence of the provided value(s) in the JSON document.
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONHas(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1154,7 +1154,7 @@ SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 4) = 0;
     {
         FunctionDocumentation::Description description = R"(
 Checks that the string passed is valid JSON.
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "isValidJSON(json)";
         FunctionDocumentation::Arguments argument = {{"json", "JSON string to validate", {"String"}}};
         FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the string is valid JSON, otherwise `0`.", {"UInt8"}};
@@ -1204,7 +1204,7 @@ SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 3);
         FunctionDocumentation::Description description = R"(
 Return the length of a JSON array or a JSON object.
 If the value does not exist or has the wrong type, `0` will be returned.
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONLength(json [, indices_or_keys, ...])";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1236,7 +1236,7 @@ SELECT JSONLength('{"a": "hello", "b": [-100, 200.0, 300]}') = 2;
     {
         FunctionDocumentation::Description description = R"(
 Return the type of a JSON value. If the value does not exist, `Null=0` will be returned.
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONType(json[, indices_or_keys, ...])";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1261,7 +1261,7 @@ SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}', 'b') = 'Array';
         FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-	
+
         factory.registerFunction<JSONOverloadResolver<NameJSONType, JSONTypeImpl>>(documentation);
     }
     factory.registerFunction<JSONOverloadResolver<NameJSONExtractInt, JSONExtractInt64Impl>>();
@@ -1283,7 +1283,7 @@ REGISTER_FUNCTION(JSONExtractCaseInsensitive)
     {
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a value of Int type using case-insensitive key matching. This function is similar to [`JSONExtractInt`](#jsonextractint).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractIntCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1305,7 +1305,7 @@ Parses JSON and extracts a value of Int type using case-insensitive key matching
     {
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a value of UInt type using case-insensitive key matching. This function is similar to [`JSONExtractUInt`](#jsonextractuint).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractUIntCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1329,7 +1329,7 @@ Parses JSON and extracts a value of UInt type using case-insensitive key matchin
     {
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a value of Float type using case-insensitive key matching. This function is similar to [`JSONExtractFloat`](#jsonextractfloat).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractFloatCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1353,7 +1353,7 @@ Parses JSON and extracts a value of Float type using case-insensitive key matchi
     {
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a boolean value using case-insensitive key matching. This function is similar to [`JSONExtractBool`](#jsonextractbool).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractBoolCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1377,7 +1377,7 @@ Parses JSON and extracts a boolean value using case-insensitive key matching. Th
     {
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a string using case-insensitive key matching. This function is similar to [`JSONExtractString`](#jsonextractstring).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractStringCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1402,7 +1402,7 @@ Parses JSON and extracts a string using case-insensitive key matching. This func
     {
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a value of the given ClickHouse data type using case-insensitive key matching. This function is similar to [`JSONExtract`](#jsonextract).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractCaseInsensitive(json [, indices_or_keys...], return_type)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1425,7 +1425,7 @@ Parses JSON and extracts a value of the given ClickHouse data type using case-in
     {
         FunctionDocumentation::Description description = R"(
 Parses key-value pairs from JSON using case-insensitive key matching. This function is similar to [`JSONExtractKeysAndValues`](#jsonextractkeysandvalues).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractKeysAndValuesCaseInsensitive(json [, indices_or_keys...], value_type)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1447,7 +1447,7 @@ Parses key-value pairs from JSON using case-insensitive key matching. This funct
     {
         FunctionDocumentation::Description description = R"(
 Returns part of the JSON as an unparsed string using case-insensitive key matching. This function is similar to [`JSONExtractRaw`](#jsonextractraw).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractRawCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1471,7 +1471,7 @@ Returns part of the JSON as an unparsed string using case-insensitive key matchi
     {
         FunctionDocumentation::Description description = R"(
 Returns an array with elements of JSON array, each represented as unparsed string, using case-insensitive key matching. This function is similar to [`JSONExtractArrayRaw`](#jsonextractarrayraw).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractArrayRawCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1495,7 +1495,7 @@ Returns an array with elements of JSON array, each represented as unparsed strin
     {
         FunctionDocumentation::Description description = R"(
 Extracts raw key-value pairs from JSON using case-insensitive key matching. This function is similar to [`JSONExtractKeysAndValuesRaw`](#jsonextractkeysandvaluesraw).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractKeysAndValuesRawCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
@@ -1519,7 +1519,7 @@ Extracts raw key-value pairs from JSON using case-insensitive key matching. This
     {
         FunctionDocumentation::Description description = R"(
 Parses a JSON string and extracts the keys using case-insensitive key matching to navigate to nested objects. This function is similar to [`JSONExtractKeys`](#jsonextractkeys).
-)";
+        )";
         FunctionDocumentation::Syntax syntax = "JSONExtractKeysCaseInsensitive(json [, indices_or_keys]...)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -1119,11 +1119,153 @@ public:
 
 REGISTER_FUNCTION(JSON)
 {
-    factory.registerFunction<JSONOverloadResolver<NameJSONHas, JSONHasImpl>>();
-    factory.registerFunction<JSONOverloadResolver<NameIsValidJSON, IsValidJSONImpl>>();
-    factory.registerFunction<JSONOverloadResolver<NameJSONLength, JSONLengthImpl>>();
+    // JSONHas
+    {
+        FunctionDocumentation::Description description = R"(
+Checks for the existence of the provided value(s) in the JSON document.
+)";
+        FunctionDocumentation::Syntax syntax = "JSONHas(json [, indices_or_keys]...)";
+        FunctionDocumentation::Arguments arguments = {
+            {"json", "JSON string to parse", {"String"}},
+            {"indices_or_keys", "A list of zero or more arguments.", {"String", "(U)Int*"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the value exists in `json`, otherwise `0`", {"(U)Int8/16/32/64"}};
+        FunctionDocumentation::Examples example = {
+        {
+            "Usage example", 
+            R"(
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 'b') = 1;
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 4) = 0;
+            )",
+            R"(
+1
+0
+            )"
+        }
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+        
+        factory.registerFunction<JSONOverloadResolver<NameJSONHas, JSONHasImpl>>(documentation);
+    }
+    
+    // isValidJSON
+    {
+        FunctionDocumentation::Description description = R"(
+Checks that the string passed is valid JSON.
+)";
+        FunctionDocumentation::Syntax syntax = "isValidJSON(json)";
+        FunctionDocumentation::Arguments arguments = {
+            {"json", "JSON string to validate", {"String"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the string is valid JSON, otherwise `0`.", {"UInt8"}};
+        FunctionDocumentation::Examples example = {
+        {
+            "Usage example",
+            R"(
+SELECT isValidJSON('{"a": "hello", "b": [-100, 200.0, 300]}') = 1;
+SELECT isValidJSON('not JSON') = 0;
+            )",
+            R"(
+1
+0
+            )"
+        },
+        {
+            "Using integers to access both JSON arrays and JSON objects",
+            R"(
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 0);            
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 1);
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 2);
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', -1);
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', -2);
+SELECT JSONHas('{"a": "hello", "b": [-100, 200.0, 300]}', 3);
+            )",
+            R"(
+0
+1
+1
+1
+1
+1
+0
+         
+            )"
+        }
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+        
+        factory.registerFunction<JSONOverloadResolver<NameIsValidJSON, IsValidJSONImpl>>(documentation);
+    }
+    
+    // JSONLength
+    {
+        FunctionDocumentation::Description description = R"(
+Return the length of a JSON array or a JSON object.
+If the value does not exist or has the wrong type, `0` will be returned.
+)";
+        FunctionDocumentation::Syntax syntax = "JSONLength(json [, indices_or_keys, ...])";
+        FunctionDocumentation::Arguments arguments = {
+            {"json", "JSON string to parse", {"String"}},
+            {"[, indices_or_keys, ...]", "Optional. A list of zero or more arguments.", {"String", "(U)Int8/16/32/64"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns the length of the JSON array or JSON object, otherwise returns `0` if the value does not exist or has the wrong type.", {"UInt64"}};
+        FunctionDocumentation::Examples example = {
+        {
+            "Usage example",
+            R"(
+SELECT JSONLength('{"a": "hello", "b": [-100, 200.0, 300]}', 'b') = 3;
+SELECT JSONLength('{"a": "hello", "b": [-100, 200.0, 300]}') = 2;
+            )",
+            R"(
+1
+1
+            )"
+        }
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+        
+        factory.registerFunction<JSONOverloadResolver<NameJSONLength, JSONLengthImpl>>(documentation);
+    }
     factory.registerFunction<JSONOverloadResolver<NameJSONKey, JSONKeyImpl>>();
-    factory.registerFunction<JSONOverloadResolver<NameJSONType, JSONTypeImpl>>();
+    
+    // JSONType
+    {
+        FunctionDocumentation::Description description = R"(
+Return the type of a JSON value. If the value does not exist, `Null=0` will be returned.
+)";
+        FunctionDocumentation::Syntax syntax = "JSONType(json[, indices_or_keys, ...])";
+        FunctionDocumentation::Arguments arguments = {
+            {"json", "JSON string to parse", {"String"}},
+            {"json[, indices_or_keys, ...]", "A list of zero or more arguments, each of which can be either string or integer.", {"String", "(U)Int8/16/32/64"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns the type of a JSON value as a string, otherwise if the value doesn't exist it returns `Null=0`", {"Enum"}};
+        FunctionDocumentation::Examples example = {
+        {
+            "Usage example",
+            R"(
+SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}') = 'Object';
+SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}', 'a') = 'String';
+SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}', 'b') = 'Array';
+            )",
+            R"(
+1
+1
+1
+            )"
+        }
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+        
+        factory.registerFunction<JSONOverloadResolver<NameJSONType, JSONTypeImpl>>(documentation);
+    }
     factory.registerFunction<JSONOverloadResolver<NameJSONExtractInt, JSONExtractInt64Impl>>();
     factory.registerFunction<JSONOverloadResolver<NameJSONExtractUInt, JSONExtractUInt64Impl>>();
     factory.registerFunction<JSONOverloadResolver<NameJSONExtractFloat, JSONExtractFloat64Impl>>();

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -1129,7 +1129,7 @@ Checks for the existence of the provided value(s) in the JSON document.
             {"json", "JSON string to parse", {"String"}},
             {"indices_or_keys", "A list of zero or more arguments.", {"String", "(U)Int*"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the value exists in `json`, otherwise `0`", {"(U)Int8/16/32/64"}};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the value exists in `json`, otherwise `0`", {"UInt8"}};
         FunctionDocumentation::Examples example = {
         {
             "Usage example",

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -1124,10 +1124,10 @@ REGISTER_FUNCTION(JSON)
         FunctionDocumentation::Description description = R"(
 Checks for the existence of the provided value(s) in the JSON document.
         )";
-        FunctionDocumentation::Syntax syntax = "JSONHas(json [, indices_or_keys]...)";
+        FunctionDocumentation::Syntax syntax = "JSONHas(json[ ,indices_or_keys, ...])";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse", {"String"}},
-            {"indices_or_keys", "A list of zero or more arguments.", {"String", "(U)Int*"}}
+            {"[ ,indices_or_keys, ...]", "A list of zero or more arguments.", {"String", "(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the value exists in `json`, otherwise `0`", {"UInt8"}};
         FunctionDocumentation::Examples example = {

--- a/src/Functions/visitParamExtractBool.cpp
+++ b/src/Functions/visitParamExtractBool.cpp
@@ -31,11 +31,12 @@ The result is `UInt8`.
         {"field_name", "The name of the field to search for.", {"const String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {
-        R"(Returns `1` if the value of the field is `true`, `0` otherwise. This means this function will return `0` including (and not only) in the following cases:
- - If the field doesn't exists.
- - If the field contains `true` as a string, e.g.: `{"field":"true"}`.
- - If the field contains `1` as a numerical value.)", 
-        {"UInt8"}
+    R"(
+Returns `1` if the value of the field is `true`, `0` otherwise. This means this function will return `0` including (and not only) in the following cases:
+- If the field doesn't exists.
+- If the field contains `true` as a string, e.g.: `{"field":"true"}`.
+- If the field contains `1` as a numerical value.)",
+    {"UInt8"}
     };
     FunctionDocumentation::Examples example = {
     {
@@ -65,7 +66,7 @@ SELECT simpleJSONExtractBool(json, 'foo') FROM jsons ORDER BY json;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONExtractBool>(documentation);
     factory.registerAlias("visitParamExtractBool", "simpleJSONExtractBool");
 }

--- a/src/Functions/visitParamExtractBool.cpp
+++ b/src/Functions/visitParamExtractBool.cpp
@@ -21,35 +21,52 @@ using FunctionSimpleJSONExtractBool = FunctionsStringSearch<ExtractParamImpl<Nam
 
 REGISTER_FUNCTION(VisitParamExtractBool)
 {
-    factory.registerFunction<FunctionSimpleJSONExtractBool>(FunctionDocumentation{
-        .description = "Parses a true/false value from the value of the field named field_name. The result is UInt8.",
-        .syntax = "simpleJSONExtractBool(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value
-        = {R"(It returns 1 if the value of the field is true, 0 otherwise. This means this function will return 0 including (and not only) in the following cases:
+    FunctionDocumentation::Description description = R"(
+Parses a true/false value from the value of the field named `field_name`.
+The result is `UInt8`.
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONExtractBool(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {
+        R"(Returns `1` if the value of the field is `true`, `0` otherwise. This means this function will return `0` including (and not only) in the following cases:
  - If the field doesn't exists.
- - If the field contains true as a string, e.g.: {"field":"true"}.
- - If the field contains 1 as a numerical value.)"},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+ - If the field contains `true` as a string, e.g.: `{"field":"true"}`.
+ - If the field contains `1` as a numerical value.)", 
+        {"UInt8"}
+    };
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":false,"bar":true}');
 INSERT INTO jsons VALUES ('{"foo":"true","qux":1}');
 
 SELECT simpleJSONExtractBool(json, 'bar') FROM jsons ORDER BY json;
-SELECT simpleJSONExtractBool(json, 'foo') FROM jsons ORDER BY json;)",
-            .result = R"(0
+SELECT simpleJSONExtractBool(json, 'foo') FROM jsons ORDER BY json;
+        )",
+        R"(
+0
 1
 0
-0)"}},
-        .category = FunctionDocumentation::Category::JSON});
+0
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONExtractBool>(documentation);
     factory.registerAlias("visitParamExtractBool", "simpleJSONExtractBool");
 }
 

--- a/src/Functions/visitParamExtractFloat.cpp
+++ b/src/Functions/visitParamExtractFloat.cpp
@@ -11,22 +11,27 @@ using FunctionSimpleJSONExtractFloat = FunctionsStringSearch<ExtractParamImpl<Na
 
 REGISTER_FUNCTION(VisitParamExtractFloat)
 {
-    factory.registerFunction<FunctionSimpleJSONExtractFloat>(FunctionDocumentation{
-        .description
-        = "Parses Float64 from the value of the field named field_name. If this is a string field, it tries to parse a number from the "
-          "beginning of the string. If the field does not exist, or it exists but does not contain a number, it returns 0.",
-        .syntax = "simpleJSONExtractFloat(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value = {"It returns the number parsed from the field if the field exists and contains a number, 0 otherwise."},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+    FunctionDocumentation::Description description = R"(
+Parses `Float64` from the value of the field named `field_name`.
+If `field_name` is a string field, it tries to parse a number from the beginning of the string.
+If the field does not exist, or it exists but does not contain a number, it returns `0`.
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONExtractFloat(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number parsed from the field if the field exists and contains a number, otherwise `0`.", {"Float64"}};
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":"-4e3"}');
 INSERT INTO jsons VALUES ('{"foo":-3.4}');
@@ -34,13 +39,22 @@ INSERT INTO jsons VALUES ('{"foo":5}');
 INSERT INTO jsons VALUES ('{"foo":"not1number"}');
 INSERT INTO jsons VALUES ('{"baz":2}');
 
-SELECT simpleJSONExtractFloat(json, 'foo') FROM jsons ORDER BY json;)",
-            .result = R"(0
+SELECT simpleJSONExtractFloat(json, 'foo') FROM jsons ORDER BY json;
+        )",
+        R"(
+0
 -4000
 0
 -3.4
-5)"}},
-        .category = FunctionDocumentation::Category::JSON});
+5
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONExtractFloat>(documentation);
     factory.registerAlias("visitParamExtractFloat", "simpleJSONExtractFloat");
 }
 

--- a/src/Functions/visitParamExtractFloat.cpp
+++ b/src/Functions/visitParamExtractFloat.cpp
@@ -53,7 +53,7 @@ SELECT simpleJSONExtractFloat(json, 'foo') FROM jsons ORDER BY json;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONExtractFloat>(documentation);
     factory.registerAlias("visitParamExtractFloat", "simpleJSONExtractFloat");
 }

--- a/src/Functions/visitParamExtractInt.cpp
+++ b/src/Functions/visitParamExtractInt.cpp
@@ -53,7 +53,7 @@ SELECT simpleJSONExtractInt(json, 'foo') FROM jsons ORDER BY json;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONExtractInt>(documentation);
     factory.registerAlias("visitParamExtractInt", "simpleJSONExtractInt");
 }

--- a/src/Functions/visitParamExtractInt.cpp
+++ b/src/Functions/visitParamExtractInt.cpp
@@ -11,22 +11,27 @@ using FunctionSimpleJSONExtractInt = FunctionsStringSearch<ExtractParamImpl<Name
 
 REGISTER_FUNCTION(VisitParamExtractInt)
 {
-    factory.registerFunction<FunctionSimpleJSONExtractInt>(FunctionDocumentation{
-        .description
-        = "Parses Int64 from the value of the field named field_name. If this is a string field, it tries to parse a number from the "
-          "beginning of the string. If the field does not exist, or it exists but does not contain a number, it returns 0.",
-        .syntax = "simpleJSONExtractInt(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value = {"It returns the number parsed from the field if the field exists and contains a number, 0 otherwise."},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+    FunctionDocumentation::Description description = R"(
+Parses `Int64` from the value of the field named `field_name`.
+If `field_name` is a string field, it tries to parse a number from the beginning of the string.
+If the field does not exist, or it exists but does not contain a number, it returns `0`.
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONExtractInt(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number parsed from the field if the field exists and contains a number, `0` otherwise", {"Int64"}};
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":"-4e3"}');
 INSERT INTO jsons VALUES ('{"foo":-3.4}');
@@ -34,13 +39,22 @@ INSERT INTO jsons VALUES ('{"foo":5}');
 INSERT INTO jsons VALUES ('{"foo":"not1number"}');
 INSERT INTO jsons VALUES ('{"baz":2}');
 
-SELECT simpleJSONExtractInt(json, 'foo') FROM jsons ORDER BY json;)",
-            .result = R"(0
+SELECT simpleJSONExtractInt(json, 'foo') FROM jsons ORDER BY json;
+        )",
+        R"(
+0
 -4
 0
 -3
-5)"}},
-        .category = FunctionDocumentation::Category::JSON});
+5
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONExtractInt>(documentation);
     factory.registerAlias("visitParamExtractInt", "simpleJSONExtractInt");
 }
 

--- a/src/Functions/visitParamExtractRaw.cpp
+++ b/src/Functions/visitParamExtractRaw.cpp
@@ -61,20 +61,28 @@ using FunctionSimpleJSONExtractRaw = FunctionsStringSearchToString<ExtractParamT
 
 REGISTER_FUNCTION(VisitParamExtractRaw)
 {
-    factory.registerFunction<FunctionSimpleJSONExtractRaw>(FunctionDocumentation{
-        .description = "Returns the value of the field named field_name as a String, including separators.",
-        .syntax = "simpleJSONExtractRaw(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value = {"The value of the field as a String including separators if the field exists, or an empty String otherwise.", {"String"}},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+    FunctionDocumentation::Description description = R"(
+Returns the value of the field named `field_name` as a `String`, including separators.
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONExtractRaw(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {
+        "Returns the value of the field as a string, including separators if the field exists, or an empty string otherwise",
+        {"String"}
+    };
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":"-4e3"}');
 INSERT INTO jsons VALUES ('{"foo":-3.4}');
@@ -82,13 +90,22 @@ INSERT INTO jsons VALUES ('{"foo":5}');
 INSERT INTO jsons VALUES ('{"foo":{"def":[1,2,3]}}');
 INSERT INTO jsons VALUES ('{"baz":2}');
 
-SELECT simpleJSONExtractRaw(json, 'foo') FROM jsons ORDER BY json;)",
-            .result = R"(
+SELECT simpleJSONExtractRaw(json, 'foo') FROM jsons ORDER BY json;
+        )",
+        R"(
+
 "-4e3"
 -3.4
 5
-{"def":[1,2,3]})"}},
-        .category = FunctionDocumentation::Category::JSON});
+{"def":[1,2,3]}
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONExtractRaw>(documentation);
     factory.registerAlias("visitParamExtractRaw", "simpleJSONExtractRaw");
 }
 

--- a/src/Functions/visitParamExtractRaw.cpp
+++ b/src/Functions/visitParamExtractRaw.cpp
@@ -104,7 +104,7 @@ SELECT simpleJSONExtractRaw(json, 'foo') FROM jsons ORDER BY json;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONExtractRaw>(documentation);
     factory.registerAlias("visitParamExtractRaw", "simpleJSONExtractRaw");
 }

--- a/src/Functions/visitParamExtractString.cpp
+++ b/src/Functions/visitParamExtractString.cpp
@@ -24,39 +24,50 @@ using FunctionSimpleJSONExtractString = FunctionsStringSearchToString<ExtractPar
 
 REGISTER_FUNCTION(VisitParamExtractString)
 {
-    factory.registerFunction<FunctionSimpleJSONExtractString>(FunctionDocumentation{
-        .description = R"(Parses String in double quotes from the value of the field named field_name.
+    FunctionDocumentation::Description description = R"(
+Parses `String` in double quotes from the value of the field named `field_name`.
 
-        There is currently no support for code points in the format \uXXXX\uYYYY that are not from the basic multilingual plane (they are converted to CESU-8 instead of UTF-8).)",
-        .syntax = "simpleJSONExtractString(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value = {R"(
-Returns the value of a field as a String, including separators.
-The value is unescaped.
-It returns an empty String: if the field doesn't contain a double quoted string,
-if unescaping fails or if the field doesn't exist.
-)"},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+**Implementation details**
+
+There is currently no support for code points in the format `\uXXXX\uYYYY` that are not from the basic multilingual plane (they are converted to CESU-8 instead of UTF-8).
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONExtractString(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the unescaped value of a field as a string, including separators. An empty string is returned if the field doesn't contain a double quoted string, if unescaping fails or if the field doesn't exist", {"String"}};
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":"\\n\\u0000"}');
 INSERT INTO jsons VALUES ('{"foo":"\\u263"}');
 INSERT INTO jsons VALUES ('{"foo":"\\u263a"}');
 INSERT INTO jsons VALUES ('{"foo":"hello}');
 
-SELECT simpleJSONExtractString(json, 'foo') FROM jsons ORDER BY json;)",
-            .result = R"(\n\0
+SELECT simpleJSONExtractString(json, 'foo') FROM jsons ORDER BY json;
+        )",
+        R"(
+\n\0
 
 ☺
-)"}},
-        .category = FunctionDocumentation::Category::JSON});
+
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONExtractString>(documentation);
     factory.registerAlias("visitParamExtractString", "simpleJSONExtractString");
 }
 

--- a/src/Functions/visitParamExtractString.cpp
+++ b/src/Functions/visitParamExtractString.cpp
@@ -66,7 +66,7 @@ SELECT simpleJSONExtractString(json, 'foo') FROM jsons ORDER BY json;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONExtractString>(documentation);
     factory.registerAlias("visitParamExtractString", "simpleJSONExtractString");
 }

--- a/src/Functions/visitParamExtractUInt.cpp
+++ b/src/Functions/visitParamExtractUInt.cpp
@@ -54,7 +54,7 @@ SELECT simpleJSONExtractUInt(json, 'foo') FROM jsons ORDER BY json;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONExtractUInt>(documentation);
     factory.registerAlias("visitParamExtractUInt", "simpleJSONExtractUInt");
 }

--- a/src/Functions/visitParamExtractUInt.cpp
+++ b/src/Functions/visitParamExtractUInt.cpp
@@ -12,22 +12,27 @@ using FunctionSimpleJSONExtractUInt = FunctionsStringSearch<ExtractParamImpl<Nam
 
 REGISTER_FUNCTION(VisitParamExtractUInt)
 {
-    factory.registerFunction<FunctionSimpleJSONExtractUInt>(FunctionDocumentation{
-        .description
-        = "Parses UInt64 from the value of the field named field_name. If this is a string field, it tries to parse a number from the "
-          "beginning of the string. If the field does not exist, or it exists but does not contain a number, it returns 0.",
-        .syntax = "simpleJSONExtractUInt(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value = {"It returns the number parsed from the field if the field exists and contains a number, 0 otherwise."},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+    FunctionDocumentation::Description description = R"(
+Parses `UInt64` from the value of the field named `field_name`.
+If `field_name` is a string field, it tries to parse a number from the beginning of the string.
+If the field does not exist, or it exists but does not contain a number, it returns `0`.
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONExtractUInt(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number parsed from the field if the field exists and contains a number, `0` otherwise", {"UInt64"}};
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":"4e3"}');
 INSERT INTO jsons VALUES ('{"foo":3.4}');
@@ -35,13 +40,22 @@ INSERT INTO jsons VALUES ('{"foo":5}');
 INSERT INTO jsons VALUES ('{"foo":"not1number"}');
 INSERT INTO jsons VALUES ('{"baz":2}');
 
-SELECT simpleJSONExtractUInt(json, 'foo') FROM jsons ORDER BY json;)",
-            .result = R"(0
+SELECT simpleJSONExtractUInt(json, 'foo') FROM jsons ORDER BY json;
+        )",
+        R"(
+0
 4
 0
 3
-5)"}},
-        .category = FunctionDocumentation::Category::JSON});
+5
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONExtractUInt>(documentation);
     factory.registerAlias("visitParamExtractUInt", "simpleJSONExtractUInt");
 }
 

--- a/src/Functions/visitParamHas.cpp
+++ b/src/Functions/visitParamHas.cpp
@@ -21,28 +21,42 @@ using FunctionSimpleJSONHas = FunctionsStringSearch<ExtractParamImpl<NameSimpleJ
 
 REGISTER_FUNCTION(VisitParamHas)
 {
-    factory.registerFunction<FunctionSimpleJSONHas>(FunctionDocumentation{
-        .description = "Checks whether there is a field named field_name.  The result is UInt8.",
-        .syntax = "simpleJSONHas(json, field_name)",
-        .arguments
-        = {{"json", "The JSON in which the field is searched for.", {"String"}},
-           {"field_name", "The name of the field to search for.", {"const String"}}},
-        .returned_value = {"It returns 1 if the field exists, 0 otherwise."},
-        .examples
-        = {{.name = "simple",
-            .query = R"(CREATE TABLE jsons
+    FunctionDocumentation::Description description = R"(
+Checks whether there is a field named `field_name`.
+)";
+    FunctionDocumentation::Syntax syntax = "simpleJSONHas(json, field_name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"json", "The JSON in which the field is searched for.", {"String"}},
+        {"field_name", "The name of the field to search for.", {"const String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the field exists, `0` otherwise",{"UInt8"}};
+    FunctionDocumentation::Examples example = {
+    {
+        "Usage example",
+        R"(
+CREATE TABLE jsons
 (
-    json String
+    `json` String
 )
-ENGINE = Memory;
+ENGINE = MergeTree
+ORDER BY tuple();
 
 INSERT INTO jsons VALUES ('{"foo":"true","qux":1}');
 
 SELECT simpleJSONHas(json, 'foo') FROM jsons;
-SELECT simpleJSONHas(json, 'bar') FROM jsons;)",
-            .result = R"(1
-0)"}},
-        .category = FunctionDocumentation::Category::JSON});
+SELECT simpleJSONHas(json, 'bar') FROM jsons;
+        )",
+        R"(
+1
+0
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
+    
+    factory.registerFunction<FunctionSimpleJSONHas>(documentation);
     factory.registerAlias("visitParamHas", "simpleJSONHas");
 }
 

--- a/src/Functions/visitParamHas.cpp
+++ b/src/Functions/visitParamHas.cpp
@@ -55,7 +55,7 @@ SELECT simpleJSONHas(json, 'bar') FROM jsons;
     FunctionDocumentation::IntroducedIn introduced_in = {21, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, example, introduced_in, category};
-    
+
     factory.registerFunction<FunctionSimpleJSONHas>(documentation);
     factory.registerAlias("visitParamHas", "simpleJSONHas");
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -27,10 +27,7 @@ JSONExtractKeysAndValuesRaw
 JSONExtractRaw
 JSONExtractString
 JSONExtractUInt
-JSONHas
 JSONKey
-JSONLength
-JSONType
 JSON_EXISTS
 JSON_QUERY
 JSON_VALUE
@@ -205,7 +202,6 @@ isDecimalOverflow
 isIPAddressInRange
 isIPv4String
 isIPv6String
-isValidJSON
 isValidUTF8
 javaHash
 javaHashUTF16LE

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -32,12 +32,9 @@ JSONExtractKeysAndValuesRaw
 JSONExtractRaw
 JSONExtractString
 JSONExtractUInt
-JSONHas
 JSONKey
-JSONLength
 JSONSharedDataPaths
 JSONSharedDataPathsWithTypes
-JSONType
 JSON_EXISTS
 JSON_QUERY
 JSON_VALUE
@@ -307,7 +304,6 @@ isDynamicElementInSharedData
 isIPAddressInRange
 isIPv4String
 isIPv6String
-isValidJSON
 isValidUTF8
 jaroSimilarity
 jaroWinklerSimilarity
@@ -546,13 +542,6 @@ shardNum
 showCertificate
 sigmoid
 sign
-simpleJSONExtractBool
-simpleJSONExtractFloat
-simpleJSONExtractInt
-simpleJSONExtractRaw
-simpleJSONExtractString
-simpleJSONExtractUInt
-simpleJSONHas
 sin
 sinh
 sipHash128


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Moves across the first batch of JSON functions to the source code for autogeneration of documentation from system tables.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
