### PR TITLE
Sharding key filter pushdown to GLOBAL IN subquery result

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1266,6 +1266,17 @@ See also:
 Right now it requires `optimize_skip_unused_shards` (the reason behind this is that one day it may be enabled by default, and it will work correctly only if data was inserted via Distributed table, i.e. data is distributed according to sharding_key).
 :::
 )", 0) \
+    DECLARE(Bool, optimize_sharding_key_global_in, true, R"(
+For filters such as `sharding_key GLOBAL IN (...)` rewrites the shard queries by applying the shard filter to the result of the GLOBAL IN subquery (requires [`optimize_skip_unused_shards`](#optimize_skip_unused_shards) to be enabled).
+
+This optimization is supported only when the left-hand side of GLOBAL IN expression is a column that is used in the sharding key expression and the sharding key is based on a single column.
+For example, for a distributed table created with `ENGINE = Distributed(<cluster>, <db>, <table>, xxHash64(field))`, the only supported query pattern is `WHERE field GLOBAL IN (...)`.
+
+Possible values:
+
+- 0 — Disabled.
+- 1 — Enabled.
+)", 0) \
     DECLARE(UInt64, optimize_skip_unused_shards_limit, 1000, R"(
 Limit for number of sharding key values, turns off `optimize_skip_unused_shards` if the limit is reached.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},
             {"s3_retry_attempts", 500, 500, "Changed the value of the obsolete setting"},
+            {"optimize_sharding_key_global_in", false, true, "New setting."},
         });
         addSettingsChanges(settings_changes_history, "25.10",
         {

--- a/src/Interpreters/ClusterProxy/executeQuery.h
+++ b/src/Interpreters/ClusterProxy/executeQuery.h
@@ -85,6 +85,7 @@ void executeQuery(
     ContextPtr context,
     const SelectQueryInfo & query_info,
     const ExpressionActionsPtr & sharding_key_expr,
+    const ASTPtr & sharding_key_ast,
     const std::string & sharding_key_column_name,
     const DistributedSettings & distributed_settings,
     AdditionalShardFilterGenerator shard_filter_generator,

--- a/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.h
+++ b/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.h
@@ -28,12 +28,18 @@ struct OptimizeShardingKeyRewriteInMatcher
     {
         /// Expression of sharding_key for the Distributed() table
         const ExpressionActionsPtr & sharding_key_expr;
+        /// AST of sharding key expression of the Distributed() table
+        const ASTPtr & sharding_key_ast;
         /// Name of the column for sharding_expr
         const std::string & sharding_key_column_name;
         /// Info for the current shard (to compare shard_num with calculated)
         const Cluster::ShardInfo & shard_info;
         /// weight -> shard mapping
         const Cluster::SlotToShard & slots;
+        /// If rewriting IN functions allowed
+        const bool allow_rewrite_in;
+        /// If rewriting GLOBAL IN functions allowed
+        const bool allow_rewrite_global_in;
     };
 
     static bool needChildVisit(ASTPtr & /*node*/, const ASTPtr & /*child*/);

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1080,6 +1080,7 @@ void StorageDistributed::read(
         local_context,
         modified_query_info,
         sharding_key_expr,
+        sharding_key,
         sharding_key_column_name,
         *distributed_settings,
         shard_filter_generator,

--- a/tests/queries/0_stateless/03603_optimize_sharding_key_global_in.reference
+++ b/tests/queries/0_stateless/03603_optimize_sharding_key_global_in.reference
@@ -1,0 +1,55 @@
+-- Simple shard key
+
+1	val-1
+500	val-500
+
+0
+
+0	val-0
+0	val-0
+499	val-499
+499	val-499
+
+-- Hash shard key
+
+1	val-1
+500	val-500
+
+0	val-0
+0	val-0
+499	val-499
+499	val-499
+
+-- Complex shard key
+
+1	val-1
+500	val-500
+
+0	val-0
+0	val-0
+499	val-499
+499	val-499
+
+-- No shard key
+
+1	val-1
+1	val-1
+500	val-500
+500	val-500
+
+default.`03603_dist_simple`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(`__table2`.`f`, 2), 0))
+default.`03603_dist_simple`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(`__table2`.`f`, 2), 1))
+default.`03603_dist_simple`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(`__table2`.`f`, 2), 0))
+default.`03603_dist_simple`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(`__table2`.`f`, 2), 1))
+default.`03603_dist_simple`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_simple`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_hash`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(xxHash32(`__table2`.`f`), 2), 0))
+default.`03603_dist_hash`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(xxHash32(`__table2`.`f`), 2), 1))
+default.`03603_dist_hash`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_hash`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_complex`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(intDiv(xxHash32(`__table2`.`f` + 1), 100), 2), 0))
+default.`03603_dist_complex`	(SELECT `__table2`.`f` AS `f` FROM `_data_xxx` AS `__table2` WHERE equals(modulo(intDiv(xxHash32(`__table2`.`f` + 1), 100), 2), 1))
+default.`03603_dist_complex`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_complex`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_nokey`	(`_data_xxx` AS `__table2`)
+default.`03603_dist_nokey`	(`_data_xxx` AS `__table2`)

--- a/tests/queries/0_stateless/03603_optimize_sharding_key_global_in.sql
+++ b/tests/queries/0_stateless/03603_optimize_sharding_key_global_in.sql
@@ -1,0 +1,102 @@
+set enable_analyzer = 1,
+    optimize_skip_unused_shards = 1,
+    prefer_localhost_replica = 0,
+    optimize_sharding_key_global_in = 1;
+
+drop table if exists 03603_local;
+create table 03603_local (key UInt32, val String) engine = MergeTree order by key
+as
+select number, 'val-' || number from numbers(1000);
+
+select '-- Simple shard key';
+
+drop table if exists 03603_dist_simple;
+
+create table 03603_dist_simple (key UInt32, val String)
+engine = Distributed(test_cluster_two_shards, currentDatabase(), 03603_local, key);
+
+select '';
+select * from 03603_dist_simple where key global in (select 1 as f union all select 500) order by key;
+
+select '';
+select count() from 03603_dist_simple where key global in (select -1 as f union all select -500) order by 1;
+
+select '';
+select * from 03603_dist_simple where key + 1 global in (select 1 as f union all select 500) order by key;
+
+drop table 03603_dist_simple;
+
+select '';
+select '-- Hash shard key';
+
+drop table if exists 03603_dist_hash;
+
+create table 03603_dist_hash (key UInt32, val String)
+engine = Distributed(test_cluster_two_shards, currentDatabase(), 03603_local, xxHash32(key));
+
+select '';
+select * from 03603_dist_hash where key global in (select 1 as f union all select 500) order by key;
+
+select '';
+select * from 03603_dist_hash where key + 1 global in (select 1 as f union all select 500) order by key;
+
+drop table 03603_dist_hash;
+
+select '';
+select '-- Complex shard key';
+
+drop table if exists 03603_dist_complex;
+
+create table 03603_dist_complex (key UInt32, val String)
+engine = Distributed(test_cluster_two_shards, currentDatabase(), 03603_local, intDiv(xxHash32(key + 1), 100));
+
+select '';
+select * from 03603_dist_complex where key global in (select 1 as f union all select 500) order by key;
+
+select '';
+select * from 03603_dist_complex where key + 1 global in (select 1 as f union all select 500) order by key;
+
+drop table 03603_dist_complex;
+
+select '';
+select '-- No shard key';
+
+drop table if exists 03603_dist_nokey;
+
+create table 03603_dist_nokey (key UInt32, val String)
+engine = Distributed(test_cluster_two_shards, currentDatabase(), 03603_local);
+
+select '';
+select * from 03603_dist_nokey where key global in (select 1 as f union all select 500) order by key;
+
+drop table 03603_dist_nokey;
+
+drop table 03603_local;
+
+select '';
+
+system flush logs query_log;
+
+with [
+    currentDatabase() || '.`03603_dist_simple`',
+    currentDatabase() || '.`03603_dist_hash`',
+    currentDatabase() || '.`03603_dist_complex`',
+    currentDatabase() || '.`03603_dist_nokey`'
+] as dist_tables,
+queries as (
+    select query_id, event_time_microseconds, arrayIntersect(tables, dist_tables)[1] as dist_table_used
+    from system.query_log
+    where current_database = currentDatabase()
+    and type = 'QueryFinish'
+    and query_kind = 'Select'
+    and is_initial_query = 1
+    and hasAny(tables, dist_tables)
+)
+select queries.dist_table_used,
+       replaceRegexpOne(extract(query_log.query, 'GLOBAL IN (\(.+\)) ORDER BY'), '\_data\_[0-9\_]+', '_data_xxx')
+from system.query_log
+    join queries on query_log.initial_query_id = queries.query_id
+where type = 'QueryFinish'
+  and is_initial_query = 0
+  and initial_query_id in (select query_id from queries)
+order by queries.event_time_microseconds, query_log.query;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Introduce optimize_sharding_key_global_in setting which enables additional filtering for GLOBAL IN subquery result on the shards, in case of sharding_key GLOBAL IN (...) queries.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details

In case of distributed tables where sharding key matches the primary key of the underlying table, the queries with IN (<subquery>) filter over the key, may be optimized by adding shardNum() filter to the subquery -- this will allow to filter IN-subquery result on each shard, and skip reading the granules which may potentially contain the values from irrelevant shards. In case of GLOBAL IN there seems to be no way to do it in a single query as the subquery is executed on the initiator.

This patch adds a setting which works similar to optimize_skip_unused_shards_rewrite_in, but for GLOBAL IN subqueries: in case it's enabled, ClickHouse will try to detect if the left-hand side of GLOBAL IN predicate is a base column for the sharding key, and if so, it will rewrite the query for the shards, by adding shard filter to GLOBAL IN subquery result. The setting is enabled by default, but also requires optimize_skip_unused_shards to be enabled, as it relies on the "expected" data distribution.
