### PR TITLE
CI: Fix integration tests CIDB results

### DIFF
--- a/ci/jobs/integration_test_check.py
+++ b/ci/jobs/integration_test_check.py
@@ -107,7 +107,7 @@ def read_test_results(results_path: Path, with_raw_logs: bool = True) -> List[Re
                 except ValueError:
                     pass
 
-            result = Result(name=name, status=status, start_time=time)
+            result = Result(name=name, status=status, duration=time)
             if len(line) == 4 and line[3]:
                 # The value can be emtpy, but when it's not,
                 # the 4th value is a pythonic list, e.g. ['file1', 'file2']

--- a/ci/jobs/scripts/integration_tests_runner.py
+++ b/ci/jobs/scripts/integration_tests_runner.py
@@ -1029,8 +1029,6 @@ class ClickhouseIntegrationTestsRunner:
         except Exception as e:
             logging.error("Can't split tests by execution time: %s", e)
             logging.error(e)
-            # TODO remove after testing
-            raise
 
         # Fallback in case play server doesn't work
         # Split tests in groups by number of tests in group


### PR DESCRIPTION
The duration value was mistakenly written to the start_time timestamp
broken in https://github.com/ClickHouse/ClickHouse/pull/84823

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
