### PR TITLE
Text index: add logging for writing/reading of segment

### DIFF
--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -530,10 +530,10 @@ GinIndexStore::Statistics GinIndexStore::getStatistics()
     return {
         .num_terms = current_postings.size(),
         .current_size = current_size,
-        .metadata_file_size = metadata_file_stream ? metadata_file_stream->offset() : 0,
-        .bloom_filter_file_size = bloom_filter_file_stream ? bloom_filter_file_stream->offset() : 0,
-        .dictionary_file_size = dict_file_stream ? dict_file_stream->offset() : 0,
-        .posting_lists_file_size = postings_file_stream ? postings_file_stream->offset() : 0,
+        .metadata_file_size = metadata_file_stream ? metadata_file_stream->count() : 0,
+        .bloom_filter_file_size = bloom_filter_file_stream ? bloom_filter_file_stream->count() : 0,
+        .dictionary_file_size = dict_file_stream ? dict_file_stream->count() : 0,
+        .posting_lists_file_size = postings_file_stream ? postings_file_stream->count() : 0,
     };
 }
 
@@ -784,7 +784,7 @@ void GinIndexStoreDeserializer::prepareSegmentForReading(UInt32 segment_id)
         "Done reading the bloom filter of text index '{}' segment id {}: size = {}",
         store->getName(),
         segment_id,
-        ReadableSize(bloom_filter_file_stream->offset() - seg_dict->bloom_filter_start_offset));
+        ReadableSize(bloom_filter_file_stream->count() - seg_dict->bloom_filter_start_offset));
 }
 
 void GinIndexStoreDeserializer::readSegmentFST(UInt32 segment_id, GinSegmentDictionaryPtr segment_dictionary)
@@ -834,7 +834,7 @@ void GinIndexStoreDeserializer::readSegmentFST(UInt32 segment_id, GinSegmentDict
         "Done reading the dictionary (FST) of text index '{}' segment id {}: size = {}",
         store->getName(),
         segment_id,
-        ReadableSize(dict_file_stream->offset() - segment_dictionary->dict_start_offset));
+        ReadableSize(dict_file_stream->count() - segment_dictionary->dict_start_offset));
 }
 
 GinSegmentedPostingsListContainer GinIndexStoreDeserializer::readSegmentedPostingsLists(const String & term)
@@ -881,7 +881,7 @@ GinSegmentedPostingsListContainer GinIndexStoreDeserializer::readSegmentedPostin
             term,
             store->getName(),
             segment_id,
-            ReadableSize(postings_file_stream->offset() - seg_dict.second->postings_start_offset));
+            ReadableSize(postings_file_stream->count() - seg_dict.second->postings_start_offset));
     }
     return container;
 }

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -209,28 +209,29 @@ public:
         v1 = 1, /// Initial version, supports adaptive compression
     };
 
-    struct Statistics
+    class Statistics
     {
+    public:
+        explicit Statistics(const GinIndexStore & store);
+
+        String toString() const;
+
+        Statistics operator-(const Statistics & other)
+        {
+            metadata_file_size -= other.metadata_file_size;
+            bloom_filter_file_size -= other.bloom_filter_file_size;
+            dictionary_file_size -= other.dictionary_file_size;
+            posting_lists_file_size -= other.posting_lists_file_size;
+            return *this;
+        }
+
+    private:
         size_t num_terms;
         size_t current_size;
         size_t metadata_file_size;
         size_t bloom_filter_file_size;
         size_t dictionary_file_size;
         size_t posting_lists_file_size;
-
-        Statistics diff(const Statistics & other) const
-        {
-            return {
-                .num_terms = num_terms,
-                .current_size = current_size,
-                .metadata_file_size = metadata_file_size - other.metadata_file_size,
-                .bloom_filter_file_size = bloom_filter_file_size - other.bloom_filter_file_size,
-                .dictionary_file_size = dictionary_file_size - other.dictionary_file_size,
-                .posting_lists_file_size = posting_lists_file_size - other.posting_lists_file_size,
-            };
-        }
-
-        String toString() const;
     };
 
     /// Container for all term's Gin Index Postings List Builder


### PR DESCRIPTION
Add trace logs while writing and reading of the text index segment.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)