### PR TITLE
Bump `abseil-cpp` for 25.4

### DIFF
--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(ABSL_ROOT_DIR "${ClickHouse_SOURCE_DIR}/contrib/abseil-cpp")
 set(ABSL_COMMON_INCLUDE_DIRS "${ABSL_ROOT_DIR}")
 
+set(CMAKE_CXX_STANDARD 17)
+
 # This is a minimized version of the function definition in CMake/AbseilHelpers.cmake
 
 #
@@ -171,10 +173,10 @@ absl_cc_library(
   HDRS
     "${DIR}/nullability.h"
   SRCS
-    "${DIR}/internal/nullability_impl.h"
+    "${DIR}/internal/nullability_deprecated.h"
   DEPS
+    absl::config
     absl::core_headers
-    absl::type_traits
   COPTS
     ${ABSL_DEFAULT_COPTS}
 )
@@ -654,6 +656,18 @@ absl_cc_library(
     absl::config
     absl::hash_function_defaults
   PUBLIC
+)
+
+# Internal-only target, do not depend on directly.
+absl_cc_library(
+  NAME
+    weakly_mixed_integer
+  HDRS
+    "${DIR}/internal/weakly_mixed_integer.h"
+  COPTS
+    ${ABSL_DEFAULT_COPTS}
+  DEPS
+    absl::config
 )
 
 # Internal-only target, do not depend on directly.
@@ -2020,8 +2034,6 @@ absl_cc_library(
 absl_cc_library(
   NAME
     log_entry
-  SRCS
-    "${DIR}/log_entry.cc"
   HDRS
     "${DIR}/log_entry.h"
   COPTS
@@ -2350,7 +2362,6 @@ absl_cc_library(
     absl::random_distributions
     absl::random_internal_nonsecure_base
     absl::random_internal_pcg_engine
-    absl::random_internal_pool_urbg
     absl::random_internal_randen_engine
     absl::random_seed_sequences
 )
@@ -2455,7 +2466,6 @@ absl_cc_library(
     absl::config
     absl::inlined_vector
     absl::nullability
-    absl::random_internal_pool_urbg
     absl::random_internal_salted_seed_seq
     absl::random_internal_seed_material
     absl::random_seed_gen_exception
@@ -2527,31 +2537,6 @@ absl_cc_library(
     absl::raw_logging_internal
     absl::span
     absl::strings
-)
-
-# Internal-only target, do not depend on directly.
-absl_cc_library(
-  NAME
-    random_internal_pool_urbg
-  SRCS
-    "${DIR}/internal/pool_urbg.cc"
-  HDRS
-    "${DIR}/internal/pool_urbg.h"
-  COPTS
-    ${ABSL_DEFAULT_COPTS}
-  LINKOPTS
-    ${ABSL_DEFAULT_LINKOPTS}
-  DEPS
-    absl::base
-    absl::config
-    absl::core_headers
-    absl::endian
-    absl::random_internal_randen
-    absl::random_internal_seed_material
-    absl::random_internal_traits
-    absl::random_seed_gen_exception
-    absl::raw_logging_internal
-    absl::span
 )
 
 # Internal-only target, do not depend on directly.
@@ -2645,12 +2630,11 @@ absl_cc_library(
   LINKOPTS
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
-    absl::core_headers
+    absl::config
     absl::inlined_vector
-    absl::random_internal_pool_urbg
+    absl::random_internal_entropy_pool
     absl::random_internal_salted_seed_seq
     absl::random_internal_seed_material
-    absl::span
     absl::type_traits
 )
 
@@ -2670,6 +2654,30 @@ absl_cc_library(
     absl::random_internal_fastmath
     absl::random_internal_iostream_state_saver
     absl::type_traits
+)
+
+# Internal-only target, do not depend on directly.
+absl_cc_library(
+  NAME
+    random_internal_entropy_pool
+  SRCS
+    "${DIR}/internal/entropy_pool.cc"
+  HDRS
+    "${DIR}/internal/entropy_pool.h"
+  COPTS
+    ${ABSL_DEFAULT_COPTS}
+  LINKOPTS
+    ${ABSL_DEFAULT_LINKOPTS}
+  DEPS
+    absl::base
+    absl::config
+    absl::core_headers
+    absl::random_internal_platform
+    absl::random_internal_randen
+    absl::random_internal_seed_material
+    absl::random_seed_gen_exception
+    absl::span
+    absl::synchronization
 )
 
 # Internal-only target, do not depend on directly.
@@ -3233,7 +3241,6 @@ absl_cc_library(
     "${DIR}/cord.cc"
     "${DIR}/cord_analysis.cc"
     "${DIR}/cord_analysis.h"
-    "${DIR}/cord_buffer.cc"
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
@@ -3256,6 +3263,7 @@ absl_cc_library(
     absl::span
     absl::strings
     absl::type_traits
+    absl::weakly_mixed_integer
   PUBLIC
 )
 
@@ -3433,40 +3441,10 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
-    absl::bad_any_cast
     absl::config
     absl::core_headers
-    absl::fast_type_id
-    absl::type_traits
     absl::utility
   PUBLIC
-)
-
-absl_cc_library(
-  NAME
-    bad_any_cast
-  HDRS
-   "${DIR}/bad_any_cast.h"
-  COPTS
-    ${ABSL_DEFAULT_COPTS}
-  DEPS
-    absl::bad_any_cast_impl
-    absl::config
-  PUBLIC
-)
-
-# Internal-only target, do not depend on directly.
-absl_cc_library(
-  NAME
-    bad_any_cast_impl
-  SRCS
-    "${DIR}/bad_any_cast.h"
-    "${DIR}/bad_any_cast.cc"
-  COPTS
-    ${ABSL_DEFAULT_COPTS}
-  DEPS
-    absl::config
-    absl::raw_logging_internal
 )
 
 absl_cc_library(
@@ -3497,7 +3475,6 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
-    absl::bad_optional_access
     absl::base_internal
     absl::config
     absl::core_headers
@@ -3505,36 +3482,6 @@ absl_cc_library(
     absl::nullability
     absl::type_traits
     absl::utility
-  PUBLIC
-)
-
-absl_cc_library(
-  NAME
-    bad_optional_access
-  HDRS
-    "${DIR}/bad_optional_access.h"
-  SRCS
-    "${DIR}/bad_optional_access.cc"
-  COPTS
-    ${ABSL_DEFAULT_COPTS}
-  DEPS
-    absl::config
-    absl::raw_logging_internal
-  PUBLIC
-)
-
-absl_cc_library(
-  NAME
-    bad_variant_access
-  HDRS
-    "${DIR}/bad_variant_access.h"
-  SRCS
-    "${DIR}/bad_variant_access.cc"
-  COPTS
-    ${ABSL_DEFAULT_COPTS}
-  DEPS
-    absl::config
-    absl::raw_logging_internal
   PUBLIC
 )
 
@@ -3548,7 +3495,6 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
-    absl::bad_variant_access
     absl::base_internal
     absl::config
     absl::core_headers

--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -2143,6 +2143,7 @@ absl_cc_library(
     absl::span
     absl::strings
     absl::variant
+  PUBLIC
 )
 
 absl_cc_library(

--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -1089,10 +1089,14 @@ absl_cc_library(
     "${DIR}/internal/address_is_readable.h"
     "${DIR}/internal/elf_mem_image.h"
     "${DIR}/internal/vdso_support.h"
+    "${DIR}/internal/decode_rust_punycode.h"
+    "${DIR}/internal/utf8_for_code_point.h"
   SRCS
     "${DIR}/internal/address_is_readable.cc"
     "${DIR}/internal/elf_mem_image.cc"
     "${DIR}/internal/vdso_support.cc"
+    "${DIR}/internal/decode_rust_punycode.cc"
+    "${DIR}/internal/utf8_for_code_point.cc"
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS

--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -2920,7 +2920,6 @@ absl_cc_library(
     "${DIR}/has_absl_stringify.h"
     "${DIR}/internal/damerau_levenshtein_distance.h"
     "${DIR}/internal/string_constant.h"
-    "${DIR}/internal/has_absl_stringify.h"
     "${DIR}/match.h"
     "${DIR}/numbers.h"
     "${DIR}/str_cat.h"

--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -1755,6 +1755,7 @@ absl_cc_library(
     absl::log_internal_proto
     absl::log_internal_log_sink_set
     absl::log_internal_nullguard
+    absl::log_internal_structured_proto
     absl::log_globals
     absl::log_entry
     absl::log_severity
@@ -2123,6 +2124,25 @@ absl_cc_library(
     absl::config
     absl::log_internal_message
     absl::strings
+)
+
+absl_cc_library(
+  NAME
+    log_internal_structured_proto
+  SRCS
+    "${DIR}/internal/structured_proto.h"
+  HDRS
+    "${DIR}/internal/structured_proto.cc"
+  COPTS
+    ${ABSL_DEFAULT_COPTS}
+  LINKOPTS
+    ${ABSL_DEFAULT_LINKOPTS}
+  DEPS
+    absl::log_internal_proto
+    absl::config
+    absl::span
+    absl::strings
+    absl::variant
 )
 
 absl_cc_library(

--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -2130,9 +2130,9 @@ absl_cc_library(
   NAME
     log_internal_structured_proto
   SRCS
-    "${DIR}/internal/structured_proto.h"
-  HDRS
     "${DIR}/internal/structured_proto.cc"
+  HDRS
+    "${DIR}/internal/structured_proto.h"
   COPTS
     ${ABSL_DEFAULT_COPTS}
   LINKOPTS

--- a/src/Common/MatchGenerator.cpp
+++ b/src/Common/MatchGenerator.cpp
@@ -5,6 +5,7 @@
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
 #pragma clang diagnostic ignored "-Wdtor-name"
+#pragma clang diagnostic ignored "-Wnullability-extension"
 #include <re2/re2.h>
 #include <re2/regexp.h>
 #include <re2/walker-inl.h>

--- a/src/Common/re2.h
+++ b/src/Common/re2.h
@@ -2,5 +2,14 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#pragma clang diagnostic ignored "-Wdtor-name"
+#pragma clang diagnostic ignored "-Wnullability-extension"
+#if defined(__clang__) && __clang_major__ >= 21
+#pragma clang diagnostic ignored "-Wms-bitfield-padding"
+#endif
 #include <re2/re2.h>
 #pragma clang diagnostic pop

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -456,7 +456,6 @@ ASTPtr DatabasePostgreSQL::getCreateTableQueryImpl(const String & table_name, Co
     }
 
     ASTStorage * ast_storage = table_storage_define->as<ASTStorage>();
-    ASTs storage_children = ast_storage->children;
     auto storage_engine_arguments = ast_storage->engine->arguments;
 
     if (storage_engine_arguments->children.empty())


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `abseil-cpp` 20250512.0
