### PR TITLE
`chcache`: add basic stats

### DIFF
--- a/rust/chcache/Cargo.lock
+++ b/rust/chcache/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "clickhouse",
  "env_logger",
  "log",
+ "memmap2",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -796,6 +797,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"

--- a/rust/chcache/Cargo.toml
+++ b/rust/chcache/Cargo.toml
@@ -8,6 +8,7 @@ blake3 = "1.5.4"
 clickhouse = { version = "0.13.1", features = ["rustls-tls"] }
 env_logger = { version = "0.11.5", default-features = false }
 log = "0.4.22"
+memmap2 = "0.9.8"
 serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_bytes = "0.11.15"
 serde_json = "1.0.140"

--- a/rust/chcache/src/counters.rs
+++ b/rust/chcache/src/counters.rs
@@ -1,0 +1,145 @@
+use std::fs::OpenOptions;
+use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use memmap2::{MmapMut, MmapOptions};
+
+#[repr(C)]
+struct CacheStats {
+    version: u8,
+
+    cache_hits_local: AtomicUsize,
+    cache_hits_remote: AtomicUsize,
+    cache_miss: AtomicUsize,
+    uncacheable: AtomicUsize,
+
+    invocation_count: AtomicUsize,
+}
+
+const SHM_SIZE: u64 = std::mem::size_of::<CacheStats>() as u64;
+
+pub struct CacheStatsTracker {
+    #[allow(dead_code)]
+    mmap: MmapMut,
+    pointer: *mut CacheStats,
+}
+
+impl CacheStatsTracker {
+    pub fn init() -> Self {
+        let local_path = xdg::BaseDirectories::with_prefix("chcache");
+
+        let mut stats_file_path = local_path
+            .get_cache_home()
+            .expect("Failed to find XDG_CACHE_HOME");
+        stats_file_path.push("stats");
+
+        let err = format!(
+            "Failed to open statistics file {}",
+            stats_file_path.display()
+        );
+        let stats_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(stats_file_path)
+            .expect(&err);
+
+        stats_file
+            .set_len(SHM_SIZE)
+            .expect("Can not set statistics file size");
+
+        let mut mmap = unsafe {
+            MmapOptions::new()
+                .map_mut(&stats_file)
+                .expect("Failed to mmap() statistics file")
+        };
+
+        let cache_stats = mmap.as_mut_ptr() as *mut CacheStats;
+
+        unsafe {
+            if ptr::read(cache_stats)
+                .invocation_count
+                .load(Ordering::Acquire)
+                == 0
+            {
+                ptr::write(
+                    cache_stats,
+                    CacheStats {
+                        version: 0,
+
+                        cache_hits_local: AtomicUsize::new(0),
+                        cache_hits_remote: AtomicUsize::new(0),
+                        cache_miss: AtomicUsize::new(0),
+                        uncacheable: AtomicUsize::new(0),
+
+                        invocation_count: AtomicUsize::new(1),
+                    },
+                )
+            }
+        };
+
+        CacheStatsTracker {
+            mmap,
+            pointer: cache_stats,
+        }
+    }
+
+    #[inline]
+    fn stats(&self) -> &CacheStats {
+        unsafe {
+            self.pointer
+                .as_ref()
+                .expect("Failed to get reference to mapped stats file")
+        }
+    }
+
+    pub fn increment_invocation(&self) {
+        self.stats()
+            .invocation_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_local_hit(&self) {
+        self.stats()
+            .cache_hits_local
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_remote_hit(&self) {
+        self.stats()
+            .cache_hits_remote
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_miss(&self) {
+        self.stats().cache_miss.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_uncacheable(&self) {
+        self.stats().uncacheable.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn dump(&self) {
+        println!("Statistics summary:");
+        println!(
+            "  {:<30} {}",
+            "invocations", self.stats().invocation_count.load(Ordering::Relaxed)
+        );
+        println!(
+            "  {:<30} {}",
+            "cache hit (local)", self.stats().cache_hits_local.load(Ordering::Relaxed)
+        );
+        println!(
+            "  {:<30} {}",
+            "cache hit (remote)", self.stats().cache_hits_remote.load(Ordering::Relaxed)
+        );
+        println!(
+            "  {:<30} {}",
+            "cache miss", self.stats().cache_miss.load(Ordering::Relaxed)
+        );
+        println!(
+            "  {:<30} {}",
+            "uncacheable", self.stats().uncacheable.load(Ordering::Relaxed)
+        );
+    }
+}

--- a/rust/chcache/src/main.rs
+++ b/rust/chcache/src/main.rs
@@ -3,12 +3,14 @@ use std::error::Error;
 
 mod compilers;
 mod config;
+mod counters;
 mod disks;
 mod traits;
 
 use crate::compilers::clang::{Clang, ClangXX};
 use crate::compilers::rustc::RustC;
 use crate::config::Config;
+use crate::counters::CacheStatsTracker;
 use crate::disks::clickhouse::ClickHouseDisk;
 use crate::disks::local::LocalDisk;
 use crate::traits::compiler::CompilerMeta;
@@ -18,12 +20,27 @@ use crate::traits::disk::Disk;
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
+    xdg::BaseDirectories::with_prefix("chcache").create_cache_directory("chcache")?;
+
     compiler_cache_entrypoint(&Config::init()).await
 }
 
 async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>> {
-    let compiler_path: String = std::env::args().nth(1).unwrap();
+    let stats = CacheStatsTracker::init();
+    stats.increment_invocation();
+
+    let compiler_path_or_command: String = std::env::args().nth(1).unwrap();
     let rest_of_args: Vec<String> = std::env::args().skip(2).collect();
+
+    match compiler_path_or_command.as_str() {
+        "stats" => {
+            stats.dump();
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    let compiler_path = compiler_path_or_command;
 
     trace!("Compiler: {}", compiler_path);
     trace!("Args: {:?}", rest_of_args);
@@ -35,18 +52,9 @@ async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>
         .to_string();
 
     let compiler = match just_compiler_name.as_str() {
-        RustC::NAME => RustC::from_args(
-            compiler_path.clone(),
-            rest_of_args.clone(),
-        ),
-        Clang::NAME => Clang::from_args(
-            compiler_path.clone(),
-            rest_of_args.clone(),
-        ),
-        ClangXX::NAME => ClangXX::from_args(
-            compiler_path.clone(),
-            rest_of_args.clone(),
-        ),
+        RustC::NAME => RustC::from_args(compiler_path.clone(), rest_of_args.clone()),
+        Clang::NAME => Clang::from_args(compiler_path.clone(), rest_of_args.clone()),
+        ClangXX::NAME => ClangXX::from_args(compiler_path.clone(), rest_of_args.clone()),
         _ => {
             panic!("Unknown compiler: {}", compiler_path);
         }
@@ -54,6 +62,8 @@ async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>
 
     if !compiler.cacheable() {
         trace!("Call is not cacheable");
+
+        stats.increment_uncacheable();
 
         let output = std::process::Command::new(compiler_path)
             .args(&rest_of_args)
@@ -88,6 +98,8 @@ async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>
         Ok(bytes) => {
             info!("Local cache hit");
 
+            stats.increment_local_hit();
+
             compiler
                 .apply_cache(&bytes)
                 .expect(&("Unable to apply local cache for hash ".to_owned() + &total_hash));
@@ -103,6 +115,8 @@ async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>
                 Ok(bytes) => {
                     info!("Loaded from ClickHouse");
 
+                    stats.increment_remote_hit();
+
                     compiler
                         .apply_cache(&bytes)
                         .expect("Unable to apply cache from ClickHouse");
@@ -113,6 +127,8 @@ async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>
                 }
                 Err(e) => {
                     trace!("Got error from CH: {:?}", e);
+
+                    stats.increment_miss();
                     compiler.compile().expect("Unable to compile")
                 }
             };
@@ -131,18 +147,16 @@ async fn compiler_cache_entrypoint(config: &Config) -> Result<(), Box<dyn Error>
     let should_upload = {
         let default_config = Config::default();
 
-        !did_load_from_local_cache && !did_load_from_clickhouse && config.user != default_config.user
+        !did_load_from_local_cache
+            && !did_load_from_clickhouse
+            && config.user != default_config.user
     };
 
     if should_upload {
         let mut tries = 3;
         loop {
             let upload_result = clickhouse_disk
-                .write(
-                    &compiler_version,
-                    &total_hash,
-                    &compiled_bytes,
-                )
+                .write(&compiler_version, &total_hash, &compiled_bytes)
                 .await;
 
             if upload_result.is_ok() {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

```
➜  cmake-build-debug git:(chcache-add-counters) ✗ rust/chcache/chcache stats
Statistics summary:
  invocations                    13983
  cache hit (local)              150
  cache hit (remote)             0
  cache miss                     13727
  uncacheable                    36
```

Closes #77170 
