### PR TITLE
CI: Fix artifact download error

### DIFF
--- a/ci/praktika/artifact.py
+++ b/ci/praktika/artifact.py
@@ -27,6 +27,9 @@ class Artifact:
         def is_s3_artifact(self):
             return self.type == Artifact.Type.S3
 
+        def is_phony(self):
+            return self.type == Artifact.Type.PHONY
+
         def parametrize(self, names):
             res = []
             for name in names:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -216,6 +216,10 @@ class Runner:
                         local_path=Settings.INPUT_DIR,
                         recursive=recursive,
                         include_pattern=include_pattern,
+                        # Job report (phony artifact) is required only for a few jobs, introduced for seamless migration from legacy CI.
+                        # Copying it may fail if the dependency job was skipped due to a user's workflow filter hook.
+                        # We choose to ignore these errors, but a better solution would be to remove these types of artifacts or implement a consistent way of working with them. TODO.
+                        no_strict=artifact.is_phony(),
                     )
 
                     if artifact.compress_zst:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI should run successfully with `ci-performance` label.

Fixes job failure in artifact download step:
```
RuntimeError: s3 command failed: [fatal error: An error occurred (404) when calling the HeadObject operation: Key "PRs/86898/acfe6893c8a2d3b05ac9ea5318f5eedd55910708/build_amd_asan/artifact_report_build_amd_asan.json" does not exist]
```