### PR TITLE
[Not For Merge] Add various profile events for tracking memory allocations

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -122,6 +122,9 @@ namespace ProfileEvents
 {
     extern const Event QueryMemoryLimitExceeded;
     extern const Event PageCacheOvercommitResize;
+
+    extern const Event MemoryTrackerAllocationsNested;
+    extern const Event MemoryTrackerDeallocationsNested;
 }
 
 using namespace std::chrono_literals;
@@ -234,6 +237,8 @@ void MemoryTracker::debugLogBigAllocationWithoutCheck(Int64 size [[maybe_unused]
 
 AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryTracker * query_tracker, double _sample_probability)
 {
+    ProfileEvents::increment(ProfileEvents::MemoryTrackerAllocationsNested);
+
     if (size < 0)
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Negative size ({}) is passed to MemoryTracker. It is a bug.", size);
 
@@ -496,6 +501,8 @@ bool MemoryTracker::updatePeak(Int64 will_be, bool log_memory_usage)
 
 AllocationTrace MemoryTracker::free(Int64 size, double _sample_probability)
 {
+    ProfileEvents::increment(ProfileEvents::MemoryTrackerDeallocationsNested);
+
     if (_sample_probability < 0)
         _sample_probability = sample_probability;
 

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -62,6 +62,12 @@
     M(PageCacheWeightLost, "Number of bytes evicted from the userspace page cache", ValueType::Bytes) \
     M(PageCacheResized, "Number of times the userspace page cache was auto-resized (typically happens a few times per second, controlled by memory_worker_period_ms).", ValueType::Number) \
     M(PageCacheOvercommitResize, "Number of times the userspace page cache was auto-resized to free memory during a memory allocation.", ValueType::Number) \
+    M(Allocations, "Total number of allocations (malloc/new)", ValueType::Number) \
+    M(Deallocations, "Total number of deallocations (free/delete)", ValueType::Number) \
+    M(MemoryTrackerAllocations, "Total number of allocations that flushed to server/query levels (only these allocations can fail the query with MEMORY_LIMIT_EXCEEDED)", ValueType::Number) \
+    M(MemoryTrackerDeallocations, "Total number of deallocations that flushed to server (MemoryTracking metric)/query levels", ValueType::Number) \
+    M(MemoryTrackerAllocationsNested, "Total number of allocations that flushed, including nested trackers", ValueType::Number) \
+    M(MemoryTrackerDeallocationsNested, "Total number of deallocations that flushed, including nested trackers", ValueType::Number) \
     M(PageCacheReadBytes, "Number of bytes read from userspace page cache.", ValueType::Bytes) \
     M(MMappedFileCacheHits, "Number of times a file has been found in the MMap cache (for the 'mmap' read_method), so we didn't have to mmap it again.", ValueType::Number) \
     M(MMappedFileCacheMisses, "Number of times a file has not been found in the MMap cache (for the 'mmap' read_method), so we had to mmap it again.", ValueType::Number) \


### PR DESCRIPTION
Note, this will slows down queries with lots of allocations, this is not the typical ClickHouse case, but i.e. rapidjson will be slowed down (~+10%).

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add various profile events for tracking memory allocations