### PR TITLE
Fix possible UAF of total_memory_tracker on shutdown

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -141,6 +141,10 @@ MemoryTracker::MemoryTracker(MemoryTracker * parent_, VariableContext level_, bo
 
 MemoryTracker::~MemoryTracker()
 {
+    /// We need to explicitly reset MainThreadStatus earlier, to avoid using total_memory_tracker after it has been destroyd
+    if (this == &total_memory_tracker)
+        DB::MainThreadStatus::reset();
+
     if ((level == VariableContext::Process || level == VariableContext::User) && peak && log_peak_memory_usage_in_destructor)
     {
         try

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -341,6 +341,7 @@ MainThreadStatus::MainThreadStatus()
 
 MainThreadStatus::~MainThreadStatus()
 {
+    reset();
     /// Stop gathering task stats. We do this to avoid issues due to static object destruction order
     /// `MainThreadStatus thread_status` inside MainThreadStatus::getInstance might call detachFromGroup which calls taskstats->updateCounters
     /// `thread_local auto metrics_provider` inside TasksStatsCounters::TasksStatsCounters holds the file descriptors open

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -358,6 +358,8 @@ public:
     static bool initialized() { return is_initialized.test(std::memory_order_relaxed); }
     static bool isMainThread() { return main_thread == current_thread; }
 
+    static void reset() { is_initialized.clear(std::memory_order_relaxed); }
+
     ~MainThreadStatus();
 
 private:


### PR DESCRIPTION
Msan report:

    WARNING: MemorySanitizer: use-of-uninitialized-value
        0 0x5621e7b15fc0 in MemoryTracker::isSizeOkForSampling(unsigned long) const build_msan/./src/Common/MemoryTracker.cpp:678:45
        1 0x5621e7b15fc0 in MemoryTracker::free(long, double) build_msan/./src/Common/MemoryTracker.cpp:502:10
        2 0x5621e78b95af in CurrentMemoryTracker::free(long) build_msan/./src/Common/CurrentMemoryTracker.cpp:119:36
        3 0x5621e78ad7be in unsigned long Memory::untrackMemory<>(void*, AllocationTrace&, unsigned long, T...) build_msan/./src/Common/memory.h:165:17
        4 0x5621e78ad7be in operator delete(void*, unsigned long) build_msan/./src/Common/AllocationInterceptors.cpp:170:31
        5 0x5621e79707bd in void std::__1::__libcpp_operator_delete[abi:ne190107]<void*, unsigned long>(void*, unsigned long) build_msan/./contrib/llvm-project/libcxx/include/new:274:3
        6 0x5621e79707bd in void std::__1::__do_deallocate_handle_size[abi:ne190107]<>(void*, unsigned long) build_msan/./contrib/llvm-project/libcxx/include/new:298:10
        7 0x5621e79707bd in std::__1::__libcpp_deallocate[abi:ne190107](void*, unsigned long, unsigned long) build_msan/./contrib/llvm-project/libcxx/include/new:311:12
        8 0x5621e79707bd in std::__1::allocator<char>::deallocate[abi:ne190107](char*, unsigned long) build_msan/./contrib/llvm-project/libcxx/include/__memory/allocator.h:132:7
        9 0x5621e79707bd in std::__1::allocator_traits<std::__1::allocator<char>>::deallocate[abi:ne190107](std::__1::allocator<char>&, char*, unsigned long) build_msan/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:312:9
        10 0x5621e79707bd in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::~basic_string() build_msan/./contrib/llvm-project/libcxx/include/string:1212:7
        11 0x5621e79707bd in DB::ErrorCodes::Error::~Error() build_msan/./src/Common/ErrorCodes.h:34:12
        12 0x5621e79675e4 in DB::ErrorCodes::ErrorPair::~ErrorPair() build_msan/./src/Common/ErrorCodes.h:49:12
        13 0x5621e79675e4 in DB::ErrorCodes::ErrorPairHolder::~ErrorPairHolder() build_msan/./src/Common/ErrorCodes.h:56:12
        14 0x5621e79675e4 in __cxx_global_array_dtor build_msan/./src/Common/ErrorCodes.cpp
        15 0x5621cb71f0db in MSanCxaAtExitWrapper(void*) work/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1281:3
        16 0x7f7c9b8cb494 in __run_exit_handlers stdlib/exit.c:113:8
        17 0x7f7c9b8cb60f in exit stdlib/exit.c:143:3
        18 0x7f7c9b8afd96 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:74:3
        19 0x7f7c9b8afe3f in __libc_start_main csu/../csu/libc-start.c:392:3
        20 0x5621cb6ed02d in _start (work/ClickHouse/build_msan/programs/clickhouse+0x94b102d) (BuildId: 11260f5dfdd16c037a6b8386ab14eab817f9438d)

      Member fields were destroyed
        0 0x5621cb71e6ed in __sanitizer_dtor_callback_fields work/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1044:5
        1 0x5621e7b0b8d3 in MemoryTracker::~MemoryTracker() build_msan/./src/Common/MemoryTracker.h:59:24
        2 0x5621e7b0b8d3 in MemoryTracker::~MemoryTracker() build_msan/./src/Common/MemoryTracker.cpp:155:1
        3 0x5621cb71f0db in MSanCxaAtExitWrapper(void*) work/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1281:3

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)