### PR TITLE
Docs: Mention setting `system_events_show_zero_values` in system.error docs

### DIFF
--- a/docs/en/operations/system-tables/errors.md
+++ b/docs/en/operations/system-tables/errors.md
@@ -12,6 +12,8 @@ import SystemTableCloud from '@site/docs/_snippets/_system_table_cloud.md';
 
 Contains error codes with the number of times they have been triggered.
 
+To show all possible error codes, including ones which were not triggered, set setting [system_events_show_zero_values](../settings/settings.md#system_events_show_zero_values) to 1.
+
 Columns:
 
 - `name` ([String](../../sql-reference/data-types/string.md)) — name of the error (`errorCodeToName`).


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)