### PR TITLE
Fix out-of-order ActionDAG JIT compilation

### DIFF
--- a/src/Interpreters/ExpressionJIT.cpp
+++ b/src/Interpreters/ExpressionJIT.cpp
@@ -497,7 +497,7 @@ void ActionsDAG::compileFunctions(size_t min_count_to_compile_expression, const 
 
             while (current_frame.next_child_to_visit < current_node->children.size())
             {
-                const auto & child = node.children[current_frame.next_child_to_visit];
+                const auto & child = current_node->children[current_frame.next_child_to_visit];
 
                 if (visited_nodes.contains(child))
                 {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix out-of-order ActionDAG JIT compilation.

When JIT compiles an "unordered" dag like:

```
0 : COLUMN () Const(String) String 'the'_String
1 : COLUMN () Const(String) String 'can'_String
2 : FUNCTION (6, 7) (no column) UInt8 or(hasToken(__table1.text, 'the'_String), hasToken(__table1.text, 'can'_String)) [or]
3 : COLUMN () Const(String) String 'idx_1'_String
4 : INPUT () (no column) UInt64 _part_index
5 : INPUT () (no column) UInt64 _part_offset
6 : FUNCTION (3, 0, 4, 5) (no column) UInt8 hasToken(__table1.text, 'the'_String) [_hasToken_index]
7 : FUNCTION (3, 1, 4, 5) (no column) UInt8 hasToken(__table1.text, 'can'_String) [_hasToken_index]
Output nodes: 2
```

Clickhouse was hanging in an infinite loop.

This happened because this entry `2 : FUNCTION (6, 7)` means that node 2 has 6 and 7 as children. As positions 6 and 7 are bigger than 2, both loops in the modified code were repeating forever.

Probably this issue haven't been exposed before because the nodes in the `ActionsDag` are always generated in dependency order from lefty to right. But this is not a requirement.

The fix seems actually a typo or a leftover.



