### PR TITLE
S3Queue: survive zookeeper connection loss without duplicates

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -216,6 +216,16 @@ Default value: `30000`.
 
 For 'Ordered' mode. Available since `24.6`. If there are several replicas of S3Queue table, each working with the same metadata directory in keeper, the value of `s3queue_buckets` needs to be equal to at least the number of replicas. If `s3queue_processing_threads` setting is used as well, it makes sense to increase the value of `s3queue_buckets` setting even further, as it defines the actual parallelism of `S3Queue` processing.
 
+### `use_persistent_processing_nodes` {#use_persistent_processing_nodes}
+
+By default S3Queue table has always used ephemeral processing nodes, which could lead to duplicates in data in case zookeeper session expires before S3Queue commits processed files in zookeeper, but after it has started processing. This setting forces the server to eliminate possibility of duplicates in case of expired keeper session. 
+
+### `persistent_processing_nodes_ttl_seconds` {#persistent_processing_nodes_ttl_seconds}
+
+In case of non-graceful server termination, it is possible that if `use_persistent_processing_nodes` is enabled, we can have not removed processing nodes. This setting defines a period of time when these processing nodes can safely be cleaned up.
+
+Default value: `3600` (1 hour).
+
 ## S3-related settings {#s3-settings}
 
 Engine supports all s3 related settings. For more information about S3 settings see [here](../../../engines/table-engines/integrations/s3.md).
@@ -305,7 +315,7 @@ Constructions with `{}` are similar to the [remote](../../../sql-reference/table
 
 - an exception happens during parsing in the middle of file processing and retries are enabled via `s3queue_loading_retries`;
 
-- `S3Queue` is configured on multiple servers pointing to the same path in zookeeper and keeper session expires before one server managed to commit processed file, which could lead to another server taking processing of the file, which could be partially or fully processed by the first server;
+- `S3Queue` is configured on multiple servers pointing to the same path in zookeeper and keeper session expires before one server managed to commit processed file, which could lead to another server taking processing of the file, which could be partially or fully processed by the first server; However, this is not true since version 25.8 if `use_persistent_processing_nodes = 1`.
 
 - abnormal server termination.
 

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -64,6 +64,7 @@ static struct InitFiu
     ONCE(rmt_merge_task_sleep_in_prepare) \
     ONCE(s3_read_buffer_throw_expired_token) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
+    ONCE(object_storage_queue_fail_commit_once) \
     REGULAR(distributed_cache_fail_connect_non_retriable) \
     REGULAR(distributed_cache_fail_connect_retriable) \
     REGULAR(object_storage_queue_fail_commit) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -132,12 +132,14 @@ ObjectStorageQueueIFileMetadata::ObjectStorageQueueIFileMetadata(
     FileStatusPtr file_status_,
     size_t max_loading_retries_,
     std::atomic<size_t> & metadata_ref_count_,
+    bool use_persistent_processing_nodes_,
     LoggerPtr log_)
     : path(path_)
     , node_name(getNodeName(path_))
     , file_status(file_status_)
     , max_loading_retries(max_loading_retries_)
     , metadata_ref_count(metadata_ref_count_)
+    , use_persistent_processing_nodes(use_persistent_processing_nodes_)
     , processing_node_path(processing_node_path_)
     , processed_node_path(processed_node_path_)
     , failed_node_path(failed_node_path_)
@@ -188,6 +190,13 @@ ObjectStorageQueueIFileMetadata::~ObjectStorageQueueIFileMetadata()
             tryLogCurrentException(__PRETTY_FUNCTION__);
         }
     }
+}
+
+std::string ObjectStorageQueueIFileMetadata::getProcessingNodesPath(bool use_persistent_processing_nodes)
+{
+    if (use_persistent_processing_nodes)
+        return "persistent_processing";
+    return "processing";
 }
 
 std::string ObjectStorageQueueIFileMetadata::getNodeName(const std::string & path)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -60,6 +60,7 @@ public:
         FileStatusPtr file_status_,
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
+        bool use_persistent_processing_nodes_,
         LoggerPtr log_);
 
     virtual ~ObjectStorageQueueIFileMetadata();
@@ -129,6 +130,8 @@ public:
         static NodeMetadata fromString(const std::string & metadata_str);
     };
 
+    static std::string getProcessingNodesPath(bool use_persistent_processing_nodes);
+
 protected:
     virtual std::pair<bool, FileStatus::State> setProcessingImpl() = 0;
     virtual void prepareProcessedRequestsImpl(Coordination::Requests & requests) = 0;
@@ -144,6 +147,7 @@ protected:
     const FileStatusPtr file_status;
     const size_t max_loading_retries;
     const std::atomic<size_t> & metadata_ref_count;
+    const bool use_persistent_processing_nodes;
 
     const std::string processing_node_path;
     const std::string processed_node_path;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -132,14 +132,18 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     const ObjectStorageQueueTableMetadata & table_metadata_,
     size_t cleanup_interval_min_ms_,
     size_t cleanup_interval_max_ms_,
+    bool use_persistent_processing_nodes_,
+    size_t persistent_processing_nodes_ttl_seconds_,
     size_t keeper_multiread_batch_size_)
     : table_metadata(table_metadata_)
     , storage_type(storage_type_)
     , mode(table_metadata.getMode())
     , zookeeper_path(zookeeper_path_)
+    , keeper_multiread_batch_size(keeper_multiread_batch_size_)
     , cleanup_interval_min_ms(cleanup_interval_min_ms_)
     , cleanup_interval_max_ms(cleanup_interval_max_ms_)
-    , keeper_multiread_batch_size(keeper_multiread_batch_size_)
+    , use_persistent_processing_nodes(use_persistent_processing_nodes_)
+    , persistent_processing_node_ttl_seconds(persistent_processing_nodes_ttl_seconds_)
     , buckets_num(table_metadata_.getBucketsNum())
     , log(getLogger("StorageObjectStorageQueue(" + zookeeper_path_.string() + ")"))
     , local_file_statuses(std::make_shared<LocalFileStatuses>())
@@ -208,6 +212,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 buckets_num,
                 table_metadata.loading_retries,
                 *metadata_ref_count,
+                use_persistent_processing_nodes,
                 log);
         case ObjectStorageQueueMode::UNORDERED:
             return std::make_shared<ObjectStorageQueueUnorderedFileMetadata>(
@@ -216,6 +221,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 file_status,
                 table_metadata.loading_retries,
                 *metadata_ref_count,
+                use_persistent_processing_nodes,
                 log);
     }
 }
@@ -473,6 +479,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
                 buckets_num,
                 table_metadata.loading_retries,
                 noop,
+                /* use_persistent_processing_nodes */false, /// Processing nodes will not be created.
                 log).prepareProcessedAtStartRequests(requests, zookeeper);
         }
 
@@ -1032,6 +1039,8 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
     }
     /// TODO because of this lock we might not update local file statuses on time on one of the nodes.
 
+    cleanupPersistentProcessingNodes(zk_client);
+
     const fs::path zookeeper_processed_path = zookeeper_path / "processed";
     const fs::path zookeeper_failed_path = zookeeper_path / "failed";
 
@@ -1248,6 +1257,101 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
         remove_nodes(/*node_limit=*/false);
 
     LOG_TRACE(log, "Node limits check finished");
+}
+
+void ObjectStorageQueueMetadata::updateSettings(const SettingsChanges & changes)
+{
+    for (const auto & change : changes)
+    {
+        if (change.name == "cleanup_interval_min_ms")
+            cleanup_interval_min_ms = change.value.safeGet<bool>();
+        if (change.name == "cleanup_interval_max_ms")
+            cleanup_interval_max_ms = change.value.safeGet<bool>();
+        if (change.name == "use_persistent_processing_nodes")
+            use_persistent_processing_nodes = change.value.safeGet<bool>();
+        if (change.name == "persistent_processing_node_ttl_seconds")
+            persistent_processing_node_ttl_seconds = change.value.safeGet<bool>();
+    }
+}
+
+void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes(zkutil::ZooKeeperPtr zk_client)
+{
+    const fs::path zookeeper_persistent_processing_path = zookeeper_path
+        / ObjectStorageQueueIFileMetadata::getProcessingNodesPath(true);
+
+    Strings persistent_processing_nodes;
+    auto code = zk_client->tryGetChildren(zookeeper_persistent_processing_path, persistent_processing_nodes);
+    if (code != Coordination::Error::ZOK)
+    {
+        if (code == Coordination::Error::ZNONODE)
+        {
+            LOG_TEST(log, "Path {} does not exist", zookeeper_persistent_processing_path.string());
+            return;
+        }
+        else
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected error: {}", magic_enum::enum_name(code));
+    }
+
+    auto current_time = getCurrentTime();
+    Strings nodes_to_remove;
+    Strings get_batch;
+    auto get_paths = [&]
+    {
+        auto response = zk_client->tryGet(get_batch);
+
+        for (size_t i = 0; i < response.size(); ++i)
+        {
+            if (response[i].error == Coordination::Error::ZNONODE)
+            {
+                LOG_ERROR(log, "Failed to fetch node metadata {}", get_batch[i]);
+                continue;
+            }
+
+            LOG_TEST(
+                log, "Node: {}, mtime: {}, ttl sec: {}, current time: {}",
+                get_batch[i], response[i].stat.mtime, persistent_processing_node_ttl_seconds.load(), current_time);
+
+            if (response[i].stat.mtime / 1000 + persistent_processing_node_ttl_seconds < current_time)
+                nodes_to_remove.push_back(get_batch[i]);
+        }
+        get_batch.clear();
+    };
+
+    for (const auto & node : persistent_processing_nodes)
+    {
+        get_batch.push_back(zookeeper_persistent_processing_path / node);
+        try
+        {
+            if (get_batch.size() == keeper_multiread_batch_size)
+                get_paths();
+        }
+        catch (const zkutil::KeeperException & e)
+        {
+            if (!Coordination::isHardwareError(e.code))
+            {
+                LOG_WARNING(log, "Unexpected exception: {}", getCurrentExceptionMessage(true));
+                chassert(false);
+            }
+
+            /// Will retry with a new zk connection.
+            throw;
+        }
+    }
+    if (!get_batch.empty())
+        get_paths();
+
+    if (nodes_to_remove.empty())
+    {
+        if (!persistent_processing_nodes.empty())
+            LOG_TRACE(log, "No persistent processing nodes to remove, "
+                     "total persistent processing nodes: {}", persistent_processing_nodes.size());
+        return;
+    }
+
+    for (const auto & node : nodes_to_remove)
+        zk_client->remove(node);
+
+    LOG_DEBUG(log, "Removed {} persistent processing nodes", nodes_to_remove.size());
 }
 
 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -1264,13 +1264,13 @@ void ObjectStorageQueueMetadata::updateSettings(const SettingsChanges & changes)
     for (const auto & change : changes)
     {
         if (change.name == "cleanup_interval_min_ms")
-            cleanup_interval_min_ms = change.value.safeGet<bool>();
+            cleanup_interval_min_ms = change.value.safeGet<UInt64>();
         if (change.name == "cleanup_interval_max_ms")
-            cleanup_interval_max_ms = change.value.safeGet<bool>();
+            cleanup_interval_max_ms = change.value.safeGet<UInt64>();
         if (change.name == "use_persistent_processing_nodes")
             use_persistent_processing_nodes = change.value.safeGet<bool>();
         if (change.name == "persistent_processing_node_ttl_seconds")
-            persistent_processing_node_ttl_seconds = change.value.safeGet<bool>();
+            persistent_processing_node_ttl_seconds = change.value.safeGet<UInt64>();
     }
 }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -59,6 +59,8 @@ public:
         const ObjectStorageQueueTableMetadata & table_metadata_,
         size_t cleanup_interval_min_ms_,
         size_t cleanup_interval_max_ms_,
+        bool use_persistent_processing_nodes_,
+        size_t persistent_processing_nodes_ttl_seconds_,
         size_t keeper_multiread_batch_size_);
 
     ~ObjectStorageQueueMetadata();
@@ -148,9 +150,17 @@ public:
     /// Set local ref count for metadata.
     void setMetadataRefCount(std::atomic<size_t> & ref_count_) { chassert(!metadata_ref_count); metadata_ref_count = &ref_count_; }
 
+    void updateSettings(const SettingsChanges & changes);
+
+    std::pair<size_t, size_t> getCleanupInterval() const { return {cleanup_interval_min_ms, cleanup_interval_max_ms }; }
+
+    size_t usePersistentProcessingNode() const { return persistent_processing_node_ttl_seconds; }
+    size_t getPersistentProcessingNodeTTL() const { return persistent_processing_node_ttl_seconds; }
+
 private:
     void cleanupThreadFunc();
     void cleanupThreadFuncImpl();
+    void cleanupPersistentProcessingNodes(zkutil::ZooKeeperPtr zk_client);
 
     void migrateToBucketsInKeeper(size_t value);
 
@@ -164,8 +174,13 @@ private:
     const ObjectStorageType storage_type;
     const ObjectStorageQueueMode mode;
     const fs::path zookeeper_path;
-    const size_t cleanup_interval_min_ms, cleanup_interval_max_ms;
     const size_t keeper_multiread_batch_size;
+
+    std::atomic<size_t> cleanup_interval_min_ms;
+    std::atomic<size_t> cleanup_interval_max_ms;
+    std::atomic<bool> use_persistent_processing_nodes;
+    std::atomic<size_t> persistent_processing_node_ttl_seconds;
+
     size_t buckets_num;
     std::unique_ptr<ThreadFromGlobalPool> update_registry_thread;
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -152,10 +152,10 @@ public:
 
     void updateSettings(const SettingsChanges & changes);
 
-    std::pair<size_t, size_t> getCleanupInterval() const { return {cleanup_interval_min_ms, cleanup_interval_max_ms }; }
+    std::pair<size_t, size_t> getCleanupIntervalMS() const { return {cleanup_interval_min_ms, cleanup_interval_max_ms }; }
 
-    size_t usePersistentProcessingNode() const { return persistent_processing_node_ttl_seconds; }
-    size_t getPersistentProcessingNodeTTL() const { return persistent_processing_node_ttl_seconds; }
+    bool usePersistentProcessingNode() const { return use_persistent_processing_nodes; }
+    size_t getPersistentProcessingNodeTTLSeconds() const { return persistent_processing_node_ttl_seconds; }
 
 private:
     void cleanupThreadFunc();

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -151,7 +151,7 @@ std::vector<std::string> ObjectStorageQueueOrderedFileMetadata::getMetadataPaths
 {
     if (DB::useBucketsForProcessing(buckets_num))
     {
-        std::vector<std::string> paths{"buckets", "failed", "processing"};
+        std::vector<std::string> paths{"buckets", "failed", "processing", "persistent_processing"};
         for (size_t i = 0; i < buckets_num; ++i)
             paths.push_back("buckets/" + toString(i));
         return paths;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
@@ -31,6 +31,7 @@ public:
         size_t buckets_num_,
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
+        bool use_persistent_processing_nodes_,
         LoggerPtr log_);
 
     struct BucketHolder;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -38,6 +38,8 @@ namespace ErrorCodes
     DECLARE(UInt64, polling_backoff_ms, 30 * 1000, "Polling backoff", 0) \
     DECLARE(UInt32, cleanup_interval_min_ms, 60000, "For unordered mode. Polling backoff min for cleanup", 0) \
     DECLARE(UInt32, cleanup_interval_max_ms, 60000, "For unordered mode. Polling backoff max for cleanup", 0) \
+    DECLARE(Bool, use_persistent_processing_nodes, false, "Whether persistent nodes should be used for processing nodes in keeper", 0) \
+    DECLARE(UInt32, persistent_processing_node_ttl_seconds, 60 * 60, "Cleanup period for abandoned processing nodes", 0) \
     DECLARE(UInt64, buckets, 0, "Number of buckets for Ordered mode parallel processing", 0) \
     DECLARE(UInt64, list_objects_batch_size, 1000, "Size of a list batch in object storage", 0) \
     DECLARE(UInt64, min_insert_block_size_rows_for_materialized_views, 0, "Override for profile setting min_insert_block_size_rows_for_materialized_views", 0) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
@@ -16,6 +16,7 @@ namespace
     {
         return Context::getGlobalContextInstance()->getZooKeeper();
     }
+
 }
 
 ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata(
@@ -24,15 +25,17 @@ ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata
     FileStatusPtr file_status_,
     size_t max_loading_retries_,
     std::atomic<size_t> & metadata_ref_count_,
+    bool use_persistent_processing_nodes_,
     LoggerPtr log_)
     : ObjectStorageQueueIFileMetadata(
         path_,
-        /* processing_node_path */zk_path / "processing" / getNodeName(path_),
+        /* processing_node_path */zk_path / getProcessingNodesPath(use_persistent_processing_nodes_) / getNodeName(path_),
         /* processed_node_path */zk_path / "processed" / getNodeName(path_),
         /* failed_node_path */zk_path / "failed" / getNodeName(path_),
         file_status_,
         max_loading_retries_,
         metadata_ref_count_,
+        use_persistent_processing_nodes_,
         log_)
 {
 }
@@ -54,7 +57,11 @@ ObjectStorageQueueUnorderedFileMetadata::prepareProcessingRequestsImpl(Coordinat
     zkutil::addCheckNotExistsRequest(requests, *zk_client, failed_node_path);
 
     result_indexes.create_processing_node_idx = requests.size();
-    requests.push_back(zkutil::makeCreateRequest(processing_node_path, node_metadata.toString(), zkutil::CreateMode::Ephemeral));
+    requests.push_back(
+        zkutil::makeCreateRequest(
+            processing_node_path,
+            node_metadata.toString(),
+            use_persistent_processing_nodes ? zkutil::CreateMode::Persistent : zkutil::CreateMode::Ephemeral));
 
     if (zk_client->isFeatureEnabled(DB::KeeperFeatureFlag::CREATE_IF_NOT_EXISTS))
     {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
@@ -17,9 +17,10 @@ public:
         FileStatusPtr file_status_,
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
+        bool use_persistent_processing_nodes_,
         LoggerPtr log_);
 
-    static std::vector<std::string> getMetadataPaths() { return {"processed", "failed", "processing"}; }
+    static std::vector<std::string> getMetadataPaths() { return {"processed", "failed", "processing", "persistent_processing"}; }
 
     /// Return vector of indexes of filtered paths.
     static void filterOutProcessedAndFailed(

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -4,6 +4,7 @@
 #include <Common/ProfileEvents.h>
 #include <Common/FailPoint.h>
 #include <Common/randomSeed.h>
+#include <Common/ZooKeeper/ZooKeeperRetries.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
@@ -59,11 +60,15 @@ namespace Setting
     extern const SettingsBool s3queue_enable_logging_to_s3queue_log;
     extern const SettingsBool stream_like_engine_allow_direct_select;
     extern const SettingsBool use_concurrency_control;
+    extern const SettingsUInt64 keeper_max_retries;
+    extern const SettingsUInt64 keeper_retry_initial_backoff_ms;
+    extern const SettingsUInt64 keeper_retry_max_backoff_ms;
 }
 
 namespace FailPoints
 {
     extern const char object_storage_queue_fail_commit[];
+    extern const char object_storage_queue_fail_commit_once[];
     extern const char object_storage_queue_fail_startup[];
 }
 
@@ -99,6 +104,8 @@ namespace ObjectStorageQueueSetting
     extern const ObjectStorageQueueSettingsBool enable_hash_ring_filtering;
     extern const ObjectStorageQueueSettingsUInt64 min_insert_block_size_rows_for_materialized_views;
     extern const ObjectStorageQueueSettingsUInt64 min_insert_block_size_bytes_for_materialized_views;
+    extern const ObjectStorageQueueSettingsBool use_persistent_processing_nodes;
+    extern const ObjectStorageQueueSettingsUInt32 persistent_processing_node_ttl_seconds;
 }
 
 namespace ErrorCodes
@@ -110,6 +117,7 @@ namespace ErrorCodes
     extern const int SUPPORT_IS_DISABLED;
     extern const int NOT_IMPLEMENTED;
     extern const int FAULT_INJECTED;
+    extern const int KEEPER_EXCEPTION;
 }
 
 namespace
@@ -133,7 +141,8 @@ namespace
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                             "Setting `cleanup_interval_min_ms` ({}) must be less or equal to `cleanup_interval_max_ms` ({})",
-                            queue_settings[ObjectStorageQueueSetting::cleanup_interval_min_ms].value, queue_settings[ObjectStorageQueueSetting::cleanup_interval_max_ms].value);
+                            queue_settings[ObjectStorageQueueSetting::cleanup_interval_min_ms].value,
+                            queue_settings[ObjectStorageQueueSetting::cleanup_interval_max_ms].value);
         }
     }
 
@@ -249,6 +258,8 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
         std::move(table_metadata),
         (*queue_settings_)[ObjectStorageQueueSetting::cleanup_interval_min_ms],
         (*queue_settings_)[ObjectStorageQueueSetting::cleanup_interval_max_ms],
+        (*queue_settings_)[ObjectStorageQueueSetting::use_persistent_processing_nodes],
+        (*queue_settings_)[ObjectStorageQueueSetting::persistent_processing_node_ttl_seconds],
         getContext()->getServerSettings()[ServerSetting::keeper_multiread_batch_size]);
 
     size_t task_count = (*queue_settings_)[ObjectStorageQueueSetting::parallel_inserts] ? (*queue_settings_)[ObjectStorageQueueSetting::processing_threads_num] : 1;
@@ -823,18 +834,53 @@ void StorageObjectStorageQueue::commit(
         ProfileEvents::increment(ProfileEvents::ObjectStorageQueueRemovedObjects, successful_objects.size());
     }
 
-    auto zk_client = getZooKeeper();
-    Coordination::Responses responses;
+    auto context = getContext();
+    const auto & settings = context->getSettingsRef();
+    ZooKeeperRetriesControl zk_retry{
+        getName(),
+        log,
+        ZooKeeperRetriesInfo{
+            settings[Setting::keeper_max_retries],
+            settings[Setting::keeper_retry_initial_backoff_ms],
+            settings[Setting::keeper_retry_max_backoff_ms],
+            context->getProcessListElement()}};
 
-    fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
-        throw Exception(ErrorCodes::FAULT_INJECTED, "Failed to commit processed files");
+    std::optional<Coordination::Error> code;
+    Coordination::Responses responses;
+    size_t try_num = 0;
+    zk_retry.retryLoop([&]
+    {
+        ++try_num;
+        auto zk_client = getZooKeeper();
+        fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
+            throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
+        });
+        fiu_do_on(FailPoints::object_storage_queue_fail_commit_once, {
+            throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
+        });
+
+        code = zk_client->tryMulti(requests, responses);
+    },
+    [&]
+    {
+        LOG_TRACE(
+            log, "Failed to commit processed files at try {}/{}",
+            try_num, toString(settings[Setting::keeper_max_retries].value));
     });
 
-    auto code = zk_client->tryMulti(requests, responses);
-    if (code != Coordination::Error::ZOK)
+    if (!code.has_value())
+    {
+        throw Exception(
+            ErrorCodes::KEEPER_EXCEPTION,
+            "Failed to commit files with {} retries, last error message: {}",
+            settings[Setting::keeper_max_retries].value, zk_retry.getLastKeeperErrorMessage());
+    }
+
+    chassert(code.value() == Coordination::Error::ZOK || Coordination::isUserError(code.value()));
+    if (code.value() != Coordination::Error::ZOK)
     {
         ProfileEvents::increment(ProfileEvents::ObjectStorageQueueUnsuccessfulCommits);
-        throw zkutil::KeeperMultiException(code, requests, responses);
+        throw zkutil::KeeperMultiException(code.value(), requests, responses);
     }
 
     ProfileEvents::increment(ProfileEvents::ObjectStorageQueueSuccessfulCommits);
@@ -880,6 +926,10 @@ static const std::unordered_set<std::string_view> changeable_settings_unordered_
     "list_objects_batch_size",
     "min_insert_block_size_rows_for_materialized_views",
     "min_insert_block_size_bytes_for_materialized_views",
+    "cleanup_interval_max_ms",
+    "cleanup_interval_min_ms",
+    "use_persistent_processing_nodes",
+    "persistent_processing_node_ttl_seconds",
 };
 
 static const std::unordered_set<std::string_view> changeable_settings_ordered_mode
@@ -897,6 +947,10 @@ static const std::unordered_set<std::string_view> changeable_settings_ordered_mo
     "list_objects_batch_size",
     "min_insert_block_size_rows_for_materialized_views",
     "min_insert_block_size_bytes_for_materialized_views",
+    "cleanup_interval_max_ms",
+    "cleanup_interval_min_ms",
+    "use_persistent_processing_nodes",
+    "persistent_processing_node_ttl_seconds",
 };
 
 static std::string normalizeSetting(const std::string & name)
@@ -1138,34 +1192,35 @@ void StorageObjectStorageQueue::alter(
         /// Alter settings which are not stored in keeper.
         for (const auto & change : changed_settings)
         {
-            std::lock_guard lock(mutex);
+            {
+                std::lock_guard lock(mutex);
 
-            if (change.name == "polling_min_timeout_ms")
-                polling_min_timeout_ms = change.value.safeGet<UInt64>();
-            if (change.name == "polling_max_timeout_ms")
-                polling_max_timeout_ms = change.value.safeGet<UInt64>();
-            if (change.name == "polling_backoff_ms")
-                polling_backoff_ms = change.value.safeGet<UInt64>();
-
-            if (change.name == "max_processed_files_before_commit")
-                commit_settings.max_processed_files_before_commit = change.value.safeGet<UInt64>();
-            if (change.name == "max_processed_rows_before_commit")
-                commit_settings.max_processed_rows_before_commit = change.value.safeGet<UInt64>();
-            if (change.name == "max_processed_bytes_before_commit")
-                commit_settings.max_processed_bytes_before_commit = change.value.safeGet<UInt64>();
-            if (change.name == "max_processing_time_sec_before_commit")
-                commit_settings.max_processing_time_sec_before_commit = change.value.safeGet<UInt64>();
-
-            if (change.name == "min_insert_block_size_rows_for_materialized_views")
-                min_insert_block_size_rows_for_materialized_views = change.value.safeGet<UInt64>();
-            if (change.name == "min_insert_block_size_bytes_for_materialized_views")
-                min_insert_block_size_bytes_for_materialized_views = change.value.safeGet<UInt64>();
-
-            if (change.name == "list_objects_batch_size")
-                list_objects_batch_size = change.value.safeGet<UInt64>();
-            if (change.name == "enable_hash_ring_filtering")
-                enable_hash_ring_filtering = change.value.safeGet<bool>();
+                if (change.name == "polling_min_timeout_ms")
+                    polling_min_timeout_ms = change.value.safeGet<UInt64>();
+                else if (change.name == "polling_max_timeout_ms")
+                    polling_max_timeout_ms = change.value.safeGet<UInt64>();
+                else if (change.name == "polling_backoff_ms")
+                    polling_backoff_ms = change.value.safeGet<UInt64>();
+                else if (change.name == "max_processed_files_before_commit")
+                    commit_settings.max_processed_files_before_commit = change.value.safeGet<UInt64>();
+                else if (change.name == "max_processed_rows_before_commit")
+                    commit_settings.max_processed_rows_before_commit = change.value.safeGet<UInt64>();
+                else if (change.name == "max_processed_bytes_before_commit")
+                    commit_settings.max_processed_bytes_before_commit = change.value.safeGet<UInt64>();
+                else if (change.name == "max_processing_time_sec_before_commit")
+                    commit_settings.max_processing_time_sec_before_commit = change.value.safeGet<UInt64>();
+                else if (change.name == "min_insert_block_size_rows_for_materialized_views")
+                    min_insert_block_size_rows_for_materialized_views = change.value.safeGet<UInt64>();
+                else if (change.name == "min_insert_block_size_bytes_for_materialized_views")
+                    min_insert_block_size_bytes_for_materialized_views = change.value.safeGet<UInt64>();
+                else if (change.name == "list_objects_batch_size")
+                    list_objects_batch_size = change.value.safeGet<UInt64>();
+                else if (change.name == "enable_hash_ring_filtering")
+                    enable_hash_ring_filtering = change.value.safeGet<bool>();
+            }
         }
+
+        files_metadata->updateSettings(changed_settings);
 
         DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(local_context, table_id, new_metadata);
         setInMemoryMetadata(new_metadata);
@@ -1235,9 +1290,13 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
     settings[ObjectStorageQueueSetting::last_processed_path] = table_metadata.last_processed_path;
     settings[ObjectStorageQueueSetting::tracked_file_ttl_sec] = table_metadata.tracked_files_ttl_sec;
     settings[ObjectStorageQueueSetting::tracked_files_limit] = table_metadata.tracked_files_limit;
-    settings[ObjectStorageQueueSetting::cleanup_interval_min_ms] = 0;
-    settings[ObjectStorageQueueSetting::cleanup_interval_max_ms] = 0;
     settings[ObjectStorageQueueSetting::buckets] = table_metadata.buckets;
+
+    auto cleanup_interval = files_metadata->getCleanupInterval();
+    settings[ObjectStorageQueueSetting::cleanup_interval_min_ms] = cleanup_interval.first;
+    settings[ObjectStorageQueueSetting::cleanup_interval_max_ms] = cleanup_interval.second;
+    settings[ObjectStorageQueueSetting::persistent_processing_node_ttl_seconds] = files_metadata->getPersistentProcessingNodeTTL();
+    settings[ObjectStorageQueueSetting::use_persistent_processing_nodes] = files_metadata->usePersistentProcessingNode();
 
     {
         std::lock_guard lock(mutex);

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1292,10 +1292,10 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
     settings[ObjectStorageQueueSetting::tracked_files_limit] = table_metadata.tracked_files_limit;
     settings[ObjectStorageQueueSetting::buckets] = table_metadata.buckets;
 
-    auto cleanup_interval = files_metadata->getCleanupInterval();
-    settings[ObjectStorageQueueSetting::cleanup_interval_min_ms] = cleanup_interval.first;
-    settings[ObjectStorageQueueSetting::cleanup_interval_max_ms] = cleanup_interval.second;
-    settings[ObjectStorageQueueSetting::persistent_processing_node_ttl_seconds] = files_metadata->getPersistentProcessingNodeTTL();
+    auto cleanup_interval_ms = files_metadata->getCleanupIntervalMS();
+    settings[ObjectStorageQueueSetting::cleanup_interval_min_ms] = cleanup_interval_ms.first;
+    settings[ObjectStorageQueueSetting::cleanup_interval_max_ms] = cleanup_interval_ms.second;
+    settings[ObjectStorageQueueSetting::persistent_processing_node_ttl_seconds] = files_metadata->getPersistentProcessingNodeTTLSeconds();
     settings[ObjectStorageQueueSetting::use_persistent_processing_nodes] = files_metadata->usePersistentProcessingNode();
 
     {

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1192,32 +1192,30 @@ void StorageObjectStorageQueue::alter(
         /// Alter settings which are not stored in keeper.
         for (const auto & change : changed_settings)
         {
-            {
-                std::lock_guard lock(mutex);
+            std::lock_guard lock(mutex);
 
-                if (change.name == "polling_min_timeout_ms")
-                    polling_min_timeout_ms = change.value.safeGet<UInt64>();
-                else if (change.name == "polling_max_timeout_ms")
-                    polling_max_timeout_ms = change.value.safeGet<UInt64>();
-                else if (change.name == "polling_backoff_ms")
-                    polling_backoff_ms = change.value.safeGet<UInt64>();
-                else if (change.name == "max_processed_files_before_commit")
-                    commit_settings.max_processed_files_before_commit = change.value.safeGet<UInt64>();
-                else if (change.name == "max_processed_rows_before_commit")
-                    commit_settings.max_processed_rows_before_commit = change.value.safeGet<UInt64>();
-                else if (change.name == "max_processed_bytes_before_commit")
-                    commit_settings.max_processed_bytes_before_commit = change.value.safeGet<UInt64>();
-                else if (change.name == "max_processing_time_sec_before_commit")
-                    commit_settings.max_processing_time_sec_before_commit = change.value.safeGet<UInt64>();
-                else if (change.name == "min_insert_block_size_rows_for_materialized_views")
-                    min_insert_block_size_rows_for_materialized_views = change.value.safeGet<UInt64>();
-                else if (change.name == "min_insert_block_size_bytes_for_materialized_views")
-                    min_insert_block_size_bytes_for_materialized_views = change.value.safeGet<UInt64>();
-                else if (change.name == "list_objects_batch_size")
-                    list_objects_batch_size = change.value.safeGet<UInt64>();
-                else if (change.name == "enable_hash_ring_filtering")
-                    enable_hash_ring_filtering = change.value.safeGet<bool>();
-            }
+            if (change.name == "polling_min_timeout_ms")
+                polling_min_timeout_ms = change.value.safeGet<UInt64>();
+            else if (change.name == "polling_max_timeout_ms")
+                polling_max_timeout_ms = change.value.safeGet<UInt64>();
+            else if (change.name == "polling_backoff_ms")
+                polling_backoff_ms = change.value.safeGet<UInt64>();
+            else if (change.name == "max_processed_files_before_commit")
+                commit_settings.max_processed_files_before_commit = change.value.safeGet<UInt64>();
+            else if (change.name == "max_processed_rows_before_commit")
+                commit_settings.max_processed_rows_before_commit = change.value.safeGet<UInt64>();
+            else if (change.name == "max_processed_bytes_before_commit")
+                commit_settings.max_processed_bytes_before_commit = change.value.safeGet<UInt64>();
+            else if (change.name == "max_processing_time_sec_before_commit")
+                commit_settings.max_processing_time_sec_before_commit = change.value.safeGet<UInt64>();
+            else if (change.name == "min_insert_block_size_rows_for_materialized_views")
+                min_insert_block_size_rows_for_materialized_views = change.value.safeGet<UInt64>();
+            else if (change.name == "min_insert_block_size_bytes_for_materialized_views")
+                min_insert_block_size_bytes_for_materialized_views = change.value.safeGet<UInt64>();
+            else if (change.name == "list_objects_batch_size")
+                list_objects_batch_size = change.value.safeGet<UInt64>();
+            else if (change.name == "enable_hash_ring_filtering")
+                enable_hash_ring_filtering = change.value.safeGet<bool>();
         }
 
         files_metadata->updateSettings(changed_settings);

--- a/tests/integration/helpers/s3_queue_common.py
+++ b/tests/integration/helpers/s3_queue_common.py
@@ -122,6 +122,7 @@ def create_table(
     }
     if version is None:
         settings["enable_hash_ring_filtering"] = 1
+        settings["use_persistent_processing_nodes"] = random.choice([True, False])
 
     settings.update(additional_settings)
 

--- a/tests/integration/test_storage_s3_queue/configs/users.xml
+++ b/tests/integration/test_storage_s3_queue/configs/users.xml
@@ -4,6 +4,8 @@
             <stream_like_engine_allow_direct_select>1</stream_like_engine_allow_direct_select>
             <s3queue_enable_logging_to_s3queue_log>1</s3queue_enable_logging_to_s3queue_log>
             <s3queue_allow_experimental_sharded_mode>1</s3queue_allow_experimental_sharded_mode>
+            <function_sleep_max_microseconds_per_block>100000000</function_sleep_max_microseconds_per_block>
+            <keeper_max_retries>6</keeper_max_retries>
         </default>
     </profiles>
 </clickhouse>

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -322,6 +322,7 @@ def test_alter_settings(started_cluster):
         ).strip()
     )
 
+    use_persistent_nodes = random.choice(["true", "false"])
     node1.query(
         f"""
         ALTER TABLE r.{table_name}
@@ -343,7 +344,7 @@ def test_alter_settings(started_cluster):
         min_insert_block_size_bytes_for_materialized_views=321,
         cleanup_interval_min_ms=34500,
         cleanup_interval_max_ms=45600,
-        use_persistent_processing_nodes=true,
+        use_persistent_processing_nodes={use_persistent_nodes},
         persistent_processing_node_ttl_seconds=89
     """
     )
@@ -366,7 +367,7 @@ def test_alter_settings(started_cluster):
         "min_insert_block_size_bytes_for_materialized_views": 321,
         "cleanup_interval_min_ms": 34500,
         "cleanup_interval_max_ms": 45600,
-        "use_persistent_processing_nodes": "true",
+        "use_persistent_processing_nodes": use_persistent_nodes,
         "persistent_processing_node_ttl_seconds": 89
     }
     string_settings = {"after_processing": "delete"}

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -340,7 +340,11 @@ def test_alter_settings(started_cluster):
         enable_hash_ring_filtering=false,
         list_objects_batch_size=1234,
         min_insert_block_size_rows_for_materialized_views=123,
-        min_insert_block_size_bytes_for_materialized_views=321
+        min_insert_block_size_bytes_for_materialized_views=321,
+        cleanup_interval_min_ms=34500,
+        cleanup_interval_max_ms=45600,
+        use_persistent_processing_nodes=true,
+        persistent_processing_node_ttl_seconds=89
     """
     )
 
@@ -360,6 +364,10 @@ def test_alter_settings(started_cluster):
         "list_objects_batch_size": 1234,
         "min_insert_block_size_rows_for_materialized_views": 123,
         "min_insert_block_size_bytes_for_materialized_views": 321,
+        "cleanup_interval_min_ms": 34500,
+        "cleanup_interval_max_ms": 45600,
+        "use_persistent_processing_nodes": "true",
+        "persistent_processing_node_ttl_seconds": 89
     }
     string_settings = {"after_processing": "delete"}
 

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import uuid
+import random
 from multiprocessing.dummy import Pool
 
 import pytest

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -545,7 +545,7 @@ def test_failed_commit(started_cluster):
 
     def check_failpoint():
         return node.contains_in_log(
-            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 710. DB::Exception: Failed to commit processed files."
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 999. Coordination::Exception: Failed to commit processed files"
         )
 
     for _ in range(100):
@@ -567,7 +567,7 @@ def test_failed_commit(started_cluster):
 
     count_failed = int(
         node.count_in_log(
-            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 710. DB::Exception: Failed to commit processed files."
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 999. Coordination::Exception: Failed to commit processed files"
         )
     )
     count = get_count()
@@ -1061,7 +1061,7 @@ def test_detach_attach_table(started_cluster):
             "s3queue_processing_threads_num": 1,
             "polling_max_timeout_ms": 0,
             "polling_min_timeout_ms": 0,
-        }
+        },
     )
 
     node.query(f"DETACH TABLE {table_name}")
@@ -1069,6 +1069,7 @@ def test_detach_attach_table(started_cluster):
 
     num_rows = 10000
     file_count = [0]
+
     def insert():
         table_name_suffix = f"{uuid.uuid4()}"
         file_count[0] += 1
@@ -1122,7 +1123,7 @@ def test_failed_startup(started_cluster):
             "s3queue_processing_threads_num": 1,
             "polling_max_timeout_ms": 0,
             "polling_min_timeout_ms": 0,
-        }
+        },
     )
     node.query(f"SYSTEM DISABLE FAILPOINT object_storage_queue_fail_startup")
 
@@ -1145,7 +1146,7 @@ def test_failed_startup(started_cluster):
             "s3queue_processing_threads_num": 1,
             "polling_max_timeout_ms": 0,
             "polling_min_timeout_ms": 0,
-        }
+        },
     )
 
     assert len(zk.get(f"{keeper_path}")) > 0
@@ -1203,3 +1204,226 @@ def test_create_or_replace_table(started_cluster):
 
     create_mv(node1, f"{db_name}.{table_name}", dst_table_name, mv_name=mv_name)
     node2.query(f"SYSTEM SYNC DATABASE REPLICA {db_name}")
+
+
+def test_persistent_processing_nodes_cleanup(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = "max_persistent_processing_nodes_cleanup"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "polling_max_timeout_ms": 1000,
+            "polling_backoff_ms": 1000,
+            "use_persistent_processing_nodes": 1,
+            "persistent_processing_node_ttl_seconds": 10,
+            "cleanup_interval_min_ms": 0,
+            "cleanup_interval_max_ms": 0,
+        },
+    )
+
+    zk = started_cluster.get_kazoo_client("zoo1")
+    zk.create(f"{keeper_path}/processing/test", b"somedata")
+    zk.create(f"{keeper_path}/persistent_processing/test", b"somedata")
+    assert b"somedata" == zk.get(f"{keeper_path}/persistent_processing/test")[0]
+
+    time.sleep(5)
+    assert b"somedata" == zk.get(f"{keeper_path}/persistent_processing/test")[0]
+    time.sleep(6)
+    try:
+        zk.get(f"{keeper_path}/persistent_processing/test")[0]
+        assert False
+    except NoNodeError:
+        pass
+    assert b"somedata" == zk.get(f"{keeper_path}/processing/test")[0]
+
+
+def test_persistent_processing(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = "max_persistent_processing"
+    dst_table_name = f"{table_name}_dst"
+    mv_name = f"{table_name}_mv"
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+    format = "a Int32, b String"
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        format=format,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "polling_max_timeout_ms": 1000,
+            "polling_backoff_ms": 1000,
+            "use_persistent_processing_nodes": 1,
+            "persistent_processing_node_ttl_seconds": 10,
+            "cleanup_interval_min_ms": 100,
+            "cleanup_interval_max_ms": 500,
+            "polling_max_timeout_ms": 1000,
+            "polling_backoff_ms": 100,
+        },
+    )
+    file_name = f"file_{table_name}.csv"
+    s3_function = f"s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/{files_path}/{file_name}', 'minio', '{minio_secret_key}')"
+    node.query(
+        f"INSERT INTO FUNCTION {s3_function} select number, randomString(100) FROM numbers(10)"
+    )
+
+    zk = started_cluster.get_kazoo_client("zoo1")
+    nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+    assert len(nodes) == 0
+
+    node.query(
+        f"""
+        CREATE TABLE {dst_table_name} ({format})
+        ENGINE = MergeTree
+        ORDER BY a;
+    """
+    )
+    node.query(
+        f"""
+        CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT * FROM {table_name} WHERE NOT sleepEachRow(1);
+        """
+    )
+
+    found = False
+    for _ in range(10):
+        nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+        if len(nodes) > 0:
+            found = True
+            break
+        time.sleep(1)
+    assert found
+
+    time.sleep(10)
+
+    nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+    assert len(nodes) == 0
+
+
+def test_persistent_processing_failed_commit_retries(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = "max_persistent_processing_failed_commit_retries"
+    dst_table_name = f"{table_name}_dst"
+    mv_name = f"{table_name}_mv"
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+    format = "a Int32, b String"
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        format=format,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "polling_max_timeout_ms": 1000,
+            "polling_backoff_ms": 1000,
+            "use_persistent_processing_nodes": 1,
+            "persistent_processing_node_ttl_seconds": 60,
+            "cleanup_interval_min_ms": 100,
+            "cleanup_interval_max_ms": 500,
+            "polling_max_timeout_ms": 1000,
+            "polling_backoff_ms": 100,
+        },
+    )
+    i = [0]
+
+    def insert():
+        i[0] += 1
+        file_name = f"file_{table_name}_{i[0]}.csv"
+        s3_function = f"s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/{files_path}/{file_name}', 'minio', '{minio_secret_key}')"
+        node.query(
+            f"INSERT INTO FUNCTION {s3_function} select number, randomString(100) FROM numbers(10)"
+        )
+
+    insert()
+
+    zk = started_cluster.get_kazoo_client("zoo1")
+    nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+    assert len(nodes) == 0
+
+    node.query(
+        f"""
+        CREATE TABLE {dst_table_name} ({format})
+        ENGINE = MergeTree
+        ORDER BY a;
+    """
+    )
+
+    node.query(f"SYSTEM ENABLE FAILPOINT object_storage_queue_fail_commit_once")
+    node.query(
+        f"""
+        CREATE MATERIALIZED VIEW {mv_name} TO {dst_table_name} AS SELECT * FROM {table_name} WHERE NOT sleepEachRow(0.3);
+        """
+    )
+
+    found = False
+    for _ in range(10):
+        nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+        if len(nodes) > 0:
+            found = True
+            break
+        time.sleep(1)
+    assert found
+
+    found = False
+    for _ in range(10):
+        if node.contains_in_log(
+            f"StorageS3Queue (default.{table_name}): Successfully committed"
+        ):
+            found = True
+            break
+        time.sleep(1)
+    assert found
+
+    assert node.contains_in_log(
+        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 1/6"
+    )
+    assert not node.contains_in_log(
+        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 5/6"
+    )
+
+    nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+    assert len(nodes) == 0
+
+    node.query(f"SYSTEM ENABLE FAILPOINT object_storage_queue_fail_commit")
+    insert()
+
+    found = False
+    for _ in range(20):
+        if node.contains_in_log(
+            f"StorageS3Queue (default.{table_name}): Failed to process data: Code: 999. Coordination::Exception: Failed to commit processed files"
+        ):
+            found = True
+            break
+        time.sleep(1)
+
+    node.query(f"SYSTEM DISABLE FAILPOINT object_storage_queue_fail_commit")
+    assert found
+
+    assert node.contains_in_log(
+        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 6/6"
+    )
+
+    found = False
+    for _ in range(30):
+        nodes = zk.get_children(f"{keeper_path}/persistent_processing")
+        if len(nodes) == 0:
+            found = True
+            break
+        time.sleep(1)
+    assert found

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -1314,7 +1314,7 @@ def test_persistent_processing(started_cluster):
 
 def test_persistent_processing_failed_commit_retries(started_cluster):
     node = started_cluster.instances["instance"]
-    table_name = "max_persistent_processing_failed_commit_retries"
+    table_name = f"max_persistent_processing_failed_commit_retries_{generate_random_string()}"
     dst_table_name = f"{table_name}_dst"
     mv_name = f"{table_name}_mv"
     keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved S3(Azure)Queue table engine to allow it to survive zookeeper connection loss without potential duplicates. Requires enabling S3Queue setting `use_persistent_processing_nodes` (changeable by `ALTER TABLE MODIFY SETTING`).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
