### PR TITLE
Fix use of uninitialized memory in getSubcolumnType

### DIFF
--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -301,7 +301,7 @@ std::optional<String> tryGetSubObjectSubcolumn(std::string_view subcolumn_name)
     if (!subcolumn_name.starts_with("^`"))
         return std::nullopt;
 
-    ReadBufferFromMemory buf(subcolumn_name.data() + 1);
+    ReadBufferFromMemory buf(subcolumn_name.data() + 1, subcolumn_name.size() - 1);
     String path;
     /// Try to read back-quoted first path element.
     if (!tryReadBackQuotedString(path, buf))

--- a/tests/queries/0_stateless/03603_getSubcolumnType_msan.sql
+++ b/tests/queries/0_stateless/03603_getSubcolumnType_msan.sql
@@ -1,0 +1,2 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/86279
+SELECT '{}'::JSON x QUALIFY x.^c0 = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/03603_getSubcolumnType_msan.sql
+++ b/tests/queries/0_stateless/03603_getSubcolumnType_msan.sql
@@ -1,2 +1,2 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/86279
-SELECT '{}'::JSON x QUALIFY x.^c0 = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT '{}'::JSON x QUALIFY x.^c0 = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT, UNKNOWN_IDENTIFIER }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix use of uninitialized memory in getSubcolumnType

Closes https://github.com/ClickHouse/ClickHouse/issues/86279

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
