### PR TITLE
Docs: update link causing failing docs check

### DIFF
--- a/docs/en/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md
+++ b/docs/en/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md
@@ -1,4 +1,4 @@
 :::tip
 If you are using a dictionary with ClickHouse Cloud please use the DDL query option to create your dictionaries, and create your dictionary as user `default`.
-Also, verify the list of supported dictionary sources in the [Cloud Compatibility guide](/cloud/guides/cloud-compatibility.md).
+Also, verify the list of supported dictionary sources in the [Cloud Compatibility guide](/whats-new/cloud-compatibility).
 :::


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Updates a link causing the docs build to fail: https://vercel.com/clickhouse/clickhouse-docs/9cUk49HKDARLgZCZ4d1FNdHLex7a

```
  [cause]: Error: Docusaurus found broken links!
  
  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
  
  Exhaustive list of all broken links found:
  - Broken link on source page path = /docs/sql-reference/dictionaries:
     -> linking to /docs/cloud/guides/cloud-compatibility.md
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
