### PR TITLE
Fix check_cpp.sh not detecting multiline comments

### DIFF
--- a/ci/jobs/scripts/check_style/check_cpp.sh
+++ b/ci/jobs/scripts/check_style/check_cpp.sh
@@ -37,7 +37,7 @@ find $ROOT_PATH/{src,base,programs,utils} -name '*.h' -or -name '*.cpp' 2>/dev/n
     grep -vP $EXCLUDE_DOCS |
     xargs grep $@ -P '((class|struct|namespace|enum|if|for|while|else|throw|switch).*|\)(\s*const)?(\s*override)?\s*)\{$|\s$|^ {1,3}[^\* ]\S|\t|^\s*(if|else if|if constexpr|else if constexpr|for|while|catch|switch)\(|\( [^\s\\]|\S \)' |
 # a curly brace not in a new line, but not for the case of C++11 init or agg. initialization | trailing whitespace | number of ws not a multiple of 4, but not in the case of comment continuation | missing whitespace after for/if/while... before opening brace | whitespaces inside braces
-    grep -v -P '(//|:\s+\*|\$\(\()| \)"' && echo "{ should be a new line"
+    grep -v -P '//|\s+\*|\$\(\(| \)"' && echo "^ style error on this line"
 # single-line comment | continuation of a multiline comment | a typical piece of embedded shell code | something like ending of raw string literal
 
 # Tabs


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

In https://github.com/ClickHouse/ClickHouse/pull/86574 it was incorrectly reporting this line, which is inside a comment:
```
  * Or, the last mark specifies the range open on the right: [ a b c .. + inf )
```

The regex already has a check "continuation of a multiline comment", but it requires the line to start with `:`, I couldn't figure out why: `:\s+\*`. @alexey-milovidov , do you remember?

This PR removes the ':', so any line starting with `*` (after whitespace) is excluded from style checking.

Also removes unnecessary (?) regex parentheses and fixes an error message.