### PR TITLE
allow increment CurrentMetrics::end()

### DIFF
--- a/src/Common/CurrentMetrics.h
+++ b/src/Common/CurrentMetrics.h
@@ -76,7 +76,12 @@ namespace CurrentMetrics
         explicit Increment(Metric metric, Value amount_ = 1)
             : Increment(&values[metric], amount_)
         {
-            assert(metric < CurrentMetrics::end());
+            // in src/Core/tests/gtest_BackgroundSchedulePool.cpp we create pool as
+            // auto pool = BackgroundSchedulePool::create(4, 0, CurrentMetrics::end(), CurrentMetrics::end(), "tests");
+            // which leads as to creation of Increment with metric == CurrentMetrics::end()
+            // actually this is not a real metric, however it is presented in CurrentMetrics::values array
+            // so we are able to increment it and we should not assert here when metric == CurrentMetrics::end()
+            assert(metric <= CurrentMetrics::end());
         }
 
         ~Increment()


### PR DESCRIPTION
otherwise in debug build unit tests crash

```
$ ./build/src/unit_tests_dbms --gtest_filter=BackgroundSchedulePool*
Note: Google Test filter = BackgroundSchedulePool*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from BackgroundSchedulePool
[ RUN      ] BackgroundSchedulePool.Schedule
unit_tests_dbms: /home/sema/work/ClickHouse/src/Common/CurrentMetrics.h:79: CurrentMetrics::Increment::Increment(Metric, Value): Assertion `metric < CurrentMetrics::end()' failed.
Aborted (core dumped)
```


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
