### PR TITLE
Remove override for linker parallelism in case of ThinLTO

### DIFF
--- a/ci/docker/fasttest/Dockerfile
+++ b/ci/docker/fasttest/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
         wget \
         git \
         xxd \
+        time \
         --yes --no-install-recommends --verbose-versions \
     && export LLVM_PUBKEY_HASH="bda960a8da687a275a2078d43c111d66b1c6a893a3275271beedf266c1ff4a0cdecb429c7a5cccf9f486ea7aa43fd27f" \
     && wget -nv -O /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key \

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -193,7 +193,7 @@ def main():
         results.append(
             Result.from_commands_run(
                 name="Build ClickHouse",
-                command=f"ninja {targets}",
+                command=f"command time -v ninja {targets}",
                 workdir=build_dir,
             )
         )
@@ -228,7 +228,7 @@ def main():
             Result.from_commands_run(
                 name="Build Packages",
                 command=[
-                    f"DESTDIR={build_dir}/root ninja programs/install",
+                    f"DESTDIR={build_dir}/root command time -v ninja programs/install",
                     f"ln -sf {build_dir}/root {Utils.cwd()}/packages/root",
                     f"cd {Utils.cwd()}/packages/ && OUTPUT_DIR={temp_dir} BUILD_TYPE={BUILD_TYPE_TO_DEB_PACKAGE_TYPE[build_type]} VERSION_STRING={version_dict['string']} DEB_ARCH={deb_arch} ./build --deb {'--rpm --tgz' if 'release' in build_type else ''}",
                 ],

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -187,7 +187,7 @@ def main():
         results.append(
             Result.from_commands_run(
                 name="Build ClickHouse",
-                command="ninja clickhouse-bundle clickhouse-stripped lexer_test",
+                command="command time -v ninja clickhouse-bundle clickhouse-stripped lexer_test",
                 workdir=build_dir,
             )
         )

--- a/cmake/limit_jobs.cmake
+++ b/cmake/limit_jobs.cmake
@@ -36,17 +36,6 @@ if (NOT PARALLEL_LINK_JOBS AND MAX_LINKER_MEMORY)
     endif()
 endif ()
 
-# ThinLTO provides its own parallel linking
-# (which is enabled only for RELWITHDEBINFO)
-#
-# But use 2 parallel jobs, since:
-# - this is what llvm does
-# - and I've verfied that lld-11 does not use all available CPU time (in peak) while linking one binary
-if (CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" AND ENABLE_THINLTO AND PARALLEL_LINK_JOBS GREATER 2)
-    message(STATUS "ThinLTO provides its own parallel linking - limiting parallel link jobs to 2.")
-    set (PARALLEL_LINK_JOBS 2)
-endif()
-
 message(STATUS "Building sub-tree with ${PARALLEL_COMPILE_JOBS} compile jobs and ${PARALLEL_LINK_JOBS} linker jobs (system: ${NUMBER_OF_LOGICAL_CORES} cores, ${TOTAL_PHYSICAL_MEMORY} MB RAM, 'OFF' means the native core count).")
 
 if (PARALLEL_COMPILE_JOBS LESS NUMBER_OF_LOGICAL_CORES)


### PR DESCRIPTION
Even though ThinLTO provides own parallelism it is not able to utilize full amount of CPU time, so let's see how it will work with default parallelism limit based on memory.

Also wrap `ninja` with `time` to measure peak memory usage and CPU time utilization

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

_Note: I will play with settings in the meantime_