### PR TITLE
Fix double free in parquet reader v3 finishRowSubgroupStage

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/ReadManager.h
+++ b/src/Processors/Formats/Impl/Parquet/ReadManager.h
@@ -101,6 +101,8 @@ private:
     void scheduleTasksIfNeeded(ReadStage stage_idx);
     void finishRowGroupStage(size_t row_group_idx, ReadStage stage, MemoryUsageDiff & diff);
     void finishRowSubgroupStage(size_t row_group_idx, size_t row_subgroup_idx, ReadStage stage, MemoryUsageDiff & diff);
+    /// Free some memory ColumnChunk that's not needed after decoding is done in all row sugroups.
+    /// Call sites should be careful to not call it from multiple threads in parallel.
     void clearColumnChunk(ColumnChunk & column, MemoryUsageDiff & diff);
     void clearRowSubgroup(RowSubgroup & row_subgroup, MemoryUsageDiff & diff);
     void setTasksToSchedule(size_t row_group_idx, ReadStage stage, std::vector<Task> add_tasks, MemoryUsageDiff & diff);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Race condition happened when a column is used both inside and outside PREWHERE.