### PR TITLE
RadixSort: Help the compiler use SIMD and the CPU do better prefetching

### DIFF
--- a/src/Common/CPUID.h
+++ b/src/Common/CPUID.h
@@ -305,47 +305,67 @@ inline bool haveAMXINT8() noexcept
             && ((CPUInfo(0x7, 0).registers.edx >> 25) & 1u);  // AMX-INT8 bit
 }
 
+inline bool haveGenuineIntel() noexcept
+{
+#if defined(__x86_64__)
+    unsigned eax = 0;
+    unsigned ebx = 0;
+    unsigned ecx = 0;
+    unsigned edx = 0;
+    __asm__("movq\t%%rbx, %%rsi\n\t"
+            "cpuid\n\t"
+            "xchgq\t%%rbx, %%rsi\n\t"
+            : "=a"(eax), "=S"(ebx), "=c"(ecx), "=d"(edx)
+            : "a"(0));
+
+    return (ebx == 0x756e6547 && edx == 0x49656e69 && ecx == 0x6c65746e);
+#else
+    return 0;
+#endif
+}
+
 #define CPU_ID_ENUMERATE(OP) \
-    OP(SSE)                  \
-    OP(SSE2)                 \
-    OP(SSE3)                 \
-    OP(SSSE3)                \
-    OP(SSE41)                \
-    OP(SSE42)                \
-    OP(F16C)                 \
-    OP(POPCNT)               \
-    OP(BMI1)                 \
-    OP(BMI2)                 \
-    OP(PCLMUL)               \
-    OP(AES)                  \
-    OP(AVX)                  \
-    OP(FMA)                  \
-    OP(AVX2)                 \
-    OP(AVX512F)              \
-    OP(AVX512DQ)             \
-    OP(AVX512IFMA)           \
-    OP(AVX512PF)             \
-    OP(AVX512ER)             \
-    OP(AVX512CD)             \
-    OP(AVX512BW)             \
-    OP(AVX512VL)             \
-    OP(AVX512VBMI)           \
-    OP(AVX512VBMI2)          \
-    OP(AVX512BF16)           \
-    OP(PREFETCHWT1)          \
-    OP(SHA)                  \
-    OP(ADX)                  \
-    OP(RDRAND)               \
-    OP(RDSEED)               \
-    OP(PCOMMIT)              \
-    OP(RDTSCP)               \
-    OP(CLFLUSHOPT)           \
-    OP(CLWB)                 \
-    OP(XSAVE)                \
-    OP(OSXSAVE)              \
-    OP(AMXBF16)              \
-    OP(AMXTILE)              \
-    OP(AMXINT8)
+    OP(SSE) \
+    OP(SSE2) \
+    OP(SSE3) \
+    OP(SSSE3) \
+    OP(SSE41) \
+    OP(SSE42) \
+    OP(F16C) \
+    OP(POPCNT) \
+    OP(BMI1) \
+    OP(BMI2) \
+    OP(PCLMUL) \
+    OP(AES) \
+    OP(AVX) \
+    OP(FMA) \
+    OP(AVX2) \
+    OP(AVX512F) \
+    OP(AVX512DQ) \
+    OP(AVX512IFMA) \
+    OP(AVX512PF) \
+    OP(AVX512ER) \
+    OP(AVX512CD) \
+    OP(AVX512BW) \
+    OP(AVX512VL) \
+    OP(AVX512VBMI) \
+    OP(AVX512VBMI2) \
+    OP(AVX512BF16) \
+    OP(PREFETCHWT1) \
+    OP(SHA) \
+    OP(ADX) \
+    OP(RDRAND) \
+    OP(RDSEED) \
+    OP(PCOMMIT) \
+    OP(RDTSCP) \
+    OP(CLFLUSHOPT) \
+    OP(CLWB) \
+    OP(XSAVE) \
+    OP(OSXSAVE) \
+    OP(AMXBF16) \
+    OP(AMXTILE) \
+    OP(AMXINT8) \
+    OP(GenuineIntel)
 
 struct CPUFlagsCache
 {

--- a/src/Common/CPUID.h
+++ b/src/Common/CPUID.h
@@ -320,7 +320,7 @@ inline bool haveGenuineIntel() noexcept
 
     return (ebx == 0x756e6547 && edx == 0x49656e69 && ecx == 0x6c65746e);
 #else
-    return 0;
+    return false;
 #endif
 }
 

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -377,7 +377,8 @@ private:
                 {
                     auto element = reader[i];
                     size_t pos = extractPart(pass, element);
-                    writer[size - 1 - (histograms[pass * HISTOGRAM_SIZE + pos]++)] = Traits::extractResult(element);
+                    writer[size - 1 - (histograms[pass * HISTOGRAM_SIZE + pos])] = Traits::extractResult(element);
+                    ++histograms[pass * HISTOGRAM_SIZE + pos];
                 }
             }
             else
@@ -386,7 +387,8 @@ private:
                 {
                     auto element = reader[i];
                     size_t pos = extractPart(pass, element);
-                    writer[histograms[pass * HISTOGRAM_SIZE + pos]++] = Traits::extractResult(element);
+                    writer[histograms[pass * HISTOGRAM_SIZE + pos]] = Traits::extractResult(element);
+                    ++histograms[pass * HISTOGRAM_SIZE + pos];
                 }
             }
         }

--- a/src/Common/TargetSpecific.cpp
+++ b/src/Common/TargetSpecific.cpp
@@ -31,6 +31,8 @@ static UInt32 getSupportedArchs()
         result |= static_cast<UInt32>(TargetArch::AMXTILE);
     if (CPU::CPUFlagsCache::have_AMXINT8)
         result |= static_cast<UInt32>(TargetArch::AMXINT8);
+    if (CPU::CPUFlagsCache::have_GenuineIntel)
+        result |= static_cast<UInt32>(TargetArch::GenuineIntel);
     return result;
 }
 
@@ -56,6 +58,7 @@ String toString(TargetArch arch)
         case TargetArch::AMXBF16: return "amxbf16";
         case TargetArch::AMXTILE: return "amxtile";
         case TargetArch::AMXINT8: return "amxint8";
+        case TargetArch::GenuineIntel: return "GenuineIntel";
     }
 }
 

--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -75,18 +75,19 @@ namespace DB
 
 enum class TargetArch : UInt32
 {
-    Default  = 0,         /// Without any additional compiler options.
-    SSE42    = (1 << 0),  /// SSE4.2
-    AVX      = (1 << 1),
-    AVX2     = (1 << 2),
-    AVX512F  = (1 << 3),
-    AVX512BW    = (1 << 4),
-    AVX512VBMI  = (1 << 5),
+    Default = 0, /// Without any additional compiler options.
+    SSE42 = (1 << 0), /// SSE4.2
+    AVX = (1 << 1),
+    AVX2 = (1 << 2),
+    AVX512F = (1 << 3),
+    AVX512BW = (1 << 4),
+    AVX512VBMI = (1 << 5),
     AVX512VBMI2 = (1 << 6),
     AVX512BF16 = (1 << 7),
     AMXBF16 = (1 << 8),
     AMXTILE = (1 << 9),
     AMXINT8 = (1 << 10),
+    GenuineIntel = (1 << 11), /// Not an instruction set, but a CPU vendor.
 };
 
 /// Runtime detection.

--- a/src/Common/benchmarks/CMakeLists.txt
+++ b/src/Common/benchmarks/CMakeLists.txt
@@ -13,6 +13,11 @@ target_link_libraries (orc_string_dictionary PRIVATE
     ch_contrib::gbenchmark_all
     dbms)
 
+clickhouse_add_executable(benchmark_radix_sort radix_sort.cpp)
+target_link_libraries (benchmark_radix_sort PRIVATE
+    ch_contrib::gbenchmark_all
+    dbms)
+
 clickhouse_add_executable(wrap_in_nullable wrap_in_nullable.cpp)
 target_link_libraries (wrap_in_nullable PRIVATE
     ch_contrib::gbenchmark_all

--- a/src/Common/benchmarks/radix_sort.cpp
+++ b/src/Common/benchmarks/radix_sort.cpp
@@ -2,7 +2,6 @@
 #include <Functions/FunctionHelpers.h>
 #include <Storages/StorageGenerateRandom.h>
 #include <benchmark/benchmark.h>
-#include "pcg_random.hpp"
 
 using namespace DB;
 

--- a/src/Common/benchmarks/radix_sort.cpp
+++ b/src/Common/benchmarks/radix_sort.cpp
@@ -1,0 +1,72 @@
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionHelpers.h>
+#include <Storages/StorageGenerateRandom.h>
+#include <benchmark/benchmark.h>
+#include "pcg_random.hpp"
+
+using namespace DB;
+
+static void BM_RadixSort_UInt8(benchmark::State & state)
+{
+    pcg64 rng;
+    UInt64 limit = DEFAULT_BLOCK_SIZE;
+    auto type = std::make_shared<DataTypeUInt8>();
+    auto column = fillColumnWithRandomData(type, limit, 0, 0, rng, nullptr);
+
+    for (auto _ : state)
+    {
+        IColumn::Permutation res;
+        column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
+        benchmark::DoNotOptimize(res);
+    }
+}
+
+static void BM_RadixSort_Int16(benchmark::State & state)
+{
+    pcg64 rng;
+    UInt64 limit = DEFAULT_BLOCK_SIZE;
+    auto type = std::make_shared<DataTypeInt16>();
+    auto column = fillColumnWithRandomData(type, limit, 0, 0, rng, nullptr);
+
+    for (auto _ : state)
+    {
+        IColumn::Permutation res;
+        column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
+        benchmark::DoNotOptimize(res);
+    }
+}
+
+static void BM_RadixSort_Int32(benchmark::State & state)
+{
+    pcg64 rng;
+    UInt64 limit = DEFAULT_BLOCK_SIZE;
+    auto type = std::make_shared<DataTypeInt32>();
+    auto column = fillColumnWithRandomData(type, limit, 0, 0, rng, nullptr);
+
+    for (auto _ : state)
+    {
+        IColumn::Permutation res;
+        column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
+        benchmark::DoNotOptimize(res);
+    }
+}
+
+static void BM_RadixSort_UInt64(benchmark::State & state)
+{
+    pcg64 rng;
+    UInt64 limit = DEFAULT_BLOCK_SIZE;
+    auto type = std::make_shared<DataTypeUInt64>();
+    auto column = fillColumnWithRandomData(type, limit, 0, 0, rng, nullptr);
+
+    for (auto _ : state)
+    {
+        IColumn::Permutation res;
+        column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
+        benchmark::DoNotOptimize(res);
+    }
+}
+
+BENCHMARK(BM_RadixSort_UInt8);
+BENCHMARK(BM_RadixSort_Int16);
+BENCHMARK(BM_RadixSort_Int32);
+BENCHMARK(BM_RadixSort_UInt64);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
RadixSort: Help the compiler use SIMD and the CPU do better prefetching. Uses dynamic dispatch to use software prefetching with Intel CPUs only. Continues the work by @taiyang-li in https://github.com/ClickHouse/ClickHouse/pull/77029

Closes https://github.com/ClickHouse/ClickHouse/pull/77029

Some comparisons:

## AMD Ryzen 9 7950X3D:

#### Master
```
BM_RadixSort_UInt8       70378 ns        70084 ns         9478
BM_RadixSort_Int16      125775 ns       125216 ns         5556
BM_RadixSort_Int32      216862 ns       215920 ns         3234
BM_RadixSort_UInt64     480289 ns       478235 ns         1451
```

#### Changes

```
BM_RadixSort_UInt8       67020 ns        66728 ns        10416
BM_RadixSort_Int16      117904 ns       117406 ns         5759
BM_RadixSort_Int32      213740 ns       212556 ns         3433
BM_RadixSort_UInt64     440626 ns       438699 ns         1598
```

## Intel(R) Xeon(R) Platinum 8488C (AWS)

#### Master
```
BM_RadixSort_UInt8      142730 ns       142728 ns         4883
BM_RadixSort_Int16      252128 ns       252126 ns         2765
BM_RadixSort_Int32      445234 ns       445227 ns         1562
BM_RadixSort_UInt64    1419912 ns      1419871 ns          492
```

#### Changes

```
BM_RadixSort_UInt8      129794 ns       129791 ns         5419
BM_RadixSort_Int16      240182 ns       240179 ns         2898
BM_RadixSort_Int32      404590 ns       404585 ns         1743
BM_RadixSort_UInt64     967091 ns       967047 ns          720
```

## Graviton 4

#### Master
```
BM_RadixSort_UInt8      147416 ns       147406 ns         4750
BM_RadixSort_Int16      233225 ns       233213 ns         3002
BM_RadixSort_Int32      377702 ns       377668 ns         1856
BM_RadixSort_UInt64     811014 ns       810942 ns          862
```

#### Changes

```
BM_RadixSort_UInt8      144136 ns       144134 ns         4855
BM_RadixSort_Int16      227042 ns       227033 ns         3086
BM_RadixSort_Int32      367189 ns       367174 ns         1906
BM_RadixSort_UInt64     797152 ns       797147 ns          878
```
