### PR TITLE
Put building standalone lexer under a flag

### DIFF
--- a/src/Parsers/CMakeLists.txt
+++ b/src/Parsers/CMakeLists.txt
@@ -36,21 +36,22 @@ if (LEXER_STANDALONE_BUILD)
     add_library(lexer-c Lexer.cpp)
     target_include_directories(lexer-c PRIVATE ..)
     target_compile_options(lexer-c PRIVATE -Os -fno-exceptions -fno-rtti -nostdlib -DLEXER_STANDALONE_BUILD)
+
+    # Check that Lexer compiles to WASM. See the usage in programs/server/play.html
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Lexer.wasm
+        COMMAND ${CMAKE_CXX_COMPILER}
+        -Os -fno-exceptions -fno-rtti -DLEXER_STANDALONE_BUILD --target=wasm32 -flto -nostdlib
+        -I${CMAKE_SOURCE_DIR}/src
+        -Wl,--no-entry -Wl,--export-all
+        ${CMAKE_CURRENT_SOURCE_DIR}/Lexer.cpp
+        -o ${CMAKE_CURRENT_BINARY_DIR}/Lexer.wasm
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Lexer.cpp
+        COMMENT "Building Lexer.wasm"
+    )
+
+    add_custom_target(lexer_wasm ALL
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Lexer.wasm
+    )
 endif ()
 
-# Check that Lexer compiles to WASM. See the usage in programs/server/play.html
-add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Lexer.wasm
-    COMMAND ${CMAKE_CXX_COMPILER}
-    -Os -fno-exceptions -fno-rtti -DLEXER_STANDALONE_BUILD --target=wasm32 -flto -nostdlib
-    -I${CMAKE_SOURCE_DIR}/src
-    -Wl,--no-entry -Wl,--export-all
-    ${CMAKE_CURRENT_SOURCE_DIR}/Lexer.cpp
-    -o ${CMAKE_CURRENT_BINARY_DIR}/Lexer.wasm
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Lexer.cpp
-    COMMENT "Building Lexer.wasm"
-)
-
-add_custom_target(lexer_wasm ALL
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Lexer.wasm
-)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Put building standalone WASM lexer under a flag.

Not everyone has a compiler capable of `wasm32` target, so let's not build it by default.
cc @yakov-olkhovskiy @alexey-milovidov 

```
FAILED: [code=1] src/Parsers/Lexer.wasm /build/source/build/src/Parsers/Lexer.wasm
cd /build/source/build/src/Parsers && /nix/store/6hyah654xshls0qdr5gqk5mpa5rvd43f-clang-wrapper-19.1.7/bin/clang++ -Os -fno-exceptions -fno-rtti -DLEXER_STANDALONE_BUILD --target=wasm32 -flto -nostdlib -I/build/source/src -Wl,--no-entry -Wl,--export-all /build/source/src/Parsers/Lexer.cpp -o /build/source/build/src/Parsers/Lexer.wasm
Warning: supplying the --target wasm32 != x86_64-unknown-linux-gnu argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead.
clang++: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'wasm32'
```


