### PR TITLE
Fail if all replicas are unavailable when reading from *cluster functions

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -42,6 +42,11 @@ namespace Setting
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
 }
 
+namespace ErrorCodes
+{
+    extern const int ALL_CONNECTION_TRIES_FAILED;
+}
+
 IStorageCluster::IStorageCluster(
     const String & cluster_name_,
     const StorageID & table_id_,
@@ -239,10 +244,10 @@ void ReadFromCluster::initializePipeline(QueryPipelineBuilder & pipeline, const 
         pipes.emplace_back(std::move(pipe));
     }
 
-    auto pipe = Pipe::unitePipes(std::move(pipes));
-    if (pipe.empty())
-        pipe = Pipe(std::make_shared<NullSource>(getOutputHeader()));
+    if (pipes.empty())
+        throw Exception(ErrorCodes::ALL_CONNECTION_TRIES_FAILED, "Cannot connect to any replica for query execution");
 
+    auto pipe = Pipe::unitePipes(std::move(pipes));
     for (const auto & processor : pipe.getProcessors())
         processors.emplace_back(processor);
 

--- a/tests/config/config.d/clusters.xml
+++ b/tests/config/config.d/clusters.xml
@@ -325,5 +325,19 @@
                 </replica>
             </shard>
         </test_shard_bind_host_fail>
+        <test_cluster_multiple_nodes_all_unavailable>
+            <node>
+                <host>127.0.0.1</host>
+                <port>1234</port>
+            </node>
+            <node>
+                <host>127.0.0.2</host>
+                <port>1234</port>
+            </node>
+            <node>
+                <host>127.0.0.3</host>
+                <port>1234</port>
+            </node>
+        </test_cluster_multiple_nodes_all_unavailable>
     </remote_servers>
 </clickhouse>

--- a/tests/queries/0_stateless/03603_reading_s3_cluster_all_nodes_unavailable.sql
+++ b/tests/queries/0_stateless/03603_reading_s3_cluster_all_nodes_unavailable.sql
@@ -1,0 +1,4 @@
+-- Tags: no-fasttest
+-- s3Cluster is not used in fast tests
+
+SELECT * FROM s3Cluster('test_cluster_multiple_nodes_all_unavailable', 'http://localhost:11111/test/a.tsv'); -- { serverError ALL_CONNECTION_TRIES_FAILED }


### PR DESCRIPTION
When reading from *cluster functions, e.g. `s3Cluster` or `deltaLakeCluster`, and all replicas are unavailable, we currently return an empty result:

```
:) SELECT * FROM s3Cluster('test_cluster_multiple_nodes_all_unavailable', 'http://minio:9023/test/a.parquet');

Query id: 8c5e3f30-44c1-47e0-9d58-9d802f29d209

Ok.

0 rows in set. Elapsed: 0.013 sec. 
```

Logs:
```
2025.08.29 16:20:20.280297 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.1:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280472 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №1, reason: Code: 210. DB::NetException: Connection refused (127.0.0.1:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280476 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.1:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280547 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №2, reason: Code: 210. DB::NetException: Connection refused (127.0.0.1:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280551 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.1:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280624 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №3, reason: Code: 210. DB::NetException: Connection refused (127.0.0.1:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280631 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.2:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280711 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №1, reason: Code: 210. DB::NetException: Connection refused (127.0.0.2:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280716 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.2:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280783 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №2, reason: Code: 210. DB::NetException: Connection refused (127.0.0.2:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280786 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.2:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280850 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №3, reason: Code: 210. DB::NetException: Connection refused (127.0.0.2:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280858 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.3:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280924 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №1, reason: Code: 210. DB::NetException: Connection refused (127.0.0.3:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280927 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.3:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.280991 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №2, reason: Code: 210. DB::NetException: Connection refused (127.0.0.3:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.280994 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Trace> Connection (127.0.0.3:1234): Connecting. Database: (not specified). User: default. Bind_Host: (not specified)
2025.08.29 16:20:20.281069 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Warning> ConnectionPoolWithFailover: Connection failed at try №3, reason: Code: 210. DB::NetException: Connection refused (127.0.0.3:1234). (NETWORK_ERROR) (version 25.9.1.1)
2025.08.29 16:20:20.281458 [ 1444699 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Test> PipelineExecutor: Thread finished. Total time: 1.7942e-05 sec. Execution time: 4.231e-06 sec. Processing time: 6.24e-06 sec. Wait time: 7.471e-06 sec.
2025.08.29 16:20:20.281585 [ 1444017 ] {8c5e3f30-44c1-47e0-9d58-9d802f29d209} <Debug> TCPHandler: Processed in 0.013430705 sec.
```

It seems that the problem was introduced [here](https://github.com/ClickHouse/ClickHouse/commit/69f132197570dd977de53a121ddc64a2fa390058#diff-326364e371a6f9dcd6722035bd77220c0c021c73cfd423b896b62cc6036c9a48R207) by allowing to skip unavailable endpoints in `ConnectionPoolWithFailover::getMany`.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fail if all replicas are unavailable when reading from *cluster functions

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
