### PR TITLE
tests: better 03532_crash_in_aggregation_because_of_lost_exception

### DIFF
--- a/tests/queries/0_stateless/03532_crash_in_aggregation_because_of_lost_exception.sh
+++ b/tests/queries/0_stateless/03532_crash_in_aggregation_because_of_lost_exception.sh
@@ -15,7 +15,7 @@ optimize table t1 final;
 """
 
 for _ in {1..100}; do
-  ($CLICKHOUSE_CLIENT -q """
+  ($CLICKHOUSE_CURL -sS "${CLICKHOUSE_URL}" -d """
     SELECT count()
     FROM
     (


### PR DESCRIPTION
In case of sanitizers the binary is pretty heavy (and can even lead to OOM, see #76143), better to send queries via HTTP with curl.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)