### PR TITLE
Reintroduce changes from #80562

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -294,8 +294,7 @@ std::string DatabaseDataLake::getStorageEndpointForTable(const DataLake::TableMe
     auto endpoint_from_settings = settings[DatabaseDataLakeSetting::storage_endpoint].value;
     if (endpoint_from_settings.empty())
         return table_metadata.getLocation();
-    else
-        return table_metadata.getLocationWithEndpoint(endpoint_from_settings);
+    return table_metadata.getLocationWithEndpoint(endpoint_from_settings);
 }
 
 bool DatabaseDataLake::empty() const
@@ -408,12 +407,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
         auto metadata_location = table_specific_properties->iceberg_metadata_file_location;
         if (!metadata_location.empty())
         {
-            const auto data_location = table_metadata.getLocation();
-            if (metadata_location.starts_with(data_location))
-            {
-                size_t remove_slash = metadata_location[data_location.size()] == '/' ? 1 : 0;
-                metadata_location = metadata_location.substr(data_location.size() + remove_slash);
-            }
+            metadata_location = table_metadata.getMetadataLocation(metadata_location);
         }
 
         (*storage_settings)[DB::DataLakeStorageSetting::iceberg_metadata_file_path] = metadata_location;

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -19,13 +19,6 @@ StorageType parseStorageTypeFromLocation(const std::string & location)
     /// Table location in catalog metadata always starts with one of s3://, file://, etc.
     /// So just extract this part of the path and deduce storage type from it.
 
-    auto capitalize_first_letter = [] (const std::string & s)
-    {
-        auto result = Poco::toLower(s);
-        result[0] = std::toupper(result[0]);
-        return result;
-    };
-
     auto pos = location.find("://");
     if (pos == std::string::npos)
     {
@@ -34,7 +27,26 @@ StorageType parseStorageTypeFromLocation(const std::string & location)
             "Unexpected path format: {}", location);
     }
 
-    auto storage_type_str = location.substr(0, pos);
+    return parseStorageTypeFromString(location.substr(0, pos));
+}
+
+StorageType parseStorageTypeFromString(const std::string & type)
+{
+    auto capitalize_first_letter = [] (const std::string & s)
+    {
+        auto result = Poco::toLower(s);
+        if (!result.empty())
+            result[0] = std::toupper(result[0]);
+        return result;
+    };
+
+    std::string storage_type_str = type;
+    auto pos = storage_type_str.find("://");
+    if (pos != std::string::npos)
+    {
+        // convert s3://, file://, etc. to s3, file etc.
+        storage_type_str = storage_type_str.substr(0,pos);
+    }
     if (capitalize_first_letter(storage_type_str) == "File")
         storage_type_str = "Local";
 
@@ -66,6 +78,8 @@ void TableMetadata::setLocation(const std::string & location_)
     if (pos == std::string::npos)
         throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Unexpected location format: {}", location_);
 
+    // pos+3 to account for ://
+    storage_type_str = location_.substr(0, pos+3);
     auto pos_to_bucket = pos + std::strlen("://");
     auto pos_to_path = location_.substr(pos_to_bucket).find('/');
 
@@ -113,8 +127,7 @@ std::string TableMetadata::constructLocation(const std::string & endpoint_) cons
 
     if (location.ends_with(bucket))
         return std::filesystem::path(location) / path / "";
-    else
-        return std::filesystem::path(location) / bucket / path / "";
+    return std::filesystem::path(location) / bucket / path / "";
 }
 
 void TableMetadata::setEndpoint(const std::string & endpoint_)
@@ -166,6 +179,10 @@ std::optional<DataLakeSpecificProperties> TableMetadata::getDataLakeSpecificProp
 
 StorageType TableMetadata::getStorageType() const
 {
+    if (!storage_type_str.empty())
+    {
+        return parseStorageTypeFromString(storage_type_str);
+    }
     return parseStorageTypeFromLocation(location_without_path);
 }
 
@@ -180,6 +197,30 @@ bool TableMetadata::hasSchema() const
 bool TableMetadata::hasStorageCredentials() const
 {
     return storage_credentials != nullptr;
+}
+
+std::string TableMetadata::getMetadataLocation(const std::string & iceberg_metadata_file_location) const
+{
+    std::string metadata_location = iceberg_metadata_file_location;
+    if (!metadata_location.empty())
+    {
+        std::string data_location = getLocation();
+
+        // Use the actual storage type prefix (e.g., s3://, file://, etc.)
+        if (metadata_location.starts_with(storage_type_str))
+            metadata_location = metadata_location.substr(storage_type_str.size());
+        if (data_location.starts_with(storage_type_str))
+            data_location = data_location.substr(storage_type_str.size());
+        else if (!endpoint.empty() && data_location.starts_with(endpoint))
+            data_location = data_location.substr(endpoint.size());
+
+        if (metadata_location.starts_with(data_location))
+        {
+            size_t remove_slash = metadata_location[data_location.size()] == '/' ? 1 : 0;
+            metadata_location = metadata_location.substr(data_location.size() + remove_slash);
+        }
+    }
+    return metadata_location;
 }
 
 DB::SettingsChanges CatalogSettings::allChanged() const

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -13,6 +13,7 @@ namespace DataLake
 
 using StorageType = DB::DatabaseDataLakeStorageType;
 StorageType parseStorageTypeFromLocation(const std::string & location);
+StorageType parseStorageTypeFromString(const std::string &type);
 
 struct DataLakeSpecificProperties
 {
@@ -39,6 +40,7 @@ public:
     void setLocation(const std::string & location_);
     std::string getLocation() const;
     std::string getLocationWithEndpoint(const std::string & endpoint_) const;
+    std::string getMetadataLocation(const std::string & iceberg_metadata_file_location) const;
 
     void setEndpoint(const std::string & endpoint_);
     std::string getEndpoint() const { return endpoint; }
@@ -82,6 +84,8 @@ private:
     /// Path to table's data: `/path/to/table/data/`
     std::string path;
     DB::NamesAndTypesList schema;
+    // Type of storage
+    std::string storage_type_str;
 
     std::string bucket;
     /// Endpoint is set and used in case we have non-AWS storage implementation, for example, Minio.

--- a/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
@@ -1,0 +1,104 @@
+services:
+  lakekeeper:
+    image: quay.io/lakekeeper/catalog:latest
+    environment:
+      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
+      - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres
+      - LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:5432/postgres
+      - RUST_LOG=info
+    command: ["serve"]
+    healthcheck:
+      test: ["CMD", "/home/nonroot/lakekeeper", "healthcheck"]
+      interval: 1s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    ports:
+      - 8181:8181
+
+
+  migrate:
+    image: quay.io/lakekeeper/catalog:latest-main
+    environment:
+      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
+      - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres
+      - LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:5432/postgres
+      - RUST_LOG=info
+    restart: "no"
+    command: ["migrate"]
+    depends_on:
+      db:
+        condition: service_healthy
+
+
+  bootstrap:
+    image: curlimages/curl
+    depends_on:
+      lakekeeper:
+        condition: service_healthy
+    restart: "no"
+    command:
+      - -w
+      - "%{http_code}"
+      - "-X"
+      - "POST"
+      - "-v"
+      - "http://lakekeeper:8181/management/v1/bootstrap"
+      - "-H"
+      - "Content-Type: application/json"
+      - "--data"
+      - '{"accept-terms-of-use": true}'
+      - "-o"
+      - "/dev/null"
+
+
+
+
+
+
+  db:
+    image: bitnami/postgresql:16.3.0
+    environment:
+      - POSTGRESQL_USERNAME=postgres
+      - POSTGRESQL_PASSWORD=postgres
+      - POSTGRESQL_DATABASE=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres"]
+      interval: 2s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
+  # TODO: can we simply use with_minio=True instead?
+  minio:
+    image: bitnami/minio:2025.4.22
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd
+      - MINIO_API_PORT_NUMBER=9000
+      - MINIO_CONSOLE_PORT_NUMBER=9001
+      - MINIO_SCHEME=http
+      - MINIO_DEFAULT_BUCKETS=warehouse-rest
+    networks: 
+      default:
+        aliases:
+          - warehouse-rest.minio
+    ports:
+      - "9002:9000"
+      - "9003:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ls", "local", "|", "grep", "warehouse-rest"]
+      interval: 2s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+
+

--- a/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
@@ -1,6 +1,6 @@
 services:
   lakekeeper:
-    image: quay.io/lakekeeper/catalog:latest
+    image: vakamo/lakekeeper:v0.9.4
     environment:
       - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
       - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres
@@ -25,7 +25,7 @@ services:
 
 
   migrate:
-    image: quay.io/lakekeeper/catalog:latest-main
+    image: vakamo/lakekeeper:v0.9.4
     environment:
       - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
       - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1517,14 +1517,17 @@ class ClickHouseCluster:
         return self.base_iceberg_hms_cmd
 
     def setup_iceberg_catalog_cmd(
-        self, instance, env_variables, docker_compose_yml_dir
+        self, instance, env_variables, docker_compose_yml_dir, extra_parameters=None
     ):
         self.with_iceberg_catalog = True
+        file_name = "docker_compose_iceberg_rest_catalog.yml"
+        if extra_parameters is not None and extra_parameters["docker_compose_file_name"] != "":
+            file_name = extra_parameters["docker_compose_file_name"]
         self.base_cmd.extend(
             [
                 "--file",
                 p.join(
-                    docker_compose_yml_dir, "docker_compose_iceberg_rest_catalog.yml"
+                    docker_compose_yml_dir, file_name
                 ),
             ]
         )
@@ -1532,7 +1535,7 @@ class ClickHouseCluster:
             "--env-file",
             instance.env_file,
             "--file",
-            p.join(docker_compose_yml_dir, "docker_compose_iceberg_rest_catalog.yml"),
+            p.join(docker_compose_yml_dir, file_name),
         )
         return self.base_iceberg_catalog_cmd
 
@@ -1761,6 +1764,7 @@ class ClickHouseCluster:
         use_docker_init_flag=False,
         clickhouse_start_cmd=CLICKHOUSE_START_COMMAND,
         with_dolor=False,
+        extra_parameters=None,
     ) -> "ClickHouseInstance":
         """Add an instance to the cluster.
 
@@ -1890,6 +1894,7 @@ class ClickHouseCluster:
             randomize_settings=randomize_settings,
             use_docker_init_flag=use_docker_init_flag,
             with_dolor=with_dolor,
+            extra_parameters=extra_parameters,
         )
 
         docker_compose_yml_dir = get_docker_compose_path()
@@ -2060,7 +2065,7 @@ class ClickHouseCluster:
         if with_iceberg_catalog and not self.with_iceberg_catalog:
             cmds.append(
                 self.setup_iceberg_catalog_cmd(
-                    instance, env_variables, docker_compose_yml_dir
+                    instance, env_variables, docker_compose_yml_dir, extra_parameters
                 )
             )
 
@@ -3863,6 +3868,7 @@ class ClickHouseInstance:
         randomize_settings=True,
         use_docker_init_flag=False,
         with_dolor=False,
+        extra_parameters=None,
     ):
         self.name = name
         self.base_cmd = cluster.base_cmd

--- a/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
+++ b/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
@@ -1,0 +1,367 @@
+import json
+import random
+import requests
+import time
+import uuid
+from datetime import datetime
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+from pyiceberg.catalog.rest import RestCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    DoubleType,
+    NestedField,
+    StringType,
+)
+
+from helpers.cluster import ClickHouseCluster
+from helpers.config_cluster import minio_secret_key, minio_access_key
+from helpers.test_tools import TSV, csv_compare
+
+BASE_URL_LOCAL = "http://localhost:8181/catalog"
+BASE_URL = "http://lakekeeper:8181/catalog"
+CATALOG_NAME = "demo"
+WAREHOUSE_NAME = "demo"
+
+DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\n(\n    `id` Nullable(Float64),\n    `data` Nullable(String)\n)\nENGINE = Iceberg('http://minio:9000/warehouse-rest/data/', 'minio', '[HIDDEN]')\n"
+
+
+def create_warehouse(minio_ip):
+    minio_endpoint = f"http://{minio_ip}:9000"
+
+    warehouse_data = {
+        "warehouse-name": "demo",
+        "project-id": "00000000-0000-0000-0000-000000000000",
+        "storage-profile": {
+            "type": "s3",
+            "bucket": "warehouse-rest",
+            "key-prefix": "",
+            "assume-role-arn": None,
+            "endpoint": minio_endpoint,
+            "region": "local-01",
+            "path-style-access": True,
+            "flavor": "minio",
+            "sts-enabled": True
+        },
+        "storage-credential": {
+            "type": "s3",
+            "credential-type": "access-key",
+            "aws-access-key-id": "minio",
+            "aws-secret-access-key": "ClickHouse_Minio_P@ssw0rd"
+        }
+    }
+
+    try:
+        response = requests.post(
+            "http://localhost:8181/management/v1/warehouse",
+            headers={"Content-Type": "application/json"},
+            json=warehouse_data,
+            timeout=30
+        )
+
+        if response.status_code == 201:
+            pass
+        elif response.status_code == 409:
+            pass
+        else:
+            response.raise_for_status()
+
+    except requests.exceptions.RequestException as e:
+        raise
+
+
+def load_catalog_impl(started_cluster):
+    minio_ip = started_cluster.get_instance_ip('minio')
+    s3_endpoint = f"http://{minio_ip}:9000"
+
+    return RestCatalog(
+        name="my_catalog",
+        warehouse=WAREHOUSE_NAME,
+        uri=BASE_URL_LOCAL,
+        token="dummy",
+        **{
+            "s3.endpoint": s3_endpoint,
+            "s3.access-key-id": minio_access_key,
+            "s3.secret-access-key": minio_secret_key,
+        },
+    )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node1",
+            main_configs=[],
+            user_configs=[],
+            stay_alive=True,
+            with_iceberg_catalog=True,
+            extra_parameters={
+                "docker_compose_file_name": "docker_compose_iceberg_lakekeeper_catalog.yml"
+            },
+        )
+
+        cluster.start()
+
+        time.sleep(15)
+
+        minio_ip = cluster.get_instance_ip('minio')
+        create_warehouse(minio_ip)
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_list_tables(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    namespace_prefix = f"clickhouse_{uuid.uuid4().hex[:8]}"
+    namespace_1 = f"{namespace_prefix}_testA"
+    namespace_2 = f"{namespace_prefix}_testB"
+    namespace_1_tables = ["tableA", "tableB"]
+    namespace_2_tables = ["tableC", "tableD"]
+
+    catalog = load_catalog_impl(started_cluster)
+
+    for namespace in [namespace_1, namespace_2]:
+        catalog.create_namespace((namespace,))
+
+    for namespace in [namespace_1, namespace_2]:
+        assert len(catalog.list_tables((namespace,))) == 0
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    tables_list = ""
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=DoubleType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+
+    for table in namespace_1_tables:
+        catalog.create_table(
+            (namespace_1, table),
+            schema=schema,
+            properties={"write.metadata.compression-codec": "none"},
+        )
+        if len(tables_list) > 0:
+            tables_list += "\n"
+        tables_list += f"{namespace_1}.{table}"
+
+    for table in namespace_2_tables:
+        catalog.create_table(
+            (namespace_2, table),
+            schema=schema,
+            properties={"write.metadata.compression-codec": "none"},
+        )
+        if len(tables_list) > 0:
+            tables_list += "\n"
+        tables_list += f"{namespace_2}.{table}"
+
+    # Verify tables were created via PyIceberg
+    assert len(catalog.list_tables((namespace_1,))) == 2
+    assert len(catalog.list_tables((namespace_2,))) == 2
+
+    assert (
+        tables_list
+        == node.query(
+            f"SELECT name FROM system.tables WHERE database = '{CATALOG_NAME}' and name ILIKE '{namespace_prefix}%' ORDER BY name"
+        ).strip()
+    )
+
+
+def test_select(started_cluster):
+    """Test select operations with Lakekeeper catalog"""
+
+    node = started_cluster.instances["node1"]
+
+    catalog = load_catalog_impl(started_cluster)
+
+    test_ref = f"test_select_{uuid.uuid4().hex[:8]}"
+    test_namespace = (f"{test_ref}_namespace",)
+    existing_namespaces = catalog.list_namespaces()
+
+    if test_namespace not in existing_namespaces:
+        catalog.create_namespace(test_namespace)
+
+    test_table_name = f"{test_ref}_table"
+    test_table_identifier = test_namespace + (test_table_name,)
+
+    try:
+        existing_tables = catalog.list_tables(namespace=test_namespace)
+
+        if test_table_identifier in existing_tables:
+            catalog.drop_table(test_table_identifier)
+    except Exception as e:
+        pass
+
+    simple_schema = Schema(
+        NestedField(field_id=1, name="id", field_type=DoubleType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+
+    table = catalog.create_table(
+        test_table_identifier,
+        schema=simple_schema,
+        properties={"write.metadata.compression-codec": "none"},
+    )
+
+    df = pd.DataFrame(
+        {
+            "id": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "data": ["hello", "world", "from", "lakekeeper", "test"],
+        }
+    )
+
+    pa_df = pa.Table.from_pandas(df)
+
+    table.append(pa_df)
+
+    scan_result = table.scan().to_pandas()
+
+    assert len(scan_result) == 5
+    assert list(scan_result["id"]) == [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert list(scan_result["data"]) == ["hello", "world", "from", "lakekeeper", "test"]
+
+    namespaces = catalog.list_namespaces()
+
+    tables = catalog.list_tables(namespace=test_namespace)
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    assert int(node.query(f"SELECT count(*) FROM {CATALOG_NAME}.`{test_namespace[0]}.{test_table_name}`")) == len(scan_result)
+
+    result = node.query(f"SELECT id, data FROM {CATALOG_NAME}.`{test_namespace[0]}.{test_table_name}` ORDER BY id FORMAT TSV")
+    expected = TSV("""
+1   hello
+2	world
+3	from
+4	lakekeeper
+5	test
+""")
+    assert csv_compare(result, expected), f"got\n{result}\nwant\n{expected}"
+
+
+
+
+def create_clickhouse_iceberg_database(
+    started_cluster, node, name, additional_settings={}
+):
+    settings = {
+        "catalog_type": "rest",
+        "warehouse": "demo",
+        "storage_endpoint": "http://minio:9000/warehouse-rest",
+    }
+
+    settings.update(additional_settings)
+
+    node.query(
+        f"""
+DROP DATABASE IF EXISTS {name};
+SET allow_experimental_database_iceberg=true;
+CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
+SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
+    """
+    )
+    show_result = node.query(f"SHOW DATABASE {name}")
+    assert minio_secret_key not in show_result
+    assert "HIDDEN" in show_result
+
+
+def test_hide_sensitive_info(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_hide_sensitive_info_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    namespace = (root_namespace,)
+    catalog = load_catalog_impl(started_cluster)
+
+    existing_namespaces = catalog.list_namespaces()
+    if namespace not in existing_namespaces:
+        catalog.create_namespace(namespace)
+
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=DoubleType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    catalog.create_table(
+        namespace + (table_name,),
+        schema=schema,
+        properties={"write.metadata.compression-codec": "none"},
+    )
+
+    create_clickhouse_iceberg_database(
+        started_cluster,
+        node,
+        CATALOG_NAME,
+        additional_settings={"catalog_credential": "SECRET_1"},
+    )
+    show_result = node.query(f"SHOW CREATE DATABASE {CATALOG_NAME}")
+    assert "SECRET_1" not in show_result
+    assert minio_secret_key not in show_result
+
+    create_clickhouse_iceberg_database(
+        started_cluster,
+        node,
+        CATALOG_NAME,
+        additional_settings={"auth_header": "SECRET_2"},
+    )
+    show_result = node.query(f"SHOW CREATE DATABASE {CATALOG_NAME}")
+    assert "SECRET_2" not in show_result
+    assert minio_secret_key not in show_result
+
+def test_tables_with_same_location(started_cluster):
+
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_tables_with_same_location_{uuid.uuid4().hex[:8]}"
+    namespace = (f"{test_ref}_namespace",)
+    catalog = load_catalog_impl(started_cluster)
+
+    table_name = f"{test_ref}_table"
+    table_name_2 = f"{test_ref}_table_2"
+
+    existing_namespaces = catalog.list_namespaces()
+    if namespace not in existing_namespaces:
+        catalog.create_namespace(namespace)
+
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=DoubleType(), required=False),
+        NestedField(field_id=2, name="symbol", field_type=StringType(), required=False),
+    )
+    table = catalog.create_table(
+        namespace + (table_name,),
+        schema=schema,
+        properties={"write.metadata.compression-codec": "none"},
+    )
+    table_2 = catalog.create_table(
+        namespace + (table_name_2,),
+        schema=schema,
+        properties={"write.metadata.compression-codec": "none"},
+    )
+
+    df1 = pd.DataFrame({"id": [1.0, 2.0, 3.0], "symbol": ["aaa", "aaa", "aaa"]})
+    df2 = pd.DataFrame({"id": [1.0, 2.0, 3.0], "symbol": ["bbb", "bbb", "bbb"]})
+
+    table.append(pa.Table.from_pandas(df1))
+    table_2.append(pa.Table.from_pandas(df2))
+
+    scan_result_1 = table.scan().to_pandas()
+    scan_result_2 = table_2.scan().to_pandas()
+    assert len(scan_result_1) == 3
+    assert len(scan_result_2) == 3
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    assert 'aaa\naaa\naaa' == node.query(
+        f"SELECT symbol FROM {CATALOG_NAME}.`{namespace[0]}.{table_name}`"
+    ).strip()
+    assert 'bbb\nbbb\nbbb' == node.query(
+        f"SELECT symbol FROM {CATALOG_NAME}.`{namespace[0]}.{table_name_2}`"
+    ).strip()
+


### PR DESCRIPTION
This pr re introduces the changes of the pr : https://github.com/ClickHouse/ClickHouse/pull/80562/files
which was reverted due to flaky container registry issue

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This pr fixes the metadata resolution when querying iceberg tables through rest catalog.
...

The [iceberg-rest catalog spec](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml) specifies config api `/v1/config` endpoint which returns the list of all catalog configuration settings.

Within this response is a field config which stores the object store details configured for the catalog.

Sample response from reference implementation of iceberg-rest spec (Empty): 
```json
{
"config": {

  }
}
```
The same however is populated in case of other rest spec implementation such as [apache lakekeeper](https://github.com/lakekeeper/lakekeeper).
```json
{
"config": {
    "region": "us-east-01",
    "s3.region": "us-east-01",
    "s3.path-style-access": "true",
    "client.region": "us-east-01",
    "s3.endpoint": "http://minio:9000/",
    "s3.remote-signing-enabled": "true"
  }
}
```

Clickhouse persists these details in the private fields of [TableMetaData](https://github.com/ClickHouse/ClickHouse/blob/master/src/Databases/DataLake/ICatalog.h#L87) class.

These fields are then used while [determining the data location](https://github.com/ClickHouse/ClickHouse/blob/master/src/Databases/DataLake/ICatalog.cpp#L86).

In cases where s3.endpoint is specified, the metadata_location and data_location do not share the same prefix (metadata_location is prefixed with s3://, while data location in this case is prefixed with http:// or https://) 
This leads to an incorrect object store path being created, which results in failure of fetching the metadata files from object store.

Full source code [here](https://github.com/ClickHouse/ClickHouse/blob/master/src/Databases/DataLake/DatabaseDataLake.cpp#L401C5-L416C6):

```cpp
if (auto table_specific_properties = table_metadata.getDataLakeSpecificProperties();
        table_specific_properties.has_value())
    {
        auto metadata_location = table_specific_properties->iceberg_metadata_file_location;
        if (!metadata_location.empty())
        {
            const auto data_location = table_metadata.getLocation();
            if (metadata_location.starts_with(data_location))
            {
                size_t remove_slash = metadata_location[data_location.size()] == '/' ? 1 : 0;
                metadata_location = metadata_location.substr(data_location.size() + remove_slash);
            }
        }

        (*storage_settings)[DB::StorageObjectStorageSetting::iceberg_metadata_file_path] = metadata_location;
    }
```

This results in errors such as the following: 

```shell
Received exception from server (version 25.4.1):
Code: 499. DB::Exception: Received from localhost:9000. DB::Exception: The specified key does not exist.: while reading key: 01969b10-840a-7d71-ac48-3299675342e1/01969b10-8d81-7cd2-bec4-65f373e1544d/s3://examples/01969b10-840a-7d71-ac48-3299675342e1/01969b10-8d81-7cd2-bec4-65f373e1544d/metadata/00001-01969b10-b3e2-7aa2-adf9-2962fe431bb2.gz.metadata.json, from bucket: examples. (S3_ERROR)
```

The above pr aims at fixing this path resolution.

It removes the s3 prefixes and http: / https:// prefixes and then compares data_location to metadata_location, to ensure that wrong s3 paths are not created downstream.