### PR TITLE
Make a test a bit faster for debug builds

### DIFF
--- a/tests/queries/0_stateless/02389_analyzer_nested_lambda.sql
+++ b/tests/queries/0_stateless/02389_analyzer_nested_lambda.sql
@@ -136,6 +136,6 @@ SELECT
 FROM numbers(1000000) FORMAT Null;
 
 SELECT
-  arrayWithConstant(pow(10,6), 1) AS nums,
+  arrayWithConstant(pow(10,5), 1) AS nums,
   arrayMap(x -> x, nums) AS m,
   arrayMap(x -> x + arraySum(m), m) AS res FORMAT Null;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make a test a bit faster for debug builds

Sometimes the query is too slow: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=86223&sha=894be82b325d369a6390bd38a1dbe0c6759f2766&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%29

```
2025-08-27 01:02:58 Received exception from server (version 25.9.1):
2025-08-27 01:02:58 Code: 159. DB::Exception: Received from localhost:9000. DB::Exception: Timeout exceeded: elapsed 354702.638675 ms, maximum: 300000 ms. (TIMEOUT_EXCEEDED)
2025-08-27 01:02:58 (query: SELECT
2025-08-27 01:02:58   arrayWithConstant(pow(10,6), 1) AS nums,
2025-08-27 01:02:58   arrayMap(x -> x, nums) AS m,
2025-08-27 01:02:58   arrayMap(x -> x + arraySum(m), m) AS res FORMAT Null;)
2025-08-27 01:02:58 , result:
2025-08-27 01:02:58 
```

For example, in an idle server with MSAN it takes 30 seconds:
```
SELECT
    arrayWithConstant(pow(10, 6), 1) AS nums,
    arrayMap(x -> x, nums) AS m,
    arrayMap(x -> (x + arraySum(m)), m) AS res
FORMAT `Null`
```

Reducing it by an order of magnitude seems reasonable. Introduced in https://github.com/ClickHouse/ClickHouse/pull/62462

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
