### PR TITLE
ci: enable memory profiler

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -516,6 +516,10 @@ def main():
             f'echo "ATTACH DATABASE datasets ENGINE=Ordinary" > {db_path}/metadata/datasets.sql',
             f"ls {db_path}/metadata",
             f"rm {perf_right_config}/config.d/text_log.xml ||:",
+            # May slow down the server
+            f"rm {perf_right_config}/config.d/memory_profiler.yaml ||:",
+            f"rm {perf_right_config}/config.d/serverwide_trace_collector.xml ||:",
+            f"rm {perf_right_config}/config.d/jemalloc_flush_profile.yaml ||:",
             # backups disk uses absolute path, and this overlaps between servers, that could lead to errors
             f"rm {perf_right_config}/config.d/backups.xml ||:",
             f"cp -rv {perf_right_config} {perf_left}/",

--- a/tests/config/config.d/memory_profiler.yaml
+++ b/tests/config/config.d/memory_profiler.yaml
@@ -1,0 +1,2 @@
+---
+total_memory_profiler_step: 100Mi

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -148,6 +148,7 @@ ln -sf $SRC_PATH/config.d/zero_copy_destructive_operations.xml $DEST_SERVER_PATH
 ln -sf $SRC_PATH/config.d/handlers.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/threadpool_writer_pool_size.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/memory_profiler.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/process_query_plan_packet.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/storage_conf_03008.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
There are cases when the total memory tracker increases without any clear indication in the logs, as in [1]. This should shed some light on the issue.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85698&sha=528856cc8dba02ab2b6ecb7024ac6e23b0e4fc8a&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20sequential%2C%201%2F2%29

Refs: https://github.com/ClickHouse/ClickHouse/issues/82036

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)