### PR TITLE
Simple fix error of compilation

### DIFF
--- a/contrib/avro-cmake/CMakeLists.txt
+++ b/contrib/avro-cmake/CMakeLists.txt
@@ -17,7 +17,7 @@ if (EXISTS "${AVROCPP_ROOT_DIR}/../../share/VERSION.txt")
         AVRO_VERSION)
 endif()
 
-string(REPLACE "\n" "" AVRO_VERSION  ${AVRO_VERSION})
+string(REPLACE "\n" "" AVRO_VERSION "${AVRO_VERSION}")
 set (AVRO_VERSION_MAJOR ${AVRO_VERSION})
 set (AVRO_VERSION_MINOR "0")
 


### PR DESCRIPTION
in `contrib/avro-cmake/CMakeLists.txt:20` missing "
> string(REPLACE "\n" "" AVRO_VERSION "${AVRO_VERSION})

```
[main] Building folder: /home/zypperia/projects/commits/ClickHouse/build 
[main] Configuring project: ClickHouse 
[proc] Executing command: /etc/profiles/per-user/zypperia/bin/cmake -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_C_COMPILER:FILEPATH=/etc/profiles/per-user/zypperia/bin/clang -DCMAKE_CXX_COMPILER:FILEPATH=/etc/profiles/per-user/zypperia/bin/clang++ --no-warn-unused-cli -S /home/zypperia/projects/commits/ClickHouse -B /home/zypperia/projects/commits/ClickHouse/build -G "Unix Makefiles"
[cmake] Not searching for unused variables given on the command line.
[cmake] -- Using compiler:
[cmake] clang version 19.1.7
[cmake] Target: x86_64-unknown-linux-gnu
[cmake] Thread model: posix
[cmake] InstalledDir: /nix/store/ldjndg6f0sm5q4pm9i8xcr3sshrx3rdw-clang-19.1.7/bin
[cmake] -- Using linker: /etc/profiles/per-user/zypperia/bin/ld.lld
[cmake] -- Using archiver: /etc/profiles/per-user/zypperia/bin/llvm-ar
[cmake] -- Using ranlib: /etc/profiles/per-user/zypperia/bin/llvm-ranlib
[cmake] -- Using install-name-tool: /etc/profiles/per-user/zypperia/bin/llvm-install-name-tool
[cmake] -- Using objcopy: /etc/profiles/per-user/zypperia/bin/llvm-objcopy
[cmake] -- Using strip: /etc/profiles/per-user/zypperia/bin/llvm-strip
[cmake] -- Using ccache: /etc/profiles/per-user/zypperia/bin/ccache (version 4.11.3)
[cmake] -- Git HEAD commit hash: b499c8df1f091cbba234bbf23ce8473a5834e8aa
[cmake] On branch master
[cmake] Your branch is up to date with 'origin/master'.
[cmake] 
[cmake] Changes not staged for commit:
[cmake]   (use "git add <file>..." to update what will be committed)
[cmake]   (use "git restore <file>..." to discard changes in working directory)
[cmake]   (commit or discard the untracked or modified content in submodules)
[cmake] 	modified:   contrib/AMQP-CPP (modified content)
[cmake] 	modified:   contrib/FastPFOR (modified content)
[cmake] 	modified:   contrib/NuRaft (modified content)
[cmake] 	modified:   contrib/SHA3IUF (modified content)
[cmake] 	modified:   contrib/ai-sdk-cpp (modified content)
[cmake] 	modified:   contrib/avro (modified content)
[cmake] 	modified:   contrib/aws (modified content)
[cmake] 	modified:   contrib/aws-crt-cpp (modified content)
[cmake] 	modified:   contrib/bzip2-cmake/CMakeLists.txt
[cmake] 	modified:   contrib/capnproto (modified content)
[cmake] 	modified:   contrib/chdig (modified content)
[cmake] 	modified:   contrib/cld2 (modified content)
[cmake] 	modified:   contrib/cppkafka (modified content)
[cmake] 	modified:   contrib/crc32-s390x (modified content)
[cmake] 	modified:   contrib/crc32-vpmsum (modified content)
[cmake] 	modified:   contrib/dragonbox (modified content)
[cmake] 	modified:   contrib/fastops (modified content)
[cmake] 	modified:   contrib/hive-metastore (modified content)
[cmake] 	modified:   contrib/icudata (modified content)
[cmake] 	modified:   contrib/isa-l (modified content)
[cmake] 	modified:   contrib/lemmagen-c (modified content)
[cmake] 	modified:   contrib/libbcrypt (modified content)
[cmake] 	modified:   contrib/libgsasl (modified content)
[cmake] 	modified:   contrib/libstemmer_c (modified content)
[cmake] 	modified:   contrib/mariadb-connector-c (modified content)
[cmake] 	modified:   contrib/mongo-c-driver (modified content)
[cmake] 	modified:   contrib/mongo-cxx-driver (modified content)
[cmake] 	modified:   contrib/morton-nd (modified content)
[cmake] 	modified:   contrib/nlp-data (modified content)
[cmake] 	modified:   contrib/numactl (modified content)
[cmake] 
[cmake] Untracked files:
[cmake]   (use "git add <file>..." to include in what will be committed)
[cmake] 	.PVS-Studio/
[cmake] 
[cmake] no changes added to commit (use "git add" and/or "git commit -a")
[cmake] -- CMAKE_BUILD_TYPE: Debug
[cmake] -- Not using LLVM XRay
[cmake] -- No official build: A checksum hash will not be added to the clickhouse executable
[cmake] The auto-calculated compile jobs limit (6) underutilizes CPU cores (16). Set PARALLEL_COMPILE_JOBS to override.
[cmake] The auto-calculated link jobs limit (3) underutilizes CPU cores (16). Set PARALLEL_LINK_JOBS to override.
[cmake] -- Building sub-tree with 6 compile jobs and 3 linker jobs (system: 16 cores, 15612 MB RAM, 'OFF' means the native core count).
[cmake] Warning: supplying the --target x86_64-linux-gnu != x86_64-unknown-linux-gnu argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead.
[cmake] -- Default libraries: -nodefaultlibs /nix/store/67pdq2cm22ypnkczf8ll611v1p469wdm-clang-wrapper-19.1.7/resource-root/lib/linux/libclang_rt.builtins-x86_64.a   -lc -lm -lrt -lpthread -ldl
[cmake] -- Some symbols from glibc will be replaced for compatibility
[cmake] -- Unit tests are enabled
[cmake] -- Building for: Linux x86_64 
[cmake] -- Adding contrib module openssl (configuring with openssl-cmake)
[cmake] -- OpenSSL version 3.2.1
[cmake] -- Adding contrib module abseil-cpp (configuring with abseil-cpp-cmake)
[cmake] -- Adding contrib module zlib-ng (configuring with zlib-ng-cmake)
[cmake] -- Adding contrib module google-protobuf (configuring with google-protobuf-cmake)
[cmake] -- Adding contrib module grpc (configuring with grpc-cmake)
[cmake] -- Adding contrib module llvm-project (configuring with llvm-project-cmake)
[cmake] -- LLVM TARGETS TO BUILD X86
[cmake] -- LLVM CMAKE CROSS COMPILING 0
[cmake] CMake Deprecation Warning at contrib/llvm-project/cmake/Modules/CMakePolicy.cmake:6 (cmake_policy):
[cmake]   The OLD behavior for policy CMP0114 will be removed from a future version
[cmake]   of CMake.
[cmake] 
[cmake]   The cmake-policies(7) manual explains that the OLD behaviors of all
[cmake]   policies are deprecated and that a policy should be set to OLD only under
[cmake]   specific short-term circumstances.  Projects should be ported to the NEW
[cmake]   behavior and not rely on setting a policy to OLD.
[cmake] Call Stack (most recent call first):
[cmake]   contrib/llvm-project/llvm/CMakeLists.txt:6 (include)
[cmake] 
[cmake] 
[cmake] CMake Deprecation Warning at contrib/llvm-project/cmake/Modules/CMakePolicy.cmake:11 (cmake_policy):
[cmake]   The OLD behavior for policy CMP0116 will be removed from a future version
[cmake]   of CMake.
[cmake] 
[cmake]   The cmake-policies(7) manual explains that the OLD behaviors of all
[cmake]   policies are deprecated and that a policy should be set to OLD only under
[cmake]   specific short-term circumstances.  Projects should be ported to the NEW
[cmake]   behavior and not rely on setting a policy to OLD.
[cmake] Call Stack (most recent call first):
[cmake]   contrib/llvm-project/llvm/CMakeLists.txt:6 (include)
[cmake] 
[cmake] 
[cmake] -- LLVM host triple: x86_64-unknown-linux-gnu
[cmake] -- Native target architecture is X86
[cmake] -- Threads enabled.
[cmake] -- Doxygen disabled.
[cmake] -- Could NOT find OCaml (missing: OCAMLFIND OCAML_VERSION OCAML_STDLIB_PATH) 
[cmake] -- OCaml bindings disabled.
[cmake] -- LLVM default target triple: x86_64-unknown-linux-gnu
[cmake] -- Targeting X86
[cmake] -- Adding contrib module miniselect (configuring with miniselect-cmake)
[cmake] -- Adding contrib module pdqsort (configuring with pdqsort-cmake)
[cmake] -- Adding contrib module pocketfft (configuring with pocketfft-cmake)
[cmake] -- Adding contrib module crc32-vpmsum (configuring with crc32-vpmsum-cmake)
[cmake] -- crc32-vpmsum library is only supported on ppc64le
[cmake] -- Adding contrib module sparsehash-c11 (configuring with sparsehash-c11-cmake)
[cmake] -- Adding contrib module magic_enum (configuring with magic-enum-cmake)
[cmake] -- Adding contrib module boost (configuring with boost-cmake)
[cmake] -- Adding contrib module cctz (configuring with cctz-cmake)
[cmake] -- Packaging with tzdata version: 2025a
[cmake] -- Adding contrib module consistent-hashing (configuring with consistent-hashing)
[cmake] -- Adding contrib module dragonbox (configuring with dragonbox-cmake)
[cmake] -- Adding contrib module vectorscan (configuring with vectorscan-cmake)
[cmake] -- Adding contrib module jemalloc (configuring with jemalloc-cmake)
[cmake] -- jemalloc malloc_conf: percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:false,background_thread:true,lg_extent_max_active_fit:8
[cmake] -- Adding contrib module libcpuid (configuring with libcpuid-cmake)
[cmake] -- Adding contrib module libdivide-cmake (configuring with libdivide-cmake)
[cmake] -- Adding contrib module libmetrohash (configuring with libmetrohash)
[cmake] -- Adding contrib module lz4 (configuring with lz4-cmake)
[cmake] -- Adding contrib module murmurhash (configuring with murmurhash)
[cmake] -- Adding contrib module replxx (configuring with replxx-cmake)
[cmake] -- Adding contrib module capnproto (configuring with capnproto-cmake)
[cmake] -- Adding contrib module yaml-cpp (configuring with yaml-cpp-cmake)
[cmake] -- Adding contrib module re2 (configuring with re2-cmake)
[cmake] -- Adding contrib module xz (configuring with xz-cmake)
[cmake] -- Adding contrib module brotli (configuring with brotli-cmake)
[cmake] -- Adding contrib module double-conversion (configuring with double-conversion-cmake)
[cmake] -- Adding contrib module croaring (configuring with croaring-cmake)
[cmake] -- Adding contrib module zstd (configuring with zstd-cmake)
[cmake] -- Adding contrib module bzip2 (configuring with bzip2-cmake)
[cmake] -- Adding contrib module minizip-ng (configuring with minizip-ng-cmake)
[cmake] -- Adding contrib module snappy (configuring with snappy-cmake)
[cmake] -- Adding contrib module thrift (configuring with thrift-cmake)
[cmake] -- Adding contrib module arrow (configuring with arrow-cmake)
[cmake] -- Adding contrib module avro (configuring with avro-cmake)
[cmake] -- Adding contrib module openldap (configuring with openldap-cmake)
[cmake] CMake Error at contrib/avro-cmake/CMakeLists.txt:20 (string):
[cmake]   string sub-command REPLACE requires at least four arguments.
```