### PR TITLE
CI: Support batch request for GH secrets or vars

### DIFF
--- a/ci/praktika/secret.py
+++ b/ci/praktika/secret.py
@@ -34,13 +34,18 @@ class Secret:
             if self.type == Secret.Type.AWS_SSM_SECRET:
                 if isinstance(self.name, list):
                     # add support for requesting all at once
-                    assert False, "TODO: Not supported"
+                    res = []
+                    for name in self.name:
+                        res.append(Secret.Config(name=name, type=self.type).get_value())
+                    return res
                 else:
                     return self.get_aws_ssm_secret()
             elif self.type in (Secret.Type.GH_SECRET, Secret.Type.GH_VAR):
                 if isinstance(self.name, list):
-                    # add support for requesting all at once
-                    assert False, "TODO: Not supported"
+                    res = []
+                    for name in self.name:
+                        res.append(Secret.Config(name=name, type=self.type).get_value())
+                    return res
                 else:
                     return self.get_gh_secret()
             else:
@@ -111,8 +116,9 @@ class Secret:
             """
             Join secrets of the same type and region, to allow requesting all at once and save on api calls if applicable
             """
-            assert (
-                self.type == other.type
+            assert self.type == other.type or all(
+                type_ in (Secret.Type.GH_SECRET, Secret.Type.GH_VAR)
+                for type_ in (self.type, other.type)
             ), f"Secrets must have the same type [{self.type}] and [{other.type}]"
             assert (
                 self.region == other.region


### PR DESCRIPTION
fix failure if CIDB credentials defined as GH secrets or vars
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
