### PR TITLE
Use IntMax as size limit for ttl drop

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -7,6 +7,8 @@
 
 #include <Common/logger_useful.h>
 
+#include <limits>
+
 namespace DB
 {
 
@@ -67,10 +69,10 @@ MergeSelectorChoices tryChooseTTLMerge(const ChooseContext & ctx)
     /// Delete parts - 1 priority
     if (!ctx.max_merge_sizes.empty())
     {
-        std::vector<size_t> max_sizes(ctx.max_merge_sizes.size(), ctx.merge_tree_settings[MergeTreeSetting::max_bytes_to_merge_at_max_space_in_pool]);
+        /// The size of the completely expired part of TTL drop is not affected by the merge pressure and the size of the storage space
+        std::vector<size_t> max_sizes(ctx.max_merge_sizes.size(), std::numeric_limits<size_t>::max());
         TTLPartDeleteMergeSelector drop_ttl_selector(ctx.next_delete_times, ctx.current_time);
 
-        /// The size of the completely expired part of TTL drop is not affected by the merge pressure and the size of the storage space
         if (auto merge_ranges = drop_ttl_selector.select(ctx.ranges, max_sizes, ctx.range_filter); !merge_ranges.empty())
             return pack(ctx, std::move(merge_ranges), MergeType::TTLDelete);
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow to start ttl drop merge for parts of any size.
