### PR TITLE
Allow GLOBAL WITH constants in parallel distributed insert select.

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -9,6 +9,8 @@
 #include <Core/ServerSettings.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <IO/ReadBuffer.h>
+#include <Interpreters/ApplyWithSubqueryVisitor.h>
+#include <Interpreters/ApplyWithAliasVisitor.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/InterpreterWatchQuery.h>
@@ -79,6 +81,7 @@ namespace Setting
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsUInt64 max_distributed_depth;
+    extern const SettingsBool enable_global_with_statement;
 }
 
 namespace MergeTreeSetting
@@ -758,6 +761,12 @@ InterpreterInsertQuery::distributedWriteIntoReplicatedMergeTreeFromClusterStorag
     {
         if (auto * select_query = select.list_of_selects->children.at(0)->as<ASTSelectQuery>())
         {
+            if (local_context->getSettingsRef()[Setting::enable_global_with_statement])
+            {
+                ApplyWithAliasVisitor::visit(select.list_of_selects->children.at(0));
+                ApplyWithSubqueryVisitor(local_context).visit(select.list_of_selects->children.at(0));
+            }
+
             JoinedTables joined_tables(Context::createCopy(local_context), *select_query);
             if (joined_tables.tablesCount() == 1)
                 src_storage = joined_tables.getLeftTableStorage();

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -761,12 +761,6 @@ InterpreterInsertQuery::distributedWriteIntoReplicatedMergeTreeFromClusterStorag
     {
         if (auto * select_query = select.list_of_selects->children.at(0)->as<ASTSelectQuery>())
         {
-            if (local_context->getSettingsRef()[Setting::enable_global_with_statement])
-            {
-                ApplyWithAliasVisitor::visit(select.list_of_selects->children.at(0));
-                ApplyWithSubqueryVisitor(local_context).visit(select.list_of_selects->children.at(0));
-            }
-
             JoinedTables joined_tables(Context::createCopy(local_context), *select_query);
             if (joined_tables.tablesCount() == 1)
                 src_storage = joined_tables.getLeftTableStorage();

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -9,8 +9,6 @@
 #include <Core/ServerSettings.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <IO/ReadBuffer.h>
-#include <Interpreters/ApplyWithSubqueryVisitor.h>
-#include <Interpreters/ApplyWithAliasVisitor.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/InterpreterWatchQuery.h>
@@ -81,7 +79,6 @@ namespace Setting
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsUInt64 max_distributed_depth;
-    extern const SettingsBool enable_global_with_statement;
 }
 
 namespace MergeTreeSetting

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1384,10 +1384,8 @@ std::optional<QueryPipeline> StorageDistributed::distributedWrite(const ASTInser
         if (auto * select_query = select.list_of_selects->children.at(0)->as<ASTSelectQuery>())
         {
             if (local_context->getSettingsRef()[Setting::enable_global_with_statement])
-            {
                 ApplyWithAliasVisitor::visit(select.list_of_selects->children.at(0));
-                ApplyWithSubqueryVisitor(local_context).visit(select.list_of_selects->children.at(0));
-            }
+            ApplyWithSubqueryVisitor(local_context).visit(select.list_of_selects->children.at(0));
 
             JoinedTables joined_tables(Context::createCopy(local_context), *select_query);
 

--- a/tests/queries/0_stateless/01099_parallel_distributed_insert_select.reference
+++ b/tests/queries/0_stateless/01099_parallel_distributed_insert_select.reference
@@ -64,3 +64,11 @@ local
 1	1
 2	1
 3	1
+distributed
+1	1
+2	1
+3	1
+local
+1	1
+2	1
+3	1

--- a/tests/queries/0_stateless/01099_parallel_distributed_insert_select.sql
+++ b/tests/queries/0_stateless/01099_parallel_distributed_insert_select.sql
@@ -279,6 +279,17 @@ SELECT number, count(number) FROM distributed_01099_b group by number order by n
 SELECT 'local';
 SELECT number, count(number) FROM local_01099_b group by number order by number;
 
+truncate table local_01099_b;
+
+SET send_logs_level='error';
+INSERT INTO distributed_01099_b with 'http://localhost:8123/?query=' || 'select+{1,2,3}+format+TSV' as url SELECT * FROM urlCluster('test_cluster_two_shards', (select url), 'TSV', 's String');
+SET send_logs_level='warning';
+
+SELECT 'distributed';
+SELECT number, count(number) FROM distributed_01099_b group by number order by number;
+SELECT 'local';
+SELECT number, count(number) FROM local_01099_b group by number order by number;
+
 DROP TABLE local_01099_b;
 SET send_logs_level='fatal';
 DROP TABLE distributed_01099_b;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support global constants from `WITH` statement for the parallel distributed `INSERT SELECT` with the `Distributed` destination table. Before, the query could throw an `Unknown expression identifier` error.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
