### PR TITLE
Add JIT support to `ColumnString` comparison.

### DIFF
--- a/base/base/memcmpSmall.h
+++ b/base/base/memcmpSmall.h
@@ -841,7 +841,7 @@ inline bool memequalSmallLikeZeroPaddedAllowOverflow15(const Char * a, size_t a_
     return 0 == memcmpSmallLikeZeroPaddedAllowOverflow15(a, a_size, b, b_size);
 }
 
-inline int memcmpSmallCharsAllowOverflow15(const char* a, size_t a_size, const char* b, size_t b_size)
+inline int memcmpSmallCharsAllowOverflow15(const UInt8* a, size_t a_size, const UInt8* b, size_t b_size)
 {
     return memcmpSmallAllowOverflow15(a, a_size, b, b_size);
 }

--- a/base/base/memcmpSmall.h
+++ b/base/base/memcmpSmall.h
@@ -840,3 +840,8 @@ inline bool memequalSmallLikeZeroPaddedAllowOverflow15(const Char * a, size_t a_
 {
     return 0 == memcmpSmallLikeZeroPaddedAllowOverflow15(a, a_size, b, b_size);
 }
+
+inline int memcmpSmallCharsAllowOverflow15(const char* a, size_t a_size, const char* b, size_t b_size)
+{
+    return memcmpSmallAllowOverflow15(a, a_size, b, b_size);
+}

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -190,7 +190,7 @@ llvm::Value * ColumnFixedString::compileComparator(llvm::IRBuilderBase & b, llvm
         module->getOrInsertFunction("memcmpSmallCharsAllowOverflow15", memcmp_func_type).getCallee()
     );
     auto * compare_result = b.CreateCall(memcmp_func, {lhs_current_ptr, n_value, rhs_current_ptr, n_value});
-    
+
     auto * lhs_greater_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 1);
     auto * lhs_less_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), -1);
     auto * lhs_equals_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 0);

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -18,6 +18,12 @@
 #    include <emmintrin.h>
 #endif
 
+#if USE_EMBEDDED_COMPILER
+#    include <llvm/IR/Function.h>
+#    include <llvm/IR/IRBuilder.h>
+#    include <llvm/IR/Module.h>
+#endif
+
 
 namespace DB
 {
@@ -161,6 +167,41 @@ void ColumnFixedString::updateHashFast(SipHash & hash) const
     hash.update(n);
     hash.update(reinterpret_cast<const char *>(chars.data()), size() * n);
 }
+
+#if USE_EMBEDDED_COMPILER
+bool ColumnFixedString::isComparatorCompilable() const { return true; }
+llvm::Value * ColumnFixedString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const
+{
+    llvm::Value * lhs_chars_ptr = b.CreateExtractValue(lhs, {0});
+    llvm::Value * lhs_row_index = b.CreateExtractValue(lhs, {1});
+    llvm::Value * rhs_chars_ptr = b.CreateExtractValue(rhs, {0});
+    llvm::Value * rhs_row_index = b.CreateExtractValue(rhs, {1});
+
+    auto * size_type = b.getInt64Ty();
+    auto * n_value = llvm::ConstantInt::get(size_type, n);
+
+    auto * lhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), lhs_chars_ptr, b.CreateMul(lhs_row_index, n_value));
+    auto * rhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), rhs_chars_ptr, b.CreateMul(rhs_row_index, n_value));
+
+    llvm::Module * module = b.GetInsertBlock()->getModule();
+    auto * memcmp_func_type = llvm::FunctionType::get(b.getInt32Ty(),
+        {lhs_current_ptr->getType(), n_value->getType(), rhs_current_ptr->getType(), n_value->getType()}, false);
+    llvm::Function * memcmp_func = llvm::dyn_cast<llvm::Function>(
+        module->getOrInsertFunction("memcmpSmallCharsAllowOverflow15", memcmp_func_type).getCallee()
+    );
+    auto * compare_result = b.CreateCall(memcmp_func, {lhs_current_ptr, n_value, rhs_current_ptr, n_value});
+    
+    auto * lhs_greater_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 1);
+    auto * lhs_less_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), -1);
+    auto * lhs_equals_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 0);
+
+    auto * is_greater = b.CreateICmpSGT(compare_result, b.getInt32(0));  // compare_result > 0
+    auto * is_less = b.CreateICmpSLT(compare_result, b.getInt32(0));     // compare_result < 0
+    auto * result_if_not_greater = b.CreateSelect(is_less, lhs_less_than_rhs_result, lhs_equals_rhs_result);
+    auto * final_result = b.CreateSelect(is_greater, lhs_greater_than_rhs_result, result_if_not_greater);
+    return final_result;
+}
+#endif
 
 struct ColumnFixedString::ComparatorBase
 {

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -169,7 +169,7 @@ void ColumnFixedString::updateHashFast(SipHash & hash) const
 }
 
 #if USE_EMBEDDED_COMPILER
-bool ColumnFixedString::isComparatorCompilable() const { return true; }
+bool ColumnFixedString::isComparatorCompilable() const { return false; }
 llvm::Value * ColumnFixedString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const
 {
     llvm::Value * lhs_chars_ptr = b.CreateExtractValue(lhs, {0});

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -169,7 +169,7 @@ void ColumnFixedString::updateHashFast(SipHash & hash) const
 }
 
 #if USE_EMBEDDED_COMPILER
-bool ColumnFixedString::isComparatorCompilable() const { return false; }
+bool ColumnFixedString::isComparatorCompilable() const { return true; }
 llvm::Value * ColumnFixedString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const
 {
     llvm::Value * lhs_chars_ptr = b.CreateExtractValue(lhs, {0});

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -158,6 +158,11 @@ public:
         return memcmpSmallAllowOverflow15(chars.data() + p1 * n, rhs.chars.data() + p2 * n, n);
     }
 
+#if USE_EMBEDDED_COMPILER
+    bool isComparatorCompilable() const override;
+    llvm::Value * compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const override;
+#endif
+
     void getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                     size_t limit, int nan_direction_hint, Permutation & res) const override;
 

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -713,7 +713,7 @@ ColumnPtr ColumnString::compress(bool force_compression) const
 #if USE_EMBEDDED_COMPILER
 bool ColumnString::isComparatorCompilable() const
 {
-    return true;
+    return false;
 }
 
 llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -738,13 +738,13 @@ llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Val
     auto * lhs_prev_index = b.CreateSub(lhs_index, const_one);
     auto * lhs_current_start_offset = load_offset(lhs_offset_ptr, lhs_prev_index);
     auto * lhs_current_end_offset = load_offset(lhs_offset_ptr, lhs_index);
-    auto * lhs_current_size = b.CreateSub(b.CreateSub(lhs_current_end_offset, lhs_current_start_offset), const_one);
+    auto * lhs_current_size = b.CreateSub(lhs_current_end_offset, lhs_current_start_offset);
     auto * lhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), lhs_chars_ptr, lhs_current_start_offset);
 
     auto * rhs_prev_index = b.CreateSub(rhs_index, const_one);
     auto * rhs_current_start_offset = load_offset(rhs_offset_ptr, rhs_prev_index);
     auto * rhs_current_end_offset = load_offset(rhs_offset_ptr, rhs_index);
-    auto * rhs_current_size = b.CreateSub(b.CreateSub(rhs_current_end_offset, rhs_current_start_offset), const_one);
+    auto * rhs_current_size = b.CreateSub(rhs_current_end_offset, rhs_current_start_offset);
     auto * rhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), rhs_chars_ptr, rhs_current_start_offset);
 
     // Call memcmpSmallAllowOverflow15, same as in ColumnString::compareAt

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -713,7 +713,7 @@ ColumnPtr ColumnString::compress(bool force_compression) const
 #if USE_EMBEDDED_COMPILER
 bool ColumnString::isComparatorCompilable() const
 {
-    return false;
+    return true;
 }
 
 llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -263,6 +263,11 @@ public:
         return memcmpSmallAllowOverflow15(chars.data() + offsetAt(n), sizeAt(n), rhs.chars.data() + rhs.offsetAt(m), rhs.sizeAt(m));
     }
 
+#if USE_EMBEDDED_COMPILER
+    bool isComparatorCompilable() const override;
+    llvm::Value * compileComparator(llvm::IRBuilderBase & /*builder*/, llvm::Value * /*lhs*/, llvm::Value * /*rhs*/, llvm::Value * /*nan_direction_hint*/) const override;
+#endif
+
     /// Variant of compareAt for string comparison with respect of collation.
     int compareAtWithCollation(size_t n, size_t m, const IColumn & rhs_, int, const Collator & collator) const override;
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -265,7 +265,7 @@ public:
 
 #if USE_EMBEDDED_COMPILER
     bool isComparatorCompilable() const override;
-    llvm::Value * compileComparator(llvm::IRBuilderBase & /*builder*/, llvm::Value * /*lhs*/, llvm::Value * /*rhs*/, llvm::Value * /*nan_direction_hint*/) const override;
+    llvm::Value * compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const override;
 #endif
 
     /// Variant of compareAt for string comparison with respect of collation.

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -141,7 +141,8 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
     for (const auto & type : sort_description_types)
     {
         auto nested_type = removeNullable(type);
-        if (!type->createColumn()->isComparatorCompilable() || (!canBeNativeType(*type) && (!WhichDataType(nested_type).isString())))
+        if (!type->createColumn()->isComparatorCompilable() ||
+            (!canBeNativeType(*type) && !WhichDataType(nested_type).isString() && !WhichDataType(nested_type).isFixedString()))
             return;
     }
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -6,6 +6,7 @@
 #include <Common/SipHash.h>
 #include <Common/typeid_cast.h>
 #include <Common/logger_useful.h>
+#include <DataTypes/DataTypeNullable.h>
 
 #include "config.h"
 
@@ -139,9 +140,11 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
 
     for (const auto & type : sort_description_types)
     {
-        if (!type->createColumn()->isComparatorCompilable() || !canBeNativeType(*type))
+        auto nested_type = removeNullable(type);
+        if (!type->createColumn()->isComparatorCompilable() || (!canBeNativeType(*type) && (!WhichDataType(nested_type).isString())))
             return;
     }
+
 
     auto description_dump = getSortDescriptionDump(description, sort_description_types);
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -137,9 +137,10 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
     if (!description.compile_sort_description || sort_description_types.empty())
         return;
 
+    bool x = true;
     for (const auto & type : sort_description_types)
     {
-        if (!type->createColumn()->isComparatorCompilable() || !canBeNativeType(*type))
+        if (!type->createColumn()->isComparatorCompilable() || !canBeNativeType(*type) || x)
             return;
     }
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -137,10 +137,9 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
     if (!description.compile_sort_description || sort_description_types.empty())
         return;
 
-    bool x = true;
     for (const auto & type : sort_description_types)
     {
-        if (!type->createColumn()->isComparatorCompilable() || !canBeNativeType(*type) || x)
+        if (!type->createColumn()->isComparatorCompilable() || !canBeNativeType(*type))
             return;
     }
 

--- a/src/Interpreters/JIT/CHJIT.cpp
+++ b/src/Interpreters/JIT/CHJIT.cpp
@@ -29,6 +29,7 @@
 #include <llvm/Support/SmallVectorMemoryBuffer.h>
 
 #include <base/getPageSize.h>
+#include <base/memcmpSmall.h>
 #include <Common/Exception.h>
 #include <Common/formatReadable.h>
 
@@ -372,6 +373,7 @@ CHJIT::CHJIT()
     symbol_resolver->registerSymbol("memset", reinterpret_cast<void *>(&memset));
     symbol_resolver->registerSymbol("memcpy", reinterpret_cast<void *>(&memcpy));
     symbol_resolver->registerSymbol("memcmp", reinterpret_cast<void *>(&memcmp));
+    symbol_resolver->registerSymbol("memcmpSmallCharsAllowOverflow15", reinterpret_cast<void *>(&memcmpSmallCharsAllowOverflow15));
 }
 
 CHJIT::~CHJIT() = default;

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -70,7 +70,7 @@ ColumnData getColumnData(const IColumn * column, size_t skip_rows)
     return result;
 }
 
-llvm::StructType * buildColumnDataLLVMStruct(llvm::IRBuilderBase & b)
+llvm::StructType * buildColumnDataStruct(llvm::IRBuilderBase & b)
 {
     auto * char_ptr_type = b.getInt8Ty()->getPointerTo();
     return llvm::StructType::get(char_ptr_type, char_ptr_type, char_ptr_type);
@@ -87,7 +87,7 @@ llvm::StructType * buildStringRefType(llvm::IRBuilderBase &b)
 llvm::StructType * buildFixedStringType(llvm::IRBuilderBase &b)
 {
     auto * data_ptr_type = b.getInt8Ty()->getPointerTo();
-    return llvm::StructType::get(data_ptr_type, b.getIntNTy(sizeof(size_t) * 8));
+    return llvm::StructType::get(data_ptr_type, b.getInt64Ty());
 }
 
 static void compileFunction(llvm::Module & module, const IFunctionBase & function)
@@ -96,7 +96,7 @@ static void compileFunction(llvm::Module & module, const IFunctionBase & functio
 
     llvm::IRBuilder<> b(module.getContext());
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
-    auto * data_type = buildColumnDataLLVMStruct(b);
+    auto * data_type = buildColumnDataStruct(b);
     auto * func_type = llvm::FunctionType::get(b.getVoidTy(), { size_type, data_type->getPointerTo() }, /*isVarArg=*/false);
 
     /// Create function in module
@@ -263,7 +263,7 @@ static void compileAddIntoAggregateStatesFunctions(llvm::Module & module,
     else
         places_type = b.getInt8Ty()->getPointerTo();
 
-    auto * column_type = buildColumnDataLLVMStruct(b);
+    auto * column_type = buildColumnDataStruct(b);
 
     auto * add_into_aggregate_states_func_declaration = llvm::FunctionType::get(b.getVoidTy(), { size_type, size_type, column_type->getPointerTo(), places_type }, false);
     auto * add_into_aggregate_states_func = llvm::Function::Create(add_into_aggregate_states_func_declaration, llvm::Function::ExternalLinkage, name, module);
@@ -448,7 +448,7 @@ static void compileInsertAggregatesIntoResultColumns(llvm::Module & module, cons
 
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
 
-    auto * column_type = buildColumnDataLLVMStruct(b);
+    auto * column_type = buildColumnDataStruct(b);
     auto * aggregate_data_places_type = b.getInt8Ty()->getPointerTo()->getPointerTo();
     auto * insert_aggregates_into_result_func_declaration = llvm::FunctionType::get(b.getVoidTy(), { size_type, size_type, column_type->getPointerTo(), aggregate_data_places_type }, false);
     auto * insert_aggregates_into_result_func = llvm::Function::Create(insert_aggregates_into_result_func_declaration, llvm::Function::ExternalLinkage, name, module);
@@ -581,7 +581,7 @@ static void compileSortDescription(llvm::Module & module,
 
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
 
-    auto * column_data_type = buildColumnDataLLVMStruct(b);
+    auto * column_data_type = buildColumnDataStruct(b);
 
     std::vector<llvm::Type *> function_argument_types = {size_type, size_type, column_data_type->getPointerTo(), column_data_type->getPointerTo()};
     auto * comparator_func_declaration = llvm::FunctionType::get(b.getInt8Ty(), function_argument_types, false);

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -67,8 +67,7 @@ ColumnData getColumnData(const IColumn * column, size_t skip_rows)
 llvm::StructType * buildColumnDataLLVMStruct(llvm::IRBuilderBase & b)
 {
     auto * char_ptr_type = b.getInt8Ty()->getPointerTo();
-    auto * column_type_enum = b.getInt32Ty();
-    return llvm::StructType::get(char_ptr_type, char_ptr_type, column_type_enum, char_ptr_type);
+    return llvm::StructType::get(char_ptr_type, char_ptr_type, char_ptr_type);
 }
 
 static void compileFunction(llvm::Module & module, const IFunctionBase & function)
@@ -593,10 +592,11 @@ static void compileSortDescription(llvm::Module & module,
 
         const auto & sort_description = description[i];
         const auto & column_type = sort_description_types[i];
+        auto nested_column_type = removeNullable(column_type);
 
         auto dummy_column = column_type->createColumn();
 
-        auto * column_native_type = toNativeType(b, removeNullable(column_type));
+        auto * column_native_type = toNativeType(b, nested_column_type);
         if (!column_native_type)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No native type for column type {}", column_type->getName());
 

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -620,12 +620,12 @@ static void compileSortDescription(llvm::Module & module,
         {
             auto * string_ref_type = buildStringRefType(b);
             auto * nullable_uninitialized = llvm::Constant::getNullValue(toNullableType(b, string_ref_type));
-            
+
             auto * column = b.CreateLoad(column_data_type, b.CreateConstInBoundsGEP1_64(column_data_type, column_arg, i));
             auto * column_data = b.CreateExtractValue(column, {0});
             auto * column_null_data = is_nullable ? b.CreateExtractValue(column, {1}) : nullptr;
             auto * column_offset_data = b.CreateExtractValue(column, {2});
-            
+
             /// build struct : {chars ptr, offset ptr, index}
             /// The string comparison logic is relatively complex, so here we only pass the raw memory pointer. The specific
             /// implementation will be completed in ColumnString::compileComparator
@@ -712,7 +712,7 @@ static void compileSortDescription(llvm::Module & module,
         }
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Not supported type for column type {}", column_type->getName());
-    
+
         llvm::Value * direction = llvm::ConstantInt::getSigned(b.getInt8Ty(), sort_description.direction);
         llvm::Value * nan_direction_hint = llvm::ConstantInt::getSigned(b.getInt8Ty(), sort_description.nulls_direction);
         llvm::Value * compare_result = dummy_column->compileComparator(b, lhs_value, rhs_value, nan_direction_hint);

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -616,7 +616,7 @@ static void compileSortDescription(llvm::Module & module,
 
         auto dummy_column = column_type->createColumn();
 
-        auto try_load_nullable_value = [&](llvm::Value * value, llvm::Value * column_null_data, llvm::Value * index_arg) -> llvm::Value *
+        auto try_load_nullable_value = [&](llvm::Value * value, llvm::Value * nullable_uninitialized, llvm::Value * column_null_data, llvm::Value * index_arg) -> llvm::Value *
         {
             if (column_null_data)
             {
@@ -646,7 +646,7 @@ static void compileSortDescription(llvm::Module & module,
             value = b.CreateInsertValue(value, column_offset_data, {1});
             value = b.CreateInsertValue(value, index_arg, {2});
 
-            return try_load_nullable_value(value, column_null_data, index_arg);
+            return try_load_nullable_value(value, nullable_uninitialized, column_null_data, index_arg);
         };
 
         auto load_column_fixed_string_value = [&](llvm::Value * column_arg, llvm::Value * index_arg, bool is_nullable)
@@ -663,7 +663,7 @@ static void compileSortDescription(llvm::Module & module,
             value = b.CreateInsertValue(value, column_data, {0});
             value = b.CreateInsertValue(value, index_arg, {1});
 
-            return try_load_nullable_value(value, column_null_data, index_arg);
+            return try_load_nullable_value(value, nullable_uninitialized, column_null_data, index_arg);
         };
 
         auto load_column_native_value = [&](llvm::Value * column_arg, llvm::Value * index_arg, bool is_nullable)
@@ -681,7 +681,7 @@ static void compileSortDescription(llvm::Module & module,
             llvm::Value * column_element_offset = b.CreateInBoundsGEP(column_native_type, column_data, index_arg);
             llvm::Value * value = b.CreateLoad(column_native_type, column_element_offset);
 
-            return try_load_nullable_value(value, column_null_data, index_arg);
+            return try_load_nullable_value(value, nullable_uninitialized, column_null_data, index_arg);
         };
 
         llvm::Value * lhs_value = nullptr;

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -80,7 +80,7 @@ llvm::StructType * buildStringRefType(llvm::IRBuilderBase &b)
 {
     auto * data_ptr_type = b.getInt8Ty()->getPointerTo();
     auto * offset_ptr_type = b.getInt8Ty()->getPointerTo();
-    auto * index_type = b.getIntNTy(sizeof(size_t) * 8);
+    auto * index_type = b.getInt64Ty();
     return llvm::StructType::get(data_ptr_type, offset_ptr_type, index_type);
 }
 

--- a/src/Interpreters/JIT/compileFunction.h
+++ b/src/Interpreters/JIT/compileFunction.h
@@ -17,16 +17,10 @@ namespace DB
   * data is raw column data.
   * null_data is null map column raw data.
   */
-enum class ColumnType : uint32_t
-{
-    NativeNumber = 0, // Native data type, e.g. UInt64, Int32, etc.
-    String = 1, // String data type
-};
 struct ColumnData
 {
     const char * data = nullptr;
     const char * null_data = nullptr;
-    ColumnType type = ColumnType::NativeNumber; // Column data type
     const char * offset_data = nullptr; // For String type, points to offsets data
 };
 

--- a/src/Interpreters/JIT/compileFunction.h
+++ b/src/Interpreters/JIT/compileFunction.h
@@ -17,10 +17,17 @@ namespace DB
   * data is raw column data.
   * null_data is null map column raw data.
   */
+enum class ColumnType : uint32_t
+{
+    NativeNumber = 0, // Native data type, e.g. UInt64, Int32, etc.
+    String = 1, // String data type
+};
 struct ColumnData
 {
     const char * data = nullptr;
     const char * null_data = nullptr;
+    ColumnType type = ColumnType::NativeNumber; // Column data type
+    const char * offset_data = nullptr; // For String type, points to offsets data
 };
 
 /** Returns ColumnData for column.

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,0 +1,10 @@
+<test>
+    <create_query>CREATE TABLE str_sort (a String, b UInt64) ENGINE = MEMEORY</create_query>
+    <fill_query>
+        INSERT INTO str_sort SELECT ('number key ' || toString(number % 400)) AS a, number % 20 AS b FROM numbers(1e7)
+    </fill_query>
+
+    <query>SELECT a, b FROM str_sort ORDER BY a, b FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS str_sort</drop_query>
+</test>

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,10 +1,12 @@
 <test>
-    <create_query>CREATE TABLE str_sort (a String, b UInt64) ENGINE = MEMEORY</create_query>
+    <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String ) ENGINE = Memory</create_query>
     <fill_query>
-        INSERT INTO str_sort SELECT ('number key ' || toString(number % 400)) AS a, number % 20 AS b FROM numbers(1e7)
+        INSERT INTO str_sort SELECT ('number key ' || toString(number % 400)) AS a, number % 20 AS b, ('ABCD' || toString(rand()%10)) as c, toString(rand() % 100000) as d FROM numbers(1e7)
     </fill_query>
 
     <query>SELECT a, b FROM str_sort ORDER BY a, b FORMAT Null</query>
+    <query>SELECT b, c FROM str_sort ORDER BY b, c FORMAT Null</query>
+    <query>SELECT a, d FROM str_sort ORDER BY c, d FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS str_sort</drop_query>
 </test>

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,13 +1,14 @@
 <test>
     <settings>
-        <max_threads>2</max_threads>
+        <max_threads>8</max_threads>
+        <min_count_to_compile_sort_description>0</min_count_to_compile_sort_description>
     </settings>
     <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
     <fill_query>
         INSERT INTO str_sort
         SELECT 
-            ('number key ' || toString(number % 400)) AS a,
-            number % 20 AS b, ('ABCD' || toString(rand()%10)) as c,
+            randomString(4) AS a,
+            rand()  AS b, cast(randomString(5) AS FixedString(5)) as c,
             toString(rand() % 100000) as d,
             rand() % 1000 as e,
             rand() % 1000 as f

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,12 +1,19 @@
 <test>
-    <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String ) ENGINE = Memory</create_query>
+    <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
     <fill_query>
-        INSERT INTO str_sort SELECT ('number key ' || toString(number % 400)) AS a, number % 20 AS b, ('ABCD' || toString(rand()%10)) as c, toString(rand() % 100000) as d FROM numbers(1e7)
+        INSERT INTO str_sort
+        SELECT 
+            ('number key ' || toString(number % 400)) AS a,
+            number % 20 AS b, ('ABCD' || toString(rand()%10)) as c,
+            toString(rand() % 100000) as d,
+            rand() % 1000 as e,
+            rand() % 1000 as f
+        FROM numbers(1e7)
     </fill_query>
 
-    <query>SELECT a, b FROM str_sort ORDER BY a, b FORMAT Null</query>
-    <query>SELECT b, c FROM str_sort ORDER BY b, c FORMAT Null</query>
-    <query>SELECT a, d FROM str_sort ORDER BY c, d FORMAT Null</query>
+    <query>SELECT a, b FROM str_sort ORDER BY a, b, e, f FORMAT Null</query>
+    <query>SELECT b, c FROM str_sort ORDER BY b, c, e, f FORMAT Null</query>
+    <query>SELECT a, d FROM str_sort ORDER BY c, d, e, f FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS str_sort</drop_query>
 </test>

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,4 +1,7 @@
 <test>
+    <settings>
+        <max_threads>2</max_threads>
+    </settings>
     <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
     <fill_query>
         INSERT INTO str_sort

--- a/tests/queries/0_stateless/00079_array_join_not_used_joined_column.sql
+++ b/tests/queries/0_stateless/00079_array_join_not_used_joined_column.sql
@@ -1,4 +1,6 @@
 -- Tags: stateful
+-- { echoOn }
 SELECT PP.Key1 AS `ym:s:paramsLevel1`, sum(arrayAll(`x_1` -> `x_1`= '', ParsedParams.Key2)) AS `ym:s:visits` FROM test.hits ARRAY JOIN ParsedParams AS `PP`  WHERE CounterID = 1704509 GROUP BY `ym:s:paramsLevel1` ORDER BY PP.Key1, `ym:s:visits` LIMIT 0, 100;
 SELECT PP.Key1 AS x1, ParsedParams.Key2 AS x2 FROM test.hits ARRAY JOIN ParsedParams AS PP WHERE CounterID = 1704509 ORDER BY x1, x2 LIMIT 10;
 SELECT ParsedParams.Key2 AS x FROM test.hits ARRAY JOIN ParsedParams AS PP ORDER BY x DESC LIMIT 10;
+-- { echoOff }

--- a/tests/queries/0_stateless/00079_array_join_not_used_joined_column.sql
+++ b/tests/queries/0_stateless/00079_array_join_not_used_joined_column.sql
@@ -1,6 +1,4 @@
 -- Tags: stateful
--- { echoOn }
 SELECT PP.Key1 AS `ym:s:paramsLevel1`, sum(arrayAll(`x_1` -> `x_1`= '', ParsedParams.Key2)) AS `ym:s:visits` FROM test.hits ARRAY JOIN ParsedParams AS `PP`  WHERE CounterID = 1704509 GROUP BY `ym:s:paramsLevel1` ORDER BY PP.Key1, `ym:s:visits` LIMIT 0, 100;
 SELECT PP.Key1 AS x1, ParsedParams.Key2 AS x2 FROM test.hits ARRAY JOIN ParsedParams AS PP WHERE CounterID = 1704509 ORDER BY x1, x2 LIMIT 10;
 SELECT ParsedParams.Key2 AS x FROM test.hits ARRAY JOIN ParsedParams AS PP ORDER BY x DESC LIMIT 10;
--- { echoOff }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add JIT support to ColumnString comparison, ​​extending JIT coverage to most ORDER BY operations.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
