### PR TITLE
add no-parallel-replica tag to 03580_improve_prewhere.sql

### DIFF
--- a/tests/queries/0_stateless/03580_improve_prewhere.sql
+++ b/tests/queries/0_stateless/03580_improve_prewhere.sql
@@ -1,3 +1,4 @@
+-- Tags: no-parallel-replicas
 -- Default settings
 set optimize_move_to_prewhere = 1;
 set move_all_conditions_to_prewhere = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
looks like parallel replica makes different plan
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
