### PR TITLE
Docs: correct key name for logger

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -822,7 +822,7 @@ The location and format of log messages.
 | `stream_compress`      | Compress log messages using LZ4. Set to `1` or `true` to enable.                                                                                                   |
 | `console`              | Enable logging to the console. Set to `1` or `true` to enable. Default is `1` if Clickhouse does not run in daemon mode, `0` otherwise.                            |
 | `console_log_level`    | Log level for console output. Defaults to `level`.                                                                                                                 |
-| `formatting.type`           | Log format for console output. Currently, only `json` is supported                                                                                                 |
+| `formatting.type`      | Log format for console output. Currently, only `json` is supported                                                                                                 |
 | `use_syslog`           | Also forward log output to syslog.                                                                                                                                 |
 | `syslog_level`         | Log level for logging to syslog.                                                                                                                                   |
 | `async`                | When `true` (default) logging will happen asynchronously (one background thread per output channel). Otherwise it will log inside the thread calling LOG           |

--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -822,7 +822,7 @@ The location and format of log messages.
 | `stream_compress`      | Compress log messages using LZ4. Set to `1` or `true` to enable.                                                                                                   |
 | `console`              | Enable logging to the console. Set to `1` or `true` to enable. Default is `1` if Clickhouse does not run in daemon mode, `0` otherwise.                            |
 | `console_log_level`    | Log level for console output. Defaults to `level`.                                                                                                                 |
-| `formatting`           | Log format for console output. Currently, only `json` is supported                                                                                                 |
+| `formatting.type`           | Log format for console output. Currently, only `json` is supported                                                                                                 |
 | `use_syslog`           | Also forward log output to syslog.                                                                                                                                 |
 | `syslog_level`         | Log level for logging to syslog.                                                                                                                                   |
 | `async`                | When `true` (default) logging will happen asynchronously (one background thread per output channel). Otherwise it will log inside the thread calling LOG           |


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Closes https://github.com/ClickHouse/clickhouse-docs/issues/4331
User reported that we specify `logger.formatting` as the key but it is actually `logger.formatting.type`. Corrects this in the documentation.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
