### PR TITLE
fix HTTP with multipart

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -270,7 +270,7 @@ void HTTPHandler::processQuery(
 
         if (has_external_data)
         {
-            /// For external data we have unspecified parametrs which literally are {'<temp_table_name>_format', '<temp_table_name>_types', '<temp_table_name>_structure'}.
+            /// For external data we have unspecified parameters which literally are {'<temp_table_name>_format', '<temp_table_name>_types', '<temp_table_name>_structure'}.
             /// That parameters are not supposed to be used in the query as a settings. They have to be skipped.
             /// But we could not just skip all parameters with suffixes '_format', '_types', '_structure',
             /// because some of them are used in the query as a settings, like 'date_time_input_format',

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1,5 +1,6 @@
 #include <Server/HTTPHandler.h>
 
+#include <Access/AccessControl.h>
 #include <Compression/CompressedReadBuffer.h>
 #include <Compression/CompressedWriteBuffer.h>
 #include <Core/ExternalTable.h>
@@ -267,16 +268,17 @@ void HTTPHandler::processQuery(
         if (reserved_param_names.contains(name))
             return true;
 
-        /// For external data we also want settings.
         if (has_external_data)
         {
-            /// Skip unneeded parameters to avoid confusing them later with context settings or query parameters.
-            /// It is a bug and ambiguity with `date_time_input_format` and `low_cardinality_allow_in_native_format` formats/settings.
+            /// For external data we have unspecified parametrs which literally are {'<temp_table_name>_format', '<temp_table_name>_types', '<temp_table_name>_structure'}.
+            /// That parameters are not supposed to be used in the query as a settings. They have to be skipped.
+            /// But we could not just skip all parameters with suffixes '_format', '_types', '_structure',
+            /// because some of them are used in the query as a settings, like 'date_time_input_format',
             static const Names reserved_param_suffixes = {"_format", "_types", "_structure"};
             for (const String & suffix : reserved_param_suffixes)
             {
                 if (endsWith(name, suffix))
-                    return true;
+                    return (!context->getAccessControl().isSettingNameAllowed(name));
             }
         }
 

--- a/tests/queries/0_stateless/03594_http_settings_when_multipart.reference
+++ b/tests/queries/0_stateless/03594_http_settings_when_multipart.reference
@@ -1,0 +1,2 @@
+{"name":"first_row","doc":{"createTime":"2024-07-09 21:06:05","id":"id_first_row"}}
+{"name":"second_row","doc":{"createTime":"2024-07-09 21:06:05","id":"id_second_row"}}

--- a/tests/queries/0_stateless/03594_http_settings_when_multipart.sh
+++ b/tests/queries/0_stateless/03594_http_settings_when_multipart.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+CLICKHOUSE_URL="${CLICKHOUSE_URL}&session_timezone=Asia/Novosibirsk"
+CLICKHOUSE_URL="${CLICKHOUSE_URL}&input_format_binary_read_json_as_string=1"
+CLICKHOUSE_URL="${CLICKHOUSE_URL}&date_time_input_format=best_effort"
+
+
+$CLICKHOUSE_CURL_COMMAND -sS $CLICKHOUSE_URL --data-binary @- <<EOF
+    CREATE OR REPLACE TABLE 03694_table (
+        name String,
+        doc JSON (
+            createTime DateTime('Asia/Novosibirsk'),
+            id String))
+    ENGINE = MergeTree
+    ORDER BY (name);
+EOF
+
+(
+    echo -ne '--multipart-from-data-boundary'
+    echo -ne '\r\n'
+    echo -ne 'Content-Type: text/plain; charset=utf-8'
+    echo -ne '\r\n'
+    echo -ne 'Content-Disposition: form-data; name=query'
+    echo -ne '\r\n'
+    echo -ne '\r\n'
+    echo -ne 'INSERT INTO 03694_table values'
+    echo -ne "('first_row', '{\"createTime\":\"2024-07-09T14:06:05.083Z\", \"id\": \"id_first_row\"}')"
+    echo -ne '\r\n'
+    echo -ne '--multipart-from-data-boundary--'
+    echo -ne '\r\n'
+) | \
+$CLICKHOUSE_CURL_COMMAND -sS \
+    $CLICKHOUSE_URL \
+    -H "Accept: application/json, text/csv, application/octet-stream" \
+    -H "Accept-Encoding: gzip, deflate" \
+    -H "Content-Type: multipart/form-data; boundary=multipart-from-data-boundary" \
+    --data-binary @-
+
+$CLICKHOUSE_CURL_COMMAND -sS \
+    $CLICKHOUSE_URL \
+    --data-binary @- <<EOF
+    INSERT INTO 03694_table VALUES ('second_row', '{"createTime":"2024-07-09T14:06:05.083Z", "id": "id_second_row"}')
+EOF
+
+$CLICKHOUSE_CURL_COMMAND -sS \
+    $CLICKHOUSE_URL \
+    --data-binary @- <<EOF
+SELECT * FROM 03694_table ORDER BY name FORMAT JSONEachRow
+EOF


### PR DESCRIPTION
parameters like `date_time_input_format` have been just ignored when HTTP with multipart 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
parameters like `date_time_input_format` have been just ignored when HTTP with multipart

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
