### PR TITLE
CI: Team notifications hook for the whole integrations team

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -14,7 +14,7 @@ def check():
         if any(file.startswith(f) for f in integrations_ecosystem_files):
             GH.post_updateable_comment(
                 comment_tags_and_bodies={
-                    "team_notigication": "@ClickHouse/integrations-ecosystem please, take a look"
+                    "team_notification": "@ClickHouse/integrations team,  please, take a look"
                 }
             )
             break


### PR DESCRIPTION
It's a follow up on https://github.com/ClickHouse/ClickHouse/pull/82042 to notify the whole Integrations team, including ClickPipes, about a new data type that was added.

### Changelog category
- CI Fix or Improvement (changelog entry is not required)

