### PR TITLE
Add all fields of DataSourceDescription in its toString() to help debug

### DIFF
--- a/src/Disks/DiskType.cpp
+++ b/src/Disks/DiskType.cpp
@@ -49,48 +49,41 @@ bool DataSourceDescription::sameKind(const DataSourceDescription & other) const
         == std::tie(other.type, other.object_storage_type, other_description);
 }
 
-std::string DataSourceDescription::toString() const
+String DataSourceDescription::name() const
 {
-    String str;
     switch (type)
     {
         case DataSourceType::Local:
-            str = "local";
-            break;
+            return "local";
         case DataSourceType::RAM:
-            str = "memory";
-            break;
+            return "memory";
         case DataSourceType::ObjectStorage:
         {
             switch (object_storage_type)
             {
                 case ObjectStorageType::S3:
-                    str = "s3";
-                    break;
+                    return "s3";
                 case ObjectStorageType::HDFS:
-                    str = "hdfs";
-                    break;
+                    return "hdfs";
                 case ObjectStorageType::Azure:
-                    str = "azure_blob_storage";
-                    break;
+                    return "azure_blob_storage";
                 case ObjectStorageType::Local:
-                    str = "local_blob_storage";
-                    break;
+                    return "local_blob_storage";
                 case ObjectStorageType::Web:
-                    str = "web";
-                    break;
+                    return "web";
                 case ObjectStorageType::None:
-                    str = "none";
-                    break;
+                    return "none";
                 case ObjectStorageType::Max:
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected object storage type: Max");
             }
         }
     }
-
-    str += fmt::format(" (description = '{}', is_encrypted = {}, is_cached = {}, zookeeper_name = '{}')",
-                       description, is_encrypted, is_cached, zookeeper_name);
-
-    return str;
 }
+
+String DataSourceDescription::toString() const
+{
+    return fmt::format("{} (description = '{}', is_encrypted = {}, is_cached = {}, zookeeper_name = '{}')",
+                       name(), description, is_encrypted, is_cached, zookeeper_name);
+}
+
 }

--- a/src/Disks/DiskType.cpp
+++ b/src/Disks/DiskType.cpp
@@ -2,8 +2,6 @@
 #include <Poco/String.h>
 #include <Common/Exception.h>
 
-#include <unordered_set>
-
 namespace DB
 {
 namespace ErrorCodes
@@ -53,32 +51,46 @@ bool DataSourceDescription::sameKind(const DataSourceDescription & other) const
 
 std::string DataSourceDescription::toString() const
 {
+    String str;
     switch (type)
     {
         case DataSourceType::Local:
-            return "local";
+            str = "local";
+            break;
         case DataSourceType::RAM:
-            return "memory";
+            str = "memory";
+            break;
         case DataSourceType::ObjectStorage:
         {
             switch (object_storage_type)
             {
                 case ObjectStorageType::S3:
-                    return "s3";
+                    str = "s3";
+                    break;
                 case ObjectStorageType::HDFS:
-                    return "hdfs";
+                    str = "hdfs";
+                    break;
                 case ObjectStorageType::Azure:
-                    return "azure_blob_storage";
+                    str = "azure_blob_storage";
+                    break;
                 case ObjectStorageType::Local:
-                    return "local_blob_storage";
+                    str = "local_blob_storage";
+                    break;
                 case ObjectStorageType::Web:
-                    return "web";
+                    str = "web";
+                    break;
                 case ObjectStorageType::None:
-                    return "none";
+                    str = "none";
+                    break;
                 case ObjectStorageType::Max:
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected object storage type: Max");
             }
         }
     }
+
+    str += fmt::format(" (description = '{}', is_encrypted = {}, is_cached = {}, zookeeper_name = '{}')",
+                       description, is_encrypted, is_cached, zookeeper_name);
+
+    return str;
 }
 }

--- a/src/Disks/DiskType.h
+++ b/src/Disks/DiskType.h
@@ -37,7 +37,6 @@ enum class MetadataStorageType : uint8_t
 };
 
 MetadataStorageType metadataTypeFromString(const String & type);
-String toString(DataSourceType data_source_type);
 
 struct DataSourceDescription
 {
@@ -45,19 +44,20 @@ struct DataSourceDescription
     ObjectStorageType object_storage_type = ObjectStorageType::None;
     MetadataStorageType metadata_type = MetadataStorageType::None;
 
-    std::string description;
+    String description;
 
     bool is_encrypted = false;
     bool is_cached = false;
 
-    std::string zookeeper_name;
+    String zookeeper_name;
 
     bool operator==(const DataSourceDescription & other) const;
     bool sameKind(const DataSourceDescription & other) const;
 
-    std::string toString() const;
-};
+    String name() const;
 
-bool canUseNativeCopy(const DataSourceDescription & left, const DataSourceDescription & right);
+    /// Returns a string with the name and all the fields of the DataSourceDescription
+    String toString() const;
+};
 
 }

--- a/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
+++ b/src/Disks/ObjectStorages/ObjectStorageFactory.cpp
@@ -94,7 +94,7 @@ ObjectStoragePtr createObjectStorage(
                     .metadata_type = MetadataStorageType::PlainRewritable,
                     .description = "",
                     .zookeeper_name = ""}
-                    .toString());
+                    .name());
 
         auto metadata_storage_metrics = DB::MetadataStorageMetrics::create<BaseObjectStorage, MetadataStorageType::PlainRewritable>();
         return std::make_shared<PlainRewritableObjectStorage<BaseObjectStorage>>(

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -235,7 +235,7 @@ std::string DataPartStorageOnDiskBase::getDiskName() const
 
 std::string DataPartStorageOnDiskBase::getDiskType() const
 {
-    return volume->getDisk()->getDataSourceDescription().toString();
+    return volume->getDisk()->getDataSourceDescription().name();
 }
 
 bool DataPartStorageOnDiskBase::isStoredOnRemoteDisk() const

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -466,14 +466,14 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> Fetcher::fetchSelected
                 if (data_disk->supportZeroCopyReplication())
                 {
                     LOG_TRACE(log, "Disk {} (with type {}) supports zero-copy replication", data_disk->getName(), data_disk->getDataSourceDescription().toString());
-                    capability.push_back(data_disk->getDataSourceDescription().toString());
+                    capability.push_back(data_disk->getDataSourceDescription().name());
                 }
             }
         }
         else if (disk->supportZeroCopyReplication())
         {
             LOG_TRACE(log, "Trying to fetch with zero copy replication, provided disk {} with type {}", disk->getName(), disk->getDataSourceDescription().toString());
-            capability.push_back(disk->getDataSourceDescription().toString());
+            capability.push_back(disk->getDataSourceDescription().name());
         }
     }
 
@@ -520,7 +520,7 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> Fetcher::fetchSelected
     {
         for (const auto & disk_candidate : data.getDisks())
         {
-            if (disk_candidate->getDataSourceDescription().toString() == remote_fs_metadata)
+            if (disk_candidate->getDataSourceDescription().name() == remote_fs_metadata)
             {
                 preffered_disk = disk_candidate;
                 break;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1304,7 +1304,7 @@ std::vector<String> StorageReplicatedMergeTree::getZookeeperZeroCopyLockPaths() 
         if (!disk->supportZeroCopyReplication())
             continue;
 
-        disk_types_with_zero_copy.insert(disk->getDataSourceDescription().toString());
+        disk_types_with_zero_copy.insert(disk->getDataSourceDescription().name());
     }
 
     const auto actual_table_shared_id = getTableSharedID();
@@ -9962,7 +9962,7 @@ zkutil::EphemeralNodeHolderPtr StorageReplicatedMergeTree::lockSharedDataTempora
     String id = part_id;
     boost::replace_all(id, "/", "_");
 
-    String zc_zookeeper_path = getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().toString(), getTableSharedID(),
+    String zc_zookeeper_path = getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().name(), getTableSharedID(),
         part_name, zookeeper_path, getContext())[0];
 
     String zookeeper_node = fs::path(zc_zookeeper_path) / id / replica_name;
@@ -10500,7 +10500,7 @@ String StorageReplicatedMergeTree::getSharedDataReplica(
     if (!zookeeper)
         return "";
 
-    Strings zc_zookeeper_paths = getZeroCopyPartPath(*getSettings(), data_source_description.toString(), getTableSharedID(), part.name,
+    Strings zc_zookeeper_paths = getZeroCopyPartPath(*getSettings(), data_source_description.name(), getTableSharedID(), part.name,
             zookeeper_path, getContext());
 
     std::set<String> replicas;
@@ -10659,7 +10659,7 @@ std::optional<String> StorageReplicatedMergeTree::getZeroCopyPartPath(const Stri
     if (!disk || !disk->supportZeroCopyReplication())
         return std::nullopt;
 
-    return getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().toString(), getTableSharedID(), part_name, zookeeper_path, getContext())[0];
+    return getZeroCopyPartPath(*getSettings(), disk->getDataSourceDescription().name(), getTableSharedID(), part_name, zookeeper_path, getContext())[0];
 }
 
 bool StorageReplicatedMergeTree::waitZeroCopyLockToDisappear(const ZeroCopyLock & lock, size_t milliseconds_to_wait)
@@ -11083,7 +11083,7 @@ bool StorageReplicatedMergeTree::removeSharedDetachedPart(DiskPtr disk, const St
             std::tie(can_remove, files_not_to_remove) = StorageReplicatedMergeTree::unlockSharedDataByID(
                 id, table_uuid, part_info,
                 detached_replica_name,
-                disk->getDataSourceDescription().toString(),
+                disk->getDataSourceDescription().name(),
                 std::make_shared<ZooKeeperWithFaultInjection>(zookeeper), local_context->getReplicatedMergeTreeSettings(),
                 getLogger("StorageReplicatedMergeTree"),
                 detached_zookeeper_path,


### PR DESCRIPTION
- Add all fields of DataSourceDescription in its toString() to help debugging
- Rename prior `toString()` to `name()` to be more explicit about what it means

Example:
```
Source data description: azure_blob_storage (description = 'http://127.0.0.1:10000/devstoreaccount1', is_
encrypted = false, is_cached = false, zookeeper_name = '')
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
