### PR TITLE
Add ability to enable JSON logging only for specific channel (i.e. console)

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -969,6 +969,8 @@ To enable JSON logging support, use the following snippet:
 <logger>
     <formatting>
         <type>json</type>
+        <!-- Can be configured on a per-channel basis (log, errorlog, console, syslog), or globally for all channels (then just omit it). -->
+        <!-- <channel></channel> -->
         <names>
             <date_time>date_time</date_time>
             <thread_name>thread_name</thread_name>

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -72,10 +72,12 @@
           </logger>
         </levels>
         -->
+
         <!-- Structured log formatting:
-        You can specify log format(for now, JSON only). In that case, the console log will be printed
-        in specified format like JSON.
-        For example, as below:
+
+        You can specify log format(for now, JSON only).
+        It can be done either on a per-channel (log, errorlog, console, syslog) level (set `channel`, i.e. `<channel>console</channel>') or for all channels (omit `channel`).
+        The log will be printed in specified format like JSON, example:
 
         {"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
         {"date_time_utc":"2024-11-06T09:06:09Z","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
@@ -91,8 +93,10 @@
         However, if you comment out all the tags under <names>, the program will print default values for as
         below.
         -->
-        <!-- <formatting>
+        <!--
+        <formatting>
             <type>json</type>
+            <channel></channel>
             <names>
                 <date_time>date_time</date_time>
                 <date_time_utc>date_time_utc</date_time_utc>
@@ -105,7 +109,8 @@
                 <source_file>source_file</source_file>
                 <source_line>source_line</source_line>
             </names>
-        </formatting> -->
+        </formatting>
+        -->
     </logger>
 
     <url_scheme_mappers>

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -621,11 +621,7 @@ void BaseDaemon::setupWatchdog()
         /// If streaming compression of logs is used then we write watchdog logs to cerr
         if (config().getRawString("logger.stream_compress", "false") == "true")
         {
-            Poco::AutoPtr<OwnPatternFormatter> pf;
-            if (config().getString("logger.formatting.type", "") == "json")
-                pf = new OwnJSONPatternFormatter(config());
-            else
-                pf = new OwnPatternFormatter;
+            Poco::AutoPtr<OwnPatternFormatter> pf = getFormatForChannel(config(), "console");
             Poco::AutoPtr<OwnFormattingChannel> log = new OwnFormattingChannel(pf, new Poco::ConsoleChannel(std::cerr));
             logger().setChannel(log);
         }

--- a/src/Loggers/Loggers.h
+++ b/src/Loggers/Loggers.h
@@ -50,3 +50,6 @@ private:
 
     Poco::AutoPtr<DB::OwnSplitChannelBase> split;
 };
+
+class OwnPatternFormatter;
+Poco::AutoPtr<OwnPatternFormatter> getFormatForChannel(Poco::Util::AbstractConfiguration & config, const std::string & channel, bool color = false);

--- a/src/Loggers/OwnJSONPatternFormatter.cpp
+++ b/src/Loggers/OwnJSONPatternFormatter.cpp
@@ -1,6 +1,5 @@
 #include <Loggers/OwnJSONPatternFormatter.h>
 
-#include <functional>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/InternalTextLogsQueue.h>
@@ -11,37 +10,37 @@
 #include <Common/DateLUTImpl.h>
 
 
-OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config)
+OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
 {
-    if (config.has("logger.formatting.names.date_time"))
-        date_time = config.getString("logger.formatting.names.date_time", "");
+    if (config.has(config_prefix + ".names.date_time"))
+        date_time = config.getString(config_prefix + ".names.date_time", "");
 
-    if (config.has("logger.formatting.names.date_time_utc"))
-        date_time_utc= config.getString("logger.formatting.names.date_time_utc", "");
+    if (config.has(config_prefix + ".names.date_time_utc"))
+        date_time_utc= config.getString(config_prefix + ".names.date_time_utc", "");
 
-    if (config.has("logger.formatting.names.thread_name"))
-        thread_name = config.getString("logger.formatting.names.thread_name", "");
+    if (config.has(config_prefix + ".names.thread_name"))
+        thread_name = config.getString(config_prefix + ".names.thread_name", "");
 
-    if (config.has("logger.formatting.names.thread_id"))
-        thread_id = config.getString("logger.formatting.names.thread_id", "");
+    if (config.has(config_prefix + ".names.thread_id"))
+        thread_id = config.getString(config_prefix + ".names.thread_id", "");
 
-    if (config.has("logger.formatting.names.level"))
-        level = config.getString("logger.formatting.names.level", "");
+    if (config.has(config_prefix + ".names.level"))
+        level = config.getString(config_prefix + ".names.level", "");
 
-    if (config.has("logger.formatting.names.query_id"))
-        query_id = config.getString("logger.formatting.names.query_id", "");
+    if (config.has(config_prefix + ".names.query_id"))
+        query_id = config.getString(config_prefix + ".names.query_id", "");
 
-    if (config.has("logger.formatting.names.logger_name"))
-        logger_name = config.getString("logger.formatting.names.logger_name", "");
+    if (config.has(config_prefix + ".names.logger_name"))
+        logger_name = config.getString(config_prefix + ".names.logger_name", "");
 
-    if (config.has("logger.formatting.names.message"))
-        message = config.getString("logger.formatting.names.message", "");
+    if (config.has(config_prefix + ".names.message"))
+        message = config.getString(config_prefix + ".names.message", "");
 
-    if (config.has("logger.formatting.names.source_file"))
-        source_file = config.getString("logger.formatting.names.source_file", "");
+    if (config.has(config_prefix + ".names.source_file"))
+        source_file = config.getString(config_prefix + ".names.source_file", "");
 
-    if (config.has("logger.formatting.names.source_line"))
-        source_line = config.getString("logger.formatting.names.source_line", "");
+    if (config.has(config_prefix + ".names.source_line"))
+        source_line = config.getString(config_prefix + ".names.source_line", "");
 
     if (date_time.empty() && thread_name.empty() && thread_id.empty() && level.empty() && query_id.empty()
         && logger_name.empty() && message.empty() && source_file.empty() && source_line.empty())

--- a/src/Loggers/OwnJSONPatternFormatter.h
+++ b/src/Loggers/OwnJSONPatternFormatter.h
@@ -26,7 +26,7 @@ class Loggers;
 class OwnJSONPatternFormatter : public OwnPatternFormatter
 {
 public:
-    explicit OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config);
+    explicit OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 
     void format(const Poco::Message & msg, std::string & text) override;
     void formatExtended(const DB::ExtendedLogMessage & msg_ext, std::string & text) const override;

--- a/tests/integration/test_structured_logging_json/configs/config_json_logging_per_channel.xml
+++ b/tests/integration/test_structured_logging_json/configs/config_json_logging_per_channel.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <logger>
+        <formatting>
+            <type>json</type>
+            <channel>errorlog</channel>
+            <names>
+                <date_time>DATE_TIME</date_time>
+                <date_time_utc>DATE_TIME_UTC</date_time_utc>
+                <thread_name>THREAD_NAME</thread_name>
+                <thread_id>THREAD_ID</thread_id>
+                <level>LEVEL</level>
+                <query_id>QUERY_ID</query_id>
+                <logger_name>LOGGER_NAME</logger_name>
+                <message>MESSAGE</message>
+                <source_file>SOURCE_FILE</source_file>
+                <source_line>SOURCE_LINE</source_line>
+            </names>
+        </formatting>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -17,6 +17,10 @@ node_no_keys = cluster.add_instance(
     "node_no_keys", main_configs=["configs/config_no_keys_json.xml"]
 )
 
+node_json_logging_per_channel = cluster.add_instance(
+    "node_json_logging_per_channel", main_configs=["configs/config_json_logging_per_channel.xml"]
+)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -147,3 +151,12 @@ def test_structured_logging_json_format(start_cluster):
         == True
     )
     assert validate_everything(config_no_keys, node_no_keys, "config_no_keys") == True
+
+def test_structured_logging_per_channel(start_cluster):
+    logs = node_json_logging_per_channel.grep_in_log("").split("\n")
+    assert len(logs) > 0
+    assert not validate_logs(logs)
+
+    error_logs = node_json_logging_per_channel.grep_in_log("", filename="clickhouse-server.err.log").strip().split("\n")
+    assert len(error_logs) > 0
+    assert validate_logs(error_logs)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ability to enable JSON logging only for specific channel, for this set `logger.formatting.channel` to one of `syslog`/`console`/`errorlog`/`log`.