### PR TITLE
Refactoring: Unnest `GinFilter::QueryString`

### DIFF
--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -30,7 +30,7 @@ GinFilter::Parameters::Parameters(
 {
 }
 
-GinFilter::QueryString::QueryString(std::string_view query_string_, const std::vector<String> & search_terms_)
+GinQueryString::GinQueryString(std::string_view query_string_, const std::vector<String> & search_terms_)
     : query_string(query_string_)
     , terms(search_terms_)
 {
@@ -187,7 +187,7 @@ bool matchInRange(const GinSegmentWithRowIdRangeVector & rowid_ranges, const Gin
 
 }
 
-bool GinFilter::contains(const GinFilter::QueryString & gin_query_string, PostingsCacheForStore & cache_store, GinSearchMode search_mode) const
+bool GinFilter::contains(const GinQueryString & gin_query_string, PostingsCacheForStore & cache_store, GinSearchMode search_mode) const
 {
     if (gin_query_string.getTerms().empty())
         return true;

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -280,7 +280,7 @@ void DefaultTokenExtractor::substringToBloomFilter(const char * data, size_t len
             bloom_filter.add(data + token_start, token_len);
 }
 
-void DefaultTokenExtractor::substringToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string, bool is_prefix, bool is_suffix) const
+void DefaultTokenExtractor::substringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string, bool is_prefix, bool is_suffix) const
 {
     gin_query_string.setQueryString({data, length});
 

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -56,7 +56,7 @@ struct ITokenExtractor
     virtual void stringLikeToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const = 0;
 
     /// Updates GIN filter from exact-match string filter value
-    virtual void stringToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string) const = 0;
+    virtual void stringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const = 0;
 
     /// Updates GIN filter from substring-match string filter value.
     /// An `ITokenExtractor` implementation may decide to skip certain
@@ -64,19 +64,19 @@ struct ITokenExtractor
     virtual void substringToGinFilter(
         const char * data,
         size_t length,
-        GinFilter::QueryString & gin_query_string,
+        GinQueryString & gin_query_string,
         bool /*is_prefix*/,
         bool /*is_suffix*/) const
     {
         stringToGinFilter(data, length, gin_query_string);
     }
 
-    virtual void stringPaddedToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string) const
+    virtual void stringPaddedToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const
     {
         stringToGinFilter(data, length, gin_query_string);
     }
 
-    virtual void stringLikeToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string) const = 0;
+    virtual void stringLikeToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const = 0;
 
     virtual bool supportsStringLike() const = 0;
 };
@@ -115,7 +115,7 @@ class ITokenExtractorHelper : public ITokenExtractor
             bloom_filter.add(token.c_str(), token.size());
     }
 
-    void stringToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string) const override
+    void stringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const override
     {
         gin_query_string.setQueryString({data, length});
         const auto & tokens = getTokensView(data, length);
@@ -123,7 +123,7 @@ class ITokenExtractorHelper : public ITokenExtractor
             gin_query_string.addTerm(token);
     }
 
-    void stringPaddedToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string) const override
+    void stringPaddedToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const override
     {
         gin_query_string.setQueryString({data, length});
 
@@ -135,7 +135,7 @@ class ITokenExtractorHelper : public ITokenExtractor
             gin_query_string.addTerm({data + token_start, token_len});
     }
 
-    void stringLikeToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string) const override
+    void stringLikeToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const override
     {
         gin_query_string.setQueryString({data, length});
 
@@ -177,7 +177,7 @@ struct DefaultTokenExtractor final : public ITokenExtractorHelper<DefaultTokenEx
     bool nextInStringPadded(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
     bool nextInStringLike(const char * data, size_t length, size_t * __restrict pos, String & token) const override;
     void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
-    void substringToGinFilter(const char * data, size_t length, GinFilter::QueryString & gin_query_string, bool is_prefix, bool is_suffix) const override;
+    void substringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string, bool is_prefix, bool is_suffix) const override;
 
     bool supportsStringLike() const override { return true; }
 };

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -101,16 +101,16 @@ private:
         };
 
         RPNElement( /// NOLINT
-            Function function_ = FUNCTION_UNKNOWN, std::unique_ptr<GinFilter::QueryString> && gin_query_string_ = nullptr)
+            Function function_ = FUNCTION_UNKNOWN, std::unique_ptr<GinQueryString> && gin_query_string_ = nullptr)
                 : function(function_), gin_query_string(std::move(gin_query_string_)) {}
 
         Function function = FUNCTION_UNKNOWN;
 
         /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS
-        std::unique_ptr<GinFilter::QueryString> gin_query_string;
+        std::unique_ptr<GinQueryString> gin_query_string;
 
         /// For FUNCTION_IN and FUNCTION_NOT_IN
-        std::vector<std::vector<GinFilter::QueryString>> gin_query_strings_for_set;
+        std::vector<std::vector<GinQueryString>> gin_query_strings_for_set;
 
         /// For FUNCTION_IN and FUNCTION_NOT_IN
         std::vector<size_t> set_key_position;


### PR DESCRIPTION
This is follow-up to #85979 which nested some classes.

Open PR #83837 does a cyclic include of two headers which isn't easy to get rid of. To break the cyclic include, a forward declaration is needed, unfortunately C++ does not allow forward-declaring nested classes. Therefore, this PR unnests the problematic class again.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)