### PR TITLE
Fix HTTP host header in url() function

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -98,7 +98,10 @@ size_t ReadWriteBufferFromHTTP::getOffset() const
 
 void ReadWriteBufferFromHTTP::prepareRequest(Poco::Net::HTTPRequest & request, std::optional<HTTPRange> range) const
 {
-    request.setHost(current_uri.getHost());
+    if (current_uri.getPort())
+        request.setHost(current_uri.getHost(), current_uri.getPort());
+    else
+        request.setHost(current_uri.getHost());
 
     if (out_stream_callback)
         request.setChunkedTransferEncoding(true);

--- a/src/IO/WriteBufferFromHTTP.cpp
+++ b/src/IO/WriteBufferFromHTTP.cpp
@@ -29,7 +29,10 @@ WriteBufferFromHTTP::WriteBufferFromHTTP(
     , session{makeHTTPSession(connection_group, uri, timeouts, proxy_configuration)}
     , request{method, uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1}
 {
-    request.setHost(uri.getHost());
+    if (uri.getPort())
+        request.setHost(uri.getHost(), uri.getPort());
+    else
+        request.setHost(uri.getHost());
     request.setChunkedTransferEncoding(true);
 
     if (!content_encoding.empty())

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -1083,7 +1083,10 @@ private:
                     .withReceiveTimeout(1);
 
                 Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, url.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
-                request.setHost(url.getHost());
+                if (url.getPort())
+                    request.setHost(url.getHost(), url.getPort());
+                else
+                    request.setHost(url.getHost());
 
                 if (!url.getUserInfo().empty())
                 {

--- a/tests/integration/test_storage_url_http_headers/test.py
+++ b/tests/integration/test_storage_url_http_headers/test.py
@@ -104,8 +104,8 @@ def test_storage_url_redirected_headers(started_cluster):
 
     print(result_redirect)
 
-    assert "Host: 127.0.0.1" in result_redirect
-    assert "Host: localhost" not in result_redirect
+    assert "Host: 127.0.0.1:8080" in result_redirect
+    assert "Host: localhost:8000" not in result_redirect
 
     result = server.exec_in_container(
         ["cat", http_headers_echo_server.RESULT_PATH], user="root"
@@ -113,8 +113,8 @@ def test_storage_url_redirected_headers(started_cluster):
 
     print(result)
 
-    assert "Host: 127.0.0.1" not in result
-    assert "Host: localhost" in result
+    assert "Host: 127.0.0.1:8080" not in result
+    assert "Host: localhost:8000" in result
 
 
 def test_with_override_content_type_url_http_headers(started_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
 Fixes HTTP requests made by the `url()` table function to properly include port numbers in the Host header when accessing non-standard ports. This resolves authentication failures when using presigned URLs with S3-compatible services like MinIO running on custom ports, which is common in development environments. (Fixes #85898)