### PR TITLE
fix mistake in `startup_scripts` documentation

### DIFF
--- a/docs/en/operations/startup-scripts.md
+++ b/docs/en/operations/startup-scripts.md
@@ -13,7 +13,7 @@ ClickHouse can run arbitrary SQL queries from the server configuration during st
 ```xml
 <clickhouse>
     <startup_scripts>
-        <throw_on_error>false<throw_on_error>
+        <throw_on_error>false</throw_on_error>
         <scripts>
             <query>CREATE ROLE OR REPLACE test_role</query>
         </scripts>


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The snippet `<throw_on_error>false<throw_on_error>` throws an error in merging the xml, causing confusion, especially when the value is set to true.
