### PR TITLE
Fix use-after-free in parquet reader v3

### DIFF
--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -329,7 +329,9 @@ private:
 ///
 ///     void someBackgroundTask(std::shared_ptr<ShutdownHelper> shutdown_)
 ///     {
-///         std::shared_lock shutdown_lock(*shutdown, std::try_to_lock);
+///         // Using a copy of the shared_ptr, can't use this->shutdown here as `this` might already
+///         // be destroyed.
+///         std::shared_lock shutdown_lock(*shutdown_, std::try_to_lock);
 ///         if (!shutdown_lock.owns_lock())
 ///             return; // shutdown was requested, `this` may be destroyed
 ///

--- a/src/Processors/Formats/Impl/Parquet/Prefetcher.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Prefetcher.cpp
@@ -395,9 +395,9 @@ void Prefetcher::decreaseTaskRefcount(Task * task, size_t amount)
 void Prefetcher::scheduleTask(Task * task)
 {
     if (parser_shared_resources && !parser_shared_resources->io_runner.isDisabled())
-        parser_shared_resources->io_runner([this, task]
+        parser_shared_resources->io_runner([this, task, _shutdown = shutdown]
             {
-                std::shared_lock shutdown_lock(*shutdown, std::try_to_lock);
+                std::shared_lock shutdown_lock(*_shutdown, std::try_to_lock);
                 if (!shutdown_lock.owns_lock())
                     return;
                 runTask(task);

--- a/src/Processors/Formats/Impl/Parquet/ReadManager.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ReadManager.cpp
@@ -570,9 +570,9 @@ void ReadManager::scheduleTasksIfNeeded(ReadStage stage_idx)
                 n += 1;
                 ++i;
             }
-            funcs.push_back([this, _batch = std::move(batch)]
+            funcs.push_back([this, _batch = std::move(batch), _shutdown = shutdown]
             {
-                std::shared_lock shutdown_lock(*shutdown, std::try_to_lock);
+                std::shared_lock shutdown_lock(*_shutdown, std::try_to_lock);
                 if (!shutdown_lock.owns_lock())
                     return;
                 runBatchOfTasks(_batch);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Oops.