### PR TITLE
Fix crash in case of const and non-const blocks in one INSERT

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -31,6 +31,7 @@
 #include <Processors/Transforms/CountingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
+#include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Transforms/PlanSquashingTransform.h>
 #include <Processors/Transforms/ApplySquashingTransform.h>
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>
@@ -435,8 +436,18 @@ QueryPipeline InterpreterInsertQuery::addInsertToSelectPipeline(ASTInsertQuery &
 
     pipeline.resize(1);
 
-    if (shouldAddSquashingForStorage(table, getContext()) && !no_squash && !async_insert)
+    bool should_squash = shouldAddSquashingForStorage(table, getContext()) && !no_squash && !async_insert;
+    if (should_squash)
     {
+        /// Squashing cannot work with const and non-const blocks
+        pipeline.addSimpleTransform([&](const SharedHeader & in_header) -> ProcessorPtr
+        {
+            /// Sparse columns will be converted to full in the InsertDependenciesBuilder,
+            /// and for squashing we don't need to convert column to full since it will do it by itself
+            bool remove_sparse = false;
+            return std::make_shared<MaterializingTransform>(in_header, remove_sparse);
+        });
+
         pipeline.addSimpleTransform(
             [&](const SharedHeader & in_header) -> ProcessorPtr
             {
@@ -485,7 +496,7 @@ QueryPipeline InterpreterInsertQuery::addInsertToSelectPipeline(ASTInsertQuery &
 
     pipeline.resize(sink_streams_size);
 
-    if (shouldAddSquashingForStorage(table, getContext()) && !no_squash && !async_insert)
+    if (should_squash)
     {
         pipeline.addSimpleTransform(
             [&](const SharedHeader & in_header) -> ProcessorPtr

--- a/tests/queries/0_stateless/03531_insert_removing_sparse_transform.reference
+++ b/tests/queries/0_stateless/03531_insert_removing_sparse_transform.reference
@@ -11,13 +11,47 @@ digraph
     n1[label="ExpressionTransform_1"];
     n2[label="ExpressionTransform_2"];
     n3[label="CountingTransform_3"];
-    n4[label="PlanSquashingTransform_4"];
-    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
-    n6[label="ApplySquashingTransform_10"];
-    n7[label="ConvertingTransform_6"];
-    n8[label="NestedElementsValidationTransform_7"];
-    n9[label="RemovingSparseTransform_8"];
-    n10[label="LogSink_9"];
+    n4[label="MaterializingTransform_4"];
+    n5[label="PlanSquashingTransform_5"];
+    n6[label="DeduplicationToken::AddTokenInfoTransform_6"];
+    n7[label="ApplySquashingTransform_11"];
+    n8[label="ConvertingTransform_7"];
+    n9[label="NestedElementsValidationTransform_8"];
+    n10[label="RemovingSparseTransform_9"];
+    n11[label="LogSink_10"];
+    n12[label="EmptySink_12"];
+  }
+  n0 -> n1;
+  n1 -> n2;
+  n2 -> n3;
+  n3 -> n4;
+  n4 -> n5;
+  n5 -> n6;
+  n6 -> n7;
+  n7 -> n8;
+  n8 -> n9;
+  n9 -> n10;
+  n10 -> n11;
+  n11 -> n12;
+}
+-- MergeTree support sparse columns - no RemovingSparseTransform
+create table t_mt (key Int) engine=MergeTree order by ();
+explain pipeline insert into t_mt select * from system.one;
+digraph
+{
+  rankdir="LR";
+  { node [shape = rect]
+    n0[label="SourceFromSingleChunk_0"];
+    n1[label="ExpressionTransform_1"];
+    n2[label="ExpressionTransform_2"];
+    n3[label="CountingTransform_3"];
+    n4[label="MaterializingTransform_4"];
+    n5[label="PlanSquashingTransform_5"];
+    n6[label="DeduplicationToken::AddTokenInfoTransform_6"];
+    n7[label="ApplySquashingTransform_10"];
+    n8[label="ConvertingTransform_7"];
+    n9[label="NestedElementsValidationTransform_8"];
+    n10[label="MergeTreeSink_9"];
     n11[label="EmptySink_11"];
   }
   n0 -> n1;
@@ -32,36 +66,6 @@ digraph
   n9 -> n10;
   n10 -> n11;
 }
--- MergeTree support sparse columns - no RemovingSparseTransform
-create table t_mt (key Int) engine=MergeTree order by ();
-explain pipeline insert into t_mt select * from system.one;
-digraph
-{
-  rankdir="LR";
-  { node [shape = rect]
-    n0[label="SourceFromSingleChunk_0"];
-    n1[label="ExpressionTransform_1"];
-    n2[label="ExpressionTransform_2"];
-    n3[label="CountingTransform_3"];
-    n4[label="PlanSquashingTransform_4"];
-    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
-    n6[label="ApplySquashingTransform_9"];
-    n7[label="ConvertingTransform_6"];
-    n8[label="NestedElementsValidationTransform_7"];
-    n9[label="MergeTreeSink_8"];
-    n10[label="EmptySink_10"];
-  }
-  n0 -> n1;
-  n1 -> n2;
-  n2 -> n3;
-  n3 -> n4;
-  n4 -> n5;
-  n5 -> n6;
-  n6 -> n7;
-  n7 -> n8;
-  n8 -> n9;
-  n9 -> n10;
-}
 -- MergeTree pushes to Log, which does not support sparse columns - RemovingSparseTransform added
 create materialized view mv to t_log as select * from t_mt;
 explain pipeline insert into t_mt select * from system.one;
@@ -73,22 +77,23 @@ digraph
     n1[label="ExpressionTransform_1"];
     n2[label="ExpressionTransform_2"];
     n3[label="CountingTransform_3"];
-    n4[label="PlanSquashingTransform_4"];
-    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
-    n6[label="ApplySquashingTransform_18"];
-    n7[label="ConvertingTransform_6"];
-    n8[label="NestedElementsValidationTransform_7"];
-    n9[label="MergeTreeSink_8"];
-    n10[label="Copy_16"];
-    n11[label="BeginingViewsTransform_9"];
-    n12[label="ExecutingInnerQueryFromView_12"];
-    n13[label="CountingTransform_11"];
-    n14[label="SquashingTransform_10"];
-    n15[label="NestedElementsValidationTransform_13"];
-    n16[label="RemovingSparseTransform_14"];
-    n17[label="LogSink_15"];
-    n18[label="FinalizingViewsTransform_17"];
-    n19[label="EmptySink_19"];
+    n4[label="MaterializingTransform_4"];
+    n5[label="PlanSquashingTransform_5"];
+    n6[label="DeduplicationToken::AddTokenInfoTransform_6"];
+    n7[label="ApplySquashingTransform_19"];
+    n8[label="ConvertingTransform_7"];
+    n9[label="NestedElementsValidationTransform_8"];
+    n10[label="MergeTreeSink_9"];
+    n11[label="Copy_17"];
+    n12[label="BeginingViewsTransform_10"];
+    n13[label="ExecutingInnerQueryFromView_13"];
+    n14[label="CountingTransform_12"];
+    n15[label="SquashingTransform_11"];
+    n16[label="NestedElementsValidationTransform_14"];
+    n17[label="RemovingSparseTransform_15"];
+    n18[label="LogSink_16"];
+    n19[label="FinalizingViewsTransform_18"];
+    n20[label="EmptySink_20"];
   }
   n0 -> n1;
   n1 -> n2;
@@ -109,6 +114,7 @@ digraph
   n16 -> n17;
   n17 -> n18;
   n18 -> n19;
+  n19 -> n20;
 }
 drop table mv;
 -- Log does not support sparse columns - RemovingSparseTransform added
@@ -122,22 +128,23 @@ digraph
     n1[label="ExpressionTransform_1"];
     n2[label="ExpressionTransform_2"];
     n3[label="CountingTransform_3"];
-    n4[label="PlanSquashingTransform_4"];
-    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
-    n6[label="ApplySquashingTransform_18"];
-    n7[label="ConvertingTransform_6"];
-    n8[label="NestedElementsValidationTransform_7"];
-    n9[label="RemovingSparseTransform_8"];
-    n10[label="LogSink_9"];
-    n11[label="Copy_16"];
-    n12[label="BeginingViewsTransform_10"];
-    n13[label="ExecutingInnerQueryFromView_13"];
-    n14[label="CountingTransform_12"];
-    n15[label="SquashingTransform_11"];
-    n16[label="NestedElementsValidationTransform_14"];
-    n17[label="MergeTreeSink_15"];
-    n18[label="FinalizingViewsTransform_17"];
-    n19[label="EmptySink_19"];
+    n4[label="MaterializingTransform_4"];
+    n5[label="PlanSquashingTransform_5"];
+    n6[label="DeduplicationToken::AddTokenInfoTransform_6"];
+    n7[label="ApplySquashingTransform_19"];
+    n8[label="ConvertingTransform_7"];
+    n9[label="NestedElementsValidationTransform_8"];
+    n10[label="RemovingSparseTransform_9"];
+    n11[label="LogSink_10"];
+    n12[label="Copy_17"];
+    n13[label="BeginingViewsTransform_11"];
+    n14[label="ExecutingInnerQueryFromView_14"];
+    n15[label="CountingTransform_13"];
+    n16[label="SquashingTransform_12"];
+    n17[label="NestedElementsValidationTransform_15"];
+    n18[label="MergeTreeSink_16"];
+    n19[label="FinalizingViewsTransform_18"];
+    n20[label="EmptySink_20"];
   }
   n0 -> n1;
   n1 -> n2;
@@ -158,4 +165,5 @@ digraph
   n16 -> n17;
   n17 -> n18;
   n18 -> n19;
+  n19 -> n20;
 }

--- a/tests/queries/0_stateless/03601_insert_squashing_remove_const.sql
+++ b/tests/queries/0_stateless/03601_insert_squashing_remove_const.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS tbl_x;
+
+CREATE TABLE tbl_x (col2  String) ENGINE = Memory;
+
+-- Produce Const and non-Const block in various SELECTs that may lead to UB w/o removing constness while squashing
+INSERT INTO tbl_x
+WITH
+    c4 AS
+    (
+        SELECT 'aaa' AS col2
+        UNION ALL
+        SELECT 'bbb'
+    ),
+    c6 AS
+    (
+        SELECT r.col2 AS col2
+        FROM (SELECT 'ccc' AS col2) AS r
+        LEFT JOIN (SELECT 'foo' AS col2) AS rt
+        USING col2
+    )
+SELECT
+    *
+FROM
+(
+    SELECT * FROM c4
+    UNION ALL
+    SELECT * FROM c6
+);


### PR DESCRIPTION
Squashing cannot work with different const and non-const blocks, but #81161 removed `MaterializingTransform` before squashing, and so it may lead to crash or "Too large size (18446462643291305296) passed to allocator. It indicates an error." error.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash in case of const and non-const blocks in one INSERT

@Algunenano thanks for bisect
@yariks5s thanks for a repro!