### PR TITLE
Fix flaky `test_keeper_reconfig_remove`

### DIFF
--- a/tests/integration/test_keeper_reconfig_remove/test.py
+++ b/tests/integration/test_keeper_reconfig_remove/test.py
@@ -14,7 +14,7 @@ cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
 
 # we set with_zookeeper=True because we modify keeper cluster used in nodes
-# using Keeper cluster that is changed with reconfig can lead to errors in ClickHouse sever or a really slow shutdown 
+# using Keeper cluster that is changed with reconfig can lead to errors in ClickHouse server or a really slow shutdown 
 # (e.g. when paired with `with_remote_database_disk`), which is not relevant for this test
 node1 = cluster.add_instance(
     "node1", main_configs=["configs/keeper1.xml"], with_zookeeper=True, stay_alive=True

--- a/tests/integration/test_keeper_reconfig_remove/test.py
+++ b/tests/integration/test_keeper_reconfig_remove/test.py
@@ -5,14 +5,26 @@ import typing as tp
 
 import pytest
 
+from multiprocessing.dummy import Pool
+
 import helpers.keeper_utils as ku
 from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
-node1 = cluster.add_instance("node1", main_configs=["configs/keeper1.xml"])
-node2 = cluster.add_instance("node2", main_configs=["configs/keeper2.xml"])
-node3 = cluster.add_instance("node3", main_configs=["configs/keeper3.xml"])
+
+# we set with_zookeeper=True because we modify keeper cluster used in nodes
+# using Keeper cluster that is changed with reconfig can lead to errors in ClickHouse sever or a really slow shutdown 
+# (e.g. when paired with `with_remote_database_disk`), which is not relevant for this test
+node1 = cluster.add_instance(
+    "node1", main_configs=["configs/keeper1.xml"], with_zookeeper=True, stay_alive=True
+)
+node2 = cluster.add_instance(
+    "node2", main_configs=["configs/keeper2.xml"], with_zookeeper=True, stay_alive=True
+)
+node3 = cluster.add_instance(
+    "node3", main_configs=["configs/keeper3.xml"], with_zookeeper=True, stay_alive=True
+)
 
 log_msg_removed = "has been removed from the cluster"
 zk1, zk2, zk3 = None, None, None
@@ -38,12 +50,41 @@ def create_client(node: ClickHouseInstance):
     )
 
 
+def start_clickhouse(node):
+    node.start_clickhouse()
+
+
+def cleanup_keepers():
+    nodes = [node1, node2, node3]
+
+    for node in nodes:
+        node.stop_clickhouse()
+
+    p = Pool(3)
+    waiters = []
+
+    for node in nodes:
+        node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/log"])
+        node.exec_in_container(
+            ["rm", "-rf", "/var/lib/clickhouse/coordination/snapshots"]
+        )
+        waiters.append(p.apply_async(start_clickhouse, args=(node,)))
+
+    for waiter in waiters:
+        waiter.wait()
+
+    for node in nodes:
+        ku.wait_until_connected(cluster, node)
+
+
 def test_reconfig_remove_followers_from_3(started_cluster):
     """
     Remove 1 follower node from cluster of 3.
     Then remove another follower from two left nodes.
     Check that remaining node is in standalone mode.
     """
+
+    cleanup_keepers()
 
     global zk1, zk2, zk3
     zk1 = create_client(node1)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Test is flaky in private only because we use disk with Keeper for database files.
In the test we remove Keepers from cluster so ClickHouse server tries to create a new file for system table while accessing Keepers that stepped down. Sometimes the test finishes if it connects to the only Keeper left but it's purely by chance.
Fix is not relying on the Keeper cluster we modify.  

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
