### PR TITLE
Docs: transfer string functions to source code (1/4)

### DIFF
--- a/src/Functions/CRC.cpp
+++ b/src/Functions/CRC.cpp
@@ -147,9 +147,74 @@ using FunctionCRC64ECMA = FunctionCRC<CRC64ECMAImpl>;
 
 REGISTER_FUNCTION(CRC)
 {
-    factory.registerFunction<FunctionCRC32ZLib>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionCRC32IEEE>({}, FunctionFactory::Case::Insensitive);
-    factory.registerFunction<FunctionCRC64ECMA>({}, FunctionFactory::Case::Insensitive);
+    FunctionDocumentation::Description description_crc32 = R"(
+Calculates the CRC32 checksum of a string using the CRC-32-IEEE 802.3 polynomial and initial value `0xffffffff` (zlib implementation).
+)";
+    FunctionDocumentation::Syntax syntax_crc32 = "CRC32(s)";
+    FunctionDocumentation::Arguments arguments_crc32 = {
+        {"s", "String to calculate CRC32 for.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_crc32 = {"Returns the CRC32 checksum of the string.", {"UInt32"}};
+    FunctionDocumentation::Examples examples_crc32 = {
+    {
+        "Usage example",
+        "SELECT CRC32('ClickHouse')",
+        R"(
+┌─CRC32('ClickHouse')─┐
+│          1538217360 │
+└─────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation_crc32 = {description_crc32, syntax_crc32, arguments_crc32, returned_value_crc32, examples_crc32, introduced_in, category};
+
+    FunctionDocumentation::Description description_crc32ieee = R"(
+Calculates the CRC32 checksum of a string using the CRC-32-IEEE 802.3 polynomial.
+)";
+    FunctionDocumentation::Syntax syntax_crc32ieee = "CRC32IEEE(s)";
+    FunctionDocumentation::Arguments arguments_crc32ieee = {
+        {"s", "String to calculate CRC32 for.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_crc32ieee = {"Returns the CRC32 checksum of the string.", {"UInt32"}};
+    FunctionDocumentation::Examples examples_crc32ieee = {
+    {
+        "Usage example",
+        "SELECT CRC32IEEE('ClickHouse');",
+        R"(
+┌─CRC32IEEE('ClickHouse')─┐
+│              3089448422 │
+└─────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation documentation_crc32ieee = {description_crc32ieee, syntax_crc32ieee, arguments_crc32ieee, returned_value_crc32ieee, examples_crc32ieee, introduced_in, category};
+
+    FunctionDocumentation::Description description_crc64 = R"(
+Calculates the CRC64 checksum of a string using the CRC-64-ECMA polynomial.
+)";
+    FunctionDocumentation::Syntax syntax_crc64 = "CRC64(s)";
+    FunctionDocumentation::Arguments arguments_crc64 = {
+        {"s", "String to calculate CRC64 for.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_crc64 = {"Returns the CRC64 checksum of the string.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_crc64 = {
+    {
+        "Usage example",
+        "SELECT CRC64('ClickHouse');",
+        R"(
+┌──CRC64('ClickHouse')─┐
+│ 12126588151325169346 │
+└──────────────────────┘
+    )"
+    }
+    };
+    FunctionDocumentation documentation_crc64 = {description_crc64, syntax_crc64, arguments_crc64, returned_value_crc64, examples_crc64, introduced_in, category};
+
+    factory.registerFunction<FunctionCRC32ZLib>(documentation_crc32, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC32IEEE>(documentation_crc32ieee, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionCRC64ECMA>(documentation_crc64, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/FunctionsStringDistance.cpp
+++ b/src/Functions/FunctionsStringDistance.cpp
@@ -518,32 +518,206 @@ using FunctionJaroWinklerSimilarity = FunctionsStringSimilarity<FunctionStringDi
 
 REGISTER_FUNCTION(StringDistance)
 {
-    constexpr auto category_string = FunctionDocumentation::Category::String;
+    FunctionDocumentation::Description description_hamming = R"(
+Calculates the [hamming distance](https://en.wikipedia.org/wiki/Hamming_distance) between two byte strings.
+)";
+    FunctionDocumentation::Syntax syntax_hamming = "byteHammingDistance(s1, s2)";
+    FunctionDocumentation::Arguments arguments_hamming = {
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_hamming = {"Returns the Hamming distance between the two strings.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_hamming = {
+    {
+        "Usage example",
+        "SELECT byteHammingDistance('karolin', 'kathrin')",
+        R"(
+┌─byteHammingDistance('karolin', 'kathrin')─┐
+│                                         3 │
+└───────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation_hamming = {description_hamming, syntax_hamming, arguments_hamming, returned_value_hamming, examples_hamming, introduced_in, category};
 
-    factory.registerFunction<FunctionByteHammingDistance>(
-        FunctionDocumentation{.description = R"(Calculates Hamming distance between two byte-strings.)", .category = category_string});
+    FunctionDocumentation::Description description_edit = R"(
+Calculates the [edit distance](https://en.wikipedia.org/wiki/Edit_distance) between two byte strings.
+)";
+    FunctionDocumentation::Syntax syntax_edit = "editDistance(s1, s2)";
+    FunctionDocumentation::Arguments arguments_edit = {
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_edit = {"Returns the edit distance between the two strings.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_edit = {
+    {
+        "Usage example",
+        "SELECT editDistance('clickhouse', 'mouse')",
+        R"(
+┌─editDistance('clickhouse', 'mouse')─┐
+│                                   6 │
+└─────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation documentation_edit = {description_edit, syntax_edit, arguments_edit, returned_value_edit, examples_edit, introduced_in, category};
+
+    FunctionDocumentation::Description description_edit_utf8 = R"(
+Calculates the [edit distance](https://en.wikipedia.org/wiki/Edit_distance) between two UTF8 strings.
+)";
+    FunctionDocumentation::Syntax syntax_edit_utf8 = "editDistanceUTF8(string1, string2)";
+    FunctionDocumentation::Arguments arguments_edit_utf8 = {
+        {"string1", "First input string.", {"String"}},
+        {"string2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_edit_utf8 = {"Returns the edit distance between the two UTF8 strings.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_edit_utf8 = {
+    {
+        "Usage example",
+        "SELECT editDistanceUTF8('我是谁', '我是我')",
+        R"(
+┌─editDistanceUTF8('我是谁', '我是我')──┐
+│                                   1 │
+└─────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_utf8 = {24, 6};
+    FunctionDocumentation documentation_edit_utf8 = {description_edit_utf8, syntax_edit_utf8, arguments_edit_utf8, returned_value_edit_utf8, examples_edit_utf8, introduced_in_utf8, category};
+
+    FunctionDocumentation::Description description_damerau = R"(
+Calculates the [Damerau-Levenshtein distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance) between two byte strings.
+)";
+    FunctionDocumentation::Syntax syntax_damerau = "damerauLevenshteinDistance(s1, s2)";
+    FunctionDocumentation::Arguments arguments_damerau = {
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_damerau = {"Returns the Damerau-Levenshtein distance between the two strings.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_damerau = {
+    {
+        "Usage example",
+        "SELECT damerauLevenshteinDistance('clickhouse', 'mouse')",
+        R"(
+┌─damerauLevenshteinDistance('clickhouse', 'mouse')─┐
+│                                                 6 │
+└───────────────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_damerau = {24, 1};
+    FunctionDocumentation documentation_damerau = {description_damerau, syntax_damerau, arguments_damerau, returned_value_damerau, examples_damerau, introduced_in_damerau, category};
+
+    FunctionDocumentation::Description description_jaccard = R"(
+Calculates the [Jaccard similarity index](https://en.wikipedia.org/wiki/Jaccard_index) between two byte strings.
+)";
+    FunctionDocumentation::Syntax syntax_jaccard = "stringJaccardIndex(s1, s2)";
+    FunctionDocumentation::Arguments arguments_jaccard = {
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_jaccard = {"Returns the Jaccard similarity index between the two strings.", {"Float64"}};
+    FunctionDocumentation::Examples examples_jaccard = {
+    {
+        "Usage example",
+        "SELECT stringJaccardIndex('clickhouse', 'mouse')",
+        R"(
+┌─stringJaccardIndex('clickhouse', 'mouse')─┐
+│                                       0.4 │
+└───────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_jaccard = {23, 11};
+    FunctionDocumentation documentation_jaccard = {description_jaccard, syntax_jaccard, arguments_jaccard, returned_value_jaccard, examples_jaccard, introduced_in_jaccard, category};
+
+    FunctionDocumentation::Description description_jaccard_utf8 = R"(
+Like [`stringJaccardIndex`](#stringJaccardIndex) but for UTF8-encoded strings.
+)";
+    FunctionDocumentation::Syntax syntax_jaccard_utf8 = "stringJaccardIndexUTF8(s1, s2)";
+    FunctionDocumentation::Arguments arguments_jaccard_utf8 = {
+        {"s1", "First input UTF8 string.", {"String"}},
+        {"s2", "Second input UTF8 string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_jaccard_utf8 = {"Returns the Jaccard similarity index between the two UTF8 strings.", {"Float64"}};
+    FunctionDocumentation::Examples examples_jaccard_utf8 = {
+    {
+        "Usage example",
+        "SELECT stringJaccardIndexUTF8('我爱你', '我也爱你')",
+        R"(
+┌─stringJaccardIndexUTF8('我爱你', '我也爱你')─┐
+│                                       0.75 │
+└─────────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_jaccard_utf8 = {23, 11};
+    FunctionDocumentation documentation_jaccard_utf8 = {description_jaccard_utf8, syntax_jaccard_utf8, arguments_jaccard_utf8, returned_value_jaccard_utf8, examples_jaccard_utf8, introduced_in_jaccard_utf8, category};
+
+    FunctionDocumentation::Description description_jaro = R"(
+Calculates the [Jaro similarity](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance#Jaro_similarity) between two byte strings.
+)";
+    FunctionDocumentation::Syntax syntax_jaro = "jaroSimilarity(s1, s2)";
+    FunctionDocumentation::Arguments arguments_jaro = {
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_jaro = {"Returns the Jaro similarity between the two strings.", {"Float64"}};
+    FunctionDocumentation::Examples examples_jaro = {
+    {
+        "Usage example",
+        "SELECT jaroSimilarity('clickhouse', 'click')",
+        R"(
+┌─jaroSimilarity('clickhouse', 'click')─┐
+│                    0.8333333333333333 │
+└───────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_jaro = {24, 1};
+    FunctionDocumentation documentation_jaro = {description_jaro, syntax_jaro, arguments_jaro, returned_value_jaro, examples_jaro, introduced_in_jaro, category};
+
+    FunctionDocumentation::Description description_jaro_winkler = R"(
+Calculates the [Jaro-Winkler similarity](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance) between two byte strings.
+)";
+    FunctionDocumentation::Syntax syntax_jaro_winkler = "jaroWinklerSimilarity(s1, s2)";
+    FunctionDocumentation::Arguments arguments_jaro_winkler = {
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_jaro_winkler = {"Returns the Jaro-Winkler similarity between the two strings.", {"Float64"}};
+    FunctionDocumentation::Examples examples_jaro_winkler = {
+    {
+        "Usage example",
+        "SELECT jaroWinklerSimilarity('clickhouse', 'click')",
+        R"(
+┌─jaroWinklerSimilarity('clickhouse', 'click')─┐
+│                           0.8999999999999999 │
+└──────────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_jaro_winkler = {24, 1};
+    FunctionDocumentation documentation_jaro_winkler = {description_jaro_winkler, syntax_jaro_winkler, arguments_jaro_winkler, returned_value_jaro_winkler, examples_jaro_winkler, introduced_in_jaro_winkler, category};
+
+    factory.registerFunction<FunctionByteHammingDistance>(documentation_hamming);
     factory.registerAlias("mismatches", NameByteHammingDistance::name);
 
-    factory.registerFunction<FunctionEditDistance>(
-        FunctionDocumentation{.description = R"(Calculates the edit distance between two byte-strings.)", .category = category_string});
+    factory.registerFunction<FunctionEditDistance>(documentation_edit);
     factory.registerAlias("levenshteinDistance", NameEditDistance::name);
 
-    factory.registerFunction<FunctionEditDistanceUTF8>(
-        FunctionDocumentation{.description = R"(Calculates the edit distance between two UTF8 strings.)", .category = category_string});
+    factory.registerFunction<FunctionEditDistanceUTF8>(documentation_edit_utf8);
     factory.registerAlias("levenshteinDistanceUTF8", NameEditDistanceUTF8::name);
 
-    factory.registerFunction<FunctionDamerauLevenshteinDistance>(
-        FunctionDocumentation{.description = R"(Calculates the Damerau-Levenshtein distance two between two byte-string.)", .category = category_string});
+    factory.registerFunction<FunctionDamerauLevenshteinDistance>(documentation_damerau);
 
-    factory.registerFunction<FunctionStringJaccardIndex>(
-        FunctionDocumentation{.description = R"(Calculates the Jaccard similarity index between two byte strings.)", .category = category_string});
-    factory.registerFunction<FunctionStringJaccardIndexUTF8>(
-        FunctionDocumentation{.description = R"(Calculates the Jaccard similarity index between two UTF8 strings.)", .category = category_string});
+    factory.registerFunction<FunctionStringJaccardIndex>(documentation_jaccard);
+    factory.registerFunction<FunctionStringJaccardIndexUTF8>(documentation_jaccard_utf8);
 
-    factory.registerFunction<FunctionJaroSimilarity>(
-        FunctionDocumentation{.description = R"(Calculates the Jaro similarity between two byte-string.)", .category = category_string});
+    factory.registerFunction<FunctionJaroSimilarity>(documentation_jaro);
 
-    factory.registerFunction<FunctionJaroWinklerSimilarity>(
-        FunctionDocumentation{.description = R"(Calculates the Jaro-Winkler similarity between two byte-string.)", .category = category_string});
+    factory.registerFunction<FunctionJaroWinklerSimilarity>(documentation_jaro_winkler);
 }
 }

--- a/src/Functions/FunctionsStringDistance.cpp
+++ b/src/Functions/FunctionsStringDistance.cpp
@@ -567,10 +567,10 @@ Calculates the [edit distance](https://en.wikipedia.org/wiki/Edit_distance) betw
     FunctionDocumentation::Description description_edit_utf8 = R"(
 Calculates the [edit distance](https://en.wikipedia.org/wiki/Edit_distance) between two UTF8 strings.
 )";
-    FunctionDocumentation::Syntax syntax_edit_utf8 = "editDistanceUTF8(string1, string2)";
+    FunctionDocumentation::Syntax syntax_edit_utf8 = "editDistanceUTF8(s1, s2)";
     FunctionDocumentation::Arguments arguments_edit_utf8 = {
-        {"string1", "First input string.", {"String"}},
-        {"string2", "Second input string.", {"String"}}
+        {"s1", "First input string.", {"String"}},
+        {"s2", "Second input string.", {"String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value_edit_utf8 = {"Returns the edit distance between the two UTF8 strings.", {"UInt64"}};
     FunctionDocumentation::Examples examples_edit_utf8 = {

--- a/src/Functions/appendTrailingCharIfAbsent.cpp
+++ b/src/Functions/appendTrailingCharIfAbsent.cpp
@@ -137,6 +137,7 @@ Appends character `c` to string `s` if `s` is non-empty and does not end with ch
 │ https://example.com/     │
 └──────────────────────────┘
         )"
+    }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;

--- a/src/Functions/appendTrailingCharIfAbsent.cpp
+++ b/src/Functions/appendTrailingCharIfAbsent.cpp
@@ -119,7 +119,30 @@ private:
 
 REGISTER_FUNCTION(AppendTrailingCharIfAbsent)
 {
-    factory.registerFunction<FunctionAppendTrailingCharIfAbsent>();
+    FunctionDocumentation::Description description = R"(
+Appends character `c` to string `s` if `s` is non-empty and does not end with character `c`.
+)";
+    FunctionDocumentation::Syntax syntax = "appendTrailingCharIfAbsent(s, c)";
+    FunctionDocumentation::Arguments arguments = {
+        {"s", "Input string.", {"String"}},
+        {"c", "Character to append if absent.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns string `s` with character `c` appended if `s` does not end with `c`.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        "SELECT appendTrailingCharIfAbsent('https://example.com', '/');",
+        R"(
+┌─appendTraili⋯.com', '/')─┐
+│ https://example.com/     │
+└──────────────────────────┘
+        )"
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionAppendTrailingCharIfAbsent>(documentation);
 }
 
 }

--- a/src/Functions/array/length.cpp
+++ b/src/Functions/array/length.cpp
@@ -16,37 +16,57 @@ Please note that the number of bytes in a string is not the same as the number o
 Unicode "code points" and it is not the same as the number of Unicode "grapheme clusters"
 (what we usually call "characters") and it is not the same as the visible string width.
 
-It is ok to have ASCII NUL bytes in strings, and they will be counted as well.
+It is ok to have ASCII NULL bytes in strings, and they will be counted as well.
     )";
     FunctionDocumentation::Syntax syntax = "length(x)";
     FunctionDocumentation::Arguments arguments = {{"x", "Value for which to calculate the number of bytes (for String/FixedString) or elements (for Array).", {"String", "FixedString", "Array(T)"}}};
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the number of number of bytes in the String/FixedString `x` / the number of elements in array `x`", {"UInt64"}};
     FunctionDocumentation::Examples examples {
-        {"string1", "SELECT length('Hello, world!')", "13"},
-        {"arr1", "SELECT length(['Hello', 'world'])", "2"},
-        {"constexpr", R"(
+    {
+        "String example",
+        "SELECT length('Hello, world!')",
+        "13"
+    },
+    {
+        "Array example",
+        "SELECT length(['Hello', 'world'])",
+        "2"
+    },
+    {
+        "constexpr example",
+        R"(
 WITH 'hello' || toString(number) AS str
 SELECT str,
 isConstant(length(str)) AS str_length_is_constant,
 isConstant(length(str::FixedString(6))) AS fixed_str_length_is_constant
 FROM numbers(3)
-        )", R"(
+        )",
+        R"(
 ┌─str────┬─str_length_is_constant─┬─fixed_str_length_is_constant─┐
 │ hello0 │                      0 │                            1 │
 │ hello1 │                      0 │                            1 │
 │ hello2 │                      0 │                            1 │
 └────────┴────────────────────────┴──────────────────────────────┘
-        )"},
-        {"unicode", "SELECT 'ёлка' AS str1, length(str1), lengthUTF8(str1), normalizeUTF8NFKD(str1) AS str2, length(str2), lengthUTF8(str2)", R"(
+        )"
+    },
+    {
+        "unicode example",
+        "SELECT 'ёлка' AS str1, length(str1), lengthUTF8(str1), normalizeUTF8NFKD(str1) AS str2, length(str2), lengthUTF8(str2)",
+        R"(
 ┌─str1─┬─length(str1)─┬─lengthUTF8(str1)─┬─str2─┬─length(str2)─┬─lengthUTF8(str2)─┐
 │ ёлка │            8 │                4 │ ёлка │           10 │                5 │
 └──────┴──────────────┴──────────────────┴──────┴──────────────┴──────────────────┘
-        )"},
-        {"ascii_vs_utf8", "SELECT 'ábc' AS str, length(str), lengthUTF8(str)", R"(
+        )"
+    },
+    {
+        "ascii_vs_utf8 example",
+        "SELECT 'ábc' AS str, length(str), lengthUTF8(str)",
+        R"(
 ┌─str─┬─length(str)──┬─lengthUTF8(str)─┐
 │ ábc │            4 │               3 │
 └─────┴──────────────┴─────────────────┘
-        )"}
+        )"
+    }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;

--- a/src/Functions/ascii.cpp
+++ b/src/Functions/ascii.cpp
@@ -75,16 +75,30 @@ using FunctionAscii = FunctionStringOrArrayToT<AsciiImpl, AsciiName, AsciiImpl::
 
 REGISTER_FUNCTION(Ascii)
 {
-    factory.registerFunction<FunctionAscii>(
-        FunctionDocumentation{
-        .description=R"(
-Returns the ASCII code point of the first character of str.  The result type is Int32.
+    FunctionDocumentation::Description description = R"(
+Returns the ASCII code point as an `Int32` of the first character of string `s`.
+)";
+    FunctionDocumentation::Syntax syntax = "ascii(s)";
+    FunctionDocumentation::Arguments arguments = {
+        {"s", "String input.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the ASCII code point of the first character. If `s` is empty, the result is `0`. If the first character is not an ASCII character or not part of the Latin-1 supplement range of UTF-16, the result is undefined.", {"Int32"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        "SELECT ascii('234')",
+        R"(
+┌─ascii('234')─┐
+│           50 │
+└──────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 11};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
-If s is empty, the result is 0. If the first character is not an ASCII character or not part of the Latin-1 Supplement range of UTF-16, the result is undefined)
-        )",
-        .examples{{"ascii", "SELECT ascii('234')", ""}},
-        .category = FunctionDocumentation::Category::String
-        }, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionAscii>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/ascii.cpp
+++ b/src/Functions/ascii.cpp
@@ -76,7 +76,7 @@ using FunctionAscii = FunctionStringOrArrayToT<AsciiImpl, AsciiName, AsciiImpl::
 REGISTER_FUNCTION(Ascii)
 {
     FunctionDocumentation::Description description = R"(
-Returns the ASCII code point as an `Int32` of the first character of string `s`.
+Returns the ASCII code point of the first character of string `s` as an `Int32`.
 )";
     FunctionDocumentation::Syntax syntax = "ascii(s)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/base32Decode.cpp
+++ b/src/Functions/base32Decode.cpp
@@ -22,13 +22,21 @@ Throws an exception in case of error.
 )";
     FunctionDocumentation::Syntax syntax = "base32Decode(encoded)";
     FunctionDocumentation::Arguments arguments = {
-        {"encoded", "[String](../data-types/string.md) column or constant. If the string is not valid Base32-encoded, an exception is thrown.", {"String"}}
+        {"encoded", "String column or constant. If the string is not valid Base32-encoded, an exception is thrown.", {"String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the decoded value of the argument.", {"String"}};
     FunctionDocumentation::Examples examples = {
-        {"Basic usage", "SELECT base32Decode('IVXGG33EMVSA====');", "┌─base32Decode('IVXGG33EMVSA====')─┐\n│ Encoded                          │\n└──────────────────────────────────┘"}
+    {
+        "Usage example",
+        "SELECT base32Decode('IVXGG33EMVSA====');",
+        R"(
+┌─base32Decode('IVXGG33EMVSA====')─┐
+│ Encoded                          │
+└──────────────────────────────────┘
+        )"
+    }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {18, 16};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/base32Decode.cpp
+++ b/src/Functions/base32Decode.cpp
@@ -16,19 +16,22 @@ using FunctionBase32Decode = FunctionBaseXXConversion<Base32DecodeImpl>;
 
 REGISTER_FUNCTION(Base32Decode)
 {
-    factory.registerFunction<FunctionBase32Decode>(FunctionDocumentation{
-        .description = R"(
-Decode a [Base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded string. The input string must be a valid Base32 encoded string, otherwise an exception will be thrown.)",
-        .arguments = {
-            {"arg", "A Base32 (rfc4648) encoded string"},
-        },
-        .examples = {
-            {"simple_decoding1", "SELECT base32Decode('ME======')", "a"},
-            {"simple_decoding2", "SELECT base32Decode('JBSWY3DP')", "Hello"},
-            {"empty_string", "SELECT base32Decode('')", ""},
-            {"non_ascii", "SELECT hex(base32Decode('4W2HIXV4'))", "E5B4745EBC"},
-        },
-        .introduced_in = {25, 5},
-        .category = FunctionDocumentation::Category::String});
+    FunctionDocumentation::Description description = R"(
+Decodes a string from [Base32](https://datatracker.ietf.org/doc/html/rfc4648#section-6), according to RFC 4648.
+Throws an exception in case of error.
+)";
+    FunctionDocumentation::Syntax syntax = "base32Decode(encoded)";
+    FunctionDocumentation::Arguments arguments = {
+        {"encoded", "[String](../data-types/string.md) column or constant. If the string is not valid Base32-encoded, an exception is thrown.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the decoded value of the argument.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+        {"Basic usage", "SELECT base32Decode('IVXGG33EMVSA====');", "┌─base32Decode('IVXGG33EMVSA====')─┐\n│ Encoded                          │\n└──────────────────────────────────┘"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionBase32Decode>(documentation);
 }
 }

--- a/src/Functions/base32Decode.cpp
+++ b/src/Functions/base32Decode.cpp
@@ -18,7 +18,7 @@ REGISTER_FUNCTION(Base32Decode)
 {
     FunctionDocumentation::Description description = R"(
 Decodes a string from [Base32](https://datatracker.ietf.org/doc/html/rfc4648#section-6), according to RFC 4648.
-Throws an exception in case of error.
+Throws an exception in case of an error.
 )";
     FunctionDocumentation::Syntax syntax = "base32Decode(encoded)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/base32Decode.cpp
+++ b/src/Functions/base32Decode.cpp
@@ -17,12 +17,12 @@ using FunctionBase32Decode = FunctionBaseXXConversion<Base32DecodeImpl>;
 REGISTER_FUNCTION(Base32Decode)
 {
     FunctionDocumentation::Description description = R"(
-Decodes a string from [Base32](https://datatracker.ietf.org/doc/html/rfc4648#section-6), according to RFC 4648.
-Throws an exception in case of an error.
+Decodes a [Base32](https://datatracker.ietf.org/doc/html/rfc4648#section-6) (RFC 4648) string.
+If the string is not valid Base32-encoded, an exception is thrown.
 )";
     FunctionDocumentation::Syntax syntax = "base32Decode(encoded)";
     FunctionDocumentation::Arguments arguments = {
-        {"encoded", "String column or constant. If the string is not valid Base32-encoded, an exception is thrown.", {"String"}}
+        {"encoded", "String column or constant.", {"String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the decoded value of the argument.", {"String"}};
     FunctionDocumentation::Examples examples = {
@@ -36,7 +36,7 @@ Throws an exception in case of an error.
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {18, 16};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 6};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/base32Encode.cpp
+++ b/src/Functions/base32Encode.cpp
@@ -16,17 +16,29 @@ using FunctionBase32Encode = FunctionBaseXXConversion<Base32EncodeImpl>;
 
 REGISTER_FUNCTION(Base32Encode)
 {
-    factory.registerFunction<FunctionBase32Encode>(FunctionDocumentation{
-        .description = R"(
-Encode a string with [Base32](https://datatracker.ietf.org/doc/html/rfc4648) encoding.)",
-        .arguments = {
-            {"arg", "A string to be encoded"},
-        },
-        .examples = {
-            {"simple_encoding1", "SELECT base32Encode('a')", "ME======"},
-            {"simple_encoding2", "SELECT base32Encode('Hello')", "JBSWY3DP"}
-        },
-        .introduced_in = {25, 5},
-        .category = FunctionDocumentation::Category::String});
+    FunctionDocumentation::Description description = R"(
+Encodes a string using [Base32](https://datatracker.ietf.org/doc/html/rfc4648#section-6).
+)";
+    FunctionDocumentation::Syntax syntax = "base32Encode(plaintext)";
+    FunctionDocumentation::Arguments arguments = {
+        {"plaintext", "Plaintext to encode.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the encoded value of the argument.", {"String", "FixedString"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        "SELECT base32Encode('Encoded')",
+        R"(
+┌─base32Encode('Encoded')─┐
+│ IVXGG33EMVSA====        │
+└─────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 6};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionBase32Encode>(documentation);
 }
 }

--- a/src/Functions/base58Decode.cpp
+++ b/src/Functions/base58Decode.cpp
@@ -16,7 +16,31 @@ using FunctionBase58Decode = FunctionBaseXXConversion<Base58DecodeImpl>;
 
 REGISTER_FUNCTION(Base58Decode)
 {
-    factory.registerFunction<FunctionBase58Decode>();
+    FunctionDocumentation::Description description = R"(
+Decodes a string from [Base58](https://tools.ietf.org/id/draft-msporny-base58-01.html) encoding.
+An exception is thrown in case of an error.
+)";
+    FunctionDocumentation::Syntax syntax = "base58Decode(encoded)";
+    FunctionDocumentation::Arguments arguments = {
+        {"encoded", "String column or constant to decode. If the string is not valid Base58-encoded, an exception is thrown.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the decoded value of the argument.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        "SELECT base58Decode('JxF12TrwUP45BMd');",
+        R"(
+┌─base58Decode⋯rwUP45BMd')─┐
+│ Hello World              │
+└──────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 7};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionBase58Decode>(documentation);
 }
 
 }

--- a/src/Functions/base58Decode.cpp
+++ b/src/Functions/base58Decode.cpp
@@ -17,12 +17,12 @@ using FunctionBase58Decode = FunctionBaseXXConversion<Base58DecodeImpl>;
 REGISTER_FUNCTION(Base58Decode)
 {
     FunctionDocumentation::Description description = R"(
-Decodes a string from [Base58](https://tools.ietf.org/id/draft-msporny-base58-01.html) encoding.
-An exception is thrown in case of an error.
+Decodes a [Base58](https://datatracker.ietf.org/doc/html/draft-msporny-base58-03#section-3) string.
+If the string is not valid Base58-encoded, an exception is thrown.
 )";
     FunctionDocumentation::Syntax syntax = "base58Decode(encoded)";
     FunctionDocumentation::Arguments arguments = {
-        {"encoded", "String column or constant to decode. If the string is not valid Base58-encoded, an exception is thrown.", {"String"}}
+        {"encoded", "String column or constant to decode.", {"String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the decoded value of the argument.", {"String"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Functions/base58Encode.cpp
+++ b/src/Functions/base58Encode.cpp
@@ -23,8 +23,18 @@ Encodes a string using [Base58](https://tools.ietf.org/id/draft-msporny-base58-0
         {"plaintext", "Plaintext to encode.", {"String"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the encoded value of the argument.", {"String"}};
-    FunctionDocumentation::Examples examples = {};
-    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        "SELECT base58Encode('ClickHouse');",
+        R"(
+┌─base58Encode('ClickHouse')─┐
+│ 4nhk8K7GHXf6zx             │
+└────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {18, 16};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/base58Encode.cpp
+++ b/src/Functions/base58Encode.cpp
@@ -15,7 +15,20 @@ using FunctionBase58Encode = FunctionBaseXXConversion<Base58EncodeImpl>;
 }
 REGISTER_FUNCTION(Base58Encode)
 {
-    factory.registerFunction<FunctionBase58Encode>();
+    FunctionDocumentation::Description description = R"(
+Encodes a string using [Base58](https://tools.ietf.org/id/draft-msporny-base58-01.html) encoding.
+)";
+    FunctionDocumentation::Syntax syntax = "base58Encode(plaintext)";
+    FunctionDocumentation::Arguments arguments = {
+        {"plaintext", "Plaintext to encode.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the encoded value of the argument.", {"String"}};
+    FunctionDocumentation::Examples examples = {};
+    FunctionDocumentation::IntroducedIn introduced_in = {};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionBase58Encode>(documentation);
 }
 
 }

--- a/src/Functions/base58Encode.cpp
+++ b/src/Functions/base58Encode.cpp
@@ -34,7 +34,7 @@ Encodes a string using [Base58](https://tools.ietf.org/id/draft-msporny-base58-0
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {18, 16};
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 7};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/base64URLEncode.cpp
+++ b/src/Functions/base64URLEncode.cpp
@@ -19,7 +19,7 @@ using FunctionBase64Encode = FunctionBaseXXConversion<Base64EncodeImpl>;
 REGISTER_FUNCTION(Base64URLEncode)
 {
     FunctionDocumentation::Description description = R"(
-Encodes a string using [Base64](https://en.wikipedia.org/wiki/Base64) representation using URL-safe alphabet, according to RFC 4648.
+Encodes a string using [Base64](https://datatracker.ietf.org/doc/html/rfc4648#section-4) (RFC 4648) representation using URL-safe alphabet.
 )";
     FunctionDocumentation::Syntax syntax = "base64URLEncode(plaintext)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/base64URLEncode.cpp
+++ b/src/Functions/base64URLEncode.cpp
@@ -18,15 +18,30 @@ using FunctionBase64Encode = FunctionBaseXXConversion<Base64EncodeImpl>;
 
 REGISTER_FUNCTION(Base64URLEncode)
 {
-    FunctionDocumentation::Description description = R"(Encodes an URL (String or FixedString) as base64 with URL-specific modifications, according to RFC 4648 (https://datatracker.ietf.org/doc/html/rfc4648#section-5).)";
-    FunctionDocumentation::Syntax syntax = "base64URLEncode(url)";
-    FunctionDocumentation::Arguments arguments = {{"url", "String column or constant."}};
-    FunctionDocumentation::ReturnedValue returned_value = {"A string containing the encoded value of the argument.", {"String"}};
-    FunctionDocumentation::Examples examples = {{"Example", "SELECT base64URLEncode('https://clickhouse.com')", "aHR0cHM6Ly9jbGlja2hvdXNlLmNvbQ"}};
-    FunctionDocumentation::IntroducedIn introduced_in = {24, 6};
-    FunctionDocumentation::Category category = FunctionDocumentation::Category::Encoding;
+    FunctionDocumentation::Description description = R"(
+Encodes a string using [Base64](https://en.wikipedia.org/wiki/Base64) representation using URL-safe alphabet, according to RFC 4648.
+)";
+    FunctionDocumentation::Syntax syntax = "base64URLEncode(plaintext)";
+    FunctionDocumentation::Arguments arguments = {
+        {"plaintext", "Plaintext column or constant to encode.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a string containing the encoded value of the argument.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        "SELECT base64URLEncode('https://clickhouse.com')",
+        R"(
+┌─base64URLEncode('https://clickhouse.com')─┐
+│ aHR0cHM6Ly9jbGlja2hvdXNlLmNvbQ            │
+└───────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {18, 16};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionBase64Encode>({description, syntax, arguments, returned_value, examples, introduced_in, category});
+    factory.registerFunction<FunctionBase64Encode>(documentation);
 }
 
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -1,7 +1,4 @@
 CAST
-CRC32
-CRC32IEEE
-CRC64
 DATE
 FQDN
 IPv4CIDRToRange
@@ -52,14 +49,11 @@ accurateCastOrNull
 acos
 acosh
 and
-appendTrailingCharIfAbsent
 asinh
 atan
 atan2
 atanh
 bar
-base58Decode
-base58Encode
 basename
 blockNumber
 blockSerializedSize

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -1,7 +1,4 @@
 CAST
-CRC32
-CRC32IEEE
-CRC64
 DATE
 FQDN
 IPv4CIDRToRange
@@ -61,22 +58,17 @@ accurateCastOrNull
 acos
 acosh
 and
-appendTrailingCharIfAbsent
-ascii
 asin
 asinh
 atan
 atan2
 atanh
 bar
-base58Decode
-base58Encode
 basename
 blockNumber
 blockSerializedSize
 blockSize
 buildId
-byteHammingDistance
 byteSize
 caseWithExpression
 catboostEvaluate
@@ -115,7 +107,6 @@ cutToFirstSignificantSubdomainWithWWW
 cutToFirstSignificantSubdomainWithWWWRFC
 cutURLParameter
 cutWWW
-damerauLevenshteinDistance
 dateDiff
 dateTime64ToSnowflake
 dateTimeToSnowflake
@@ -179,8 +170,6 @@ dumpColumnStructure
 dynamicElement
 dynamicType
 e
-editDistance
-editDistanceUTF8
 enabledProfiles
 enabledRoles
 encodeURLComponent
@@ -289,8 +278,6 @@ isIPAddressInRange
 isIPv4String
 isIPv6String
 isValidUTF8
-jaroSimilarity
-jaroWinklerSimilarity
 joinGet
 joinGetOrNull
 left
@@ -511,8 +498,6 @@ sparseGramsUTF8
 sqrt
 startsWith
 startsWithUTF8
-stringJaccardIndex
-stringJaccardIndexUTF8
 structureToCapnProtoSchema
 structureToProtobufSchema
 substring


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Transfers string functions docs into the source code. Part 1/4.
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
