### PR TITLE
CI: Add clean up for docker buildx kit

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -198,6 +198,18 @@ def _build_dockers(workflow, job_name):
     return Result.create_from(results=results, info=job_info)
 
 
+def _clean_buildx_volumes():
+    Shell.check("docker buildx rm --all-inactive --force", verbose=True)
+    Shell.check(
+        "docker ps -a --filter name=buildx_buildkit -q | xargs -r docker rm -f",
+        verbose=True,
+    )
+    Shell.check(
+        "docker volume ls -q | grep buildx_buildkit | xargs -r docker volume rm",
+        verbose=True,
+    )
+
+
 def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
     # debug info
     GH.print_log_in_group("GITHUB envs", Shell.get_output("env | grep GITHUB"))
@@ -613,6 +625,7 @@ if __name__ == "__main__":
             Settings.DOCKER_BUILD_AMD_LINUX_JOB_NAME,
         ):
             result = _build_dockers(workflow, job_name)
+            _clean_buildx_volumes()
         elif job_name == Settings.CI_CONFIG_JOB_NAME:
             result = _config_workflow(workflow, job_name)
         elif job_name == Settings.FINISH_WORKFLOW_JOB_NAME:


### PR DESCRIPTION
Docker buildx needs special handling to clean up volumes after the build
Fixes the occasional "no free space available" error on the runners

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
