### PR TITLE
Fix rare crash in async inserts

### DIFF
--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -129,14 +129,17 @@ AsynchronousInsertQueue::InsertQuery::InsertQuery(
     }
 
     setting_changes = settings->changes();
-    for (auto it = setting_changes.begin(); it != setting_changes.end(); ++it)
+    for (auto it = setting_changes.begin(); it != setting_changes.end();)
     {
         if (settings_to_skip.contains(it->name))
+        {
             it = setting_changes.erase(it);
+        }
         else
         {
             siphash.update(it->name);
             applyVisitor(FieldVisitorHash(siphash), it->value);
+            ++it;
         }
     }
 

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -62,8 +62,6 @@ public:
     /// because all tables may be already unloaded when we destroy AsynchronousInsertQueue
     void flushAndShutdown();
 
-private:
-
     struct InsertQuery
     {
     public:
@@ -93,6 +91,7 @@ private:
         std::vector<SettingChange> setting_changes;
     };
 
+private:
     struct DataChunk : public std::variant<String, Block>
     {
         using std::variant<String, Block>::variant;

--- a/src/Interpreters/tests/gtest_async_insert_key.cpp
+++ b/src/Interpreters/tests/gtest_async_insert_key.cpp
@@ -1,0 +1,49 @@
+#include <Core/Settings.h>
+#include <Interpreters/AsynchronousInsertQueue.h>
+#include <Parsers/ParserInsertQuery.h>
+#include <Parsers/parseQuery.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+TEST(AsyncInsertKey, SettingsChanges)
+{
+    String query_str = "INSERT INTO test (a, b, c) VALUES (1, 2, 3)";
+    ParserInsertQuery parser(query_str.data() + query_str.size(), false);
+    ASTPtr query = parseQuery(parser, query_str, DBMS_DEFAULT_MAX_QUERY_SIZE, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+
+    Settings settings1;
+    Settings settings2;
+    Settings settings3;
+    Settings settings4;
+
+    settings1.set("async_insert", 1);
+    settings1.set("log_comment", "test1");
+    settings1.set("insert_deduplication_token", "token1");
+
+    settings2.set("async_insert", 1);
+    settings2.set("log_comment", "test2");
+    settings2.set("insert_deduplication_token", "token2");
+
+    settings3.set("async_insert", 1);
+    settings3.set("async_insert_busy_timeout", 100);
+    settings3.set("log_comment", "test3");
+    settings3.set("insert_deduplication_token", "token3");
+
+    settings4.set("async_insert", 1);
+    settings4.set("async_insert_busy_timeout", 200);
+    settings4.set("log_comment", "test3");
+    settings4.set("insert_deduplication_token", "token3");
+
+    auto kind = AsynchronousInsertQueueDataKind::Parsed;
+
+    AsynchronousInsertQueue::InsertQuery key1(query, {}, {}, settings1, kind);
+    AsynchronousInsertQueue::InsertQuery key2(query, {}, {}, settings2, kind);
+    AsynchronousInsertQueue::InsertQuery key3(query, {}, {}, settings3, kind);
+    AsynchronousInsertQueue::InsertQuery key4(query, {}, {}, settings4, kind);
+
+    EXPECT_EQ(key1, key2);
+    EXPECT_NE(key1, key3);
+    EXPECT_NE(key2, key3);
+    EXPECT_NE(key3, key4);
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed rare crash in asynchronous inserts that change settings `log_comment` or `insert_deduplication_token`

