### PR TITLE
Extra retries for disk access check in Azure

### DIFF
--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -234,10 +234,12 @@ try
 {
     const std::string_view payload("test", 4);
     const auto read_settings = getReadSettings();
+    auto write_settings = getWriteSettings();
+    write_settings.is_initial_access_check = true;
 
     /// write
     {
-        auto file = writeFile(path, std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, payload.size()), WriteMode::Rewrite);
+        auto file = writeFile(path, std::min<size_t>(DBMS_DEFAULT_BUFFER_SIZE, payload.size()), WriteMode::Rewrite, write_settings);
         try
         {
             file->write(payload.data(), payload.size());

--- a/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
@@ -62,7 +62,7 @@ WriteBufferFromAzureBlobStorage::WriteBufferFromAzureBlobStorage(
     , log(getLogger("WriteBufferFromAzureBlobStorage"))
     , buffer_allocation_policy(createBufferAllocationPolicy(*settings_))
     , max_single_part_upload_size(settings_->max_single_part_upload_size)
-    , max_unexpected_write_error_retries(settings_->max_unexpected_write_error_retries)
+    , max_unexpected_write_error_retries(write_settings_.is_initial_access_check ? settings_->max_unexpected_write_error_retries * 3 : settings_->max_unexpected_write_error_retries)
     , blob_path(blob_path_)
     , write_settings(write_settings_)
     , blob_container_client(blob_container_client_)
@@ -121,7 +121,7 @@ void WriteBufferFromAzureBlobStorage::execWithRetry(std::function<void(size_t)> 
         }
         catch (const Azure::Core::RequestFailedException & e)
         {
-            if (i == num_tries - 1 || !isRetryableAzureException(e))
+            if (i == num_tries - 1 || !isRetryableAzureException(e, /* may_be_provisioning_access */ write_settings.is_initial_access_check))
                 throw;
 
             LOG_DEBUG(log, "Write at attempt {} for blob `{}` failed: {} {}", i + 1, blob_path, e.what(), e.Message);

--- a/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
+++ b/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
@@ -6,10 +6,15 @@
 namespace DB
 {
 
-bool isRetryableAzureException(const Azure::Core::RequestFailedException & e)
+bool isRetryableAzureException(const Azure::Core::RequestFailedException & e, bool may_be_provisioning_access)
 {
     /// Always retry transport errors.
     if (dynamic_cast<const Azure::Core::Http::TransportException *>(&e))
+        return true;
+
+    /// Azure may be provisioning access for quite a long time, so 403 is retriable in some cases
+    /// It makes sense for IDisk::checkAccess() which is called early on startup and terminates the server/keeper if the check fails
+    if (may_be_provisioning_access && e.StatusCode == Azure::Core::Http::HttpStatusCode::Forbidden)
         return true;
 
     /// Retry other 5xx errors just in case.

--- a/src/IO/AzureBlobStorage/isRetryableAzureException.h
+++ b/src/IO/AzureBlobStorage/isRetryableAzureException.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-bool isRetryableAzureException(const Azure::Core::RequestFailedException & e);
+bool isRetryableAzureException(const Azure::Core::RequestFailedException & e, bool may_be_provisioning_access = false);
 
 }
 

--- a/src/IO/WriteSettings.h
+++ b/src/IO/WriteSettings.h
@@ -31,6 +31,8 @@ struct WriteSettings
     bool write_through_distributed_cache = false;
     DistributedCacheSettings distributed_cache_settings;
 
+    bool is_initial_access_check = false;
+
     bool operator==(const WriteSettings & other) const = default;
 };
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add extra retries for disk access check (`skip_access_check=0`) in Azure because it may be provisioning access for quite a long time

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
