### PR TITLE
ci: add separate test "OOM in dmesg" in case of OOM in integration tests

### DIFF
--- a/ci/jobs/scripts/integration_tests_runner.py
+++ b/ci/jobs/scripts/integration_tests_runner.py
@@ -45,6 +45,7 @@ TASK_TIMEOUT = 8 * 60 * 60  # 8 hours
 NO_CHANGES_MSG = "Nothing to run"
 
 JOB_TIMEOUT_TEST_NAME = "Job Timeout Expired"
+OOM_IN_DMESG_TEST_NAME = "OOM in dmesg"
 
 
 # Search test by the common prefix.
@@ -1215,7 +1216,15 @@ def run():
     if is_ci:
         # Dump dmesg (to capture possible OOMs)
         logging.info("Dumping dmesg")
-        subprocess.check_call("sudo -E dmesg -T", shell=True)
+        subprocess.check_call("sudo -E dmesg -T | tee dmesg.log", shell=True)
+        with open("dmesg.log", "rb") as dmesg:
+            dmesg = dmesg.read()
+            if (
+                b"Out of memory: Killed process" in dmesg
+                or b"oom_reaper: reaped process" in dmesg
+                or b"oom-kill:constraint=CONSTRAINT_NONE" in dmesg
+            ):
+                test_results.insert(0, (OOM_IN_DMESG_TEST_NAME, "FAIL", "", ""))
 
     status = (state, description)
     out_results_file = os.path.join(runner.path(), "test_results.tsv")


### PR DESCRIPTION
This is very handy, will allow to monitor such things

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)