### PR TITLE
Docs: include `SYSTEM` command in headings to improve search results

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -10,13 +10,13 @@ import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
 # SYSTEM Statements
 
-## RELOAD EMBEDDED DICTIONARIES {#reload-embedded-dictionaries}
+## SYSTEM RELOAD EMBEDDED DICTIONARIES {#reload-embedded-dictionaries}
 
 Reload all [Internal dictionaries](../../sql-reference/dictionaries/index.md).
 By default, internal dictionaries are disabled.
 Always returns `Ok.` regardless of the result of the internal dictionary update.
 
-## RELOAD DICTIONARIES {#reload-dictionaries}
+## SYSTEM RELOAD DICTIONARIES {#reload-dictionaries}
 
 Reloads all dictionaries that have been successfully loaded before.
 By default, dictionaries are loaded lazily (see [dictionaries_lazy_load](../../operations/server-configuration-parameters/settings.md#dictionaries_lazy_load)), so instead of being loaded automatically at startup, they are initialized on first access through dictGet function or SELECT from tables with ENGINE = Dictionary. The `SYSTEM RELOAD DICTIONARIES` query reloads such dictionaries (LOADED).
@@ -28,7 +28,7 @@ Always returns `Ok.` regardless of the result of the dictionary update.
 SYSTEM RELOAD DICTIONARIES [ON CLUSTER cluster_name]
 ```
 
-## RELOAD DICTIONARY {#reload-dictionary}
+## SYSTEM RELOAD DICTIONARY {#reload-dictionary}
 
 Completely reloads a dictionary `dictionary_name`, regardless of the state of the dictionary (LOADED / NOT_LOADED / FAILED).
 Always returns `Ok.` regardless of the result of updating the dictionary.
@@ -43,7 +43,7 @@ The status of the dictionary can be checked by querying the `system.dictionaries
 SELECT name, status FROM system.dictionaries;
 ```
 
-## RELOAD MODELS {#reload-models}
+## SYSTEM RELOAD MODELS {#reload-models}
 
 :::note
 This statement and `SYSTEM RELOAD MODEL` merely unload catboost models from the clickhouse-library-bridge. The function `catboostEvaluate()`
@@ -58,7 +58,7 @@ Unloads all CatBoost models.
 SYSTEM RELOAD MODELS [ON CLUSTER cluster_name]
 ```
 
-## RELOAD MODEL {#reload-model}
+## SYSTEM RELOAD MODEL {#reload-model}
 
 Unloads a CatBoost model at `model_path`.
 
@@ -68,7 +68,7 @@ Unloads a CatBoost model at `model_path`.
 SYSTEM RELOAD MODEL [ON CLUSTER cluster_name] <model_path>
 ```
 
-## RELOAD FUNCTIONS {#reload-functions}
+## SYSTEM RELOAD FUNCTIONS {#reload-functions}
 
 Reloads all registered [executable user defined functions](/sql-reference/functions/udf#executable-user-defined-functions) or one of them from a configuration file.
 
@@ -79,7 +79,7 @@ SYSTEM RELOAD FUNCTIONS [ON CLUSTER cluster_name]
 SYSTEM RELOAD FUNCTION [ON CLUSTER cluster_name] function_name
 ```
 
-## RELOAD ASYNCHRONOUS METRICS {#reload-asynchronous-metrics}
+## SYSTEM RELOAD ASYNCHRONOUS METRICS {#reload-asynchronous-metrics}
 
 Re-calculates all [asynchronous metrics](../../operations/system-tables/asynchronous_metrics.md). Since asynchronous metrics are periodically updated based on setting [asynchronous_metrics_update_period_s](../../operations/server-configuration-parameters/settings.md), updating them manually using this statement is typically not necessary.
 
@@ -87,21 +87,21 @@ Re-calculates all [asynchronous metrics](../../operations/system-tables/asynchro
 SYSTEM RELOAD ASYNCHRONOUS METRICS [ON CLUSTER cluster_name]
 ```
 
-## DROP DNS CACHE {#drop-dns-cache}
+## SYSTEM DROP DNS CACHE {#drop-dns-cache}
 
 Clears ClickHouse's internal DNS cache. Sometimes (for old ClickHouse versions) it is necessary to use this command when changing the infrastructure (changing the IP address of another ClickHouse server or the server used by dictionaries).
 
-For more convenient (automatic) cache management, see disable_internal_dns_cache, dns_cache_max_entries, dns_cache_update_period parameters.
+For more convenient (automatic) cache management, see `disable_internal_dns_cache`, `dns_cache_max_entries`, `dns_cache_update_period` parameters.
 
-## DROP MARK CACHE {#drop-mark-cache}
+## SYSTEM DROP MARK CACHE {#drop-mark-cache}
 
 Clears the mark cache.
 
-## DROP ICEBERG METADATA CACHE {#drop-iceberg-metadata-cache}
+## SYSTEM DROP ICEBERG METADATA CACHE {#drop-iceberg-metadata-cache}
 
 Clears the iceberg metadata cache.
 
-## DROP REPLICA {#drop-replica}
+## SYSTEM DROP REPLICA {#drop-replica}
 
 Dead replicas of `ReplicatedMergeTree` tables can be dropped using following syntax:
 
@@ -119,7 +119,7 @@ The second one does the same for all replicated tables in the database.
 The third one does the same for all replicated tables on the local server.
 The fourth one is useful to remove metadata of dead replica when all other replicas of a table were dropped. It requires the table path to be specified explicitly. It must be the same path as was passed to the first argument of `ReplicatedMergeTree` engine on table creation.
 
-## DROP DATABASE REPLICA {#drop-database-replica}
+## SYSTEM DROP DATABASE REPLICA {#drop-database-replica}
 
 Dead replicas of `Replicated` databases can be dropped using following syntax:
 
@@ -131,22 +131,22 @@ SYSTEM DROP DATABASE REPLICA 'replica_name' [FROM SHARD 'shard_name'] FROM ZKPAT
 
 Similar to `SYSTEM DROP REPLICA`, but removes the `Replicated` database replica path from ZooKeeper when there's no database to run `DROP DATABASE`. Please note that it does not remove `ReplicatedMergeTree` replicas (so you may need `SYSTEM DROP REPLICA` as well). Shard and replica names are the names that were specified in `Replicated` engine arguments when creating the database. Also, these names can be obtained from `database_shard_name` and `database_replica_name` columns in `system.clusters`. If the `FROM SHARD` clause is missing, then `replica_name` must be a full replica name in `shard_name|replica_name` format.
 
-## DROP UNCOMPRESSED CACHE {#drop-uncompressed-cache}
+## SYSTEM DROP UNCOMPRESSED CACHE {#drop-uncompressed-cache}
 
 Clears the uncompressed data cache.
 The uncompressed data cache is enabled/disabled with the query/user/profile-level setting [`use_uncompressed_cache`](../../operations/settings/settings.md#use_uncompressed_cache).
 Its size can be configured using the server-level setting [`uncompressed_cache_size`](../../operations/server-configuration-parameters/settings.md#uncompressed_cache_size).
 
-## DROP COMPILED EXPRESSION CACHE {#drop-compiled-expression-cache}
+## SYSTEM DROP COMPILED EXPRESSION CACHE {#drop-compiled-expression-cache}
 
 Clears the compiled expression cache.
 The compiled expression cache is enabled/disabled with the query/user/profile-level setting [`compile_expressions`](../../operations/settings/settings.md#compile_expressions).
 
-## DROP QUERY CONDITION CACHE {#drop-query-condition-cache}
+## SYSTEM DROP QUERY CONDITION CACHE {#drop-query-condition-cache}
 
 Clears the query condition cache.
 
-## DROP QUERY CACHE {#drop-query-cache}
+## SYSTEM DROP QUERY CACHE {#drop-query-cache}
 
 ```sql
 SYSTEM DROP QUERY CACHE;
@@ -156,7 +156,7 @@ SYSTEM DROP QUERY CACHE TAG '<tag>'
 Clears the [query cache](../../operations/query-cache.md).
 If a tag is specified, only query cache entries with the specified tag are deleted.
 
-## DROP FORMAT SCHEMA CACHE {#system-drop-schema-format}
+## SYSTEM DROP FORMAT SCHEMA CACHE {#system-drop-schema-format}
 
 Clears cache for schemas loaded from [`format_schema_path`](../../operations/server-configuration-parameters/settings.md#format_schema_path).
 
@@ -169,7 +169,7 @@ Note: If no target is specified, both caches are cleared.
 SYSTEM DROP FORMAT SCHEMA CACHE [FOR Protobuf/Files]
 ```
 
-## FLUSH LOGS {#flush-logs}
+## SYSTEM FLUSH LOGS {#flush-logs}
 
 Flushes buffered log messages to system tables, e.g. system.query_log. Mainly useful for debugging since most system tables have a default flush interval of 7.5 seconds.
 This will also create system tables even if message queue is empty.
@@ -184,7 +184,7 @@ If you don't want to flush everything, you can flush one or more individual logs
 SYSTEM FLUSH LOGS query_log, system.query_views_log;
 ```
 
-## RELOAD CONFIG {#reload-config}
+## SYSTEM RELOAD CONFIG {#reload-config}
 
 Reloads ClickHouse configuration. Used when configuration is stored in ZooKeeper. Note that `SYSTEM RELOAD CONFIG` does not reload `USER` configuration stored in ZooKeeper, it only reloads `USER` configuration that is stored in `users.xml`.  To reload all `USER` config use `SYSTEM RELOAD USERS`
 
@@ -192,7 +192,7 @@ Reloads ClickHouse configuration. Used when configuration is stored in ZooKeeper
 SYSTEM RELOAD CONFIG [ON CLUSTER cluster_name]
 ```
 
-## RELOAD USERS {#reload-users}
+## SYSTEM RELOAD USERS {#reload-users}
 
 Reloads all access storages, including: users.xml, local disk access storage, replicated (in ZooKeeper) access storage.
 
@@ -200,13 +200,13 @@ Reloads all access storages, including: users.xml, local disk access storage, re
 SYSTEM RELOAD USERS [ON CLUSTER cluster_name]
 ```
 
-## SHUTDOWN {#shutdown}
+## SYSTEM SHUTDOWN {#shutdown}
 
 <CloudNotSupportedBadge/>
 
 Normally shuts down ClickHouse (like `service clickhouse-server stop` / `kill {$pid_clickhouse-server}`)
 
-## KILL {#kill}
+## SYSTEM KILL {#kill}
 
 Aborts ClickHouse process (like `kill -9 {$ pid_clickhouse-server}`)
 
@@ -214,7 +214,7 @@ Aborts ClickHouse process (like `kill -9 {$ pid_clickhouse-server}`)
 
 ClickHouse can manage [distributed](../../engines/table-engines/special/distributed.md) tables. When a user inserts data into these tables, ClickHouse first creates a queue of the data that should be sent to cluster nodes, then asynchronously sends it. You can manage queue processing with the [`STOP DISTRIBUTED SENDS`](#stop-distributed-sends), [FLUSH DISTRIBUTED](#flush-distributed), and [`START DISTRIBUTED SENDS`](#start-distributed-sends) queries. You can also synchronously insert distributed data with the [`distributed_foreground_insert`](../../operations/settings/settings.md#distributed_foreground_insert) setting.
 
-### STOP DISTRIBUTED SENDS {#stop-distributed-sends}
+### SYSTEM STOP DISTRIBUTED SENDS {#stop-distributed-sends}
 
 Disables background data distribution when inserting data into distributed tables.
 
@@ -226,7 +226,7 @@ SYSTEM STOP DISTRIBUTED SENDS [db.]<distributed_table_name> [ON CLUSTER cluster_
 In case of [`prefer_localhost_replica`](../../operations/settings/settings.md#prefer_localhost_replica) is enabled (the default), the data to local shard will be inserted anyway.
 :::
 
-### FLUSH DISTRIBUTED {#flush-distributed}
+### SYSTEM FLUSH DISTRIBUTED {#flush-distributed}
 
 Forces ClickHouse to send data to cluster nodes synchronously. If any nodes are unavailable, ClickHouse throws an exception and stops query execution. You can retry the query until it succeeds, which will happen when all nodes are back online.
 
@@ -240,7 +240,7 @@ SYSTEM FLUSH DISTRIBUTED [db.]<distributed_table_name> [ON CLUSTER cluster_name]
 Each pending block is stored in disk with settings from the initial INSERT query, so that is why sometimes you may want to override settings.
 :::
 
-### START DISTRIBUTED SENDS {#start-distributed-sends}
+### SYSTEM START DISTRIBUTED SENDS {#start-distributed-sends}
 
 Enables background data distribution when inserting data into distributed tables.
 
@@ -248,7 +248,7 @@ Enables background data distribution when inserting data into distributed tables
 SYSTEM START DISTRIBUTED SENDS [db.]<distributed_table_name> [ON CLUSTER cluster_name]
 ```
 
-### STOP LISTEN {#stop-listen}
+### SYSTEM STOP LISTEN {#stop-listen}
 
 Closes the socket and gracefully terminates the existing connections to the server on the specified port with the specified protocol.
 
@@ -263,7 +263,7 @@ SYSTEM STOP LISTEN [ON CLUSTER cluster_name] [QUERIES ALL | QUERIES DEFAULT | QU
 - If `QUERIES DEFAULT [EXCEPT .. [,..]]` modifier is specified, all default protocols are stopped, unless specified with `EXCEPT` clause.
 - If `QUERIES CUSTOM [EXCEPT .. [,..]]` modifier is specified, all custom protocols are stopped, unless specified with `EXCEPT` clause.
 
-### START LISTEN {#start-listen}
+### SYSTEM START LISTEN {#start-listen}
 
 Allows new connections to be established on the specified protocols.
 
@@ -277,7 +277,7 @@ SYSTEM START LISTEN [ON CLUSTER cluster_name] [QUERIES ALL | QUERIES DEFAULT | Q
 
 ClickHouse can manage background processes in [MergeTree](../../engines/table-engines/mergetree-family/mergetree.md) tables.
 
-### STOP MERGES {#stop-merges}
+### SYSTEM STOP MERGES {#stop-merges}
 
 <CloudNotSupportedBadge/>
 
@@ -291,7 +291,7 @@ SYSTEM STOP MERGES [ON CLUSTER cluster_name] [ON VOLUME <volume_name> | [db.]mer
 `DETACH / ATTACH` table will start background merges for the table even in case when merges have been stopped for all MergeTree tables before.
 :::
 
-### START MERGES {#start-merges}
+### SYSTEM START MERGES {#start-merges}
 
 <CloudNotSupportedBadge/>
 
@@ -301,7 +301,7 @@ Provides possibility to start background merges for tables in the MergeTree fami
 SYSTEM START MERGES [ON CLUSTER cluster_name] [ON VOLUME <volume_name> | [db.]merge_tree_family_table_name]
 ```
 
-### STOP TTL MERGES {#stop-ttl-merges}
+### SYSTEM STOP TTL MERGES {#stop-ttl-merges}
 
 Provides possibility to stop background delete old data according to [TTL expression](../../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-ttl) for tables in the MergeTree family:
 Returns `Ok.` even if table does not exist or table has not MergeTree engine. Returns error when database does not exist:
@@ -310,7 +310,7 @@ Returns `Ok.` even if table does not exist or table has not MergeTree engine. Re
 SYSTEM STOP TTL MERGES [ON CLUSTER cluster_name] [[db.]merge_tree_family_table_name]
 ```
 
-### START TTL MERGES {#start-ttl-merges}
+### SYSTEM START TTL MERGES {#start-ttl-merges}
 
 Provides possibility to start background delete old data according to [TTL expression](../../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-ttl) for tables in the MergeTree family:
 Returns `Ok.` even if table does not exist. Returns error when database does not exist:
@@ -319,7 +319,7 @@ Returns `Ok.` even if table does not exist. Returns error when database does not
 SYSTEM START TTL MERGES [ON CLUSTER cluster_name] [[db.]merge_tree_family_table_name]
 ```
 
-### STOP MOVES {#stop-moves}
+### SYSTEM STOP MOVES {#stop-moves}
 
 Provides possibility to stop background move data according to [TTL table expression with TO VOLUME or TO DISK clause](../../engines/table-engines/mergetree-family/mergetree.md#mergetree-table-ttl) for tables in the MergeTree family:
 Returns `Ok.` even if table does not exist. Returns error when database does not exist:
@@ -328,7 +328,7 @@ Returns `Ok.` even if table does not exist. Returns error when database does not
 SYSTEM STOP MOVES [ON CLUSTER cluster_name] [[db.]merge_tree_family_table_name]
 ```
 
-### START MOVES {#start-moves}
+### SYSTEM START MOVES {#start-moves}
 
 Provides possibility to start background move data according to [TTL table expression with TO VOLUME and TO DISK clause](../../engines/table-engines/mergetree-family/mergetree.md#mergetree-table-ttl) for tables in the MergeTree family:
 Returns `Ok.` even if table does not exist. Returns error when database does not exist:
@@ -337,7 +337,7 @@ Returns `Ok.` even if table does not exist. Returns error when database does not
 SYSTEM START MOVES [ON CLUSTER cluster_name] [[db.]merge_tree_family_table_name]
 ```
 
-### SYSTEM UNFREEZE {#query_language-system-unfreeze}
+### SYSTEM SYSTEM UNFREEZE {#query_language-system-unfreeze}
 
 Clears a frozen backup with the specified name from all the disks. See more about unfreezing separate parts in [ALTER TABLE table_name UNFREEZE WITH NAME ](/sql-reference/statements/alter/partition#unfreeze-partition)
 
@@ -345,7 +345,7 @@ Clears a frozen backup with the specified name from all the disks. See more abou
 SYSTEM UNFREEZE WITH NAME <backup_name>
 ```
 
-### WAIT LOADING PARTS {#wait-loading-parts}
+### SYSTEM WAIT LOADING PARTS {#wait-loading-parts}
 
 Wait until all asynchronously loading data parts of a table (outdated data parts) will became loaded.
 
@@ -357,7 +357,7 @@ SYSTEM WAIT LOADING PARTS [ON CLUSTER cluster_name] [db.]merge_tree_family_table
 
 ClickHouse can manage background replication related processes in [ReplicatedMergeTree](/engines/table-engines/mergetree-family/replication) tables.
 
-### STOP FETCHES {#stop-fetches}
+### SYSTEM STOP FETCHES {#stop-fetches}
 
 <CloudNotSupportedBadge/>
 
@@ -368,7 +368,7 @@ Always returns `Ok.` regardless of the table engine and even if table or databas
 SYSTEM STOP FETCHES [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### START FETCHES {#start-fetches}
+### SYSTEM START FETCHES {#start-fetches}
 
 <CloudNotSupportedBadge/>
 
@@ -379,7 +379,7 @@ Always returns `Ok.` regardless of the table engine and even if table or databas
 SYSTEM START FETCHES [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### STOP REPLICATED SENDS {#stop-replicated-sends}
+### SYSTEM STOP REPLICATED SENDS {#stop-replicated-sends}
 
 Provides possibility to stop background sends to other replicas in cluster for new inserted parts for tables in the `ReplicatedMergeTree` family:
 
@@ -387,7 +387,7 @@ Provides possibility to stop background sends to other replicas in cluster for n
 SYSTEM STOP REPLICATED SENDS [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### START REPLICATED SENDS {#start-replicated-sends}
+### SYSTEM START REPLICATED SENDS {#start-replicated-sends}
 
 Provides possibility to start background sends to other replicas in cluster for new inserted parts for tables in the `ReplicatedMergeTree` family:
 
@@ -395,7 +395,7 @@ Provides possibility to start background sends to other replicas in cluster for 
 SYSTEM START REPLICATED SENDS [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### STOP REPLICATION QUEUES {#stop-replication-queues}
+### SYSTEM STOP REPLICATION QUEUES {#stop-replication-queues}
 
 Provides possibility to stop background fetch tasks from replication queues which stored in Zookeeper for tables in the `ReplicatedMergeTree` family. Possible background tasks types - merges, fetches, mutation, DDL statements with ON CLUSTER clause:
 
@@ -403,7 +403,7 @@ Provides possibility to stop background fetch tasks from replication queues whic
 SYSTEM STOP REPLICATION QUEUES [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### START REPLICATION QUEUES {#start-replication-queues}
+### SYSTEM START REPLICATION QUEUES {#start-replication-queues}
 
 Provides possibility to start background fetch tasks from replication queues which stored in Zookeeper for tables in the `ReplicatedMergeTree` family. Possible background tasks types - merges, fetches, mutation, DDL statements with ON CLUSTER clause:
 
@@ -411,7 +411,7 @@ Provides possibility to start background fetch tasks from replication queues whi
 SYSTEM START REPLICATION QUEUES [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### STOP PULLING REPLICATION LOG {#stop-pulling-replication-log}
+### SYSTEM STOP PULLING REPLICATION LOG {#stop-pulling-replication-log}
 
 Stops loading new entries from replication log to replication queue in a `ReplicatedMergeTree` table.
 
@@ -419,7 +419,7 @@ Stops loading new entries from replication log to replication queue in a `Replic
 SYSTEM STOP PULLING REPLICATION LOG [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### START PULLING REPLICATION LOG {#start-pulling-replication-log}
+### SYSTEM START PULLING REPLICATION LOG {#start-pulling-replication-log}
 
 Cancels `SYSTEM STOP PULLING REPLICATION LOG`.
 
@@ -427,7 +427,7 @@ Cancels `SYSTEM STOP PULLING REPLICATION LOG`.
 SYSTEM START PULLING REPLICATION LOG [ON CLUSTER cluster_name] [[db.]replicated_merge_tree_family_table_name]
 ```
 
-### SYNC REPLICA {#sync-replica}
+### SYSTEM SYNC REPLICA {#sync-replica}
 
 Wait until a `ReplicatedMergeTree` table will be synced with other replicas in a cluster, but no more than `receive_timeout` seconds.
 
@@ -452,7 +452,7 @@ Waits until the specified [replicated database](/engines/database-engines/replic
 SYSTEM SYNC DATABASE REPLICA replicated_database_name;
 ```
 
-### RESTART REPLICA {#restart-replica}
+### SYSTEM RESTART REPLICA {#restart-replica}
 
 Provides possibility to reinitialize Zookeeper session's state for `ReplicatedMergeTree` table, will compare current state with Zookeeper as source of truth and add tasks to Zookeeper queue if needed.
 Initialization of replication queue based on ZooKeeper data happens in the same way as for `ATTACH TABLE` statement. For a short time, the table will be unavailable for any operations.
@@ -461,7 +461,7 @@ Initialization of replication queue based on ZooKeeper data happens in the same 
 SYSTEM RESTART REPLICA [ON CLUSTER cluster_name] [db.]replicated_merge_tree_family_table_name
 ```
 
-### RESTORE REPLICA {#restore-replica}
+### SYSTEM RESTORE REPLICA {#restore-replica}
 
 Restores a replica if data is [possibly] present but Zookeeper metadata is lost.
 
@@ -480,7 +480,7 @@ Parts present on a replica before metadata loss are not re-fetched from other on
 Parts in all states are moved to `detached/` folder. Parts active before data loss (committed) are attached.
 :::
 
-### RESTORE DATABASE REPLICA {#restore-database-replica}
+### SYSTEM RESTORE DATABASE REPLICA {#restore-database-replica}
 
 Restores a replica if data is [possibly] present but Zookeeper metadata is lost.
 
@@ -540,11 +540,11 @@ Another way:
 SYSTEM RESTORE REPLICA test ON CLUSTER cluster;
 ```
 
-### RESTART REPLICAS {#restart-replicas}
+### SYSTEM RESTART REPLICAS {#restart-replicas}
 
 Provides possibility to reinitialize Zookeeper sessions state for all `ReplicatedMergeTree` tables, will compare current state with Zookeeper as source of true and add tasks to Zookeeper queue if needed
 
-### DROP FILESYSTEM CACHE {#drop-filesystem-cache}
+### SYSTEM DROP FILESYSTEM CACHE {#drop-filesystem-cache}
 
 Allows to drop filesystem cache.
 
@@ -552,7 +552,7 @@ Allows to drop filesystem cache.
 SYSTEM DROP FILESYSTEM CACHE [ON CLUSTER cluster_name]
 ```
 
-### SYNC FILE CACHE {#sync-file-cache}
+### SYSTEM SYNC FILE CACHE {#sync-file-cache}
 
 :::note
 It's too heavy and has potential for misuse.
@@ -564,7 +564,7 @@ Will do sync syscall.
 SYSTEM SYNC FILE CACHE [ON CLUSTER cluster_name]
 ```
 
-### LOAD PRIMARY KEY {#load-primary-key}
+### SYSTEM LOAD PRIMARY KEY {#load-primary-key}
 
 Load the primary keys for the given table or for all tables.
 
@@ -576,7 +576,7 @@ SYSTEM LOAD PRIMARY KEY [db.]name
 SYSTEM LOAD PRIMARY KEY
 ```
 
-### UNLOAD PRIMARY KEY {#unload-primary-key}
+### SYSTEM UNLOAD PRIMARY KEY {#unload-primary-key}
 
 Unload the primary keys for the given table or for all tables.
 
@@ -594,7 +594,7 @@ Commands to control background tasks performed by [Refreshable Materialized View
 
 Keep an eye on [`system.view_refreshes`](../../operations/system-tables/view_refreshes.md) while using them.
 
-### REFRESH VIEW {#refresh-view}
+### SYSTEM REFRESH VIEW {#refresh-view}
 
 Trigger an immediate out-of-schedule refresh of a given view.
 
@@ -602,11 +602,11 @@ Trigger an immediate out-of-schedule refresh of a given view.
 SYSTEM REFRESH VIEW [db.]name
 ```
 
-### WAIT VIEW {#wait-view}
+### SYSTEM WAIT VIEW {#wait-view}
 
 Wait for the currently running refresh to complete. If the refresh fails, throws an exception. If no refresh is running, completes immediately, throwing an exception if previous refresh failed.
 
-### STOP [REPLICATED] VIEW, STOP VIEWS {#stop-view-stop-views}
+### SYSTEM STOP [REPLICATED] VIEW, STOP VIEWS {#stop-view-stop-views}
 
 Disable periodic refreshing of the given view or all refreshable views. If a refresh is in progress, cancel it too.
 
@@ -619,7 +619,7 @@ SYSTEM STOP VIEW [db.]name
 SYSTEM STOP VIEWS
 ```
 
-### START [REPLICATED] VIEW, START VIEWS {#start-view-start-views}
+### SYSTEM START [REPLICATED] VIEW, START VIEWS {#start-view-start-views}
 
 Enable periodic refreshing for the given view or all refreshable views. No immediate refresh is triggered.
 
@@ -632,7 +632,7 @@ SYSTEM START VIEW [db.]name
 SYSTEM START VIEWS
 ```
 
-### CANCEL VIEW {#cancel-view}
+### SYSTEM CANCEL VIEW {#cancel-view}
 
 If there's a refresh in progress for the given view on the current replica, interrupt and cancel it. Otherwise do nothing.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
A search like `SYSTEM RESTORE DATABASE REPLICA` does not return a result but `RESTORE DATABASE REPLICA` does. A simple fix for now is just to make the full command as the header.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
