### PR TITLE
Bump `krb5` to 1.22.1-final

### DIFF
--- a/contrib/krb5-cmake/CMakeLists.txt
+++ b/contrib/krb5-cmake/CMakeLists.txt
@@ -132,16 +132,18 @@ set(ALL_SRCS
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/ser_sctx.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/k5sealv3.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/acquire_cred.c"
-    "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/k5unseal.c"
+    # "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/k5unseal.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/rel_cred.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/util_cksum.c"
+    "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/verify_mic.c"
+    "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/unwrap.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/disp_com_err_status.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/gssapi_generic.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/rel_oid_set.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/oid_ops.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_buffer.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_buffer_set.c"
-    "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_set.c"
+    # "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_set.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_token.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/disp_major_status.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_seqstate.c"
@@ -415,6 +417,7 @@ set(ALL_SRCS
     "${KRB5_SOURCE_DIR}/lib/krb5/os/realm_dom.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/os/dnssrv.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/os/mk_faddr.c"
+    "${KRB5_SOURCE_DIR}/lib/krb5/os/addr.c"
     # "${KRB5_SOURCE_DIR}/lib/krb5/os/dnsglue.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/os/sendto_kdc.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/os/hostrealm_registry.c"
@@ -585,11 +588,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
         file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/kcmrpc.hin"
             DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/include_private/"
         )
-        file(RENAME 
+        file(RENAME
             "${CMAKE_CURRENT_BINARY_DIR}/include_private/kcmrpc.cin"
             "${CMAKE_CURRENT_BINARY_DIR}/include_private/kcmrpc.c"
         )
-        file(RENAME 
+        file(RENAME
             "${CMAKE_CURRENT_BINARY_DIR}/include_private/kcmrpc.hin"
             "${CMAKE_CURRENT_BINARY_DIR}/include_private/kcmrpc.h"
         )

--- a/contrib/krb5-cmake/autoconf_darwin.h
+++ b/contrib/krb5-cmake/autoconf_darwin.h
@@ -635,7 +635,7 @@
 #define PACKAGE_NAME "Kerberos 5"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "Kerberos 5 1.17.1"
+#define PACKAGE_STRING "Kerberos 5 1.22.1"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "krb5"
@@ -644,7 +644,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.17.1"
+#define PACKAGE_VERSION "1.22.1"
 
 /* Define if setjmp indicates POSIX interface */
 #define POSIX_SETJMP 1

--- a/contrib/krb5-cmake/autoconf_linux.h
+++ b/contrib/krb5-cmake/autoconf_linux.h
@@ -637,7 +637,7 @@
 #define PACKAGE_NAME "Kerberos 5"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "Kerberos 5 1.17.1"
+#define PACKAGE_STRING "Kerberos 5 1.22.1"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "krb5"
@@ -646,7 +646,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.17.1"
+#define PACKAGE_VERSION "1.22.1"
 
 /* Define if setjmp indicates POSIX interface */
 /* #undef POSIX_SETJMP */


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `krb5` 1.22.1-final


