### PR TITLE
Fix flakiness in 03549_system_query_metric_log_with_queries_with_same_query_id

### DIFF
--- a/tests/queries/0_stateless/03549_system_query_metric_log_with_queries_with_same_query_id.sh
+++ b/tests/queries/0_stateless/03549_system_query_metric_log_with_queries_with_same_query_id.sh
@@ -10,11 +10,12 @@ readonly same_query_not_finish="${query_prefix}_not_two_finish"
 readonly same_query_finish="${query_prefix}_two_finish"
 
 # We launch two queries so that the second is not run because the first one is still running.
-$CLICKHOUSE_CLIENT --query-id="$same_query_not_finish" -q "SELECT sleep(60) SETTINGS function_sleep_max_microseconds_per_block=100000000, query_metric_log_interval=100, replace_running_query=0 FORMAT Null; -- { serverError QUERY_WAS_CANCELLED}" &
+$CLICKHOUSE_CLIENT --query-id="$same_query_not_finish" -q "SELECT sleep(120) SETTINGS function_sleep_max_microseconds_per_block=1000000000, query_metric_log_interval=100, replace_running_query=0 FORMAT Null; -- { serverError QUERY_WAS_CANCELLED}" &
 
 # In this case, we let the first one running a little bit and run the second one so that it cancels the first one.
-$CLICKHOUSE_CLIENT --query-id="$same_query_finish" -q "SELECT sleep(60) SETTINGS function_sleep_max_microseconds_per_block=100000000, query_metric_log_interval=0, replace_running_query=0 FORMAT Null; -- { serverError QUERY_WAS_CANCELLED}" &
+$CLICKHOUSE_CLIENT --query-id="$same_query_finish" -q "SELECT sleep(120) SETTINGS function_sleep_max_microseconds_per_block=1000000000, query_metric_log_interval=0, replace_running_query=0 FORMAT Null; -- { serverError QUERY_WAS_CANCELLED}" &
 
+# Ensure both queries have started
 while true; do
     $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS system.query_log;"
     count=$($CLICKHOUSE_CLIENT -q """
@@ -26,21 +27,21 @@ while true; do
             event_date >= yesterday()
             AND current_database = currentDatabase()
             AND (query_id = '$same_query_not_finish' OR query_id = '$same_query_finish')
+            AND query ILIKE 'SELECT %'
             AND type = 'QueryStart';
     """)
 
-    # For queries with serverError, there's an additional query to set the send_logs_level, so there will be more than 2
     if [[ $count -ge 2 ]]; then
         break
     fi
     sleep 0.5
 done
 
-$CLICKHOUSE_CLIENT --query-id="$same_query_finish" -q "SELECT sleep(1) SETTINGS query_metric_log_interval=100, replace_running_query=1 FORMAT Null;" &
+$CLICKHOUSE_CLIENT --query-id="$same_query_finish" -q "SELECT sleep(2) SETTINGS query_metric_log_interval=100, replace_running_query=1 FORMAT Null;" &
 $CLICKHOUSE_CLIENT --query-id="$same_query_not_finish" -q "SELECT 'a' SETTINGS query_metric_log_interval=0, replace_running_query=0 FORMAT Null;" 2> /dev/null
 
 # Kill the initial query because the second one didn't replace it
-$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$same_query_not_finish' FORMAT Null" &
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$same_query_not_finish' SYNC FORMAT Null" &
 
 wait
 
@@ -61,7 +62,7 @@ $CLICKHOUSE_CLIENT -q """
     SELECT if(count() > 1, 'ok', 'error') FROM system.query_metric_log WHERE event_date >= yesterday() AND query_id = '$same_query_not_finish';
 """
 
-# We check that there's enough metrics collected by the second query Note we cannot really
+# We check that there's enough metrics collected by the second query. Note we cannot really
 # distinguish from which of the two queries it comes from, though. We rely on the
 # query_metric_log_interval=0 to ensure that one doesn't collect anything.
 $CLICKHOUSE_CLIENT -q """
@@ -75,5 +76,5 @@ $CLICKHOUSE_CLIENT -q """
         AND query_id = '$same_query_finish'
         AND query LIKE 'SELECT%'
         AND current_database = currentDatabase();
-    SELECT if(count() > 1, 'ok', 'error') FROM system.query_metric_log WHERE event_date >= yesterday() AND query_id = '$same_query_finish';
+    SELECT if(count() >= 1, 'ok', 'error') FROM system.query_metric_log WHERE event_date >= yesterday() AND query_id = '$same_query_finish';
 """


### PR DESCRIPTION
- From [this CI job](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=43ba2ada9a9a5f702eb7013eeaab160d9b8e44ec&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%201%2F4%29) we see that there was only one entry in `system.query_metric_log`. Let's increase the time for the query and decrease the period to collect the query_metric_log. Let's also accept only one entry:

```sql
SELECT event_time_microseconds
FROM file('query_metric_log2.tsv')
WHERE query_id = 'test_bxfnn0sa_two_finish'

Query id: f9279803-796e-49d4-a339-67aa5b7a6cb1

   ┌────event_time_microseconds─┐
1. │ 2025-07-15 18:24:29.484320 │
   └────────────────────────────┘
```

- From [this other CI job](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=da642604433b6132df906ef9be44a271a408a590&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29) we see the queries finished before running the queries that cancelled them. Most feasible reason is because `system.query_log` didn't write the `QueryStart` of both of them **yet**. The last two queries need to be executed while the first two are still running for the test to make sense:

```sql
SELECT
    query_id,
    type,
    event_time_microseconds,
    query_duration_ms,
    query,
    exception
FROM file('query_log.tsv.zst')
WHERE (query_id LIKE 'test_%_two_finish%') AND (query ILIKE 'SELECT %')

Query id: ba6c6e8e-2473-4036-aec3-4b3f22eafeff

   ┌─query_id─────────────────────┬─type────────┬────event_time_microseconds─┬─query_duration_ms─┬─query──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─exception─┐
1. │ test_xvti03ix_two_finish     │ QueryStart  │ 2025-08-07 17:52:00.629661 │                 0 │ SELECT sleep(60) SETTINGS function_sleep_max_microseconds_per_block=100000000, query_metric_log_interval=0, replace_running_query=0 FORMAT Null;   │           │
2. │ test_xvti03ix_not_two_finish │ QueryStart  │ 2025-08-07 17:52:00.629169 │                 0 │ SELECT sleep(60) SETTINGS function_sleep_max_microseconds_per_block=100000000, query_metric_log_interval=100, replace_running_query=0 FORMAT Null; │           │
3. │ test_xvti03ix_two_finish     │ QueryFinish │ 2025-08-07 17:53:00.735182 │             60111 │ SELECT sleep(60) SETTINGS function_sleep_max_microseconds_per_block=100000000, query_metric_log_interval=0, replace_running_query=0 FORMAT Null;   │           │
4. │ test_xvti03ix_not_two_finish │ QueryFinish │ 2025-08-07 17:53:00.737352 │             60113 │ SELECT sleep(60) SETTINGS function_sleep_max_microseconds_per_block=100000000, query_metric_log_interval=100, replace_running_query=0 FORMAT Null; │           │
5. │ test_xvti03ix_two_finish     │ QueryStart  │ 2025-08-07 17:53:03.563382 │                 0 │ SELECT sleep(1) SETTINGS query_metric_log_interval=100, replace_running_query=1 FORMAT Null;                                                       │           │
6. │ test_xvti03ix_not_two_finish │ QueryStart  │ 2025-08-07 17:53:03.713425 │                 0 │ SELECT 'a' SETTINGS query_metric_log_interval=0, replace_running_query=0 FORMAT Null;                                                              │           │
7. │ test_xvti03ix_not_two_finish │ QueryFinish │ 2025-08-07 17:53:03.778373 │                71 │ SELECT 'a' SETTINGS query_metric_log_interval=0, replace_running_query=0 FORMAT Null;                                                              │           │
8. │ test_xvti03ix_two_finish     │ QueryFinish │ 2025-08-07 17:53:04.641985 │              1084 │ SELECT sleep(1) SETTINGS query_metric_log_interval=100, replace_running_query=1 FORMAT Null;                                                       │           │
   └──────────────────────────────┴─────────────┴────────────────────────────┴───────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────┘
```

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
