### PR TITLE
Fix large setting values breaking S3Queue tables

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.cpp
@@ -138,11 +138,11 @@ ObjectStorageQueueTableMetadata::ObjectStorageQueueTableMetadata(const Poco::JSO
     , mode(json->getValue<String>("mode"))
     , last_processed_path(getOrDefault<String>(json, "last_processed_file", "s3queue_", ""))
     , after_processing(actionFromString(json->getValue<String>("after_processing")))
-    , loading_retries(getOrDefault(json, "loading_retries", "", 10))
-    , processing_threads_num(getOrDefault(json, "processing_threads_num", "s3queue_", 1))
-    , tracked_files_limit(getOrDefault(json, "tracked_files_limit", "s3queue_", 0))
-    , tracked_files_ttl_sec(getOrDefault(json, "tracked_files_ttl_sec", "", getOrDefault(json, "tracked_file_ttl_sec", "s3queue_", 0)))
-    , buckets(getOrDefault(json, "buckets", "", 0))
+    , loading_retries(getOrDefault(json, "loading_retries", "", 10ULL))
+    , processing_threads_num(getOrDefault(json, "processing_threads_num", "s3queue_", 1ULL))
+    , tracked_files_limit(getOrDefault(json, "tracked_files_limit", "s3queue_", 0ULL))
+    , tracked_files_ttl_sec(getOrDefault(json, "tracked_files_ttl_sec", "", getOrDefault(json, "tracked_file_ttl_sec", "s3queue_", 0ULL)))
+    , buckets(getOrDefault(json, "buckets", "", 0ULL))
 {
     validateMode(mode);
 }

--- a/tests/queries/0_stateless/03592_s3queue_large_settings.sql
+++ b/tests/queries/0_stateless/03592_s3queue_large_settings.sql
@@ -1,0 +1,6 @@
+-- Tags: no-fasttest
+
+CREATE TABLE s3_queue (name String, value UInt32) ENGINE = S3Queue('http://localhost:11111/test/{a,b,c}.tsv', 'user', 'password', CSV) SETTINGS s3queue_tracked_files_limit = 18446744073709551615, mode = 'ordered';
+
+DETACH TABLE s3_queue;
+ATTACH TABLE s3_queue;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix large setting values breaking S3Queue tables and replica restart.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
