### PR TITLE
Unflake `01576_alter_low_cardinality_and_select`

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -53,22 +53,6 @@ std::mutex DiskLocal::reservation_mutex;
 
 using DiskLocalPtr = std::shared_ptr<DiskLocal>;
 
-std::optional<size_t> fileSizeSafe(const fs::path & path)
-{
-    std::error_code ec;
-
-    size_t size = fs::file_size(path, ec);
-    if (!ec)
-        return size;
-
-    if (ec == std::errc::no_such_file_or_directory)
-        return std::nullopt;
-    if (ec == std::errc::operation_not_supported)
-        return std::nullopt;
-
-    throw fs::filesystem_error("DiskLocal", path, ec);
-}
-
 class DiskLocalReservation : public IReservation
 {
 public:

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -338,8 +338,6 @@ bool DiskLocal::renameExchangeIfSupported(const std::string & old_path, const st
 
 std::unique_ptr<ReadBufferFromFileBase> DiskLocal::readFile(const String & path, const ReadSettings & settings, std::optional<size_t> read_hint, std::optional<size_t> file_size) const
 {
-    if (!file_size.has_value())
-        file_size = fileSizeSafe(fs::path(disk_path) / path);
     return createReadBufferFromFileBase(fs::path(disk_path) / path, settings, read_hint, file_size);
 }
 

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -82,7 +82,7 @@ public:
         const String & path,
         const ReadSettings & settings,
         std::optional<size_t> read_hint,
-        std::optional<size_t> file_size) const override;
+        std::optional<size_t> file_size = {}) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & path,

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -82,7 +82,7 @@ public:
         const String & path,
         const ReadSettings & settings,
         std::optional<size_t> read_hint,
-        std::optional<size_t> file_size = {}) const override;
+        std::optional<size_t> file_size) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & path,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix reading file size separately from opening it. Relates to https://github.com/ClickHouse/ClickHouse/pull/33372, which was introduced in response to a bug in Linux kernels prior to `5.10` release. 

Closes https://github.com/ClickHouse/ClickHouse/issues/83699


