### PR TITLE
Use statistics for join-reorder

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -83,6 +83,7 @@
 #include <Storages/StorageValues.h>
 #include <Storages/StorageView.h>
 #include <Storages/ReadInOrderOptimizer.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 
 #include <Columns/Collator.h>
 #include <Columns/ColumnAggregateFunction.h>

--- a/src/Processors/QueryPlan/Optimizations/joinOrder.h
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.h
@@ -4,6 +4,7 @@
 #include <Core/Joins.h>
 #include <Interpreters/JoinOperator.h>
 #include <Interpreters/JoinExpressionActions.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 
 namespace DB
 {
@@ -49,11 +50,6 @@ struct DPJoinEntry
     bool isLeaf() const;
 
     String dump() const;
-};
-
-struct ColumnStats
-{
-    UInt64 num_distinct_values;
 };
 
 struct RelationStats

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -190,8 +190,7 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, ActionsDAG::Node * f
             if (prewhere_info)
                 prewhere_node = const_cast<ActionsDAG::Node *>(prewhere_info->prewhere_actions.tryFindInOutputs(prewhere_info->prewhere_column_name));
 
-            auto estimator_ = reading->getConditionSelectivityEstimator();
-            if (estimator_ != nullptr)
+            if (auto estimator_ = reading->getConditionSelectivityEstimator())
             {
                 auto relation_profile = estimator_->estimateRelationProfile(filter, prewhere_node);
                 RelationStats stats {.estimated_rows = relation_profile.rows, .column_stats = relation_profile.column_stats, .table_name = table_display_name};

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -267,7 +267,7 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, ActionsDAG::Node * f
 
     if (const auto * filter_step = typeid_cast<const FilterStep *>(step))
     {
-        auto & dag = filter_step->getExpression();
+        const auto & dag = filter_step->getExpression();
         auto * predicate = const_cast<ActionsDAG::Node *>(dag.tryFindInOutputs(filter_step->getFilterColumnName()));
         auto stats = estimateReadRowsCount(*node.children.front(), predicate);
         remapColumnStats(stats.column_stats, filter_step->getExpression());

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -20,6 +20,7 @@
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Interpreters/FullSortingMergeJoin.h>
 
+#include <Interpreters/Context.h>
 #include <Interpreters/TableJoin.h>
 #include <Processors/QueryPlan/CreateSetAndFilterOnTheFlyStep.h>
 
@@ -50,6 +51,11 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+namespace Setting
+{
+    extern const SettingsBool allow_statistics_optimize;
+}
+
 RelationStats getDummyStats(ContextPtr context, const String & table_name);
 RelationStats getDummyStats(const String & dummy_stats_str, const String & table_name);
 
@@ -57,6 +63,7 @@ namespace QueryPlanOptimizations
 {
 
 const size_t MAX_ROWS = std::numeric_limits<size_t>::max();
+static String dumpStatsForLogs(const RelationStats & stats);
 
 static size_t functionDoesNotChangeNumberOfValues(std::string_view function_name, size_t num_args)
 {
@@ -169,13 +176,29 @@ struct RuntimeHashStatisticsContext
     }
 };
 
-RelationStats estimateReadRowsCount(QueryPlan::Node & node, bool has_filter = false)
+RelationStats estimateReadRowsCount(QueryPlan::Node & node, ActionsDAG::Node * filter = nullptr)
 {
     IQueryPlanStep * step = node.step.get();
     if (const auto * reading = typeid_cast<const ReadFromMergeTree *>(step))
     {
         String table_display_name = reading->getStorageID().getTableName();
 
+        if (reading->getContext()->getSettingsRef()[Setting::allow_statistics_optimize])
+        {
+            ActionsDAG::Node * prewhere_node = nullptr;
+            auto prewhere_info = reading->getPrewhereInfo();
+            if (prewhere_info)
+                prewhere_node = const_cast<ActionsDAG::Node *>(prewhere_info->prewhere_actions.tryFindInOutputs(prewhere_info->prewhere_column_name));
+
+            auto estimator_ = reading->getConditionSelectivityEstimator();
+            if (estimator_ != nullptr)
+            {
+                auto relation_profile = estimator_->estimateRelationProfile(filter, prewhere_node);
+                RelationStats stats {.estimated_rows = relation_profile.rows, .column_stats = relation_profile.column_stats, .table_name = table_display_name};
+                LOG_TRACE(getLogger("optimizeJoin"), "estimate statistics {}", dumpStatsForLogs(stats));
+                return stats;
+            }
+        }
         if (auto dummy_stats = getDummyStats(reading->getContext(), table_display_name); !dummy_stats.table_name.empty())
             return dummy_stats;
 
@@ -206,7 +229,7 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, bool has_filter = fa
             if (is_filtered_by_index)
                 break;
         }
-        has_filter = has_filter || reading->getPrewhereInfo();
+        bool has_filter = filter || reading->getPrewhereInfo();
 
         /// If any conditions are pushed down to storage but not used in the index,
         /// we cannot precisely estimate the row count
@@ -228,7 +251,7 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, bool has_filter = fa
 
     if (const auto * limit_step = typeid_cast<const LimitStep *>(step))
     {
-        auto estimated = estimateReadRowsCount(*node.children.front(), has_filter);
+        auto estimated = estimateReadRowsCount(*node.children.front(), filter);
         auto limit = limit_step->getLimit();
         if (!estimated.estimated_rows || estimated.estimated_rows > limit)
             estimated.estimated_rows = limit;
@@ -237,15 +260,17 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, bool has_filter = fa
 
     if (const auto * expression_step = typeid_cast<const ExpressionStep *>(step))
     {
-        auto stats = estimateReadRowsCount(*node.children.front(), has_filter);
+        auto stats = estimateReadRowsCount(*node.children.front(), filter);
         remapColumnStats(stats.column_stats, expression_step->getExpression());
         return stats;
     }
 
-    if (const auto * expression_step = typeid_cast<const FilterStep *>(step))
+    if (const auto * filter_step = typeid_cast<const FilterStep *>(step))
     {
-        auto stats = estimateReadRowsCount(*node.children.front(), true);
-        remapColumnStats(stats.column_stats, expression_step->getExpression());
+        auto & dag = filter_step->getExpression();
+        auto * predicate = const_cast<ActionsDAG::Node *>(dag.tryFindInOutputs(filter_step->getFilterColumnName()));
+        auto stats = estimateReadRowsCount(*node.children.front(), predicate);
+        remapColumnStats(stats.column_stats, filter_step->getExpression());
         return stats;
     }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -186,8 +186,7 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, ActionsDAG::Node * f
         if (reading->getContext()->getSettingsRef()[Setting::allow_statistics_optimize])
         {
             ActionsDAG::Node * prewhere_node = nullptr;
-            auto prewhere_info = reading->getPrewhereInfo();
-            if (prewhere_info)
+            if (auto prewhere_info = reading->getPrewhereInfo())
                 prewhere_node = const_cast<ActionsDAG::Node *>(prewhere_info->prewhere_actions.tryFindInOutputs(prewhere_info->prewhere_column_name));
 
             if (auto estimator_ = reading->getConditionSelectivityEstimator())

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -48,6 +48,7 @@
 #include <Storages/MergeTree/MergeTreeSource.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/RequestResponse.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Poco/Logger.h>
 #include <Common/JSONBuilder.h>
 #include <Common/logger_useful.h>
@@ -3034,6 +3035,11 @@ std::shared_ptr<ParallelReadingExtension> ReadFromMergeTree::getParallelReadingE
         read_task_callback.value(),
         number_of_current_replica.value_or(client_info.number_of_current_replica),
         context->getClusterForParallelReplicas()->getShardsInfo().at(0).getAllNodeCount());
+}
+
+ConditionSelectivityEstimatorPtr ReadFromMergeTree::getConditionSelectivityEstimator() const
+{
+    return data.getConditionSelectivityEstimatorByPredicate(storage_snapshot, nullptr, getContext());
 }
 
 }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -272,6 +272,8 @@ public:
     void clearParallelReadingExtension();
     std::shared_ptr<ParallelReadingExtension> getParallelReadingExtension();
 
+    ConditionSelectivityEstimatorPtr getConditionSelectivityEstimator() const;
+
 private:
     MergeTreeReaderSettings reader_settings;
 

--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -327,9 +327,9 @@ StorageID IStorage::getStorageID() const
     return storage_id;
 }
 
-ConditionSelectivityEstimator IStorage::getConditionSelectivityEstimatorByPredicate(const StorageSnapshotPtr &, const ActionsDAG *, ContextPtr) const
+ConditionSelectivityEstimatorPtr IStorage::getConditionSelectivityEstimatorByPredicate(const StorageSnapshotPtr &, const ActionsDAG *, ContextPtr) const
 {
-    return {};
+    return nullptr;
 }
 
 void IStorage::renameInMemory(const StorageID & new_table_id)

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -67,6 +67,7 @@ class BackupEntriesCollector;
 class RestorerFromBackup;
 
 class ConditionSelectivityEstimator;
+using ConditionSelectivityEstimatorPtr = std::shared_ptr<ConditionSelectivityEstimator>;
 
 class ActionsDAG;
 
@@ -119,7 +120,7 @@ public:
     /// Returns true if the storage supports queries with the PREWHERE section.
     virtual bool supportsPrewhere() const { return false; }
 
-    virtual ConditionSelectivityEstimator getConditionSelectivityEstimatorByPredicate(const StorageSnapshotPtr &, const ActionsDAG *, ContextPtr) const;
+    virtual ConditionSelectivityEstimatorPtr getConditionSelectivityEstimatorByPredicate(const StorageSnapshotPtr &, const ActionsDAG *, ContextPtr) const;
 
     /// Returns which columns supports PREWHERE, or empty std::nullopt if all columns is supported.
     /// This is needed for engines whose aggregates data from multiple tables, like Merge.

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -781,24 +781,22 @@ std::map<std::string, DiskPtr> MergeTreeData::getDistinctDisksForParts(const Dat
     return results;
 }
 
-ConditionSelectivityEstimator MergeTreeData::getConditionSelectivityEstimatorByPredicate(
+ConditionSelectivityEstimatorPtr MergeTreeData::getConditionSelectivityEstimatorByPredicate(
     const StorageSnapshotPtr & storage_snapshot, const ActionsDAG * filter_dag, ContextPtr local_context) const
 {
     if (!local_context->getSettingsRef()[Setting::allow_statistics_optimize])
-        return {};
+        return nullptr;
 
     const auto & parts = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data).parts;
 
-    if (parts.empty() || !filter_dag)
+    if (parts.empty())
         return {};
 
     ASTPtr expression_ast;
 
-    ConditionSelectivityEstimator estimator;
-    ActionsDAGWithInversionPushDown inverted_dag(filter_dag->getOutputs().front(), local_context);
-    PartitionPruner partition_pruner(storage_snapshot->metadata, inverted_dag, local_context);
+    ConditionSelectivityEstimatorPtr estimator = std::make_shared<ConditionSelectivityEstimator>(local_context);
 
-    if (partition_pruner.isUseless())
+    auto build_estimator_all_partitions = [&]()
     {
         /// Read all partitions.
         for (const auto & part : parts)
@@ -806,14 +804,27 @@ ConditionSelectivityEstimator MergeTreeData::getConditionSelectivityEstimatorByP
         {
             auto stats = part.data_part->loadStatistics();
             /// TODO: We only have one stats file for every part.
-            estimator.incrementRowCount(part.data_part->rows_count);
+            estimator->incrementRowCount(part.data_part->rows_count);
             for (const auto & stat : stats)
-                estimator.addStatistics(stat);
+                estimator->addStatistics(stat);
         }
         catch (...)
         {
             tryLogCurrentException(log, fmt::format("while loading statistics on part {}", part.data_part->info.getPartNameV1()));
         }
+    };
+    if (filter_dag == nullptr)
+    {
+        build_estimator_all_partitions();
+        return estimator;
+    }
+
+    ActionsDAGWithInversionPushDown inverted_dag(filter_dag->getOutputs().front(), local_context);
+    PartitionPruner partition_pruner(storage_snapshot->metadata, inverted_dag, local_context);
+
+    if (partition_pruner.isUseless())
+    {
+        build_estimator_all_partitions();
     }
     else
     {
@@ -823,9 +834,9 @@ ConditionSelectivityEstimator MergeTreeData::getConditionSelectivityEstimatorByP
             if (!partition_pruner.canBePruned(*part.data_part))
             {
                 auto stats = part.data_part->loadStatistics();
-                estimator.incrementRowCount(part.data_part->rows_count);
+                estimator->incrementRowCount(part.data_part->rows_count);
                 for (const auto & stat : stats)
-                    estimator.addStatistics(stat);
+                    estimator->addStatistics(stat);
             }
         }
         catch (...)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -813,6 +813,7 @@ ConditionSelectivityEstimatorPtr MergeTreeData::getConditionSelectivityEstimator
             tryLogCurrentException(log, fmt::format("while loading statistics on part {}", part.data_part->info.getPartNameV1()));
         }
     };
+
     if (filter_dag == nullptr)
     {
         build_estimator_all_partitions();

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -492,7 +492,7 @@ public:
 
     bool supportsPrewhere() const override { return true; }
 
-    ConditionSelectivityEstimator getConditionSelectivityEstimatorByPredicate(const StorageSnapshotPtr &, const ActionsDAG *, ContextPtr) const override;
+    ConditionSelectivityEstimatorPtr getConditionSelectivityEstimatorByPredicate(const StorageSnapshotPtr &, const ActionsDAG *, ContextPtr) const override;
 
     bool supportsFinal() const override;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -212,6 +212,7 @@ void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPer
     }
 
     result_block = permuteBlockIfNeeded(result_block, permutation);
+    calculateAndSerializeStatistics(result_block);
 
     if (header.empty())
         header = result_block.cloneEmpty();
@@ -235,7 +236,6 @@ void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPer
         auto granules_to_write = getGranulesToWrite(*index_granularity, flushed_block.rows(), getCurrentMark(), /* last_block = */ false);
         writeDataBlockPrimaryIndexAndSkipIndices(flushed_block, granules_to_write);
         setCurrentMark(getCurrentMark() + granules_to_write.size());
-        calculateAndSerializeStatistics(flushed_block);
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -37,7 +37,7 @@ public:
     MergeTreeWhereOptimizer(
         std::unordered_map<std::string, UInt64> column_sizes_,
         const StorageMetadataPtr & metadata_snapshot,
-        const ConditionSelectivityEstimator & estimator_,
+        ConditionSelectivityEstimatorPtr estimator_,
         const Names & queried_columns_,
         const std::optional<NameSet> & supported_columns_,
         LoggerPtr log_);
@@ -162,7 +162,7 @@ private:
 
     static NameSet determineArrayJoinedNames(const ASTSelectQuery & select);
 
-    const ConditionSelectivityEstimator estimator;
+    ConditionSelectivityEstimatorPtr estimator;
 
     const NameSet table_columns;
     const Names queried_columns;

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -16,7 +16,6 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
 }
 
 RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(ActionsDAG::Node * filter, ActionsDAG::Node * prewhere) const

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -14,10 +14,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-}
-
 RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(ActionsDAG::Node * filter, ActionsDAG::Node * prewhere) const
 {
     if (filter == nullptr && prewhere == nullptr)

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -1,4 +1,3 @@
-#include "Interpreters/ActionsDAG.h"
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 
 #include <stack>

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -14,7 +14,7 @@
 namespace DB
 {
 
-RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(ActionsDAG::Node * filter, ActionsDAG::Node * prewhere) const
+RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(const ActionsDAG::Node * filter, const ActionsDAG::Node * prewhere) const
 {
     if (filter == nullptr && prewhere == nullptr)
     {
@@ -142,7 +142,7 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfile() const
     return result;
 }
 
-RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(ActionsDAG::Node * node) const
+RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(const ActionsDAG::Node * node) const
 {
     RPNBuilderTreeContext tree_context(getContext());
     return estimateRelationProfile(RPNBuilderTreeNode(node, tree_context));

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -29,6 +29,8 @@ class ConditionSelectivityEstimator : public WithContext
 {
     struct ColumnEstimator;
     using ColumnEstimators = std::unordered_map<String, ColumnEstimator>;
+
+    friend class ConditionSelectivityEstimatorBuilder;
 public:
     explicit ConditionSelectivityEstimator(ContextPtr context_) : WithContext(context_) {}
 
@@ -36,9 +38,6 @@ public:
     RelationProfile estimateRelationProfile(ActionsDAG::Node * node) const;
     RelationProfile estimateRelationProfile(const RPNBuilderTreeNode & node) const;
     RelationProfile estimateRelationProfile() const;
-
-    void addStatistics(ColumnStatisticsPtr column_stat);
-    void incrementRowCount(UInt64 rows);
 
     struct RPNElement
     {
@@ -78,8 +77,6 @@ private:
     {
         ColumnStatisticsPtr stats;
 
-        void addStatistics(ColumnStatisticsPtr other_stats);
-
         Float64 estimateRanges(const PlainRanges & ranges) const;
         UInt64 estimateCardinality() const;
     };
@@ -99,5 +96,18 @@ private:
 };
 
 using ConditionSelectivityEstimatorPtr = std::shared_ptr<ConditionSelectivityEstimator>;
+
+class ConditionSelectivityEstimatorBuilder
+{
+public:
+    ConditionSelectivityEstimatorBuilder(ContextPtr context_);
+    void addStatistics(ColumnStatisticsPtr column_stats);
+    void incrementRowCount(UInt64 rows);
+    ConditionSelectivityEstimatorPtr getEstimator() const;
+
+private:
+    bool has_data = false;
+    ConditionSelectivityEstimatorPtr estimator;
+};
 
 }

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -34,8 +34,8 @@ class ConditionSelectivityEstimator : public WithContext
 public:
     explicit ConditionSelectivityEstimator(ContextPtr context_) : WithContext(context_) {}
 
-    RelationProfile estimateRelationProfile(ActionsDAG::Node * filter, ActionsDAG::Node * prewhere) const;
-    RelationProfile estimateRelationProfile(ActionsDAG::Node * node) const;
+    RelationProfile estimateRelationProfile(const ActionsDAG::Node * filter, const ActionsDAG::Node * prewhere) const;
+    RelationProfile estimateRelationProfile(const ActionsDAG::Node * node) const;
     RelationProfile estimateRelationProfile(const RPNBuilderTreeNode & node) const;
     RelationProfile estimateRelationProfile() const;
 
@@ -100,7 +100,7 @@ using ConditionSelectivityEstimatorPtr = std::shared_ptr<ConditionSelectivityEst
 class ConditionSelectivityEstimatorBuilder
 {
 public:
-    ConditionSelectivityEstimatorBuilder(ContextPtr context_);
+    explicit ConditionSelectivityEstimatorBuilder(ContextPtr context_);
     void addStatistics(ColumnStatisticsPtr column_stats);
     void incrementRowCount(UInt64 rows);
     ConditionSelectivityEstimatorPtr getEstimator() const;

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -269,7 +269,7 @@ UInt64 ColumnStatistics::rowCount() const
 String ColumnStatistics::debugString() const
 {
     String ret;
-    for (auto [type, single_stats] : stats)
+    for (const auto & [type, single_stats] : stats)
     {
         ret += single_stats->debugString();
         ret += " | ";

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -266,12 +266,12 @@ UInt64 ColumnStatistics::rowCount() const
     return rows;
 }
 
-String ColumnStatistics::debugString() const
+String ColumnStatistics::getNameForLogs() const
 {
     String ret;
     for (const auto & [type, single_stats] : stats)
     {
-        ret += single_stats->debugString();
+        ret += single_stats->getNameForLogs();
         ret += " | ";
     }
     ret += "rows: " + std::to_string(rows);

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -266,6 +266,18 @@ UInt64 ColumnStatistics::rowCount() const
     return rows;
 }
 
+String ColumnStatistics::debugString() const
+{
+    String ret;
+    for (auto [type, single_stats] : stats)
+    {
+        ret += single_stats->debugString();
+        ret += " | ";
+    }
+    ret += "rows: " + std::to_string(rows);
+    return ret;
+}
+
 void MergeTreeStatisticsFactory::registerCreator(StatisticsType stats_type, Creator creator)
 {
     if (!creators.emplace(stats_type, std::move(creator)).second)

--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -50,6 +50,7 @@ public:
     virtual Float64 estimateEqual(const Field & val) const; /// cardinality of val in the column
     virtual Float64 estimateLess(const Field & val) const;  /// summarized cardinality of values < val in the column
     virtual Float64 estimateRange(const Range & range) const;
+    virtual String debugString() const = 0;
 
 protected:
     SingleStatisticsDescription stat;
@@ -81,6 +82,8 @@ public:
     Float64 estimateEqual(const Field & val) const;
     Float64 estimateRange(const Range & range) const;
     UInt64 estimateCardinality() const;
+
+    String debugString() const;
 
 private:
     friend class MergeTreeStatisticsFactory;

--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -50,7 +50,7 @@ public:
     virtual Float64 estimateEqual(const Field & val) const; /// cardinality of val in the column
     virtual Float64 estimateLess(const Field & val) const;  /// summarized cardinality of values < val in the column
     virtual Float64 estimateRange(const Range & range) const;
-    virtual String debugString() const = 0;
+    virtual String getNameForLogs() const = 0;
 
 protected:
     SingleStatisticsDescription stat;
@@ -83,7 +83,7 @@ public:
     Float64 estimateRange(const Range & range) const;
     UInt64 estimateCardinality() const;
 
-    String debugString() const;
+    String getNameForLogs() const;
 
 private:
     friend class MergeTreeStatisticsFactory;

--- a/src/Storages/Statistics/StatisticsCountMinSketch.h
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.h
@@ -24,6 +24,7 @@ public:
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;
 
+    String debugString() const override { return "CMSketch"; }
 private:
     using Sketch = datasketches::count_min_sketch<UInt64>;
     Sketch sketch;

--- a/src/Storages/Statistics/StatisticsCountMinSketch.h
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.h
@@ -24,7 +24,7 @@ public:
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf) override;
 
-    String debugString() const override { return "CMSketch"; }
+    String getNameForLogs() const override { return "CMSketch"; }
 private:
     using Sketch = datasketches::count_min_sketch<UInt64>;
     Sketch sketch;

--- a/src/Storages/Statistics/StatisticsMinMax.h
+++ b/src/Storages/Statistics/StatisticsMinMax.h
@@ -20,7 +20,7 @@ public:
 
     Float64 estimateLess(const Field & val) const override;
 
-    String debugString() const override { return "MinMax : (" + toString(min) + ", " + toString(max); }
+    String getNameForLogs() const override { return "MinMax : (" + toString(min) + ", " + toString(max); }
 private:
     Float64 min = std::numeric_limits<Float64>::max();
     Float64 max = std::numeric_limits<Float64>::min();

--- a/src/Storages/Statistics/StatisticsMinMax.h
+++ b/src/Storages/Statistics/StatisticsMinMax.h
@@ -20,6 +20,7 @@ public:
 
     Float64 estimateLess(const Field & val) const override;
 
+    String debugString() const override { return "MinMax : (" + toString(min) + ", " + toString(max); }
 private:
     Float64 min = std::numeric_limits<Float64>::max();
     Float64 max = std::numeric_limits<Float64>::min();

--- a/src/Storages/Statistics/StatisticsTDigest.h
+++ b/src/Storages/Statistics/StatisticsTDigest.h
@@ -20,6 +20,8 @@ public:
     Float64 estimateLess(const Field & val) const override;
     Float64 estimateEqual(const Field & val) const override;
 
+    String debugString() const override { return "TDigest"; }
+
 private:
     QuantileTDigest<Float64> t_digest;
     DataTypePtr data_type;

--- a/src/Storages/Statistics/StatisticsTDigest.h
+++ b/src/Storages/Statistics/StatisticsTDigest.h
@@ -20,7 +20,7 @@ public:
     Float64 estimateLess(const Field & val) const override;
     Float64 estimateEqual(const Field & val) const override;
 
-    String debugString() const override { return "TDigest"; }
+    String getNameForLogs() const override { return "TDigest"; }
 
 private:
     QuantileTDigest<Float64> t_digest;

--- a/src/Storages/Statistics/StatisticsUniq.h
+++ b/src/Storages/Statistics/StatisticsUniq.h
@@ -21,6 +21,7 @@ public:
 
     UInt64 estimateCardinality() const override;
 
+    String debugString() const override { return "Uniq : " + std::to_string(estimateCardinality()); }
 private:
     std::unique_ptr<Arena> arena;
     AggregateFunctionPtr collector;

--- a/src/Storages/Statistics/StatisticsUniq.h
+++ b/src/Storages/Statistics/StatisticsUniq.h
@@ -21,7 +21,7 @@ public:
 
     UInt64 estimateCardinality() const override;
 
-    String debugString() const override { return "Uniq : " + std::to_string(estimateCardinality()); }
+    String getNameForLogs() const override { return "Uniq : " + std::to_string(estimateCardinality()); }
 private:
     std::unique_ptr<Arena> arena;
     AggregateFunctionPtr collector;

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -95,13 +95,13 @@ TEST(Statistics, Estimator)
     ColumnStatisticsPtr stats_c = mock_statistics("c");
     stats_c->build(std::move(c));
 
-    ConditionSelectivityEstimator estimator;
+    ConditionSelectivityEstimator estimator(getContext().context);
     estimator.addStatistics(stats_a);
     estimator.addStatistics(stats_b);
     estimator.addStatistics(stats_c);
     estimator.incrementRowCount(10000);
 
-    auto test_impl = [&](const String & expression, Int32 real_result, Float64 eps)
+    auto test_impl = [&](const String & expression, Int64 real_result, Float64 eps)
     {
         ParserExpressionWithOptionalAlias exp_parser(false);
         ContextPtr context = getContext().context;
@@ -110,10 +110,10 @@ TEST(Statistics, Estimator)
         RPNBuilderTreeNode node(ast.get(), tree_context);
         auto estimate_result = estimator.estimateRelationProfile(node);
         std::cout << expression << " " << real_result << " "<< estimate_result.rows << std::endl;
-        EXPECT_LT(std::abs(real_result - estimate_result.rows), 10000 * eps);
+        EXPECT_LT(std::abs(real_result - static_cast<Int64>(estimate_result.rows)), 10000 * eps);
     };
 
-    auto test_f = [&](const String & expression, Int32 real_result, Float64 eps = 0.001)
+    auto test_f = [&](const String & expression, Int64 real_result, Float64 eps = 0.001)
     {
         test_impl(expression, real_result, eps);
         /// Let's test 'not expression'

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -367,6 +367,7 @@
 03273_primary_index_cache_low_cardinality
     profile events
 03279_join_choose_build_table
+03279_join_choose_build_table_statistics
 03275_subcolumns_in_primary_key.gen
 03277_json_subcolumns_in_primary_key.gen
 03165_string_functions_with_token_text_indexes

--- a/tests/queries/0_stateless/03279_join_choose_build_table_statistics.reference
+++ b/tests/queries/0_stateless/03279_join_choose_build_table_statistics.reference
@@ -1,0 +1,4 @@
+ok	ok	ok	auto
+ok	ok	ok	auto
+ok	ok	ok	auto
+ok	ok	ok	auto

--- a/tests/queries/0_stateless/03279_join_choose_build_table_statistics.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table_statistics.sql
@@ -1,0 +1,101 @@
+
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS sales;
+
+SET enable_analyzer = 1;
+
+CREATE TABLE sales (
+    id Int32,
+    date Date,
+    amount Decimal(10, 2),
+    product_id Int32
+) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO sales SELECT number, '2024-05-05' + INTERVAL intDiv(number, 1000) DAY , (number + 1) % 100, number % 100_000 FROM numbers(1_000_000);
+
+CREATE TABLE products (id Int32, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO products SELECT number, 'product ' || toString(number) FROM numbers(100_000);
+
+SET query_plan_join_swap_table = 'auto';
+SET query_plan_optimize_join_order_limit = 2;
+SET allow_statistics_optimize=1;
+SET allow_experimental_statistics=1;
+
+SELECT * FROM products, sales
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_no_stats' FORMAT Null;
+
+SELECT * FROM sales, products
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_no_stats' FORMAT Null;
+
+SET mutations_sync = 2;
+ALTER TABLE sales ADD STATISTICS date TYPE CountMin;
+ALTER TABLE sales MATERIALIZE STATISTICS date;
+
+SELECT * FROM products, sales
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_stats' FORMAT Null;
+
+SELECT * FROM sales, products
+WHERE sales.product_id = products.id AND date = '2024-05-07'
+SETTINGS log_comment = '03279_join_choose_build_table_stats' FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- condtitions are pushed down, but no filter by index applied
+-- build table is as it's written in query
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 100 AND 2000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
+AND query like '%products, sales%'
+AND log_comment = '03279_join_choose_build_table_no_stats'
+ORDER BY event_time DESC
+LIMIT 1;
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 100 AND 2000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
+AND query like '%sales, products%'
+AND log_comment = '03279_join_choose_build_table_no_stats'
+ORDER BY event_time DESC
+LIMIT 1;
+
+-- after adding index, optimizer can choose best table order
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 100 AND 2000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
+AND query like '%products, sales%'
+AND log_comment = '03279_join_choose_build_table_stats'
+ORDER BY event_time DESC
+LIMIT 1;
+
+SELECT
+    if(ProfileEvents['JoinBuildTableRowCount'] BETWEEN 100 AND 2000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinBuildTableRowCount'])),
+    if(ProfileEvents['JoinProbeTableRowCount'] BETWEEN 90_000 AND 110_000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinProbeTableRowCount'])),
+    if(ProfileEvents['JoinResultRowCount'] == 1000, 'ok', format('fail({}): {}', query_id, ProfileEvents['JoinResultRowCount'])),
+    Settings['query_plan_join_swap_table'],
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_date >= yesterday() AND query_kind = 'Select' AND current_database = currentDatabase()
+AND query like '%sales, products%'
+AND log_comment = '03279_join_choose_build_table_stats'
+ORDER BY event_time DESC
+LIMIT 1;
+
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS sales;

--- a/tests/queries/0_stateless/03279_join_choose_build_table_statistics.sql
+++ b/tests/queries/0_stateless/03279_join_choose_build_table_statistics.sql
@@ -1,3 +1,4 @@
+-- Tags: no-fasttest
 
 DROP TABLE IF EXISTS products;
 DROP TABLE IF EXISTS sales;

--- a/tests/queries/0_stateless/03580_improve_prewhere.reference
+++ b/tests/queries/0_stateless/03580_improve_prewhere.reference
@@ -1,5 +1,4 @@
 -- { echoOn }
-set allow_statistics_optimize = 1;
 -- Condition: lower(primary_key) = '00' can't make use of primary key index. It shouldn't be moved to the end of prewhere conditions.
 select trimLeft(explain) from (
 EXPLAIN actions=1

--- a/tests/queries/0_stateless/03580_improve_prewhere.sql
+++ b/tests/queries/0_stateless/03580_improve_prewhere.sql
@@ -1,4 +1,4 @@
--- Default settings
+-- Tags: no-fasttest
 set optimize_move_to_prewhere = 1;
 set move_all_conditions_to_prewhere = 1;
 set enable_multiple_prewhere_read_steps = 1;
@@ -6,13 +6,15 @@ set move_primary_key_columns_to_end_of_prewhere = 1;
 set allow_reorder_prewhere_conditions = 1;
 set enable_analyzer = 1;
 set enable_parallel_replicas = 0;
+set allow_experimental_statistics = 1;
+set allow_statistics_optimize = 1;
 
 DROP TABLE IF EXISTS test_improve_prewhere;
 
 CREATE TABLE test_improve_prewhere (
-    primary_key String,
-    normal_column LowCardinality(String),
-    value UInt32,
+    primary_key String STATISTICS(CountMin),
+    normal_column String STATISTICS(CountMin),
+    value UInt32 STATISTICS(TDigest),
     date Date
 ) ENGINE = MergeTree()
 ORDER BY primary_key
@@ -27,7 +29,6 @@ SELECT
 FROM numbers(100000);
 
 -- { echoOn }
-set allow_statistics_optimize = 1;
 -- Condition: lower(primary_key) = '00' can't make use of primary key index. It shouldn't be moved to the end of prewhere conditions.
 select trimLeft(explain) from (
 EXPLAIN actions=1

--- a/tests/queries/0_stateless/03580_improve_prewhere.sql
+++ b/tests/queries/0_stateless/03580_improve_prewhere.sql
@@ -15,17 +15,16 @@ CREATE TABLE test_improve_prewhere (
     primary_key String STATISTICS(CountMin),
     normal_column String STATISTICS(CountMin),
     value UInt32 STATISTICS(TDigest),
-    date Date
+    date Date STATISTICS(CountMin),
 ) ENGINE = MergeTree()
-ORDER BY primary_key
-PARTITION BY toYYYYMM(date);
+ORDER BY primary_key;
 
 INSERT INTO test_improve_prewhere
 SELECT
-    hex(rand() % 10) AS primary_key,
-    arrayElement(['hello', 'world', 'test', 'example', 'sample'], rand() % 5 + 1) AS normal_column,
-    rand() % 1000 + 1 AS value,
-    toDate('2025-08-01') + (rand() % 10) AS date
+    hex(number % 100) AS primary_key,
+    arrayElement(['hello', 'world', 'test', 'example', 'sample'], number % 5 + 1) AS normal_column,
+    number % 1000 + 1 AS value,
+    toDate('2025-08-01') + number AS date
 FROM numbers(100000);
 
 -- { echoOn }


### PR DESCRIPTION
Test TPC-H Q5 only enable join order, the explain result is

```
lineitem[6001215] ⋈ (orders[227597] ⋈ (customer[150000] ⋈ (supplier[10000] ⋈ (nation[25] ⋈ region[1]))))
```

which is a left-deep tree. The execution time (scale factor = 1) is ~5s.

After enabling statistics, the join order is

```
lineitem[6001215] ⋈ (orders[168246] ⋈ customer[150000]) ⋈ (supplier[10000] ⋈ (nation[25] ⋈ region[1]))
```

a bushy tree, kudos to @vdimir (https://github.com/ClickHouse/ClickHouse/pull/80848). Execution time is ~100ms

The schema with stats of tpch is here https://github.com/ClickHouse/clickhouse-private/pull/37717/files#diff-5232d60c26166ca83763de3f2b871d4014d55ca8acba8f808c164cfa11092c95

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Join reordering now uses statistics. The feature can be enabled by setting `allow_statistics_optimize = 1` and `query_plan_optimize_join_order_limit = 10`.