### PR TITLE
ci: increase waiting for gdb to collect stacktraces in integration tests during hangs

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3914,8 +3914,14 @@ services:
             {keytab_path}
             {krb5_conf}
         entrypoint: /integration-tests-entrypoint.sh {entrypoint_cmd}
-        # increase it to allow jeprof to dump the profile report
-        stop_grace_period: 5m
+        # Increase it to allow jeprof to dump the profile report and gdb collect stacktraces
+        #
+        # NOTE: it has been proven that 5m is not enough slightly, but anyway
+        # this should not be a problem, since in
+        # integration-tests-entrypoint.sh we have "timeout" of 1 minute, and
+        # later we will attach with gdb to collect stacktraces, and once it
+        # will be done it will exit.
+        stop_grace_period: 10m
         tmpfs: {tmpfs}
         {mem_limit}
         cap_add:


### PR DESCRIPTION
It has been proven that 5m is not enough here [1]

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=19c8bb4dfcb5d83708c30691b0f6b2f4f03839d1&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%201%2F5%29&name_1=Integration%20tests%20%28amd_binary%2C%201%2F5%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)