### PR TITLE
Docs: clarify async_insert_max_query_number setting

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5685,7 +5685,8 @@ Timeout for waiting for processing asynchronous insertion
 Maximum size in bytes of unparsed data collected per query before being inserted
 )", 0) \
     DECLARE(UInt64, async_insert_max_query_number, 450, R"(
-Maximum number of insert queries before being inserted
+Maximum number of insert queries before being inserted.
+Only takes effect if setting [`async_insert_deduplicate`](#async_insert_deduplicate) is 1.
 )", 0) \
     DECLARE(Milliseconds, async_insert_poll_timeout_ms, 10, R"(
 Timeout for polling data from asynchronous insert queue


### PR DESCRIPTION
### Description
Fix inaccurate description of the `async_insert_max_query_number` setting.

### Reason
The previous docs did not fully match the implementation. [See code reference](https://github.com/jkartseva/ClickHouse/blob/b319ff1da26b8165fcf038cc1c2777d7e36243b2/src/Interpreters/AsynchronousInsertQueue.cpp#L419C9-L420C1).

```cpp
bool has_enough_queries = data->entries.size() >= key.settings.async_insert_max_query_number && key.settings.async_insert_deduplicate;
```
### Changelog category (leave one):
- Documentation (changelog entry is not required)