### PR TITLE
Fix analyzer - only prevent cast for second argument of IN functions.

### DIFF
--- a/src/Analyzer/FunctionNode.cpp
+++ b/src/Analyzer/FunctionNode.cpp
@@ -249,13 +249,6 @@ ASTPtr FunctionNode::toASTImpl(const ConvertToASTOptions & options) const
     if (function_name == "_CAST" && !argument_nodes.empty() && argument_nodes[0]->getNodeType() == QueryTreeNodeType::CONSTANT)
         new_options.add_cast_for_constants = false;
 
-    /// Avoid cast for `IN tuple(...)` expression.
-    /// Tuples could be quite big, and adding a type may significantly increase query size.
-    /// It should be safe because set type for `column IN tuple` is deduced from `column` type.
-    if (isNameOfInFunction(function_name) && argument_nodes.size() > 1 && argument_nodes[1]->getNodeType() == QueryTreeNodeType::CONSTANT
-        && !static_cast<const ConstantNode *>(argument_nodes[1].get())->hasSourceExpression())
-        new_options.add_cast_for_constants = false;
-
     const auto & parameters = getParameters();
     if (!parameters.getNodes().empty())
     {
@@ -263,7 +256,25 @@ ASTPtr FunctionNode::toASTImpl(const ConvertToASTOptions & options) const
         function_ast->parameters = function_ast->children.back();
     }
 
-    function_ast->children.push_back(arguments.toAST(new_options));
+    /// We have to avoid cast for second argument of `IN` functions - it can be a quite big
+    /// tuple, and adding a type may significantly increase query size.
+    /// It should be safe because set type for `column IN tuple` is deduced from `column` type.
+    if (isNameOfInFunction(function_name) && argument_nodes.size() > 1 && argument_nodes[1]->getNodeType() == QueryTreeNodeType::CONSTANT
+        && !static_cast<const ConstantNode *>(argument_nodes[1].get())->hasSourceExpression())
+    {
+        auto expression_list_ast = std::make_shared<ASTExpressionList>();
+
+        expression_list_ast->children.push_back(argument_nodes[0]->toAST(new_options));
+
+        auto arg_options = new_options;
+        arg_options.add_cast_for_constants = false;
+        expression_list_ast->children.push_back(argument_nodes[1]->toAST(arg_options));
+
+        function_ast->children.push_back(expression_list_ast);
+    }
+    else
+        function_ast->children.push_back(arguments.toAST(new_options));
+
     function_ast->arguments = function_ast->children.back();
 
     auto window_node = getWindowNode();

--- a/tests/queries/0_stateless/03593_remote_map_in.reference
+++ b/tests/queries/0_stateless/03593_remote_map_in.reference
@@ -1,0 +1,4 @@
+value1	0
+value2	0
+value1	0
+value2	0

--- a/tests/queries/0_stateless/03593_remote_map_in.sql
+++ b/tests/queries/0_stateless/03593_remote_map_in.sql
@@ -1,0 +1,6 @@
+SET enable_analyzer = 1;
+
+SELECT
+    arrayJoin(arrayMap(tag -> (map('a', 'value1', 'b', 'value2')[tag]), ['a', 'b'])) AS path,
+    path IN ['Uncategorized'] AS in_category
+FROM remote('127.0.0.{1,2}', system.one);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prevent unnecessary optimization of the first argument of `IN` functions sometimes resulting in error when array mapping is used.

closes #80887

Explanation: since column containing map internally presented as an array of tuples we cannot rely on its type with `arrayElement` function because it expects different argument for map than for array.