### PR TITLE
Disable non sensical binary operations with IPv4/IPv6

### DIFF
--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1776,7 +1776,8 @@ public:
         }
 
         /// Special case - one argument is IPv4 and the other is Ipv4 or an integer
-        if ((isIPv4(arguments[0]) && (isIPv4(arguments[1]) || isInt(arguments[1]))) || (isIPv4(arguments[1]) && isInt(arguments[0])))
+        if ((isIPv4(arguments[0]) && (isIPv4(arguments[1]) || isInteger(arguments[1])))
+            || (isIPv4(arguments[1]) && isInteger(arguments[0])))
         {
             DataTypes new_arguments {
                     isIPv4(arguments[0]) ? std::make_shared<DataTypeUInt32>() : arguments[0],
@@ -1787,7 +1788,8 @@ public:
         }
 
         /// Special case -one argument is IPv6 and the other is Ipv4 or an integer
-        if ((isIPv6(arguments[0]) && (isIPv6(arguments[1]) || isInt(arguments[1]))) || (isIPv6(arguments[1]) && isInt(arguments[0])))
+        if ((isIPv6(arguments[0]) && (isIPv6(arguments[1]) || isInteger(arguments[1])))
+            || (isIPv6(arguments[1]) && isInteger(arguments[0])))
         {
             DataTypes new_arguments {
                     isIPv6(arguments[0]) ? std::make_shared<DataTypeUInt128>() : arguments[0],

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -1775,8 +1775,8 @@ public:
             return arguments[0];
         }
 
-        /// Special case - one or both arguments are IPv4
-        if (isIPv4(arguments[0]) || isIPv4(arguments[1]))
+        /// Special case - one argument is IPv4 and the other is Ipv4 or an integer
+        if ((isIPv4(arguments[0]) && (isIPv4(arguments[1]) || isInt(arguments[1]))) || (isIPv4(arguments[1]) && isInt(arguments[0])))
         {
             DataTypes new_arguments {
                     isIPv4(arguments[0]) ? std::make_shared<DataTypeUInt32>() : arguments[0],
@@ -1786,8 +1786,8 @@ public:
             return getReturnTypeImplStatic2(new_arguments, context);
         }
 
-        /// Special case - one or both arguments are IPv6
-        if (isIPv6(arguments[0]) || isIPv6(arguments[1]))
+        /// Special case -one argument is IPv6 and the other is Ipv4 or an integer
+        if ((isIPv6(arguments[0]) && (isIPv6(arguments[1]) || isInt(arguments[1]))) || (isIPv6(arguments[1]) && isInt(arguments[0])))
         {
             DataTypes new_arguments {
                     isIPv6(arguments[0]) ? std::make_shared<DataTypeUInt128>() : arguments[0],

--- a/tests/queries/0_stateless/03603_ip_binary_operators.sql
+++ b/tests/queries/0_stateless/03603_ip_binary_operators.sql
@@ -1,0 +1,30 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/71415
+SELECT now() + CAST(toFixedString(materialize(toNullable('1')), 1), 'IPv6'); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT CAST('2000-01-01', 'Date32') - CAST(0, 'IPv4');  -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (c0 IPv4) ENGINE = Memory;
+SELECT (t0.c0, t0.c0) * t0.c0 FROM t0; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+DROP TABLE IF EXISTS t0;
+
+SELECT materialize('1')::IPv6 + '2000-01-01 00:00:00'::DateTime;  -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+-- https://github.com/ClickHouse/ClickHouse/issues/83963
+CREATE TABLE `02763_alias__fuzz_25` (`x` DateTime64(3), `y` IPv4, `z` Float32 ALIAS x + y) ENGINE = MergeTree ORDER BY x; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+-- Other non sensical operations
+SELECT toIPv4('127.0.0.1') + 0.1; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT 0.1 + toIPv4('127.0.0.1'); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT toIPv6('127.0.0.1') + 0.1; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT 0.1 + toIPv6('127.0.0.1'); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+SELECT toIPv4('127.0.0.1') + 0.1::Float32; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT toIPv6('127.0.0.1') + 0.1::Float32; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT toIPv4('127.0.0.1') + 0.1::BFloat16; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT toIPv6('127.0.0.1') + 0.1::BFloat16; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+SELECT toIPv4('127.0.0.1') + INTERVAL 1 SECOND; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT toIPv6('127.0.0.1') + INTERVAL 1 SECOND; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+
+SELECT toIPv4('127.0.0.1') + toDecimal32(0.1, 2); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}
+SELECT toIPv6('127.0.0.1') + toDecimal32(0.1, 2); -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable non sensical binary operations with IPv4/IPv6: Plus / minus of a IPv4/IPv6 with a non integer type is disabled. Before it would allow operations with floating types and throw logical errors with some other types (such as DateTime).

Tagged as a breaking change just on the off chance case somebody was using this in queries or table/view definitions

Closes https://github.com/ClickHouse/ClickHouse/issues/71415

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
