### PR TITLE
ci: increase delay for server startup

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -397,7 +397,7 @@ profiles:
             assert False
         started = False
         try:
-            for _ in range(5):
+            for _ in range(15):
                 pid = Shell.get_output(f"cat {pid_file}").strip()
                 if not pid:
                     Utils.sleep(1)

--- a/src/Common/StatusFile.cpp
+++ b/src/Common/StatusFile.cpp
@@ -42,8 +42,8 @@ StatusFile::FillFunction StatusFile::write_full_info = [](WriteBuffer & out)
 };
 
 
-StatusFile::StatusFile(std::string path_, FillFunction fill_)
-    : path(std::move(path_)), fill(std::move(fill_))
+StatusFile::StatusFile(std::string path_, FillFunction fill)
+    : path(std::move(path_))
 {
     /// If file already exists. NOTE Minor race condition.
     if (fs::exists(path))
@@ -86,6 +86,7 @@ StatusFile::StatusFile(std::string path_, FillFunction fill_)
         WriteBufferFromFileDescriptor out(fd, 1024);
         try
         {
+            LOG_INFO(getLogger("StatusFile"), "Writing pid {} to {}", getpid(), path);
             fill(out);
             out.finalize();
         }

--- a/src/Common/StatusFile.h
+++ b/src/Common/StatusFile.h
@@ -16,9 +16,9 @@ class WriteBuffer;
 class StatusFile : private boost::noncopyable
 {
 public:
-    using FillFunction = std::function<void(WriteBuffer&)>;
+    using FillFunction = std::function<void(WriteBuffer &)>;
 
-    StatusFile(std::string path_, FillFunction fill_);
+    StatusFile(std::string path_, FillFunction fill);
     ~StatusFile();
 
     /// You can use one of these functions to fill the file or provide your own.
@@ -27,7 +27,6 @@ public:
 
 private:
     const std::string path;
-    FillFunction fill;
     int fd = -1;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes (especially with sanitizers) 5 seconds is not enough
apparently, for instance here:

    2025.08.14 16:48:54.019889 [ 1780 ] {} <Debug> Application: Sending logical errors is enabled
    2025.08.14 16:48:57.229532 [ 1780 ] {} <Information> Application: Starting ClickHouse 25.8.1.1 (revision: 54501, git hash: c3c0b78d4d228b623e5a22c1cb0552b46a2eb433, build id: 06F54D60226B6627FA4B24BBF9FEDB9B3F9D86A2), PID 1780

It does something for 3 seconds

Also cleanup StatusFile and add some logs to make debugging easier