### PR TITLE
Don't store whole manifest file entries for position deletes in object info

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -146,7 +146,6 @@ Plan getPlan(
                     plan.partitions.push_back({});
 
                 IcebergDataObjectInfoPtr data_object_info = std::make_shared<IcebergDataObjectInfo>(data_file);
-                data_object_info->sequence_number = data_file.added_sequence_number;
                 std::shared_ptr<DataFilePlan> data_file_ptr;
                 if (!plan.path_to_data_file.contains(manifest_file.manifest_file_path))
                 {
@@ -176,7 +175,7 @@ Plan getPlan(
         for (auto & data_file : plan.partitions[partition_index])
         {
             if (data_file->data_object_info->sequence_number <= delete_file.added_sequence_number)
-                data_file->data_object_info->position_deletes_objects.push_back(delete_file);
+                data_file->data_object_info->addPositionDeleteObject(delete_file);
         }
     }
     plan.history = std::move(snapshots_info);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#if USE_AVRO
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Poco/JSON/Array.h>
@@ -25,48 +26,8 @@ extern const int LOGICAL_ERROR;
 extern const int NOT_IMPLEMENTED;
 }
 
-#if USE_AVRO
-namespace
-{
 
 using namespace DB::Iceberg;
-
-
-std::vector<ManifestFileEntry>
-definePositionDeletesSpan(ManifestFileEntry data_object_, const std::vector<ManifestFileEntry> & position_deletes_objects_)
-{
-    ///Object in position_deletes_objects_ are sorted by common_partition_specification, partition_key_value and added_sequence_number.
-    /// It is done to have an invariant that position deletes objects which corresponds
-    /// to the data object form a subsegment in a position_deletes_objects_ vector.
-    /// We need to take all position deletes objects which has the same partition schema and value and has added_sequence_number
-    /// greater than or equal to the data object added_sequence_number (https://iceberg.apache.org/spec/#scan-planning)
-    /// ManifestFileEntry has comparator by default which helps to do that.
-    auto beg_it = std::lower_bound(position_deletes_objects_.begin(), position_deletes_objects_.end(), data_object_);
-    auto end_it = std::upper_bound(
-        position_deletes_objects_.begin(),
-        position_deletes_objects_.end(),
-        data_object_,
-        [](const ManifestFileEntry & lhs, const ManifestFileEntry & rhs)
-        {
-            return std::tie(lhs.common_partition_specification, lhs.partition_key_value)
-                < std::tie(rhs.common_partition_specification, rhs.partition_key_value);
-        });
-    if (beg_it - position_deletes_objects_.begin() > end_it - position_deletes_objects_.begin())
-    {
-        throw DB::Exception(
-            DB::ErrorCodes::LOGICAL_ERROR,
-            "Position deletes objects are not sorted by common_partition_specification and partition_key_value, "
-            "beginning: {}, end: {}, position_deletes_objects size: {}",
-            beg_it - position_deletes_objects_.begin(),
-            end_it - position_deletes_objects_.begin(),
-            position_deletes_objects_.size());
-    }
-    return {beg_it, end_it};
-}
-
-}
-
-#endif
 
 namespace DB
 {
@@ -76,37 +37,25 @@ namespace Setting
 extern const SettingsBool use_roaring_bitmap_iceberg_positional_deletes;
 };
 
-#if USE_AVRO
-
-IcebergDataObjectInfo::IcebergDataObjectInfo(
-    Iceberg::ManifestFileEntry data_manifest_file_entry_,
-    const std::vector<Iceberg::ManifestFileEntry> & all_position_delete_entries_,
-    String format_)
+IcebergDataObjectInfo::IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_)
     : RelativePathWithMetadata(data_manifest_file_entry_.file_path)
     , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
     , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
-    , position_deletes_objects(definePositionDeletesSpan(data_manifest_file_entry_, all_position_delete_entries_))
+    , sequence_number(data_manifest_file_entry_.added_sequence_number)
 {
     auto toupper = [](String & str)
     {
         std::transform(str.begin(), str.end(), str.begin(), ::toupper);
         return str;
     };
-    if (!position_deletes_objects.empty() && toupper(format_) != "PARQUET")
+    if (!position_deletes_objects.empty() && toupper(data_manifest_file_entry_.file_format) != "PARQUET")
     {
         throw Exception(
             ErrorCodes::NOT_IMPLEMENTED,
             "Position deletes are only supported for data files of Parquet format in Iceberg, but got {}",
-            format_);
+            data_manifest_file_entry_.file_format);
     }
 }
-
-IcebergDataObjectInfo::IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_)
-    : RelativePathWithMetadata(data_manifest_file_entry_.file_path)
-    , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
-    , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
-    , position_deletes_objects({})
-{}
 
 std::shared_ptr<ISimpleTransform> IcebergDataObjectInfo::getPositionDeleteTransformer(
     ObjectStoragePtr object_storage,
@@ -120,6 +69,6 @@ std::shared_ptr<ISimpleTransform> IcebergDataObjectInfo::getPositionDeleteTransf
     else
         return std::make_shared<IcebergBitmapPositionDeleteTransform>(header, self, object_storage, format_settings, context_);
 }
+}
 
 #endif
-}

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
@@ -22,7 +22,6 @@
 
 namespace DB::ErrorCodes
 {
-extern const int LOGICAL_ERROR;
 extern const int NOT_IMPLEMENTED;
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
@@ -7,6 +7,7 @@
 #include <Storages/ObjectStorage/IObjectIterator.h>
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h>
 #include <base/defines.h>
 
 
@@ -19,17 +20,7 @@ struct IcebergDataObjectInfo : public RelativePathWithMetadata, std::enable_shar
     /// Full path to the data object file
     /// It is used to filter position deletes objects by data file path.
     /// It is also used to create a filter for the data object in the position delete transform.
-    explicit IcebergDataObjectInfo(
-        Iceberg::ManifestFileEntry data_manifest_file_entry_,
-        const std::vector<Iceberg::ManifestFileEntry> & all_position_delete_entries_,
-        String format);
-
     explicit IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_);
-
-    String data_object_file_path_key; // Full path to the data object file
-    Int32 underlying_format_read_schema_id;
-    std::vector<Iceberg::ManifestFileEntry> position_deletes_objects;
-    Int64 sequence_number;
 
     bool hasPositionDeleteTransformer() const override { return !position_deletes_objects.empty(); }
 
@@ -38,6 +29,18 @@ struct IcebergDataObjectInfo : public RelativePathWithMetadata, std::enable_shar
         const SharedHeader & header,
         const std::optional<FormatSettings> & format_settings,
         ContextPtr context_) override;
+
+    void addPositionDeleteObject(Iceberg::ManifestFileEntry position_delete_object)
+    {
+        position_deletes_objects.emplace_back(
+            position_delete_object.file_path, position_delete_object.file_format, position_delete_object.reference_data_file_path);
+    }
+
+
+    String data_object_file_path_key; // Full path to the data object file
+    Int32 underlying_format_read_schema_id;
+    std::vector<Iceberg::PositionDeleteObject> position_deletes_objects;
+    Int64 sequence_number;
 };
 
 using IcebergDataObjectInfoPtr = std::shared_ptr<IcebergDataObjectInfo>;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -70,6 +70,42 @@ extern const SettingsBool use_iceberg_partition_pruning;
 
 using namespace Iceberg;
 
+namespace
+{
+std::span<const ManifestFileEntry>
+definePositionDeletesSpan(ManifestFileEntry data_object_, const std::vector<ManifestFileEntry> & position_deletes_objects_)
+{
+    ///Object in position_deletes_objects_ are sorted by common_partition_specification, partition_key_value and added_sequence_number.
+    /// It is done to have an invariant that position deletes objects which corresponds
+    /// to the data object form a subsegment in a position_deletes_objects_ vector.
+    /// We need to take all position deletes objects which has the same partition schema and value and has added_sequence_number
+    /// greater than or equal to the data object added_sequence_number (https://iceberg.apache.org/spec/#scan-planning)
+    /// ManifestFileEntry has comparator by default which helps to do that.
+    auto beg_it = std::lower_bound(position_deletes_objects_.begin(), position_deletes_objects_.end(), data_object_);
+    auto end_it = std::upper_bound(
+        position_deletes_objects_.begin(),
+        position_deletes_objects_.end(),
+        data_object_,
+        [](const ManifestFileEntry & lhs, const ManifestFileEntry & rhs)
+        {
+            return std::tie(lhs.common_partition_specification, lhs.partition_key_value)
+                < std::tie(rhs.common_partition_specification, rhs.partition_key_value);
+        });
+    if (beg_it - position_deletes_objects_.begin() > end_it - position_deletes_objects_.begin())
+    {
+        throw DB::Exception(
+            DB::ErrorCodes::LOGICAL_ERROR,
+            "Position deletes objects are not sorted by common_partition_specification and partition_key_value, "
+            "beginning: {}, end: {}, position_deletes_objects size: {}",
+            beg_it - position_deletes_objects_.begin(),
+            end_it - position_deletes_objects_.begin(),
+            position_deletes_objects_.size());
+    }
+    return {beg_it, end_it};
+}
+
+}
+
 std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
 {
     if (!data_snapshot)
@@ -262,7 +298,12 @@ ObjectInfoPtr IcebergIterator::next(size_t)
     Iceberg::ManifestFileEntry manifest_file_entry;
     if (blocking_queue.pop(manifest_file_entry))
     {
-        return std::make_shared<IcebergDataObjectInfo>(manifest_file_entry, position_deletes_files, manifest_file_entry.file_format);
+        IcebergDataObjectInfoPtr object_info = std::make_shared<IcebergDataObjectInfo>(manifest_file_entry);
+        for (const auto & position_delete : definePositionDeletesSpan(manifest_file_entry, position_deletes_files))
+        {
+            object_info->addPositionDeleteObject(position_delete);
+        }
+        return object_info;
     }
     return nullptr;
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "config.h"
+
+#if USE_AVRO
+
+#include <base/types.h>
+#include <optional>
+
+namespace DB::Iceberg {
+    struct PositionDeleteObject {
+        String file_path;
+        String file_format;
+        std::optional<String> reference_data_file_path;
+    };
+}
+
+
+#endif

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h
@@ -3,15 +3,17 @@
 
 #if USE_AVRO
 
-#include <base/types.h>
 #include <optional>
+#include <base/types.h>
 
-namespace DB::Iceberg {
-    struct PositionDeleteObject {
-        String file_path;
-        String file_format;
-        std::optional<String> reference_data_file_path;
-    };
+namespace DB::Iceberg
+{
+struct PositionDeleteObject
+{
+    String file_path;
+    String file_format;
+    std::optional<String> reference_data_file_path;
+};
 }
 
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -18,20 +18,20 @@
 #include <Parsers/ASTLiteral.h>
 #include <Processors/Formats/ISchemaReader.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSource.h>
 
-namespace DB
-{
-
-namespace Setting
+namespace DB::Setting
 {
 extern const SettingsNonZeroUInt64 max_block_size;
 }
-
-namespace ErrorCodes
+namespace DB::ErrorCodes
 {
 extern const int LOGICAL_ERROR;
 }
+
+namespace DB::Iceberg
+{
 
 
 void IcebergPositionDeleteTransform::initializeDeleteSources()
@@ -43,7 +43,7 @@ void IcebergPositionDeleteTransform::initializeDeleteSources()
         std::make_shared<ASTIdentifier>(IcebergPositionDeleteTransform::data_file_path_column_name),
         std::make_shared<ASTLiteral>(Field(iceberg_data_path)));
 
-    for (const auto & position_deletes_object : relevant_position_deletes_objects)
+    for (const auto & position_deletes_object : iceberg_object_info->position_deletes_objects)
     {
         /// Skip position deletes that do not match the data file path.
         if (position_deletes_object.reference_data_file_path.has_value()

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
@@ -8,10 +8,8 @@
 #include <Processors/ISimpleTransform.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h>
 
-
-namespace DB
+namespace DB::Iceberg
 {
-
 class IcebergPositionDeleteTransform : public ISimpleTransform
 {
 public:
@@ -30,7 +28,6 @@ public:
         , object_storage(object_storage_)
         , format_settings(format_settings_)
         , context(context_)
-        , relevant_position_deletes_objects(iceberg_object_info_->position_deletes_objects)
     {
         initializeDeleteSources();
     }
@@ -49,7 +46,6 @@ protected:
     const ObjectStoragePtr object_storage;
     const std::optional<FormatSettings> format_settings;
     ContextPtr context;
-    std::span<const Iceberg::ManifestFileEntry> relevant_position_deletes_objects;
 
     /// We need to keep the read buffers alive since the delete_sources depends on them.
     std::vector<std::unique_ptr<ReadBuffer>> delete_read_buffers;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
