### PR TITLE
Limit plan step description length.

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2112,7 +2112,7 @@ Apply sharding for JOIN if join keys contain a prefix of PRIMARY KEY for both ta
 Show internal aliases (such as __table1) in EXPLAIN PLAN instead of those specified in the original query.
 )", 0) \
     \
-    DECLARE(UInt64, query_plan_max_step_description_length, 128, R"(
+    DECLARE(UInt64, query_plan_max_step_description_length, 250, R"(
 Maximum length of step description in EXPLAIN PLAN.
 )", 0) \
     \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2112,6 +2112,10 @@ Apply sharding for JOIN if join keys contain a prefix of PRIMARY KEY for both ta
 Show internal aliases (such as __table1) in EXPLAIN PLAN instead of those specified in the original query.
 )", 0) \
     \
+    DECLARE(UInt64, query_plan_max_step_description_length, 128, R"(
+Maximum length of step description in EXPLAIN PLAN.
+)", 0) \
+    \
     DECLARE(UInt64, preferred_block_size_bytes, 1000000, R"(
 This setting adjusts the data block size for query processing and represents additional fine-tuning to the more rough 'max_block_size' setting. If the columns are large and with 'max_block_size' rows the block size is likely to be larger than the specified amount of bytes, its size will be lowered for better CPU cache locality.
 )", 0) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2112,7 +2112,7 @@ Apply sharding for JOIN if join keys contain a prefix of PRIMARY KEY for both ta
 Show internal aliases (such as __table1) in EXPLAIN PLAN instead of those specified in the original query.
 )", 0) \
     \
-    DECLARE(UInt64, query_plan_max_step_description_length, 250, R"(
+    DECLARE(UInt64, query_plan_max_step_description_length, 500, R"(
 Maximum length of step description in EXPLAIN PLAN.
 )", 0) \
     \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -49,7 +49,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"max_iceberg_data_file_bytes", 100000000, 100000000, "New setting."},
             {"query_plan_optimize_join_order_limit", 1, 1, "New setting"},
             {"query_plan_display_internal_aliases", false, false, "New setting"},
-            {"query_plan_max_step_description_length", 1000000000, 250, "New setting"},
+            {"query_plan_max_step_description_length", 1000000000, 500, "New setting"},
             {"allow_experimental_delta_lake_writes", false, false, "New setting."},
             {"delta_lake_insert_max_bytes_in_data_file", 1_GiB, 1_GiB, "New setting."},
             {"delta_lake_insert_max_rows_in_data_file", 100000, 100000, "New setting."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -49,6 +49,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"max_iceberg_data_file_bytes", 100000000, 100000000, "New setting."},
             {"query_plan_optimize_join_order_limit", 1, 1, "New setting"},
             {"query_plan_display_internal_aliases", false, false, "New setting"},
+            {"query_plan_max_step_description_length", 1000000000, 250, "New setting"},
             {"allow_experimental_delta_lake_writes", false, false, "New setting."},
             {"delta_lake_insert_max_bytes_in_data_file", 1_GiB, 1_GiB, "New setting."},
             {"delta_lake_insert_max_rows_in_data_file", 100000, 100000, "New setting."},

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -623,7 +623,10 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                     context = interpreter.getContext();
                 }
 
-                auto pipeline = plan.buildQueryPipeline(QueryPlanOptimizationSettings(context), BuildQueryPipelineSettings(context));
+                auto optimization_settings = QueryPlanOptimizationSettings(context);
+                optimization_settings.is_explain = true;
+                optimization_settings.max_step_description_length = query_context->getSettingsRef()[Setting::query_plan_max_step_description_length];
+                auto pipeline = plan.buildQueryPipeline(optimization_settings, BuildQueryPipelineSettings(context));
 
                 if (settings.graph)
                 {

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -45,6 +45,7 @@ namespace Setting
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool allow_statistics_optimize;
     extern const SettingsBool format_display_secrets_in_show_and_select;
+    extern const SettingsUInt64 query_plan_max_step_description_length;
 }
 
 namespace ErrorCodes
@@ -479,9 +480,10 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
     bool single_line = false;
     bool insert_buf = true;
 
-    options.setExplain();
-
     ContextPtr query_context = getContext();
+
+    options.setExplain();
+    options.max_step_description_length = query_context->getSettingsRef()[Setting::query_plan_max_step_description_length];
 
     switch (ast.getKind())
     {
@@ -571,6 +573,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 auto optimization_settings = QueryPlanOptimizationSettings(context);
                 optimization_settings.keep_logical_steps = settings.keep_logical_steps;
                 optimization_settings.is_explain = true;
+                optimization_settings.max_step_description_length = query_context->getSettingsRef()[Setting::query_plan_max_step_description_length];
                 plan.optimize(optimization_settings);
             }
 
@@ -596,7 +599,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 single_line = true;
             }
             else
-                plan.explainPlan(buf, settings.query_plan_options);
+                plan.explainPlan(buf, settings.query_plan_options, 0, query_context->getSettingsRef()[Setting::query_plan_max_step_description_length]);
             break;
         }
         case ASTExplainQuery::QueryPipeline:

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1575,7 +1575,7 @@ static bool hasWithTotalsInAnySubqueryInFromClause(const ASTSelectQuery & query)
 }
 
 template <size_t size>
-void executeExpression(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, const char (&description)[size])
+ALWAYS_INLINE void executeExpression(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, const char (&description)[size])
 {
     if (!expression)
         return;

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1574,6 +1574,21 @@ static bool hasWithTotalsInAnySubqueryInFromClause(const ASTSelectQuery & query)
     return false;
 }
 
+template <size_t size>
+void executeExpression(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, const char (&description)[size])
+{
+    if (!expression)
+        return;
+
+    auto dag = expression->dag.clone();
+    if (expression->project_input)
+        dag.appendInputsForUnusedColumns(*query_plan.getCurrentHeader());
+
+    auto expression_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(dag));
+
+    expression_step->setStepDescription(description);
+    query_plan.addStep(std::move(expression_step));
+}
 
 void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<Pipe> prepared_pipe)
 {
@@ -1770,7 +1785,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                 query_plan.addStep(std::move(row_level_security_step));
             }
 
-            const auto add_filter_step = [&](auto & new_filter_info, const std::string & description)
+            const auto add_filter_step = [&](auto & new_filter_info, const auto & description)
             {
                 auto filter_step = std::make_unique<FilterStep>(
                     query_plan.getCurrentHeader(),
@@ -1841,13 +1856,13 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                             plan.getCurrentHeader(),
                             std::move(order_descr),
                             0 /* LIMIT */, sort_settings);
-                        sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_pos));
+                        sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_pos), options.max_step_description_length);
                         plan.addStep(std::move(sorting_step));
                     };
 
                     auto crosswise_connection = CreateSetAndFilterOnTheFlyStep::createCrossConnection();
                     auto add_create_set
-                        = [&settings, crosswise_connection](QueryPlan & plan, const Names & key_names, JoinTableSide join_pos)
+                        = [&settings, crosswise_connection, max_len = options.max_step_description_length](QueryPlan & plan, const Names & key_names, JoinTableSide join_pos)
                     {
                         auto creating_set_step = std::make_unique<CreateSetAndFilterOnTheFlyStep>(
                             plan.getCurrentHeader(),
@@ -1855,7 +1870,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                             settings[Setting::max_rows_in_set_to_optimize_join],
                             crosswise_connection,
                             join_pos);
-                        creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_pos));
+                        creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_pos), max_len);
 
                         auto * step_raw_ptr = creating_set_step.get();
                         plan.addStep(std::move(creating_set_step));
@@ -1918,7 +1933,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                         analysis_result.optimize_read_in_order,
                         /* use_new_analyzer_ = */ false);
 
-                    join_step->setStepDescription(fmt::format("JOIN {}", expressions.join->pipelineType()));
+                    join_step->setStepDescription(fmt::format("JOIN {}", expressions.join->pipelineType()), options.max_step_description_length);
                     std::vector<QueryPlanPtr> plans;
                     plans.emplace_back(std::make_unique<QueryPlan>(std::move(query_plan)));
                     plans.emplace_back(std::move(joined_plan));
@@ -2972,21 +2987,6 @@ void InterpreterSelectQuery::executeRollupOrCube(QueryPlan & query_plan, Modific
     query_plan.addStep(std::move(step));
 }
 
-void InterpreterSelectQuery::executeExpression(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, const std::string & description)
-{
-    if (!expression)
-        return;
-
-    auto dag = expression->dag.clone();
-    if (expression->project_input)
-        dag.appendInputsForUnusedColumns(*query_plan.getCurrentHeader());
-
-    auto expression_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(dag));
-
-    expression_step->setStepDescription(description);
-    query_plan.addStep(std::move(expression_step));
-}
-
 static bool windowDescriptionComparator(const WindowDescription * _left, const WindowDescription * _right)
 {
     const auto & left = _left->full_sort_description;
@@ -3070,7 +3070,7 @@ void InterpreterSelectQuery::executeWindow(QueryPlan & query_plan)
                 window.partition_by,
                 0 /* LIMIT */,
                 sort_settings);
-            sorting_step->setStepDescription("Sorting for window '" + window.window_name + "'");
+            sorting_step->setStepDescription(fmt::format("Sorting for window '{}'", window.window_name), options.max_step_description_length);
             query_plan.addStep(std::move(sorting_step));
         }
 
@@ -3080,7 +3080,7 @@ void InterpreterSelectQuery::executeWindow(QueryPlan & query_plan)
             = settings[Setting::query_plan_enable_multithreading_after_window_functions] && ((i + 1) == windows_sorted.size());
 
         auto window_step = std::make_unique<WindowStep>(query_plan.getCurrentHeader(), window, window.window_functions, streams_fan_out);
-        window_step->setStepDescription("Window step for window '" + window.window_name + "'");
+        window_step->setStepDescription(fmt::format("Window step for window '{}'", window.window_name), options.max_step_description_length);
 
         query_plan.addStep(std::move(window_step));
     }
@@ -3143,7 +3143,7 @@ void InterpreterSelectQuery::executeMergeSorted(QueryPlan & query_plan, const st
 
     auto merging_sorted = std::make_unique<SortingStep>(
         query_plan.getCurrentHeader(), std::move(sort_description), max_block_size, limit, exact_rows_before_limit);
-    merging_sorted->setStepDescription("Merge sorted streams " + description);
+    merging_sorted->setStepDescription(fmt::format("Merge sorted streams {}", description), options.max_step_description_length);
     query_plan.addStep(std::move(merging_sorted));
 }
 

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -176,7 +176,6 @@ private:
     void executeMergeAggregated(QueryPlan & query_plan, bool overflow_row, bool final, bool has_grouping_sets);
     void executeTotalsAndHaving(QueryPlan & query_plan, bool has_having, const ActionsAndProjectInputsFlagPtr & expression, bool remove_filter, bool overflow_row, bool final);
     void executeHaving(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, bool remove_filter);
-    static void executeExpression(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, const std::string & description);
     /// FIXME should go through ActionsDAG to behave as a proper function
     void executeWindow(QueryPlan & query_plan);
     void executeOrder(QueryPlan & query_plan, InputOrderInfoPtr sorting_info);

--- a/src/Interpreters/SelectQueryOptions.h
+++ b/src/Interpreters/SelectQueryOptions.h
@@ -60,6 +60,8 @@ struct SelectQueryOptions
     bool build_logical_plan = false;
     bool ignore_rename_columns = false;
 
+    size_t max_step_description_length = 0;
+
     /** During read from MergeTree parts will be removed from snapshot after they are not needed.
       * This optimization will break subsequent execution of the same query tree, because table node
       * will no more have valid snapshot.

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -412,7 +412,7 @@ public:
 };
 
 template <size_t size>
-void addExpressionStep(
+ALWAYS_INLINE void addExpressionStep(
     const PlannerContextPtr & planner_context,
     QueryPlan & query_plan,
     ActionsAndProjectInputsFlagPtr & expression_actions,
@@ -449,7 +449,7 @@ void addExpressionStep(
 }
 
 template <size_t size>
-void addFilterStep(
+ALWAYS_INLINE void addFilterStep(
     const PlannerContextPtr & planner_context,
     QueryPlan & query_plan,
     FilterAnalysisResult & filter_analysis_result,
@@ -790,7 +790,7 @@ void addSortingStep(QueryPlan & query_plan,
 }
 
 template<size_t size>
-void addMergeSortingStep(QueryPlan & query_plan,
+ALWAYS_INLINE void addMergeSortingStep(QueryPlan & query_plan,
     const QueryAnalysisResult & query_analysis_result,
     const PlannerContextPtr & planner_context,
     const char (&description)[size])

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -411,13 +411,14 @@ public:
     UInt64 partial_sorting_limit = 0;
 };
 
+template <size_t size>
 void addExpressionStep(
     const PlannerContextPtr & planner_context,
     QueryPlan & query_plan,
     ActionsAndProjectInputsFlagPtr & expression_actions,
     const CorrelatedSubtrees & correlated_subtrees,
     const SelectQueryOptions & select_query_options,
-    const std::string & step_description,
+    const char (&step_description)[size],
     UsefulSets & useful_sets)
 {
     NameSet input_columns_set;
@@ -447,12 +448,13 @@ void addExpressionStep(
     query_plan.addStep(std::move(expression_step));
 }
 
+template <size_t size>
 void addFilterStep(
     const PlannerContextPtr & planner_context,
     QueryPlan & query_plan,
     FilterAnalysisResult & filter_analysis_result,
     const SelectQueryOptions & select_query_options,
-    const std::string & step_description,
+    const char (&step_description)[size],
     UsefulSets & useful_sets)
 {
     for (const auto & correlated_subquery : filter_analysis_result.correlated_subtrees.subqueries)
@@ -763,7 +765,10 @@ void addDistinctStep(QueryPlan & query_plan,
         column_names,
         pre_distinct);
 
-    distinct_step->setStepDescription(pre_distinct ? "Preliminary DISTINCT" : "DISTINCT");
+    if (pre_distinct)
+        distinct_step->setStepDescription("Preliminary DISTINCT");
+    else
+        distinct_step->setStepDescription("DISTINCT");
     query_plan.addStep(std::move(distinct_step));
 }
 
@@ -784,10 +789,11 @@ void addSortingStep(QueryPlan & query_plan,
     query_plan.addStep(std::move(sorting_step));
 }
 
+template<size_t size>
 void addMergeSortingStep(QueryPlan & query_plan,
     const QueryAnalysisResult & query_analysis_result,
     const PlannerContextPtr & planner_context,
-    const std::string & description)
+    const char (&description)[size])
 {
     const auto & query_context = planner_context->getQueryContext();
     const auto & settings = query_context->getSettingsRef();
@@ -800,7 +806,7 @@ void addMergeSortingStep(QueryPlan & query_plan,
         settings[Setting::max_block_size],
         query_analysis_result.partial_sorting_limit,
         settings[Setting::exact_rows_before_limit]);
-    merging_sorted->setStepDescription("Merge sorted streams " + description);
+    merging_sorted->setStepDescription(description);
     query_plan.addStep(std::move(merging_sorted));
 }
 
@@ -986,7 +992,10 @@ void addPreliminaryLimitStep(QueryPlan & query_plan,
 
     auto limit
         = std::make_unique<LimitStep>(query_plan.getCurrentHeader(), limit_length, limit_offset, settings[Setting::exact_rows_before_limit]);
-    limit->setStepDescription(do_not_skip_offset ? "preliminary LIMIT (with OFFSET)" : "preliminary LIMIT (without OFFSET)");
+    if (do_not_skip_offset)
+        limit->setStepDescription("preliminary LIMIT (with OFFSET)");
+    else
+        limit->setStepDescription("preliminary LIMIT (without OFFSET)");
     query_plan.addStep(std::move(limit));
 }
 
@@ -1102,7 +1111,8 @@ void addPreliminarySortOrDistinctOrLimitStepsIfNeeded(
 
 void addWindowSteps(QueryPlan & query_plan,
     const PlannerContextPtr & planner_context,
-    WindowAnalysisResult & window_analysis_result)
+    WindowAnalysisResult & window_analysis_result,
+    size_t max_step_description_length)
 {
     const auto & query_context = planner_context->getQueryContext();
     const auto & settings = query_context->getSettingsRef();
@@ -1140,7 +1150,7 @@ void addWindowSteps(QueryPlan & query_plan,
                 window_description.partition_by,
                 0 /*limit*/,
                 sort_settings);
-            sorting_step->setStepDescription("Sorting for window '" + window_description.window_name + "'");
+            sorting_step->setStepDescription("Sorting for window '" + window_description.window_name + "'", max_step_description_length);
             query_plan.addStep(std::move(sorting_step));
         }
 
@@ -1151,7 +1161,7 @@ void addWindowSteps(QueryPlan & query_plan,
 
         auto window_step
             = std::make_unique<WindowStep>(query_plan.getCurrentHeader(), window_description, window_description.window_functions, streams_fan_out);
-        window_step->setStepDescription("Window step for window '" + window_description.window_name + "'");
+        window_step->setStepDescription("Window step for window '" + window_description.window_name + "'", max_step_description_length);
         query_plan.addStep(std::move(window_step));
     }
 }
@@ -1421,7 +1431,7 @@ void Planner::buildPlanForUnionNode()
             recursive_cte_columns.emplace_back(recursive_cte_table_column.type, recursive_cte_table_column.name);
 
         auto read_from_recursive_cte_step = std::make_unique<ReadFromRecursiveCTEStep>(std::make_shared<const Block>(Block(std::move(recursive_cte_columns))), query_tree);
-        read_from_recursive_cte_step->setStepDescription(query_tree->toAST()->formatForErrorMessage());
+        read_from_recursive_cte_step->setStepDescription(query_tree->toAST()->formatForErrorMessage(), select_query_options.max_step_description_length);
         query_plan.addStep(std::move(read_from_recursive_cte_step));
         return;
     }
@@ -1835,7 +1845,7 @@ void Planner::buildPlanForQueryNode()
                         "Before window functions",
                         useful_sets);
 
-                addWindowSteps(query_plan, planner_context, window_analysis_result);
+                addWindowSteps(query_plan, planner_context, window_analysis_result, select_query_options.max_step_description_length);
             }
 
             if (expression_analysis_result.hasQualify())
@@ -1891,12 +1901,12 @@ void Planner::buildPlanForQueryNode()
               * then merge the sorted streams is enough, since remote servers already did full ORDER BY.
               */
             if (query_processing_info.isFromAggregationState())
-                addMergeSortingStep(query_plan, query_analysis_result, planner_context, "after aggregation stage for ORDER BY");
+                addMergeSortingStep(query_plan, query_analysis_result, planner_context, "Merge sorted streams after aggregation stage for ORDER BY");
             else if (!query_processing_info.isFirstStage() &&
                 !expression_analysis_result.hasAggregation() &&
                 !expression_analysis_result.hasWindow() &&
                 !(query_node.isGroupByWithTotals() && !query_analysis_result.aggregate_final))
-                addMergeSortingStep(query_plan, query_analysis_result, planner_context, "for ORDER BY, without aggregation");
+                addMergeSortingStep(query_plan, query_analysis_result, planner_context, "Merge sorted streams for ORDER BY, without aggregation");
             else
                 addSortingStep(query_plan, query_analysis_result, planner_context);
         }

--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -443,7 +443,7 @@ QueryPlan decorrelateQueryPlan(
             aggeregating_step->usingMemoryBoundMerging(),
             aggeregating_step->explicitSortingRequired()
         );
-        result_step->setStepDescription(aggeregating_step->getStepDescription());
+        result_step->setStepDescription(*aggeregating_step);
 
         decorrelated_query_plan.addStep(std::move(result_step));
 

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -898,7 +898,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 
                 updatePrewhereOutputsIfNeeded(table_expression_query_info, table_expression_data.getColumnNames(), storage_snapshot);
 
-                const auto add_filter = [&](FilterDAGInfo & filter_info, std::unique_ptr<IDescriptionHolder> description)
+                const auto add_filter = [&](FilterDAGInfo & filter_info, DescriptionHolderPtr description)
                 {
                     bool is_final = table_expression_query_info.table_expression_modifiers
                         && table_expression_query_info.table_expression_modifiers->hasFinal();

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -943,7 +943,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 if (row_policy_filter_info)
                 {
                     table_expression_data.setRowLevelFilterActions(row_policy_filter_info->actions.clone());
-                    add_filter(*row_policy_filter_info, std::make_unique<DescriptionHolder<26>>("Row-level security filter"));
+                    add_filter(*row_policy_filter_info, makeDescription("Row-level security filter"));
                 }
 
                 if (query_context->canUseParallelReplicasCustomKey())
@@ -951,7 +951,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                     if (settings[Setting::parallel_replicas_count] > 1)
                     {
                         if (auto parallel_replicas_custom_key_filter_info= buildCustomKeyFilterIfNeeded(storage, table_expression_query_info, planner_context))
-                            add_filter(*parallel_replicas_custom_key_filter_info, std::make_unique<DescriptionHolder<36>>("Parallel replicas custom key filter"));
+                            add_filter(*parallel_replicas_custom_key_filter_info, makeDescription("Parallel replicas custom key filter"));
                     }
                     else if (auto * distributed = typeid_cast<StorageDistributed *>(storage.get());
                              distributed && query_context->canUseParallelReplicasCustomKeyForCluster(*distributed->getCluster()))
@@ -969,7 +969,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 if (auto additional_filters_info = buildAdditionalFiltersIfNeeded(storage, table_expression_alias, table_expression_query_info, planner_context))
                 {
                     appendSetsFromActionsDAG(additional_filters_info->actions, useful_sets);
-                    add_filter(*additional_filters_info, std::make_unique<DescriptionHolder<18>>("additional filter"));
+                    add_filter(*additional_filters_info, makeDescription("additional filter"));
                 }
 
                 if (!select_query_options.build_logical_plan)

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -54,6 +54,7 @@
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromTableStep.h>
 #include <Processors/QueryPlan/ReadFromTableFunctionStep.h>
+#include <Processors/QueryPlan/Optimizations/Utils.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 
 #include <Storages/StorageDummy.h>
@@ -873,7 +874,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 const auto & prewhere_actions = table_expression_data.getPrewhereFilterActions();
                 const auto & columns_names = table_expression_data.getColumnNames();
 
-                std::vector<std::pair<FilterDAGInfo, std::string>> where_filters;
+                std::vector<std::pair<FilterDAGInfo, DescriptionHolderPtr>> where_filters;
 
                 if (prewhere_actions && select_query_options.build_logical_plan)
                 {
@@ -882,7 +883,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                             prewhere_actions->clone(),
                             prewhere_actions->getOutputs().at(0)->result_name,
                             true},
-                        "Prewhere");
+                        makeDescription("Prewhere"));
                 }
                 else if (prewhere_actions)
                 {
@@ -897,7 +898,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 
                 updatePrewhereOutputsIfNeeded(table_expression_query_info, table_expression_data.getColumnNames(), storage_snapshot);
 
-                const auto add_filter = [&](FilterDAGInfo & filter_info, std::string description)
+                const auto add_filter = [&](FilterDAGInfo & filter_info, std::unique_ptr<IDescriptionHolder> description)
                 {
                     bool is_final = table_expression_query_info.table_expression_modifiers
                         && table_expression_query_info.table_expression_modifiers->hasFinal();
@@ -942,7 +943,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 if (row_policy_filter_info)
                 {
                     table_expression_data.setRowLevelFilterActions(row_policy_filter_info->actions.clone());
-                    add_filter(*row_policy_filter_info, "Row-level security filter");
+                    add_filter(*row_policy_filter_info, std::make_unique<DescriptionHolder<26>>("Row-level security filter"));
                 }
 
                 if (query_context->canUseParallelReplicasCustomKey())
@@ -950,7 +951,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                     if (settings[Setting::parallel_replicas_count] > 1)
                     {
                         if (auto parallel_replicas_custom_key_filter_info= buildCustomKeyFilterIfNeeded(storage, table_expression_query_info, planner_context))
-                            add_filter(*parallel_replicas_custom_key_filter_info, "Parallel replicas custom key filter");
+                            add_filter(*parallel_replicas_custom_key_filter_info, std::make_unique<DescriptionHolder<36>>("Parallel replicas custom key filter"));
                     }
                     else if (auto * distributed = typeid_cast<StorageDistributed *>(storage.get());
                              distributed && query_context->canUseParallelReplicasCustomKeyForCluster(*distributed->getCluster()))
@@ -968,7 +969,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 if (auto additional_filters_info = buildAdditionalFiltersIfNeeded(storage, table_expression_alias, table_expression_query_info, planner_context))
                 {
                     appendSetsFromActionsDAG(additional_filters_info->actions, useful_sets);
-                    add_filter(*additional_filters_info, "additional filter");
+                    add_filter(*additional_filters_info, std::make_unique<DescriptionHolder<18>>("additional filter"));
                 }
 
                 if (!select_query_options.build_logical_plan)
@@ -1244,7 +1245,7 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                             std::move(filter_info.actions),
                             filter_info.column_name,
                             filter_info.do_remove_column);
-                        filter_step->setStepDescription(description);
+                        description->setStepDescription(*filter_step);
                         query_plan.addStep(std::move(filter_step));
                     }
                 }
@@ -1408,8 +1409,10 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 ActionsDAG::MatchColumnsMode::Position,
                 true /*ignore_constant_values*/);
             auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_actions_dag));
-            std::string step_description = table_expression_data.isRemote() ? "Change remote column names to local column names" : "Change column names";
-            rename_step->setStepDescription(std::move(step_description));
+            if (table_expression_data.isRemote())
+                rename_step->setStepDescription("Change remote column names to local column names");
+            else
+                rename_step->setStepDescription("Change column names");
             query_plan.addStep(std::move(rename_step));
         }
     }
@@ -1523,7 +1526,8 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
     const QueryTreeNodePtr & right_table_expression,
     const ColumnIdentifierSet & outer_scope_columns,
     PlannerContextPtr & planner_context,
-    const SelectQueryInfo & select_query_info)
+    const SelectQueryInfo & select_query_info,
+    size_t max_step_description_length)
 {
     const auto & left_header = left_plan.getCurrentHeader();
     const auto & right_header = right_plan.getCurrentHeader();
@@ -1606,16 +1610,16 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
 
             auto sorting_step = std::make_unique<SortingStep>(
                 plan.getCurrentHeader(), std::move(sort_description), 0 /*limit*/, sort_settings, true /*is_sorting_for_merge_join*/);
-            sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_table_side));
+            sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_table_side), max_step_description_length);
             plan.addStep(std::move(sorting_step));
         };
 
         auto crosswise_connection = CreateSetAndFilterOnTheFlyStep::createCrossConnection();
-        auto add_create_set = [&settings, crosswise_connection](QueryPlan & plan, const Names & key_names, JoinTableSide join_table_side)
+        auto add_create_set = [&settings, crosswise_connection, max_step_description_length](QueryPlan & plan, const Names & key_names, JoinTableSide join_table_side)
         {
             auto creating_set_step = std::make_unique<CreateSetAndFilterOnTheFlyStep>(
                 plan.getCurrentHeader(), key_names, settings[Setting::max_rows_in_set_to_optimize_join], crosswise_connection, join_table_side);
-            creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_table_side));
+            creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_table_side), max_step_description_length);
 
             auto * step_raw_ptr = creating_set_step.get();
             plan.addStep(std::move(creating_set_step));
@@ -1697,7 +1701,7 @@ std::tuple<QueryPlan, JoinPtr> buildJoinQueryPlan(
         auto setting_swap = settings[Setting::query_plan_join_swap_table];
         join_step->swap_join_tables = setting_swap.is_auto ? std::nullopt : std::make_optional(setting_swap.base);
 
-        join_step->setStepDescription(fmt::format("JOIN {}", join_pipeline_type));
+        join_step->setStepDescription(fmt::format("JOIN {}", join_pipeline_type), max_step_description_length);
 
         std::vector<QueryPlanPtr> plans;
         plans.emplace_back(std::make_unique<QueryPlan>(std::move(left_plan)));
@@ -1750,7 +1754,8 @@ JoinTreeQueryPlan buildQueryPlanForCrossJoinNode(
     std::vector<JoinTreeQueryPlan> plans,
     const ColumnIdentifierSet & outer_scope_columns,
     PlannerContextPtr & planner_context,
-    const SelectQueryInfo & select_query_info)
+    const SelectQueryInfo & select_query_info,
+    size_t max_step_description_length)
 {
     auto & cross_join_node = join_table_expression->as<CrossJoinNode &>();
     for (const auto & plan : plans)
@@ -1789,7 +1794,8 @@ JoinTreeQueryPlan buildQueryPlanForCrossJoinNode(
             cross_join_node.getTableExpressions()[i],
             outer_scope_columns,
             planner_context,
-            select_query_info);
+            select_query_info,
+            max_step_description_length);
 
         for (const auto & right_join_tree_query_plan_row_policy : right_join_tree_query_plan.used_row_policies)
             left_join_tree_query_plan.used_row_policies.insert(right_join_tree_query_plan_row_policy);
@@ -1821,7 +1827,8 @@ JoinTreeQueryPlan buildQueryPlanForJoinNodeLegacy(
     JoinTreeQueryPlan right_join_tree_query_plan,
     const ColumnIdentifierSet & outer_scope_columns,
     PlannerContextPtr & planner_context,
-    const SelectQueryInfo & select_query_info)
+    const SelectQueryInfo & select_query_info,
+    size_t max_step_description_length)
 {
     auto & join_node = join_table_expression->as<JoinNode &>();
 
@@ -2135,7 +2142,8 @@ JoinTreeQueryPlan buildQueryPlanForJoinNodeLegacy(
         join_node.getRightTableExpression(),
         outer_scope_columns,
         planner_context,
-        select_query_info);
+        select_query_info,
+        max_step_description_length);
 
     for (const auto & right_join_tree_query_plan_row_policy : right_join_tree_query_plan.used_row_policies)
         left_join_tree_query_plan.used_row_policies.insert(right_join_tree_query_plan_row_policy);
@@ -2199,7 +2207,8 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
     JoinTreeQueryPlan right_join_tree_query_plan,
     const ColumnIdentifierSet & outer_scope_columns,
     PlannerContextPtr & planner_context,
-    const SelectQueryInfo & select_query_info)
+    const SelectQueryInfo & select_query_info,
+    size_t max_step_description_length)
 {
     auto & join_node = join_table_expression->as<JoinNode &>();
     if (left_join_tree_query_plan.stage != QueryProcessingStage::FetchColumns)
@@ -2212,7 +2221,7 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(
     const auto & settings = query_context->getSettingsRef();
     if (!settings[Setting::query_plan_use_new_logical_join_step])
         return buildQueryPlanForJoinNodeLegacy(
-            join_table_expression, std::move(left_join_tree_query_plan), std::move(right_join_tree_query_plan), outer_scope_columns, planner_context, select_query_info);
+            join_table_expression, std::move(left_join_tree_query_plan), std::move(right_join_tree_query_plan), outer_scope_columns, planner_context, select_query_info, max_step_description_length);
 
     auto join_step_logical = buildJoinStepLogical(
         left_join_tree_query_plan.query_plan.getCurrentHeader(),
@@ -2479,7 +2488,8 @@ JoinTreeQueryPlan buildJoinTreeQueryPlan(const QueryTreeNodePtr & query_node,
                 std::move(right_query_plan),
                 table_expressions_outer_scope_columns[i],
                 planner_context,
-                select_query_info));
+                select_query_info,
+                select_query_options.max_step_description_length));
         }
         else if (table_expression_node_type == QueryTreeNodeType::CROSS_JOIN)
         {
@@ -2502,7 +2512,8 @@ JoinTreeQueryPlan buildJoinTreeQueryPlan(const QueryTreeNodePtr & query_node,
                 std::move(plans),
                 table_expressions_outer_scope_columns[i],
                 planner_context,
-                select_query_info));
+                select_query_info,
+                select_query_options.max_step_description_length));
         }
         else
         {

--- a/src/Processors/QueryPlan/CreateSetAndFilterOnTheFlyStep.cpp
+++ b/src/Processors/QueryPlan/CreateSetAndFilterOnTheFlyStep.cpp
@@ -128,7 +128,7 @@ void CreateSetAndFilterOnTheFlyStep::transformPipeline(QueryPipelineBuilder & pi
         if (stream_type != QueryPipelineBuilder::StreamType::Main)
             return nullptr;
         auto res = std::make_shared<CreatingSetsOnTheFlyTransform>(header, column_names, num_streams, own_set);
-        res->setDescription(this->getStepDescription());
+        res->setDescription(std::string(this->getStepDescription()));
         return res;
     });
 

--- a/src/Processors/QueryPlan/IQueryPlanStep.cpp
+++ b/src/Processors/QueryPlan/IQueryPlanStep.cpp
@@ -1,3 +1,5 @@
+#include <string_view>
+#include <variant>
 #include <IO/Operators.h>
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>
@@ -48,6 +50,32 @@ const SharedHeader & IQueryPlanStep::getOutputHeader() const
         throw Exception(ErrorCodes::LOGICAL_ERROR, "QueryPlanStep {} does not have output stream.", getName());
 
     return output_header;
+}
+
+std::string_view IQueryPlanStep::getStepDescription() const
+{
+    if (std::holds_alternative<std::string_view>(step_description))
+        return std::get<std::string_view>(step_description);
+    if (std::holds_alternative<std::string>(step_description))
+        return std::get<std::string>(step_description);
+
+    return {};
+}
+
+void IQueryPlanStep::setStepDescription(std::string description, size_t limit)
+{
+    if (description.size() > limit)
+    {
+        description.resize(limit);
+        description.shrink_to_fit();
+    }
+
+    step_description = std::move(description);
+}
+
+void IQueryPlanStep::setStepDescription(const IQueryPlanStep & step)
+{
+    step_description = step.step_description;
 }
 
 QueryPlanStepPtr IQueryPlanStep::clone() const

--- a/src/Processors/QueryPlan/IQueryPlanStep.cpp
+++ b/src/Processors/QueryPlan/IQueryPlanStep.cpp
@@ -1,5 +1,3 @@
-#include <string_view>
-#include <variant>
 #include <IO/Operators.h>
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/CurrentThread.h>
+#include "base/defines.h"
 #include <Core/Block_fwd.h>
 #include <Core/SortDescription.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
@@ -62,7 +63,7 @@ public:
     void setStepDescription(const IQueryPlanStep & step);
 
     template <size_t size>
-    void setStepDescription(const char (&description)[size]) { step_description = std::string_view(description); }
+    ALWAYS_INLINE void setStepDescription(const char (&description)[size]) { step_description = std::string_view(description); }
 
     struct Serialization;
     struct Deserialization;
@@ -126,6 +127,8 @@ protected:
 
     /// Text description about what current step does.
     std::variant<std::string, std::string_view> step_description;
+
+    friend class DescriptionHolder;
 
     /// This field is used to store added processors from this step.
     /// It is used only for introspection (EXPLAIN PIPELINE).

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Common/CurrentThread.h>
-#include "base/defines.h"
 #include <Core/Block_fwd.h>
 #include <Core/SortDescription.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
@@ -63,7 +62,7 @@ public:
     void setStepDescription(const IQueryPlanStep & step);
 
     template <size_t size>
-    ALWAYS_INLINE void setStepDescription(const char (&description)[size]) { step_description = std::string_view(description); }
+    ALWAYS_INLINE void setStepDescription(const char (&description)[size]) { step_description = std::string_view(description, size - 1); }
 
     struct Serialization;
     struct Deserialization;

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -4,7 +4,6 @@
 #include <Core/Block_fwd.h>
 #include <Core/SortDescription.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
-#include <string_view>
 #include <variant>
 
 namespace DB

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -4,6 +4,8 @@
 #include <Core/Block_fwd.h>
 #include <Core/SortDescription.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <string_view>
+#include <variant>
 
 namespace DB
 {
@@ -56,8 +58,12 @@ public:
     const SharedHeader & getOutputHeader() const;
 
     /// Methods to describe what this step is needed for.
-    const std::string & getStepDescription() const { return step_description; }
-    void setStepDescription(std::string description) { step_description = std::move(description); }
+    std::string_view getStepDescription() const;
+    void setStepDescription(std::string description, size_t limit);
+    void setStepDescription(const IQueryPlanStep & step);
+
+    template <size_t size>
+    void setStepDescription(const char (&description)[size]) { step_description = std::string_view(description); }
 
     struct Serialization;
     struct Deserialization;
@@ -120,7 +126,7 @@ protected:
     SharedHeader output_header;
 
     /// Text description about what current step does.
-    std::string step_description;
+    std::variant<std::string, std::string_view> step_description;
 
     /// This field is used to store added processors from this step.
     /// It is used only for introspection (EXPLAIN PIPELINE).

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -610,7 +610,8 @@ static void addSortingForMergeJoin(
     QueryPlan::Nodes & nodes,
     const SortingStep::Settings & sort_settings,
     const JoinSettings & join_settings,
-    const TableJoin & table_join)
+    const TableJoin & table_join,
+    size_t max_step_description_length)
 {
     auto join_kind = table_join.kind();
     auto join_strictness = table_join.strictness();
@@ -623,7 +624,7 @@ static void addSortingForMergeJoin(
 
         auto sorting_step = std::make_unique<SortingStep>(
             node->step->getOutputHeader(), std::move(sort_description), 0 /*limit*/, sort_settings, true /*is_sorting_for_merge_join*/);
-        sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_table_side));
+        sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_table_side), max_step_description_length);
         node = &nodes.emplace_back(QueryPlan::Node{std::move(sorting_step), {node}});
     };
 
@@ -632,7 +633,7 @@ static void addSortingForMergeJoin(
     {
         auto creating_set_step = std::make_unique<CreateSetAndFilterOnTheFlyStep>(
             node->step->getOutputHeader(), key_names, join_settings.max_rows_in_set_to_optimize_join, crosswise_connection, join_table_side);
-        creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_table_side));
+        creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_table_side), max_step_description_length);
 
         auto * step_raw_ptr = creating_set_step.get();
         node = &nodes.emplace_back(QueryPlan::Node{std::move(creating_set_step), {node}});
@@ -695,7 +696,7 @@ static void constructPhysicalStep(
     node.children.resize(1);
 
     auto * join_left_node = node.children[0];
-    makeExpressionNodeOnTopOf(*join_left_node, std::move(left_pre_join_actions), nodes, "Left Join Actions");
+    makeExpressionNodeOnTopOf(*join_left_node, std::move(left_pre_join_actions), nodes, makeDescription("Left Join Actions"));
 
     node.step = std::make_unique<FilledJoinStep>(join_left_node->step->getOutputHeader(), join_ptr, join_settings.max_block_size);
 
@@ -703,7 +704,7 @@ static void constructPhysicalStep(
     makeFilterNodeOnTopOf(
         node, std::move(post_join_actions),
         residual_filter_condition.first, residual_filter_condition.second,
-        nodes, "Post Join Actions");
+        nodes, makeDescription("Post Join Actions"));
 }
 
 static void constructPhysicalStep(
@@ -727,13 +728,13 @@ static void constructPhysicalStep(
     auto * join_left_node = node.children[0];
     auto * join_right_node = node.children[1];
 
-    makeExpressionNodeOnTopOf(*join_left_node, std::move(left_pre_join_actions), nodes, "Left Pre Join Actions");
+    makeExpressionNodeOnTopOf(*join_left_node, std::move(left_pre_join_actions), nodes, makeDescription("Left Pre Join Actions"));
 
-    makeExpressionNodeOnTopOf(*join_right_node, std::move(right_pre_join_actions), nodes, "Right Pre Join Actions");
+    makeExpressionNodeOnTopOf(*join_right_node, std::move(right_pre_join_actions), nodes, makeDescription("Right Pre Join Actions"));
 
     if (const auto * fsmjoin = dynamic_cast<const FullSortingMergeJoin *>(join_ptr.get()))
         addSortingForMergeJoin(fsmjoin, join_left_node, join_right_node, nodes,
-            sorting_settings, join_settings, fsmjoin->getTableJoin());
+            sorting_settings, join_settings, fsmjoin->getTableJoin(), optimization_settings.max_step_description_length);
 
     auto required_output_from_join = post_join_actions.getRequiredColumnsNames();
     auto join_step = std::make_unique<JoinStep>(
@@ -756,7 +757,7 @@ static void constructPhysicalStep(
     makeFilterNodeOnTopOf(
         node, std::move(post_join_actions),
         residual_filter_condition.first, residual_filter_condition.second,
-        nodes, "Post Join Actions");
+        nodes, makeDescription("Post Join Actions"));
 }
 
 static QueryPlanNode buildPhysicalJoinImpl(
@@ -1351,7 +1352,7 @@ QueryPlanStepPtr JoinStepLogical::clone() const
         std::move(new_actions_after_join),
         join_settings,
         sorting_settings);
-    result_step->setStepDescription(getStepDescription());
+    result_step->setStepDescription(*this);
     return result_step;
 }
 

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -31,6 +31,8 @@ struct Optimization
 {
     struct ExtraSettings
     {
+        size_t max_step_description_length;
+
         /// Vector-search-related settings
         size_t max_limit_for_vector_search_queries;
         bool vector_search_with_rescoring;
@@ -165,12 +167,14 @@ std::optional<String> optimizeUseAggregateProjections(
     QueryPlan::Node & node,
     QueryPlan::Nodes & nodes,
     bool allow_implicit_projections,
-    bool is_parallel_replicas_initiator_with_projection_support);
+    bool is_parallel_replicas_initiator_with_projection_support,
+    size_t max_step_description_length);
 
 std::optional<String> optimizeUseNormalProjections(
     Stack & stack,
     QueryPlan::Nodes & nodes,
-    bool is_parallel_replicas_initiator_with_projection_support);
+    bool is_parallel_replicas_initiator_with_projection_support,
+    size_t max_step_description_length);
 
 bool addPlansForSets(const QueryPlanOptimizationSettings & optimization_settings, QueryPlan & plan, QueryPlan::Node & node, QueryPlan::Nodes & nodes);
 

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -93,6 +93,8 @@ struct QueryPlanOptimizationSettings
 
     /// Other settings related to plan-level optimizations
 
+    size_t max_step_description_length = 0;
+
     bool optimize_use_implicit_projections;
     bool force_use_projection;
     String force_projection_name;

--- a/src/Processors/QueryPlan/Optimizations/Utils.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Utils.cpp
@@ -19,7 +19,7 @@ bool isPassthroughActions(const ActionsDAG & actions_dag)
 template <typename Step, typename ...Args>
 bool makeExpressionNodeOnTopOfImpl(
     QueryPlan::Node & node, ActionsDAG actions_dag, QueryPlan::Nodes & nodes,
-    std::string_view step_description, Args && ...args)
+    DescriptionHolderPtr step_description, Args && ...args)
 {
     const auto & header = node.step->getOutputHeader();
     if (!header && !actions_dag.getInputs().empty())
@@ -27,26 +27,26 @@ bool makeExpressionNodeOnTopOfImpl(
 
     QueryPlanStepPtr step = std::make_unique<Step>(header, std::move(actions_dag), std::forward<Args>(args)...);
 
-    if (!step_description.empty())
-        step->setStepDescription(std::string(step_description));
+    if (step_description)
+        step_description->setStepDescription(*step);
 
     auto * new_node = &nodes.emplace_back(std::move(node));
     node = QueryPlan::Node{std::move(step), {new_node}};
     return true;
 }
 
-bool makeExpressionNodeOnTopOf(QueryPlan::Node & node, ActionsDAG actions_dag, QueryPlan::Nodes & nodes, std::string_view step_description)
+bool makeExpressionNodeOnTopOf(QueryPlan::Node & node, ActionsDAG actions_dag, QueryPlan::Nodes & nodes, DescriptionHolderPtr step_description)
 {
-    return makeExpressionNodeOnTopOfImpl<ExpressionStep>(node, std::move(actions_dag), nodes, step_description);
+    return makeExpressionNodeOnTopOfImpl<ExpressionStep>(node, std::move(actions_dag), nodes, std::move(step_description));
 }
 
 bool makeFilterNodeOnTopOf(
     QueryPlan::Node & node, ActionsDAG actions_dag, const String & filter_column_name, bool remove_filer,
-    QueryPlan::Nodes & nodes, std::string_view step_description)
+    QueryPlan::Nodes & nodes, DescriptionHolderPtr step_description)
 {
     if (filter_column_name.empty())
-        return makeExpressionNodeOnTopOfImpl<ExpressionStep>(node, std::move(actions_dag), nodes, step_description);
-    return makeExpressionNodeOnTopOfImpl<FilterStep>(node, std::move(actions_dag), nodes, step_description, filter_column_name, remove_filer);
+        return makeExpressionNodeOnTopOfImpl<ExpressionStep>(node, std::move(actions_dag), nodes, std::move(step_description));
+    return makeExpressionNodeOnTopOfImpl<FilterStep>(node, std::move(actions_dag), nodes, std::move(step_description), filter_column_name, remove_filer);
 }
 
 

--- a/src/Processors/QueryPlan/Optimizations/Utils.h
+++ b/src/Processors/QueryPlan/Optimizations/Utils.h
@@ -2,7 +2,6 @@
 
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
-#include "base/defines.h"
 
 namespace DB
 {
@@ -21,7 +20,7 @@ class DescriptionHolder : public IDescriptionHolder
 {
 public:
     template <size_t size>
-    ALWAYS_INLINE explicit DescriptionHolder(const char (&description_)[size]) : description(description_, size) {}
+    ALWAYS_INLINE explicit DescriptionHolder(const char (&description_)[size]) : description(description_, size - 1) {}
 
     void setStepDescription(IQueryPlanStep & step) const override
     {

--- a/src/Processors/QueryPlan/Optimizations/Utils.h
+++ b/src/Processors/QueryPlan/Optimizations/Utils.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
 

--- a/src/Processors/QueryPlan/Optimizations/liftUpArrayJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpArrayJoin.cpp
@@ -4,11 +4,12 @@
 #include <Processors/QueryPlan/ArrayJoinStep.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/ArrayJoinAction.h>
+#include "Processors/QueryPlan/IQueryPlanStep.h"
 
 namespace DB::QueryPlanOptimizations
 {
 
-size_t tryLiftUpArrayJoin(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes, const Optimization::ExtraSettings & /*settings*/)
+size_t tryLiftUpArrayJoin(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes, const Optimization::ExtraSettings & settings)
 {
     if (parent_node->children.size() != 1)
         return 0;
@@ -34,8 +35,6 @@ size_t tryLiftUpArrayJoin(QueryPlan::Node * parent_node, QueryPlan::Nodes & node
     if (split_actions.first.trivial())
         return 0;
 
-    auto description = parent->getStepDescription();
-
     /// Add new expression step before ARRAY JOIN.
     /// Expression/Filter -> ArrayJoin -> Something
     auto & node = nodes.emplace_back();
@@ -45,16 +44,18 @@ size_t tryLiftUpArrayJoin(QueryPlan::Node * parent_node, QueryPlan::Nodes & node
 
     node.step = std::make_unique<ExpressionStep>(node.children.at(0)->step->getOutputHeader(),
                                                  std::move(split_actions.first));
-    node.step->setStepDescription(description);
+    node.step->setStepDescription(*parent);
     array_join_step->updateInputHeader(node.step->getOutputHeader());
 
+    QueryPlanStepPtr new_step;
     if (expression_step)
-        parent = std::make_unique<ExpressionStep>(array_join_step->getOutputHeader(), std::move(split_actions.second));
+        new_step = std::make_unique<ExpressionStep>(array_join_step->getOutputHeader(), std::move(split_actions.second));
     else
-        parent = std::make_unique<FilterStep>(array_join_step->getOutputHeader(), std::move(split_actions.second),
+        new_step = std::make_unique<FilterStep>(array_join_step->getOutputHeader(), std::move(split_actions.second),
                                               filter_step->getFilterColumnName(), filter_step->removesFilterColumn());
 
-    parent->setStepDescription(description + " [split]");
+    new_step->setStepDescription(fmt::format("{} [split]", parent->getStepDescription()), settings.max_step_description_length);
+    parent = std::move(new_step);
     return 3;
 }
 

--- a/src/Processors/QueryPlan/Optimizations/liftUpArrayJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpArrayJoin.cpp
@@ -4,7 +4,6 @@
 #include <Processors/QueryPlan/ArrayJoinStep.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/ArrayJoinAction.h>
-#include "Processors/QueryPlan/IQueryPlanStep.h"
 
 namespace DB::QueryPlanOptimizations
 {

--- a/src/Processors/QueryPlan/Optimizations/liftUpUnion.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpUnion.cpp
@@ -51,7 +51,7 @@ size_t tryLiftUpUnion(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes, c
             expr_node.step = std::make_unique<ExpressionStep>(
                 expr_node.children.front()->step->getOutputHeader(),
                 expression->getExpression().clone());
-            expr_node.step->setStepDescription(expression->getStepDescription());
+            expr_node.step->setStepDescription(*expression);
         }
 
         ///       - Expression - Something
@@ -90,7 +90,7 @@ size_t tryLiftUpUnion(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes, c
                 distinct->getColumnNames(),
                 distinct->isPreliminary());
 
-            distinct_node.step->setStepDescription(distinct->getStepDescription());
+            distinct_node.step->setStepDescription(*distinct);
         }
 
         ///       - Distinct - Something

--- a/src/Processors/QueryPlan/Optimizations/mergeExpressions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/mergeExpressions.cpp
@@ -70,7 +70,7 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, co
             std::move(merged),
             parent_filter->getFilterColumnName(),
             parent_filter->removesFilterColumn());
-            filter->setStepDescription(fmt::format("({} + {})", parent_filter->getStepDescription(), child_expr->getStepDescription()), settings.max_step_description_length);
+        filter->setStepDescription(fmt::format("({} + {})", parent_filter->getStepDescription(), child_expr->getStepDescription()), settings.max_step_description_length);
 
         parent_node->step = std::move(filter);
         parent_node->children.swap(child_node->children);

--- a/src/Processors/QueryPlan/Optimizations/mergeExpressions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/mergeExpressions.cpp
@@ -21,7 +21,7 @@ static void removeFromOutputs(ActionsDAG & dag, const ActionsDAG::Node & node)
     }
 }
 
-size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, const Optimization::ExtraSettings & /*settings*/)
+size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, const Optimization::ExtraSettings & settings)
 {
     if (parent_node->children.size() != 1)
         return false;
@@ -49,7 +49,7 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, co
         auto merged = ActionsDAG::merge(std::move(child_actions), std::move(parent_actions));
 
         auto expr = std::make_unique<ExpressionStep>(child_expr->getInputHeaders().front(), std::move(merged));
-        expr->setStepDescription("(" + parent_expr->getStepDescription() + " + " + child_expr->getStepDescription() + ")");
+        expr->setStepDescription(fmt::format("({} + {})", parent_expr->getStepDescription(), child_expr->getStepDescription()), settings.max_step_description_length);
 
         parent_node->step = std::move(expr);
         parent_node->children.swap(child_node->children);
@@ -70,7 +70,7 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, co
             std::move(merged),
             parent_filter->getFilterColumnName(),
             parent_filter->removesFilterColumn());
-        filter->setStepDescription("(" + parent_filter->getStepDescription() + " + " + child_expr->getStepDescription() + ")");
+            filter->setStepDescription(fmt::format("({} + {})", parent_filter->getStepDescription(), child_expr->getStepDescription()), settings.max_step_description_length);
 
         parent_node->step = std::move(filter);
         parent_node->children.swap(child_node->children);
@@ -79,7 +79,7 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, co
 
     return 0;
 }
-size_t tryMergeFilters(QueryPlan::Node * parent_node, QueryPlan::Nodes &, const Optimization::ExtraSettings & /*settings*/)
+size_t tryMergeFilters(QueryPlan::Node * parent_node, QueryPlan::Nodes &, const Optimization::ExtraSettings & settings)
 {
     if (parent_node->children.size() != 1)
         return false;
@@ -121,7 +121,7 @@ size_t tryMergeFilters(QueryPlan::Node * parent_node, QueryPlan::Nodes &, const 
                                                    std::move(child_actions),
                                                    condition.result_name,
                                                    true);
-        filter->setStepDescription("(" + parent_filter->getStepDescription() + " + " + child_filter->getStepDescription() + ")");
+        filter->setStepDescription(fmt::format("({} + {})", parent_filter->getStepDescription(), child_filter->getStepDescription()), settings.max_step_description_length);
 
         parent_node->step = std::move(filter);
         parent_node->children.swap(child_node->children);

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -12,6 +12,7 @@
 #include <Storages/MergeTree/MergeTreeWhereOptimizer.h>
 #include <Storages/StorageDummy.h>
 #include <Storages/StorageMerge.h>
+#include "Processors/QueryPlan/IQueryPlanStep.h"
 
 namespace DB
 {
@@ -150,7 +151,6 @@ void optimizePrewhere(Stack & stack, QueryPlan::Nodes &)
     if (!filter_step)
         return;
 
-    auto filter_step_description = filter_step->getStepDescription();
     const auto & context = source_step_with_filter->getContext();
     const auto & settings = context->getSettingsRef();
 
@@ -212,23 +212,25 @@ void optimizePrewhere(Stack & stack, QueryPlan::Nodes &)
 
     source_step_with_filter->updatePrewhereInfo(prewhere_info);
 
+    QueryPlanStepPtr new_step;
     if (!optimize_result.fully_moved_to_prewhere)
     {
-        filter_node->step = std::make_unique<FilterStep>(
+        new_step = std::make_unique<FilterStep>(
             source_step_with_filter->getOutputHeader(),
             std::move(remaining_expr),
             filter_step->getFilterColumnName(),
             filter_step->removesFilterColumn());
-        filter_node->step->setStepDescription(std::move(filter_step_description));
     }
     else
     {
         /// Have to keep this expression to change column names to column identifiers
-        filter_node->step = std::make_unique<ExpressionStep>(
+        new_step = std::make_unique<ExpressionStep>(
             source_step_with_filter->getOutputHeader(),
             std::move(remaining_expr));
-        filter_node->step->setStepDescription(std::move(filter_step_description));
     }
+
+    new_step->setStepDescription(*filter_step);
+    filter_node->step = std::move(new_step);
 }
 
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -12,7 +12,6 @@
 #include <Storages/MergeTree/MergeTreeWhereOptimizer.h>
 #include <Storages/StorageDummy.h>
 #include <Storages/StorageMerge.h>
-#include "Processors/QueryPlan/IQueryPlanStep.h"
 
 namespace DB
 {

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -48,6 +48,7 @@ void optimizeTreeFirstPass(const QueryPlanOptimizationSettings & optimization_se
 
 
     Optimization::ExtraSettings extra_settings = {
+        optimization_settings.max_step_description_length,
         optimization_settings.max_limit_for_vector_search_queries,
         optimization_settings.vector_search_with_rescoring,
         optimization_settings.vector_search_filter_strategy,
@@ -167,6 +168,7 @@ void optimizeTreeSecondPass(
     bool has_reading_from_mt = false;
 
     Optimization::ExtraSettings extra_settings = {
+        optimization_settings.max_step_description_length,
         optimization_settings.max_limit_for_vector_search_queries,
         optimization_settings.vector_search_with_rescoring,
         optimization_settings.vector_search_filter_strategy,
@@ -242,7 +244,8 @@ void optimizeTreeSecondPass(
                         *frame.node,
                         nodes,
                         optimization_settings.optimize_use_implicit_projections,
-                        optimization_settings.is_parallel_replicas_initiator_with_projection_support);
+                        optimization_settings.is_parallel_replicas_initiator_with_projection_support,
+                        optimization_settings.max_step_description_length);
                     if (applied_projection)
                         applied_projection_names.insert(*applied_projection);
                 }
@@ -267,7 +270,8 @@ void optimizeTreeSecondPass(
             if (auto applied_projection = optimizeUseNormalProjections(
                 stack,
                 nodes,
-                optimization_settings.is_parallel_replicas_initiator_with_projection_support))
+                optimization_settings.is_parallel_replicas_initiator_with_projection_support,
+                optimization_settings.max_step_description_length))
             {
                 applied_projection_names.insert(*applied_projection);
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -467,7 +467,8 @@ std::optional<String> optimizeUseAggregateProjections(
     QueryPlan::Node & node,
     QueryPlan::Nodes & nodes,
     bool allow_implicit_projections,
-    bool is_parallel_replicas_initiator_with_projection_support)
+    bool is_parallel_replicas_initiator_with_projection_support,
+    size_t max_step_description_length)
 {
     if (node.children.size() != 1)
         return {};
@@ -830,7 +831,7 @@ std::optional<String> optimizeUseAggregateProjections(
         });
     }
 
-    projection_reading->setStepDescription(selected_projection_name);
+    projection_reading->setStepDescription(selected_projection_name, max_step_description_length);
     auto & projection_reading_node = nodes.emplace_back(QueryPlan::Node{.step = std::move(projection_reading)});
 
     /// Root node of optimized child plan using @projection_name

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -77,7 +77,8 @@ static std::optional<ActionsDAG> makeMaterializingDAG(const Block & proj_header,
 std::optional<String> optimizeUseNormalProjections(
     Stack & stack,
     QueryPlan::Nodes & nodes,
-    bool is_parallel_replicas_initiator_with_projection_support)
+    bool is_parallel_replicas_initiator_with_projection_support,
+    size_t max_step_description_length)
 {
     const auto & frame = stack.back();
 
@@ -388,7 +389,7 @@ std::optional<String> optimizeUseNormalProjections(
         });
     }
 
-    projection_reading->setStepDescription(best_candidate->projection->name);
+    projection_reading->setStepDescription(best_candidate->projection->name, max_step_description_length);
 
     auto & projection_reading_node = nodes.emplace_back(QueryPlan::Node{.step = std::move(projection_reading)});
     auto * next_node = &projection_reading_node;

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -319,13 +319,16 @@ JSONBuilder::ItemPtr QueryPlan::explainPlan(const ExplainPlanOptions & options) 
 static void explainStep(
     IQueryPlanStep & step,
     IQueryPlanStep::FormatSettings & settings,
-    const ExplainPlanOptions & options)
+    const ExplainPlanOptions & options,
+    size_t max_description_lengs)
 {
     std::string prefix(settings.offset, ' ');
     settings.out << prefix;
     settings.out << step.getName();
 
-    const auto & description = step.getStepDescription();
+    auto description = step.getStepDescription();
+    if (max_description_lengs)
+        description = description.substr(0, max_description_lengs);
     if (options.description && !description.empty())
         settings.out <<" (" << description << ')';
 
@@ -387,11 +390,11 @@ std::string debugExplainStep(IQueryPlanStep & step)
     WriteBufferFromOwnString out;
     ExplainPlanOptions options{.actions = true};
     IQueryPlanStep::FormatSettings settings{.out = out};
-    explainStep(step, settings, options);
+    explainStep(step, settings, options, 0);
     return out.str();
 }
 
-void QueryPlan::explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & options, size_t indent) const
+void QueryPlan::explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & options, size_t indent, size_t max_description_lengs) const
 {
     checkInitialized();
 
@@ -414,7 +417,7 @@ void QueryPlan::explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & opt
         if (!frame.is_description_printed)
         {
             settings.offset = (indent + stack.size() - 1) * settings.indent;
-            explainStep(*frame.node->step, settings, options);
+            explainStep(*frame.node->step, settings, options, max_description_lengs);
             frame.is_description_printed = true;
         }
 

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -102,7 +102,7 @@ public:
     };
 
     JSONBuilder::ItemPtr explainPlan(const ExplainPlanOptions & options) const;
-    void explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & options, size_t indent = 0) const;
+    void explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & options, size_t indent = 0, size_t max_description_lengs = 0) const;
     void explainPipeline(WriteBuffer & buffer, const ExplainPipelineOptions & options) const;
     void explainEstimate(MutableColumns & columns) const;
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -181,6 +181,7 @@ namespace Setting
     extern const SettingsBool use_query_condition_cache;
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
     extern const SettingsBool enable_shared_storage_snapshot_in_query;
+    extern const SettingsUInt64 query_plan_max_step_description_length;
 }
 
 namespace MergeTreeSetting
@@ -380,7 +381,8 @@ ReadFromMergeTree::ReadFromMergeTree(
     }
 
     /// Add explicit description.
-    setStepDescription(data.getStorageID().getFullNameNotQuoted());
+    std::string description = data.getStorageID().getFullNameNotQuoted();
+    setStepDescription(description, context->getSettingsRef()[Setting::query_plan_max_step_description_length]);
     enable_vertical_final = query_info.isFinal() && context->getSettingsRef()[Setting::enable_vertical_final]
         && data.merging_params.mode == MergeTreeData::MergingParams::Replacing;
 }

--- a/src/Processors/QueryPlan/ReadFromPreparedSource.cpp
+++ b/src/Processors/QueryPlan/ReadFromPreparedSource.cpp
@@ -2,9 +2,16 @@
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/IStorage.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsUInt64 query_plan_max_step_description_length;
+}
 
 ReadFromPreparedSource::ReadFromPreparedSource(Pipe pipe_)
     : ISourceStep(pipe_.getSharedHeader())
@@ -30,7 +37,8 @@ ReadFromStorageStep::ReadFromStorageStep(
     , context(std::move(context_))
     , query_info(query_info_)
 {
-    setStepDescription(storage->getName());
+    auto description = storage->getName();
+    setStepDescription(description, context->getSettingsRef()[Setting::query_plan_max_step_description_length]);
 
     for (const auto & processor : pipe.getProcessors())
         processor->setStorageLimits(query_info.storage_limits);

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -53,6 +53,7 @@ namespace DB
 {
 namespace Setting
 {
+    extern const SettingsUInt64 query_plan_max_step_description_length;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
@@ -881,7 +882,7 @@ ReadFromParallelRemoteReplicasStep::ReadFromParallelRemoteReplicasStep(
     }
 
     auto description = fmt::format("Query: {} Replicas: {}", formattedAST(query_ast), fmt::join(replicas, ", "));
-    setStepDescription(std::move(description));
+    setStepDescription(std::move(description), context->getSettingsRef()[Setting::query_plan_max_step_description_length]);
 }
 
 void ReadFromParallelRemoteReplicasStep::enableMemoryBoundMerging()

--- a/tests/queries/0_stateless/02383_join_and_filtering_set.reference
+++ b/tests/queries/0_stateless/02383_join_and_filtering_set.reference
@@ -1,19 +1,24 @@
+Test 1000  2 6
 Ok
 Ok
 Ok
 Ok
 Ok
+Test 1000 LEFT 2 5
 Ok
 Ok
 Ok
 Ok
 Ok
+Test 1000 RIGHT 2 5
 Ok
 Ok
 Ok
 Ok
 Ok
+Test 1000 FULL 0 0
 Ok
 Ok
+Test 0  0 0
 Ok
 Ok

--- a/tests/queries/0_stateless/02383_join_and_filtering_set.sh
+++ b/tests/queries/0_stateless/02383_join_and_filtering_set.sh
@@ -47,6 +47,8 @@ DESC=$(sed -n "$SED_EXPR" <<<  "$QUERY_RESULT")
 # - expected number of steps in pipeline
 function test() {
 
+echo "Test $1 $2 $3 $4"
+
 PARAM_VALUE=$1
 JOIN_KIND=${2:-}
 

--- a/tests/queries/0_stateless/02918_optimize_count_for_merge_tables.reference
+++ b/tests/queries/0_stateless/02918_optimize_count_for_merge_tables.reference
@@ -7,9 +7,9 @@ Expression ((Projection + Before ORDER BY))
   Aggregating
     Expression (Before GROUP BY)
       ReadFromMerge
-        Expression (( + ))
+        Expression
           ReadFromMergeTree (default.mt1)
-        Expression (( + ))
+        Expression
           ReadFromMergeTree (default.mt2)
-        Expression (( + ))
+        Expression
           ReadFromStorage (TinyLog)

--- a/tests/queries/0_stateless/03217_filtering_in_storage_merge.reference
+++ b/tests/queries/0_stateless/03217_filtering_in_storage_merge.reference
@@ -2,5 +2,5 @@ Expression ((Project names + Projection))
   Aggregating
     Expression (Before GROUP BY)
       ReadFromMerge
-        Filter (( + ( + ( + ))))
+        Filter
           ReadFromMergeTree (default.test_03217_merge_replica_1)

--- a/tests/queries/0_stateless/03604_plan_step_description_limit.reference
+++ b/tests/queries/0_stateless/03604_plan_step_description_limit.reference
@@ -1,0 +1,10 @@
+Expression (Pro)
+  Expression (Pro)
+    Aggregating
+      Expression (Bef)
+        Expression (Cha)
+          ReadFromSystemNumbers
+Expression ((Pr)
+  Aggregating
+    Expression ((Be)
+      ReadFromSystemNumbers

--- a/tests/queries/0_stateless/03604_plan_step_description_limit.sql
+++ b/tests/queries/0_stateless/03604_plan_step_description_limit.sql
@@ -1,0 +1,4 @@
+set enable_analyzer=1;
+
+explain description=1, optimize=0 select sum(number + 1) from numbers(10) settings query_plan_max_step_description_length=3;
+explain description=1, optimize=1 select sum(number + 1) from numbers(10) settings query_plan_max_step_description_length=3;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Limit query plan description in the `EXPLAIN` query. Do not calculate the description for queries other than `EXPLAIN`. Added a setting `query_plan_max_step_description_length`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
