### PR TITLE
CI: Support requesting multiple AWS params at once, fix throttling

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -44,31 +44,31 @@ BASE_BRANCH = "master"
 
 azure_secret = Secret.Config(
     name="azure_connection_string",
-    type=Secret.Type.AWS_SSM_VAR,
+    type=Secret.Type.AWS_SSM_PARAMETER,
 )
 
 chcache_secret = Secret.Config(
     name="chcache_password",
-    type=Secret.Type.AWS_SSM_VAR,
+    type=Secret.Type.AWS_SSM_PARAMETER,
     region="us-east-1",
 )
 
 SECRETS = [
     Secret.Config(
         name="dockerhub_robot_password",
-        type=Secret.Type.AWS_SSM_VAR,
+        type=Secret.Type.AWS_SSM_PARAMETER,
     ),
     Secret.Config(
         name="clickhouse-test-stat-url",
-        type=Secret.Type.AWS_SSM_VAR,
+        type=Secret.Type.AWS_SSM_PARAMETER,
     ),
     Secret.Config(
         name="clickhouse-test-stat-login",
-        type=Secret.Type.AWS_SSM_VAR,
+        type=Secret.Type.AWS_SSM_PARAMETER,
     ),
     Secret.Config(
         name="clickhouse-test-stat-password",
-        type=Secret.Type.AWS_SSM_VAR,
+        type=Secret.Type.AWS_SSM_PARAMETER,
     ),
     azure_secret,
     chcache_secret,

--- a/ci/jobs/collect_statistics.py
+++ b/ci/jobs/collect_statistics.py
@@ -113,15 +113,15 @@ if __name__ == "__main__":
     cidb = CIDB(
         url=Secret.Config(
             name="clickhouse-test-stat-url",
-            type=Secret.Type.AWS_SSM_VAR,
+            type=Secret.Type.AWS_SSM_PARAMETER,
         ).get_value(),
         user=Secret.Config(
             name="clickhouse-test-stat-login",
-            type=Secret.Type.AWS_SSM_VAR,
+            type=Secret.Type.AWS_SSM_PARAMETER,
         ).get_value(),
         passwd=Secret.Config(
             name="clickhouse-test-stat-password",
-            type=Secret.Type.AWS_SSM_VAR,
+            type=Secret.Type.AWS_SSM_PARAMETER,
         ).get_value(),
     )
 

--- a/ci/jobs/docker_server_job.py
+++ b/ci/jobs/docker_server_job.py
@@ -42,7 +42,7 @@ def docker_login(relogin: bool = True) -> None:
             "docker login --username 'robotclickhouse' --password-stdin",
             strict=True,
             stdin_str=Secret.Config(
-                "dockerhub_robot_password", type=Secret.Type.AWS_SSM_VAR
+                "dockerhub_robot_password", type=Secret.Type.AWS_SSM_PARAMETER
             ).get_value(),
             encoding="utf-8",
         )

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -143,7 +143,9 @@ def main():
             Shell.check(f"ln -sf {clickhouse_bin_path} {clickhouse_server_link}")
         Shell.check(f"chmod +x {clickhouse_bin_path}")
     else:
-        os.environ["CH_HOSTNAME"] = "https://build-cache.eu-west-1.aws.clickhouse-staging.com"
+        os.environ["CH_HOSTNAME"] = (
+            "https://build-cache.eu-west-1.aws.clickhouse-staging.com"
+        )
         os.environ["CH_USER"] = "ci_builder"
         os.environ["CH_PASSWORD"] = chcache_secret.get_value()
         os.environ["CH_USE_LOCAL_CACHE"] = "false"

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -95,7 +95,9 @@ chmod a+rw -R /packages
 exit 1
 """
     (TEMP_PATH / "server_test.sh").write_text(server_test, encoding="utf-8")
-    (TEMP_PATH / "initd_via_systemd_test.sh").write_text(initd_via_systemd_test, encoding="utf-8")
+    (TEMP_PATH / "initd_via_systemd_test.sh").write_text(
+        initd_via_systemd_test, encoding="utf-8"
+    )
     (TEMP_PATH / "initd_test.sh").write_text(initd_test, encoding="utf-8")
     (TEMP_PATH / "keeper_test.sh").write_text(keeper_test, encoding="utf-8")
     (TEMP_PATH / "binary_test.sh").write_text(binary_test, encoding="utf-8")

--- a/ci/jobs/scripts/log_cluster.py
+++ b/ci/jobs/scripts/log_cluster.py
@@ -27,12 +27,12 @@ class LogCluster:
         if not self.url:
             url = Secret.Config(
                 name=self.URL_SECRET,
-                type=Secret.Type.AWS_SSM_VAR,
+                type=Secret.Type.AWS_SSM_PARAMETER,
             ).get_value()
             self.url = "https://" + url.removeprefix("https://")
         passwd = Secret.Config(
             name=self.PASSWD_SECRET,
-            type=Secret.Type.AWS_SSM_VAR,
+            type=Secret.Type.AWS_SSM_PARAMETER,
         ).get_value()
         if not self.url:
             print("ERROR: failed to retrive password for LogCluster")

--- a/ci/praktika/secret.py
+++ b/ci/praktika/secret.py
@@ -1,19 +1,21 @@
 import dataclasses
 import os
+from typing import List, Union
 
 from .utils import Shell
 
 
 class Secret:
+
     class Type:
-        AWS_SSM_VAR = "aws parameter"
+        AWS_SSM_PARAMETER = "aws parameter"
         AWS_SSM_SECRET = "aws secret"
         GH_SECRET = "gh secret"
         GH_VAR = "gh var"
 
     @dataclasses.dataclass
     class Config:
-        name: str
+        name: Union[List[str], str]
         type: str
         region: str = ""
 
@@ -24,16 +26,27 @@ class Secret:
             return self.type == Secret.Type.GH_VAR
 
         def get_value(self):
-            if self.type == Secret.Type.AWS_SSM_VAR:
-                return self.get_aws_ssm_var()
+            if self.type == Secret.Type.AWS_SSM_PARAMETER:
+                if isinstance(self.name, list):
+                    return self.get_aws_ssm_parameters()
+                else:
+                    return self.get_aws_ssm_parameter()
             if self.type == Secret.Type.AWS_SSM_SECRET:
-                return self.get_aws_ssm_secret()
+                if isinstance(self.name, list):
+                    # add support for requesting all at once
+                    assert False, "TODO: Not supported"
+                else:
+                    return self.get_aws_ssm_secret()
             elif self.type in (Secret.Type.GH_SECRET, Secret.Type.GH_VAR):
-                return self.get_gh_secret()
+                if isinstance(self.name, list):
+                    # add support for requesting all at once
+                    assert False, "TODO: Not supported"
+                else:
+                    return self.get_gh_secret()
             else:
                 assert False, f"Not supported secret type, secret [{self}]"
 
-        def get_aws_ssm_var(self):
+        def get_aws_ssm_parameter(self):
             region = ""
             if self.region:
                 region = f" --region {self.region}"
@@ -42,6 +55,37 @@ class Secret:
                 strict=True,
             )
             return res
+
+        def get_aws_ssm_parameters(self):
+            """
+            Request multiple parameters at once to avoid rate limiting
+            """
+            region = ""
+            if self.region:
+                region = f" --region {self.region}"
+            assert isinstance(self.name, list)
+            res = Shell.get_output(
+                f"aws ssm get-parameters --names {' '.join(self.name)} --with-decryption --output text --query 'Parameters[*].[Name,Value]' {region}",
+                strict=True,
+            )
+            name_value_pairs = res.split("\n")
+            names = [n.split("\t")[0].strip() for n in name_value_pairs]
+            values = [n.split("\t")[1].strip() for n in name_value_pairs]
+
+            for n in self.name:
+                if n not in names:
+                    raise RuntimeError(f"Failed to get value for parameter [{n}]")
+
+            # Sort to match requested order and validate values:
+            name_value_pairs = list(zip(names, values))
+            name_value_pairs.sort(key=lambda x: self.name.index(x[0]))
+
+            for name, value in name_value_pairs:
+                if not value:
+                    raise RuntimeError(f"Empty value for parameter [{name}]")
+
+            values = [pair[1] for pair in name_value_pairs]
+            return values
 
         def get_aws_ssm_secret(self):
             name, secret_key_name = self.name, ""
@@ -62,6 +106,30 @@ class Secret:
                 print(f"ERROR: Failed to get secret [{self.name}]")
                 raise RuntimeError()
             return res
+
+        def join_with(self, other):
+            """
+            Join secrets of the same type and region, to allow requesting all at once and save on api calls if applicable
+            """
+            assert (
+                self.type == other.type
+            ), f"Secrets must have the same type [{self.type}] and [{other.type}]"
+            assert (
+                self.region == other.region
+            ), f"Secrets must have the same region [{self.region}] and [{other.region}]"
+            assert (
+                self.name != other.name
+            ), f"Secrets must have different names [{self.name}] and [{other.name}]"
+            assert isinstance(
+                other.name, str
+            ), f"Secret [{other.name}] must be single name"
+
+            # Convert self.name to list if it's a string
+            if isinstance(self.name, str):
+                self.name = [self.name]
+
+            self.name.append(other.name)
+            return self
 
         def __repr__(self):
             return self.name


### PR DESCRIPTION
AWS SSM parameter store rate limit of 40TPS gets exhousted sometimes, causing a throttling error:
`An error occurred (ThrottlingException) when calling the GetParameter operation (reached max retries: 2): Rate exceeded`

Change adds support in praktika to join multiple Secret.Config(s) into one and request them with one api call

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
