### PR TITLE
Docs: transfer rounding function documentation to source code

### DIFF
--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -117,7 +117,7 @@ If the input value has equal distance to two neighboring numbers, the function u
         FunctionDocumentation::Syntax syntax = "round(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Integer. Defaults to `0`.", {"`Integer`"}}
+            {"[, N]", "Optional. The number of decimal places to round to. Integer. Defaults to `0`.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -10,7 +10,7 @@ REGISTER_FUNCTION(Round)
     {
         FunctionDocumentation::Description description = R"(
 Returns the largest rounded number less than or equal `x`.
-A rounded number is a multiple of 1 / 10 * N, or the nearest number of the appropriate data type if 1 / 10 * N isn't exact.
+A rounded number is a multiple of `1 / 10 * N`, or the nearest number of the appropriate data type if `1 / 10 * N` isn't exact.
 
 Integer arguments may be rounded with negative `N` argument, with non-negative `N` the function returns `x`, i.e. does nothing.
 
@@ -18,15 +18,31 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
 )";
         FunctionDocumentation::Syntax syntax = "floor(x[, N])";
         FunctionDocumentation::Arguments arguments = {
-            {"x", "The value to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
-            {"N", "The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"`(U)Int*`"}}
+            {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
+            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
-            {"Basic usage", "SELECT floor(123.45, 1) AS rounded", "┌─rounded─┐\n│   123.4 │\n└─────────┘"},
-            {"Negative precision", "SELECT floor(123.45, -1)", "┌─rounded─┐\n│     120 │\n└─────────┘"}
+        {
+            "Basic usage",
+            "SELECT floor(123.45, 1) AS rounded",
+            R"(
+┌─rounded─┐
+│   123.4 │
+└─────────┘
+            )"
+        },
+        {
+            "Negative precision",
+            "SELECT floor(123.45, -1)",
+            R"(
+┌─floor(123.45, -1)─┐
+│               120 │
+└───────────────────┘
+            )"
+        }
         };
-        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
         factory.registerFunction<FunctionFloor>(documentation, FunctionFactory::Case::Insensitive);
@@ -34,16 +50,35 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
 
     {
         FunctionDocumentation::Description description = R"(
-Like `floor` but returns the smallest rounded number greater than or equal `x`.
+Like [`floor`](#floor) but returns the smallest rounded number greater than or equal `x`.
 )";
         FunctionDocumentation::Syntax syntax = "ceiling(x[, N])";
         FunctionDocumentation::Arguments arguments = {
-            {"x", "The value to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
-            {"N", "The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"`(U)Int*`"}}
+            {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
+            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
-        FunctionDocumentation::Examples examples = {};
-        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
+        FunctionDocumentation::Examples examples = {
+            {
+                "Basic usage",
+                "SELECT ceiling(123.45, 1) AS rounded",
+                R"(
+┌─rounded─┐
+│   123.5 │
+└─────────┘
+            )"
+            },
+            {
+                "Negative precision",
+                "SELECT ceiling(123.45, -1)",
+                R"(
+┌─ceiling(123.45, -1)─┐
+│                 130 │
+└─────────────────────┘
+            )"
+            }
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
         factory.registerFunction<FunctionCeil>(documentation, FunctionFactory::Case::Insensitive);
@@ -51,18 +86,18 @@ Like `floor` but returns the smallest rounded number greater than or equal `x`.
 
     {
         FunctionDocumentation::Description description = R"(
-Like `floor` but returns the rounded number with largest absolute value that has an absolute value less than or equal to `x`'s.
+Like [`floor`](#floor) but returns the rounded number with largest absolute value that has an absolute value less than or equal to `x`'s.
 )";
         FunctionDocumentation::Syntax syntax = "truncate(x[, N])";
         FunctionDocumentation::Arguments arguments = {
-            {"x", "The value to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
-            {"N", "The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"`(U)Int*`"}}
+            {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
+            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
             {"Basic usage", "SELECT truncate(123.499, 1) AS res;", "┌───res─┐\n│ 123.4 │\n└───────┘"}
         };
-        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
         factory.registerFunction<FunctionTrunc>(documentation, FunctionFactory::Case::Insensitive);
@@ -70,22 +105,46 @@ Like `floor` but returns the rounded number with largest absolute value that has
 
     {
         FunctionDocumentation::Description description = R"(
-Rounds a value to a specified number of decimal places.
+Rounds a value to a specified number of decimal places `N`.
+
+- If `N > 0`, the function rounds to the right of the decimal point.
+- If `N < 0`, the function rounds to the left of the decimal point.
+- If `N = 0`, the function rounds to the next integer.
 
 The function returns the nearest number of the specified order.
 If the input value has equal distance to two neighboring numbers, the function uses banker's rounding for `Float*` inputs and rounds away from zero for the other number types (`Decimal*`).
 )";
         FunctionDocumentation::Syntax syntax = "round(x[, N])";
         FunctionDocumentation::Arguments arguments = {
-            {"x", "A number to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
-            {"N", "The number of decimal places to round to. Integer. Defaults to `0`. If `N > 0`, the function rounds to the right of the decimal point. If `N < 0`, the function rounds to the left of the decimal point. If `N = 0`, the function rounds to the next integer.", {"`Integer`"}}
+            {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
+            {"[, N]", "Optional. The number of decimal places to round to. Integer. Defaults to `0`.", {"`Integer`"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
-            {"Float inputs", "SELECT number / 2 AS x, round(x) FROM system.numbers LIMIT 3;", "┌───x─┬─round(divide(number, 2))─┐\n│   0 │                        0 │\n│ 0.5 │                        0 │\n│   1 │                        1 │\n└─────┴──────────────────────────┘"},
-            {"Decimal inputs", "SELECT cast(number / 2 AS  Decimal(10,4)) AS x, round(x) FROM system.numbers LIMIT 3;", "┌───x─┬─round(CAST(divide(number, 2), 'Decimal(10, 4)'))─┐\n│   0 │                                                0 │\n│ 0.5 │                                                1 │\n│   1 │                                                1 │\n└─────┴──────────────────────────────────────────────────┘"}
+        {
+            "Float inputs",
+            "SELECT number / 2 AS x, round(x) FROM system.numbers LIMIT 3;",
+            R"(
+┌───x─┬─round(x)─┐
+│   0 │        0 │
+│ 0.5 │        0 │
+│   1 │        1 │
+└─────┴──────────┘
+            )"
+        },
+        {
+            "Decimal inputs",
+            "SELECT cast(number / 2 AS  Decimal(10,4)) AS x, round(x) FROM system.numbers LIMIT 3;",
+            R"(
+┌───x─┬─round(x)─┐
+│   0 │        0 │
+│ 0.5 │        1 │
+│   1 │        1 │
+└─────┴──────────┘
+            )"
+        }
         };
-        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
         factory.registerFunction<FunctionRound>(documentation, FunctionFactory::Case::Insensitive);
@@ -93,35 +152,40 @@ If the input value has equal distance to two neighboring numbers, the function u
 
     {
         FunctionDocumentation::Description description = R"(
-Rounds a number to a specified decimal position.
+Rounds a number to a specified decimal position `N`.
+If the rounding number is halfway between two numbers, the function uses a method of rounding called banker's rounding, which is the default rounding method for floating point numbers defined in IEEE 754.
 
-If the rounding number is halfway between two numbers, the function uses banker's rounding.
-Banker's rounding is a method of rounding fractional numbers
-When the rounding number is halfway between two numbers, it's rounded to the nearest even digit at the specified decimal position.
-For example: 3.5 rounds up to 4, 2.5 rounds down to 2.
-It's the default rounding method for floating point numbers defined in IEEE 754.
-The `round` function performs the same rounding for floating point numbers.
-The `roundBankers` function also rounds integers the same way, for example, `roundBankers(45, -1) = 40`.
+- If `N > 0`, the function rounds to the right of the decimal point
+- If `N < 0`, the function rounds to the left of the decimal point
+- If `N = 0`, the function rounds to the next integer
 
-In other cases, the function rounds numbers to the nearest integer.
+:::info Notes
+- When the rounding number is halfway between two numbers, it's rounded to the nearest even digit at the specified decimal position.
+  For example: `3.5` rounds up to `4`, `2.5` rounds down to `2`.
+- The `round` function performs the same rounding for floating point numbers.
+- The `roundBankers` function also rounds integers the same way, for example, `roundBankers(45, -1) = 40`.
+- In other cases, the function rounds numbers to the nearest integer.
+:::
 
+:::tip Use banker's rounding for summation or subtraction of numbers
 Using banker's rounding, you can reduce the effect that rounding numbers has on the results of summing or subtracting these numbers.
 
-For example, sum numbers 1.5, 2.5, 3.5, 4.5 with different rounding:
-- No rounding: 1.5 + 2.5 + 3.5 + 4.5 = 12.
-- Banker's rounding: 2 + 2 + 4 + 4 = 12.
-- Rounding to the nearest integer: 2 + 3 + 4 + 5 = 14.
+For example, sum numbers `1.5, 2.5, 3.5, 4.5` with different rounding:
+- No rounding: `1.5 + 2.5 + 3.5 + 4.5 = 12`.
+- Banker's rounding: `2 + 2 + 4 + 4 = 12`.
+- Rounding to the nearest integer: `2 + 3 + 4 + 5 = 14`.
+:::
 )";
-        FunctionDocumentation::Syntax syntax = "roundBankers(x [, N])";
+        FunctionDocumentation::Syntax syntax = "roundBankers(x[, N])";
         FunctionDocumentation::Arguments arguments = {
-            {"x", "A number to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
-            {"N", "The number of decimal places to round to. Integer. Defaults to `0`. If `N > 0`, the function rounds to the right of the decimal point. If `N < 0`, the function rounds to the left of the decimal point. If `N = 0`, the function rounds to the next integer.", {"`Integer`"}}
+            {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
+            {"[, N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a value rounded by the banker's rounding method.", {"Same as input type"}};
         FunctionDocumentation::Examples examples = {
             {"Basic usage", "SELECT number / 2 AS x, roundBankers(x, 0) AS b FROM system.numbers LIMIT 10", "┌───x─┬─b─┐\n│   0 │ 0 │\n│ 0.5 │ 0 │\n│   1 │ 1 │\n│ 1.5 │ 2 │\n│   2 │ 2 │\n│ 2.5 │ 2 │\n│   3 │ 3 │\n│ 3.5 │ 4 │\n│   4 │ 4 │\n│ 4.5 │ 4 │\n└─────┴───┘"}
         };
-        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
         factory.registerFunction<FunctionRoundBankers>(documentation, FunctionFactory::Case::Sensitive);
@@ -129,18 +193,32 @@ For example, sum numbers 1.5, 2.5, 3.5, 4.5 with different rounding:
 
     {
         FunctionDocumentation::Description description = R"(
-Accepts a number and rounds it down to an element in the specified array. If the value is less than the lowest bound, the lowest bound is returned.
+Rounds a number down to an element in the specified array.
+If the value is less than the lower bound, the lower bound is returned.
 )";
         FunctionDocumentation::Syntax syntax = "roundDown(num, arr)";
         FunctionDocumentation::Arguments arguments = {
-            {"num", "A number to round down.", {"`Numeric`"}},
-            {"arr", "Array of elements to round `num` down to.", {"`Array` of `UInt`/`Float` type"}}
+            {"num", "A number to round down.", {"(U)Int*", "Decimal*", "Float*"}},
+            {"arr", "Array of elements to round `num` down to.", {"Array((U)Int*)", "Array(Float*)"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns number rounded down to an element in `arr`. If the value is less than the lowest bound, the lowest bound is returned.", {"`UInt`/`Float` type deduced from the type of `arr`"}};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a number rounded down to an element in `arr`. If the value is less than the lowest bound, the lowest bound is returned.", {"(U)Int*", "Float*"}};
         FunctionDocumentation::Examples examples = {
-            {"Basic usage", "SELECT *, roundDown(*, [3, 4, 5]) FROM system.numbers WHERE number IN (0, 1, 2, 3, 4, 5)", "┌─number─┬─roundDown(number, [3, 4, 5])─┐\n│      0 │                            3 │\n│      1 │                            3 │\n│      2 │                            3 │\n│      3 │                            3 │\n│      4 │                            4 │\n│      5 │                            5 │\n└────────┴──────────────────────────────┘"}
+        {
+            "Usage example",
+            "SELECT *, roundDown(*, [3, 4, 5]) FROM system.numbers WHERE number IN (0, 1, 2, 3, 4, 5)",
+            R"(
+┌─number─┬─roundDown(number, [3, 4, 5])─┐
+│      0 │                            3 │
+│      1 │                            3 │
+│      2 │                            3 │
+│      3 │                            3 │
+│      4 │                            4 │
+│      5 │                            5 │
+└────────┴──────────────────────────────┘
+            )"
+        }
         };
-        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
         FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
         factory.registerFunction<FunctionRoundDown>(documentation);

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -9,10 +9,10 @@ REGISTER_FUNCTION(Round)
 {
     {
         FunctionDocumentation::Description description = R"(
-Returns the largest rounded number less than or equal `x`.
-A rounded number is a multiple of `1 / 10 * N`, or the nearest number of the appropriate data type if `1 / 10 * N` isn't exact.
+Returns the largest rounded number less than or equal `x`, where the rounded number is a multiple of `1 / 10 * N`, or the nearest number of the appropriate data type if `1 / 10 * N` isn't exact.
 
-Integer arguments may be rounded with negative `N` argument, with non-negative `N` the function returns `x`, i.e. does nothing.
+Integer arguments may be rounded with a negative `N` argument.
+With non-negative `N` the function returns `x`.
 
 If rounding causes an overflow (for example, `floor(-128, -1)`), the result is undefined.
 )";
@@ -24,7 +24,7 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
         {
-            "Basic usage",
+            "Usage example",
             "SELECT floor(123.45, 1) AS rounded",
             R"(
 ┌─rounded─┐
@@ -86,12 +86,12 @@ Like [`floor`](#floor) but returns the smallest rounded number greater than or e
 
     {
         FunctionDocumentation::Description description = R"(
-Like [`floor`](#floor) but returns the rounded number with largest absolute value that has an absolute value less than or equal to `x`'s.
+Like [`floor`](#floor) but returns the rounded number with the largest absolute value less than or equal to that of `x`.
 )";
         FunctionDocumentation::Syntax syntax = "truncate(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
+            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -117,7 +117,7 @@ If the input value has equal distance to two neighboring numbers, the function u
         FunctionDocumentation::Syntax syntax = "round(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Integer. Defaults to `0`.", {"(U)Int*"}}
+            {"[, N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -19,7 +19,7 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
         FunctionDocumentation::Syntax syntax = "floor(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
+            {"N", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -55,7 +55,7 @@ Like [`floor`](#floor) but returns the smallest rounded number greater than or e
         FunctionDocumentation::Syntax syntax = "ceiling(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
+            {"N", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -91,7 +91,7 @@ Like [`floor`](#floor) but returns the rounded number with the largest absolute 
         FunctionDocumentation::Syntax syntax = "truncate(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer.", {"(U)Int*"}}
+            {"N", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -117,7 +117,7 @@ If the input value has equal distance to two neighboring numbers, the function u
         FunctionDocumentation::Syntax syntax = "round(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
+            {"N", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -161,7 +161,7 @@ If the rounding number is halfway between two numbers, the function uses a metho
 
 :::info Notes
 - When the rounding number is halfway between two numbers, it's rounded to the nearest even digit at the specified decimal position.
-  For example: `3.5` rounds up to `4`, `2.5` rounds down to `2`.
+For example: `3.5` rounds up to `4`, `2.5` rounds down to `2`.
 - The `round` function performs the same rounding for floating point numbers.
 - The `roundBankers` function also rounds integers the same way, for example, `roundBankers(45, -1) = 40`.
 - In other cases, the function rounds numbers to the nearest integer.

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -178,7 +178,7 @@ For example, sum numbers `1.5, 2.5, 3.5, 4.5` with different rounding:
 )";
         FunctionDocumentation::Syntax syntax = "roundBankers(x[, N])";
         FunctionDocumentation::Arguments arguments = {
-            {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
+            {"x", "A number to round.", {"(U)Int*", "Decimal*", "Float*"}},
             {"[, N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a value rounded by the banker's rounding method.", {"(U)Int*", "Decimal*", "Float*"}};

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -181,7 +181,7 @@ For example, sum numbers `1.5, 2.5, 3.5, 4.5` with different rounding:
             {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
             {"[, N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value = {"Returns a value rounded by the banker's rounding method.", {"Same as input type"}};
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a value rounded by the banker's rounding method.", {"(U)Int*", "Decimal*", "Float*"}};
         FunctionDocumentation::Examples examples = {
             {"Basic usage", "SELECT number / 2 AS x, roundBankers(x, 0) AS b FROM system.numbers LIMIT 10", "┌───x─┬─b─┐\n│   0 │ 0 │\n│ 0.5 │ 0 │\n│   1 │ 1 │\n│ 1.5 │ 2 │\n│   2 │ 2 │\n│ 2.5 │ 2 │\n│   3 │ 3 │\n│ 3.5 │ 4 │\n│   4 │ 4 │\n│ 4.5 │ 4 │\n└─────┴───┘"}
         };

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -7,12 +7,144 @@ namespace DB
 
 REGISTER_FUNCTION(Round)
 {
-    factory.registerFunction<FunctionRound>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionRoundBankers>({}, FunctionFactory::Case::Sensitive);
-    factory.registerFunction<FunctionFloor>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionCeil>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionTrunc>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionRoundDown>();
+    {
+        FunctionDocumentation::Description description = R"(
+Returns the largest rounded number less than or equal `x`.
+A rounded number is a multiple of 1 / 10 * N, or the nearest number of the appropriate data type if 1 / 10 * N isn't exact.
+
+Integer arguments may be rounded with negative `N` argument, with non-negative `N` the function returns `x`, i.e. does nothing.
+
+If rounding causes an overflow (for example, `floor(-128, -1)`), the result is undefined.
+)";
+        FunctionDocumentation::Syntax syntax = "floor(x[, N])";
+        FunctionDocumentation::Arguments arguments = {
+            {"x", "The value to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
+            {"N", "The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"`(U)Int*`"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::Examples examples = {
+            {"Basic usage", "SELECT floor(123.45, 1) AS rounded", "┌─rounded─┐\n│   123.4 │\n└─────────┘"},
+            {"Negative precision", "SELECT floor(123.45, -1)", "┌─rounded─┐\n│     120 │\n└─────────┘"}
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+        factory.registerFunction<FunctionFloor>(documentation, FunctionFactory::Case::Insensitive);
+    }
+
+    {
+        FunctionDocumentation::Description description = R"(
+Like `floor` but returns the smallest rounded number greater than or equal `x`.
+)";
+        FunctionDocumentation::Syntax syntax = "ceiling(x[, N])";
+        FunctionDocumentation::Arguments arguments = {
+            {"x", "The value to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
+            {"N", "The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"`(U)Int*`"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::Examples examples = {};
+        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+        factory.registerFunction<FunctionCeil>(documentation, FunctionFactory::Case::Insensitive);
+    }
+
+    {
+        FunctionDocumentation::Description description = R"(
+Like `floor` but returns the rounded number with largest absolute value that has an absolute value less than or equal to `x`'s.
+)";
+        FunctionDocumentation::Syntax syntax = "truncate(x[, N])";
+        FunctionDocumentation::Arguments arguments = {
+            {"x", "The value to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
+            {"N", "The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"`(U)Int*`"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::Examples examples = {
+            {"Basic usage", "SELECT truncate(123.499, 1) AS res;", "┌───res─┐\n│ 123.4 │\n└───────┘"}
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+        factory.registerFunction<FunctionTrunc>(documentation, FunctionFactory::Case::Insensitive);
+    }
+
+    {
+        FunctionDocumentation::Description description = R"(
+Rounds a value to a specified number of decimal places.
+
+The function returns the nearest number of the specified order.
+If the input value has equal distance to two neighboring numbers, the function uses banker's rounding for `Float*` inputs and rounds away from zero for the other number types (`Decimal*`).
+)";
+        FunctionDocumentation::Syntax syntax = "round(x[, N])";
+        FunctionDocumentation::Arguments arguments = {
+            {"x", "A number to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
+            {"N", "The number of decimal places to round to. Integer. Defaults to `0`. If `N > 0`, the function rounds to the right of the decimal point. If `N < 0`, the function rounds to the left of the decimal point. If `N = 0`, the function rounds to the next integer.", {"`Integer`"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Same as input type"}};
+        FunctionDocumentation::Examples examples = {
+            {"Float inputs", "SELECT number / 2 AS x, round(x) FROM system.numbers LIMIT 3;", "┌───x─┬─round(divide(number, 2))─┐\n│   0 │                        0 │\n│ 0.5 │                        0 │\n│   1 │                        1 │\n└─────┴──────────────────────────┘"},
+            {"Decimal inputs", "SELECT cast(number / 2 AS  Decimal(10,4)) AS x, round(x) FROM system.numbers LIMIT 3;", "┌───x─┬─round(CAST(divide(number, 2), 'Decimal(10, 4)'))─┐\n│   0 │                                                0 │\n│ 0.5 │                                                1 │\n│   1 │                                                1 │\n└─────┴──────────────────────────────────────────────────┘"}
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+        factory.registerFunction<FunctionRound>(documentation, FunctionFactory::Case::Insensitive);
+    }
+
+    {
+        FunctionDocumentation::Description description = R"(
+Rounds a number to a specified decimal position.
+
+If the rounding number is halfway between two numbers, the function uses banker's rounding.
+Banker's rounding is a method of rounding fractional numbers
+When the rounding number is halfway between two numbers, it's rounded to the nearest even digit at the specified decimal position.
+For example: 3.5 rounds up to 4, 2.5 rounds down to 2.
+It's the default rounding method for floating point numbers defined in IEEE 754.
+The `round` function performs the same rounding for floating point numbers.
+The `roundBankers` function also rounds integers the same way, for example, `roundBankers(45, -1) = 40`.
+
+In other cases, the function rounds numbers to the nearest integer.
+
+Using banker's rounding, you can reduce the effect that rounding numbers has on the results of summing or subtracting these numbers.
+
+For example, sum numbers 1.5, 2.5, 3.5, 4.5 with different rounding:
+- No rounding: 1.5 + 2.5 + 3.5 + 4.5 = 12.
+- Banker's rounding: 2 + 2 + 4 + 4 = 12.
+- Rounding to the nearest integer: 2 + 3 + 4 + 5 = 14.
+)";
+        FunctionDocumentation::Syntax syntax = "roundBankers(x [, N])";
+        FunctionDocumentation::Arguments arguments = {
+            {"x", "A number to round.", {"`Float*`", "`Decimal*`", "`(U)Int*`"}},
+            {"N", "The number of decimal places to round to. Integer. Defaults to `0`. If `N > 0`, the function rounds to the right of the decimal point. If `N < 0`, the function rounds to the left of the decimal point. If `N = 0`, the function rounds to the next integer.", {"`Integer`"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns a value rounded by the banker's rounding method.", {"Same as input type"}};
+        FunctionDocumentation::Examples examples = {
+            {"Basic usage", "SELECT number / 2 AS x, roundBankers(x, 0) AS b FROM system.numbers LIMIT 10", "┌───x─┬─b─┐\n│   0 │ 0 │\n│ 0.5 │ 0 │\n│   1 │ 1 │\n│ 1.5 │ 2 │\n│   2 │ 2 │\n│ 2.5 │ 2 │\n│   3 │ 3 │\n│ 3.5 │ 4 │\n│   4 │ 4 │\n│ 4.5 │ 4 │\n└─────┴───┘"}
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+        factory.registerFunction<FunctionRoundBankers>(documentation, FunctionFactory::Case::Sensitive);
+    }
+
+    {
+        FunctionDocumentation::Description description = R"(
+Accepts a number and rounds it down to an element in the specified array. If the value is less than the lowest bound, the lowest bound is returned.
+)";
+        FunctionDocumentation::Syntax syntax = "roundDown(num, arr)";
+        FunctionDocumentation::Arguments arguments = {
+            {"num", "A number to round down.", {"`Numeric`"}},
+            {"arr", "Array of elements to round `num` down to.", {"`Array` of `UInt`/`Float` type"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns number rounded down to an element in `arr`. If the value is less than the lowest bound, the lowest bound is returned.", {"`UInt`/`Float` type deduced from the type of `arr`"}};
+        FunctionDocumentation::Examples examples = {
+            {"Basic usage", "SELECT *, roundDown(*, [3, 4, 5]) FROM system.numbers WHERE number IN (0, 1, 2, 3, 4, 5)", "┌─number─┬─roundDown(number, [3, 4, 5])─┐\n│      0 │                            3 │\n│      1 │                            3 │\n│      2 │                            3 │\n│      3 │                            3 │\n│      4 │                            4 │\n│      5 │                            5 │\n└────────┴──────────────────────────────┘"}
+        };
+        FunctionDocumentation::IntroducedIn introduced_in = {};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+        FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+        factory.registerFunction<FunctionRoundDown>(documentation);
+    }
 
     /// Compatibility aliases.
     factory.registerAlias("ceiling", "ceil", FunctionFactory::Case::Insensitive);

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -9,7 +9,7 @@ REGISTER_FUNCTION(Round)
 {
     {
         FunctionDocumentation::Description description = R"(
-Returns the largest rounded number less than or equal `x`, where the rounded number is a multiple of `1 / 10 * N`, or the nearest number of the appropriate data type if `1 / 10 * N` isn't exact.
+Returns the largest rounded number less than or equal to `x`, where the rounded number is a multiple of `1 / 10 * N`, or the nearest number of the appropriate data type if `1 / 10 * N` isn't exact.
 
 Integer arguments may be rounded with a negative `N` argument.
 With non-negative `N` the function returns `x`.
@@ -19,7 +19,7 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
         FunctionDocumentation::Syntax syntax = "floor(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
+            {"[N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -50,12 +50,12 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
 
     {
         FunctionDocumentation::Description description = R"(
-Like [`floor`](#floor) but returns the smallest rounded number greater than or equal `x`.
+Like [`floor`](#floor) but returns the smallest rounded number greater than or equal to `x`.
 )";
         FunctionDocumentation::Syntax syntax = "ceiling(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
+            {"[N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer. Can be negative.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -91,7 +91,7 @@ Like [`floor`](#floor) but returns the rounded number with the largest absolute 
         FunctionDocumentation::Syntax syntax = "truncate(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "The value to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer.", {"(U)Int*"}}
+            {"[N]", "Optional. The number of decimal places to round to. Defaults to zero, which means rounding to an integer.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {
@@ -117,7 +117,7 @@ If the input value has equal distance to two neighboring numbers, the function u
         FunctionDocumentation::Syntax syntax = "round(x[, N])";
         FunctionDocumentation::Arguments arguments = {
             {"x", "A number to round.", {"Float*", "Decimal*", "(U)Int*"}},
-            {"[, N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
+            {"[N]", "Optional. The number of decimal places to round to. Defaults to `0`.", {"(U)Int*"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a rounded number of the same type as `x`.", {"Float*", "Decimal*", "(U)Int*"}};
         FunctionDocumentation::Examples examples = {

--- a/src/Functions/roundAge.cpp
+++ b/src/Functions/roundAge.cpp
@@ -38,17 +38,39 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundAge> : PositiveM
 REGISTER_FUNCTION(RoundAge)
 {
     FunctionDocumentation::Description description = R"(
-Accepts a number within various commonly used ranges of human age and returns either a maximum or a minimum within that range.
+Takes a number representing a human age, compares it to standard age ranges, and returns either the highest or lowest value within the range it falls in.
+
+- Returns `0`, for $age \lt 1$.
+- Returns `17`, for $1 \leq age \leq 17$.
+- Returns `18`, for $18 \leq age \leq 24$.
+- Returns `25`, for $25 \leq age \leq 34$.
+- Returns `35`, for $35 \leq age \leq 44$.
+- Returns `45`, for $45 \leq age \leq 54$.
+- Returns `55`, for $age \geq 55$.
 )";
     FunctionDocumentation::Syntax syntax = "roundAge(num)";
     FunctionDocumentation::Arguments arguments = {
-        {"age", "A number representing an age in years.", {"`UInt`/`Float`"}}
+        {"age", "A number representing an age in years.", {"(U)Int*", "Float*"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for age < 1. Returns `17`, for 1 ≤ age ≤ 17. Returns `18`, for 18 ≤ age ≤ 24. Returns `25`, for 25 ≤ age ≤ 34. Returns `35`, for 35 ≤ age ≤ 44. Returns `45`, for 45 ≤ age ≤ 54. Returns `55`, for age ≥ 55.", {"`UInt8`"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns either the highest or lowest age of the range `age` falls within.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {
-        {"Basic usage", "SELECT *, roundAge(*) FROM system.numbers WHERE number IN (0, 5, 20, 31, 37, 54, 72);", "┌─number─┬─roundAge(number)─┐\n│      0 │                0 │\n│      5 │               17 │\n│     20 │               18 │\n│     31 │               25 │\n│     37 │               35 │\n│     54 │               45 │\n│     72 │               55 │\n└────────┴──────────────────┘"}
+    {
+        "Usage example",
+        "SELECT *, roundAge(*) FROM system.numbers WHERE number IN (0, 5, 20, 31, 37, 54, 72);",
+        R"(
+┌─number─┬─roundAge(number)─┐
+│      0 │                0 │
+│      5 │               17 │
+│     20 │               18 │
+│     31 │               25 │
+│     37 │               35 │
+│     54 │               45 │
+│     72 │               55 │
+└────────┴──────────────────┘
+        )"
+    }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
     factory.registerFunction<FunctionRoundAge>(documentation);

--- a/src/Functions/roundAge.cpp
+++ b/src/Functions/roundAge.cpp
@@ -38,7 +38,7 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundAge> : PositiveM
 REGISTER_FUNCTION(RoundAge)
 {
     FunctionDocumentation::Description description = R"(
-Takes a number representing a human age, compares it to standard age ranges, and returns either the highest or lowest value within the range it falls in.
+Takes a number representing a human age, compares it to standard age ranges, and returns either the highest or lowest value of the range the number falls within.
 
 - Returns `0`, for $age \lt 1$.
 - Returns `17`, for $1 \leq age \leq 17$.

--- a/src/Functions/roundAge.cpp
+++ b/src/Functions/roundAge.cpp
@@ -40,13 +40,13 @@ REGISTER_FUNCTION(RoundAge)
     FunctionDocumentation::Description description = R"(
 Takes a number representing a human age, compares it to standard age ranges, and returns either the highest or lowest value of the range the number falls within.
 
-- Returns `0`, for $age \lt 1$.
-- Returns `17`, for $1 \leq age \leq 17$.
-- Returns `18`, for $18 \leq age \leq 24$.
-- Returns `25`, for $25 \leq age \leq 34$.
-- Returns `35`, for $35 \leq age \leq 44$.
-- Returns `45`, for $45 \leq age \leq 54$.
-- Returns `55`, for $age \geq 55$.
+- Returns `0`, for `age < 1`.
+- Returns `17`, for `1 ≤ age ≤ 17`.
+- Returns `18`, for `18 ≤ age ≤ 24`.
+- Returns `25`, for `25 ≤ age ≤ 34`.
+- Returns `35`, for `35 ≤ age ≤ 44`.
+- Returns `45`, for `45 ≤ age ≤ 54`.
+- Returns `55`, for `age ≥ 55`.
 )";
     FunctionDocumentation::Syntax syntax = "roundAge(num)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/roundAge.cpp
+++ b/src/Functions/roundAge.cpp
@@ -37,7 +37,21 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundAge> : PositiveM
 
 REGISTER_FUNCTION(RoundAge)
 {
-    factory.registerFunction<FunctionRoundAge>();
+    FunctionDocumentation::Description description = R"(
+Accepts a number within various commonly used ranges of human age and returns either a maximum or a minimum within that range.
+)";
+    FunctionDocumentation::Syntax syntax = "roundAge(num)";
+    FunctionDocumentation::Arguments arguments = {
+        {"age", "A number representing an age in years.", {"`UInt`/`Float`"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for age < 1. Returns `17`, for 1 ≤ age ≤ 17. Returns `18`, for 18 ≤ age ≤ 24. Returns `25`, for 25 ≤ age ≤ 34. Returns `35`, for 35 ≤ age ≤ 44. Returns `45`, for 45 ≤ age ≤ 54. Returns `55`, for age ≥ 55.", {"`UInt8`"}};
+    FunctionDocumentation::Examples examples = {
+        {"Basic usage", "SELECT *, roundAge(*) FROM system.numbers WHERE number IN (0, 5, 20, 31, 37, 54, 72);", "┌─number─┬─roundAge(number)─┐\n│      0 │                0 │\n│      5 │               17 │\n│     20 │               18 │\n│     31 │               25 │\n│     37 │               35 │\n│     54 │               45 │\n│     72 │               55 │\n└────────┴──────────────────┘"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+    factory.registerFunction<FunctionRoundAge>(documentation);
 }
 
 }

--- a/src/Functions/roundDuration.cpp
+++ b/src/Functions/roundDuration.cpp
@@ -46,7 +46,21 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundDuration> : Posi
 
 REGISTER_FUNCTION(RoundDuration)
 {
-    factory.registerFunction<FunctionRoundDuration>();
+    FunctionDocumentation::Description description = R"(
+Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to numbers from the set of commonly used durations: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.
+)";
+    FunctionDocumentation::Syntax syntax = "roundDuration(num)";
+    FunctionDocumentation::Arguments arguments = {
+        {"num", "A number to round to one of the numbers in the set of common durations.", {"`UInt`/`Float`"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for `num` < 1. Otherwise, one of: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.", {"`UInt16`"}};
+    FunctionDocumentation::Examples examples = {
+        {"Basic usage", "SELECT *, roundDuration(*) FROM system.numbers WHERE number IN (0, 9, 19, 47, 101, 149, 205, 271, 421, 789, 1423, 2345, 4567, 9876, 24680, 42573)", "┌─number─┬─roundDuration(number)─┐\n│      0 │                     0 │\n│      9 │                     1 │\n│     19 │                    10 │\n│     47 │                    30 │\n│    101 │                    60 │\n│    149 │                   120 │\n│    205 │                   180 │\n│    271 │                   240 │\n│    421 │                   300 │\n│    789 │                   600 │\n│   1423 │                  1200 │\n│   2345 │                  1800 │\n│   4567 │                  3600 │\n│   9876 │                  7200 │\n│  24680 │                 18000 │\n│  42573 │                 36000 │\n└────────┴───────────────────────┘"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+    factory.registerFunction<FunctionRoundDuration>(documentation);
 }
 
 }

--- a/src/Functions/roundDuration.cpp
+++ b/src/Functions/roundDuration.cpp
@@ -52,7 +52,7 @@ If the number is less than one, it returns `0`.
 )";
     FunctionDocumentation::Syntax syntax = "roundDuration(num)";
     FunctionDocumentation::Arguments argument = {{"num", "A number to round to one of the numbers in the set of common durations.", {"(U)Int*", "Float*"}}};
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for `num` < 1. Otherwise, one of: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.", {"`UInt16`"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for `num` < 1. Otherwise, one of: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.", {"UInt16"}};
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",

--- a/src/Functions/roundDuration.cpp
+++ b/src/Functions/roundDuration.cpp
@@ -47,7 +47,7 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundDuration> : Posi
 REGISTER_FUNCTION(RoundDuration)
 {
     FunctionDocumentation::Description description = R"(
-Rounds a number down to one of the numbers from a set of commonly used durations: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.
+Rounds a number down to the closest from a set of commonly used durations: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.
 If the number is less than one, it returns `0`.
 )";
     FunctionDocumentation::Syntax syntax = "roundDuration(num)";

--- a/src/Functions/roundDuration.cpp
+++ b/src/Functions/roundDuration.cpp
@@ -47,19 +47,41 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundDuration> : Posi
 REGISTER_FUNCTION(RoundDuration)
 {
     FunctionDocumentation::Description description = R"(
-Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to numbers from the set of commonly used durations: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.
+Rounds a number down to one of the numbers from a set of commonly used durations: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.
+If the number is less than one, it returns `0`.
 )";
     FunctionDocumentation::Syntax syntax = "roundDuration(num)";
-    FunctionDocumentation::Arguments arguments = {
-        {"num", "A number to round to one of the numbers in the set of common durations.", {"`UInt`/`Float`"}}
-    };
+    FunctionDocumentation::Arguments argument = {{"num", "A number to round to one of the numbers in the set of common durations.", {"(U)Int*", "Float*"}}};
     FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for `num` < 1. Otherwise, one of: `1, 10, 30, 60, 120, 180, 240, 300, 600, 1200, 1800, 3600, 7200, 18000, 36000`.", {"`UInt16`"}};
     FunctionDocumentation::Examples examples = {
-        {"Basic usage", "SELECT *, roundDuration(*) FROM system.numbers WHERE number IN (0, 9, 19, 47, 101, 149, 205, 271, 421, 789, 1423, 2345, 4567, 9876, 24680, 42573)", "┌─number─┬─roundDuration(number)─┐\n│      0 │                     0 │\n│      9 │                     1 │\n│     19 │                    10 │\n│     47 │                    30 │\n│    101 │                    60 │\n│    149 │                   120 │\n│    205 │                   180 │\n│    271 │                   240 │\n│    421 │                   300 │\n│    789 │                   600 │\n│   1423 │                  1200 │\n│   2345 │                  1800 │\n│   4567 │                  3600 │\n│   9876 │                  7200 │\n│  24680 │                 18000 │\n│  42573 │                 36000 │\n└────────┴───────────────────────┘"}
+    {
+        "Usage example",
+        "SELECT *, roundDuration(*) FROM system.numbers WHERE number IN (0, 9, 19, 47, 101, 149, 205, 271, 421, 789, 1423, 2345, 4567, 9876, 24680, 42573)",
+        R"(
+┌─number─┬─roundDuration(number)─┐
+│      0 │                     0 │
+│      9 │                     1 │
+│     19 │                    10 │
+│     47 │                    30 │
+│    101 │                    60 │
+│    149 │                   120 │
+│    205 │                   180 │
+│    271 │                   240 │
+│    421 │                   300 │
+│    789 │                   600 │
+│   1423 │                  1200 │
+│   2345 │                  1800 │
+│   4567 │                  3600 │
+│   9876 │                  7200 │
+│  24680 │                 18000 │
+│  42573 │                 36000 │
+└────────┴───────────────────────┘
+        )"
+    }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
-    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+    FunctionDocumentation documentation = {description, syntax, argument, returned_value, examples, introduced_in, category};
     factory.registerFunction<FunctionRoundDuration>(documentation);
 }
 

--- a/src/Functions/roundToExp2.cpp
+++ b/src/Functions/roundToExp2.cpp
@@ -84,7 +84,21 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundToExp2> : Positi
 
 REGISTER_FUNCTION(RoundToExp2)
 {
-    factory.registerFunction<FunctionRoundToExp2>();
+    FunctionDocumentation::Description description = R"(
+Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to the nearest (whole non-negative) degree of two.
+)";
+    FunctionDocumentation::Syntax syntax = "roundToExp2(num)";
+    FunctionDocumentation::Arguments arguments = {
+        {"num", "A number to round.", {"`UInt`/`Float`"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for `num` < 1. Otherwise, returns `num` rounded down to the nearest (whole non-negative) degree of two.", {"`UInt8` for `num` < 1, otherwise `UInt`/`Float` equivalent to the input type"}};
+    FunctionDocumentation::Examples examples = {
+        {"Basic usage", "SELECT *, roundToExp2(*) FROM system.numbers WHERE number IN (0, 2, 5, 10, 19, 50)", "┌─number─┬─roundToExp2(number)─┐\n│      0 │                   0 │\n│      2 │                   2 │\n│      5 │                   4 │\n│     10 │                   8 │\n│     19 │                  16 │\n│     50 │                  32 │\n└────────┴─────────────────────┘"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+    factory.registerFunction<FunctionRoundToExp2>(documentation);
 }
 
 }

--- a/src/Functions/roundToExp2.cpp
+++ b/src/Functions/roundToExp2.cpp
@@ -85,17 +85,31 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundToExp2> : Positi
 REGISTER_FUNCTION(RoundToExp2)
 {
     FunctionDocumentation::Description description = R"(
-Accepts a number. If the number is less than one, it returns `0`. Otherwise, it rounds the number down to the nearest (whole non-negative) degree of two.
+Rounds a number down to the nearest (whole non-negative) degree of two.
+If the number is less than one, it returns `0`.
 )";
     FunctionDocumentation::Syntax syntax = "roundToExp2(num)";
     FunctionDocumentation::Arguments arguments = {
-        {"num", "A number to round.", {"`UInt`/`Float`"}}
+        {"num", "A number to round.", {"(U)Int*", "Float*"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0`, for `num` < 1. Otherwise, returns `num` rounded down to the nearest (whole non-negative) degree of two.", {"`UInt8` for `num` < 1, otherwise `UInt`/`Float` equivalent to the input type"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `num` rounded down to the nearest (whole non-negative) degree of two, otherwise `0` for `num < 1`.", {"(U)Int*", "Float*"}};
     FunctionDocumentation::Examples examples = {
-        {"Basic usage", "SELECT *, roundToExp2(*) FROM system.numbers WHERE number IN (0, 2, 5, 10, 19, 50)", "┌─number─┬─roundToExp2(number)─┐\n│      0 │                   0 │\n│      2 │                   2 │\n│      5 │                   4 │\n│     10 │                   8 │\n│     19 │                  16 │\n│     50 │                  32 │\n└────────┴─────────────────────┘"}
+    {
+        "Usage example",
+        "SELECT *, roundToExp2(*) FROM system.numbers WHERE number IN (0, 2, 5, 10, 19, 50)",
+        R"(
+┌─number─┬─roundToExp2(number)─┐
+│      0 │                   0 │
+│      2 │                   2 │
+│      5 │                   4 │
+│     10 │                   8 │
+│     19 │                  16 │
+│     50 │                  32 │
+└────────┴─────────────────────┘
+        )"
+    }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Rounding;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
     factory.registerFunction<FunctionRoundToExp2>(documentation);

--- a/src/Functions/roundToExp2.cpp
+++ b/src/Functions/roundToExp2.cpp
@@ -85,14 +85,14 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameRoundToExp2> : Positi
 REGISTER_FUNCTION(RoundToExp2)
 {
     FunctionDocumentation::Description description = R"(
-Rounds a number down to the nearest (whole non-negative) degree of two.
+Rounds a number down to the nearest (whole non-negative) power of two.
 If the number is less than one, it returns `0`.
 )";
     FunctionDocumentation::Syntax syntax = "roundToExp2(num)";
     FunctionDocumentation::Arguments arguments = {
         {"num", "A number to round.", {"(U)Int*", "Float*"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns `num` rounded down to the nearest (whole non-negative) degree of two, otherwise `0` for `num < 1`.", {"(U)Int*", "Float*"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `num` rounded down to the nearest (whole non-negative) power of two, otherwise `0` for `num < 1`.", {"(U)Int*", "Float*"}};
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -70,7 +70,6 @@ byteSize
 caseWithExpression
 catboostEvaluate
 cbrt
-ceil
 concat
 concatAssumeInjective
 connectionId
@@ -137,7 +136,6 @@ finalizeAggregation
 firstSignificantSubdomainCustom
 firstSignificantSubdomainCustomRFC
 flattenTuple
-floor
 format
 formatReadableQuantity
 formatReadableSize
@@ -380,11 +378,6 @@ right
 rightPad
 rightPadUTF8
 rightUTF8
-round
-roundAge
-roundBankers
-roundDown
-roundDuration
 roundToExp2
 rowNumberInAllBlocks
 rowNumberInBlock
@@ -561,7 +554,6 @@ translateUTF8
 trimBoth
 trimLeft
 trimRight
-trunc
 tryBase58Decode
 tumble
 tumbleEnd

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -378,7 +378,6 @@ right
 rightPad
 rightPadUTF8
 rightUTF8
-roundToExp2
 rowNumberInAllBlocks
 rowNumberInBlock
 runningAccumulate

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -82,7 +82,6 @@ byteSize
 caseWithExpression
 catboostEvaluate
 cbrt
-ceil
 compareSubstrings
 concat
 concatAssumeInjective
@@ -220,7 +219,6 @@ firstSignificantSubdomainCustom
 firstSignificantSubdomainCustomRFC
 firstSignificantSubdomainRFC
 flattenTuple
-floor
 format
 formatQuery
 formatQueryOrNull
@@ -509,12 +507,6 @@ right
 rightPad
 rightPadUTF8
 rightUTF8
-round
-roundAge
-roundBankers
-roundDown
-roundDuration
-roundToExp2
 rowNumberInAllBlocks
 rowNumberInBlock
 runningAccumulate
@@ -712,7 +704,6 @@ translateUTF8
 trimBoth
 trimLeft
 trimRight
-trunc
 tryBase58Decode
 tumble
 tumbleEnd


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Transfers documentation for [rounding functions](https://clickhouse.com/docs/sql-reference/functions/rounding-functions) into the source code.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
