### PR TITLE
try fix 00365_statistics_in_formats flakyness

### DIFF
--- a/tests/queries/0_stateless/00365_statistics_in_formats.sh
+++ b/tests/queries/0_stateless/00365_statistics_in_formats.sh
@@ -12,8 +12,10 @@ $CLICKHOUSE_CLIENT --query="SELECT number FROM numbers LIMIT 10 FORMAT JSON" | g
 $CLICKHOUSE_CLIENT --query="SELECT number FROM numbers LIMIT 10 FORMAT JSONCompact" | grep 'rows_read';
 $CLICKHOUSE_CLIENT --query="SELECT number FROM numbers LIMIT 10 FORMAT XML" | grep 'rows_read';
 
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSON" | grep 'rows_read';
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSONCompact" | grep 'rows_read';
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT number FROM numbers LIMIT 10 FORMAT XML" | grep 'rows_read';
+# use_query_cache=0 - to ensure that results are not cached and we always get the proper statistics for number of rows read
+# wait_end_of_query=1 - to ensure that the query statistics are sent after the query is fully executed
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSON" | grep 'rows_read';
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSONCompact" | grep 'rows_read';
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT XML" | grep 'rows_read';
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS numbers";

--- a/tests/queries/0_stateless/00365_statistics_in_formats.sh
+++ b/tests/queries/0_stateless/00365_statistics_in_formats.sh
@@ -13,9 +13,9 @@ $CLICKHOUSE_CLIENT --query="SELECT number FROM numbers LIMIT 10 FORMAT JSONCompa
 $CLICKHOUSE_CLIENT --query="SELECT number FROM numbers LIMIT 10 FORMAT XML" | grep 'rows_read';
 
 # use_query_cache=0 - to ensure that results are not cached and we always get the proper statistics for number of rows read
-# wait_end_of_query=1 - to ensure that the query statistics are sent after the query is fully executed
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSON" | grep 'rows_read';
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSONCompact" | grep 'rows_read';
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT XML" | grep 'rows_read';
+# http_wait_end_of_query=1 - to ensure that the query statistics are sent after the query is fully executed
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&http_wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSON" | grep 'rows_read';
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&http_wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT JSONCompact" | grep 'rows_read';
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?use_query_cache=0&http_wait_end_of_query=1" -d "SELECT number FROM numbers LIMIT 10 FORMAT XML" | grep 'rows_read';
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS numbers";


### PR DESCRIPTION
Try to fix `00365_statistics_in_formats` flakyness. It looks like when using curl, statistics for `rows_read` for `JSONCompact` is sometimes 0 when it should be 10. I suspect that this might be either due to using query_cache or rows are returned in streaming fashion and statistics are sometimes not updated before connection is closed. Try setting `use_query_cache=0` and `http_wait_end_of_query=1` to see if that makes a difference.

Closes: https://github.com/ClickHouse/ClickHouse/issues/85785

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
