### PR TITLE
Fix merge predicate message

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h
@@ -131,8 +131,8 @@ public:
 
         if (left.projection_names != right.projection_names)
             return std::unexpected(PreformattedMessage::create(
-                    "Parts have different projection sets: {{}} in '{}' and {{}} in '{}'",
-                    fmt::join(left.projection_names, ", "), left.name, fmt::join(right.projection_names, ", "), right.name));
+                    "Parts have different projection sets: {} in '{}' and {} in '{}'",
+                    left.projection_names, left.name, right.projection_names, right.name));
 
         return {};
     }

--- a/src/Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.cpp
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.cpp
@@ -40,7 +40,7 @@ std::expected<void, PreformattedMessage> MergeTreeMergePredicate::canMergeParts(
     if (left.projection_names != right.projection_names)
     {
         return std::unexpected(PreformattedMessage::create(
-            "Parts have different projection sets: {} in {} and {} in {}",
+            "Parts have different projection sets: {} in '{}' and {} in '{}'",
             left.projection_names, left.name, right.projection_names, right.name));
     }
 

--- a/src/Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.cpp
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.cpp
@@ -40,11 +40,8 @@ std::expected<void, PreformattedMessage> MergeTreeMergePredicate::canMergeParts(
     if (left.projection_names != right.projection_names)
     {
         return std::unexpected(PreformattedMessage::create(
-            "Parts have different projection sets: {{{}}} in {} and {{{}}} in {}",
-            fmt::join(left.projection_names, ", "),
-            left.name,
-            fmt::join(right.projection_names, ", "),
-            right.name));
+            "Parts have different projection sets: {} in {} and {} in {}",
+            left.projection_names, left.name, right.projection_names, right.name));
     }
 
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix messages like this

```
Can't merge parts 1751241600_228778_228778_1_396003 and 1751241600_228779_259742_1012_396003. Reason: Parts have different projection sets: {} in 'projection' and {} in '1751241600_228778_228778_1_396003'
```
