### PR TITLE
Docs: move documentation for time-series functions to source code

### DIFF
--- a/src/Functions/TimeSeries/timeSeriesRange.cpp
+++ b/src/Functions/TimeSeries/timeSeriesRange.cpp
@@ -299,19 +299,12 @@ public:
 REGISTER_FUNCTION(TimeSeriesRange)
 {
     FunctionDocumentation::Description description = R"(
-Generates a range of timestamps.
+Generates a range of timestamps [start_timestamp, start_timestamp + step, start_timestamp + 2 * step, ..., end_timestamp].
 
-- If function `timeSeriesRange()` is called with `start_timestamp` equal to `end_timestamp`
-then it returns a 1-element array containing that timestamp: `[start_timestamp]`
-- Function `timeSeriesRange()` is similar to function [range](../functions/array-functions.md#range).
+If `start_timestamp` is equal to `end_timestamp`, the function returns a 1-element array containing `[start_timestamp]`.
 
-For example, if the type of timestamps is `DateTime64(3)` and `start_timestamp < end_timestamp` then
-`timeSeriesRange(start_timestamp, end_timestamp, step)` returns the same result as the following expression:
-
-```sql
-range(start_timestamp::Int64, end_timestamp::Int64 + 1, step::Int64)::Array(DateTime64(3))
-```
-        )";
+Function `timeSeriesRange()` is similar to function [range](../functions/array-functions.md#range).
+)";
     FunctionDocumentation::Syntax syntax = "timeSeriesRange(start_timestamp, end_timestamp, step)";
     FunctionDocumentation::Arguments arguments = {{"start_timestamp", "Start of the range.", {"DateTime64", "DateTime", "UInt32"}},
                                                   {"end_timestamp", "End of the range.", {"DateTime64", "DateTime", "UInt32"}},
@@ -343,12 +336,11 @@ REGISTER_FUNCTION(TimeSeriesFromGrid)
 Converts an array of values `[x1, x2, x3, ...]` to an array of tuples
 `[(start_timestamp, x1), (start_timestamp + step, x2), (start_timestamp + 2 * step, x3), ...]`.
 
-If some of the values `[x1, x2, x3, ...]` are `NULL` then the function won't copy such null values to the result array
-but will still increase the current timestamp, i.e. for example for `[value1, NULL, x2]` the function will return
-`[(start_timestamp, x1), (start_timestamp + 2 * step, x2)]`.
+The current timestamp is increased by `step` until it becomes greater than `end_timestamp`
+If the number of the values doesn't match the number of the timestamps, the function throws an exception.
 
-The current timestamp is increased by step until it becomes greater than end_timestamp, each timestamp will be combined with a value
-from a specified array of values. If number of the values doesn't match number of the timestamps the function will throw an exception.
+NULL values in `[x1, x2, x3, ...]` are skipped but the current timestamp is still incremented.
+For example, for `[value1, NULL, x2]` the function returns `[(start_timestamp, x1), (start_timestamp + 2 * step, x2)]`.
     )";
     FunctionDocumentation::Syntax syntax = "timeSeriesFromGrid(start_timestamp, end_timestamp, step, values)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/TimeSeries/timeSeriesRange.cpp
+++ b/src/Functions/TimeSeries/timeSeriesRange.cpp
@@ -36,11 +36,8 @@ public:
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionTimeSeriesRange<with_values>>(); }
 
     String getName() const override { return name; }
-
     size_t getNumberOfArguments() const override { return with_values ? 4 : 3; }
-
     bool isDeterministic() const override { return true; }
-
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override

--- a/src/Functions/TimeSeries/timeSeriesRange.cpp
+++ b/src/Functions/TimeSeries/timeSeriesRange.cpp
@@ -302,14 +302,37 @@ public:
 REGISTER_FUNCTION(TimeSeriesRange)
 {
     FunctionDocumentation::Description description = R"(
-        Returns a range of timestamps [start_timestamp, start_timestamp + step, start_timestamp + 2 * step, ..., end_timestamp].
+Generates a range of timestamps.
+
+- If function `timeSeriesRange()` is called with `start_timestamp` equal to `end_timestamp`
+then it returns a 1-element array containing that timestamp: `[start_timestamp]`
+- Function `timeSeriesRange()` is similar to function [range](../functions/array-functions.md#range).
+
+For example, if the type of timestamps is `DateTime64(3)` and `start_timestamp < end_timestamp` then
+`timeSeriesRange(start_timestamp, end_timestamp, step)` returns the same result as the following expression:
+
+```sql
+range(start_timestamp::Int64, end_timestamp::Int64 + 1, step::Int64)::Array(DateTime64(3))
+```
         )";
     FunctionDocumentation::Syntax syntax = "timeSeriesRange(start_timestamp, end_timestamp, step)";
     FunctionDocumentation::Arguments arguments = {{"start_timestamp", "Start of the range.", {"DateTime64", "DateTime", "UInt32"}},
                                                   {"end_timestamp", "End of the range.", {"DateTime64", "DateTime", "UInt32"}},
-                                                  {"step", "Step of the range in seconds", {"Decimal64", "Decimal32", "UInt64", "UInt32"}}};
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns a range of timestamps", {"Array(DateTime64)"}};
-    FunctionDocumentation::Examples examples = {{"Example", "SELECT timeSeriesRange('2025-06-01 00:00:00'::DateTime64(3), '2025-06-01 00:01:00'::DateTime64(3), 30)", "['2025-06-01 00:00:00.000', '2025-06-01 00:00:30.000', '2025-06-01 00:01:00.000']"}};
+                                                  {"step", "Step of the range in seconds", {"UInt32/64", "Decimal32/64"}}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a range of timestamps.", {"Array(DateTime64)"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+SELECT timeSeriesRange('2025-06-01 00:00:00'::DateTime64(3), '2025-06-01 00:01:00'::DateTime64(3), 30)
+        )",
+        R"(
+┌────────────────────────────────────result─────────────────────────────────────────┐
+│ ['2025-06-01 00:00:00.000', '2025-06-01 00:00:30.000', '2025-06-01 00:01:00.000'] │
+└───────────────────────────────────────────────────────────────────────────────────┘
+        )"
+    }
+    };
     FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::TimeSeries;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
@@ -320,21 +343,37 @@ REGISTER_FUNCTION(TimeSeriesRange)
 REGISTER_FUNCTION(TimeSeriesFromGrid)
 {
     FunctionDocumentation::Description description = R"(
-        Converts array of values [value1, value2, value3, ...] to array of tuples
-        [(start_timestamp, value1), (start_timestamp + step, value2), (start_timestamp + 2 * step, value3), ...].
-        If some of the values [value1, value2, value3, ...] are NULL then the function won't copy such null values to the result array
-        but will still increase the current timestamp, i.e. for example for [value1, NULL, value2] the function will return
-        [(start_timestamp, value1), (start_timestamp + 2 * step, value2)].
-        The current timestamp is increased by step until it becomes greater than end_timestamp, each timestamp will be combined with a value
-        from a specified array of values. If number of the values doesn't match number of the timestamps the function will throw an exception.
-        )";
+Converts an array of values `[x1, x2, x3, ...]` to an array of tuples
+`[(start_timestamp, x1), (start_timestamp + step, x2), (start_timestamp + 2 * step, x3), ...]`.
+
+If some of the values `[x1, x2, x3, ...]` are `NULL` then the function won't copy such null values to the result array
+but will still increase the current timestamp, i.e. for example for `[value1, NULL, x2]` the function will return
+`[(start_timestamp, x1), (start_timestamp + 2 * step, x2)]`.
+
+The current timestamp is increased by step until it becomes greater than end_timestamp, each timestamp will be combined with a value
+from a specified array of values. If number of the values doesn't match number of the timestamps the function will throw an exception.
+    )";
     FunctionDocumentation::Syntax syntax = "timeSeriesFromGrid(start_timestamp, end_timestamp, step, values)";
-    FunctionDocumentation::Arguments arguments = {{"start_timestamp", "Start of the grid.", {"DateTime64", "DateTime", "UInt32"}},
-                                                  {"end_timestamp", "End of the grid.", {"DateTime64", "DateTime", "UInt32"}},
-                                                  {"step", "Step of the grid in seconds", {"Decimal64", "Decimal32", "UInt64", "UInt32"}},
-                                                  {"values", "array of values", {"Array(Nullable(Float64))", "Array(Float64)", "Array(Nullable(Float32))", "Array(Float32)"}}};
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns values from the source array of values combined with timestamps on a regular time grid described by start timestamp and step", {"Array(DateTime64, Float64"}};
-    FunctionDocumentation::Examples examples = {{"Example", "SELECT timeSeriesFromGrid('2025-06-01 00:00:00'::DateTime64(3), '2025-06-01 00:01:30.000'::DateTime64(3), 30, [10, 20, NULL, 30])", "[('2025-06-01 00:00:00.000',10),('2025-06-01 00:00:30.000',20),('2025-06-01 00:01:30.000',30)]"}};
+    FunctionDocumentation::Arguments arguments = {
+        {"start_timestamp", "Start of the grid.", {"DateTime64", "DateTime", "UInt32"}},
+        {"end_timestamp", "End of the grid.", {"DateTime64", "DateTime", "UInt32"}},
+        {"step", "Step of the grid in seconds", {"Decimal64", "Decimal32", "UInt32/64"}},
+        {"values", "Array of values", {"Array(Float*)", "Array(Nullable(Float*))"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns values from the source array of values combined with timestamps on a regular time grid described by `start_timestamp` and `step`.", {"Array(Tuple(DateTime64, Float64))"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+SELECT timeSeriesFromGrid('2025-06-01 00:00:00'::DateTime64(3), '2025-06-01 00:01:30.000'::DateTime64(3), 30, [10, 20, NULL, 30]) AS result;
+        )",
+        R"(
+┌─────────────────────────────────────────────result─────────────────────────────────────────────┐
+│ [('2025-06-01 00:00:00.000',10),('2025-06-01 00:00:30.000',20),('2025-06-01 00:01:30.000',30)] │
+└────────────────────────────────────────────────────────────────────────────────────────────────┘
+        )"
+    }
+    };
     FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::TimeSeries;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Move documentation for time-series functions into the source code for generation of documentation from system tables.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
