### PR TITLE
Inline `appendDefaultRow`

### DIFF
--- a/src/Interpreters/HashJoin/AddedColumns.cpp
+++ b/src/Interpreters/HashJoin/AddedColumns.cpp
@@ -186,19 +186,4 @@ void AddedColumns<true>::appendFromBlock(const RowRefList * row_ref_list, bool)
     }
 }
 
-
-template<>
-void AddedColumns<false>::appendDefaultRow()
-{
-    ++lazy_defaults_count;
-}
-
-template<>
-void AddedColumns<true>::appendDefaultRow()
-{
-    if (has_columns_to_add)
-    {
-        lazy_output.addDefault();
-    }
-}
 }

--- a/src/Interpreters/HashJoin/AddedColumns.h
+++ b/src/Interpreters/HashJoin/AddedColumns.h
@@ -170,7 +170,18 @@ public:
     void appendFromBlock(const RowRefList * row_ref_list, bool has_default);
     void appendFromBlock(const RowRef * row_ref, bool has_default);
 
-    void appendDefaultRow();
+    void appendDefaultRow()
+    {
+        if constexpr (!lazy)
+        {
+            ++lazy_defaults_count;
+        }
+        else
+        {
+            if (has_columns_to_add)
+                lazy_output.addDefault();
+        }
+    }
 
     void applyLazyDefaults();
 

--- a/tests/performance/join_many_default_rows.xml
+++ b/tests/performance/join_many_default_rows.xml
@@ -1,0 +1,3 @@
+<test>
+  <query>SELECT * FROM numbers_mt(1e9) lhs LEFT JOIN numbers_mt(1e3) rhs USING (number) FORMAT Null settings max_threads=8</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`HashJoin` performance optimised slightly in the case of `LEFT/RIGHT` join having a lot of unmatched rows.

---

Not a big deal, around 10% on the added test, more for the sake of not having a `call` in 
the hot loop. 

x86:
<img width="2086" height="62" alt="Screenshot 2025-08-28 at 12 46 18" src="https://github.com/user-attachments/assets/dfc7cba8-1e85-40f2-9ccb-654d84caf22a" />

arm:
<img width="1802" height="61" alt="Screenshot 2025-08-28 at 12 47 48" src="https://github.com/user-attachments/assets/e9dc4a1f-19a5-438c-b0d0-37b3242f9870" />

