### PR TITLE
Integration tests: add filelock for tests with shared networking

### DIFF
--- a/ci/docker/integration/runner/requirements.txt
+++ b/ci/docker/integration/runner/requirements.txt
@@ -111,3 +111,4 @@ tzlocal==2.1
 urllib3==2.2.2
 websocket-client==1.8.0
 wheel==0.46.1
+filelock==3.18.0


### PR DESCRIPTION
Fix error `Pool overlaps with other one on this address space` by using lock file for parallel tests which use same subnet. For details see usages of `tests/integration/compose/docker_compose_net.yml`

Example report
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3d9fffd8d7e67632c01a17cab33e726fb7a6c34d&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
