### PR TITLE
Exception when no active replicas for s3Cluster request

### DIFF
--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -509,3 +509,14 @@ def test_cluster_default_expression(started_cluster):
     )
 
     assert result == expected_result
+
+
+def test_dead_cluster(started_cluster):
+    node = started_cluster.instances["s0_1_0"]
+
+    with started_cluster.pause_container("s0_0_0"):
+        with started_cluster.pause_container("s0_0_1"):
+            result = node.query_and_get_error(
+                f"SELECT * FROM s3Cluster(first_shard, 'http://minio1:9001/root/data/clickhouse/part1.csv', 'minio', '{minio_secret_key}', 'CSV', 'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') order by name"
+            )
+            assert "Can't find active replicas in cluster" in result


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Exception if no active replicas in cluster request

### Documentation entry for user-facing changes
Requests with cluster table functions like `s3Cluster`, `icebergCluster`, etc. returns empty response without any error after timeout if all replicas in cluster are unavailable.

This PR returns an exception in this case.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
