### PR TITLE
Set capabilities automatically in Docker

### DIFF
--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -74,7 +74,7 @@ RUN arch=${TARGETARCH:-amd64} \
     ; done \
     && rm /tmp/*.tgz /install -r \
     && chmod +x /entrypoint.sh \
-    && apk add --no-cache bash tzdata \
+    && apk add --no-cache bash tzdata libcap \
     && cp /usr/share/zoneinfo/UTC /etc/localtime \
     && echo "UTC" > /etc/timezone
 

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -25,6 +25,7 @@ RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list 
         locales \
         tzdata \
         wget \
+        libcap2-bin \
     && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 


### PR DESCRIPTION
I find [this instruction](https://clickhouse.com/docs/knowledgebase/configure_cap_ipc_lock_and_cap_sys_nice_in_docker) quite inconvenient. It would be better to set up capabilities automatically.


### Downside

AFAIK writing capabilities in runtime leads to copying of ClickHouse executable to the writable layer of a container. This executable is quite heavy, so writing capabilities slows down initial container start up.


### Alternative approaches

I took the idea of the current implementation [here](https://github.com/ClickHouse/ClickHouse/blob/76e5a24e146a90bd8c77c19b40b00e7ae9d8784c/programs/install/Install.cpp#L889-L890).

There is [alternative approach](https://github.com/hashicorp/vault/blob/73c6504eeacdfb4633cea8248191aae51a7fb8b5/.release/docker/docker-entrypoint.sh#L92-L99) which involves test run of the executable. I chose current method because it doesn't touch executable if no capabilities can be applied. This is not a very serious reason though.

It is also possible to add capabilities to a file in the image, but:
- there are open Moby issues when capabilities may be lost ([1](https://github.com/moby/moby/issues/35699), [2](https://github.com/moby/moby/issues/40375))
- these capabilities become mandatory

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Automatically set available capabilities for ClickHouse executable in Docker. Now users only need to add the desired capabilities to `docker run`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
