### PR TITLE
Fix non-delta data types handling in unity catalog

### DIFF
--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -190,30 +190,47 @@ bool UnityCatalog::tryGetTableMetadata(
             if (result.requiresSchema())
             {
                 DB::NamesAndTypesList schema;
-                auto columns_json = object->getArray("columns");
-
-                for (size_t i = 0; i < columns_json->size(); ++i)
+                try
                 {
-                    const auto column_json = columns_json->get(static_cast<int>(i)).extract<Poco::JSON::Object::Ptr>();
-                    std::string name = column_json->getValue<String>("name");
-                    auto is_nullable = column_json->getValue<bool>("nullable");
-                    auto type_json_str = column_json->get("type_json").extract<String>();
-                    DB::DataTypePtr data_type;
-                    /// NOTE: Weird case with OSS Unity catalog, when instead of JSON for simple we have just string with type name
-                    if (type_json_str.starts_with("\"") && type_json_str.ends_with("\"") && !type_json_str.contains('{'))
+                    auto columns_json = object->getArray("columns");
+
+                    for (size_t i = 0; i < columns_json->size(); ++i)
                     {
-                        type_json_str.pop_back();
-                        String type_name = type_json_str.substr(1);
-                        auto data_type_from_str = DB::DeltaLakeMetadata::getSimpleTypeByName(type_name);
-                        data_type = is_nullable ? makeNullable(data_type_from_str) : data_type_from_str;
+                        const auto column_json = columns_json->get(static_cast<int>(i)).extract<Poco::JSON::Object::Ptr>();
+                        std::string name = column_json->getValue<String>("name");
+                        auto is_nullable = column_json->getValue<bool>("nullable");
+                        auto type_json_str = column_json->get("type_json").extract<String>();
+                        DB::DataTypePtr data_type;
+                        /// NOTE: Weird case with OSS Unity catalog, when instead of JSON for simple we have just string with type name
+                        if (type_json_str.starts_with("\"") && type_json_str.ends_with("\"") && !type_json_str.contains('{'))
+                        {
+                            type_json_str.pop_back();
+                            String type_name = type_json_str.substr(1);
+                            auto data_type_from_str = DB::DeltaLakeMetadata::getSimpleTypeByName(type_name);
+                            data_type = is_nullable ? makeNullable(data_type_from_str) : data_type_from_str;
+                        }
+                        else
+                        {
+                            Poco::JSON::Parser parser;
+                            auto parsed_json_type = parser.parse(type_json_str);
+                            data_type = DB::DeltaLakeMetadata::getFieldType(parsed_json_type.extract<Poco::JSON::Object::Ptr>(), "type", is_nullable);
+                        }
+                        schema.push_back({name, data_type});
                     }
-                    else
+                }
+                catch (...)
+                {
+                    /// Non-delta tables can have very weird datatypes in schemas like https://docs.databricks.com/aws/en/sql/language-manual/data-types/null-type
+                    /// We still don't know how to read them so we can ignore absense of schema and return weird output for SHOW CREATE TABLE.
+                    if (!result.isDefaultReadableTable())
                     {
-                        Poco::JSON::Parser parser;
-                        auto parsed_json_type = parser.parse(type_json_str);
-                        data_type = DB::DeltaLakeMetadata::getFieldType(parsed_json_type.extract<Poco::JSON::Object::Ptr>(), "type", is_nullable);
+                        LOG_DEBUG(
+                            log, "Cannot read table `{}` because of schema parsing exception `{}`, but it is not delta table, so we ignore this error",
+                            full_table_name, DB::getCurrentExceptionMessage(false));
+                        return true;
                     }
-                    schema.push_back({name, data_type});
+
+                    throw;
                 }
 
                 result.setSchema(schema);

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -221,7 +221,7 @@ bool UnityCatalog::tryGetTableMetadata(
                 catch (...)
                 {
                     /// Non-delta tables can have very weird datatypes in schemas like https://docs.databricks.com/aws/en/sql/language-manual/data-types/null-type
-                    /// We still don't know how to read them so we can ignore absense of schema and return weird output for SHOW CREATE TABLE.
+                    /// We still don't know how to read them so we can ignore absence of schema and return weird output for SHOW CREATE TABLE.
                     if (!result.isDefaultReadableTable())
                     {
                         LOG_DEBUG(

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -7,6 +7,7 @@ import os
 import re
 import random
 import time
+import subprocess
 import uuid
 from datetime import datetime, timedelta
 from helpers.cluster import ClickHouseCluster
@@ -364,3 +365,55 @@ settings warehouse = 'unity', catalog_type='unity', vended_credentials=True
 
     # This query will fail if bug exists
     print(node1.query(f"SHOW TABLES FROM {schema_name}"))
+
+
+@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
+def test_view_with_void(started_cluster, use_delta_kernel):
+    #25/08/20 16:45:23 WARN ObjectStore: Version information not found in metastore. hive.metastore.schema.verification is not enabled so recording the schema version 2.3.0
+    #25/08/20 16:45:23 WARN ObjectStore: setMetaStoreSchemaVersion called but recording version is disabled: version = 2.3.0, comment = Set by MetaStore UNKNOWN@172.18.0.2
+    #25/08/20 16:45:24 WARN ObjectStore: Failed to get database global_temp, returning NoSuchObjectException
+    # Catalog unity does not support views.
+    pytest.skip("Unfortunately open source Unity Catalog doesn't support views")
+    table_name_src = f"ntz_schema_{uuid.uuid4()}".replace("-", "_")
+    node1 = started_cluster.instances["node1"]
+    node1.query(f"drop database if exists {table_name_src}")
+
+    schema_name = f"schema_with_timetstamp_ntz_{use_delta_kernel}_{uuid.uuid4()}".replace("-", "_")
+    execute_spark_query(node1, f"CREATE SCHEMA {schema_name}")
+    table_name = f"table_with_timestamp_{use_delta_kernel}_{uuid.uuid4()}".replace("-", "_")
+    view_name = f"test_view_{table_name}"
+    schema = "event_date DATE, event_time TIMESTAMP"
+    create_query = f"CREATE TABLE {schema_name}.{table_name} ({schema}) using Delta location '/tmp/{table_name_src}/{table_name}'"
+    execute_spark_query(node1, create_query)
+    execute_spark_query(
+        node1,
+        f"CREATE VIEW {schema_name}.{view_name} AS SELECT * FROM {schema_name}.{table_name}",
+    )
+
+    node1.query(
+        f"""
+drop database if exists {table_name};
+create database {table_name_src}
+engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog')
+settings warehouse = 'unity', catalog_type='unity', vended_credentials=false, allow_experimental_delta_kernel_rs={use_delta_kernel}
+        """,
+        settings={"allow_experimental_database_unity_catalog": "1"},
+    )
+
+    ntz_tables = list(
+        sorted(
+            node1.query(
+                f"SHOW TABLES FROM {table_name_src} LIKE '{schema_name}%'",
+                settings={"use_hive_partitioning": "0"},
+            )
+            .strip()
+            .split("\n")
+        )
+    )
+
+    assert len(ntz_tables) == 1
+
+    def get_schemas():
+        return execute_spark_query(node1, f"SHOW SCHEMAS")
+
+    assert schema_name in get_schemas()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now unity catalog will ignore schemas with weird data types in case of non-delta tables. Fixes #85699.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
