### PR TITLE
Docs: Document from what version vector indexes are usable

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/annindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/annindexes.md
@@ -76,6 +76,7 @@ ClickHouse provides a special "vector similarity" index to perform approximate v
 :::note
 Vector similarity indexes are currently beta.
 To enable them, please first run `SET enable_vector_similarity_index = 1`.
+A usable/testable version of vector similarity indexes is available in ClickHouse version 25.8 and onwards.
 If you run into problems, kindly open an issue in the [ClickHouse repository](https://github.com/clickhouse/clickhouse/issues).
 :::
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)