### PR TITLE
Always schedule direct IO to threadpool for pread_threadpool

### DIFF
--- a/src/Disks/IO/ThreadPoolReader.cpp
+++ b/src/Disks/IO/ThreadPoolReader.cpp
@@ -113,7 +113,9 @@ std::future<IAsynchronousReader::Result> ThreadPoolReader::submit(Request reques
     /// disable pread with nowait.
     static const bool has_pread_nowait_support = !hasBugInPreadV2();
 
-    if (has_pread_nowait_support)
+    /// RWF_NOWAIT is ignored for O_DIRECT (mostly, it may return EAGAIN if it cannot lock the inode in case of ext4, see [1])
+    ///   [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=548feebec7e93e58b647dba70b3303dcb569c914
+    if (has_pread_nowait_support && !request.direct_io)
     {
         /// It reports real time spent including the time spent while thread was preempted doing nothing.
         /// And it is Ok for the purpose of this watch (it is used to lower the number of threads to read from tables).

--- a/src/IO/AsynchronousReadBufferFromFile.h
+++ b/src/IO/AsynchronousReadBufferFromFile.h
@@ -28,7 +28,8 @@ public:
         std::optional<size_t> file_size_ = std::nullopt,
         ThrottlerPtr throttler_ = {},
         FilesystemReadPrefetchesLogPtr prefetches_log_ = nullptr)
-        : AsynchronousReadBufferFromFileDescriptor(reader_, priority_, -1, buf_size, existing_memory, alignment, file_size_, throttler_, prefetches_log_)
+        : AsynchronousReadBufferFromFileDescriptor(
+            reader_, priority_, -1, buf_size, flags, existing_memory, alignment, file_size_, throttler_, prefetches_log_)
         , file_name(file_name_)
     {
         file = OpenedFileCache::instance().get(file_name, flags);

--- a/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp
+++ b/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp
@@ -10,6 +10,7 @@
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/getRandomASCIIString.h>
 #include <IO/AsynchronousReadBufferFromFileDescriptor.h>
+#include <IO/WriteBufferFromFile.h>
 #include <IO/WriteHelpers.h>
 #include <base/getThreadId.h>
 
@@ -51,6 +52,7 @@ std::future<IAsynchronousReader::Result> AsynchronousReadBufferFromFileDescripto
     request.offset = file_offset_of_buffer_end;
     request.priority = Priority{base_priority.value + priority.value};
     request.ignore = bytes_to_ignore;
+    request.direct_io = direct_io;
     bytes_to_ignore = 0;
 
     /// This is a workaround of a read pass EOF bug in linux kernel with pread()
@@ -162,6 +164,7 @@ AsynchronousReadBufferFromFileDescriptor::AsynchronousReadBufferFromFileDescript
     Priority priority_,
     int fd_,
     size_t buf_size,
+    int flags,
     char * existing_memory,
     size_t alignment,
     std::optional<size_t> file_size_,
@@ -185,6 +188,8 @@ AsynchronousReadBufferFromFileDescriptor::AsynchronousReadBufferFromFileDescript
             buf_size);
 
     prefetch_buffer.alignment = alignment;
+
+    direct_io = (flags != -1) && (flags & O_DIRECT);
 }
 
 AsynchronousReadBufferFromFileDescriptor::~AsynchronousReadBufferFromFileDescriptor()

--- a/src/IO/AsynchronousReadBufferFromFileDescriptor.h
+++ b/src/IO/AsynchronousReadBufferFromFileDescriptor.h
@@ -28,6 +28,7 @@ protected:
     size_t file_offset_of_buffer_end = 0; /// What offset in file corresponds to working_buffer.end().
     size_t bytes_to_ignore = 0;           /// How many bytes should we ignore upon a new read request.
     int fd;
+    bool direct_io;
     ThrottlerPtr throttler;
 
     bool nextImpl() override;
@@ -43,6 +44,7 @@ public:
         Priority priority_,
         int fd_,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
+        int flags = -1,
         char * existing_memory = nullptr,
         size_t alignment = 0,
         std::optional<size_t> file_size_ = std::nullopt,

--- a/src/IO/AsynchronousReader.h
+++ b/src/IO/AsynchronousReader.h
@@ -50,6 +50,7 @@ public:
         char * buf = nullptr;
         Priority priority;
         size_t ignore = 0;
+        bool direct_io = false;
     };
 
     struct Result

--- a/tests/queries/0_stateless/03595_pread_threadpool_direct_io.reference
+++ b/tests/queries/0_stateless/03595_pread_threadpool_direct_io.reference
@@ -1,0 +1,2 @@
+1	ThreadPoolRead	1
+2	ThreadPoolRead	1

--- a/tests/queries/0_stateless/03595_pread_threadpool_direct_io.sql
+++ b/tests/queries/0_stateless/03595_pread_threadpool_direct_io.sql
@@ -1,0 +1,50 @@
+-- Tags: no-parallel-replicas, no-object-storage
+
+set min_bytes_to_use_direct_io = 0;
+
+drop table if exists 03595_data;
+
+create table 03595_data (key UInt32, val String) engine = MergeTree order by key
+as
+select number, 'val-' || number from numbers(100000);
+
+select * from 03595_data
+format Null
+settings
+    local_filesystem_read_method = 'pread_threadpool',
+    min_bytes_to_use_direct_io = 1,
+    log_query_threads = 1,
+    use_uncompressed_cache = 0;
+
+-- If previous query was running w/o O_DIRECT (due to some bug) it may fill pagecache,
+-- and then subsequent query will read from cache (if it will ignore O_DIRECT flag as well) with RWF_NOWAIT,
+-- so let's make sure that this is not the case
+select * from 03595_data
+format Null
+settings
+    local_filesystem_read_method = 'pread_threadpool',
+    min_bytes_to_use_direct_io = 1,
+    log_query_threads = 1,
+    use_uncompressed_cache = 0;
+
+system flush logs query_log, query_thread_log;
+
+with queries as (
+    select query_id, row_number() over(order by event_time_microseconds) as ordinal
+    from system.query_log
+    where type = 'QueryFinish'
+     and current_database = currentDatabase()
+     and query_kind = 'Select'
+     and Settings['min_bytes_to_use_direct_io'] = '1'
+)
+select queries.ordinal, thread_name, sum(ProfileEvents['OSReadBytes']) > 0 as disk_reading
+from system.query_thread_log qtl
+    join queries
+        on queries.query_id = qtl.query_id
+where current_database = currentDatabase()
+  and query_id in (select query_id from queries)
+  and ProfileEvents['OSReadBytes'] > 0
+group by 1, 2
+order by 1, 2;
+
+drop table 03595_data;


### PR DESCRIPTION
Closes #85689 

preadv2 with RWF_NOWAIT may perform reads from device and return data (not EAGAIN) when called on fd with O_DIRECT flag. This leads to data reading being executed in query thread, instead of threadpool which is intended for pread_threadpool.

This patch skips preadv2 / pagecache checking logic when direct io is requested, so that it always executed in threadpool.

<details>
<summary>Simple reproducer out of ClickHouse context</summary>

```c
// "iotest.c"

#define _GNU_SOURCE
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/syscall.h>
#include <sys/uio.h>
#include <unistd.h>
#include <errno.h>
#include <assert.h>

#define ALIGNMENT 131072
#define BUF_SIZE ALIGNMENT

int main(int argc, char *argv[]) {
    if (argc != 2) {
        fprintf(stderr, "Usage: %s <filename>\n", argv[0]);
        return 1;
    }
    const char *filename = argv[1];

    int fd = open(filename, O_RDONLY | O_DIRECT | O_CLOEXEC);
    if (fd < 0) {
        perror("open");
        return 1;
    }

    void *buf;
    if (posix_memalign(&buf, ALIGNMENT, BUF_SIZE) != 0) {
        perror("posix_memalign");
        close(fd);
        return 1;
    }

    memset(buf, 0, BUF_SIZE);

    struct iovec iov = {
        .iov_base = buf,
        .iov_len = BUF_SIZE
    };

    ssize_t offset = 0;
    ssize_t ret = 0;

    while (ret >= 0)
    {
        ret = syscall(SYS_preadv2, fd, &iov, 1, offset, offset >> 32, RWF_NOWAIT);

        if (ret >= 0) {
            printf("preadv2 RWF_NOWAIT succeeded, read %zd bytes\n", ret);
        } else {
            if (errno == EAGAIN) {
                printf("preadv2 RWF_NOWAIT returned EAGAIN (data not in page cache)\n");
                return 1;
            } else {
                perror("preadv2");
                return 1;
            }
        }

        if (ret == 0)
        {
            break;
        }

        offset += ret;
    }

    free(buf);
    close(fd);

    return 0;
}
```

```sh
# Build
clang -o iotest iotest.c

# Create non-cached data file on ext4 fs
dd if=/dev/urandom of=/tmp/trash.dat oflag=direct bs=128K count=100

# Read the file (it'll succeed, while failing for fd opened w/o O_DIRECT).
# Running it with strace + blktrace shows successful preadv2 along with
# disk reads.
./iotest /tmp/trash.dat
```

</details>

(or added test which demonstrates this behavior)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

cc @kssenii 