### PR TITLE
DRAFT: Fix memory accounting in merges/mutations

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -141,22 +141,6 @@ public:
         return rss.load(std::memory_order_relaxed);
     }
 
-    // Merges and mutations may pass memory ownership to other threads thus in the end of execution
-    // MemoryTracker for background task may have a non-zero counter.
-    // This method is intended to fix the counter inside of background_memory_tracker.
-    // NOTE: We can't use alloc/free methods to do it, because they also will change the value inside
-    // of total_memory_tracker.
-    void adjustOnBackgroundTaskEnd(const MemoryTracker * child)
-    {
-        auto background_memory_consumption = child->amount.load(std::memory_order_relaxed);
-        amount.fetch_sub(background_memory_consumption, std::memory_order_relaxed);
-
-        // Also fix CurrentMetrics::MergesMutationsMemoryTracking
-        auto metric_loaded = metric.load(std::memory_order_relaxed);
-        if (metric_loaded != CurrentMetrics::end())
-            CurrentMetrics::sub(metric_loaded, background_memory_consumption);
-    }
-
     Int64 getPeak() const
     {
         return peak.load(std::memory_order_relaxed);

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -118,9 +118,6 @@ const MemoryTracker & MergeListElement::getMemoryTracker() const
     return thread_group->memory_tracker;
 }
 
-MergeListElement::~MergeListElement()
-{
-    background_memory_tracker.adjustOnBackgroundTaskEnd(&getMemoryTracker());
-}
+MergeListElement::~MergeListElement() = default;
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix memory accounting in merges/mutations

Likely after calling adjustOnBackgroundTaskEnd() we will properly flush this memory to the parent memory tracker (and it should be background_memory_tracker, so it can be accounted twice.
