### PR TITLE
Forbid altering columns whose subcolumns are used in PK or partition expression

### DIFF
--- a/tests/queries/0_stateless/03597_alter_column_with_subcolumn_in_key.sql
+++ b/tests/queries/0_stateless/03597_alter_column_with_subcolumn_in_key.sql
@@ -1,0 +1,14 @@
+drop table if exists test;
+create table test (id UInt32, t Tuple(a UInt32)) engine=MergeTree order by t.a;
+insert into test select 1, tuple(1);
+alter table test update t = tuple(2) where 1; -- {serverError CANNOT_UPDATE_COLUMN}
+alter table test modify column t Tuple(a String); -- {serverError ALTER_OF_COLUMN_IS_FORBIDDEN}
+drop table test;
+
+drop table if exists test;
+create table test (id UInt32, json JSON) engine=MergeTree order by json.a::Int64;
+insert into test select 1, '{"a" : 42}';
+alter table test update json = '{}' where 1; -- {serverError CANNOT_UPDATE_COLUMN}
+alter table test modify column json JSON(a String); -- {serverError ALTER_OF_COLUMN_IS_FORBIDDEN}
+drop table test;
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Forbid altering columns whose subcolumns are used in PK or partition expression.

Closes https://github.com/ClickHouse/ClickHouse/issues/84777

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
