### PR TITLE
Trivial count optimization in parquet reader v3

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Reader.h
+++ b/src/Processors/Formats/Impl/Parquet/Reader.h
@@ -25,6 +25,7 @@ namespace DB::Parquet
 
 // TODO [parquet]:
 //  * column_mapper
+//  * find a way to make this compatible at all with our implementation of iceberg positioned deletes: https://github.com/ClickHouse/ClickHouse/pull/83094 (prewhere causes nonconsecutive row idxs in chunk)
 //  * allow_geoparquet_parser
 //  * test on files from https://github.com/apache/parquet-testing
 //  * check fields for false sharing, add cacheline padding as needed

--- a/src/Processors/Formats/Impl/ParquetV3BlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetV3BlockInputFormat.h
@@ -44,6 +44,7 @@ private:
     FormatFilterInfoPtr format_filter_info;
 
     std::optional<Parquet::ReadManager> reader;
+    bool reported_count = false; // if need_only_count
 
     BlockMissingValues previous_block_missing_values;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Don't read a column on `select count()`.