### PR TITLE
Fix LogicalError if parallel queries are trying to acquire single lock

### DIFF
--- a/src/Interpreters/InterpreterParallelWithQuery.cpp
+++ b/src/Interpreters/InterpreterParallelWithQuery.cpp
@@ -87,6 +87,7 @@ void InterpreterParallelWithQuery::executeSubqueries(const ASTs & subqueries)
         {
             ContextMutablePtr subquery_context = Context::createCopy(context);
             subquery_context->makeQueryContext();
+            subquery_context->setCurrentQueryId({});
 
             auto callback = [this, subquery, subquery_context, error_found]
             {

--- a/tests/queries/0_stateless/03604_parallel_with_query_lock.sql
+++ b/tests/queries/0_stateless/03604_parallel_with_query_lock.sql
@@ -1,0 +1,6 @@
+SET max_threads = 1;
+SET lock_acquire_timeout = 1;
+
+CREATE TABLE t0 (c0 Int) ENGINE = Memory();
+
+INSERT INTO TABLE t0 (c0) SELECT 1 PARALLEL WITH TRUNCATE t0; -- { serverError DEADLOCK_AVOIDED }


### PR DESCRIPTION
Before the patch, `parallel with` queries shared the same query_id used to acquire the table drop lock.

Closes: #79413

### Changelog category (leave one):
Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description]
Fix LogicalError if parallel queries are trying to acquire single lock

