### PR TITLE
Add MT setting `max_digestion_size_per_segment` back, mark as obsolete

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -864,6 +864,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"dynamic_serialization_version", "v2", "v2", "Add a setting to control Dynamic serialization versions"},
             {"search_orphaned_parts_disks", "any", "any", "New setting"},
             {"shared_merge_tree_virtual_parts_discovery_batch", 1, 1, "New setting"},
+            {"max_digestion_size_per_segment", 256_MiB, 256_MiB, "Obsolete setting"},
             {"shared_merge_tree_update_replica_flags_delay_ms", 30000, 30000, "New setting"},
             {"write_marks_for_substreams_in_compact_parts", false, true, "Enable writing marks for substreams in compact parts by default"},
             {"allow_part_offset_column_in_projections", false, true, "Now projections can use _part_offset column."},

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1921,6 +1921,7 @@ namespace ErrorCodes
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, Seconds, replicated_fetches_http_receive_timeout, 0) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, replicated_max_parallel_fetches_for_host, DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, CleanDeletedRows, clean_deleted_rows, CleanDeletedRows::Never) \
+    MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, max_digestion_size_per_segment, 256_MiB) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, kill_delay_period, 30) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, kill_delay_period_random_add, 10) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, kill_threads, 128) \

--- a/tests/queries/0_stateless/02995_merge_tree_settings_settings_25_8_1.tsv
+++ b/tests/queries/0_stateless/02995_merge_tree_settings_settings_25_8_1.tsv
@@ -89,6 +89,7 @@ max_compress_block_size	0
 max_concurrent_queries	0
 max_delay_to_insert	1
 max_delay_to_mutate_ms	1000
+max_digestion_size_per_segment	268435456
 max_file_name_length	127
 max_files_to_modify_in_alter_columns	75
 max_files_to_remove_in_alter_columns	50


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/pull/84590 removed MergeTree setting `max_digestion_size_per_segment`. This PR adds it back but marks it as "obsolet" so that systems with older compatibility level don't break.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)