### PR TITLE
Fix send_logs_source_regexp (after async logging refactoring)

### DIFF
--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -399,10 +399,9 @@ void OwnAsyncSplitChannel::log(Poco::Message && msg)
         /// Based on logger_useful.h this won't be called if the message is not needed
         /// so we can create the AsyncLogMessage as it won't penalize performance by being unused
         auto msg_priority = msg.getPriority();
-        const auto & msg_source = msg.getSource();
         auto notification = std::make_shared<AsyncLogMessage>(std::move(msg));
         if (const auto & logs_queue = CurrentThread::getInternalTextLogsQueue();
-            logs_queue && logs_queue->isNeeded(msg_priority, msg_source))
+            logs_queue && logs_queue->isNeeded(msg_priority, notification->msg.getSource()))
         {
             /// If we need to push to the TCP queue, do it now since it expects to receive all messages synchronously
             pushExtendedMessageToInternalTCPTextLogQueue(notification->msg_ext, logs_queue);

--- a/tests/queries/0_stateless/02359_send_logs_source_regexp.reference
+++ b/tests/queries/0_stateless/02359_send_logs_source_regexp.reference
@@ -1,1 +1,2 @@
-1
+Planner
+executeQuery

--- a/tests/queries/0_stateless/02359_send_logs_source_regexp.sh
+++ b/tests/queries/0_stateless/02359_send_logs_source_regexp.sh
@@ -7,5 +7,4 @@ CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=trace
 
 [ ! -z "$CLICKHOUSE_CLIENT_REDEFINED" ] && CLICKHOUSE_CLIENT=$CLICKHOUSE_CLIENT_REDEFINED
 
-regexp="executeQuery|InterpreterSelectQuery"
-$CLICKHOUSE_CLIENT --send_logs_source_regexp "$regexp" -q "SELECT 1;" 2> >(grep -v -E "$regexp" 1>&2)
+$CLICKHOUSE_CLIENT --allow_experimental_analyzer=1 --send_logs_source_regexp "executeQuery|Interpreter|Planner" -q "SELECT 1 FORMAT Null" |& grep -o -E 'executeQuery|Interpreter|Planner' | LC_ALL=c sort -u


### PR DESCRIPTION
The test does not check send_logs_source_regexp, hence we did not noticed it before (sigh)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix send_logs_source_regexp (after async logging refactoring in #85105)

@Algunenano looks like we do not need to backport, since original PR has not been included into any release