### PR TITLE
Recover the Replicated Database forcefully after restoring database metadata in Keeper

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1811,6 +1811,10 @@ void DatabaseReplicated::restoreDatabaseMetadataInKeeper(ContextPtr)
         LOG_DEBUG(log, "It seems that the metadata was restored previously: {}.", e.what());
     }
 
+    /// Force the database to recover to update the restored metadata
+    auto current_zookeeper = getContext()->getZooKeeper();
+    current_zookeeper->set(replica_path + "/digest", DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST);
+
     reinitializeDDLWorker();
 }
 

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -49,7 +49,6 @@ namespace FailPoints
     extern const char database_replicated_delay_entry_execution[];
 }
 
-static constexpr const char * FORCE_AUTO_RECOVERY_DIGEST = "42";
 
 DatabaseReplicatedDDLWorker::DatabaseReplicatedDDLWorker(DatabaseReplicated * db, ContextPtr context_)
     : DDLWorker(

--- a/src/Databases/DatabaseReplicatedWorker.h
+++ b/src/Databases/DatabaseReplicatedWorker.h
@@ -42,6 +42,8 @@ public:
 
     bool isUnsyncedAfterRecovery() const { return unsynced_after_recovery; }
 
+    static constexpr const char * FORCE_AUTO_RECOVERY_DIGEST = "42";
+
 private:
     bool initializeMainThread() override;
     void initializeReplication() override;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Recover the Replicated Database forcefully after restoring the database metadata in Keeper.

The issue in https://github.com/ClickHouse/ClickHouse/issues/85664 is that when restoring metadata, it sets the digest of the replica to "0" in `DatabaseReplicated::createReplicaNodesInZooKeeper`.
If another node restores the table metadata, it will just reinitialize the DDL Worker.
When restarting, the DB might not has any tables locally, and the local digest is 0, it matches to the keeper digest, so it won't update the restored metadata.

In this PR, after restoring database metadata in Keeper, before reinitializing the DDL Worker, set the replica digest to 42 to force the database to recover to update the restored metadata.

Closes https://github.com/ClickHouse/ClickHouse/issues/85664

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
