### PR TITLE
Function `nowInBlock64`: Fix bug #85534

### DIFF
--- a/src/Functions/nowInBlock.cpp
+++ b/src/Functions/nowInBlock.cpp
@@ -2,7 +2,9 @@
 #include <Columns/ColumnsDateTime.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
 #include <Functions/extractTimeZoneFromFunctionArguments.h>
 #include <Interpreters/Context.h>
@@ -48,11 +50,12 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        if (arguments.size() > 1)
-            throw Exception(ErrorCodes::TOO_MANY_ARGUMENTS_FOR_FUNCTION, "Function {} should have 0 or 1 arguments", getName());
+        FunctionArgumentDescriptors mandatory_args{};
+        FunctionArgumentDescriptors optional_args{
+            {"timezone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"}
+        };
 
-        if (arguments.size() == 1 && !isStringOrFixedString(arguments[0].type))
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "1st argument of function {} should be String or FixedString", getName());
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         if (arguments.size() == 1)
             return std::make_shared<DataTypeDateTime>(extractTimeZoneNameFromFunctionArguments(arguments, 0, 0, allow_nonconst_timezone_arguments));

--- a/src/Functions/nowInBlock.cpp
+++ b/src/Functions/nowInBlock.cpp
@@ -17,12 +17,6 @@ namespace Setting
     extern const SettingsBool allow_nonconst_timezone_arguments;
 }
 
-namespace ErrorCodes
-{
-    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
-}
-
 namespace
 {
 

--- a/src/Functions/nowInBlock64.cpp
+++ b/src/Functions/nowInBlock64.cpp
@@ -13,7 +13,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
 }
 
 namespace

--- a/src/Functions/nowInBlock64.cpp
+++ b/src/Functions/nowInBlock64.cpp
@@ -37,22 +37,22 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
+        FunctionArgumentDescriptors mandatory_args{
+        };
+        FunctionArgumentDescriptors optional_args{
+            {"scale", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isInteger), isColumnConst, "const (U)Int*"},
+            {"timezone", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"}
+        };
+
+        validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
+
         if (arguments.empty())
             return std::make_shared<DataTypeDateTime64>(DataTypeDateTime64::default_scale);
-
-        if (arguments.size() > 2)
-            throw Exception(ErrorCodes::TOO_MANY_ARGUMENTS_FOR_FUNCTION, "Function {} should have 0, 1 or 2 arguments", getName());
-
-        if (!isInteger(arguments[0].type))
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "1st argument of function {} should be (U)Int*", getName());
 
         auto scale = static_cast<UInt32>(arguments[0].column->get64(0));
 
         if (arguments.size() == 1)
             return std::make_shared<DataTypeDateTime64>(scale);
-
-        if (!isStringOrFixedString(arguments[1].type))
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "2nd argument of function {} should be String or FixedString", getName());
 
         return std::make_shared<DataTypeDateTime64>(scale, extractTimeZoneNameFromFunctionArguments(arguments, 1, 1, false));
     }

--- a/tests/queries/0_stateless/02372_nowInBlock.sql
+++ b/tests/queries/0_stateless/02372_nowInBlock.sql
@@ -3,4 +3,4 @@ SET max_rows_to_read = 0, max_bytes_to_read = 0;
 SELECT count() FROM (SELECT DISTINCT nowInBlock(), nowInBlock('Pacific/Pitcairn') FROM system.numbers LIMIT 2);
 SELECT nowInBlock(1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT nowInBlock(NULL) IS NULL;
-SELECT nowInBlock('UTC', 'UTC'); -- { serverError TOO_MANY_ARGUMENTS_FOR_FUNCTION }
+SELECT nowInBlock('UTC', 'UTC'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/03567_nowInBlock64.sql
+++ b/tests/queries/0_stateless/03567_nowInBlock64.sql
@@ -1,11 +1,14 @@
 SET max_rows_to_read = 0, max_bytes_to_read = 0;
 
-SELECT nowInBlock64(3, 'America/Sao_Paulo', 3); --{serverError TOO_MANY_ARGUMENTS_FOR_FUNCTION}
-SELECT nowInBlock64(10); --{serverError ARGUMENT_OUT_OF_BOUND}
-SELECT nowInBlock64('string'); --{serverError ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT nowInBlock64(3, true); --{serverError ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT nowInBlock64(3, 3); --{serverError ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT nowInBlock64(3, 'string'); --{serverError BAD_ARGUMENTS}
+SELECT nowInBlock64(3, 'America/Sao_Paulo', 3); --{ serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT nowInBlock64(10); --{ serverError ARGUMENT_OUT_OF_BOUND}
+SELECT nowInBlock64('string'); --{ serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT nowInBlock64(3, true); --{ serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT nowInBlock64(3, 3); --{ serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT nowInBlock64(3, 'string'); --{ serverError BAD_ARGUMENTS }
 
 SELECT count() FROM (SELECT DISTINCT nowInBlock64(), nowInBlock64(3), nowInBlock64(3, 'Pacific/Pitcairn') FROM system.numbers LIMIT 3);
 SELECT nowInBlock64(NULL) IS NULL;
+
+-- Bug 85534
+SELECT nowInBlock64(materialize(toUInt128(3)), 'America/Sao_Paulo') FORMAT Null; -- { serverError ILLEGAL_COLUMN }


### PR DESCRIPTION
Resolves #85534

Fixes a bad pointer access in [new function](https://github.com/ClickHouse/ClickHouse/pull/84178) `nowInBlock64`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)