### PR TITLE
docs: Add `ReplicatedCoalescingMergeTree` in `Data replication` section

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/replication.md
+++ b/docs/en/engines/table-engines/mergetree-family/replication.md
@@ -28,12 +28,13 @@ ENGINE = ReplicatedMergeTree
 Replication is only supported for tables in the MergeTree family:
 
 - ReplicatedMergeTree
-- ReplicatedSummingMergeTree
+- ReplicatedCollapsingMergeTree
 - ReplicatedReplacingMergeTree
 - ReplicatedAggregatingMergeTree
-- ReplicatedCollapsingMergeTree
-- ReplicatedVersionedCollapsingMergeTree
+- ReplicatedSummingMergeTree
+- ReplicatedCoalescingMergeTree
 - ReplicatedGraphiteMergeTree
+- ReplicatedVersionedCollapsingMergeTree
 
 Replication works at the level of an individual table, not the entire server. A server can store both replicated and non-replicated tables at the same time.
 


### PR DESCRIPTION
According to https://github.com/ClickHouse/ClickHouse/blob/bd222f79b5c283452717dc94eda908ceaa208dc2/src/Storages/MergeTree/registerStorageMergeTree.cpp#L943, there is an implementation for `ReplicatedCoalescingMergeTree`, but it is not mentioned in the documentation.
Is it correct to assume that `ReplicatedCoalescingMergeTree` is in fact officially supported?
If so, I believe this documentation update is appropriate, and I would like to go ahead and merge it.

The order of the list follows the order in the source code.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

