### PR TITLE
Docs: correct types in toSecond

### DIFF
--- a/src/Functions/toHour.cpp
+++ b/src/Functions/toHour.cpp
@@ -19,7 +19,7 @@ Returns the hour component (0-23) of a `DateTime` or `DateTime64` value.
     {
         {"datetime", "Date with time to get the hour from.", {"DateTime", "DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns the hour of the given `Date` or `DateTime` value", {"UInt8"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the hour (0-23) of `datetime`.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",

--- a/src/Functions/toMillisecond.cpp
+++ b/src/Functions/toMillisecond.cpp
@@ -18,7 +18,7 @@ Returns the millisecond component (0-999) of a `DateTime` or `DateTime64` value.
     {
         {"datetime", "Date with time to get the millisecond from.", {"DateTime", "DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns the millisecond in the minute (0 - 59) of the given `Date` or `DateTime`", {"UInt16"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the millisecond in the minute (0 - 59) of `datetime`.", {"UInt16"}};
     FunctionDocumentation::Examples examples = {
         {"Usage example", R"(
 SELECT toMillisecond(toDateTime64('2023-04-21 10:20:30.456', 3));

--- a/src/Functions/toMinute.cpp
+++ b/src/Functions/toMinute.cpp
@@ -18,9 +18,9 @@ Returns the minute component (0-59) of a `Date` or `DateTime` value.
     FunctionDocumentation::Syntax syntax = "toMinute(datetime)";
     FunctionDocumentation::Arguments arguments =
     {
-        {"datetime", "Date or date with time to get the minute from.", {"Date", "Date32", "DateTime", "DateTime64"}}
+        {"datetime", "Date with time to get the minute from.", {"DateTime", "DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns the minute of the hour (0 - 59) of the given `Date` or `DateTime` value", {"UInt8"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the minute of the hour (0 - 59) of `datetime`.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {
         {"Usage example", R"(
 SELECT toMinute(toDateTime('2023-04-21 10:20:30'))

--- a/src/Functions/toSecond.cpp
+++ b/src/Functions/toSecond.cpp
@@ -19,7 +19,7 @@ Returns the second component (0-59) of a `DateTime` or `DateTime64` value.
     {
         {"datetime", "Date with time to get the second from.", {"DateTime", "DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns the second in the minute (0 - 59) of the given `Date` or `DateTime` value", {"UInt8"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the second in the minute (0 - 59) of `datetime`.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {
         {"Usage example", R"(
 SELECT toSecond(toDateTime('2023-04-21 10:20:30'))

--- a/src/Functions/toSecond.cpp
+++ b/src/Functions/toSecond.cpp
@@ -12,12 +12,12 @@ using FunctionToSecond = FunctionDateOrDateTimeToSomething<DataTypeUInt8, ToSeco
 REGISTER_FUNCTION(ToSecond)
 {
     FunctionDocumentation::Description description = R"(
-Returns the second component (0-59) of a `Date` or `DateTime` value.
+Returns the second component (0-59) of a `DateTime` or `DateTime64` value.
         )";
     FunctionDocumentation::Syntax syntax = "toSecond(datetime)";
     FunctionDocumentation::Arguments arguments =
     {
-        {"datetime", "Date or date with time to get the second from.", {"Date", "Date32", "DateTime", "DateTime64"}}
+        {"datetime", "Date with time to get the second from.", {"DateTime", "DateTime64"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the second in the minute (0 - 59) of the given `Date` or `DateTime` value", {"UInt8"}};
     FunctionDocumentation::Examples examples = {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Follow up to fix types of `toSecond`, `toMillisecond`, `toMinute` which don't support `Date` or `Date64`
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
