### PR TITLE
Dynamic memory_limit_mb for TSan (should fix OOMs for TSan stateless jobs)

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -50,7 +50,7 @@ const char * __msan_default_options()
 #ifdef THREAD_SANITIZER
 const char * __tsan_default_options()
 {
-    return "halt_on_error=1 abort_on_error=1 history_size=7 memory_limit_mb=46080 second_deadlock_stack=1 max_allocation_size_mb=32768";
+    return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768";
 }
 #endif
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -521,7 +521,8 @@ class ClickHouseCluster:
         #
         #    [1]: https://github.com/ClickHouse/ClickHouse/issues/43426#issuecomment-1368512678
         self.env_variables["ASAN_OPTIONS"] = "use_sigaltstack=0"
-        self.env_variables["TSAN_OPTIONS"] = "use_sigaltstack=0"
+        # In integration tests we spawn multiple servers, so let's aim to not more then 5GiB
+        self.env_variables["TSAN_OPTIONS"] = f"use_sigaltstack=0 memory_limit_mb=5120"
         self.env_variables["CLICKHOUSE_WATCHDOG_ENABLE"] = "0"
         self.env_variables["CLICKHOUSE_NATS_TLS_SECURE"] = "0"
 


### PR DESCRIPTION
Otherwise after using different type of instances (in particular VMs with 32GiB of RAM for sequential stateless runs), clickhouse-server may got KILLed by OOM killer [1], and it should be TSan internal memory.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85698&sha=528856cc8dba02ab2b6ecb7024ac6e23b0e4fc8a&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20sequential%2C%201%2F2%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)