### PR TITLE
Setting Query without Value will Set Value To 1

### DIFF
--- a/docs/en/sql-reference/statements/select/index.md
+++ b/docs/en/sql-reference/statements/select/index.md
@@ -284,6 +284,8 @@ You can specify the necessary settings right in the `SELECT` query. The setting 
 
 Other ways to make settings see [here](/operations/settings/overview).
 
+For boolean settings set to true, you can use a shorthand syntax by omitting the value assignment. When only the setting name is specified, it is automatically set to `1` (true).
+
 **Example**
 
 ```sql

--- a/docs/en/sql-reference/statements/set.md
+++ b/docs/en/sql-reference/statements/set.md
@@ -20,4 +20,12 @@ You can also set all the values from the specified settings profile in a single 
 SET profile = 'profile-name-from-the-settings-file'
 ```
 
+For boolean settings set to true, you can use a shorthand syntax by omitting the value assignment. When only the setting name is specified, it is automatically set to `1` (true).
+
+```sql
+-- These are equivalent:
+SET force_index_by_date = 1
+SET force_index_by_date
+```
+
 For more information, see [Settings](../../operations/settings/settings.md).

--- a/src/Parsers/ParserExplainQuery.cpp
+++ b/src/Parsers/ParserExplainQuery.cpp
@@ -54,7 +54,7 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 
     {
         ASTPtr settings;
-        ParserSetQuery parser_settings(true);
+        ParserSetQuery parser_settings(true, false);
 
         auto begin = pos;
         if (parser_settings.parse(pos, settings, expected))

--- a/src/Parsers/ParserSetQuery.cpp
+++ b/src/Parsers/ParserSetQuery.cpp
@@ -242,10 +242,17 @@ bool ParserSetQuery::parseNameValuePairWithParameterOrDefault(
     if (!name_p.parse(pos, node, expected))
         return false;
 
-    if (!s_eq.ignore(pos, expected))
-        return false;
-
     tryGetIdentifierNameInto(node, name);
+
+    if (!s_eq.check(pos, expected))
+    {
+        change.name = name;
+        change.value = Field(UInt64(1));
+
+        return true;
+    }
+
+    s_eq.ignore(pos);
 
     /// Parameter
     if (name.starts_with(QUERY_PARAMETER_NAME_PREFIX))

--- a/src/Parsers/ParserSetQuery.cpp
+++ b/src/Parsers/ParserSetQuery.cpp
@@ -228,7 +228,7 @@ bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & p
 }
 
 bool ParserSetQuery::parseNameValuePairWithParameterOrDefault(
-    SettingChange & change, String & default_settings, ParserSetQuery::Parameter & parameter, IParser::Pos & pos, Expected & expected, bool en_shorthand_syntax)
+    SettingChange & change, String & default_settings, ParserSetQuery::Parameter & parameter, IParser::Pos & pos, Expected & expected, bool enable_shorthand_syntax)
 {
     ParserCompoundIdentifier name_p;
     ParserLiteralOrMap value_p;
@@ -245,7 +245,7 @@ bool ParserSetQuery::parseNameValuePairWithParameterOrDefault(
 
     have_eq = s_eq.ignore(pos, expected);
 
-    if (!en_shorthand_syntax && !have_eq)
+    if (!enable_shorthand_syntax && !have_eq)
         return false;
 
     tryGetIdentifierNameInto(node, name);

--- a/src/Parsers/ParserSetQuery.cpp
+++ b/src/Parsers/ParserSetQuery.cpp
@@ -228,7 +228,7 @@ bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & p
 }
 
 bool ParserSetQuery::parseNameValuePairWithParameterOrDefault(
-    SettingChange & change, String & default_settings, ParserSetQuery::Parameter & parameter, IParser::Pos & pos, Expected & expected)
+    SettingChange & change, String & default_settings, ParserSetQuery::Parameter & parameter, IParser::Pos & pos, Expected & expected, bool parse_internals_only)
 {
     ParserCompoundIdentifier name_p;
     ParserLiteralOrMap value_p;
@@ -244,6 +244,8 @@ bool ParserSetQuery::parseNameValuePairWithParameterOrDefault(
         return false;
 
     have_eq = s_eq.ignore(pos, expected);
+    if (parse_internals_only && !have_eq)
+        return false;
 
     tryGetIdentifierNameInto(node, name);
 
@@ -323,7 +325,7 @@ bool ParserSetQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         String name_of_default_setting;
         Parameter parameter;
 
-        if (!parseNameValuePairWithParameterOrDefault(setting, name_of_default_setting, parameter, pos, expected))
+        if (!parseNameValuePairWithParameterOrDefault(setting, name_of_default_setting, parameter, pos, expected, parse_only_internals))
             return false;
 
         if (!parameter.first.empty())

--- a/src/Parsers/ParserSetQuery.h
+++ b/src/Parsers/ParserSetQuery.h
@@ -25,7 +25,8 @@ public:
                                                          String & default_settings,
                                                          Parameter & parameter,
                                                          IParser::Pos & pos,
-                                                         Expected & expected);
+                                                         Expected & expected,
+                                                         bool parse_internals_only = false);
 
 protected:
     const char * getName() const override { return "SET query"; }

--- a/src/Parsers/ParserSetQuery.h
+++ b/src/Parsers/ParserSetQuery.h
@@ -26,7 +26,7 @@ public:
                                                          Parameter & parameter,
                                                          IParser::Pos & pos,
                                                          Expected & expected,
-                                                         bool en_shorthand_syntax);
+                                                         bool enable_shorthand_syntax);
 
 protected:
     const char * getName() const override { return "SET query"; }

--- a/src/Parsers/ParserSetQuery.h
+++ b/src/Parsers/ParserSetQuery.h
@@ -17,7 +17,7 @@ class ParserSetQuery : public IParserBase
 public:
     using Parameter = std::pair<std::string, std::string>;
 
-    explicit ParserSetQuery(bool parse_only_internals_ = false) : parse_only_internals(parse_only_internals_) {}
+    explicit ParserSetQuery(bool parse_only_internals_ = false, bool shorthand_syntax_ = true) : parse_only_internals(parse_only_internals_), shorthand_syntax(shorthand_syntax_) {}
 
     static bool parseNameValuePair(SettingChange & change, IParser::Pos & pos, Expected & expected);
 
@@ -26,13 +26,14 @@ public:
                                                          Parameter & parameter,
                                                          IParser::Pos & pos,
                                                          Expected & expected,
-                                                         bool parse_internals_only = false);
+                                                         bool en_shorthand_syntax);
 
 protected:
     const char * getName() const override { return "SET query"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
     /// Parse the list `name = value` pairs, without SET.
     bool parse_only_internals;
+    bool shorthand_syntax;
 };
 
 }

--- a/src/Parsers/ParserSetQuery.h
+++ b/src/Parsers/ParserSetQuery.h
@@ -10,6 +10,7 @@ struct SettingChange;
 
 /** Query like this:
   * SET name1 = value1, name2 = value2, ...
+  * SET name1,... (shorthand for 'name1 = 1')
   */
 class ParserSetQuery : public IParserBase
 {

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
@@ -25,8 +25,6 @@ force_index_by_date	0	0	0
 log_queries	1	0	1
 force_index_by_date	1	1	0
 log_queries	1	1	1
-force_index_by_date	1	1	0
-log_queries	1	1	1
 1
 2
 3

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
@@ -1,0 +1,17 @@
+1
+1
+1
+force_index_by_date	0	0	0
+force_index_by_date	1	1	0
+force_index_by_date	0	0	0
+force_index_by_date	1	1	0
+force_index_by_date	0	1	0
+1
+force_index_by_date	0	1	0
+log_queries	1	0	1
+force_index_by_date	1	1	0
+log_queries	0	1	1
+force_index_by_date	0	1	0
+log_queries	1	1	1
+force_index_by_date	0	0	0
+log_queries	1	0	1

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
@@ -2,15 +2,40 @@ force_index_by_date	1	1	0
 force_index_by_date	0	1	0
 force_index_by_date	1	1	0
 force_index_by_date	0	0	0
+"force_index_by_date","1",1,"0"
+force_index_by_date	1	1	0
+log_queries	1	1	1
+force_index_by_date	0	1	0
+log_queries	1	1	1
+force_index_by_date	1	1	0
+log_queries	0	1	1
+"force_index_by_date","1",1,"0"
+"log_queries","1",1,"1"
 force_index_by_date	1	1	0
 force_index_by_date	0	0	0
 force_index_by_date	1	1	0
 force_index_by_date	0	1	0
-force_index_by_date	1	1	0
-log_queries	1	1	1
+force_index_by_date	0	0	0
+log_queries	1	0	1
 force_index_by_date	1	1	0
 log_queries	0	1	1
 force_index_by_date	0	1	0
 log_queries	1	1	1
 force_index_by_date	0	0	0
 log_queries	1	0	1
+force_index_by_date	1	1	0
+log_queries	1	1	1
+force_index_by_date	1	1	0
+log_queries	1	1	1
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.reference
@@ -1,14 +1,13 @@
-1
-1
-1
+force_index_by_date	1	1	0
+force_index_by_date	0	1	0
+force_index_by_date	1	1	0
 force_index_by_date	0	0	0
 force_index_by_date	1	1	0
 force_index_by_date	0	0	0
 force_index_by_date	1	1	0
 force_index_by_date	0	1	0
-1
-force_index_by_date	0	1	0
-log_queries	1	0	1
+force_index_by_date	1	1	0
+log_queries	1	1	1
 force_index_by_date	1	1	0
 log_queries	0	1	1
 force_index_by_date	0	1	0

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
@@ -1,0 +1,21 @@
+SELECT 1 SETTINGS force_index_by_date;
+SELECT 1 SETTINGS force_index_by_date = 1;
+SELECT 1 SETTINGS force_index_by_date = 0;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
+SET force_index_by_date;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
+SET force_index_by_date = DEFAULT;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
+SET force_index_by_date = 1;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
+SET force_index_by_date = 0;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
+
+SELECT 1 SETTINGS force_index_by_date, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SET force_index_by_date, log_queries = 0;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SET force_index_by_date = 0, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SET force_index_by_date = DEFAULT, log_queries = DEFAULT;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
@@ -2,6 +2,12 @@ SELECT name, value, changed, default FROM system.settings WHERE name = 'force_in
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = 1;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = DEFAULT;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date FORMAT CSV;
+
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date = 0, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries = 0;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries FORMAT CSV;
 
 SET force_index_by_date;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
@@ -12,10 +18,31 @@ SELECT name, value, changed, default FROM system.settings WHERE name = 'force_in
 SET force_index_by_date = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
 
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries;
+SET force_index_by_date = DEFAULT, log_queries = DEFAULT;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
 SET force_index_by_date, log_queries = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
 SET force_index_by_date = 0, log_queries;
 SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
 SET force_index_by_date = DEFAULT, log_queries = DEFAULT;
 SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SET force_index_by_date, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date UNION ALL
+SELECT name, value, changed, default FROM system.settings WHERE name = 'log_queries' SETTINGS log_queries;
+
+CREATE TABLE t
+(
+  id UInt32
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS async_insert, optimize_on_insert;
+
+INSERT INTO t SETTINGS async_insert, optimize_on_insert VALUES (1), (2), (3);
+INSERT INTO t SETTINGS async_insert=0, optimize_on_insert VALUES (4), (5), (6);
+INSERT INTO t SETTINGS async_insert, optimize_on_insert=0 VALUES (7), (8), (9);
+INSERT INTO t SETTINGS async_insert=1, optimize_on_insert=1 VALUES (10), (11), (12);
+
+SELECT id from t ORDER BY id ASC;

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
@@ -1,7 +1,8 @@
-SELECT 1 SETTINGS force_index_by_date;
-SELECT 1 SETTINGS force_index_by_date = 1;
-SELECT 1 SETTINGS force_index_by_date = 0;
-SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = 0;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = 1;
+SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = DEFAULT;
+
 SET force_index_by_date;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
 SET force_index_by_date = DEFAULT;
@@ -11,8 +12,7 @@ SELECT name, value, changed, default FROM system.settings WHERE name = 'force_in
 SET force_index_by_date = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
 
-SELECT 1 SETTINGS force_index_by_date, log_queries;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries;
 SET force_index_by_date, log_queries = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
 SET force_index_by_date = 0, log_queries;

--- a/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
+++ b/tests/queries/0_stateless/03595_set_query_no_eq_set_to_one.sql
@@ -4,9 +4,9 @@ SELECT name, value, changed, default FROM system.settings WHERE name = 'force_in
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date = DEFAULT;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date FORMAT CSV;
 
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date = 0, log_queries;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries = 0;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name SETTINGS force_index_by_date, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name SETTINGS force_index_by_date = 0, log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name SETTINGS force_index_by_date, log_queries = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') SETTINGS force_index_by_date, log_queries FORMAT CSV;
 
 SET force_index_by_date;
@@ -19,18 +19,15 @@ SET force_index_by_date = 0;
 SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date';
 
 SET force_index_by_date = DEFAULT, log_queries = DEFAULT;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name;
 SET force_index_by_date, log_queries = 0;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name;
 SET force_index_by_date = 0, log_queries;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name;
 SET force_index_by_date = DEFAULT, log_queries = DEFAULT;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name;
 SET force_index_by_date, log_queries;
-SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries');
-
-SELECT name, value, changed, default FROM system.settings WHERE name = 'force_index_by_date' SETTINGS force_index_by_date UNION ALL
-SELECT name, value, changed, default FROM system.settings WHERE name = 'log_queries' SETTINGS log_queries;
+SELECT name, value, changed, default FROM system.settings WHERE name IN ('force_index_by_date', 'log_queries') ORDER BY name;
 
 CREATE TABLE t
 (


### PR DESCRIPTION
Closes #85676

Example:

```sql
SELECT 1 SETTINGS use_query_cache;
```

is equivalent to

```sql
SELECT 1 SETTINGS use_query_cache=1;
```

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Treat a bare setting name in query setting as equal to `1` (e.g. `SELECT ... SETTINGS use_query_cache` is equivalent to `use_query_cache = 1`).