### PR TITLE
Fix leaking of MergesMutationsMemoryTracking and fix query_views_log for streaming

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -119,9 +119,9 @@ public:
 
     /// NOTE: The caller should call background_memory_tracker.adjustOnBackgroundTaskEnd() at the end (see existing callers),
     /// and make sure that you are the only user of this shared_ptr (usually it is managed via ThreadGroupSwitcher)
-    static ThreadGroupPtr createForBackgroundProcess(ContextPtr storage_context);
+    static ThreadGroupPtr createForMergeMutate(ContextPtr storage_context);
 
-    static ThreadGroupPtr createForMaterializedView();
+    static ThreadGroupPtr createForMaterializedView(ContextPtr context);
 
     std::vector<UInt64> getInvolvedThreadIds() const;
     size_t getPeakThreadsUsage() const;
@@ -146,6 +146,8 @@ private:
     size_t peak_threads_usage TSA_GUARDED_BY(mutex) = 0;
 
     UInt64 elapsed_total_threads_counter_ms TSA_GUARDED_BY(mutex) = 0;
+
+    static ThreadGroupPtr create(ContextPtr context);
 };
 
 /**

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -117,6 +117,8 @@ public:
     /// When new query starts, new thread group is created for it, current thread becomes master thread of the query
     static ThreadGroupPtr createForQuery(ContextPtr query_context_, FatalErrorCallback fatal_error_callback_ = {});
 
+    /// NOTE: The caller should call background_memory_tracker.adjustOnBackgroundTaskEnd() at the end (see existing callers),
+    /// and make sure that you are the only user of this shared_ptr (usually it is managed via ThreadGroupSwitcher)
     static ThreadGroupPtr createForBackgroundProcess(ContextPtr storage_context);
 
     static ThreadGroupPtr createForMaterializedView();

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -74,7 +74,7 @@ MergeListElement::MergeListElement(const StorageID & table_id_, FutureMergedMuta
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Got {} source parts for mutation {}: {}", future_part->parts.size(),
                         result_part_info.getPartNameV1(), fmt::join(source_part_names, ", "));
 
-    thread_group = ThreadGroup::createForBackgroundProcess(context);
+    thread_group = ThreadGroup::createForMergeMutate(context);
 }
 
 MergeInfo MergeListElement::getInfo() const

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -1089,18 +1089,13 @@ void StorageBuffer::writeBlockToDestination(const Block & block, StoragePtr tabl
 
 void StorageBuffer::backgroundFlush()
 {
+    try
     {
-        auto thread_group = ThreadGroup::createForBackgroundProcess(getContext());
-        ThreadGroupSwitcher group_switcher(thread_group, "BufferBgrFlush");
-
-        try
-        {
-            flushAllBuffers(true);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-        }
+        flushAllBuffers(true);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 
     reschedule();


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix leaking of `MergesMutationsMemoryTracking` due to `Buffer` tables and fix `query_views_log` for streaming from `Kafka` (and others)

For `Buffer` we started to use `background_memory_tracker` since #79963, but forgot to call `background_memory_tracker.adjustOnBackgroundTaskEnd()`, like we do for merges/mutations and this leads to drift in `MergesMutationsMemoryTracking` (significant one), which later will lead to TOO_MANY_PARTS, because merges will stop.

At first I actually added it (`adjustOnBackgroundTaskEnd()`) but later decided that it is wrong, merges/mutations should not take care about `Buffer` flushes. Instead I've just created separate `MemoryTracker` with `total_memory_tracker` as parent, that does not requires such hacks. And this also fixes `query_views_log` for streaming from `Kafka` (and others), since previously there was no `ThreadGroup` for them.

_Note, maybe it will be a good idea to have a RAII for return value of createForBackgroundProcess() that will take care of adjustOnBackgroundTaskEnd(), but but this is not can be tricky since you need to make sure that there are no users of it (i.e. ThreadGroupSwitcher already finished)._

Fixes: #79963 (cc @CheSema )
Fixes: #86398