### PR TITLE
Add TableFunctionRemote Support for Parallel Replicas in GlobalJoin

### DIFF
--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -500,6 +500,14 @@ public:
     {
         if (auto * table_node = node->as<TableNode>())
             storages.push_back(table_node->getStorage());
+        else if (auto * table_func_node = node->as<TableFunctionNode>())
+        {
+            /// See https://github.com/ClickHouse/ClickHouse/issues/77990
+            /// Now that parallel replicas support TableFunctionRemote, GlobalJoin also needs to support TableFunctionRemote.
+            const auto & name = table_func_node->getTableFunctionName();
+            if (name == "cluster" || name == "clusterAllReplicas" || name == "remote" || name == "remoteSecure")
+                storages.push_back(table_func_node->getStorage());
+        }
     }
 
     std::vector<StoragePtr> storages;

--- a/tests/queries/0_stateless/03595_parallel_replicas_join_remote.reference
+++ b/tests/queries/0_stateless/03595_parallel_replicas_join_remote.reference
@@ -1,19 +1,6 @@
-ReadFromMergeTree (default.test_join_remote_l)
-ReadFromMemoryStorage
-ReadFromRemoteParallelReplicas
-1
-ReadFromMergeTree (default.test_join_remote_l)
-ReadFromMergeTree (default.test_join_remote_r)
-ReadFromRemote (Read from remote replica)
-ReadFromRemoteParallelReplicas
 1
 1
 1
-ReadFromMergeTree (default.test_join_remote_l)
-ReadFromMemoryStorage
-ReadFromRemoteParallelReplicas
 1
-ReadFromMergeTree (default.test_join_remote_l)
-ReadFromMemoryStorage
-ReadFromRemoteParallelReplicas
+1
 1

--- a/tests/queries/0_stateless/03595_parallel_replicas_join_remote.reference
+++ b/tests/queries/0_stateless/03595_parallel_replicas_join_remote.reference
@@ -1,0 +1,19 @@
+ReadFromMergeTree (default.test_join_remote_l)
+ReadFromMemoryStorage
+ReadFromRemoteParallelReplicas
+1
+ReadFromMergeTree (default.test_join_remote_l)
+ReadFromMergeTree (default.test_join_remote_r)
+ReadFromRemote (Read from remote replica)
+ReadFromRemoteParallelReplicas
+1
+1
+1
+ReadFromMergeTree (default.test_join_remote_l)
+ReadFromMemoryStorage
+ReadFromRemoteParallelReplicas
+1
+ReadFromMergeTree (default.test_join_remote_l)
+ReadFromMemoryStorage
+ReadFromRemoteParallelReplicas
+1

--- a/tests/queries/0_stateless/03595_parallel_replicas_join_remote.sql
+++ b/tests/queries/0_stateless/03595_parallel_replicas_join_remote.sql
@@ -9,15 +9,11 @@ INSERT INTO test_join_remote_r VALUES (1);
 
 SET parallel_replicas_only_with_analyzer = 0;  -- necessary for CI run with disabled analyzer
 SET serialize_query_plan = 0;
-SET enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1;
+SET enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1, cluster_for_parallel_replicas='test_cluster_one_shard_three_replicas_localhost';
 
-SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN cluster(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromMemoryStorage%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
 SELECT 1 FROM test_join_remote_l x JOIN cluster(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
-SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN clusterAllReplicas(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromRemote%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
 SELECT 1 FROM test_join_remote_l x JOIN clusterAllReplicas(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
-SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN remote(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromMemoryStorage%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
 SELECT 1 FROM test_join_remote_l x JOIN remote(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
-SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN remoteSecure(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromMemoryStorage%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
 SELECT 1 FROM test_join_remote_l x JOIN remoteSecure(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
 
 DROP TABLE test_join_remote_l;

--- a/tests/queries/0_stateless/03595_parallel_replicas_join_remote.sql
+++ b/tests/queries/0_stateless/03595_parallel_replicas_join_remote.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS test_join_remote_l;
+DROP TABLE IF EXISTS test_join_remote_r;
+
+CREATE TABLE test_join_remote_l (c Int) ENGINE=MergeTree() ORDER BY tuple();
+CREATE TABLE test_join_remote_r (c Int) ENGINE=MergeTree() ORDER BY tuple();
+INSERT INTO test_join_remote_l VALUES (1);
+INSERT INTO test_join_remote_r VALUES (1);
+
+
+SET parallel_replicas_only_with_analyzer = 0;  -- necessary for CI run with disabled analyzer
+SET serialize_query_plan = 0;
+SET enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1;
+
+SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN cluster(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromMemoryStorage%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
+SELECT 1 FROM test_join_remote_l x JOIN cluster(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
+SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN clusterAllReplicas(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromRemote%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
+SELECT 1 FROM test_join_remote_l x JOIN clusterAllReplicas(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
+SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN remote(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromMemoryStorage%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
+SELECT 1 FROM test_join_remote_l x JOIN remote(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
+SELECT trimLeft(replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')) FROM (explain SELECT 1 FROM test_join_remote_l x JOIN remoteSecure(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%ReadFromMemoryStorage%' OR explain LIKE '%ReadFromRemoteParallelReplicas%' SETTINGS enable_analyzer = 1;
+SELECT 1 FROM test_join_remote_l x JOIN remoteSecure(test_cluster_one_shard_three_replicas_localhost, currentDatabase(), test_join_remote_r) y ON TRUE;
+
+DROP TABLE test_join_remote_l;
+DROP TABLE test_join_remote_r;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1447
<!-- End of fixes issue link part, do not remove -->

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This PR closes #77990.
Add TableFunctionRemote support for parallel replicas in globalJoin.

