### PR TITLE
Ignore UNKNOWN_DATABASE while obtaining table columns sizes for system.columns (fixes 00076_system_columns_bytes flakiness)

### DIFF
--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -20,13 +20,17 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-
+#include <Common/Exception.h>
 
 namespace DB
 {
 namespace Setting
 {
     extern const SettingsSeconds lock_acquire_timeout;
+}
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_DATABASE;
 }
 
 StorageSystemColumns::StorageSystemColumns(const StorageID & table_id_)
@@ -148,7 +152,19 @@ protected:
 
                 /// Certain information about a table - should be calculated only when the corresponding columns are queried.
                 if (columns_mask[7] || columns_mask[8] || columns_mask[9])
-                    column_sizes = storage->getColumnSizes();
+                {
+                    /// Can throw UNKNOWN_DATABASE in case of Merge table
+                    try
+                    {
+                        column_sizes = storage->getColumnSizes();
+                    }
+                    catch (const Exception & e)
+                    {
+                        if (e.code() != ErrorCodes::UNKNOWN_DATABASE)
+                            throw;
+                        tryLogCurrentException(getLogger("SystemColumns"), fmt::format("While obtaining columns sizes for {}", storage->getStorageID().getNameForLogs()), LogsLevel::debug);
+                    }
+                }
 
                 if (columns_mask[11])
                     cols_required_for_partition_key = metadata_snapshot->getColumnsRequiredForPartitionKey();

--- a/tests/queries/0_stateless/00076_system_columns_bytes.sql
+++ b/tests/queries/0_stateless/00076_system_columns_bytes.sql
@@ -1,3 +1,4 @@
--- Tags: stateful
+-- Ensure that there will be at least one non-empty MergeTree table
+SYSTEM FLUSH LOGS text_log;
 -- NOTE: database = currentDatabase() is not mandatory
 SELECT sum(data_compressed_bytes) > 0, sum(data_uncompressed_bytes) > 0, sum(marks_bytes) > 0 FROM system.columns;

--- a/tests/queries/0_stateless/00076_system_columns_bytes.sql
+++ b/tests/queries/0_stateless/00076_system_columns_bytes.sql
@@ -1,4 +1,3 @@
--- Ensure that there will be at least one non-empty MergeTree table
-SYSTEM FLUSH LOGS text_log;
+-- Tags: stateful
 -- NOTE: database = currentDatabase() is not mandatory
 SELECT sum(data_compressed_bytes) > 0, sum(data_uncompressed_bytes) > 0, sum(marks_bytes) > 0 FROM system.columns;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Ignore UNKNOWN_DATABASE while obtaining table columns sizes for system.columns