### PR TITLE
Support Startup & Shutdown Log Levels

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -827,6 +827,8 @@ The location and format of log messages.
 | `syslog_level`         | Log level for logging to syslog.                                                                                                                                   |
 | `async`                | When `true` (default) logging will happen asynchronously (one background thread per output channel). Otherwise it will log inside the thread calling LOG           |
 | `async_queue_max_size` | When using async logging, the max amount of messages that will be kept in the the queue waiting for flushing. Extra messages will be dropped                       |
+| `startupLevel`         | Startup level is used to set the root logger level at server startup. After startup log level is reverted to the `level` setting                                   |
+| `shutdownLevel`        | Shutdown level is used to set the root logger level at server Shutdown.                                                                                            |
 
 **Log format specifiers**
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1019,6 +1019,22 @@ try
 
     Poco::Logger * log = &logger();
 
+    // If the startupLevel is set in the config, we override the root logger level.
+    // Specific loggers can still override it.
+    std::string default_logger_level_config = config().getString("logger.level", "");
+    bool should_restore_default_logger_level = false;
+    if (config().has("logger.startupLevel") && !config().getString("logger.startupLevel").empty())
+    {
+        /// Set the root logger level to the startup level.
+        /// This is useful for debugging startup issues.
+        /// The root logger level will be reset to the default level after the server is fully initialized.
+        config().setString("logger.level", config().getString("logger.startupLevel"));
+        Loggers::updateLevels(config(), logger());
+        should_restore_default_logger_level = true;
+
+        LOG_INFO(log, "Starting root logger in level {}", config().getString("logger.startupLevel"));
+    }
+
     MainThreadStatus::getInstance();
 
     ServerSettings server_settings;
@@ -2724,6 +2740,14 @@ try
                 LOG_INFO(log, "Listening for {}", server.getDescription());
             }
 
+            // Restore the root logger level to the default level after the server is fully initialized.
+            if (should_restore_default_logger_level)
+            {
+                config().setString("logger.level", default_logger_level_config);
+                Loggers::updateLevels(config(), logger());
+                LOG_INFO(log, "Restored default logger level to {}", default_logger_level_config);
+            }
+
             global_context->setServerCompletelyStarted();
             LOG_INFO(log, "Ready for connections.");
         }
@@ -2750,6 +2774,16 @@ try
 #endif
 
         SCOPE_EXIT_SAFE({
+            if (config().has("logger.shutdownLevel") && !config().getString("logger.shutdownLevel").empty())
+            {
+                /// Set the root logger level to the shutdown level.
+                /// This is useful for debugging shutdown issues.
+                /// The root logger level will be reset to the default level after the server is fully initialized.
+                config().setString("logger.level", config().getString("logger.shutdownLevel"));
+                Loggers::updateLevels(config(), logger());
+
+                LOG_INFO(log, "Set root logger in level {} before shutdown", config().getString("logger.shutdownLevel"));
+            }
             LOG_DEBUG(log, "Received termination signal.");
 
             CurrentMetrics::set(CurrentMetrics::IsServerShuttingDown, 1);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2778,7 +2778,6 @@ try
             {
                 /// Set the root logger level to the shutdown level.
                 /// This is useful for debugging shutdown issues.
-                /// The root logger level will be reset to the default level after the server is fully initialized.
                 config().setString("logger.level", config().getString("logger.shutdownLevel"));
                 Loggers::updateLevels(config(), logger());
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -22,6 +22,15 @@
             [1]: https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/Logger.h#L105-L114
         -->
         <level>trace</level>
+
+        <!-- Startup level is used to set the root logger level at server startup.
+             It is useful for debugging startup issues.
+             The root logger level will be reset to the default level after the server is fully initialized -->
+        <!-- <startupLevel>trace</startupLevel> -->
+       <!-- Shutdown level is used to set the root logger level at server Shutdown.
+             It is useful for debugging shutdown issues -->
+        <!-- <shutdownLevel>trace</shutdownLevel> -->
+
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <!-- Rotation policy
@@ -1580,7 +1589,7 @@
         <max_replicated_fetches_network_bandwidth>1000000000</max_replicated_fetches_network_bandwidth>
     </replicated_merge_tree>
     -->
-    
+
     <!-- Settings to fine-tune DatabaseReplicatedSettings. See documentation in source code, in DatabaseReplicatedSettings.h -->
     <!--
     <database_replicated>

--- a/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger.xml
+++ b/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger.xml
@@ -1,0 +1,7 @@
+ <clickhouse>
+    <logger>
+        <level>none</level>
+        <startupLevel>trace</startupLevel>
+        <shutdownLevel>trace</shutdownLevel>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_server_startup_and_shutdown_logs/test.py
+++ b/tests/integration/test_server_startup_and_shutdown_logs/test.py
@@ -28,13 +28,10 @@ def test_server_no_logging(started_cluster):
     # The log level is set to 'none' in the logger.xml configuration.
     assert instance.http_query("SELECT 1") == "1\n"
 
-    assert not instance.contains_in_log("HTTP Request for HTTPHandler-factory", timeout=5)
+    assert not instance.contains_in_log("HTTP Request for HTTPHandler-factory")
 
     # shutdown Clickhouse
-    signal = 15 # SIGTERM
-    instance.exec_in_container(
-        ["bash", "-c", "pkill -{} clickhouse".format(signal)], user="root"
-    )
+    instance.stop_clickhouse()
 
     assert instance.contains_in_log("Set root logger in level trace before shutdown")
 

--- a/tests/integration/test_server_startup_and_shutdown_logs/test.py
+++ b/tests/integration/test_server_startup_and_shutdown_logs/test.py
@@ -18,10 +18,9 @@ def started_cluster():
     try:
         cluster.start()
         # Validate on startup we increase the log level.
-        instance.wait_for_log_line("Starting root logger in level trace")
+        assert instance.contains_in_log("Starting root logger in level trace")
         yield cluster
     finally:
-        # Validate on shutdown we set the log level to trace.
         cluster.shutdown()
 
 def test_server_no_logging(started_cluster):
@@ -29,6 +28,14 @@ def test_server_no_logging(started_cluster):
     # The log level is set to 'none' in the logger.xml configuration.
     assert instance.http_query("SELECT 1") == "1\n"
 
-    with pytest.raises(Exception):
-        # Attempting to wait for HTTP logs should raise an exception since logging is disabled.
-        instance.wait_for_log_line("HTTP Request for HTTPHandler-factory", timeout=5)
+    assert not instance.contains_in_log("HTTP Request for HTTPHandler-factory", timeout=5)
+
+    # shutdown Clickhouse
+    signal = 15 # SIGTERM
+    instance.exec_in_container(
+        ["bash", "-c", "pkill -{} clickhouse".format(signal)], user="root"
+    )
+
+    assert instance.contains_in_log("Set root logger in level trace before shutdown")
+
+    instance.start_clickhouse()

--- a/tests/integration/test_server_startup_and_shutdown_logs/test.py
+++ b/tests/integration/test_server_startup_and_shutdown_logs/test.py
@@ -1,0 +1,34 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/config.d/logger.xml",
+    ],
+    user_configs=[],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        # Validate on startup we increase the log level.
+        instance.wait_for_log_line("Starting root logger in level trace")
+        yield cluster
+    finally:
+        # Validate on shutdown we set the log level to trace.
+        cluster.shutdown()
+
+def test_server_no_logging(started_cluster):
+    # Check that the server starts without logging.
+    # The log level is set to 'none' in the logger.xml configuration.
+    assert instance.http_query("SELECT 1") == "1\n"
+
+    with pytest.raises(Exception):
+        # Attempting to wait for HTTP logs should raise an exception since logging is disabled.
+        instance.wait_for_log_line("HTTP Request for HTTPHandler-factory", timeout=5)


### PR DESCRIPTION
Alter the log levels on startup & shutdown if the respective values are set. This allows for a higher log level during startup & shutdown of clickhouse.

Fixes: #85958

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

New configuration options: `logger.startupLevel` & `logger.shutdownLevel` allow for overriding the log level during the startup & shutdown of Clickhouse respectively.

This can be useful to help investigate startup & shutdown issues.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
