### PR TITLE
Fix possible inconsistency for dictionaries with update_field on MEMORY_LIMIT_EXCEEDED errors

### DIFF
--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -992,7 +992,7 @@ SOURCE(ODBC(... invalidate_query 'SELECT update_time FROM dictionary_source wher
 
 For `Cache`, `ComplexKeyCache`, `SSDCache`, and `SSDComplexKeyCache` dictionaries both synchronous and asynchronous updates are supported.
 
-It is also possible for `Flat`, `Hashed`, `ComplexKeyHashed` dictionaries to only request data that was changed after the previous update. If `update_field` is specified as part of the dictionary source configuration, value of the previous update time in seconds will be added to the data request. Depends on source type (Executable, HTTP, MySQL, PostgreSQL, ClickHouse, or ODBC) different logic will be applied to `update_field` before request data from an external source.
+It is also possible for `Flat`, `Hashed`, `HashedArray`, `ComplexKeyHashed` dictionaries to only request data that was changed after the previous update. If `update_field` is specified as part of the dictionary source configuration, value of the previous update time in seconds will be added to the data request. Depends on source type (Executable, HTTP, MySQL, PostgreSQL, ClickHouse, or ODBC) different logic will be applied to `update_field` before request data from an external source.
 
 - If the source is HTTP then `update_field` will be added as a query parameter with the last update time as the parameter value.
 - If the source is Executable then `update_field` will be added as an executable script argument with the last update time as the argument value.

--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <Dictionaries/FlatDictionary.h>
 
 #include <Core/Defines.h>
@@ -480,10 +481,10 @@ void FlatDictionary::updateData()
     else
     {
         auto pipeline(source_ptr->loadUpdatedAll());
-        mergeBlockWithPipe<DictionaryKeyType::Simple>(
+        update_field_loaded_block = std::make_shared<Block>(mergeBlockWithPipe<DictionaryKeyType::Simple>(
             dict_struct.getKeysSize(),
             *update_field_loaded_block,
-            std::move(pipeline));
+            std::move(pipeline)));
     }
 
     if (update_field_loaded_block)

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -494,7 +494,7 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::updateData()
 
             /// We are using this to keep saved data if input stream consists of multiple blocks
             if (!update_field_loaded_block)
-                update_field_loaded_block = std::make_shared<DB::Block>(block.cloneEmpty());
+                update_field_loaded_block = std::make_shared<Block>(block.cloneEmpty());
 
             for (size_t attribute_index = 0; attribute_index < block.columns(); ++attribute_index)
             {
@@ -507,10 +507,10 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::updateData()
     else
     {
         auto pipe = source_ptr->loadUpdatedAll();
-        mergeBlockWithPipe<dictionary_key_type>(
+        update_field_loaded_block = std::make_shared<Block>(mergeBlockWithPipe<dictionary_key_type>(
             dict_struct.getKeysSize(),
             *update_field_loaded_block,
-            std::move(pipe));
+            std::move(pipe)));
     }
 
     if (update_field_loaded_block)

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -893,7 +893,7 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
 
             /// We are using this to keep saved data if input stream consists of multiple blocks
             if (!update_field_loaded_block)
-                update_field_loaded_block = std::make_shared<DB::Block>(block.cloneEmpty());
+                update_field_loaded_block = std::make_shared<Block>(block.cloneEmpty());
 
             for (size_t attribute_index = 0; attribute_index < block.columns(); ++attribute_index)
             {
@@ -906,10 +906,10 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
     else
     {
         auto pipe = source_ptr->loadUpdatedAll();
-        mergeBlockWithPipe<dictionary_key_type>(
+        update_field_loaded_block = std::make_shared<Block>(mergeBlockWithPipe<dictionary_key_type>(
             dict_struct.getKeysSize(),
             *update_field_loaded_block,
-            std::move(pipe));
+            std::move(pipe)));
     }
 
     if (update_field_loaded_block)

--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -712,7 +712,7 @@ void RangeHashedDictionary<dictionary_key_type>::updateData()
 
             /// We are using this to keep saved data if input stream consists of multiple blocks
             if (!update_field_loaded_block)
-                update_field_loaded_block = std::make_shared<DB::Block>(block.cloneEmpty());
+                update_field_loaded_block = std::make_shared<Block>(block.cloneEmpty());
 
             for (size_t attribute_index = 0; attribute_index < block.columns(); ++attribute_index)
             {
@@ -729,10 +729,10 @@ void RangeHashedDictionary<dictionary_key_type>::updateData()
         auto pipe = source_ptr->loadUpdatedAll();
 
         /// Use complex dictionary key type to count range columns as part of complex primary key during update
-        mergeBlockWithPipe<DictionaryKeyType::Complex>(
+        update_field_loaded_block = std::make_shared<Block>(mergeBlockWithPipe<DictionaryKeyType::Complex>(
             dict_struct.getKeysSize() + range_columns_size,
             *update_field_loaded_block,
-            std::move(pipe));
+            std::move(pipe)));
     }
 
     if (update_field_loaded_block)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible inconsistency for dictionaries with update_field on MEMORY_LIMIT_EXCEEDED errors

Before this patch it was possible that the dictionary with `update_field` can be left in a inconsistent state after `MEMORY_LIMIT_EXCEEDED` error during update (some columns was updated - new filter has been applied and new values added, while others does not).

After this patch this block will not be cached on update, so reuse is not possible, and we cannot simply cut the column to an old value since we applies filters at first, but, since IColumn::filter() return new column, so this should not increase memory usage (except for the time when `mergeBlockWithPipe` is running).
