### PR TITLE
storage log uses sizes.json in right way

### DIFF
--- a/src/Common/FileChecker.h
+++ b/src/Common/FileChecker.h
@@ -25,7 +25,7 @@ public:
     void setPath(const String & file_info_path_);
     String getPath() const;
 
-    void update(const String & full_file_path);
+    void reloadSizeFromDisk(const String & full_file_path);
     void setEmpty(const String & full_file_path);
     void save() const;
     bool empty() const { return map.empty(); }
@@ -37,10 +37,7 @@ public:
     DataValidationTasksPtr getDataValidationTasks();
     std::optional<CheckResult> checkNextEntry(DataValidationTasksPtr & check_data_tasks) const;
 
-    /// Truncate files that have excessive size to the expected size.
-    /// Throw exception if the file size is less than expected.
-    /// The purpose of this function is to rollback a group of unfinished writes.
-    void repair();
+    void checkConsistency();
 
     /// Returns stored file size.
     size_t getFileSize(const String & full_file_path) const;

--- a/src/Storages/StorageLog.h
+++ b/src/Storages/StorageLog.h
@@ -96,6 +96,8 @@ private:
 
     /// Saves the sizes of the data and marks files.
     void saveFileSizes(const WriteLock &);
+    /// Reload files sizes from disk and saves the sizes of the data and marks files.
+    void reloadAndSaveFileSizes(const WriteLock &);
 
     /// Recalculates the number of rows stored in this table.
     void updateTotalRows(const WriteLock &);

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -480,7 +480,7 @@ namespace
                 {
                     if (i == sizes_json_pos)
                         continue;
-                    file_checker.update(temp_dir / fs::path{file_paths[i]}.filename());
+                    file_checker.reloadSizeFromDisk(temp_dir / fs::path{file_paths[i]}.filename());
                 }
                 file_checker.save();
                 backup_entries[sizes_json_pos] = {file_paths[sizes_json_pos], std::make_shared<BackupEntryFromSmallFile>(temp_disk, sizes_json_path, read_settings)};


### PR DESCRIPTION
In https://github.com/ClickHouse/ClickHouse/pull/81787
I found out that `storageLog` write dedicated file `sizes.json` to handle atomicity at append. 
But it does not rely on it at startup. Instead it tries to repair files in d-tor, which is unreliable.
I made it to rely on `sizes.json` at startup.

So the right schema should be the following:
- zero step: write files and write their sizes in `sizes.json`.
- when read files, read them only up to the sizes from `sizes.json`.
- when update files, files have to be open with append mode and the position should be set at the sizes from `sizes.json`.

I close that PR. It requires an ability to write a file with append mode not in the actual end of the file but into the logical offset which is store in `sizes.json`. Will do that when it is necessary. Right now, the current solution does not perform atomic updates in particular circumstances but no complains are known.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
tables with storage log engine properly rely on file `sizes.json`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
