### PR TITLE
Fix possible deadlock in case of jemalloc profile flushes enabled

### DIFF
--- a/src/Common/Jemalloc.cpp
+++ b/src/Common/Jemalloc.cpp
@@ -60,7 +60,7 @@ void setJemallocProfileActive(bool value)
     LOG_TRACE(getLogger("SystemJemalloc"), "Profiling is {}", value ? "enabled" : "disabled");
 }
 
-std::string flushJemallocProfile(const std::string & file_prefix)
+std::string flushJemallocProfile(const std::string & file_prefix, bool log)
 {
     checkJemallocProfilingEnabled();
     char * prefix_buffer;
@@ -68,7 +68,8 @@ std::string flushJemallocProfile(const std::string & file_prefix)
     int n = mallctl("opt.prof_prefix", &prefix_buffer, &prefix_size, nullptr, 0); // NOLINT
     if (!n && std::string_view(prefix_buffer) != "jeprof")
     {
-        LOG_TRACE(getLogger("SystemJemalloc"), "Flushing memory profile with prefix {}", prefix_buffer);
+        if (log)
+            LOG_TRACE(getLogger("SystemJemalloc"), "Flushing memory profile with prefix {}", prefix_buffer);
         mallctl("prof.dump", nullptr, nullptr, nullptr, 0);
         return prefix_buffer;
     }
@@ -77,7 +78,8 @@ std::string flushJemallocProfile(const std::string & file_prefix)
     std::string profile_dump_path = fmt::format("{}.{}.{}.heap", file_prefix, getpid(), profile_counter.fetch_add(1));
     const auto * profile_dump_path_str = profile_dump_path.c_str();
 
-    LOG_TRACE(getLogger("SystemJemalloc"), "Flushing memory profile to {}", profile_dump_path_str);
+    if (log)
+        LOG_TRACE(getLogger("SystemJemalloc"), "Flushing memory profile to {}", profile_dump_path_str);
     mallctl("prof.dump", nullptr, nullptr, &profile_dump_path_str, sizeof(profile_dump_path_str)); // NOLINT
     return profile_dump_path;
 }

--- a/src/Common/Jemalloc.h
+++ b/src/Common/Jemalloc.h
@@ -17,7 +17,7 @@ void checkJemallocProfilingEnabled();
 
 void setJemallocProfileActive(bool value);
 
-std::string flushJemallocProfile(const std::string & file_prefix);
+std::string flushJemallocProfile(const std::string & file_prefix, bool log);
 
 void setJemallocBackgroundThreads(bool enabled);
 

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -333,9 +333,12 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
                 static std::atomic<uint64_t> flush_count = 0;
                 auto * flush_prefix = DB::getJemallocValue<char *>("opt.prof_prefix");
                 if (!flush_prefix)
-                    LOG_WARNING(getLogger("MemoryTracker"), "Cannot flush memory profile, empty prefix");
+                {
+                    if (throw_if_memory_exceeded)
+                        LOG_WARNING(getLogger("MemoryTracker"), "Cannot flush memory profile, empty prefix");
+                }
                 else if (flush_count.fetch_add(1, std::memory_order_relaxed) < 100) // so we don't flush too many profiles
-                    DB::flushJemallocProfile(flush_prefix);
+                    DB::flushJemallocProfile(flush_prefix, /*log=*/ throw_if_memory_exceeded);
             }
         }
 #endif
@@ -485,7 +488,8 @@ bool MemoryTracker::updatePeak(Int64 will_be, bool log_memory_usage)
                 auto * flush_prefix = DB::getJemallocValue<char *>("opt.prof_prefix");
                 if (!flush_prefix)
                 {
-                    LOG_WARNING(getLogger("MemoryTracker"), "Cannot flush memory profile, empty prefix");
+                    if (log_memory_usage)
+                        LOG_WARNING(getLogger("MemoryTracker"), "Cannot flush memory profile, empty prefix");
                 }
                 else
                 {
@@ -493,12 +497,13 @@ bool MemoryTracker::updatePeak(Int64 will_be, bool log_memory_usage)
                     if (static_cast<uint64_t>(will_be) > (previous_peak + jemalloc_flush_profile_interval_bytes)
                         && previous_flushed_peak.compare_exchange_strong(previous_peak, will_be, std::memory_order_relaxed))
                     {
-                        LOG_INFO(
-                            getLogger("MemoryTracker"),
-                            "Flushing memory after updating peak to {}",
-                            formatReadableSizeWithBinarySuffix(will_be));
+                        if (log_memory_usage)
+                            LOG_INFO(
+                                getLogger("MemoryTracker"),
+                                "Flushing memory after updating peak to {}",
+                                formatReadableSizeWithBinarySuffix(will_be));
                         previous_flushed_peak.store(will_be, std::memory_order_relaxed);
-                        DB::flushJemallocProfile(flush_prefix);
+                        DB::flushJemallocProfile(flush_prefix, /*log=*/ log_memory_usage);
                     }
                 }
             }

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -652,7 +652,7 @@ String JemallocDumpStats::run()
 
 String JemallocFlushProfile::run()
 {
-    return flushJemallocProfile("/tmp/jemalloc_keeper");
+    return flushJemallocProfile("/tmp/jemalloc_keeper", /* log= */ true);
 }
 
 String JemallocEnableProfile::run()

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -917,7 +917,7 @@ BlockIO InterpreterSystemQuery::execute()
         case Type::JEMALLOC_FLUSH_PROFILE:
         {
             getContext()->checkAccess(AccessType::SYSTEM_JEMALLOC);
-            flushJemallocProfile("/tmp/jemalloc_clickhouse");
+            flushJemallocProfile("/tmp/jemalloc_clickhouse", /* log= */ true);
             break;
         }
 #else


### PR DESCRIPTION
In case of
jemalloc_flush_profile_interval_bytes/jemalloc_flush_profile_on_memory_exceeded>0 the deadlock became possible again during memory allocations:

    1  0x00007f4e4c997002 in pthread_mutex_lock () from /lib/x86_64-linux-gnu/libc.so.6
    2  0x000055b5a697daaf in pthread_mutex_lock (arg=0x7f4c30020590) at ./ci/tmp/build/./src/Common/ThreadFuzzer.cpp:447
    3  0x000055b5ab409b93 in Poco::MutexImpl::lockImpl (this=0x80) at ./base/poco/Foundation/include/Poco/Mutex_POSIX.h:60
    4  Poco::FastMutex::lock (this=0x80) at ./base/poco/Foundation/include/Poco/Mutex.h:229
    5  Poco::ScopedLock<Poco::FastMutex>::ScopedLock (this=<optimized out>, mutex=...) at ./base/poco/Foundation/include/Poco/ScopedLock.h:37
    6  0x000055b5b65e9b05 in Poco::Thread::name (this=0x7f4c300204e8) at ./base/poco/Foundation/include/Poco/Thread.h:267
    7  Poco::Message::init (this=this@entry=0x7f4c2315c650) at ./ci/tmp/build/./base/poco/Foundation/src/Message.cpp:127
    8  0x000055b5b65e9e66 in Poco::Message::Message (this=0x7f4c2315c650, source=..., text=..., prio=<optimized out>, file=..., line=71, fmt_str=..., fmt_str_args=...) at ./ci/tmp/build/./base/poco/Foundation/src/Message.cpp:61
    9  0x000055b5a694d236 in DB::flushJemallocProfile (file_prefix=...) at ./ci/tmp/build/./src/Common/Jemalloc.cpp:71
    10 0x000055b5a694680c in MemoryTracker::allocImpl (this=<optimized out>, size=32, throw_if_memory_exceeded=<optimized out>, query_tracker=<optimized out>, _sample_probability=<optimized out>) at ./ci/tmp/build/./src/Common/MemoryTracker.cpp:338
    11 0x000055b5a6892064 in trackMemory<> (size=25, trace=...) at ./src/Common/memory.h:134
    12 operator new (size=25) at ./ci/tmp/build/./src/Common/AllocationInterceptors.cpp:55
    20 0x000055b5b65e9b36 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string (this=0x7f4c2315cbb0, __str=...) at ./contrib/llvm-project/libcxx/include/string:1005
    21 Poco::Thread::name (this=0x7f4c300204e8) at ./base/poco/Foundation/include/Poco/Thread.h:269
    22 Poco::Message::init (this=this@entry=0x7f4c2315ccc8) at ./ci/tmp/build/./base/poco/Foundation/src/Message.cpp:127
    23 0x000055b5b65e9e66 in Poco::Message::Message (this=0x7f4c2315ccc8, source=..., text=..., prio=<optimized out>, file=..., line=49, fmt_str=..., fmt_str_args=...) at ./ci/tmp/build/./base/poco/Foundation/src/Message.cpp:61
    24 0x000055b5a6a0cf93 in ServerErrorHandler::logMessageImpl (this=<optimized out>, priority=<optimized out>, msg=...) at ./src/Common/ErrorHandlers.h:49
    25 0x000055b5b65b252c in Poco::ErrorHandler::logMessage (priority=Poco::Message::PRIO_TEST, msg=...) at ./ci/tmp/build/./base/poco/Foundation/src/ErrorHandler.cpp:97
    26 0x000055b5b666eab4 in Poco::Net::TCPServerDispatcher::enqueue (this=0x7f4c31b3e000, socket=...) at ./ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:146
    27 0x000055b5b666d94c in Poco::Net::TCPServer::run (this=0x7f4c300204c0) at ./ci/tmp/build/./base/poco/Net/src/TCPServer.cpp:148

Because we cannot assume that logging is safe from any `new`.

**And this should fix the flakiness of `test_global_overcommit_tracker`**

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible deadlock in case of jemalloc profile flushes enabled