### PR TITLE
Flush buffer when sending chunk header to executable udf

### DIFF
--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -580,6 +580,7 @@ namespace
         {
             writeText(chunk.getNumRows(), *buffer);
             writeChar('\n', *buffer);
+            buffer->next();
         }
 
     private:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Fix missing chunk header when send_chunk_header is enabled and UDF is invoked via HTTP protocol.

Ref https://github.com/ClickHouse/ClickHouse/issues/85994
