### PR TITLE
Remove redundant mutability in `SerializationMap` deserialization

### DIFF
--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -492,8 +492,9 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
     DeserializeBinaryBulkStatePtr & state,
     SubstreamsCache * cache) const
 {
-    auto & column_map = assert_cast<ColumnMap &>(*column->assumeMutable());
-    nested->deserializeBinaryBulkWithMultipleStreams(column_map.getNestedColumnPtr(), rows_offset, limit, settings, state, cache);
+    const auto & column_map = assert_cast<const ColumnMap &>(*column);
+    ColumnPtr nested_ptr = column_map.getNestedColumnPtr();
+    nested->deserializeBinaryBulkWithMultipleStreams(nested_ptr, rows_offset, limit, settings, state, cache);
 }
 
 }


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)