### PR TITLE
`memalign` does not exist on darwin

### DIFF
--- a/src/Common/AllocationInterceptors.h
+++ b/src/Common/AllocationInterceptors.h
@@ -16,8 +16,12 @@
 #define __real_posix_memalign(memptr, alignment, size) ::posix_memalign(memptr, alignment, size)
 #define __real_aligned_alloc(alignment, size) ::aligned_alloc(alignment, size)
 #define __real_valloc(size) ::valloc(size)
-#define __real_memalign(alignment, size) ::memalign(alignment, size)
 #define __real_free ::free
+
+#if !defined(OS_DARWIN)
+#define __real_memalign(alignment, size) ::memalign(alignment, size)
+#endif
+
 #if !defined(USE_MUSL) && defined(OS_LINUX)
 #define __real_pvalloc(size) ::pvalloc(size)
 #endif


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not try to intercept `memalign` on darwin.


```
       > /nix/var/nix/builds/nix-build-clickhouse-25.8.2.29-lts.drv-83717-2635540951/source/src/Common/AllocationInt
erceptors.cpp:300:18: error: no member named 'memalign' in the global namespace                                     
       >   300 |     void * res = __real_memalign(alignment, size);                                                 
       >       |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                  
       > /nix/var/nix/builds/nix-build-clickhouse-25.8.2.29-lts.drv-83717-2635540951/source/src/Common/AllocationInt
erceptors.h:19:44: note: expanded from macro '__real_memalign'                                                      
       >    19 | #define __real_memalign(alignment, size) ::memalign(alignment, size)                               
       >       |                                          ~~^                                                       
       > 1 error generated.     
```
