### PR TITLE
FunctionDocumentation: Improve debug-ability of some weird exceptions

### DIFF
--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -18,7 +18,7 @@ VersionNumber VERSION_UNKNOWN = {0};
 
 /// Example input 'types' vector: {"(U)Int*", "Float*"}
 /// Example output string: [`(U)Int*`](/sql-reference/data-types/int-uint) or [`Float*`](/sql-reference/data-types/float)
-String mapTypesToTypesWithLinks(const std::vector<std::string> & types)
+String mapTypesToTypesWithLinks(const std::vector<std::string> & types, const FunctionDocumentation::Syntax & syntax)
 {
     String result;
     bool is_first = true;
@@ -115,7 +115,7 @@ String mapTypesToTypesWithLinks(const std::vector<std::string> & types)
         else if (type == "NULL")
             result += "`](/sql-reference/syntax#null)";
         else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected data type: {}", type);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected data type in function {}: {}", type, syntax);
     }
     result += "\n";
     return result;
@@ -132,7 +132,7 @@ String FunctionDocumentation::argumentsAsString() const
         /// We assume that if 'type' is empty(), 'description' already ends with a type definition. This is a reasonable assumption to be
         /// able to handle special cases which cannot be represented by the type mapping in mapTypesToTypesWithLinks.
         if (!types.empty())
-            result += mapTypesToTypesWithLinks(types);
+            result += mapTypesToTypesWithLinks(types, syntax);
     }
     return result;
 }
@@ -157,7 +157,7 @@ String FunctionDocumentation::returnedValueAsString() const
     /// We assume that if 'type' is empty(), 'description' already ends with a type definition. This is a reasonable assumption to be
     /// able to handle special cases which cannot be represented by the type mapping in mapTypesToTypesWithLinks.
     if (!returned_value.types.empty())
-        result += mapTypesToTypesWithLinks(returned_value.types);
+        result += mapTypesToTypesWithLinks(returned_value.types, syntax);
     return boost::algorithm::trim_copy(result);
 }
 

--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -115,7 +115,7 @@ String mapTypesToTypesWithLinks(const std::vector<std::string> & types, const Fu
         else if (type == "NULL")
             result += "`](/sql-reference/syntax#null)";
         else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected data type in function {}: {}", type, syntax);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected data type in function {}: {}", syntax, type);
     }
     result += "\n";
     return result;


### PR DESCRIPTION
I have seen some cases where `mapTypesToTypesWithLinks` complains about unexpected data types. This PR makes the exception more verbose, this should help to trace them back to the bad function docs.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)