### PR TITLE
Text indexes: Decrease default segment size

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -80,15 +80,13 @@ For example, with separators = `['%21', '%']` string `%21abc` would be tokenized
 
 Optional parameter `segment_digestion_threshold_bytes` determines the byte size of index segments.
 
-- `segment_digestion_threshold_bytes = 0`: Unlimited size, a single segment is created for each index granule.
+- `segment_digestion_threshold_bytes = 0`: Unlimited size, a single segment is created per part.
 - `segment_digestion_threshold_bytes = B`: A new segment is created every `B` bytes of text input.
 
-Default value: `0`.
+Default value: `10 * 1024 * 1024 * 1024` (10 GiB).
 
-We do not recommend changing `segment_digestion_threshold_bytes`.
-The default value will work well in virtually all situations.
-The presence of more than one segment causes redundant data storage and slower full-text search queries.
-The only reason to provide a non-zero value (e.g. `256MB`) for `segment_digestion_threshold_bytes` is if you get out-of-memory exceptions during index creation.
+We recommend changing `segment_digestion_threshold_bytes` to a lower value only if you regularly experience OOMs during index creation, in particular during merges.
+In general, the smaller segments are, the more data is stored redundantly and the slower full-text search becomes.
 
 Optional parameter `bloom_filter_false_positive_rate` determines the false-positive rate of the bloom filter.
 

--- a/programs/fst-dump-tree/FstDumpTree.cpp
+++ b/programs/fst-dump-tree/FstDumpTree.cpp
@@ -170,15 +170,15 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
         GinDictionaries segment_dictionaries(number_of_segments);
         if (version == DB::GinIndexStore::Format::v1)
         {
-            std::vector<DB::GinIndexSegment> segments(number_of_segments);
-            segment_metadata_read_buffer->readStrict(reinterpret_cast<char *>(segments.data()), number_of_segments * sizeof(DB::GinIndexSegment));
+            std::vector<DB::GinSegmentDescriptor> segment_descriptors(number_of_segments);
+            segment_metadata_read_buffer->readStrict(reinterpret_cast<char *>(segment_descriptors.data()), number_of_segments * sizeof(DB::GinSegmentDescriptor));
             for (UInt32 i = 0; i < number_of_segments; ++i)
             {
                 auto seg_dict = std::make_shared<DB::GinDictionary>();
-                seg_dict->postings_start_offset = segments[i].postings_start_offset;
-                seg_dict->dict_start_offset = segments[i].dict_start_offset;
-                seg_dict->bloom_filter_start_offset = segments[i].bloom_filter_start_offset;
-                segment_dictionaries[segments[i].segment_id] = seg_dict;
+                seg_dict->postings_start_offset = segment_descriptors[i].postings_start_offset;
+                seg_dict->dict_start_offset = segment_descriptors[i].dict_start_offset;
+                seg_dict->bloom_filter_start_offset = segment_descriptors[i].bloom_filter_start_offset;
+                segment_dictionaries[segment_descriptors[i].segment_id] = seg_dict;
             }
         }
 

--- a/programs/fst-dump-tree/FstDumpTree.cpp
+++ b/programs/fst-dump-tree/FstDumpTree.cpp
@@ -249,7 +249,7 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
                         auto buf = std::make_unique<char[]>(compressed_fst_size);
                         dictionary_read_buffer->readStrict(reinterpret_cast<char *>(buf.get()), compressed_fst_size);
 
-                        const auto & codec = DB::GinIndexCompressionFactory::zstdCodec();
+                        const auto & codec = DB::GinCompressionFactory::zstdCodec();
                         codec->decompress(
                             buf.get(),
                             static_cast<UInt32>(compressed_fst_size),

--- a/programs/fst-dump-tree/FstDumpTree.cpp
+++ b/programs/fst-dump-tree/FstDumpTree.cpp
@@ -166,15 +166,15 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
         }
 
         /// Read segment metadata
-        using GinSegmentDictionaries = std::unordered_map<UInt32, DB::GinSegmentDictionaryPtr>;
-        GinSegmentDictionaries segment_dictionaries(number_of_segments);
+        using GinDictionaries = std::unordered_map<UInt32, DB::GinDictionaryPtr>;
+        GinDictionaries segment_dictionaries(number_of_segments);
         if (version == DB::GinIndexStore::Format::v1)
         {
             std::vector<DB::GinIndexSegment> segments(number_of_segments);
             segment_metadata_read_buffer->readStrict(reinterpret_cast<char *>(segments.data()), number_of_segments * sizeof(DB::GinIndexSegment));
             for (UInt32 i = 0; i < number_of_segments; ++i)
             {
-                auto seg_dict = std::make_shared<DB::GinSegmentDictionary>();
+                auto seg_dict = std::make_shared<DB::GinDictionary>();
                 seg_dict->postings_start_offset = segments[i].postings_start_offset;
                 seg_dict->dict_start_offset = segments[i].dict_start_offset;
                 seg_dict->bloom_filter_start_offset = segments[i].bloom_filter_start_offset;
@@ -206,7 +206,7 @@ int mainEntryClickHouseFstDumpTree(int argc, char ** argv)
 
                     /// Read bloom filter
                     bloom_filter_read_buffer->seek(segment_dict->bloom_filter_start_offset, SEEK_SET);
-                    segment_dict->bloom_filter = DB::GinSegmentDictionaryBloomFilter::deserialize(*bloom_filter_read_buffer);
+                    segment_dict->bloom_filter = DB::GinDictionaryBloomFilter::deserialize(*bloom_filter_read_buffer);
 
                     fmt::println(
                         "[Segment {}]: bloom filter size = {}",

--- a/src/Functions/searchAnyAll.cpp
+++ b/src/Functions/searchAnyAll.cpp
@@ -117,10 +117,10 @@ void executeSearchAny(
     std::vector<std::string_view> tokens;
     for (size_t i = 0; i < input_rows_count; ++i)
     {
-        const auto value = col_input.getDataAt(i);
+        const std::string_view value = col_input.getDataAt(i).toView();
         col_result[i] = false;
 
-        tokens = token_extractor->getTokensView(value.data, value.size);
+        tokens = token_extractor->getTokensView(value.data(), value.size());
         for (const auto & token : tokens)
         {
             if (needles.contains(token))

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -70,18 +70,13 @@ void GinFilter::addRowRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UI
         GinSegmentWithRowIdRange & last_rowid_range = rowid_ranges.back();
 
         if (last_rowid_range.segment_id == segment_id &&
-            last_rowid_range.range_end + 1 == rowid_start)
+            last_rowid_range.range_rowid_end + 1 == rowid_start)
         {
-            last_rowid_range.range_end = rowid_end;
+            last_rowid_range.range_rowid_end = rowid_end;
             return;
         }
     }
     rowid_ranges.push_back({segment_id, rowid_start, rowid_end});
-}
-
-void GinFilter::clear()
-{
-    rowid_ranges.clear();
 }
 
 namespace
@@ -103,23 +98,23 @@ bool hasEmptyPostingsList(const GinPostingsListsCache & postings_lists_cache)
 }
 
 /// Helper method to check if all terms in postings list cache has intersection with given row ID range
-bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 segment_id, UInt32 range_start, UInt32 range_end)
+bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 segment_id, UInt32 range_rowid_start, UInt32 range_rowid_end)
 {
     /// Check for each term
     GinIndexPostingsList range_bitset;
-    range_bitset.addRange(range_start, range_end + 1);
+    range_bitset.addRange(range_rowid_start, range_rowid_end + 1);
 
     for (const auto & term_postings : postings_lists_cache)
     {
         /// Check if it is in the same segment by searching for segment_id
         const GinSegmentedPostingsListContainer & container = term_postings.second;
         auto container_it = container.find(segment_id);
-        if (container_it == container.cend())
+        if (container_it == container.end())
             return false;
         auto min_in_container = container_it->second->minimum();
         auto max_in_container = container_it->second->maximum();
 
-        if (range_start > max_in_container || min_in_container > range_end)
+        if (range_rowid_start > max_in_container || min_in_container > range_rowid_end)
             return false;
 
         range_bitset &= *container_it->second;
@@ -131,7 +126,7 @@ bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
 }
 
 /// Helper method to check if any term in postings list cache has intersection with given row ID range
-bool matchAnyInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 segment_id, UInt32 range_start, UInt32 range_end)
+bool matchAnyInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 segment_id, UInt32 range_rowid_start, UInt32 range_rowid_end)
 {
     /// Check for each term
     GinIndexPostingsList postings_bitset;
@@ -139,18 +134,18 @@ bool matchAnyInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
     {
         /// Check if it is in the same segment by searching for segment_id
         const GinSegmentedPostingsListContainer & container = term_postings.second;
-        if (auto container_it = container.find(segment_id); container_it != container.cend())
+        if (auto container_it = container.find(segment_id); container_it != container.end())
             postings_bitset |= *container_it->second;
     }
 
     GinIndexPostingsList range_bitset;
-    range_bitset.addRange(range_start, range_end + 1);
+    range_bitset.addRange(range_rowid_start, range_rowid_end + 1);
     return range_bitset.intersect(postings_bitset);
 }
 
 
 template <GinSearchMode search_mode>
-bool matchInRange(const GinSegmentWithRowIdRangeVector & rowid_ranges, const GinPostingsListsCache & postings_lists_cache)
+bool matchInRange(const GinSegmentsWithRowIdRange & rowid_ranges, const GinPostingsListsCache & postings_lists_cache)
 {
     if (hasEmptyPostingsList(postings_lists_cache))
         switch (search_mode)
@@ -171,12 +166,12 @@ bool matchInRange(const GinSegmentWithRowIdRangeVector & rowid_ranges, const Gin
         switch (search_mode)
         {
             case GinSearchMode::Any: {
-                if (matchAnyInRange(postings_lists_cache, rowid_range.segment_id, rowid_range.range_start, rowid_range.range_end))
+                if (matchAnyInRange(postings_lists_cache, rowid_range.segment_id, rowid_range.range_rowid_start, rowid_range.range_rowid_end))
                     return true;
                 break;
             }
             case GinSearchMode::All: {
-                if (matchAllInRange(postings_lists_cache, rowid_range.segment_id, rowid_range.range_start, rowid_range.range_end))
+                if (matchAllInRange(postings_lists_cache, rowid_range.segment_id, rowid_range.range_rowid_start, rowid_range.range_rowid_end))
                     return true;
                 break;
             }

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -101,7 +101,7 @@ bool hasEmptyPostingsList(const GinPostingsListsCache & postings_lists_cache)
 bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 segment_id, UInt32 range_rowid_start, UInt32 range_rowid_end)
 {
     /// Check for each term
-    GinIndexPostingsList range_bitset;
+    GinPostingsList range_bitset;
     range_bitset.addRange(range_rowid_start, range_rowid_end + 1);
 
     for (const auto & term_postings : postings_lists_cache)
@@ -130,7 +130,7 @@ bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
 bool matchAnyInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 segment_id, UInt32 range_rowid_start, UInt32 range_rowid_end)
 {
     /// Check for each term
-    GinIndexPostingsList postings_bitset;
+    GinPostingsList postings_bitset;
     for (const auto & term_postings : postings_lists_cache)
     {
         /// Check if it is in the same segment by searching for segment_id
@@ -139,7 +139,7 @@ bool matchAnyInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
             postings_bitset |= *container_it->second;
     }
 
-    GinIndexPostingsList range_bitset;
+    GinPostingsList range_bitset;
     range_bitset.addRange(range_rowid_start, range_rowid_end + 1);
     return range_bitset.intersect(postings_bitset);
 }

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -50,10 +50,10 @@ void GinFilter::add(const String & term, UInt32 row_id, GinIndexStorePtr & store
     }
     else
     {
-        auto builder = std::make_shared<GinIndexPostingsBuilder>();
-        builder->add(row_id);
+        auto postings_list_builder = std::make_shared<GinPostingsListBuilder>();
+        postings_list_builder->add(row_id);
 
-        store->setPostingsBuilder(term, builder);
+        store->setPostingsListBuilder(term, postings_list_builder);
     }
 }
 

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -62,7 +62,7 @@ void GinFilter::add(const String & term, UInt32 row_id, GinIndexStorePtr & store
 void GinFilter::addRowIdRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UInt32 rowid_end)
 {
     /// Check that segment ids are monotonic increasing
-    assert(segments_with_rowid_range.empty() || segments_with_rowid_range.back().segment_id <= segment_id);
+    chassert(segments_with_rowid_range.empty() || segments_with_rowid_range.back().segment_id <= segment_id);
 
     if (!segments_with_rowid_range.empty())
     {
@@ -111,8 +111,9 @@ bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
         auto container_it = container.find(segment_id);
         if (container_it == container.end())
             return false;
-        auto min_in_container = container_it->second->minimum();
-        auto max_in_container = container_it->second->maximum();
+
+        UInt32 min_in_container = container_it->second->minimum();
+        UInt32 max_in_container = container_it->second->maximum();
 
         if (range_rowid_start > max_in_container || min_in_container > range_rowid_end)
             return false;

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -36,7 +36,7 @@ GinQueryString::GinQueryString(std::string_view query_string_, const std::vector
 {
 }
 
-void GinFilter::add(const String & term, UInt32 rowID, GinIndexStorePtr & store) const
+void GinFilter::add(const String & term, UInt32 row_id, GinIndexStorePtr & store) const
 {
     if (term.length() > FST::MAX_TERM_LENGTH)
         return;
@@ -45,13 +45,13 @@ void GinFilter::add(const String & term, UInt32 rowID, GinIndexStorePtr & store)
 
     if (it != store->getPostingsListBuilder().end())
     {
-        if (!it->second->contains(rowID))
-            it->second->add(rowID);
+        if (!it->second->contains(row_id))
+            it->second->add(row_id);
     }
     else
     {
         auto builder = std::make_shared<GinIndexPostingsBuilder>();
-        builder->add(rowID);
+        builder->add(row_id);
 
         store->setPostingsBuilder(term, builder);
     }
@@ -66,7 +66,7 @@ void GinFilter::addRowRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UI
 
     if (!rowid_ranges.empty())
     {
-        /// Try to merge the rowID range with the last one in the container
+        /// Try to merge the row_id range with the last one in the container
         GinSegmentWithRowIdRange & last_rowid_range = rowid_ranges.back();
 
         if (last_rowid_range.segment_id == segment_id &&

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -191,8 +191,8 @@ bool GinFilter::contains(const GinQueryString & query_string, GinPostingsListsCa
     GinPostingsListsCachePtr postings_lists_cache = postings_lists_cache_for_store.getPostingsLists(query_string.getQueryString());
     if (postings_lists_cache == nullptr)
     {
-        GinIndexStoreDeserializer reader(postings_lists_cache_for_store.store);
-        postings_lists_cache = reader.createPostingsCacheFromTerms(query_string.getTerms());
+        GinIndexStoreDeserializer deserializer(postings_lists_cache_for_store.store);
+        postings_lists_cache = deserializer.createPostingsListsCacheFromTerms(query_string.getTerms());
         postings_lists_cache_for_store.cache[query_string.getQueryString()] = postings_lists_cache;
     }
 

--- a/src/Interpreters/GinFilter.cpp
+++ b/src/Interpreters/GinFilter.cpp
@@ -90,8 +90,8 @@ bool hasEmptyPostingsList(const GinPostingsListsCache & postings_lists_cache)
 
     for (const auto & term_postings : postings_lists_cache)
     {
-        const GinSegmentedPostingsListContainer & container = term_postings.second;
-        if (container.empty())
+        const GinSegmentPostingsLists & segment_postings_lists = term_postings.second;
+        if (segment_postings_lists.empty())
             return true;
     }
     return false;
@@ -107,9 +107,9 @@ bool matchAllInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
     for (const auto & term_postings : postings_lists_cache)
     {
         /// Check if it is in the same segment by searching for segment_id
-        const GinSegmentedPostingsListContainer & container = term_postings.second;
-        auto container_it = container.find(segment_id);
-        if (container_it == container.end())
+        const GinSegmentPostingsLists & segment_postings_lists = term_postings.second;
+        auto container_it = segment_postings_lists.find(segment_id);
+        if (container_it == segment_postings_lists.end())
             return false;
 
         UInt32 min_in_container = container_it->second->minimum();
@@ -134,8 +134,8 @@ bool matchAnyInRange(const GinPostingsListsCache & postings_lists_cache, UInt32 
     for (const auto & term_postings : postings_lists_cache)
     {
         /// Check if it is in the same segment by searching for segment_id
-        const GinSegmentedPostingsListContainer & container = term_postings.second;
-        if (auto container_it = container.find(segment_id); container_it != container.end())
+        const GinSegmentPostingsLists & segment_postings_lists = term_postings.second;
+        if (auto container_it = segment_postings_lists.find(segment_id); container_it != segment_postings_lists.end())
             postings_bitset |= *container_it->second;
     }
 

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -34,7 +34,7 @@ public:
     /// Add term which are tokens generated from the query string
     bool addTerm(std::string_view term)
     {
-        if (term.length() > FST::MAX_TERM_LENGTH) [[unlikely]]
+        if (term.length() > FST::MAX_TERM_LENGTH)
             return false;
 
         terms.push_back(String(term));

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -60,9 +60,9 @@ struct GinSegmentWithRowIdRange
 
 using GinSegmentsWithRowIdRange = std::vector<GinSegmentWithRowIdRange>;
 
-/// GinFilter provides underlying functionalities for building text index and also
-/// it does filtering the unmatched rows according to its query string.
-/// It also builds and uses skipping index which stores (segment_id, rowid_start, rowid_end) triples.
+/// GinFilter provides two types of functionality:
+/// 1) it builds a text index, and
+/// 2) it filters the unmatched rows according to its query string.
 class GinFilter
 {
 public:
@@ -90,15 +90,13 @@ public:
 
     GinFilter() = default;
 
-    /// Add term (located at 'data' with length 'len') and its row ID to the postings list builder
-    /// for building text index for the given store.
+    /// Add term and its row ID to the postings list builder for building the text index for the given store.
     void add(const String & term, UInt32 row_id, GinIndexStorePtr & store) const;
 
-    /// Accumulate (segment_id, rowid_start, rowid_end) for building skipping index
+    /// Accumulate (segment_id, rowid_start, rowid_end) for building the text index.
     void addRowIdRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UInt32 rowid_end);
 
-    /// Check if the filter (built from query string) contains any rows in given filter by using
-    /// given postings list cache
+    /// Check if the filter (built from query string) contains any rows in given filter by using given postings list cache.
     bool contains(const GinQueryString & query_string, GinPostingsListsCacheForStore & postings_lists_cache_for_store, GinSearchMode mode = GinSearchMode::All) const;
 
     const GinSegmentsWithRowIdRange & getSegmentsWithRowIdRange() const { return segments_with_rowid_range; }

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -18,18 +18,6 @@ enum class GinSearchMode : uint8_t
     All
 };
 
-struct GinSegmentWithRowIdRange
-{
-    /// Segment ID of the row ID range
-    UInt32 segment_id;
-
-    /// First and last row ID in the range (both are inclusive)
-    UInt32 range_rowid_start;
-    UInt32 range_rowid_end;
-};
-
-using GinSegmentsWithRowIdRange = std::vector<GinSegmentWithRowIdRange>;
-
 class GinQueryString
 {
 public:
@@ -59,6 +47,18 @@ private:
     /// Tokenized terms from query string
     std::vector<String> terms;
 };
+
+struct GinSegmentWithRowIdRange
+{
+    /// Segment ID of the row ID range
+    UInt32 segment_id;
+
+    /// First and last row ID in the range (both are inclusive)
+    UInt32 range_rowid_start;
+    UInt32 range_rowid_end;
+};
+
+using GinSegmentsWithRowIdRange = std::vector<GinSegmentWithRowIdRange>;
 
 /// GinFilter provides underlying functionalities for building text index and also
 /// it does filtering the unmatched rows according to its query string.
@@ -95,20 +95,20 @@ public:
     void add(const String & term, UInt32 row_id, GinIndexStorePtr & store) const;
 
     /// Accumulate (segment_id, rowid_start, rowid_end) for building skipping index
-    void addRowRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UInt32 rowid_end);
+    void addRowIdRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UInt32 rowid_end);
 
     /// Check if the filter (built from query string) contains any rows in given filter by using
     /// given postings list cache
     bool contains(const GinQueryString & query_string, GinPostingsListsCacheForStore & postings_lists_cache_for_store, GinSearchMode mode = GinSearchMode::All) const;
 
-    const GinSegmentsWithRowIdRange & getFilter() const { return rowid_ranges; }
-    GinSegmentsWithRowIdRange & getFilter() { return rowid_ranges; }
+    const GinSegmentsWithRowIdRange & getSegmentsWithRowIdRange() const { return segments_with_rowid_range; }
+    GinSegmentsWithRowIdRange & getSegmentsWithRowIdRange() { return segments_with_rowid_range; }
 
     size_t memoryUsageBytes() const;
 
 private:
     /// Row ID ranges which are (segment_id, rowid_start, rowid_end)
-    GinSegmentsWithRowIdRange rowid_ranges;
+    GinSegmentsWithRowIdRange segments_with_rowid_range;
 };
 
 }

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -23,14 +23,12 @@ struct GinSegmentWithRowIdRange
     /// Segment ID of the row ID range
     UInt32 segment_id;
 
-    /// First row ID in the range
-    UInt32 range_start;
-
-    /// Last row ID in the range (inclusive)
-    UInt32 range_end;
+    /// First and last row ID in the range (both are inclusive)
+    UInt32 range_rowid_start;
+    UInt32 range_rowid_end;
 };
 
-using GinSegmentWithRowIdRangeVector = std::vector<GinSegmentWithRowIdRange>;
+using GinSegmentsWithRowIdRange = std::vector<GinSegmentWithRowIdRange>;
 
 class GinQueryString
 {
@@ -43,10 +41,7 @@ public:
     const std::vector<String> & getTerms() const { return terms; }
 
     /// Set the query string of the filter
-    void setQueryString(std::string_view query_string_)
-    {
-        query_string = query_string_;
-    }
+    void setQueryString(std::string_view query_string_) { query_string = query_string_; }
 
     /// Add term which are tokens generated from the query string
     bool addTerm(std::string_view term)
@@ -102,21 +97,18 @@ public:
     /// Accumulate (segment_id, rowid_start, rowid_end) for building skipping index
     void addRowRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UInt32 rowid_end);
 
-    /// Clear the content
-    void clear();
-
     /// Check if the filter (built from query string) contains any rows in given filter by using
     /// given postings list cache
     bool contains(const GinQueryString & query_string, GinPostingsListsCacheForStore & postings_lists_cache_for_store, GinSearchMode mode = GinSearchMode::All) const;
 
-    const GinSegmentWithRowIdRangeVector & getFilter() const { return rowid_ranges; }
-    GinSegmentWithRowIdRangeVector & getFilter() { return rowid_ranges; }
+    const GinSegmentsWithRowIdRange & getFilter() const { return rowid_ranges; }
+    GinSegmentsWithRowIdRange & getFilter() { return rowid_ranges; }
 
     size_t memoryUsageBytes() const;
 
 private:
     /// Row ID ranges which are (segment_id, rowid_start, rowid_end)
-    GinSegmentWithRowIdRangeVector rowid_ranges;
+    GinSegmentsWithRowIdRange rowid_ranges;
 };
 
 }

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -6,7 +6,6 @@
 namespace DB
 {
 
-static constexpr UInt64 UNLIMITED_ROWS_PER_POSTINGS_LIST = 0;
 static constexpr UInt64 DEFAULT_NGRAM_SIZE = 3;
 static constexpr auto DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE = 0.001; /// 0.1%
 

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -90,7 +90,7 @@ public:
         /// For split tokenizer
         std::optional<std::vector<String>> separators;
 
-        bool operator<=>(const Parameters& other) const = default;
+        bool operator<=>(const Parameters & other) const = default;
     };
 
     GinFilter() = default;
@@ -107,7 +107,7 @@ public:
 
     /// Check if the filter (built from query string) contains any rows in given filter by using
     /// given postings list cache
-    bool contains(const GinQueryString & gin_query_string, PostingsCacheForStore & cache_store, GinSearchMode mode = GinSearchMode::All) const;
+    bool contains(const GinQueryString & query_string, GinPostingsListsCacheForStore & postings_lists_cache_for_store, GinSearchMode mode = GinSearchMode::All) const;
 
     const GinSegmentWithRowIdRangeVector & getFilter() const { return rowid_ranges; }
     GinSegmentWithRowIdRangeVector & getFilter() { return rowid_ranges; }

--- a/src/Interpreters/GinFilter.h
+++ b/src/Interpreters/GinFilter.h
@@ -97,7 +97,7 @@ public:
 
     /// Add term (located at 'data' with length 'len') and its row ID to the postings list builder
     /// for building text index for the given store.
-    void add(const String & term, UInt32 rowID, GinIndexStorePtr & store) const;
+    void add(const String & term, UInt32 row_id, GinIndexStorePtr & store) const;
 
     /// Accumulate (segment_id, rowid_start, rowid_end) for building skipping index
     void addRowRangeToGinFilter(UInt32 segment_id, UInt32 rowid_start, UInt32 rowid_end);

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -280,9 +280,9 @@ void DefaultTokenExtractor::substringToBloomFilter(const char * data, size_t len
             bloom_filter.add(data + token_start, token_len);
 }
 
-void DefaultTokenExtractor::substringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string, bool is_prefix, bool is_suffix) const
+void DefaultTokenExtractor::substringToGinFilter(const char * data, size_t length, GinQueryString & query_string, bool is_prefix, bool is_suffix) const
 {
-    gin_query_string.setQueryString({data, length});
+    query_string.setQueryString({data, length});
 
     size_t cur = 0;
     size_t token_start = 0;
@@ -293,7 +293,7 @@ void DefaultTokenExtractor::substringToGinFilter(const char * data, size_t lengt
         // first token is ignored, unless substring is prefix and
         // last token is ignored, unless substring is suffix
         if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
-            gin_query_string.addTerm({data + token_start, token_len});
+            query_string.addTerm({data + token_start, token_len});
 }
 
 SplitTokenExtractor::SplitTokenExtractor(const std::vector<String> & separators_)

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -56,7 +56,7 @@ struct ITokenExtractor
     virtual void stringLikeToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const = 0;
 
     /// Updates GIN filter from exact-match string filter value
-    virtual void stringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const = 0;
+    virtual void stringToGinFilter(const char * data, size_t length, GinQueryString & query_string) const = 0;
 
     /// Updates GIN filter from substring-match string filter value.
     /// An `ITokenExtractor` implementation may decide to skip certain
@@ -64,19 +64,19 @@ struct ITokenExtractor
     virtual void substringToGinFilter(
         const char * data,
         size_t length,
-        GinQueryString & gin_query_string,
+        GinQueryString & query_string,
         bool /*is_prefix*/,
         bool /*is_suffix*/) const
     {
-        stringToGinFilter(data, length, gin_query_string);
+        stringToGinFilter(data, length, query_string);
     }
 
-    virtual void stringPaddedToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const
+    virtual void stringPaddedToGinFilter(const char * data, size_t length, GinQueryString & query_string) const
     {
-        stringToGinFilter(data, length, gin_query_string);
+        stringToGinFilter(data, length, query_string);
     }
 
-    virtual void stringLikeToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const = 0;
+    virtual void stringLikeToGinFilter(const char * data, size_t length, GinQueryString & query_string) const = 0;
 
     virtual bool supportsStringLike() const = 0;
 };
@@ -115,35 +115,35 @@ class ITokenExtractorHelper : public ITokenExtractor
             bloom_filter.add(token.c_str(), token.size());
     }
 
-    void stringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const override
+    void stringToGinFilter(const char * data, size_t length, GinQueryString & query_string) const override
     {
-        gin_query_string.setQueryString({data, length});
+        query_string.setQueryString({data, length});
         const auto & tokens = getTokensView(data, length);
         for (const auto & token : tokens)
-            gin_query_string.addTerm(token);
+            query_string.addTerm(token);
     }
 
-    void stringPaddedToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const override
+    void stringPaddedToGinFilter(const char * data, size_t length, GinQueryString & query_string) const override
     {
-        gin_query_string.setQueryString({data, length});
+        query_string.setQueryString({data, length});
 
         size_t cur = 0;
         size_t token_start = 0;
         size_t token_len = 0;
 
         while (cur < length && static_cast<const Derived *>(this)->nextInStringPadded(data, length, &cur, &token_start, &token_len))
-            gin_query_string.addTerm({data + token_start, token_len});
+            query_string.addTerm({data + token_start, token_len});
     }
 
-    void stringLikeToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string) const override
+    void stringLikeToGinFilter(const char * data, size_t length, GinQueryString & query_string) const override
     {
-        gin_query_string.setQueryString({data, length});
+        query_string.setQueryString({data, length});
 
         size_t cur = 0;
         String token;
 
         while (cur < length && static_cast<const Derived *>(this)->nextInStringLike(data, length, &cur, token))
-            gin_query_string.addTerm(token);
+            query_string.addTerm(token);
     }
 };
 
@@ -177,7 +177,7 @@ struct DefaultTokenExtractor final : public ITokenExtractorHelper<DefaultTokenEx
     bool nextInStringPadded(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const override;
     bool nextInStringLike(const char * data, size_t length, size_t * __restrict pos, String & token) const override;
     void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
-    void substringToGinFilter(const char * data, size_t length, GinQueryString & gin_query_string, bool is_prefix, bool is_suffix) const override;
+    void substringToGinFilter(const char * data, size_t length, GinQueryString & query_string, bool is_prefix, bool is_suffix) const override;
 
     bool supportsStringLike() const override { return true; }
 };

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -49,7 +49,7 @@ const CompressionCodecPtr & GinCompressionFactory::zstdCodec()
 }
 
 #if USE_FASTPFOR
-UInt64 GinIndexPostingListDeltaPforSerialization::serialize(WriteBuffer & buffer, const roaring::Roaring & rowids)
+UInt64 GinIndexPostingListDeltaPforSerialization::serialize(WriteBuffer & buffer, const GinPostingsList & rowids)
 {
     std::vector<UInt32> deltas = encodeDeltaScalar(rowids);
 
@@ -114,7 +114,7 @@ std::shared_ptr<FastPForLib::IntegerCODEC> GinIndexPostingListDeltaPforSerializa
     return codec;
 }
 
-std::vector<UInt32> GinIndexPostingListDeltaPforSerialization::encodeDeltaScalar(const roaring::Roaring & rowids)
+std::vector<UInt32> GinIndexPostingListDeltaPforSerialization::encodeDeltaScalar(const GinPostingsList & rowids)
 {
     const UInt64 num_rowids = rowids.cardinality();
     std::vector<UInt32> deltas(num_rowids);
@@ -135,7 +135,7 @@ void GinIndexPostingListDeltaPforSerialization::decodeDeltaScalar(std::vector<UI
 }
 #endif
 
-UInt64 GinIndexPostingListRoaringZstdSerialization::serialize(WriteBuffer & buffer, const roaring::Roaring & rowids)
+UInt64 GinIndexPostingListRoaringZstdSerialization::serialize(WriteBuffer & buffer, const GinPostingsList & rowids)
 {
     const UInt64 num_rowids = rowids.cardinality();
 

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -918,22 +918,22 @@ GinSegmentedPostingsListContainer GinIndexStoreDeserializer::readSegmentedPostin
     return container;
 }
 
-GinPostingsCachePtr GinIndexStoreDeserializer::createPostingsCacheFromTerms(const std::vector<String> & terms)
+GinPostingsListsCachePtr GinIndexStoreDeserializer::createPostingsCacheFromTerms(const std::vector<String> & terms)
 {
-    auto postings_cache = std::make_shared<GinPostingsCache>();
+    auto postings_lists_cache = std::make_shared<GinPostingsListsCache>();
     for (const auto & term : terms)
     {
         // Make sure don't read for duplicated terms
-        if (postings_cache->contains(term))
+        if (postings_lists_cache->contains(term))
             continue;
 
         auto container = readSegmentedPostingsLists(term);
-        (*postings_cache)[term] = container;
+        (*postings_lists_cache)[term] = container;
     }
-    return postings_cache;
+    return postings_lists_cache;
 }
 
-GinPostingsCachePtr PostingsCacheForStore::getPostings(const String & query_string) const
+GinPostingsListsCachePtr GinPostingsListsCacheForStore::getPostingsLists(const String & query_string) const
 {
     auto it = cache.find(query_string);
     if (it == cache.end())

--- a/src/Storages/MergeTree/GinIndexStore.cpp
+++ b/src/Storages/MergeTree/GinIndexStore.cpp
@@ -738,7 +738,7 @@ void GinIndexStoreDeserializer::readSegments()
     if (num_segments == 0)
         return;
 
-    assert(metadata_file_stream != nullptr);
+    chassert(metadata_file_stream != nullptr);
 
     LOG_TRACE(logger, "Start reading text index '{}' segments of part '{}'", store->getName(), store->storage->getPartDirectory());
 
@@ -791,7 +791,7 @@ void GinIndexStoreDeserializer::prepareSegmentForReading(UInt32 segment_id)
             /// V1 supports bloom filter, so we can delay reading a segment until it's needed.
 
             /// Set file pointer of filter file
-            assert(bloom_filter_file_stream != nullptr);
+            chassert(bloom_filter_file_stream != nullptr);
             bloom_filter_file_stream->seek(seg_dict->bloom_filter_start_offset, SEEK_SET);
             seg_dict->bloom_filter = GinSegmentDictionaryBloomFilter::deserialize(*bloom_filter_file_stream);
             break;
@@ -810,7 +810,7 @@ void GinIndexStoreDeserializer::prepareSegmentForReading(UInt32 segment_id)
 void GinIndexStoreDeserializer::readSegmentFST(UInt32 segment_id, GinSegmentDictionaryPtr segment_dictionary)
 {
     /// Set file pointer of dictionary file
-    assert(dict_file_stream != nullptr);
+    chassert(dict_file_stream != nullptr);
     dict_file_stream->seek(segment_dictionary->dict_start_offset, SEEK_SET);
 
     LOG_TRACE(
@@ -865,7 +865,7 @@ void GinIndexStoreDeserializer::readSegmentFST(UInt32 segment_id, GinSegmentDict
 
 GinSegmentedPostingsListContainer GinIndexStoreDeserializer::readSegmentedPostingsLists(const String & term)
 {
-    assert(postings_file_stream != nullptr);
+    chassert(postings_file_stream != nullptr);
 
     GinSegmentedPostingsListContainer container;
     for (auto const & seg_dict : store->segment_dictionaries)

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -198,7 +198,7 @@ class GinIndexStore
 {
 public:
     static constexpr auto GIN_SEGMENT_ID_FILE_TYPE = ".gin_sid";
-    static constexpr auto GIN_SEGMENT_METADATA_FILE_TYPE = ".gin_seg";
+    static constexpr auto GIN_SEGMENT_DESCRIPTOR_FILE_TYPE = ".gin_seg";
     static constexpr auto GIN_BLOOM_FILTER_FILE_TYPE = ".gin_bflt";
     static constexpr auto GIN_DICTIONARY_FILE_TYPE = ".gin_dict";
     static constexpr auto GIN_POSTINGS_FILE_TYPE = ".gin_post";
@@ -217,7 +217,7 @@ public:
 
         Statistics operator-(const Statistics & other)
         {
-            metadata_file_size -= other.metadata_file_size;
+            segment_descriptor_file_size -= other.segment_descriptor_file_size;
             bloom_filter_file_size -= other.bloom_filter_file_size;
             dictionary_file_size -= other.dictionary_file_size;
             posting_lists_file_size -= other.posting_lists_file_size;
@@ -227,7 +227,7 @@ public:
     private:
         size_t num_terms;
         size_t current_size_bytes;
-        size_t metadata_file_size;
+        size_t segment_descriptor_file_size;
         size_t bloom_filter_file_size;
         size_t dictionary_file_size;
         size_t posting_lists_file_size;
@@ -329,7 +329,7 @@ private:
     UInt64 current_size_bytes = 0;
 
     /// File streams for segment, bloom filter, dictionaries and postings lists
-    std::unique_ptr<WriteBufferFromFileBase> metadata_file_stream;
+    std::unique_ptr<WriteBufferFromFileBase> segment_descriptor_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> bloom_filter_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> dict_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> postings_file_stream;
@@ -381,7 +381,7 @@ private:
     GinIndexStorePtr store;
 
     /// File streams for reading Gin Index
-    std::unique_ptr<ReadBufferFromFileBase> metadata_file_stream;
+    std::unique_ptr<ReadBufferFromFileBase> segment_descriptor_file_stream;
     std::unique_ptr<ReadBufferFromFileBase> bloom_filter_file_stream;
     std::unique_ptr<ReadBufferFromFileBase> dict_file_stream;
     std::unique_ptr<ReadBufferFromFileBase> postings_file_stream;

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -343,10 +343,10 @@ private:
 using GinIndexStorePtr = std::shared_ptr<GinIndexStore>;
 
 /// Map of <segment_id, postings_list>
-using GinSegmentedPostingsListContainer = std::unordered_map<UInt32, GinPostingsListPtr>;
+using GinSegmentPostingsLists = std::unordered_map<UInt32, GinPostingsListPtr>;
 
 /// Postings lists and terms built from query string
-using GinPostingsListsCache = std::unordered_map<String, GinSegmentedPostingsListContainer>;
+using GinPostingsListsCache = std::unordered_map<String, GinSegmentPostingsLists>;
 using GinPostingsListsCachePtr = std::shared_ptr<GinPostingsListsCache>;
 
 /// Gin index store reader which helps to read segments, dictionaries and postings list
@@ -365,10 +365,10 @@ public:
     void prepareSegmentForReading(UInt32 segment_id);
 
     /// Read FST for given segment dictionary from .gin_dict files
-    void readSegmentFST(UInt32 segment_id, GinDictionaryPtr segment_dictionary);
+    void readSegmentFST(UInt32 segment_id, GinDictionary & dictionary);
 
     /// Read postings lists for the term
-    GinSegmentedPostingsListContainer readSegmentedPostingsLists(const String & term);
+    GinSegmentPostingsLists readSegmentPostingsLists(const String & term);
 
     /// Read postings lists for terms (which are created by tokenzing query string)
     GinPostingsListsCachePtr createPostingsListsCacheFromTerms(const std::vector<String> & terms);

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -187,7 +187,7 @@ struct GinDictionary
     std::unique_ptr<FST::FiniteStateTransducer> fst;
     std::mutex fst_mutex;
 
-    /// Bloom filter created from the segment's dictionary
+    /// Bloom filter created from the dictionary
     std::unique_ptr<GinDictionaryBloomFilter> bloom_filter;
 };
 

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -92,7 +92,7 @@ private:
 };
 
 /// Build a postings list for a term
-class GinIndexPostingsBuilder
+class GinPostingsListBuilder
 {
 public:
     /// Check whether a row_id is already added
@@ -119,7 +119,7 @@ private:
     roaring::Roaring rowids;
 };
 
-using GinIndexPostingsBuilderPtr = std::shared_ptr<GinIndexPostingsBuilder>;
+using GinPostingsListBuilderPtr = std::shared_ptr<GinPostingsListBuilder>;
 
 /// Gin index segment descriptor, which contains:
 struct GinIndexSegment
@@ -234,7 +234,7 @@ public:
     };
 
     /// Container for all term's Gin Index Postings List Builder
-    using GinIndexPostingsBuilderContainer = absl::flat_hash_map<String, GinIndexPostingsBuilderPtr>;
+    using GinPostingsListBuilderContainer = absl::flat_hash_map<String, GinPostingsListBuilderPtr>;
 
     GinIndexStore(const String & name_, DataPartStoragePtr storage_);
     GinIndexStore(
@@ -260,10 +260,10 @@ public:
     Format getVersion();
 
     /// Get current postings list builder
-    const GinIndexPostingsBuilderContainer & getPostingsListBuilder() const { return current_postings; }
+    const GinPostingsListBuilderContainer & getPostingsListBuilder() const { return current_postings_list_builder_container; }
 
     /// Set postings list builder for given term
-    void setPostingsBuilder(const String & term, GinIndexPostingsBuilderPtr builder) { current_postings[term] = builder; }
+    void setPostingsListBuilder(const String & term, GinPostingsListBuilderPtr builder) { current_postings_list_builder_container[term] = builder; }
 
     /// Check if we need to write segment to Gin index files
     bool needToWriteCurrentSegment() const;
@@ -322,7 +322,7 @@ private:
     GinSegmentDictionaries segment_dictionaries;
 
     /// Container for building postings lists during index construction
-    GinIndexPostingsBuilderContainer current_postings;
+    GinPostingsListBuilderContainer current_postings_list_builder_container;
 
     /// For the segmentation of Gin indexes
     GinIndexSegment current_segment;

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -8,6 +8,7 @@
 #include <IO/WriteBufferFromFileBase.h>
 #include <Interpreters/BloomFilter.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
+#include <base/unit.h>
 
 #include <roaring.hh>
 #include <mutex>
@@ -44,6 +45,7 @@
 
 namespace DB
 {
+static constexpr UInt64 DEFAULT_SEGMENT_DIGESTION_THRESHOLD_BYTES = 10_GiB;
 static constexpr UInt64 UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES = 0;
 
 /// An in-memory posting list is a 32-bit Roaring Bitmap

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -301,9 +301,6 @@ private:
     /// Stores segment ID to disk
     void writeSegmentId();
 
-    /// Get a range of next available segment IDs
-    UInt32 getNextSegmentIdRange(size_t n);
-
     const String name;
     const DataPartStoragePtr storage;
     MutableDataPartStoragePtr data_part_storage_builder;

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -304,8 +304,8 @@ private:
     /// Get a range of next available segment IDs
     UInt32 getNextSegmentIdRange(size_t n);
 
-    String name;
-    DataPartStoragePtr storage;
+    const String name;
+    const DataPartStoragePtr storage;
     MutableDataPartStoragePtr data_part_storage_builder;
 
     UInt32 cached_segment_num = 0;

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -298,7 +298,7 @@ private:
     /// Initialize segment ID by either reading from file .gin_sid or setting to default value
     void initSegmentId();
 
-    /// Stores segment id into disk
+    /// Stores segment ID to disk
     void writeSegmentId();
 
     /// Get a range of next available segment IDs
@@ -328,21 +328,21 @@ private:
     GinIndexSegment current_segment;
     UInt64 current_size_bytes = 0;
 
-    const UInt64 segment_digestion_threshold_bytes = 0;
-    const double bloom_filter_false_positive_rate = 0.0;
-
     /// File streams for segment, bloom filter, dictionaries and postings lists
     std::unique_ptr<WriteBufferFromFileBase> metadata_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> bloom_filter_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> dict_file_stream;
     std::unique_ptr<WriteBufferFromFileBase> postings_file_stream;
 
+    const UInt64 segment_digestion_threshold_bytes = 0;
+    const double bloom_filter_false_positive_rate = 0.0;
+
     LoggerPtr logger = getLogger("TextIndex");
 };
 
 using GinIndexStorePtr = std::shared_ptr<GinIndexStore>;
 
-/// Container for postings lists for each segment
+/// Map of <segment_id, postings_list>
 using GinSegmentedPostingsListContainer = std::unordered_map<UInt32, GinPostingsListPtr>;
 
 /// Postings lists and terms built from query string

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -142,10 +142,10 @@ struct GinIndexSegment
 
 /// This class encapsulates an instance of `BloomFilter` class.
 /// The main responsibility is handling the serialization.
-class GinSegmentDictionaryBloomFilter
+class GinDictionaryBloomFilter
 {
 public:
-    GinSegmentDictionaryBloomFilter(UInt64 unique_count_, size_t bits_per_rows_, size_t num_hashes_);
+    GinDictionaryBloomFilter(UInt64 unique_count_, size_t bits_per_rows_, size_t num_hashes_);
 
     /// Adds token to bloom filter
     void add(std::string_view token);
@@ -157,7 +157,7 @@ public:
     UInt64 serialize(WriteBuffer & write_buffer);
     /// Deserialize from ReadBuffer
 
-    static std::unique_ptr<GinSegmentDictionaryBloomFilter> deserialize(ReadBuffer & read_buffer);
+    static std::unique_ptr<GinDictionaryBloomFilter> deserialize(ReadBuffer & read_buffer);
 
 private:
     /// Estimated number of entries
@@ -171,7 +171,7 @@ private:
     BloomFilter bloom_filter;
 };
 
-struct GinSegmentDictionary
+struct GinDictionary
 {
     /// .gin_bflt file offset of this segment's bloom filter
     UInt64 bloom_filter_start_offset;
@@ -188,10 +188,10 @@ struct GinSegmentDictionary
     std::mutex fst_mutex;
 
     /// Bloom filter created from the segment's dictionary
-    std::unique_ptr<GinSegmentDictionaryBloomFilter> bloom_filter;
+    std::unique_ptr<GinDictionaryBloomFilter> bloom_filter;
 };
 
-using GinSegmentDictionaryPtr = std::shared_ptr<GinSegmentDictionary>;
+using GinDictionaryPtr = std::shared_ptr<GinDictionary>;
 
 /// Gin index store which has gin index meta data for the corresponding column data part
 class GinIndexStore
@@ -316,7 +316,7 @@ private:
     UInt32 next_available_segment_id = 0;
 
     /// Dictionaries indexed by segment ID
-    using GinSegmentDictionaries = std::unordered_map<UInt32, GinSegmentDictionaryPtr>;
+    using GinSegmentDictionaries = std::unordered_map<UInt32, GinDictionaryPtr>;
 
     /// Term's dictionaries which are loaded from .gin_dict files
     GinSegmentDictionaries segment_dictionaries;
@@ -365,7 +365,7 @@ public:
     void prepareSegmentForReading(UInt32 segment_id);
 
     /// Read FST for given segment dictionary from .gin_dict files
-    void readSegmentFST(UInt32 segment_id, GinSegmentDictionaryPtr segment_dictionary);
+    void readSegmentFST(UInt32 segment_id, GinDictionaryPtr segment_dictionary);
 
     /// Read postings lists for the term
     GinSegmentedPostingsListContainer readSegmentedPostingsLists(const String & term);

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -28,7 +28,7 @@
 /// There are 4 types of index files in a store:
 ///  1. Segment ID file(.gin_sid): it contains one byte for version followed by the next available segment ID.
 ///  2. Segment Metadata file(.gin_seg): it contains index segment metadata.
-///     - Its file format is an array of GinIndexSegment as defined in this file.
+///     - Its file format is an array of GinSegmentDescriptor as defined in this file.
 ///     - postings_start_offset points to the file(.gin_post) starting position for the segment's postings list.
 ///     - dict_start_offset points to the file(.gin_dict) starting position for the segment's dictionaries.
 ///  3. Dictionary file(.gin_dict): it contains dictionaries.
@@ -122,7 +122,7 @@ private:
 using GinPostingsListBuilderPtr = std::shared_ptr<GinPostingsListBuilder>;
 
 /// Gin index segment descriptor, which contains:
-struct GinIndexSegment
+struct GinSegmentDescriptor
 {
     ///  Segment ID retrieved from next available ID from file .gin_sid
     UInt32 segment_id = 0;
@@ -325,7 +325,7 @@ private:
     GinPostingsListBuilderContainer current_postings_list_builder_container;
 
     /// For the segmentation of Gin indexes
-    GinIndexSegment current_segment;
+    GinSegmentDescriptor current_segment;
     UInt64 current_size_bytes = 0;
 
     /// File streams for segment, bloom filter, dictionaries and postings lists

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -46,11 +46,11 @@ namespace DB
 {
 static constexpr UInt64 UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES = 0;
 
-/// GinIndexPostingsList which uses 32-bit Roaring
-using GinIndexPostingsList = roaring::Roaring;
-using GinPostingsListPtr = std::shared_ptr<GinIndexPostingsList>;
+/// GinPostingsList which uses 32-bit Roaring
+using GinPostingsList = roaring::Roaring;
+using GinPostingsListPtr = std::shared_ptr<GinPostingsList>;
 
-class GinIndexCompressionFactory
+class GinCompressionFactory
 {
 public:
     static const CompressionCodecPtr & zstdCodec();

--- a/src/Storages/MergeTree/GinIndexStore.h
+++ b/src/Storages/MergeTree/GinIndexStore.h
@@ -345,8 +345,8 @@ using GinIndexStorePtr = std::shared_ptr<GinIndexStore>;
 using GinSegmentedPostingsListContainer = std::unordered_map<UInt32, GinIndexPostingsListPtr>;
 
 /// Postings lists and terms built from query string
-using GinPostingsCache = std::unordered_map<String, GinSegmentedPostingsListContainer>;
-using GinPostingsCachePtr = std::shared_ptr<GinPostingsCache>;
+using GinPostingsListsCache = std::unordered_map<String, GinSegmentedPostingsListContainer>;
+using GinPostingsListsCachePtr = std::shared_ptr<GinPostingsListsCache>;
 
 /// Gin index store reader which helps to read segments, dictionaries and postings list
 class GinIndexStoreDeserializer : private boost::noncopyable
@@ -370,7 +370,7 @@ public:
     GinSegmentedPostingsListContainer readSegmentedPostingsLists(const String & term);
 
     /// Read postings lists for terms (which are created by tokenzing query string)
-    GinPostingsCachePtr createPostingsCacheFromTerms(const std::vector<String> & terms);
+    GinPostingsListsCachePtr createPostingsCacheFromTerms(const std::vector<String> & terms);
 
 private:
     /// Initialize gin index files
@@ -388,20 +388,20 @@ private:
     LoggerPtr logger = getLogger("TextIndex");
 };
 
-/// PostingsCacheForStore contains postings lists from 'store' which are retrieved from Gin index files for the terms in query strings
-/// GinPostingsCache is per query string (one query can have multiple query strings): when skipping index (row ID ranges) is used for the part during the
+/// GinPostingsListsCacheForStore contains postings lists from 'store' which are retrieved from Gin index files for the terms in query strings
+/// GinPostingsListsCache is per query string (one query can have multiple query strings): when skipping index (row ID ranges) is used for the part during the
 /// query, the postings cache is created and associated with the store where postings lists are read
 /// for the tokenized query string. The postings caches are released automatically when the query is done.
-struct PostingsCacheForStore
+struct GinPostingsListsCacheForStore
 {
     /// Which store to retrieve postings lists
     GinIndexStorePtr store;
 
-    /// map of <query, postings lists>
-    std::unordered_map<String, GinPostingsCachePtr> cache;
+    /// Map of <query, postings lists>
+    std::unordered_map<String, GinPostingsListsCachePtr> cache;
 
     /// Get postings lists for query string, return nullptr if not found
-    GinPostingsCachePtr getPostings(const String & query_string) const;
+    GinPostingsListsCachePtr getPostingsLists(const String & query_string) const;
 };
 
 /// A singleton for storing GinIndexStores

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -501,7 +501,7 @@ void MergeTreeDataPartWriterOnDisk::fillSkipIndicesChecksums(MergeTreeData::Data
         {
             String filename_without_extension = skip_indices[i]->getFileName();
             checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
-            checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
+            checksums.files[filename_without_extension + GinIndexStore::GIN_SEGMENT_DESCRIPTOR_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
             checksums.files[filename_without_extension + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
             checksums.files[filename_without_extension + GinIndexStore::GIN_DICTIONARY_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();
             checksums.files[filename_without_extension + GinIndexStore::GIN_POSTINGS_FILE_TYPE] = MergeTreeDataPartChecksums::Checksum();

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1830,9 +1830,9 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
         MergeTreeIndexGranulePtr granule = nullptr;
         size_t last_index_mark = 0;
 
-        PostingsCacheForStore cache_in_store;
+        GinPostingsListsCacheForStore postings_lists_cache_for_store;
         if (dynamic_cast<const MergeTreeIndexGin *>(index_helper.get()))
-            cache_in_store.store = GinIndexStoreFactory::instance().get(index_helper->getFileName(), part->getDataPartStoragePtr());
+            postings_lists_cache_for_store.store = GinIndexStoreFactory::instance().get(index_helper->getFileName(), part->getDataPartStoragePtr());
 
         for (size_t i = 0; i < ranges_size; ++i)
         {
@@ -1881,7 +1881,9 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
                 {
                     bool result = false;
                     if (const auto * gin_filter_condition = dynamic_cast<const MergeTreeIndexConditionGin *>(&*condition))
-                        result = cache_in_store.store ? gin_filter_condition->mayBeTrueOnGranuleInPart(granule, cache_in_store) : true;
+                        result = postings_lists_cache_for_store.store
+                                    ? gin_filter_condition->mayBeTrueOnGranuleInPart(granule, postings_lists_cache_for_store)
+                                    : true;
                     else
                         result = condition->mayBeTrueOnGranule(granule);
 

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -118,7 +118,7 @@ void MergeTreeIndexAggregatorGin::update(const Block & block, size_t * pos, size
     const auto & index_column_name = index_columns[0];
     const auto & index_column = block.getByName(index_column_name);
 
-    UInt32 start_row_id = store->getNextRowIDRange(rows_read);
+    UInt32 start_row_id = store->getNextRowIdRange(rows_read);
 
     size_t current_position = *pos;
     for (size_t i = 0; i < rows_read; ++i)
@@ -128,7 +128,7 @@ void MergeTreeIndexAggregatorGin::update(const Block & block, size_t * pos, size
             granule->gin_filter.add(String(token), start_row_id + i, store);
         store->incrementCurrentSizeBy(value.size());
     }
-    granule->gin_filter.addRowIdRangeToGinFilter(store->getCurrentSegmentID(), start_row_id, static_cast<UInt32>(start_row_id + rows_read - 1));
+    granule->gin_filter.addRowIdRangeToGinFilter(store->getCurrentSegmentId(), start_row_id, static_cast<UInt32>(start_row_id + rows_read - 1));
 
     if (store->needToWriteCurrentSegment())
         store->writeSegment();

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -42,7 +42,7 @@ static const String ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE = "bloom_filter_fa
 MergeTreeIndexGranuleGin::MergeTreeIndexGranuleGin(const String & index_name_)
     : index_name(index_name_)
     , gin_filter()
-    , has_elems(false)
+    , initialized(false)
 {
 }
 
@@ -76,7 +76,7 @@ void MergeTreeIndexGranuleGin::deserializeBinary(ReadBuffer & istr, MergeTreeInd
     if (filter_size != 0)
         istr.readStrict(reinterpret_cast<char *>(gin_filter.getSegmentsWithRowIdRange().data()), filter_size * sizeof(GinSegmentsWithRowIdRange::value_type));
 
-    has_elems = true;
+    initialized = true;
 }
 
 size_t MergeTreeIndexGranuleGin::memoryUsageBytes() const
@@ -133,7 +133,7 @@ void MergeTreeIndexAggregatorGin::update(const Block & block, size_t * pos, size
     if (store->needToWriteCurrentSegment())
         store->writeSegment();
 
-    granule->has_elems = true;
+    granule->initialized = true;
     *pos += rows_read;
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -118,7 +118,7 @@ void MergeTreeIndexAggregatorGin::update(const Block & block, size_t * pos, size
     const auto & index_column_name = index_columns[0];
     const auto & index_column = block.getByName(index_column_name);
 
-    auto start_row_id = store->getNextRowIDRange(rows_read);
+    UInt32 start_row_id = store->getNextRowIDRange(rows_read);
 
     size_t current_position = *pos;
     for (size_t i = 0; i < rows_read; ++i)

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -79,12 +79,10 @@ void MergeTreeIndexGranuleGin::deserializeBinary(ReadBuffer & istr, MergeTreeInd
     has_elems = true;
 }
 
-
 size_t MergeTreeIndexGranuleGin::memoryUsageBytes() const
 {
     return gin_filter.memoryUsageBytes();
 }
-
 
 MergeTreeIndexAggregatorGin::MergeTreeIndexAggregatorGin(
     GinIndexStorePtr store_,

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -604,8 +604,8 @@ bool MergeTreeIndexConditionGin::tryPrepareSetGinFilter(
         for (size_t row = 0; row < prepared_set->getTotalRowCount(); ++row)
         {
             gin_query_infos.back().emplace_back();
-            auto ref = column->getDataAt(row);
-            token_extractor->stringToGinFilter(ref.data, ref.size, gin_query_infos.back().back());
+            std::string_view value = column->getDataAt(row).toView();
+            token_extractor->stringToGinFilter(value.data(), value.size(), gin_query_infos.back().back());
         }
     }
 

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -56,7 +56,7 @@ void MergeTreeIndexGranuleGin::serializeBinary(WriteBuffer & ostr) const
 
     size_t filter_size = gin_filter.getFilter().size();
     size_serialization->serializeBinary(filter_size, ostr, {});
-    ostr.write(reinterpret_cast<const char *>(gin_filter.getFilter().data()), filter_size * sizeof(GinSegmentWithRowIdRangeVector::value_type));
+    ostr.write(reinterpret_cast<const char *>(gin_filter.getFilter().data()), filter_size * sizeof(GinSegmentsWithRowIdRange::value_type));
 }
 
 void MergeTreeIndexGranuleGin::deserializeBinary(ReadBuffer & istr, MergeTreeIndexVersion version)
@@ -74,7 +74,7 @@ void MergeTreeIndexGranuleGin::deserializeBinary(ReadBuffer & istr, MergeTreeInd
     gin_filter.getFilter().resize(filter_size);
 
     if (filter_size != 0)
-        istr.readStrict(reinterpret_cast<char *>(gin_filter.getFilter().data()), filter_size * sizeof(GinSegmentWithRowIdRangeVector::value_type));
+        istr.readStrict(reinterpret_cast<char *>(gin_filter.getFilter().data()), filter_size * sizeof(GinSegmentsWithRowIdRange::value_type));
 
     has_elems = true;
 }

--- a/src/Storages/MergeTree/MergeTreeIndexGin.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.cpp
@@ -727,7 +727,7 @@ MergeTreeIndexPtr ginIndexCreator(const IndexDescription & index)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Tokenizer {} not supported", tokenizer);
 
     UInt64 segment_digestion_threshold_bytes
-        = getOption<UInt64>(options, ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES).value_or(UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES);
+        = getOption<UInt64>(options, ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES).value_or(DEFAULT_SEGMENT_DIGESTION_THRESHOLD_BYTES);
 
     double bloom_filter_false_positive_rate
         = getOption<double>(options, ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE).value_or(DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE);
@@ -783,7 +783,7 @@ void ginIndexValidator(const IndexDescription & index, bool /*attach*/)
     }
 
     UInt64 segment_digestion_threshold_bytes
-        = getOption<UInt64>(options, ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES).value_or(UNLIMITED_SEGMENT_DIGESTION_THRESHOLD_BYTES);
+        = getOption<UInt64>(options, ARGUMENT_SEGMENT_DIGESTION_THRESHOLD_BYTES).value_or(DEFAULT_SEGMENT_DIGESTION_THRESHOLD_BYTES);
 
     double bloom_filter_false_positive_rate
         = getOption<double>(options, ARGUMENT_BLOOM_FILTER_FALSE_POSITIVE_RATE).value_or(DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE);

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -19,12 +19,12 @@ struct MergeTreeIndexGranuleGin final : public IMergeTreeIndexGranule
     void serializeBinary(WriteBuffer & ostr) const override;
     void deserializeBinary(ReadBuffer & istr, MergeTreeIndexVersion version) override;
 
-    bool empty() const override { return !has_elems; }
+    bool empty() const override { return !initialized; }
     size_t memoryUsageBytes() const override;
 
     const String index_name;
     GinFilter gin_filter;
-    bool has_elems;
+    bool initialized;
 };
 
 using MergeTreeIndexGranuleGinPtr = std::shared_ptr<MergeTreeIndexGranuleGin>;

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -66,7 +66,7 @@ public:
 
     bool alwaysUnknownOrTrue() const override;
     bool mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx_granule) const override;
-    bool mayBeTrueOnGranuleInPart(MergeTreeIndexGranulePtr idx_granule, PostingsCacheForStore & cache_store) const;
+    bool mayBeTrueOnGranuleInPart(MergeTreeIndexGranulePtr idx_granule, GinPostingsListsCacheForStore & postings_lists_cache_for_store) const;
 
 private:
     struct KeyTuplePositionMapping
@@ -101,16 +101,16 @@ private:
         };
 
         RPNElement( /// NOLINT
-            Function function_ = FUNCTION_UNKNOWN, std::unique_ptr<GinQueryString> && gin_query_string_ = nullptr)
-                : function(function_), gin_query_string(std::move(gin_query_string_)) {}
+            Function function_ = FUNCTION_UNKNOWN, std::unique_ptr<GinQueryString> && query_string_ = nullptr)
+                : function(function_), query_string(std::move(query_string_)) {}
 
         Function function = FUNCTION_UNKNOWN;
 
         /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS
-        std::unique_ptr<GinQueryString> gin_query_string;
+        std::unique_ptr<GinQueryString> query_string;
 
         /// For FUNCTION_IN and FUNCTION_NOT_IN
-        std::vector<std::vector<GinQueryString>> gin_query_strings_for_set;
+        std::vector<std::vector<GinQueryString>> query_strings_for_set;
 
         /// For FUNCTION_IN and FUNCTION_NOT_IN
         std::vector<size_t> set_key_position;

--- a/src/Storages/MergeTree/MergeTreeIndexGin.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGin.h
@@ -42,7 +42,6 @@ struct MergeTreeIndexAggregatorGin final : IMergeTreeIndexAggregator
     bool empty() const override { return !granule || granule->empty(); }
     MergeTreeIndexGranulePtr getGranuleAndReset() override;
     void update(const Block & block, size_t * pos, size_t limit) override;
-    void addToGinFilter(UInt32 rowID, const char * data, size_t length, GinFilter & gin_filter);
 
     GinIndexStorePtr store;
     Names index_columns;

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -798,7 +798,7 @@ static NameSet collectFilesToSkip(
         {
             auto index_filename = index->getFileName();
             files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE);
-            files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE);
+            files_to_skip.insert(index_filename + GinIndexStore::GIN_SEGMENT_DESCRIPTOR_FILE_TYPE);
             files_to_skip.insert(index_filename + GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE);
             files_to_skip.insert(index_filename + GinIndexStore::GIN_DICTIONARY_FILE_TYPE);
             files_to_skip.insert(index_filename + GinIndexStore::GIN_POSTINGS_FILE_TYPE);
@@ -882,7 +882,7 @@ static NameToNameVector collectFilesForRenames(
             static const std::array<String, 2> suffixes = {".idx2", ".idx"};
             static const std::array<String, 5> gin_suffixes = {
                 GinIndexStore::GIN_SEGMENT_ID_FILE_TYPE,
-                GinIndexStore::GIN_SEGMENT_METADATA_FILE_TYPE,
+                GinIndexStore::GIN_SEGMENT_DESCRIPTOR_FILE_TYPE,
                 GinIndexStore::GIN_BLOOM_FILTER_FILE_TYPE,
                 GinIndexStore::GIN_DICTIONARY_FILE_TYPE,
                 GinIndexStore::GIN_POSTINGS_FILE_TYPE,


### PR DESCRIPTION
Note: Contains commits from https://github.com/ClickHouse/ClickHouse/pull/86131 and will be rebased on `master` once the other commit is merged.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced the segment size for text indexes from unlimited to 10 GiB. This reduces the risk of OOMs during merges of large parts which we have seen in internal testing.