### PR TITLE
Fix detection of systemd in init.d script (fixes "Install packages" check)

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -18,6 +18,9 @@ set -e
 trap "bash -ex /packages/preserve_logs.sh" ERR
 test_env='TEST_THE_DEFAULT_PARAMETER=15'
 echo "$test_env" >> /etc/default/clickhouse
+# Note, clickhouse-server service notify systemd only when it is ready to
+# accept connections, so we do not need to wait until it will open the port for
+# listening manually here.
 systemctl restart clickhouse-server
 clickhouse-client -q 'SELECT version()'
 grep "$test_env" /proc/$(cat /var/run/clickhouse-server/clickhouse-server.pid)/environ"""
@@ -26,6 +29,7 @@ set -e
 trap "bash -ex /packages/preserve_logs.sh" ERR
 test_env='TEST_THE_DEFAULT_PARAMETER=15'
 echo "$test_env" >> /etc/default/clickhouse
+# Note, this should use systemctl
 /etc/init.d/clickhouse-server start
 clickhouse-client -q 'SELECT version()'
 grep "$test_env" /proc/$(cat /var/run/clickhouse-server/clickhouse-server.pid)/environ"""

--- a/packages/clickhouse-server.init
+++ b/packages/clickhouse-server.init
@@ -101,6 +101,11 @@ forcestop()
 
 service_or_func()
 {
+    if [ -n "${SYSTEMCTL_SKIP_REDIRECT+x}" ]; then
+        $1
+        return
+    fi
+
     if [ -x "/bin/systemctl" ] && [ -d /run/systemd/system ]; then
         if [ -f /etc/systemd/system/clickhouse-server.service ] || [ -f /lib/systemd/system/clickhouse-server.service ]; then
             systemctl $1 $PROGRAM

--- a/packages/clickhouse-server.init
+++ b/packages/clickhouse-server.init
@@ -101,11 +101,14 @@ forcestop()
 
 service_or_func()
 {
-    if [ -x "/bin/systemctl" ] && [ -f /etc/systemd/system/clickhouse-server.service ] && [ -d /run/systemd/system ]; then
-        systemctl $1 $PROGRAM
-    else
-        $1
+    if [ -x "/bin/systemctl" ] && [ -d /run/systemd/system ]; then
+        if [ -f /etc/systemd/system/clickhouse-server.service ] || [ -f /lib/systemd/system/clickhouse-server.service ]; then
+            systemctl $1 $PROGRAM
+            return
+        fi
     fi
+
+    $1
 }
 
 forcerestart()


### PR DESCRIPTION
Previously only /etc/systemd/system/clickhouse-server.service has been checked, but it is not where the service is installed by default, by default it is /lib/systemd/system/clickhouse-server.service.

In /etc you will have the file only if you have a complete override.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix detection of systemd in init.d script (fixes "Install packages" check)