### PR TITLE
Integration tests: increase the period of selected tests for batch splitting to 30 days

### DIFF
--- a/ci/jobs/scripts/integration_tests_runner.py
+++ b/ci/jobs/scripts/integration_tests_runner.py
@@ -805,7 +805,7 @@ class ClickhouseIntegrationTestsRunner:
                     median(test_duration_ms) AS test_duration_ms
                 FROM checks
                 WHERE (check_name LIKE 'Integration%')
-                    AND (check_start_time >= ({start_time_filter} - toIntervalDay(7)))
+                    AND (check_start_time >= ({start_time_filter} - toIntervalDay(30)))
                     AND (check_start_time <= ({start_time_filter} - toIntervalHour(2)))
                     AND ((head_ref = 'master') AND startsWith(head_repo, 'ClickHouse/'))
                     AND (test_name != '')


### PR DESCRIPTION
Increase the period of selected tests for batch splitting to 30 days.
7 days is not enough: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=85905&sha=7933b349e67d0da574f4df3a347e590ca735511b&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%202%2F5%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
