### PR TITLE
Support filtering by complete URL string in http_handlers (including schema and host:port)

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -656,6 +656,7 @@ Configuration options for `http_handlers` work as follows.
 - `method`
 - `headers`
 - `url`
+- `full_url`
 - `handler`
 
 Each of these are discussed below:
@@ -664,17 +665,27 @@ Each of these are discussed below:
   (https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) in the HTTP protocol. It is an optional configuration. If it is not defined in the   
   configuration file, it does not match the method portion of the HTTP request.
 
-- `url` is responsible for matching the URL part of the HTTP request. It is compatible with [RE2](https://github.com/google/re2)'s regular 
-  expressions. It is an optional configuration. If it is not defined in the configuration file, it does not match the URL portion of the HTTP 
-  request.
+- `url` is responsible for matching the URL part (path and query string) of the HTTP request.
+  If the `url` prefixed with `regex:` it expects [RE2](https://github.com/google/re2)'s regular expressions.
+  It is an optional configuration. If it is not defined in the configuration file, it does not match the URL portion of the HTTP request.
+
+- `full_url` same as `url`, but, includes complete URL, i.e. `schema://host:port/path?query_string`.
+  Note, ClickHouse does not support "virtual hosts", so the `host` is an IP address (and not the value of `Host` header).
+
+- `empty_query_string` - ensures that there is no query string (`?query_string`) in the request
 
 - `headers` are responsible for matching the header part of the HTTP request. It is compatible with RE2's regular expressions. It is an optional 
   configuration. If it is not defined in the configuration file, it does not match the header portion of the HTTP request.
 
-- `handler` contains the main processing part. Now `handler` can configure `type`, `status`, `content_type`, `http_response_headers`, 
-  `response_content`, `query`, `query_param_name`. `type` currently supports three types: [`predefined_query_handler`](#predefined_query_handler), 
-  [`dynamic_query_handler`](#dynamic_query_handler), [`static`](#static).
+- `handler` contains the main processing part.
 
+  It can have the following `type`:
+  - [`predefined_query_handler`](#predefined_query_handler)
+  - [`dynamic_query_handler`](#dynamic_query_handler)
+  - [`static`](#static)
+  - [`redirect`](#redirect)
+
+  And the following parameters:
   - `query` — use with `predefined_query_handler` type, executes query when the handler is called.
   - `query_param_name` — use with `dynamic_query_handler` type, extracts and executes the value corresponding to the `query_param_name` value in 
        HTTP request parameters.
@@ -683,6 +694,8 @@ Each of these are discussed below:
   - `http_response_headers` — use with any type, response headers map. Could be used to set content type as well.
   - `response_content` — use with `static` type, response content sent to client, when using the prefix 'file://' or 'config://', find the content 
     from the file or configuration sends to client.
+  - `user` - user to execute the query from (default user is `default`).
+    **Note**, you do not need to specify password for this user.
 
 The configuration methods for different `type`s are discussed next.
 
@@ -951,6 +964,27 @@ $ curl -vv -H 'XXX:xxx' 'http://localhost:8123/get_relative_path_static_handler'
 <
 <html><body>Relative Path File</body></html>
 * Connection #0 to host localhost left intact
+```
+
+### redirect {#redirect}
+
+`redirect` will do a `302` redirect to `location`
+
+For instance this is how you can automatically add set user to `play` for ClickHouse play:
+
+```xml
+<clickhouse>
+    <http_handlers>
+        <rule>
+            <methods>GET</methods>
+            <url>/play</url>
+            <handler>
+                <type>redirect</type>
+                <location>/play?user=play</location>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>
 ```
 
 ## HTTP response headers {#http-response-headers}

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1666,7 +1666,9 @@
     <!-- Uncomment to use custom http handlers.
 
         rules are checked from top to bottom, first match runs the handler
-            url - to match request URL, you can use 'regex:' prefix to use regex match(optional)
+            url - to match request URL (path and query string only), you can use 'regex:' prefix to use regex match(optional)
+            full_url - to match request **full** URL (schema, host:port, path and query string), you can use 'regex:' prefix to use regex match(optional)
+                       note, ClickHouse does not support "virtual hosts" so "host" will contain IP address not the "Host" header.
             empty_query_string - check that there is no query string in the URL
             methods - to match request method, you can use commas to separate multiple method matches(optional)
             headers - to match request headers, match each child element (child element name is header name), you can use 'regex:' prefix to use regex match(optional)
@@ -1699,6 +1701,22 @@
             <handler>
                 <type>predefined_query_handler</type>
                 <query>SELECT * FROM system.settings</query>
+            </handler>
+        </rule>
+
+        <rule>
+            <url>/play</url>
+            <handler>
+                <type>redirect</type>
+                <location>/play?user=play</location>
+            </handler>
+        </rule>
+
+        <rule>
+            <full_url>regex:http?://[^/]/dashboard</full_url>
+            <handler>
+                <type>redirect</type>
+                <location>/dashboard?user=play</location>
             </handler>
         </rule>
 

--- a/src/Server/HTTPHandlerFactory.h
+++ b/src/Server/HTTPHandlerFactory.h
@@ -52,8 +52,12 @@ public:
         {
             if (filter_type == "handler")
                 continue;
+            /// URI (path and query string)
             if (filter_type == "url")
                 addFilter(urlFilter(config, prefix + ".url"));
+            /// URL (schema, host:port, path and query string)
+            else if (filter_type == "full_url")
+                addFilter(fullUrlFilter(config, prefix + ".full_url"));
             else if (filter_type == "empty_query_string")
                 addFilter(emptyQueryStringFilter());
             else if (filter_type == "headers")

--- a/src/Server/HTTPHandlerRequestFilter.h
+++ b/src/Server/HTTPHandlerRequestFilter.h
@@ -76,6 +76,22 @@ static inline auto urlFilter(const Poco::Util::AbstractConfiguration & config, c
     };
 }
 
+static inline auto fullUrlFilter(const Poco::Util::AbstractConfiguration & config, const std::string & config_path)
+{
+    return [expression = getExpression(config.getString(config_path))](const HTTPServerRequest & request)
+    {
+        const auto & server_address = request.serverAddress();
+        std::string url(fmt::format("{}://{}{}",
+            request.isSecure() ? "https" : "http",
+            server_address.toString(),
+            request.getURI()
+        ));
+
+        const auto & end = find_first_symbols<'?'>(url.data(), url.data() + url.size());
+        return checkExpression(std::string_view(url.data(), end - url.data()), expression);
+    };
+}
+
 static inline auto emptyQueryStringFilter()
 {
     return [](const HTTPServerRequest & request)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4473,11 +4473,12 @@ class ClickHouseInstance:
         return (None, str(code) + " " + http.client.responses[code] + ": " + r.text)
 
     # Connects to the instance via HTTP interface, sends a query and returns the answer
-    def http_request(self, url, method="GET", params=None, data=None, headers=None):
-        logging.debug(f"Sending HTTP request {url} to {self.name}")
-        url = "http://" + self.ip_address + ":8123/" + url
+    # @param url - URI without leading slash
+    def http_request(self, url, method="GET", params=None, data=None, headers=None, *args, **kwargs):
+        logging.debug(f"Sending HTTP request '{url}' to {self.name}")
+        url = f"http://{self.ip_address}:8123/{url}"
         return requests.request(
-            method=method, url=url, params=params, data=data, headers=headers
+            method=method, url=url, params=params, data=data, headers=headers, *args, **kwargs
         )
 
     def stop_clickhouse(self, stop_wait_sec=30, kill=False):

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -676,3 +676,36 @@ def test_headers_in_response():
             "query_param_with_url", method="GET", headers={"PARAMS_XXX": "test_param"})
         assert response_predefined.headers["X-My-Answer"] == f"Iam predefined"
         assert response_predefined.headers["X-My-Common-Header"] == "Common header present"
+
+
+def test_redirect_handler():
+    with contextlib.closing(
+        SimpleCluster(
+            ClickHouseCluster(__file__), "redirect_handler", "test_redirect_handler"
+        )
+    ) as cluster:
+        def get(uri, *args, **kwargs):
+            return cluster.instance.http_request(uri, method="GET", allow_redirects=False, *args, **kwargs)
+
+        req = get("")
+        assert req.status_code == 302
+        assert req.headers["Location"] == "/play"
+
+        req = get("/pla")
+        assert req.status_code == 302
+        assert req.headers["Location"] == "/play"
+
+        req = get("/foo/pla")
+        assert req.status_code == 404
+
+        # Host does not match - no redirect, and we do not add defaults so, it will be 404
+        req = get("/play")
+        assert req.status_code == 404
+
+        req = get("/dashboard")
+        assert req.status_code == 302
+        assert req.headers["Location"] == "/dashboard?from=http://:8123/dashboard"
+
+        # Query string is not empty - no redirect, and we do not add defaults so, it will be 404
+        req = get("/dashboard?foo=bar")
+        assert req.status_code == 404

--- a/tests/integration/test_http_handlers_config/test_redirect_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_redirect_handler/config.xml
@@ -1,0 +1,41 @@
+<clickhouse>
+    <http_handlers>
+        <rule>
+            <methods>GET</methods>
+            <url>/</url>
+            <handler>
+                <type>redirect</type>
+                <location>/play</location>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET</methods>
+            <url>regex:^/pla</url>
+            <handler>
+                <type>redirect</type>
+                <location>/play</location>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET</methods>
+            <full_url>http://127.0.0.1:8123/play</full_url>
+            <empty_query_string></empty_query_string>
+            <handler>
+                <type>redirect</type>
+                <location>/play?from=http://127.0.0.1:8123/play</location>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET</methods>
+            <full_url>regex:^http://[^:]*:8123/dashboard</full_url>
+            <empty_query_string></empty_query_string>
+            <handler>
+                <type>redirect</type>
+                <location>/dashboard?from=http://:8123/dashboard</location>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>


### PR DESCRIPTION
Can be used to i.e. redirect from HTTPS to HTTP

Also update the documentation to include missing configuration directives.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support filtering by complete URL string (`full_url` directive) in `http_handlers` (including schema and host:port)