### PR TITLE
CI: remove swagger from docs job

### DIFF
--- a/ci/jobs/docs_job.py
+++ b/ci/jobs/docs_job.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         Result.from_commands_run(
             name=testname,
             command=[
-                "yarn build-swagger",
                 "export DOCUSAURUS_IGNORE_SSG_WARNINGS=true && yarn build-docs",
             ],
             workdir="/opt/clickhouse-docs",

--- a/docs/en/sql-reference/data-types/domains/index.md
+++ b/docs/en/sql-reference/data-types/domains/index.md
@@ -9,7 +9,7 @@ title: 'Domains'
 
 # Domains
 
-Domains are special-purpose types that add some extra features atop of existing base type, but leaving on-wire and on-disc format of the underlying data type intact. At the moment, ClickHouse does not support user-defined domains.
+Domains are special-purpose types that add extra features on top of existing base types, while leaving the on-wire and on-disk format of the underlying data type intact. Currently, ClickHouse does not support user-defined domains.
 
 You can use domains anywhere corresponding base type can be used, for example:
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Currently we are building swagger documentation (https://clickhouse.com/docs/cloud/manage/api/swagger) as part of docs check because we do this in the docs build. Docs check is currently failing due to an issue with the OpenAPI spec, however this check does not strictly need to run for ClickHouse/ClickHouse.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
