### PR TITLE
Fix ALTER COLUMN IF EXISTS runtime checks to handle column state changes

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -496,6 +496,11 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
 
 void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context) const
 {
+    /// Helper function for column existence check with IF EXISTS
+    auto should_skip_column_operation = [&]() -> bool {
+        return if_exists && !metadata.columns.has(column_name);
+    };
+
     if (type == ADD_COLUMN)
     {
         ColumnDescription column(column_name, data_type);
@@ -586,10 +591,16 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
 
         /// Otherwise just clear data on disk
         if (!clear && !partition)
+        {
+            if (should_skip_column_operation())
+                return;
             metadata.columns.remove(column_name);
+        }
     }
     else if (type == MODIFY_COLUMN)
     {
+        if (should_skip_column_operation())
+            return;
         metadata.columns.modify(column_name, after_column, first, [&](ColumnDescription & column)
         {
             if (to_remove == RemoveProperty::DEFAULT
@@ -680,8 +691,7 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
     }
     else if (type == COMMENT_COLUMN)
     {
-        // If column doesn't exist and IF EXISTS is used, skip silently
-        if (!metadata.columns.has(column_name) && if_exists)
+        if (should_skip_column_operation())
             return;
 
         metadata.columns.modify(column_name,
@@ -948,6 +958,8 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
     }
     else if (type == RENAME_COLUMN)
     {
+        if (should_skip_column_operation())
+            return;
         metadata.columns.rename(column_name, rename_to);
         RenameColumnData rename_data{column_name, rename_to};
         RenameColumnVisitor rename_visitor(rename_data);

--- a/tests/queries/0_stateless/03595_alter_if_exists_mixed_commands.reference
+++ b/tests/queries/0_stateless/03595_alter_if_exists_mixed_commands.reference
@@ -1,0 +1,2 @@
+y	String					
+b	String	DEFAULT	\'test\'			

--- a/tests/queries/0_stateless/03595_alter_if_exists_mixed_commands.sql
+++ b/tests/queries/0_stateless/03595_alter_if_exists_mixed_commands.sql
@@ -1,0 +1,30 @@
+-- Tags: no-replicated-database
+-- Test runtime IF EXISTS checks for mixed replicated/non-replicated ALTER commands
+-- This test verifies that IF EXISTS clauses work correctly when mixing different types
+-- of ALTER operations (replicated and non-replicated) in the same statement
+
+DROP TABLE IF EXISTS test_alter_mixed;
+
+-- Test 1: COMMENT COLUMN IF EXISTS with column deleted by previous command
+CREATE TABLE test_alter_mixed (x Int32, y String) ENGINE = Memory;
+-- This should succeed - DROP removes x, COMMENT with IF EXISTS should be silently ignored
+ALTER TABLE test_alter_mixed DROP COLUMN x, COMMENT COLUMN IF EXISTS x 'test comment';
+DESC test_alter_mixed;
+
+DROP TABLE test_alter_mixed;
+
+-- Test 2: Multiple operations with mixed types in sequence
+CREATE TABLE test_alter_mixed (a Int32, b String, c Float64) ENGINE = Memory;
+-- Complex case: multiple drops and modifications including comments
+ALTER TABLE test_alter_mixed 
+    DROP COLUMN a, 
+    DROP COLUMN IF EXISTS a,
+    MODIFY COLUMN IF EXISTS a Int64,
+    COMMENT COLUMN IF EXISTS a 'should be ignored',
+    RENAME COLUMN IF EXISTS a TO a_renamed,
+    MODIFY COLUMN IF EXISTS b String DEFAULT 'test',
+    DROP COLUMN c,
+    MODIFY COLUMN IF EXISTS c Float32;
+DESC test_alter_mixed;
+
+DROP TABLE test_alter_mixed;

--- a/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.reference
+++ b/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.reference
@@ -1,5 +1,3 @@
 c1	String					
 c1	String					
 y	String					
-y	String					
-b	String	DEFAULT	\'test\'			

--- a/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.reference
+++ b/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.reference
@@ -1,0 +1,5 @@
+c1	String					
+c1	String					
+y	String					
+y	String					
+b	String	DEFAULT	\'test\'			

--- a/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.sql
+++ b/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.sql
@@ -1,0 +1,61 @@
+-- Test runtime IF EXISTS checks for ALTER COLUMN commands
+-- This test verifies that IF EXISTS clauses work correctly when column state changes
+-- between validate() and apply() phases within the same ALTER statement
+
+DROP TABLE IF EXISTS test_alter_if_exists;
+
+-- Test 1: DROP COLUMN IF EXISTS with column deleted by previous command
+CREATE TABLE test_alter_if_exists (c0 Int32, c1 String) ENGINE = Memory;
+-- This should succeed - first DROP removes c0, second DROP with IF EXISTS should be silently ignored
+ALTER TABLE test_alter_if_exists DROP COLUMN c0, DROP COLUMN IF EXISTS c0;
+DESC test_alter_if_exists;
+
+DROP TABLE test_alter_if_exists;
+
+-- Test 2: MODIFY COLUMN IF EXISTS with column deleted by previous command  
+CREATE TABLE test_alter_if_exists (c0 Int32, c1 String) ENGINE = Memory;
+-- This should succeed - DROP removes c0, MODIFY with IF EXISTS should be silently ignored
+ALTER TABLE test_alter_if_exists DROP COLUMN c0, MODIFY COLUMN IF EXISTS c0 Int64;
+DESC test_alter_if_exists;
+
+DROP TABLE test_alter_if_exists;
+
+-- Test 3: COMMENT COLUMN IF EXISTS with column deleted by previous command
+CREATE TABLE test_alter_if_exists (x Int32, y String) ENGINE = Memory;
+-- This should succeed - DROP removes x, COMMENT with IF EXISTS should be silently ignored
+ALTER TABLE test_alter_if_exists DROP COLUMN x, COMMENT COLUMN IF EXISTS x 'test comment';
+DESC test_alter_if_exists;
+
+DROP TABLE test_alter_if_exists;
+
+-- Test 4: RENAME COLUMN IF EXISTS with column deleted by previous command
+CREATE TABLE test_alter_if_exists (x Int32, y String) ENGINE = Memory;
+-- This should succeed - DROP removes x, RENAME with IF EXISTS should be silently ignored
+ALTER TABLE test_alter_if_exists DROP COLUMN x, RENAME COLUMN IF EXISTS x TO z;
+DESC test_alter_if_exists;
+
+DROP TABLE test_alter_if_exists;
+
+-- Test 5: Multiple operations in sequence
+CREATE TABLE test_alter_if_exists (a Int32, b String, c Float64) ENGINE = Memory;
+-- Complex case: multiple drops and modifications
+ALTER TABLE test_alter_if_exists 
+    DROP COLUMN a, 
+    DROP COLUMN IF EXISTS a,
+    MODIFY COLUMN IF EXISTS a Int64,
+    COMMENT COLUMN IF EXISTS a 'should be ignored',
+    RENAME COLUMN IF EXISTS a TO a_renamed,
+    MODIFY COLUMN IF EXISTS b String DEFAULT 'test',
+    DROP COLUMN c,
+    MODIFY COLUMN IF EXISTS c Float32;
+DESC test_alter_if_exists;
+
+DROP TABLE test_alter_if_exists;
+
+-- Test 6: Verify that without IF EXISTS, operations fail as expected
+CREATE TABLE test_alter_if_exists (x Int32, y String) ENGINE = Memory;
+
+-- This should fail - trying to drop non-existent column without IF EXISTS
+ALTER TABLE test_alter_if_exists DROP COLUMN x, DROP COLUMN x; -- { serverError NOT_FOUND_COLUMN_IN_BLOCK }
+
+DROP TABLE IF EXISTS test_alter_if_exists;

--- a/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.sql
+++ b/tests/queries/0_stateless/03595_alter_if_exists_runtime_check.sql
@@ -20,15 +20,7 @@ DESC test_alter_if_exists;
 
 DROP TABLE test_alter_if_exists;
 
--- Test 3: COMMENT COLUMN IF EXISTS with column deleted by previous command
-CREATE TABLE test_alter_if_exists (x Int32, y String) ENGINE = Memory;
--- This should succeed - DROP removes x, COMMENT with IF EXISTS should be silently ignored
-ALTER TABLE test_alter_if_exists DROP COLUMN x, COMMENT COLUMN IF EXISTS x 'test comment';
-DESC test_alter_if_exists;
-
-DROP TABLE test_alter_if_exists;
-
--- Test 4: RENAME COLUMN IF EXISTS with column deleted by previous command
+-- Test 3: RENAME COLUMN IF EXISTS with column deleted by previous command
 CREATE TABLE test_alter_if_exists (x Int32, y String) ENGINE = Memory;
 -- This should succeed - DROP removes x, RENAME with IF EXISTS should be silently ignored
 ALTER TABLE test_alter_if_exists DROP COLUMN x, RENAME COLUMN IF EXISTS x TO z;
@@ -36,26 +28,5 @@ DESC test_alter_if_exists;
 
 DROP TABLE test_alter_if_exists;
 
--- Test 5: Multiple operations in sequence
-CREATE TABLE test_alter_if_exists (a Int32, b String, c Float64) ENGINE = Memory;
--- Complex case: multiple drops and modifications
-ALTER TABLE test_alter_if_exists 
-    DROP COLUMN a, 
-    DROP COLUMN IF EXISTS a,
-    MODIFY COLUMN IF EXISTS a Int64,
-    COMMENT COLUMN IF EXISTS a 'should be ignored',
-    RENAME COLUMN IF EXISTS a TO a_renamed,
-    MODIFY COLUMN IF EXISTS b String DEFAULT 'test',
-    DROP COLUMN c,
-    MODIFY COLUMN IF EXISTS c Float32;
-DESC test_alter_if_exists;
-
-DROP TABLE test_alter_if_exists;
-
--- Test 6: Verify that without IF EXISTS, operations fail as expected
+-- Test 4: Verify that without IF EXISTS, operations fail as expected
 CREATE TABLE test_alter_if_exists (x Int32, y String) ENGINE = Memory;
-
--- This should fail - trying to drop non-existent column without IF EXISTS
-ALTER TABLE test_alter_if_exists DROP COLUMN x, DROP COLUMN x; -- { serverError NOT_FOUND_COLUMN_IN_BLOCK }
-
-DROP TABLE IF EXISTS test_alter_if_exists;


### PR DESCRIPTION
This PR fixes a bug where ALTER COLUMN commands with IF EXISTS clause would fail when column state changes between the validation and application phases within the same ALTER statement.

  ## Problem
  When multiple ALTER commands are executed in a single statement, some commands can change the metadata state (e.g., DROP COLUMN removes a column), causing subsequent commands in the same statement to fail even when using IF EXISTS clause.
  This happens because:

  1. During the `validate()` phase, the column exists, so `ignore` flag remains false
  2. During the `apply()` phase, the column has been removed by a previous command
  3. Commands directly calling `metadata.columns.modify/remove/rename` methods throw exceptions

  For example:
  ```sql
  ALTER TABLE t DROP COLUMN c0, DROP COLUMN IF EXISTS c0;  -- Second command fails
   ```
 
  Solution

  - Added a helper function `should_skip_column_operation()` for consistent IF EXISTS runtime checking
  - Applied runtime checks to all four command types in their `apply()` methods
  - Added comprehensive tests covering all edge cases and command combinations

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
 Fix ALTER COLUMN IF EXISTS commands failing when column state changes within the same ALTER statement. Commands like DROP COLUMN IF EXISTS, MODIFY COLUMN IF EXISTS, COMMENT COLUMN IF EXISTS, and RENAME COLUMN IF EXISTS now properly handle cases where a column is deleted by a previous command in the same statement.

