### PR TITLE
Docs: move NLP functions documentation to source code

### DIFF
--- a/ci/jobs/scripts/check_style/check_typos.sh
+++ b/ci/jobs/scripts/check_style/check_typos.sh
@@ -12,4 +12,4 @@ codespell \
     --quiet-level 2 \
     "$ROOT_PATH"/{src,base,programs,utils} \
     $@ | grep -P '.' \
-    && echo -e "\nFound some typos in code.\nSee the files utils/check-style/codespell* if you want to add an exception."
+    && echo -e "\nFound some typos in the code.\nSee ci/jobs/scripts/check_style/codespell-ignore-*.list if you want to add a line or word exception."

--- a/ci/jobs/scripts/check_style/codespell-ignore-words.list
+++ b/ci/jobs/scripts/check_style/codespell-ignore-words.list
@@ -42,3 +42,4 @@ XIRR
 xnpv
 XNPV
 Tage
+

--- a/ci/jobs/scripts/check_style/codespell-ignore-words.list
+++ b/ci/jobs/scripts/check_style/codespell-ignore-words.list
@@ -41,5 +41,4 @@ xirr
 XIRR
 xnpv
 XNPV
-Tage
-
+tage

--- a/ci/jobs/scripts/check_style/codespell-ignore-words.list
+++ b/ci/jobs/scripts/check_style/codespell-ignore-words.list
@@ -41,3 +41,4 @@ xirr
 XIRR
 xnpv
 XNPV
+Tage

--- a/src/Functions/FunctionsCharsetClassification.cpp
+++ b/src/Functions/FunctionsCharsetClassification.cpp
@@ -149,8 +149,40 @@ using FunctionDetectLanguageUnknown = FunctionTextClassificationString<CharsetCl
 
 REGISTER_FUNCTION(DetectCharset)
 {
-    factory.registerFunction<FunctionDetectCharset>();
-    factory.registerFunction<FunctionDetectLanguageUnknown>();
+    FunctionDocumentation::Description description_charset = R"(
+Detects the character set of a non-UTF8-encoded input string.
+)";
+    FunctionDocumentation::Syntax syntax_charset = "detectCharset(s)";
+    FunctionDocumentation::Arguments arguments_charset = {
+        {"s", "The text to analyze.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_charset = {"Returns a string containing the code of the detected character set", {"String"}};
+    FunctionDocumentation::Examples examples_charset = {
+        {"Basic usage", "SELECT detectCharset('Ich bleibe für ein paar Tage.')", "WINDOWS-1252"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_charset = {22, 2};
+    FunctionDocumentation::Category category_charset = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation_charset = {description_charset, syntax_charset, arguments_charset, returned_value_charset, examples_charset, introduced_in_charset, category_charset};
+
+    factory.registerFunction<FunctionDetectCharset>(documentation_charset);
+
+    FunctionDocumentation::Description description_unknown = R"(
+Similar to the [`detectLanguage`](#detectLanguage) function, except the detectLanguageUnknown function works with non-UTF8-encoded strings.
+Prefer this version when your character set is UTF-16 or UTF-32.
+)";
+    FunctionDocumentation::Syntax syntax_unknown = "detectLanguageUnknown('s')";
+    FunctionDocumentation::Arguments arguments_unknown = {
+        {"s", "The text to analyze.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_unknown = {"Returns the 2-letter ISO code of the detected language. Other possible results: `un` = unknown, can not detect any language, `other` = the detected language does not have 2 letter code.", {"String"}};
+    FunctionDocumentation::Examples examples_unknown = {
+        {"Basic usage", "SELECT detectLanguageUnknown('Ich bleibe für ein paar Tage.')", "de"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_unknown = {22, 2};
+    FunctionDocumentation::Category category_unknown = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation_unknown = {description_unknown, syntax_unknown, arguments_unknown, returned_value_unknown, examples_unknown, introduced_in_unknown, category_unknown};
+
+    factory.registerFunction<FunctionDetectLanguageUnknown>(documentation_unknown);
 }
 
 }

--- a/src/Functions/FunctionsLanguageClassification.cpp
+++ b/src/Functions/FunctionsLanguageClassification.cpp
@@ -238,7 +238,7 @@ REGISTER_FUNCTION(DetectLanguage)
 Detects the language of the UTF8-encoded input string.
 The function uses the [CLD2 library](https://github.com/CLD2Owners/cld2) for detection and returns the 2-letter ISO language code.
 
-The `detectLanguage` function works best when providing over 200 characters in the input string.
+The longer the input, the more precise the language detection will be.
 )";
     FunctionDocumentation::Syntax syntax_detect = "detectLanguage(s)";
     FunctionDocumentation::Arguments arguments_detect = {

--- a/src/Functions/FunctionsLanguageClassification.cpp
+++ b/src/Functions/FunctionsLanguageClassification.cpp
@@ -234,8 +234,42 @@ using FunctionDetectLanguage = FunctionTextClassificationString<FunctionDetectLa
 
 REGISTER_FUNCTION(DetectLanguage)
 {
-    factory.registerFunction<FunctionDetectLanguage>();
-    factory.registerFunction<FunctionDetectLanguageMixed>();
+    FunctionDocumentation::Description description_detect = R"(
+Detects the language of the UTF8-encoded input string.
+The function uses the [CLD2 library](https://github.com/CLD2Owners/cld2) for detection and returns the 2-letter ISO language code.
+
+The `detectLanguage` function works best when providing over 200 characters in the input string.
+)";
+    FunctionDocumentation::Syntax syntax_detect = "detectLanguage(s)";
+    FunctionDocumentation::Arguments arguments_detect = {
+        {"text_to_be_analyzed", "The text to analyze.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_detect = {"Returns the 2-letter ISO code of the detected language. Other possible results: `un` = unknown, can not detect any language, `other` = the detected language does not have 2 letter code.", {"String"}};
+    FunctionDocumentation::Examples examples_detect = {
+        {"Mixed language text", "SELECT detectLanguage('Je pense que je ne parviendrai jamais à parler français comme un natif. Where there\\'s a will, there\\'s a way.')", "fr"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_detect = {22, 2};
+    FunctionDocumentation::Category category_detect = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation_detect = {description_detect, syntax_detect, arguments_detect, returned_value_detect, examples_detect, introduced_in_detect, category_detect};
+
+    factory.registerFunction<FunctionDetectLanguage>(documentation_detect);
+
+    FunctionDocumentation::Description description_mixed = R"(
+Similar to the [`detectLanguage`](#detectLanguage) function, but `detectLanguageMixed` returns a `Map` of 2-letter language codes that are mapped to the percentage of the certain language in the text.
+)";
+    FunctionDocumentation::Syntax syntax_mixed = "detectLanguageMixed(s)";
+    FunctionDocumentation::Arguments arguments_mixed = {
+        {"s", "The text to analyze", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_mixed = {"Returns a map with keys which are 2-letter ISO codes and corresponding values which are a percentage of the text found for that language", {"Map(String, Float32)"}};
+    FunctionDocumentation::Examples examples_mixed = {
+        {"Mixed languages", "SELECT detectLanguageMixed('二兎を追う者は一兎をも得ず二兎を追う者は一兎をも得ず A vaincre sans peril, on triomphe sans gloire.')", "{'ja':0.62,'fr':0.36}"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_mixed = {22, 2};
+    FunctionDocumentation::Category category_mixed = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation_mixed = {description_mixed, syntax_mixed, arguments_mixed, returned_value_mixed, examples_mixed, introduced_in_mixed, category_mixed};
+
+    factory.registerFunction<FunctionDetectLanguageMixed>(documentation_mixed);
 }
 
 }

--- a/src/Functions/FunctionsProgrammingClassification.cpp
+++ b/src/Functions/FunctionsProgrammingClassification.cpp
@@ -119,9 +119,7 @@ using FunctionDetectProgrammingLanguage = FunctionTextClassificationString<Funct
 REGISTER_FUNCTION(DetectProgrammingLanguage)
 {
     FunctionDocumentation::Description description = R"(
-Determines the programming language from the source code.
-Calculates all the unigrams and bigrams of commands in the source code.
-Then using a marked-up dictionary with weights of unigrams and bigrams of commands for various programming languages finds the biggest weight of the programming language and returns it.
+Determines the programming language from a given source code snippet.
 )";
     FunctionDocumentation::Syntax syntax = "detectProgrammingLanguage('source_code')";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/FunctionsProgrammingClassification.cpp
+++ b/src/Functions/FunctionsProgrammingClassification.cpp
@@ -118,7 +118,24 @@ using FunctionDetectProgrammingLanguage = FunctionTextClassificationString<Funct
 
 REGISTER_FUNCTION(DetectProgrammingLanguage)
 {
-    factory.registerFunction<FunctionDetectProgrammingLanguage>();
+    FunctionDocumentation::Description description = R"(
+Determines the programming language from the source code.
+Calculates all the unigrams and bigrams of commands in the source code.
+Then using a marked-up dictionary with weights of unigrams and bigrams of commands for various programming languages finds the biggest weight of the programming language and returns it.
+)";
+    FunctionDocumentation::Syntax syntax = "detectProgrammingLanguage('source_code')";
+    FunctionDocumentation::Arguments arguments = {
+        {"source_code", "String representation of the source code to analyze.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns programming language", {"String"}};
+    FunctionDocumentation::Examples examples = {
+        {"C++ code detection", "SELECT detectProgrammingLanguage('#include <iostream>')", "C++"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionDetectProgrammingLanguage>(documentation);
 }
 
 }

--- a/src/Functions/FunctionsProgrammingClassification.cpp
+++ b/src/Functions/FunctionsProgrammingClassification.cpp
@@ -131,7 +131,7 @@ Then using a marked-up dictionary with weights of unigrams and bigrams of comman
     FunctionDocumentation::Examples examples = {
         {"C++ code detection", "SELECT detectProgrammingLanguage('#include <iostream>')", "C++"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 2};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::NLP;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/FunctionsTonalityClassification.cpp
+++ b/src/Functions/FunctionsTonalityClassification.cpp
@@ -87,8 +87,6 @@ REGISTER_FUNCTION(DetectTonality)
 {
     FunctionDocumentation::Description description = R"(
 Determines the sentiment of the provided text data.
-Uses a marked-up sentiment dictionary, in which each word has a tonality ranging from -12 to 6.
-For each piece of text, it calculates the average sentiment value of its words and returns it in the range [-1, 1].
 
 :::note Limitation
 This function is limited in its current form in that it makes use of the embedded emotional dictionary and only works for the Russian language.
@@ -104,9 +102,9 @@ This function is limited in its current form in that it makes use of the embedde
         "Russian sentiment analysis",
         R"(
 SELECT
-detectTonality('Шарик - хороший пёс'),
-detectTonality('Шарик - пёс'),
-detectTonality('Шарик - плохой пёс')
+    detectTonality('Шарик - хороший пёс'),
+    detectTonality('Шарик - пёс'),
+    detectTonality('Шарик - плохой пёс')
         )",
         "0.44445, 0, -0.3"
     }

--- a/src/Functions/FunctionsTonalityClassification.cpp
+++ b/src/Functions/FunctionsTonalityClassification.cpp
@@ -85,7 +85,37 @@ using FunctionDetectTonality = FunctionTextClassificationFloat<FunctionDetectTon
 
 REGISTER_FUNCTION(DetectTonality)
 {
-    factory.registerFunction<FunctionDetectTonality>();
+    FunctionDocumentation::Description description = R"(
+Determines the sentiment of the provided text data.
+Uses a marked-up sentiment dictionary, in which each word has a tonality ranging from -12 to 6.
+For each piece of text, it calculates the average sentiment value of its words and returns it in the range [-1, 1].
+
+:::note Limitation
+This function is limited in its current form in that it makes use of the embedded emotional dictionary and only works for the Russian language.
+:::
+)";
+    FunctionDocumentation::Syntax syntax = "detectTonality(s)";
+    FunctionDocumentation::Arguments arguments = {
+        {"s", "The text to be analyzed.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the average sentiment value of the words in text", {"Float32"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Russian sentiment analysis",
+        R"(
+SELECT
+detectTonality('Шарик - хороший пёс'),
+detectTonality('Шарик - пёс'),
+detectTonality('Шарик - плохой пёс')
+        )",
+        "0.44445, 0, -0.3"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 2};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionDetectTonality>(documentation);
 }
 
 }

--- a/src/Functions/lemmatize.cpp
+++ b/src/Functions/lemmatize.cpp
@@ -132,7 +132,7 @@ REGISTER_FUNCTION(Lemmatize)
 {
     FunctionDocumentation::Description description = R"(
 Performs lemmatization on a given word.
-Needs dictionaries to operate, which can be obtained from [github](https://github.com/vpodpecan/lemmagen3/tree/master/src/lemmagen3/models).
+This function needs dictionaries to operate, which can be obtained from [github](https://github.com/vpodpecan/lemmagen3/tree/master/src/lemmagen3/models). For more details on loading a dictionary from a local file see page ["Defining Dictionaries"](/sql-reference/dictionaries#local-file).
 )";
     FunctionDocumentation::Syntax syntax = "lemmatize(lang, word)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/lemmatize.cpp
+++ b/src/Functions/lemmatize.cpp
@@ -130,7 +130,24 @@ public:
 
 REGISTER_FUNCTION(Lemmatize)
 {
-    factory.registerFunction<FunctionLemmatize>();
+    FunctionDocumentation::Description description = R"(
+Performs lemmatization on a given word.
+Needs dictionaries to operate, which can be obtained from [github](https://github.com/vpodpecan/lemmagen3/tree/master/src/lemmagen3/models).
+)";
+    FunctionDocumentation::Syntax syntax = "lemmatize(lang, word)";
+    FunctionDocumentation::Arguments arguments = {
+        {"lang", "Language which rules will be applied.", {"String"}},
+        {"word", "Lowercase word that needs to be lemmatized.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the lemmatized form of the word", {"String"}};
+    FunctionDocumentation::Examples examples = {
+        {"English lemmatization", "SELECT lemmatize('en', 'wolves')", "wolf"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionLemmatize>(documentation);
 }
 
 }

--- a/src/Functions/stem.cpp
+++ b/src/Functions/stem.cpp
@@ -134,7 +134,32 @@ public:
 
 REGISTER_FUNCTION(Stem)
 {
-    factory.registerFunction<FunctionStem>();
+    FunctionDocumentation::Description description = R"(
+Performs stemming on a given word.
+)";
+    FunctionDocumentation::Syntax syntax = "stem(lang, word)";
+    FunctionDocumentation::Arguments arguments = {
+        {"lang", "Language which rules will be applied. Use the two letter ISO 639-1 code.", {"String"}},
+        {"word", "Lowercase word that needs to be stemmed.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the stemmed form of the word", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "English stemming",
+        R"(
+SELECT arrayMap(x -> stem('en', x),
+['I', 'think', 'it', 'is', 'a', 'blessing', 'in', 'disguise']) AS res
+        )",
+        R"(
+['I','think','it','is','a','bless','in','disguis']
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionStem>(documentation);
 }
 
 }

--- a/src/Functions/synonyms.cpp
+++ b/src/Functions/synonyms.cpp
@@ -126,7 +126,33 @@ public:
 
 REGISTER_FUNCTION(Synonyms)
 {
-    factory.registerFunction<FunctionSynonyms>({}, FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description = R"(
+Finds synonyms of a given word.
+
+There are two types of synonym extensions:
+- `plain`
+- `wordnet`
+
+With the `plain` extension type you need to provide a path to a simple text file, where each line corresponds to a certain synonym set.
+Words in this line must be separated with space or tab characters.
+
+With the `wordnet` extension type you need to provide a path to a directory with the WordNet thesaurus in it.
+The thesaurus must contain a WordNet sense index.
+)";
+    FunctionDocumentation::Syntax syntax = "synonyms(ext_name, word)";
+    FunctionDocumentation::Arguments arguments = {
+        {"ext_name", "Name of the extension in which search will be performed.", {"String"}},
+        {"word", "Word that will be searched in extension.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns array of synonyms for the given word.", {"Array(String)"}};
+    FunctionDocumentation::Examples examples = {
+        {"Find synonyms", "SELECT synonyms('list', 'important')", "['important','big','critical','crucial']"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::NLP;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionSynonyms>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Moves the NLP functions to source code for autogeneration of documentation from system tables.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
