### PR TITLE
Fix usage of masking rules in integration tests

### DIFF
--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -97,7 +97,7 @@ public:
         /// FIXME(nikitamikhylov): There is a misuse of the SensitiveDataMasker class.
         /// It is used in some places where we serialize a query to the storage (Keeper for example).
         /// Effectively breaking it by wiping the crucial information (credentials, etc).
-        /// So, rules that may touch a query (those that mask passwords) should be checked in `applyThrow` method only. 
+        /// So, rules that may touch a query (those that mask passwords) should be checked in `applyThrow` method only.
         if (throw_on_match)
             return 0;
 

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -14,7 +14,9 @@
 #include <Common/ProfileEvents.h>
 
 
-#include <iostream>
+#ifndef NDEBUG
+#    include <iostream>
+#endif
 
 
 namespace ProfileEvents

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -66,8 +66,6 @@ public:
         , regexp(regexp_string, RE2::Quiet)
         , replacement(replacement_string)
     {
-        std::cout << "Loaded rule " << name << " (regexp: " << regexp_string << ", replacement: " << replacement_string << ", throw_on_match: " << throw_on_match << ")" << std::endl;
-
         if (!regexp.ok())
             throw Exception(ErrorCodes::CANNOT_COMPILE_REGEXP,
                 "SensitiveDataMasker: cannot compile re2: {}, error: {}. "
@@ -81,8 +79,6 @@ public:
 
         if (throw_on_match && m > 0)
         {
-            std::cout << "Trigggered " << regexp_string << " was triggered on the log line " << data << ", throw_on_match: {}" << throw_on_match << std::endl;
-
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "The rule {} was triggered on the log line {}",
                 name, data);

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -13,7 +13,6 @@
 #include <Common/StringUtils.h>
 #include <Common/ProfileEvents.h>
 
-
 #ifndef NDEBUG
 #    include <iostream>
 #endif

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -74,7 +74,7 @@ public:
                 regexp_string_, regexp.error());
     }
 
-    uint64_t apply(std::string & data) const
+    uint64_t applyThrow(std::string & data) const
     {
         auto m = RE2::GlobalReplace(&data, regexp, replacement);
 
@@ -91,11 +91,15 @@ public:
 
     uint64_t applyNoThrow(std::string & data) const
     {
+        if (throw_on_match)
+            return 0;
+
         auto m = RE2::GlobalReplace(&data, regexp, replacement);
 #ifndef NDEBUG
         matches_count += m;
 #endif
         return m;
+
     }
 
     const std::string & getName() const { return name; }
@@ -200,7 +204,7 @@ size_t SensitiveDataMasker::wipeSensitiveDataThrow(std::string & data) const
 {
     size_t matches = 0;
     for (const auto & rule : all_masking_rules)
-        matches += rule->apply(data);
+        matches += rule->applyThrow(data);
     return matches;
 }
 

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -89,6 +89,15 @@ public:
         return m;
     }
 
+    uint64_t applyNoThrow(std::string & data) const
+    {
+        auto m = RE2::GlobalReplace(&data, regexp, replacement);
+#ifndef NDEBUG
+        matches_count += m;
+#endif
+        return m;
+    }
+
     const std::string & getName() const { return name; }
     const std::string & getReplacementString() const { return replacement_string; }
 #ifndef NDEBUG
@@ -187,11 +196,19 @@ void SensitiveDataMasker::addMaskingRule(
 }
 
 
-size_t SensitiveDataMasker::wipeSensitiveData(std::string & data) const
+size_t SensitiveDataMasker::wipeSensitiveDataThrow(std::string & data) const
 {
     size_t matches = 0;
     for (const auto & rule : all_masking_rules)
         matches += rule->apply(data);
+    return matches;
+}
+
+size_t SensitiveDataMasker::wipeSensitiveData(std::string & data) const
+{
+    size_t matches = 0;
+    for (const auto & rule : all_masking_rules)
+        matches += rule->applyNoThrow(data);
 
     if (matches)
         ProfileEvents::increment(ProfileEvents::QueryMaskingRulesMatch, matches);

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -94,6 +94,10 @@ public:
 
     uint64_t applyNoThrow(std::string & data) const
     {
+        /// FIXME(nikitamikhylov): There is a misuse of the SensitiveDataMasker class.
+        /// It is used in some places where we serialize a query to the storage (Keeper for example).
+        /// Effectively breaking it by wiping the crucial information (credentials, etc).
+        /// So, rules that may touch a query (those that mask passwords) should be checked in `applyThrow` method only. 
         if (throw_on_match)
             return 0;
 

--- a/src/Common/SensitiveDataMasker.h
+++ b/src/Common/SensitiveDataMasker.h
@@ -54,6 +54,7 @@ public:
 
     /// Returns the number of matched rules.
     size_t wipeSensitiveData(std::string & data) const;
+    size_t wipeSensitiveDataThrow(std::string & data) const;
 
     /// setInstance is not thread-safe and should be called once in single-thread mode.
     /// https://github.com/ClickHouse/ClickHouse/pull/6810#discussion_r321183367

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -57,7 +57,7 @@ void OwnSplitChannel::log(Poco::Message && msg)
     if (const auto & masker = SensitiveDataMasker::getInstance())
     {
         auto message_text = msg.getText();
-        auto matches = masker->wipeSensitiveData(message_text);
+        auto matches = masker->wipeSensitiveDataThrow(message_text);
         if (matches > 0)
         {
             msg.setText(message_text);
@@ -296,7 +296,7 @@ public:
         if (const auto & masker = SensitiveDataMasker::getInstance())
         {
             auto message_text = msg.getText();
-            auto matches = masker->wipeSensitiveData(message_text);
+            auto matches = masker->wipeSensitiveDataThrow(message_text);
             if (matches > 0)
                 msg.setText(message_text);
         }

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -495,6 +495,8 @@ cppkafka::Configuration KafkaConfigLoader::getConsumerConfiguration(TKafkaStorag
 
     for (auto & property : conf.get_all())
     {
+        if (property.first.find("password") != std::string::npos)
+            continue;
         LOG_TRACE(params.log, "Consumer set property {}:{}", property.first, property.second);
     }
 

--- a/tests/config/config.d/query_masking_rules.xml
+++ b/tests/config/config.d/query_masking_rules.xml
@@ -1,14 +1,14 @@
 <!-- Config for test server -->
 <clickhouse>
     <query_masking_rules>
-        <rule>
+        <rule_topsecret>
             <regexp>TOPSECRET.TOPSECRET</regexp>
             <replace>[hidden]</replace>
-        </rule>
-        <rule>
+        </rule_topsecret>
+        <rule_passwords_in_tests>
             <name>Detect passwords in tests</name>
             <regexp>(?i)P@ssw0rd</regexp>
             <throw_on_match>true</throw_on_match>
-        </rule>
+        </rule_passwords_in_tests>
     </query_masking_rules>
 </clickhouse>

--- a/tests/config/config.d/query_masking_rules.xml
+++ b/tests/config/config.d/query_masking_rules.xml
@@ -2,6 +2,10 @@
 <clickhouse>
     <query_masking_rules>
         <rule>
+            <regexp>TOPSECRET.TOPSECRET</regexp>
+            <replace>[hidden]</replace>
+        </rule>
+        <rule>
             <name>Detect passwords in tests</name>
             <regexp>(?i)P@ssw0rd</regexp>
             <throw_on_match>true</throw_on_match>

--- a/tests/config/config.d/query_masking_rules.xml
+++ b/tests/config/config.d/query_masking_rules.xml
@@ -2,10 +2,6 @@
 <clickhouse>
     <query_masking_rules>
         <rule>
-            <regexp>TOPSECRET.TOPSECRET</regexp>
-            <replace>[hidden]</replace>
-        </rule>
-        <rule>
             <name>Detect passwords in tests</name>
             <regexp>(?i)P@ssw0rd</regexp>
             <throw_on_match>true</throw_on_match>

--- a/tests/integration/helpers/0_common_masking_rules.xml
+++ b/tests/integration/helpers/0_common_masking_rules.xml
@@ -1,0 +1,1 @@
+../../../tests/config/config.d/query_masking_rules.xml

--- a/tests/integration/helpers/0_common_masking_rules.xml
+++ b/tests/integration/helpers/0_common_masking_rules.xml
@@ -3,10 +3,6 @@
 <clickhouse>
     <query_masking_rules>
         <rule>
-            <regexp>TOPSECRET.TOPSECRET</regexp>
-            <replace>[hidden]</replace>
-        </rule>
-        <rule>
             <name>Detect passwords in tests</name>
             <regexp>(?i)P@ssw0rd</regexp>
             <throw_on_match>true</throw_on_match>

--- a/tests/integration/helpers/0_common_masking_rules.xml
+++ b/tests/integration/helpers/0_common_masking_rules.xml
@@ -1,1 +1,15 @@
-../../../tests/config/config.d/query_masking_rules.xml
+<!-- Config for test server -->
+<!-- Same file as tests/config/config.d/query_masking_rules.xml -->
+<clickhouse>
+    <query_masking_rules>
+        <rule>
+            <regexp>TOPSECRET.TOPSECRET</regexp>
+            <replace>[hidden]</replace>
+        </rule>
+        <rule>
+            <name>Detect passwords in tests</name>
+            <regexp>(?i)P@ssw0rd</regexp>
+            <throw_on_match>true</throw_on_match>
+        </rule>
+    </query_masking_rules>
+</clickhouse>

--- a/tests/integration/helpers/0_common_masking_rules.xml
+++ b/tests/integration/helpers/0_common_masking_rules.xml
@@ -2,10 +2,10 @@
 <!-- Same file as tests/config/config.d/query_masking_rules.xml -->
 <clickhouse>
     <query_masking_rules>
-        <rule>
+        <rule_topsecret>
             <name>Detect passwords in tests</name>
             <regexp>(?i)P@ssw0rd</regexp>
             <throw_on_match>true</throw_on_match>
-        </rule>
+        </rule_topsecret>
     </query_masking_rules>
 </clickhouse>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -5308,6 +5308,8 @@ class ClickHouseInstance:
         if self.use_distributed_plan is not None:
             use_distributed_plan = self.use_distributed_plan
 
+        write_embedded_config("0_common_masking_rules.xml", self.config_d_dir)
+
         if use_old_analyzer:
             write_embedded_config("0_common_enable_old_analyzer.xml", users_d_dir)
 

--- a/tests/integration/test_plain_rewritable_backward_compatibility/configs/remove_masking_rules.xml
+++ b/tests/integration/test_plain_rewritable_backward_compatibility/configs/remove_masking_rules.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <!--
+        Remove all masking rules (enabled by default in every test).
+        This config will be enabled for the old instance only.
+    -->
+    <query_masking_rules remove="remove"></query_masking_rules>
+</clickhouse>

--- a/tests/integration/test_plain_rewritable_backward_compatibility/test.py
+++ b/tests/integration/test_plain_rewritable_backward_compatibility/test.py
@@ -16,10 +16,15 @@ setup_settings = {
     'stay_alive': True,
     'with_remote_database_disk': False,
 }
-node_25_4 = cluster.add_instance("node_25_4", image="clickhouse/clickhouse-server", tag="25.4", with_installed_binary=True, **setup_settings)
-node_25_6 = cluster.add_instance("node_25_6", image="clickhouse/clickhouse-server", tag="25.6", with_installed_binary=True, **setup_settings)
-node_25_8 = cluster.add_instance("node_25_8", image="clickhouse/clickhouse-server", tag="25.8", with_installed_binary=True, **setup_settings)
-node_25_10 = cluster.add_instance("node_25_10", image="clickhouse/clickhouse-server", tag="25.10", with_installed_binary=True, **setup_settings)
+
+main_configs_to_replace = {
+    'main_configs' : ["configs/storage_conf.xml", "configs/remove_masking_rules.xml"]
+}
+
+node_25_4 = cluster.add_instance("node_25_4", image="clickhouse/clickhouse-server", tag="25.4", with_installed_binary=True, **setup_settings | main_configs_to_replace)
+node_25_6 = cluster.add_instance("node_25_6", image="clickhouse/clickhouse-server", tag="25.6", with_installed_binary=True, **setup_settings | main_configs_to_replace)
+node_25_8 = cluster.add_instance("node_25_8", image="clickhouse/clickhouse-server", tag="25.8", with_installed_binary=True, **setup_settings | main_configs_to_replace)
+node_25_10 = cluster.add_instance("node_25_10", image="clickhouse/clickhouse-server", tag="25.10", with_installed_binary=True, **setup_settings | main_configs_to_replace)
 node_master = cluster.add_instance("node_master", **setup_settings)
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_storage_delta/configs/config.d/remove_masking_rules.xml
+++ b/tests/integration/test_storage_delta/configs/config.d/remove_masking_rules.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <!--
+        Remove all masking rules (enabled by default in every test).
+        This config will be enabled for the old instance only.
+    -->
+    <query_masking_rules remove="remove"></query_masking_rules>
+</clickhouse>

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -151,6 +151,7 @@ def started_cluster():
                 "configs/config.d/filesystem_caches.xml",
                 "configs/config.d/remote_servers.xml",
                 "configs/config.d/metadata_log.xml",
+                "configs/config.d/remove_masking_rules.xml",
             ],
             user_configs=["configs/users.d/users.xml"],
             with_installed_binary=True,


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the credentials leakage detection in integration tests in CI. It now works in a pretty simple way: all the passwords for external systems should have a form `ClickHouse_X_P@s$w0rd` and ClickHouse will crash with a logical error if a substring like this was printed in logs utilizing the feature called "Query Masking Rules".

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
