### PR TITLE
ci: increase stop_grace_period for clickhouse containers to allow gdb finish

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3904,7 +3904,7 @@ services:
             {krb5_conf}
         entrypoint: /integration-tests-entrypoint.sh {entrypoint_cmd}
         # increase it to allow jeprof to dump the profile report
-        stop_grace_period: 2m
+        stop_grace_period: 5m
         tmpfs: {tmpfs}
         {mem_limit}
         cap_add:

--- a/tests/integration/integration-tests-entrypoint.sh
+++ b/tests/integration/integration-tests-entrypoint.sh
@@ -29,7 +29,7 @@ server_exit_code=$?
 
 function dump_stacktraces_on_shutdown()
 {
-    # Half of timeout of the stop_grace_period for clickhouse service
+    # 1m should be enough to finish the server
     sleep 1m
     if kill -0 "$PID"; then
         echo "Attaching gdb to obtain thread stacktraces"


### PR DESCRIPTION
I'm trying to debug test_global_overcommit_tracker test, I've added obtaining stacktraces with gdb for it, but 2min was not enough [1] for gdb:

    node-1  | Sending TERM to 8
    node-1  | USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
    node-1  | root           1  0.0  0.0   6860  3200 ?        Ss   16:58   0:00 bash /integration-tests-entrypoint.sh clickhouse server --config-file=/etc/clickhouse-server/config.xml --log-file=/var/log/clickhouse-server/clickhouse-server.log --errorlog-file=/var/log/clickhouse-server/clickhouse-server.err.log --
    node-1  | root           8  3.7  1.4 26891480 946812 ?     Sl   16:58   0:22 clickhouse server --config-file=/etc/clickhouse-server/config.xml --log-file=/var/log/clickhouse-server/clickhouse-server.log --errorlog-file=/var/log/clickhouse-server/clickhouse-server.err.log --
    node-1  | root         787  0.0  0.0   9416  2816 ?        R    17:08   0:00 ps aux
    node-1  | Attaching gdb to obtain thread stacktraces
    node-1 exited with code 137

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=86b9c82d40470ec5a0d81d30f82639a263b67f30&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%202%2F4%29&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%202%2F4%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/ClickHouse/issues/85972