### PR TITLE
ci: fix integration tests execution time and some other improvements around

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4117,7 +4117,11 @@ class ClickHouseInstance:
         self.clickhouse_start_command_in_daemon = "{} --daemon -- {}".format(
             clickhouse_start_command_with_conf, clickhouse_start_extra_args
         )
-        self.clickhouse_stay_alive_command = "bash -c \"trap 'pkill tail' INT TERM; {}; coproc tail -f /dev/null; wait $$!\"".format(
+        # NOTE: as a child command we have only clickhouse, so it is OK to assume so
+        # and there is no other way to kill clickhouse properly (easily), since
+        # clickhosue is spawned with --daemon, and it is not a child neither in
+        # the same session.
+        self.clickhouse_stay_alive_command = "bash -c \"trap 'pkill tail; pkill clickhouse' INT TERM; {}; coproc tail -f /dev/null; wait $$!\"".format(
             self.clickhouse_start_command_in_daemon
         )
 

--- a/tests/integration/integration-tests-entrypoint.sh
+++ b/tests/integration/integration-tests-entrypoint.sh
@@ -29,8 +29,14 @@ server_exit_code=$?
 
 function dump_stacktraces_on_shutdown()
 {
-    # 1m should be enough to finish the server
-    sleep 1m
+    # 60 sec should be enough to finish the server
+    for _ in {1..60}; do
+        if ! kill -0 "$PID" 2>/dev/null; then
+            return
+        fi
+        sleep 1
+    done
+
     if kill -0 "$PID"; then
         echo "Attaching gdb to obtain thread stacktraces"
         gdb -batch -ex 'thread apply all bt full' -p "$PID" > /var/log/clickhouse-server/stdout.log

--- a/tests/integration/integration-tests-entrypoint.sh
+++ b/tests/integration/integration-tests-entrypoint.sh
@@ -10,15 +10,14 @@ if [[ ! -v MALLOC_CONF ]]; then
 fi
 
 PID=0
-if [[ $JEMALLOC_PROFILER -eq 1 ]]; then
-    function handle_term()
-    {
-        echo "Sending TERM to $PID"
-        ps aux
-        kill -TERM "$PID"
-    }
-    trap handle_term TERM
-fi
+
+function handle_term()
+{
+    echo "Sending TERM to $PID"
+    ps aux
+    kill -TERM "$PID"
+}
+trap handle_term TERM
 
 echo "Runnig: $*"
 "$@" &

--- a/tests/integration/integration-tests-entrypoint.sh
+++ b/tests/integration/integration-tests-entrypoint.sh
@@ -39,7 +39,7 @@ function dump_stacktraces_on_shutdown()
 
     if kill -0 "$PID"; then
         echo "Attaching gdb to obtain thread stacktraces"
-        gdb -batch -ex 'thread apply all bt full' -p "$PID" > /var/log/clickhouse-server/stdout.log
+        gdb -batch -ex 'thread apply all bt' -p "$PID" > /var/log/clickhouse-server/stdout.log
     fi
 }
 dump_stacktraces_on_shutdown &


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Problems
- became slower after gdb attach has been added on hangs - https://github.com/ClickHouse/ClickHouse/pull/86043
- after jemalloc profiler had been added, we don't properly killing the server https://github.com/ClickHouse/ClickHouse/pull/85539
- and fix killing server for `stay_alive=True`