### PR TITLE
Use NonZeroUInt64 for logs_to_keep in DatabaseReplicatedSettings

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -83,7 +83,7 @@ namespace DatabaseReplicatedSetting
     extern const DatabaseReplicatedSettingsString collection_name;
     extern const DatabaseReplicatedSettingsFloat max_broken_tables_ratio;
     extern const DatabaseReplicatedSettingsUInt64 max_replication_lag_to_enqueue;
-    extern const DatabaseReplicatedSettingsUInt32 logs_to_keep;
+    extern const DatabaseReplicatedSettingsNonZeroUInt64 logs_to_keep;
 }
 
 namespace ErrorCodes

--- a/src/Databases/DatabaseReplicatedSettings.cpp
+++ b/src/Databases/DatabaseReplicatedSettings.cpp
@@ -22,7 +22,7 @@ extern const int UNKNOWN_SETTING;
     DECLARE(Bool, check_consistency, true, "Check consistency of local metadata and metadata in Keeper, do replica recovery on inconsistency", 0) \
     DECLARE(UInt64, max_retries_before_automatic_recovery, 10, "Max number of attempts to execute a queue entry before marking replica as lost recovering it from snapshot (0 means infinite)", 0) \
     DECLARE(Bool, allow_skipping_old_temporary_tables_ddls_of_refreshable_materialized_views, false, "If enabled, when processing DDLs in Replicated databases, it skips creating and exchanging DDLs of the temporary tables of refreshable materialized views if possible", 0) \
-    DECLARE(UInt32, logs_to_keep, 1000, "Default number of logs to keep in ZooKeeper for Replicated database.", 0) \
+    DECLARE(NonZeroUInt64, logs_to_keep, 1000, "Default number of logs to keep in ZooKeeper for Replicated database.", 0) \
 
 DECLARE_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)

--- a/src/Databases/DatabaseReplicatedSettings.h
+++ b/src/Databases/DatabaseReplicatedSettings.h
@@ -22,7 +22,7 @@ struct DatabaseReplicatedSettingsImpl;
     M(CLASS_NAME, Float) \
     M(CLASS_NAME, String) \
     M(CLASS_NAME, UInt64) \
-    M(CLASS_NAME, UInt32)
+    M(CLASS_NAME, NonZeroUInt64)
 
 DATABASE_REPLICATED_SETTINGS_SUPPORTED_TYPES(DatabaseReplicatedSettings, DECLARE_SETTING_TRAIT)
 

--- a/tests/integration/test_database_replicated_settings/test.py
+++ b/tests/integration/test_database_replicated_settings/test.py
@@ -176,3 +176,13 @@ def test_database_replicated_settings(
     settings_dict_from_logs = get_settings_from_logs(node, db_name)
     assert setting_dict == settings_dict_from_logs
     node.query(f"DROP DATABASE IF EXISTS {db_name}")
+
+
+def test_database_replicated_settings_zero_logs_to_keep(started_cluster):
+    db_name = "test_" + get_random_string()
+
+    assert "A setting's value has to be greater than 0" in node1.query_and_get_error(
+        f"CREATE DATABASE {db_name} ENGINE=Replicated('/test/{db_name}', "
+        + r"'{shard}', '{replica}') "
+        + "SETTINGS logs_to_keep=0"
+    )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `NonZeroUInt64` for `logs_to_keep` in DatabaseReplicatedSettings.

If `logs_to_keep` is zero, the replica is always in the lost state.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
