### PR TITLE
Fix querying system.distributed_ddl_queue

### DIFF
--- a/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
+++ b/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
@@ -255,8 +255,8 @@ void StorageSystemDDLWorkerQueue::fillData(MutableColumns & res_columns, Context
         ddl_task_status_paths.push_back(ddl_zookeeper_path / task_path / "finished");
     }
 
-    auto ddl_tasks_info = zookeeper->get(ddl_task_full_paths);
-    auto ddl_task_statuses = zookeeper->getChildren(ddl_task_status_paths);
+    auto ddl_tasks_info = zookeeper->tryGet(ddl_task_full_paths);
+    auto ddl_task_statuses = zookeeper->tryGetChildren(ddl_task_status_paths);
 
     for (size_t i = 0; i < ddl_task_paths.size(); ++i)
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix querying `system.distributed_ddl_queue` in cases where tasks are missing certain Keeper nodes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
