### PR TITLE
Docs: add a note about overflow for `round`, `ceil`

### DIFF
--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -113,6 +113,8 @@ Rounds a value to a specified number of decimal places `N`.
 
 The function returns the nearest number of the specified order.
 If the input value has equal distance to two neighboring numbers, the function uses banker's rounding for `Float*` inputs and rounds away from zero for the other number types (`Decimal*`).
+
+If rounding causes an overflow (for example, `round(255, -1)`), the result is undefined.
 )";
         FunctionDocumentation::Syntax syntax = "round(x[, N])";
         FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/FunctionsRound.cpp
+++ b/src/Functions/FunctionsRound.cpp
@@ -51,6 +51,7 @@ If rounding causes an overflow (for example, `floor(-128, -1)`), the result is u
     {
         FunctionDocumentation::Description description = R"(
 Like [`floor`](#floor) but returns the smallest rounded number greater than or equal to `x`.
+If rounding causes an overflow (for example, `ceiling(255, -1)`), the result is undefined.
 )";
         FunctionDocumentation::Syntax syntax = "ceiling(x[, N])";
         FunctionDocumentation::Arguments arguments = {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Closes https://github.com/ClickHouse/clickhouse-docs/issues/3298, addressing user feedback about a note to warn about unexpected results when values overflow like we have for `floor`.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
