### PR TITLE
ci: sanity checks for cherry pick script against empty responses from GitHub

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -611,7 +611,9 @@ class CherryPickPRs:
         self.repo = gh.get_repo(repo)
         self.dry_run = dry_run
         self.error = None  # type: Optional[Exception]
+
         self.release_prs = gh.get_release_pulls(repo)
+        logging.info(f"Release PRs: {self.release_prs}")
 
     def get_open_cherry_pick_prs(self) -> PullRequests:
         """

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -131,12 +131,15 @@ class GitHub(github.Github):
         return prs
 
     def get_release_pulls(self, repo_name: str) -> PullRequests:
-        return self.get_pulls_from_search(
+        prs = self.get_pulls_from_search(
             query=f"type:pr repo:{repo_name} is:open",
             sort="created",
             order="asc",
             label="release",
         )
+        # Ensure that the answer from GitHub is correct (we should always have some releases)
+        assert prs
+        return prs
 
     def sleep_on_rate_limit(self) -> None:
         for limit, data in self.get_rate_limit().raw_data.items():


### PR DESCRIPTION
Today there was one cherry-pick run that closes few PRs with a comment "The release branch 25.7 for the cherry-pick doesn't have an opened PR, closing this PR." even though the release PR was never closed.

But the script assumed so [1]:

    2025-08-20T14:11:09.0957244Z INFO:root:An opened release PR `25.7` for cherry-pick PR https://github.com/ClickHouse/ClickHouse/pull/85490 is not found, going to close it
    ...
    2025-08-20T14:11:48.7892801Z INFO:root:Active releases: 24.8, 25.3, 25.5, 25.6, 25.7
    ...
    2025-08-20T14:13:41.8261936Z INFO:root:The cherry-pick PR #85490 for PR #85038 is discarded

  [1]: https://github.com/ClickHouse/ClickHouse/actions/runs/17100818473/job/48496622985

Which reminds me that recently GitHub returns zero results for issue/PRs searches, so maybe this happened again? Including API?

This is just a crazy idea.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)