### PR TITLE
Fix LOGICAL_ERROR when using DROP COLUMN with COMMENT COLUMN IF EXISTS

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -686,9 +686,12 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
         // If column doesn't exist and IF EXISTS is used, skip silently
         if (!metadata.columns.has(column_name) && if_exists)
             return;
-        
+
         metadata.columns.modify(column_name,
-            [&](ColumnDescription & column) { column.comment = *comment; });
+            [&](ColumnDescription & column)
+            {
+                column.comment = *comment;
+            });
     }
     else if (type == COMMENT_TABLE)
     {

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -683,6 +683,10 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
     }
     else if (type == COMMENT_COLUMN)
     {
+        // If column doesn't exist and IF EXISTS is used, skip silently
+        if (!metadata.columns.has(column_name) && if_exists)
+            return;
+        
         metadata.columns.modify(column_name,
             [&](ColumnDescription & column) { column.comment = *comment; });
     }

--- a/tests/queries/0_stateless/03595_alter_drop_column_comment_if_exists.reference
+++ b/tests/queries/0_stateless/03595_alter_drop_column_comment_if_exists.reference
@@ -1,0 +1,8 @@
+c1	Int32					
+c2	String					
+c1	Int32					
+c2	String					
+c2	String			existing column comment		
+test_alter_drop_comment	c2	existing column comment
+id	Int32					
+value	String			existing value column		

--- a/tests/queries/0_stateless/03595_alter_drop_column_comment_if_exists.sql
+++ b/tests/queries/0_stateless/03595_alter_drop_column_comment_if_exists.sql
@@ -1,0 +1,73 @@
+-- Test for issue #85608: Logical Error when using DROP COLUMN and COMMENT COLUMN IF EXISTS in same ALTER
+-- This test verifies that COMMENT COLUMN IF EXISTS works correctly when the column is being dropped in the same ALTER statement
+
+-- Test with Memory engine
+DROP TABLE IF EXISTS test_alter_drop_comment;
+
+CREATE TABLE test_alter_drop_comment (
+    c0 Int,
+    c1 Int,
+    c2 String
+) ENGINE = Memory;
+
+-- Test case 1: DROP COLUMN + COMMENT COLUMN IF EXISTS (should succeed)
+-- This was previously failing with "Cannot find column c0 in ColumnsDescription"
+ALTER TABLE test_alter_drop_comment 
+    DROP COLUMN c0, 
+    COMMENT COLUMN IF EXISTS c0 'this comment should be silently ignored';
+
+-- Verify that c0 is dropped and c1, c2 remain
+DESCRIBE test_alter_drop_comment;
+
+-- Test case 2: COMMENT COLUMN IF EXISTS on non-existent column (should succeed)
+ALTER TABLE test_alter_drop_comment 
+    COMMENT COLUMN IF EXISTS non_existent_column 'this should be ignored';
+
+-- Verify table structure is unchanged
+DESCRIBE test_alter_drop_comment;
+
+-- Test case 3: COMMENT COLUMN without IF EXISTS on non-existent column (should fail)
+ALTER TABLE test_alter_drop_comment 
+    COMMENT COLUMN non_existent_column 'this should fail'; -- { serverError NOT_FOUND_COLUMN_IN_BLOCK }
+
+-- Test case 4: Multiple operations with IF EXISTS
+ALTER TABLE test_alter_drop_comment 
+    DROP COLUMN c1,
+    COMMENT COLUMN IF EXISTS c1 'dropped column comment',
+    COMMENT COLUMN IF EXISTS c2 'existing column comment';
+
+-- Verify final state - only c2 should remain with comment
+DESCRIBE test_alter_drop_comment;
+
+SELECT table, name, comment 
+FROM system.columns 
+WHERE table = 'test_alter_drop_comment' AND database = currentDatabase()
+ORDER BY name;
+
+DROP TABLE test_alter_drop_comment;
+
+-- Test with different table engines
+-- Test with MergeTree
+CREATE TABLE test_alter_drop_comment_mt (
+    id Int32,
+    value String,
+    status Int8
+) ENGINE = MergeTree() ORDER BY id;
+
+ALTER TABLE test_alter_drop_comment_mt 
+    DROP COLUMN status,
+    COMMENT COLUMN IF EXISTS status 'dropped status column',
+    COMMENT COLUMN IF EXISTS value 'existing value column';
+
+DESCRIBE test_alter_drop_comment_mt;
+
+DROP TABLE test_alter_drop_comment_mt;
+
+-- Test edge case: try to drop and comment the same column without IF EXISTS (should fail)
+CREATE TABLE test_alter_fail (c0 Int, c1 Int) ENGINE = Memory;
+
+ALTER TABLE test_alter_fail 
+    DROP COLUMN c0, 
+    COMMENT COLUMN c0 'this should fail'; -- { serverError NOT_FOUND_COLUMN_IN_BLOCK }
+
+DROP TABLE test_alter_fail;


### PR DESCRIPTION
This commit fixes issue #85608 where using `COMMENT COLUMN IF EXISTS` in the same ALTER statement after `DROP COLUMN` would cause a LOGICAL_ERROR instead of silently skipping the comment operation.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `LOGICAL_ERROR` when using `COMMENT COLUMN IF EXISTS` in the same `ALTER` statement after `DROP COLUMN`. The `IF EXISTS` clause now correctly skips the comment operation when the column has been dropped within the same statement.

