### PR TITLE
Add ability to tune pending signals in attempt to overcome CANNOT_CREATE_TIMER

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1878,4 +1878,17 @@
 
     <skip_binary_checksum_checks>false</skip_binary_checksum_checks>
     -->
+
+    <!-- Tune maximum core file size (RLIMIT_CORE) -->
+    <!--
+    <core_dump>
+        <size_limit></size_limit>
+    </core_dump>
+    -->
+
+    <!-- Tune maximum number of pending signals
+         (You may want to increase it if you see CANNOT_CREATE_TIMER exceptions) -->
+    <!--
+    <pending_signals></pending_signals>
+    -->
 </clickhouse>

--- a/src/Common/AsynchronousMetrics.h
+++ b/src/Common/AsynchronousMetrics.h
@@ -151,6 +151,7 @@ private:
 
     std::optional<ReadBufferFromFilePRead> vm_max_map_count TSA_GUARDED_BY(data_mutex);
     std::optional<ReadBufferFromFilePRead> vm_maps TSA_GUARDED_BY(data_mutex);
+    std::optional<ReadBufferFromFilePRead> process_status TSA_GUARDED_BY(data_mutex);
 
     std::vector<std::unique_ptr<ReadBufferFromFilePRead>> thermal TSA_GUARDED_BY(data_mutex);
 

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -282,6 +282,22 @@ void BaseDaemon::initialize(Application & self)
         }
     }
 
+#if defined(OS_LINUX)
+    /// Configure RLIMIT_SIGPENDING
+    /// (query profiler creates lots of timers - timer_create(), and this requires slot in pending signals)
+    if (auto pending_signals = config().getUInt64("pending_signals", 0); pending_signals > 0)
+    {
+        struct rlimit rlim;
+        if (getrlimit(RLIMIT_SIGPENDING, &rlim))
+            throw Poco::Exception("Cannot getrlimit");
+        rlim.rlim_cur = pending_signals;
+        if (setrlimit(RLIMIT_SIGPENDING, &rlim))
+        {
+            std::cerr << "Cannot set pending signals to " + std::to_string(rlim.rlim_cur) << std::endl;
+        }
+    }
+#endif
+
     /// This must be done before any usage of DateLUT. In particular, before any logging.
     if (config().has("timezone"))
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ability to tune pending signals in attemp to overcome CANNOT_CREATE_TIMER (for query profilers, `query_profiler_real_time_period_ns`/`query_profiler_cpu_time_period_ns`). And also collect `SigQ` from the `/proc/self/status` for introspection (if `ProcessSignalQueueSize` is near to `ProcessSignalQueueLimit`, then you will likely get `CANNOT_CREATE_TIMER` errors).