### PR TITLE
Fix IPv6 support in listen_host for ArrowFlight

### DIFF
--- a/src/Server/ArrowFlightHandler.cpp
+++ b/src/Server/ArrowFlightHandler.cpp
@@ -153,6 +153,35 @@ namespace ErrorCodes
 extern const int UNKNOWN_EXCEPTION;
 }
 
+namespace
+{
+    arrow::flight::Location addressToArrowLocation(const Poco::Net::SocketAddress & address_to_listen, bool use_tls)
+    {
+        auto ip_to_listen = address_to_listen.host();
+        auto port_to_listen = address_to_listen.port();
+
+        /// Function arrow::flight::Location::ForGrpc*() builds an URL based so it requires IPv6 address to be enclosed in brackets
+        String host_component = (ip_to_listen.family() == Poco::Net::AddressFamily::IPv6) ? ("[" + ip_to_listen.toString() + "]") : ip_to_listen.toString();
+
+        arrow::Result<arrow::flight::Location> parse_location_status;
+        if (use_tls)
+            parse_location_status = arrow::flight::Location::ForGrpcTls(host_component, port_to_listen);
+        else
+            parse_location_status = arrow::flight::Location::ForGrpcTcp(host_component, port_to_listen);
+
+        if (!parse_location_status.ok())
+        {
+            throw Exception(
+                ErrorCodes::UNKNOWN_EXCEPTION,
+                "Invalid address {} for Arrow Flight Server: {}",
+                address_to_listen.toString(),
+                parse_location_status.status().ToString());
+        }
+
+        return std::move(parse_location_status).ValueOrDie();
+    }
+}
+
 ArrowFlightHandler::ArrowFlightHandler(IServer & server_, const Poco::Net::SocketAddress & address_to_listen_)
     : server(server_)
     , log(getLogger("ArrowFlightHandler"))
@@ -174,25 +203,7 @@ void ArrowFlightHandler::start()
 {
     bool use_tls = server.config().getBool("arrowflight.enable_ssl", false);
 
-    arrow::Result<arrow::flight::Location> parse_location_status;
-
-    if (use_tls)
-    {
-        parse_location_status = arrow::flight::Location::ForGrpcTls(address_to_listen.host().toString(), address_to_listen.port());
-    }
-    else
-    {
-        parse_location_status = arrow::flight::Location::ForGrpcTcp(address_to_listen.host().toString(), address_to_listen.port());
-    }
-    if (!parse_location_status.ok())
-    {
-        throw Exception(
-            ErrorCodes::UNKNOWN_EXCEPTION,
-            "Invalid address {} for Arrow Flight Server: {}",
-            address_to_listen.toString(),
-            parse_location_status->ToString());
-    }
-    location = std::move(parse_location_status).ValueOrDie();
+    auto location = addressToArrowLocation(address_to_listen, use_tls);
 
     arrow::flight::FlightServerOptions options(location);
     options.auth_handler = std::make_unique<arrow::flight::NoOpAuthHandler>();

--- a/src/Server/ArrowFlightHandler.h
+++ b/src/Server/ArrowFlightHandler.h
@@ -97,7 +97,6 @@ public:
 private:
     IServer & server;
     LoggerPtr log;
-    arrow::flight::Location location;
     const Poco::Net::SocketAddress address_to_listen;
     std::optional<ThreadFromGlobalPool> server_thread;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix support for IPv6 in `listen_host` for ArrowFlight.

Before this PR a server with the following lines in the config
```
<clickhouse>
    <arrowflight_port>8888</arrowflight_port>
    <listen_host>::</listen_host>
</clickhouse>
```
failed on startup with the following exception:
```
<Error> Application: std::exception. Code: 1001, type: std::runtime_error, e.what() = /clickhouse/contrib/arrow/cpp/src/arrow/result.cc:28: ValueOrDie called on an error: Invalid: Cannot parse URI: 'grpc+tcp://:::8888'
, Stack trace (when copying this message, always include the lines below):

0. /clickhouse/contrib/llvm-project/libcxx/include/__exception/exception.h:113: std::runtime_error::runtime_error(String const&)
1. /clickhouse/contrib/arrow/cpp/src/arrow/util/logging.cc:74: arrow::util::CerrLog::~CerrLog()
2. /clickhouse/contrib/arrow/cpp/src/arrow/util/logging.cc:69: arrow::util::CerrLog::~CerrLog()
3. /clickhouse/contrib/arrow/cpp/src/arrow/util/logging.cc:254: arrow::util::ArrowLog::~ArrowLog()
4. /clickhouse/contrib/arrow/cpp/src/arrow/result.cc:28: arrow::internal::DieWithMessage(String const&)
5. /clickhouse/contrib/arrow/cpp/src/arrow/result.cc:31: arrow::internal::InvalidValueOrDie(arrow::Status const&)
6. /clickhouse/contrib/arrow/cpp/src/arrow/result.h:322: DB::ArrowFlightHandler::start()
7. /clickhouse/src/Server/ProtocolServerAdapter.h:41: DB::Server::main(std::vector<String, std::allocator<String>> const&)
8. /clickhouse/base/poco/Util/src/Application.cpp:315: Poco::Util::Application::run()
9. /clickhouse/programs/server/Server.cpp:623: DB::Server::run()
10. /clickhouse/base/poco/Util/src/ServerApplication.cpp:131: Poco::Util::ServerApplication::run(int, char**)
11. /clickhouse/programs/server/Server.cpp:410: mainEntryClickHouseServer(int, char**)
12. /clickhouse/programs/main.cpp:381: main
```