### PR TITLE
Fix seeking at the end of the decompressed block

### DIFF
--- a/src/IO/ReadBuffer.cpp
+++ b/src/IO/ReadBuffer.cpp
@@ -107,6 +107,15 @@ bool ReadBuffer::next()
     }
     else
     {
+        /// It might happen that we need to skip all data in the buffer,
+        /// in this case we should call next() one more time to load new data.
+        if (nextimpl_working_buffer_offset == working_buffer.size())
+        {
+            pos = working_buffer.end();
+            nextimpl_working_buffer_offset = 0;
+            return next();
+        }
+
         pos = working_buffer.begin() + std::min(nextimpl_working_buffer_offset, working_buffer.size());
         chassert(position() < working_buffer.end());
     }

--- a/tests/queries/0_stateless/03620_json_advanced_shared_data_seek_bug.sql
+++ b/tests/queries/0_stateless/03620_json_advanced_shared_data_seek_bug.sql
@@ -1,0 +1,9 @@
+set use_variant_as_common_type = 1;
+
+drop table if exists test;
+create table test (id UInt64, json JSON(max_dynamic_paths=2, a.b.c UInt32)) engine=MergeTree order by id settings min_rows_for_wide_part=1000000000, min_bytes_for_wide_part=10000000000, index_granularity = 39547, object_serialization_version = 'v3', object_shared_data_serialization_version = 'advanced', object_shared_data_serialization_version_for_zero_level_parts = 'advanced', object_shared_data_buckets_for_compact_part = 3, object_shared_data_buckets_for_wide_part = 1, dynamic_serialization_version = 'v3';
+
+insert into test select number, number < 500000 ? toJSONString(map('a.b.c', number, 'a.b.d', number::UInt32, 'a.b.e', 'str_' || toString(number))) :  toJSONString(map('a.b.c', number, 'a.b.d', number::UInt32, 'a.b.e', 'str_' || toString(number), 'b.b._' || toString(number % 5), number::UInt32)) from numbers(400000, 200000);
+
+select json.b.b.`_1`.:String from test format Null settings max_threads=1;
+drop table test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix seeking at the end of the decompressed block.

Closes https://github.com/ClickHouse/ClickHouse/issues/86830

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
