### PR TITLE
ci: fix distribution of integration tests on weekends

### DIFF
--- a/ci/jobs/scripts/integration_tests_runner.py
+++ b/ci/jobs/scripts/integration_tests_runner.py
@@ -805,7 +805,7 @@ class ClickhouseIntegrationTestsRunner:
                     median(test_duration_ms) AS test_duration_ms
                 FROM checks
                 WHERE (check_name LIKE 'Integration%')
-                    AND (check_start_time >= ({start_time_filter} - toIntervalDay(4)))
+                    AND (check_start_time >= ({start_time_filter} - toIntervalDay(7)))
                     AND (check_start_time <= ({start_time_filter} - toIntervalHour(2)))
                     AND ((head_ref = 'master') AND startsWith(head_repo, 'ClickHouse/'))
                     AND (test_name != '')


### PR DESCRIPTION
On weekends it fails [1]:

    ERROR:root:Can't split tests by execution time: Number of tests should be more than 400. Actual 4
    ERROR:root:Number of tests should be more than 400. Actual 4
    ERROR:root:Exception: Number of tests should be more than 400. Actual 4

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85539&sha=1b83471eccd7324a0728d5d0a52f1952dd12c11f&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20old%20analyzer%2C%201%2F6%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)