### PR TITLE
Fix crc32c build on older ARM CPUs

### DIFF
--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -35,7 +35,6 @@ if (ARCH_NATIVE)
     # according to the current CPU's capabilities, detected using clang.
     if (ARCH_AMD64)
         GET_CPU_FEATURES (TEST_FEATURE_RESULT)
-        message(FATAL_ERROR "PMO: ${TEST_FEATURE_RESULT}")
 
         TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} ssse3 ENABLE_SSSE3)
         TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} sse4.1 ENABLE_SSE41)

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -13,36 +13,45 @@ if (ARCH_NATIVE)
     set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=native")
     list(APPEND RUSTFLAGS_CPU "-C" "target-feature=native")
 
+    macro(TEST_CPU_FEATURE TEST_FEATURE_RESULT feat flag)
+        if (${TEST_FEATURE_RESULT} MATCHES "\"\\+${feat}\"")
+            set(${flag} ON)
+        else ()
+            set(${flag} OFF)
+        endif ()
+    endmacro()
+
+    macro(RUN_TEST_CPU_FEATURE TEST_FEATURE_RESULT)
+       execute_process(
+            COMMAND sh -c "clang -E - -march=native -###"
+            INPUT_FILE /dev/null
+            OUTPUT_QUIET
+            ERROR_VARIABLE ${TEST_FEATURE_RESULT})
+    endmacro()
+
     # Populate the ENABLE_ option flags. This is required for the build of some third-party dependencies, specifically snappy, which
     # (somewhat weirdly) expects the relative SNAPPY_HAVE_ preprocessor variables to be populated, in addition to the microarchitecture
     # feature flags being enabled in the compiler. This fixes the ARCH_NATIVE flag by automatically populating the ENABLE_ option flags
     # according to the current CPU's capabilities, detected using clang.
     if (ARCH_AMD64)
-        execute_process(
-            COMMAND sh -c "clang -E - -march=native -###"
-            INPUT_FILE /dev/null
-            OUTPUT_QUIET
-            ERROR_VARIABLE TEST_FEATURE_RESULT)
+        RUN_TEST_CPU_FEATURE (TEST_FEATURE_RESULT)
+        message(FATAL_ERROR "PMO: ${TEST_FEATURE_RESULT}")
 
-        macro(TEST_AMD64_FEATURE TEST_FEATURE_RESULT feat flag)
-            if (${TEST_FEATURE_RESULT} MATCHES "\"\\+${feat}\"")
-                set(${flag} ON)
-            else ()
-                set(${flag} OFF)
-            endif ()
-        endmacro()
-
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} ssse3 ENABLE_SSSE3)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} sse4.1 ENABLE_SSE41)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} sse4.2 ENABLE_SSE42)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} vpclmulqdq ENABLE_PCLMULQDQ)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} popcnt ENABLE_POPCNT)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} avx ENABLE_AVX)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} avx2 ENABLE_AVX2)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} avx512f ENABLE_AVX512)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} avx512vbmi ENABLE_AVX512_VBMI)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} bmi ENABLE_BMI)
-        TEST_AMD64_FEATURE (${TEST_FEATURE_RESULT} bmi2 ENABLE_BMI2)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} ssse3 ENABLE_SSSE3)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} sse4.1 ENABLE_SSE41)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} sse4.2 ENABLE_SSE42)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} vpclmulqdq ENABLE_PCLMULQDQ)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} popcnt ENABLE_POPCNT)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} avx ENABLE_AVX)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} avx2 ENABLE_AVX2)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} avx512f ENABLE_AVX512)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} avx512vbmi ENABLE_AVX512_VBMI)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} bmi ENABLE_BMI)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} bmi2 ENABLE_BMI2)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} aes ENABLE_AES)
+    elseif (ARCH_AARCH64)
+        RUN_TEST_CPU_FEATURE (TEST_FEATURE_RESULT)
+        TEST_CPU_FEATURE (${TEST_FEATURE_RESULT} aes ENABLE_AES)
     endif ()
 
 elseif (ARCH_AARCH64)

--- a/contrib/crc32c-cmake/CMakeLists.txt
+++ b/contrib/crc32c-cmake/CMakeLists.txt
@@ -12,10 +12,14 @@ set(CRC32C_SOURCES
     "${CRC32C_DIR}/src/crc32c.cc"
 )
 
-if(ARCH_AARCH64)
+# crc32c_arm64.cc uses the vmull_p64 instruction, which is only available when building
+# with the `aes` flag, which is included among others under the `crypto` flag.
+# We only add the `crypto` flag when building on modern ARM CPUs, so we can't
+# build that file on older ARM CPUs.
+if(ARCH_AARCH64 AND (NOT NO_ARMV81_OR_HIGHER))
   include_directories(${CRC32C_CMAKE_DIR}/aarch64)
   list(APPEND CRC32C_SOURCES "${CRC32C_DIR}/src/crc32c_arm64.cc")
-else()
+elseif(ARCH_AMD64)
   if(ENABLE_SSE42)
     include_directories(${CRC32C_CMAKE_DIR}/x86_64/sse42)
     list(APPEND CRC32C_SOURCES "${CRC32C_DIR}/src/crc32c_sse42.cc")

--- a/contrib/crc32c-cmake/CMakeLists.txt
+++ b/contrib/crc32c-cmake/CMakeLists.txt
@@ -12,11 +12,14 @@ set(CRC32C_SOURCES
     "${CRC32C_DIR}/src/crc32c.cc"
 )
 
-# crc32c_arm64.cc uses the vmull_p64 instruction, which is only available when building
-# with the `aes` flag.
-if(ARCH_AARCH64 AND ENABLE_AES)
+if(ARCH_AARCH64)
   include_directories(${CRC32C_CMAKE_DIR}/aarch64)
-  list(APPEND CRC32C_SOURCES "${CRC32C_DIR}/src/crc32c_arm64.cc")
+
+  # crc32c_arm64.cc uses the vmull_p64 instruction, which is only available when building
+  # with the `aes` flag.
+  if (ENABLE_AES)
+    list(APPEND CRC32C_SOURCES "${CRC32C_DIR}/src/crc32c_arm64.cc")
+  endif()
 elseif(ARCH_AMD64)
   if(ENABLE_SSE42)
     include_directories(${CRC32C_CMAKE_DIR}/x86_64/sse42)

--- a/contrib/crc32c-cmake/CMakeLists.txt
+++ b/contrib/crc32c-cmake/CMakeLists.txt
@@ -13,10 +13,8 @@ set(CRC32C_SOURCES
 )
 
 # crc32c_arm64.cc uses the vmull_p64 instruction, which is only available when building
-# with the `aes` flag, which is included among others under the `crypto` flag.
-# We only add the `crypto` flag when building on modern ARM CPUs, so we can't
-# build that file on older ARM CPUs.
-if(ARCH_AARCH64 AND (NOT NO_ARMV81_OR_HIGHER))
+# with the `aes` flag.
+if(ARCH_AARCH64 AND ENABLE_AES)
   include_directories(${CRC32C_CMAKE_DIR}/aarch64)
   list(APPEND CRC32C_SOURCES "${CRC32C_DIR}/src/crc32c_arm64.cc")
 elseif(ARCH_AMD64)


### PR DESCRIPTION
`crc32c_arm64.cc` uses the `vmull_p64` instruction, which is only available when building with the `aes` flag.
Let's check whether that's available when building with `ARCH_NATIVE` in a similar fashion it's done for AMD64.

Closes https://github.com/ClickHouse/ClickHouse/issues/86499

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crc32c build on older ARM CPUs without support for the `vmull_p64` instruction

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
