### PR TITLE
Text index: avoid redundant re-initializing in searchAny/searchAll functions

### DIFF
--- a/src/Functions/searchAnyAll.cpp
+++ b/src/Functions/searchAnyAll.cpp
@@ -39,7 +39,7 @@ FunctionSearchImpl<SearchTraits>::FunctionSearchImpl(ContextPtr context)
 }
 
 template <class SearchTraits>
-void FunctionSearchImpl<SearchTraits>::setGinFilterParameters(const GinFilterParameters & params)
+void FunctionSearchImpl<SearchTraits>::trySetGinFilterParameters(const GinFilterParameters & params)
 {
     /// Index parameters can be set multiple times.
     /// This happens exactly in a case that same searchAny/searchAll query is used again.
@@ -68,7 +68,7 @@ void FunctionSearchImpl<SearchTraits>::setGinFilterParameters(const GinFilterPar
 }
 
 template <class SearchTraits>
-void FunctionSearchImpl<SearchTraits>::setSearchTokens(const std::vector<String> & tokens)
+void FunctionSearchImpl<SearchTraits>::trySetSearchTokens(const std::vector<String> & tokens)
 {
     static constexpr size_t supported_number_of_needles = 64;
 

--- a/src/Functions/searchAnyAll.cpp
+++ b/src/Functions/searchAnyAll.cpp
@@ -23,7 +23,6 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int LOGICAL_ERROR;
     extern const int SUPPORT_IS_DISABLED;
 }
 

--- a/src/Functions/searchAnyAll.cpp
+++ b/src/Functions/searchAnyAll.cpp
@@ -45,9 +45,44 @@ void FunctionSearchImpl<SearchTraits>::setGinFilterParameters(const GinFilterPar
     /// Index parameters can be set multiple times.
     /// This happens exactly in a case that same searchAny/searchAll query is used again.
     /// This is fine because the parameters would be same.
-    if (parameters.has_value() && params != parameters.value())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Function '{}': Different index parameters are set.", getName());
-    parameters = params;
+    if (token_extractor != nullptr)
+        return;
+
+    if (params.tokenizer == DefaultTokenExtractor::getExternalName())
+        token_extractor = std::make_unique<DefaultTokenExtractor>();
+    else if (params.tokenizer == NgramTokenExtractor::getExternalName())
+    {
+        auto ngrams = params.ngram_size.value_or(DEFAULT_NGRAM_SIZE);
+        if (ngrams < 2 || ngrams > 8)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Ngrams argument of function '{}' should be between 2 and 8, got: {}", name, ngrams);
+        token_extractor = std::make_unique<NgramTokenExtractor>(ngrams);
+    }
+    else if (params.tokenizer == SplitTokenExtractor::getExternalName())
+    {
+        const auto & separators = params.separators.value_or(std::vector<String>{" "});
+        token_extractor = std::make_unique<SplitTokenExtractor>(separators);
+    }
+    else if (params.tokenizer == NoOpTokenExtractor::getExternalName())
+        token_extractor = std::make_unique<NoOpTokenExtractor>();
+    else
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function '{}' supports only tokenizers 'default', 'ngram', 'split', and 'no_op'", name);
+}
+
+template <class SearchTraits>
+void FunctionSearchImpl<SearchTraits>::setSearchTokens(const std::vector<String> & tokens)
+{
+    static constexpr size_t supported_number_of_needles = 64;
+
+    if (needles.has_value())
+        return;
+
+    needles = FunctionSearchNeedles();
+    for (UInt64 pos = 0; const auto & token : tokens)
+        if (auto [_, inserted] = needles->emplace(token, pos); inserted)
+            ++pos;
+
+    if (needles->size() > supported_number_of_needles)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function '{}' supports a max of {} needles", name, supported_number_of_needles);
 }
 
 template <class SearchTraits>
@@ -71,17 +106,13 @@ namespace
 {
 constexpr size_t arg_input = 0;
 constexpr size_t arg_needles = 1;
-constexpr size_t supported_number_of_needles = 64;
-
-/// Map needle into a position (for bitmap operations).
-using Needles = absl::flat_hash_map<String, UInt64>;
 
 template <typename StringColumnType>
 void executeSearchAny(
-    std::unique_ptr<ITokenExtractor> token_extractor,
+    const ITokenExtractor* token_extractor,
     StringColumnType & col_input,
     size_t input_rows_count,
-    const Needles & needles,
+    const FunctionSearchNeedles & needles,
     PaddedPODArray<UInt8> & col_result)
 {
     for (size_t i = 0; i < input_rows_count; ++i)
@@ -103,10 +134,10 @@ void executeSearchAny(
 
 template <typename StringColumnType>
 void executeSearchAll(
-    std::unique_ptr<ITokenExtractor> token_extractor,
+    const ITokenExtractor* token_extractor,
     StringColumnType & col_input,
     size_t input_rows_count,
-    const Needles & needles,
+    const FunctionSearchNeedles & needles,
     PaddedPODArray<UInt8> & col_result)
 {
     const size_t ns = needles.size();
@@ -137,10 +168,10 @@ void executeSearchAll(
 
 template <class SearchTraits, typename StringColumnType>
 void execute(
-    std::unique_ptr<ITokenExtractor> token_extractor,
+    const ITokenExtractor* token_extractor,
     StringColumnType & col_input,
     size_t input_rows_count,
-    const Needles & needles,
+    const FunctionSearchNeedles & needles,
     PaddedPODArray<UInt8> & col_result)
 {
     col_result.resize(input_rows_count);
@@ -148,10 +179,10 @@ void execute(
     switch (SearchTraits::search_mode)
     {
         case GinSearchMode::Any:
-            executeSearchAny(std::move(token_extractor), col_input, input_rows_count, needles, col_result);
+            executeSearchAny(token_extractor, col_input, input_rows_count, needles, col_result);
             break;
         case GinSearchMode::All:
-            executeSearchAll(std::move(token_extractor), col_input, input_rows_count, needles, col_result);
+            executeSearchAll(token_extractor, col_input, input_rows_count, needles, col_result);
             break;
     }
 }
@@ -164,10 +195,10 @@ ColumnPtr FunctionSearchImpl<SearchTraits>::executeImpl(
     if (input_rows_count == 0)
         return ColumnVector<UInt8>::create();
 
-    if (!parameters.has_value())
+    if (token_extractor == nullptr || !needles.has_value())
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Function '{}' should be used with the index column, but got column '{}'",
+            "Function '{}' must be used with the index column, but got column '{}'",
             getName(),
             arguments[arg_input].name);
 
@@ -175,52 +206,17 @@ ColumnPtr FunctionSearchImpl<SearchTraits>::executeImpl(
     auto col_needles = arguments[arg_needles].column;
     auto col_result = ColumnVector<UInt8>::create();
 
-    std::unique_ptr<ITokenExtractor> token_extractor;
-    if (parameters->tokenizer == DefaultTokenExtractor::getExternalName())
-        token_extractor = std::make_unique<DefaultTokenExtractor>();
-    else if (parameters->tokenizer == NgramTokenExtractor::getExternalName())
-    {
-        auto ngrams = parameters->ngram_size.value_or(DEFAULT_NGRAM_SIZE);
-        if (ngrams < 2 || ngrams > 8)
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS, "Ngrams argument of function '{}' should be between 2 and 8, got: {}", name, ngrams);
-        token_extractor = std::make_unique<NgramTokenExtractor>(ngrams);
-    }
-    else if (parameters->tokenizer == SplitTokenExtractor::getExternalName())
-    {
-        const auto & separators = parameters->separators.value_or(std::vector<String>{" "});
-        token_extractor = std::make_unique<SplitTokenExtractor>(separators);
-    }
-    else if (parameters->tokenizer == NoOpTokenExtractor::getExternalName())
-        token_extractor = std::make_unique<NoOpTokenExtractor>();
-    else
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function '{}' supports only tokenizers 'default', 'ngram', 'split', and 'no_op'", name);
-
-    Needles needles;
-    if (const ColumnConst * col_needles_const = checkAndGetColumnConst<ColumnArray>(col_needles.get()))
-    {
-        /// TODO(ahmadov): initialize needles once for the given parameters. They are constant.
-        for (UInt64 pos = 0; const auto & needle_field : col_needles_const->getValue<Array>())
-        {
-            const auto & needle = needle_field.safeGet<String>();
-            if (auto [_, inserted] = needles.emplace(needle, pos); inserted)
-                ++pos;
-        }
-    }
-    else
+    if (const ColumnConst * col_needles_const = checkAndGetColumnConst<ColumnArray>(col_needles.get()); !col_needles_const)
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Needles argument of function '{}' should be Array(String), got: {}",
+            "Needles argument of function '{}' must be Array(String), got: {}",
             name,
             col_needles->getFamilyName());
 
-    if (needles.size() > supported_number_of_needles)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function '{}' supports a max of {} needles", name, supported_number_of_needles);
-
     if (const auto * column_string = checkAndGetColumn<ColumnString>(col_input.get()))
-        execute<SearchTraits>(std::move(token_extractor), *column_string, input_rows_count, needles, col_result->getData());
+        execute<SearchTraits>(token_extractor.get(), *column_string, input_rows_count, needles.value(), col_result->getData());
     else if (const auto * column_fixed_string = checkAndGetColumn<ColumnFixedString>(col_input.get()))
-        execute<SearchTraits>(std::move(token_extractor), *column_fixed_string, input_rows_count, needles, col_result->getData());
+        execute<SearchTraits>(token_extractor.get(), *column_fixed_string, input_rows_count, needles.value(), col_result->getData());
 
     return col_result;
 }

--- a/src/Functions/searchAnyAll.h
+++ b/src/Functions/searchAnyAll.h
@@ -3,6 +3,7 @@
 #include <Functions/IFunction.h>
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/GinFilter.h>
+#include <Interpreters/ITokenExtractor.h>
 
 namespace DB
 {
@@ -22,6 +23,9 @@ struct SearchAllTraits
 };
 }
 
+/// Map needle into a position (for bitmap operations).
+using FunctionSearchNeedles = absl::flat_hash_map<String, UInt64>;
+
 template <class SearchTraits>
 class FunctionSearchImpl : public IFunction
 {
@@ -37,12 +41,14 @@ public:
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
     void setGinFilterParameters(const GinFilterParameters & params);
+    void setSearchTokens(const std::vector<String> & tokens);
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override;
 
 private:
     const bool allow_experimental_full_text_index;
-    std::optional<GinFilterParameters> parameters;
+    std::unique_ptr<ITokenExtractor> token_extractor;
+    std::optional<FunctionSearchNeedles> needles;
 };
 }

--- a/src/Functions/searchAnyAll.h
+++ b/src/Functions/searchAnyAll.h
@@ -40,8 +40,8 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
-    void setGinFilterParameters(const GinFilterParameters & params);
-    void setSearchTokens(const std::vector<String> & tokens);
+    void trySetGinFilterParameters(const GinFilterParameters & params);
+    void trySetSearchTokens(const std::vector<String> & tokens);
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override;

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -30,6 +30,12 @@ GinFilterParameters::GinFilterParameters(
 {
 }
 
+GinFilter::GinFilter(std::string_view query_string_, const std::vector<String> & search_terms_)
+    : query_string(query_string_)
+    , terms(search_terms_)
+{
+}
+
 void GinFilter::add(const String & term, UInt32 rowID, GinIndexStorePtr & store) const
 {
     if (term.length() > FST::MAX_TERM_LENGTH)

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -60,6 +60,10 @@ using GinSegmentWithRowIdRangeVector = std::vector<GinSegmentWithRowIdRange>;
 class GinFilter
 {
 public:
+    GinFilter() = default;
+
+    GinFilter(std::string_view query_string_, const std::vector<String> & search_terms_);
+
     /// Add term (located at 'data' with length 'len') and its row ID to the postings list builder
     /// for building text index for the given store.
     void add(const String & term, UInt32 rowID, GinIndexStorePtr & store) const;

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -445,9 +445,7 @@ bool MergeTreeIndexConditionGin::traverseASTEquals(
             if (element.getType() != Field::Types::String)
                 return false;
             const auto & value = element.safeGet<String>();
-            gin_filters.emplace_back(GinFilter());
-            gin_filters.back().addTerm(value);
-            gin_filters.back().setQueryString(value);
+            gin_filters.emplace_back(GinFilter(value, {value}));
             search_tokens.push_back(value);
         }
         out.function = function_name == "searchAny" ? RPNElement::FUNCTION_SEARCH_ANY : RPNElement::FUNCTION_SEARCH_ALL;
@@ -463,15 +461,15 @@ bool MergeTreeIndexConditionGin::traverseASTEquals(
             {
                 auto * search_function = typeid_cast<FunctionSearchImpl<traits::SearchAnyTraits> *>(adaptor->getFunction().get());
                 chassert(search_function != nullptr);
-                search_function->setGinFilterParameters(gin_filter_params);
-                search_function->setSearchTokens(search_tokens);
+                search_function->trySetGinFilterParameters(gin_filter_params);
+                search_function->trySetSearchTokens(search_tokens);
             }
             else
             {
                 auto * search_function = typeid_cast<FunctionSearchImpl<traits::SearchAllTraits> *>(adaptor->getFunction().get());
                 chassert(search_function != nullptr);
-                search_function->setGinFilterParameters(gin_filter_params);
-                search_function->setSearchTokens(search_tokens);
+                search_function->trySetGinFilterParameters(gin_filter_params);
+                search_function->trySetSearchTokens(search_tokens);
             }
         }
         return true;

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -438,8 +438,23 @@ bool MergeTreeIndexConditionGin::traverseASTEquals(
     }
     if (function_name == "searchAny" || function_name == "searchAll")
     {
+        GinFilters gin_filters;
+        std::vector<String> search_tokens;
+        for (const auto & element : const_value.safeGet<Array>())
         {
-            /// TODO(ahmadov): move this block to another place, e.g. optimizations.
+            if (element.getType() != Field::Types::String)
+                return false;
+            const auto & value = element.safeGet<String>();
+            gin_filters.emplace_back(GinFilter());
+            gin_filters.back().addTerm(value);
+            gin_filters.back().setQueryString(value);
+            search_tokens.push_back(value);
+        }
+        out.function = function_name == "searchAny" ? RPNElement::FUNCTION_SEARCH_ANY : RPNElement::FUNCTION_SEARCH_ALL;
+        out.set_gin_filters = std::vector<GinFilters>{std::move(gin_filters)};
+
+        {
+            /// TODO(ahmadov): move this block to another place, e.g. optimizations or query tree re-write.
             const auto * function_dag_node = function_node.getDAGNode();
             chassert(function_dag_node != nullptr && function_dag_node->function_base != nullptr);
             const auto * adaptor = typeid_cast<const FunctionToFunctionBaseAdaptor *>(function_dag_node->function_base.get());
@@ -449,27 +464,16 @@ bool MergeTreeIndexConditionGin::traverseASTEquals(
                 auto * search_function = typeid_cast<FunctionSearchImpl<traits::SearchAnyTraits> *>(adaptor->getFunction().get());
                 chassert(search_function != nullptr);
                 search_function->setGinFilterParameters(gin_filter_params);
+                search_function->setSearchTokens(search_tokens);
             }
             else
             {
                 auto * search_function = typeid_cast<FunctionSearchImpl<traits::SearchAllTraits> *>(adaptor->getFunction().get());
                 chassert(search_function != nullptr);
                 search_function->setGinFilterParameters(gin_filter_params);
+                search_function->setSearchTokens(search_tokens);
             }
         }
-
-        GinFilters gin_filters;
-        for (const auto & element : const_value.safeGet<Array>())
-        {
-            if (element.getType() != Field::Types::String)
-                return false;
-            const auto & value = element.safeGet<String>();
-            gin_filters.emplace_back(GinFilter());
-            gin_filters.back().addTerm(value);
-            gin_filters.back().setQueryString(value);
-        }
-        out.function = function_name == "searchAny" ? RPNElement::FUNCTION_SEARCH_ANY : RPNElement::FUNCTION_SEARCH_ALL;
-        out.set_gin_filters = std::vector<GinFilters>{std::move(gin_filters)};
         return true;
     }
     if (function_name == "hasToken" || function_name == "hasTokenOrNull")


### PR DESCRIPTION
Initialize `token_extractor` only once since it's not changing. Also, the same applies to the search tokens.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

