### PR TITLE
Fix incompatible exception about wildcard partition strategy

### DIFF
--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -232,8 +232,16 @@ std::shared_ptr<IPartitionStrategy> PartitionStrategyFactory::get(StrategyType s
                 globbed_path,
                 partition_columns_in_data_file);
         case StrategyType::NONE:
+        {
+            if (!partition_columns_in_data_file && strategy == PartitionStrategyFactory::StrategyType::NONE)
+            {
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Partition strategy `none` cannot be used with partition_columns_in_data_file=0");
+            }
             /// Unreachable for plain object storage, used only by Data Lakes for now
             return nullptr;
+        }
     }
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -82,8 +82,11 @@ void StorageObjectStorageConfiguration::initialize(
     }
     else if (configuration_to_initialize.partition_strategy_type == PartitionStrategyFactory::StrategyType::NONE)
     {
-        // Promote to wildcard in case it is not data lake to make it backwards compatible
-        configuration_to_initialize.partition_strategy_type = PartitionStrategyFactory::StrategyType::WILDCARD;
+        if (configuration_to_initialize.getRawPath().hasPartitionWildcard())
+        {
+            // Promote to wildcard in case it is not data lake to make it backwards compatible
+            configuration_to_initialize.partition_strategy_type = PartitionStrategyFactory::StrategyType::WILDCARD;
+        }
     }
 
     if (configuration_to_initialize.format == "auto")

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2882,12 +2882,17 @@ def test_file_pruning_with_hive_style_partitioning(started_cluster):
 
     # 1 file with 2 rows.
     assert 1 == int(
-        node.query(f"SELECT uniqExact(_path) FROM {table_name} WHERE b == 3 AND c == '1'")
+        node.query(
+            f"SELECT uniqExact(_path) FROM {table_name} WHERE b == 3 AND c == '1'"
+        )
     )
 
     query_id = f"{table_name}_query_3"
     assert 2 == int(
-        node.query(f"SELECT count() FROM {table_name} WHERE b == 3 AND c == '1'", query_id=query_id)
+        node.query(
+            f"SELECT count() FROM {table_name} WHERE b == 3 AND c == '1'",
+            query_id=query_id,
+        )
     )
     # Check files are pruned.
     check_read_files(1, query_id)
@@ -2898,3 +2903,19 @@ def test_file_pruning_with_hive_style_partitioning(started_cluster):
     )
     # Nothing is pruned, because `a` is not a partition column.
     check_read_files(10, query_id)
+
+
+def test_partition_by_without_wildcard(started_cluster):
+    node = started_cluster.instances["dummy"]
+    table_name = f"test_partition_by_without_wildcard_{generate_random_string()}"
+    bucket = started_cluster.minio_bucket
+
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_name}"
+    # An exception "Partition strategy wildcard can not be used without a '_partition_id' wildcard"
+    # should not be thrown.
+    node.query(
+        f"""
+CREATE TABLE {table_name} (a Int32, b Int32, c String) ENGINE = S3('{url}', format = 'Parquet')
+PARTITION BY (b, c)
+"""
+    )

--- a/tests/queries/0_stateless/03547_s3_partition_by_require_partition_wildcard.sql
+++ b/tests/queries/0_stateless/03547_s3_partition_by_require_partition_wildcard.sql
@@ -1,3 +1,0 @@
--- Tags: no-parallel, no-fasttest, no-random-settings
-
-CREATE TABLE s3_03547 (id UInt64) ENGINE=S3(s3_conn, format=Parquet) PARTITION BY id; -- {serverError BAD_ARGUMENTS}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception `Partition strategy wildcard can not be used without a '_partition_id' wildcard.` when creating a table with `PARTITION BY`, but without partition wildcard, which used to work in versions before 25.8. Closes https://github.com/ClickHouse/clickhouse-private/issues/37567.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
