### PR TITLE
Fix reading subcolumns of alias columns

### DIFF
--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -27,6 +27,7 @@
 
 namespace DB
 {
+
 namespace Setting
 {
     extern const SettingsBool group_by_use_nulls;
@@ -258,7 +259,9 @@ std::tuple<FunctionNode *, ColumnNode *, TableNode *> getTypedNodesForOptimizati
         return {};
 
     auto * first_argument_column_node = function_arguments_nodes.front()->as<ColumnNode>();
-    if (!first_argument_column_node || first_argument_column_node->getColumnName() == "__grouping_set")
+    if (!first_argument_column_node
+        || first_argument_column_node->getColumnName() == "__grouping_set"
+        || first_argument_column_node->hasExpression())
         return {};
 
     auto column_source = first_argument_column_node->getColumnSource();

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -4718,11 +4718,22 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
         {
             for (const auto & subcolumn : columns_description.getSubcolumns(column_name_and_type.name))
                 table_expression_data.subcolumn_names.insert(subcolumn.name);
-            const auto & column_default = columns_description.getDefault(column_name_and_type.name);
+
+            const auto & column_default = columns_description.getDefault(column_name_and_type.getNameInStorage());
 
             if (column_default && column_default->kind == ColumnDefaultKind::Alias)
             {
                 auto alias_expression = buildQueryTree(column_default->expression, scope.context);
+
+                if (column_name_and_type.isSubcolumn())
+                {
+                    auto get_subcolumn_function = std::make_shared<FunctionNode>("getSubcolumn");
+                    get_subcolumn_function->getArguments().getNodes().push_back(alias_expression);
+                    get_subcolumn_function->getArguments().getNodes().push_back(std::make_shared<ConstantNode>(column_name_and_type.getSubcolumnName()));
+
+                    alias_expression = std::move(get_subcolumn_function);
+                }
+
                 auto column_node = std::make_shared<ColumnNode>(column_name_and_type, std::move(alias_expression), table_expression_node);
                 column_name_to_column_node.emplace(column_name_and_type.name, column_node);
                 alias_columns_to_resolve.emplace_back(column_name_and_type.name, column_node);

--- a/tests/queries/0_stateless/02470_suspicious_low_cardinality_msan.sql
+++ b/tests/queries/0_stateless/02470_suspicious_low_cardinality_msan.sql
@@ -2,5 +2,5 @@ DROP TABLE IF EXISTS alias_2__fuzz_25;
 SET allow_suspicious_low_cardinality_types = 1;
 CREATE TABLE alias_2__fuzz_25 (`dt` LowCardinality(Date), `col` DateTime, `col2` Nullable(Int256), `colAlias0` Nullable(DateTime64(3)) ALIAS col, `colAlias3` Nullable(Int32) ALIAS col3 + colAlias0, `colAlias1` LowCardinality(UInt16) ALIAS colAlias0 + col2, `colAlias2` LowCardinality(Int32) ALIAS colAlias0 + colAlias1, `col3` Nullable(UInt8)) ENGINE = MergeTree ORDER BY dt;
 insert into alias_2__fuzz_25 (dt, col, col2, col3) values ('2020-02-01', 1, 2, 3);
-SELECT colAlias0, colAlias2, colAlias3 FROM alias_2__fuzz_25; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT colAlias0, colAlias2, colAlias3 FROM alias_2__fuzz_25; -- { serverError ILLEGAL_COLUMN }
 DROP TABLE alias_2__fuzz_25;

--- a/tests/queries/0_stateless/02470_suspicious_low_cardinality_msan.sql
+++ b/tests/queries/0_stateless/02470_suspicious_low_cardinality_msan.sql
@@ -2,5 +2,5 @@ DROP TABLE IF EXISTS alias_2__fuzz_25;
 SET allow_suspicious_low_cardinality_types = 1;
 CREATE TABLE alias_2__fuzz_25 (`dt` LowCardinality(Date), `col` DateTime, `col2` Nullable(Int256), `colAlias0` Nullable(DateTime64(3)) ALIAS col, `colAlias3` Nullable(Int32) ALIAS col3 + colAlias0, `colAlias1` LowCardinality(UInt16) ALIAS colAlias0 + col2, `colAlias2` LowCardinality(Int32) ALIAS colAlias0 + colAlias1, `col3` Nullable(UInt8)) ENGINE = MergeTree ORDER BY dt;
 insert into alias_2__fuzz_25 (dt, col, col2, col3) values ('2020-02-01', 1, 2, 3);
-SELECT colAlias0, colAlias2, colAlias3 FROM alias_2__fuzz_25; -- { serverError ILLEGAL_COLUMN }
+SELECT colAlias0, colAlias2, colAlias3 FROM alias_2__fuzz_25; -- { serverError ILLEGAL_COLUMN, ILLEGAL_TYPE_OF_ARGUMENT }
 DROP TABLE alias_2__fuzz_25;

--- a/tests/queries/0_stateless/03594_alias_subcolumns.reference
+++ b/tests/queries/0_stateless/03594_alias_subcolumns.reference
@@ -1,0 +1,81 @@
+2
+1
+1
+0
+QUERY id: 0
+  PROJECTION COLUMNS
+    aa.size0 UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: aa.size0, result_type: UInt64, source_id: 3
+        EXPRESSION
+          FUNCTION id: 4, function_name: getSubcolumn, function_type: ordinary, result_type: UInt64
+            ARGUMENTS
+              LIST id: 5, nodes: 2
+                COLUMN id: 6, column_name: a, result_type: Array(UInt64), source_id: 3
+                CONSTANT id: 7, constant_value: \'size0\', constant_value_type: String
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.t_alias_subcolumns
+  ORDER BY
+    LIST id: 8, nodes: 1
+      SORT id: 9, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 10, column_name: id, result_type: UInt64, source_id: 3
+0
+1
+0
+1
+QUERY id: 0
+  PROJECTION COLUMNS
+    na.null UInt8
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: na.null, result_type: UInt8, source_id: 3
+        EXPRESSION
+          FUNCTION id: 4, function_name: getSubcolumn, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 5, nodes: 2
+                COLUMN id: 6, column_name: n, result_type: Nullable(String), source_id: 3
+                CONSTANT id: 7, constant_value: \'null\', constant_value_type: String
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.t_alias_subcolumns
+  ORDER BY
+    LIST id: 8, nodes: 1
+      SORT id: 9, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 10, column_name: id, result_type: UInt64, source_id: 3
+2
+1
+QUERY id: 0
+  PROJECTION COLUMNS
+    count() UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: count, function_type: aggregate, result_type: UInt64
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.t_alias_subcolumns
+  WHERE
+    FUNCTION id: 4, function_name: not, function_type: ordinary, result_type: UInt8
+      ARGUMENTS
+        LIST id: 5, nodes: 1
+          FUNCTION id: 6, function_name: empty, function_type: ordinary, result_type: UInt8
+            ARGUMENTS
+              LIST id: 7, nodes: 1
+                COLUMN id: 8, column_name: aa, result_type: Array(UInt64), source_id: 3
+                  EXPRESSION
+                    COLUMN id: 9, column_name: a, result_type: Array(UInt64), source_id: 3
+1
+1
+QUERY id: 0
+  PROJECTION COLUMNS
+    count(na) UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: count, function_type: aggregate, result_type: UInt64
+        ARGUMENTS
+          LIST id: 3, nodes: 1
+            COLUMN id: 4, column_name: na, result_type: Nullable(String), source_id: 5
+              EXPRESSION
+                COLUMN id: 6, column_name: n, result_type: Nullable(String), source_id: 5
+  JOIN TREE
+    TABLE id: 5, alias: __table1, table_name: default.t_alias_subcolumns

--- a/tests/queries/0_stateless/03594_alias_subcolumns.sql
+++ b/tests/queries/0_stateless/03594_alias_subcolumns.sql
@@ -1,0 +1,40 @@
+DROP TABLE IF EXISTS t_alias_subcolumns;
+
+SET enable_analyzer = 1;
+SET optimize_functions_to_subcolumns = 1;
+
+CREATE TABLE t_alias_subcolumns
+(
+    id UInt64,
+    a Array(UInt64),
+    n Nullable(String),
+    aa Array(UInt64) ALIAS a,
+    ab Array(UInt64) ALIAS arrayFilter(x -> x % 2 = 0, a),
+    na Nullable(String) ALIAS n,
+    nb Nullable(String) ALIAS substring(n, 1, 3)
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_alias_subcolumns VALUES (0, [1, 2], 'ffffffff') (1, [3], NULL);
+
+SELECT aa.size0 FROM t_alias_subcolumns ORDER BY id;
+SELECT ab.size0 FROM t_alias_subcolumns ORDER BY id;
+
+EXPLAIN QUERY TREE SELECT aa.size0 FROM t_alias_subcolumns ORDER BY id;
+
+SELECT na.null FROM t_alias_subcolumns ORDER BY id;
+SELECT nb.null FROM t_alias_subcolumns ORDER BY id;
+
+EXPLAIN QUERY TREE SELECT na.null FROM t_alias_subcolumns ORDER BY id;
+
+SELECT count() FROM t_alias_subcolumns WHERE NOT empty(aa);
+SELECT count() FROM t_alias_subcolumns WHERE NOT empty(ab);
+
+EXPLAIN QUERY TREE SELECT count() FROM t_alias_subcolumns WHERE NOT empty(aa);
+
+SELECT count(na) FROM t_alias_subcolumns;
+SELECT count(nb) FROM t_alias_subcolumns;
+
+EXPLAIN QUERY TREE SELECT count(na) FROM t_alias_subcolumns;
+
+DROP TABLE t_alias_subcolumns;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed reading subcolumns of columns with `ALIAS` modifier. Fixed possible incorrect result of queries that use `ALIAS` columns of types `Array` and `Nullable` with enabled `optimize_functions_to_subcolumns`.

Fixes #85633.