### PR TITLE
Fix logical error during fs cache dynamic resize

### DIFF
--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -42,16 +42,20 @@ struct FileSegmentMetadata : private boost::noncopyable
     bool isEvictingOrRemoved(const CachePriorityGuard::Lock & lock) const
     {
         auto iterator = getQueueIterator();
-        if (!iterator || removed)
-            return false;
+        if (removed)
+            return true;
+        if (!iterator)
+            return false; /// Iterator is set only on first space reservation attempt.
         return iterator->getEntry()->isEvicting(lock);
     }
 
     bool isEvictingOrRemoved(const LockedKey & lock) const
     {
         auto iterator = getQueueIterator();
-        if (!iterator || removed)
-            return false;
+        if (removed)
+            return true;
+        if (!iterator)
+            return false; /// Iterator is set only on first space reservation attempt.
         return iterator->getEntry()->isEvicting(lock);
     }
 

--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -41,9 +41,9 @@ struct FileSegmentMetadata : private boost::noncopyable
 
     bool isEvictingOrRemoved(const CachePriorityGuard::Lock & lock) const
     {
-        auto iterator = getQueueIterator();
         if (removed)
             return true;
+        auto iterator = getQueueIterator();
         if (!iterator)
             return false; /// Iterator is set only on first space reservation attempt.
         return iterator->getEntry()->isEvicting(lock);
@@ -51,9 +51,9 @@ struct FileSegmentMetadata : private boost::noncopyable
 
     bool isEvictingOrRemoved(const LockedKey & lock) const
     {
-        auto iterator = getQueueIterator();
         if (removed)
             return true;
+        auto iterator = getQueueIterator();
         if (!iterator)
             return false; /// Iterator is set only on first space reservation attempt.
         return iterator->getEntry()->isEvicting(lock);

--- a/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
+++ b/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
@@ -34,7 +34,7 @@ function select_func {
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null SETTINGS filesystem_cache_segments_batch_size=1"
+        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null SETTINGS filesystem_cache_segments_batch_size=1, max_read_buffer_size_remote_fs=50000"
     done
 }
 

--- a/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
+++ b/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
@@ -34,7 +34,7 @@ function select_func {
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null"
+        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null SETTINGS filesystem_cache_segments_batch_size=1"
     done
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error during filesystem cache dynamic resize. Closes https://github.com/ClickHouse/ClickHouse/issues/86122. Closes https://github.com/ClickHouse/clickhouse-core-incidents/issues/473.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
