### PR TITLE
tests: fix test_async_logger_metrics flakiness

### DIFF
--- a/tests/integration/test_async_logger_metrics/test.py
+++ b/tests/integration/test_async_logger_metrics/test.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from concurrent.futures import ThreadPoolExecutor
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
@@ -17,6 +18,8 @@ node = cluster.add_instance(
 def start_cluster():
     try:
         cluster.start()
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            list(executor.submit(node.query, "select 1") for _ in range(100))
         yield cluster
     finally:
         cluster.shutdown()


### PR DESCRIPTION
CI sometimes fails [1] due to no dropped messages for textlog.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85440&sha=latest&name_0=PR&name_1=Integration+tests+%28arm_binary%2C+distributed+plan%2C+2%2F4%29

Add more logs to ensure that there will be drops.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)