### PR TITLE
Mute `-Wmissing-noreturn`

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -44,3 +44,4 @@ no_warning(thread-safety-negative) # experimental flag, too many false positives
 no_warning(unsafe-buffer-usage) # too aggressive
 no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
 no_warning(nrvo) # not eliding copy on return - too aggressive
+no_warning(missing-noreturn) # too aggressive with no clear benefit, see https://github.com/ClickHouse/ClickHouse/pull/86416


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`-Wmissing-noreturn` is too aggressive in `clang-21`.
See also https://github.com/ClickHouse/ClickHouse/pull/86416
