### PR TITLE
Docs: escape `<` symbol which breaks Docusaurus build

### DIFF
--- a/src/Functions/FunctionsHashingMisc.cpp
+++ b/src/Functions/FunctionsHashingMisc.cpp
@@ -572,7 +572,7 @@ For the 32-bit version see [`xxHash32`](#xxHash32)
     FunctionDocumentation::Description halfMD5_description = R"(
 [Interprets](../..//sql-reference/functions/type-conversion-functions.md/#type_conversion_functions-reinterpretAsString) all the input
 parameters as strings and calculates the MD5 hash value for each of them. Then combines hashes, takes the first 8 bytes of the hash of the
-resulting string, and interprets them as [UInt64](../../../sql-reference/data-types/int-uint.md) in big-endian byte order. The function is
+resulting string, and interprets them as [UInt64](/sql-reference/data-types/int-uint) in big-endian byte order. The function is
 relatively slow (5 million short strings per second per processor core).
 
 Consider using the [`sipHash64`](#sipHash64) function instead.

--- a/src/Functions/kostikConsistentHash.cpp
+++ b/src/Functions/kostikConsistentHash.cpp
@@ -29,7 +29,7 @@ REGISTER_FUNCTION(KostikConsistentHash)
 {
     FunctionDocumentation::Description description = R"(
 An O(1) time and space consistent hash algorithm by Konstantin 'Kostik' Oblakov.
-Only efficient with n <= 32768.
+Only efficient with `n <= 32768`.
 )";
     FunctionDocumentation::Syntax syntax = "kostikConsistentHash(input, n)";
     FunctionDocumentation::Arguments arguments = {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Fix for a Docusaurus build breaking (https://github.com/ClickHouse/clickhouse-docs/actions/runs/17430581913/job/49487830880?pr=4379):

```
× Module build failed:
  ╰─▶   × Error: MDX compilation failed for file "/Users/sstruw/Desktop/clickhouse-docs/docs/sql-reference/functions/hash-functions.md"
        │ Cause: Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`
        │ Details:
        │ {
        │   "column": 24,
        │   "message": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
        │   "line": 3062,
        │   "name": "3062:24",
        │   "place": {
        │     "_bufferIndex": 23,
        │     "_index": 2,
        │     "line": 3062,
        │     "column": 24,
        │     "offset": 87095
        │   },
        │   "reason": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
        │   "ruleId": "unexpected-character",
        │   "source": "micromark-extension-mdx-jsx",
        │   "url": "https://github.com/micromark/micromark-extension-mdx-jsx#unexpected-character-at-expected-expect"
        │ }
```
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
