### PR TITLE
tests: better searching for clickhouse binary in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3629,20 +3629,28 @@ def main(args):
 
 
 def find_binary(name):
-    if os.access(name, os.X_OK):
+    def is_executable(path):
+        return os.access(path, os.X_OK) and os.path.isfile(path)
+
+    if is_executable(name):
         return name
     paths = os.environ.get("PATH").split(":")
     for path in paths:
         bin_path = os.path.join(path, name)
-        if os.access(bin_path, os.X_OK):
+        if is_executable(bin_path):
             return bin_path
 
     # maybe it wasn't in PATH
     bin_path = os.path.join("/usr/local/bin", name)
-    if os.access(bin_path, os.X_OK):
+    if is_executable(bin_path):
         return bin_path
     bin_path = os.path.join("/usr/bin", name)
-    if os.access(bin_path, os.X_OK):
+    if is_executable(bin_path):
+        return bin_path
+
+    # Default binary path if source folder contains build
+    bin_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), f"../build/programs/{name}")
+    if is_executable(bin_path):
         return bin_path
 
     raise TestException(f"{name} was not found in PATH")


### PR DESCRIPTION
- Ignore folders
- Add default location of binary for project with build folder

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)