### PR TITLE
Add allow_reentry option to windowFunnel aggregate function

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/parametric-functions.md
+++ b/docs/en/sql-reference/aggregate-functions/parametric-functions.md
@@ -323,7 +323,8 @@ windowFunnel(window, [mode, [mode, ... ]])(timestamp, cond1, cond2, ..., condN)
   - `'strict_deduplication'` — If the same condition holds for the sequence of events, then such repeating event interrupts further processing. Note: it may work unexpectedly if several conditions hold for the same event.
   - `'strict_order'` — Don't allow interventions of other events. E.g. in the case of `A->B->D->C`, it stops finding `A->B->C` at the `D` and the max event level is 2.
   - `'strict_increase'` — Apply conditions only to events with strictly increasing timestamps.
-  - `'strict_once'` — Count each event only once in the chain even if it meets the condition several times
+  - `'strict_once'` — Count each event only once in the chain even if it meets the condition several times.
+  - `'allow_reentry'` — Allow reentry to previously completed steps while maintaining strict order. E.g. in the case of `A->B->A->C`, it allows finding `A->B->C` by treating the second `A` as reentry. This mode is useful for analyzing funnels where users might revisit previous steps.
 
 **Returned value**
 
@@ -387,6 +388,37 @@ Result:
 ┌─level─┬─c─┐
 │     4 │ 1 │
 └───────┴───┘
+```
+
+**Example with allow_reentry mode**
+
+This example demonstrates how `allow_reentry` mode works with user reentry patterns:
+
+```sql
+-- Sample data: user visits checkout -> product detail -> checkout again -> payment
+-- Without allow_reentry: stops at level 2 (product detail page)
+-- With allow_reentry: reaches level 4 (payment completion)
+
+SELECT
+    level,
+    count() AS users
+FROM
+(
+    SELECT
+        user_id,
+        windowFunnel(3600, 'strict_order', 'allow_reentry')(
+            timestamp,
+            action = 'begin_checkout',      -- Step 1: Begin checkout
+            action = 'view_product_detail', -- Step 2: View product detail  
+            action = 'begin_checkout',      -- Step 3: Begin checkout again (reentry)
+            action = 'complete_payment'     -- Step 4: Complete payment
+        ) AS level
+    FROM user_events
+    WHERE event_date = today()
+    GROUP BY user_id
+)
+GROUP BY level
+ORDER BY level ASC;
 ```
 
 ## retention {#retention}

--- a/docs/en/sql-reference/aggregate-functions/parametric-functions.md
+++ b/docs/en/sql-reference/aggregate-functions/parametric-functions.md
@@ -324,7 +324,7 @@ windowFunnel(window, [mode, [mode, ... ]])(timestamp, cond1, cond2, ..., condN)
   - `'strict_order'` — Don't allow interventions of other events. E.g. in the case of `A->B->D->C`, it stops finding `A->B->C` at the `D` and the max event level is 2.
   - `'strict_increase'` — Apply conditions only to events with strictly increasing timestamps.
   - `'strict_once'` — Count each event only once in the chain even if it meets the condition several times.
-  - `'allow_reentry'` — Allow reentry to previously completed steps while maintaining strict order. E.g. in the case of `A->B->A->C`, it allows finding `A->B->C` by treating the second `A` as reentry. This mode is useful for analyzing funnels where users might revisit previous steps.
+  - `'allow_reentry'` — Ignore events that violate the strict order. E.g. in the case of A->A->B->C, it finds A->B->C by ignoring the redundant A and the max event level is 3.
 
 **Returned value**
 

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp
@@ -327,7 +327,7 @@ private:
                             break;
                         }
                     }
-                    
+
                     if (is_reentry)
                     {
                         for (size_t event = 0; event < events_timestamp.size(); ++event)
@@ -448,7 +448,7 @@ private:
                             break;
                         }
                     }
-                    
+
                     if (is_reentry)
                     {
                         for (size_t event = 0; event < event_sequences.size(); ++event)
@@ -599,7 +599,7 @@ public:
             else
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Aggregate function {} doesn't support a parameter: {}", getName(), option);
         }
-        
+
         /// Validate option combinations
         if (allow_reentry && !strict_order)
         {

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -180,17 +180,11 @@ drop table funnel_test_strict_increase;
 -- Test allow_reentry mode
 drop table if exists funnel_test_allow_reentry;
 create table funnel_test_allow_reentry (dt DateTime, user int, event String) engine = MergeTree() partition by dt order by user;
--- Test case 1: Basic reentry pattern - a->b->a->c (should reach level 3 with allow_reentry)
 insert into funnel_test_allow_reentry values (1, 1, 'a') (2, 1, 'b') (3, 1, 'a') (4, 1, 'c');
--- Test case 2: Multiple reentries - a->b->a->b->c (should reach level 3 with allow_reentry)
 insert into funnel_test_allow_reentry values (1, 2, 'a') (2, 2, 'b') (3, 2, 'a') (4, 2, 'b') (5, 2, 'c');
--- Test case 3: Reentry to later completed step - a->b->c->b->d (should reach level 4 with allow_reentry)
 insert into funnel_test_allow_reentry values (1, 3, 'a') (2, 3, 'b') (3, 3, 'c') (4, 3, 'b') (5, 3, 'd');
--- Test case 4: Invalid jump (not reentry) - a->c->b (should stop at level 1 even with allow_reentry)
 insert into funnel_test_allow_reentry values (1, 4, 'a') (2, 4, 'c') (3, 4, 'b');
--- Test case 5: Complex reentry pattern - a->b->c->a->b->c->d (should reach level 4 with allow_reentry)
 insert into funnel_test_allow_reentry values (1, 5, 'a') (2, 5, 'b') (3, 5, 'c') (4, 5, 'a') (5, 5, 'b') (6, 5, 'c') (7, 5, 'd');
--- Compare strict_order vs strict_order + allow_reentry
 select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c') as strict_order_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
 [1, 2]
 [2, 2]
@@ -203,37 +197,30 @@ select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a',
 [3, 3]
 [4, 1]
 [5, 3]
--- Test 4-step funnel with reentry
 select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c', event='d') as strict_order_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 0]
-[2, 0]
-[3, 3]
+[1, 2]
+[2, 2]
+[3, 4]
 [4, 1]
 [5, 3]
 select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c', event='d') as allow_reentry_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 0]
-[2, 0]
+[1, 3]
+[2, 3]
 [3, 4]
 [4, 1]
 [5, 4]
--- Test combination with other modes
 select user, windowFunnel(86400, 'strict_order', 'allow_reentry', 'strict_deduplication')(dt, event='a', event='b', event='c') as combined_modes from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 2]
-[2, 2]
+[1, 3]
+[2, 1]
 [3, 3]
 [4, 1]
 [5, 3]
 drop table funnel_test_allow_reentry;
--- Test real-world e-commerce reentry scenario
 drop table if exists funnel_test_ecommerce;
 create table funnel_test_ecommerce (timestamp UInt32, user_id UInt32, action String) engine=Memory;
--- User 1: Typical reentry pattern - checkout -> product_detail -> checkout -> payment
 insert into funnel_test_ecommerce values (100, 1, 'begin_checkout') (200, 1, 'view_product_detail') (300, 1, 'begin_checkout') (400, 1, 'complete_payment');
--- User 2: Multiple product views with reentry - checkout -> product1 -> product2 -> checkout -> payment  
 insert into funnel_test_ecommerce values (100, 2, 'begin_checkout') (200, 2, 'view_product_detail') (250, 2, 'view_product_detail') (300, 2, 'begin_checkout') (400, 2, 'complete_payment');
--- User 3: No reentry, normal flow - checkout -> product_detail -> payment
 insert into funnel_test_ecommerce values (100, 3, 'begin_checkout') (200, 3, 'view_product_detail') (300, 3, 'complete_payment');
--- Test the e-commerce funnel with window of 600 seconds
 select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as normal_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
 [1, 2]
 [2, 2]
@@ -242,13 +229,12 @@ select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, ac
 [1, 3]
 [2, 3]
 [3, 3]
--- Test 4-step e-commerce funnel
 select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as normal_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-[1, 2]
-[2, 2]
-[3, 0]
+[1, 1]
+[2, 1]
+[3, 1]
 select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as reentry_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-[1, 4]
-[2, 4]
-[3, 0]
+[1, 1]
+[2, 1]
+[3, 1]
 drop table funnel_test_ecommerce;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -177,3 +177,78 @@ SELECT '-';
 -
 DROP TABLE IF EXISTS funnel_test2;
 drop table funnel_test_strict_increase;
+-- Test allow_reentry mode
+drop table if exists funnel_test_allow_reentry;
+create table funnel_test_allow_reentry (dt DateTime, user int, event String) engine = MergeTree() partition by dt order by user;
+-- Test case 1: Basic reentry pattern - a->b->a->c (should reach level 3 with allow_reentry)
+insert into funnel_test_allow_reentry values (1, 1, 'a') (2, 1, 'b') (3, 1, 'a') (4, 1, 'c');
+-- Test case 2: Multiple reentries - a->b->a->b->c (should reach level 3 with allow_reentry)
+insert into funnel_test_allow_reentry values (1, 2, 'a') (2, 2, 'b') (3, 2, 'a') (4, 2, 'b') (5, 2, 'c');
+-- Test case 3: Reentry to later completed step - a->b->c->b->d (should reach level 4 with allow_reentry)
+insert into funnel_test_allow_reentry values (1, 3, 'a') (2, 3, 'b') (3, 3, 'c') (4, 3, 'b') (5, 3, 'd');
+-- Test case 4: Invalid jump (not reentry) - a->c->b (should stop at level 1 even with allow_reentry)
+insert into funnel_test_allow_reentry values (1, 4, 'a') (2, 4, 'c') (3, 4, 'b');
+-- Test case 5: Complex reentry pattern - a->b->c->a->b->c->d (should reach level 4 with allow_reentry)
+insert into funnel_test_allow_reentry values (1, 5, 'a') (2, 5, 'b') (3, 5, 'c') (4, 5, 'a') (5, 5, 'b') (6, 5, 'c') (7, 5, 'd');
+-- Compare strict_order vs strict_order + allow_reentry
+select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c') as strict_order_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+[1, 2]
+[2, 2]
+[3, 3]
+[4, 1]
+[5, 3]
+select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as allow_reentry_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+[1, 3]
+[2, 3]
+[3, 3]
+[4, 1]
+[5, 3]
+-- Test 4-step funnel with reentry
+select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c', event='d') as strict_order_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+[1, 0]
+[2, 0]
+[3, 3]
+[4, 1]
+[5, 3]
+select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c', event='d') as allow_reentry_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+[1, 0]
+[2, 0]
+[3, 4]
+[4, 1]
+[5, 4]
+-- Test combination with other modes
+select user, windowFunnel(86400, 'strict_order', 'allow_reentry', 'strict_deduplication')(dt, event='a', event='b', event='c') as combined_modes from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+[1, 2]
+[2, 2]
+[3, 3]
+[4, 1]
+[5, 3]
+drop table funnel_test_allow_reentry;
+-- Test real-world e-commerce reentry scenario
+drop table if exists funnel_test_ecommerce;
+create table funnel_test_ecommerce (timestamp UInt32, user_id UInt32, action String) engine=Memory;
+-- User 1: Typical reentry pattern - checkout -> product_detail -> checkout -> payment
+insert into funnel_test_ecommerce values (100, 1, 'begin_checkout') (200, 1, 'view_product_detail') (300, 1, 'begin_checkout') (400, 1, 'complete_payment');
+-- User 2: Multiple product views with reentry - checkout -> product1 -> product2 -> checkout -> payment  
+insert into funnel_test_ecommerce values (100, 2, 'begin_checkout') (200, 2, 'view_product_detail') (250, 2, 'view_product_detail') (300, 2, 'begin_checkout') (400, 2, 'complete_payment');
+-- User 3: No reentry, normal flow - checkout -> product_detail -> payment
+insert into funnel_test_ecommerce values (100, 3, 'begin_checkout') (200, 3, 'view_product_detail') (300, 3, 'complete_payment');
+-- Test the e-commerce funnel with window of 600 seconds
+select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as normal_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
+[1, 2]
+[2, 2]
+[3, 3]
+select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as reentry_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
+[1, 3]
+[2, 3]
+[3, 3]
+-- Test 4-step e-commerce funnel
+select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as normal_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
+[1, 2]
+[2, 2]
+[3, 0]
+select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as reentry_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
+[1, 4]
+[2, 4]
+[3, 0]
+drop table funnel_test_ecommerce;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -182,23 +182,18 @@ create table funnel_test_reentry (uid Int32, dt UInt32, event String) engine = M
 insert into funnel_test_reentry values (1, 10, 'a'), (1, 20, 'a'), (1, 30, 'b'), (1, 40, 'a'), (1, 50, 'c');
 insert into funnel_test_reentry values (2, 10, 'a'), (2, 20, 'c'), (2, 30, 'b'), (2, 40, 'c');
 insert into funnel_test_reentry values (3, 10, 'a'), (3, 20, 'c');
-
 select uid, windowFunnel(100, 'strict_order')(dt, event='a', event='b', event='a', event='c') as res
 from funnel_test_reentry where uid = 1 group by uid format JSONCompactEachRow;
 [1, 1]
-
 select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='a', event='c') as res
 from funnel_test_reentry where uid = 1 group by uid format JSONCompactEachRow;
 [1, 4]
-
 select uid, windowFunnel(100, 'strict_order')(dt, event='a', event='b', event='c') as res
 from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
 [2, 1]
-
 select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
 from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
 [2, 3]
-
 select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
 from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
 [3, 2]

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -177,64 +177,29 @@ SELECT '-';
 -
 DROP TABLE IF EXISTS funnel_test2;
 drop table funnel_test_strict_increase;
--- Test allow_reentry mode
-drop table if exists funnel_test_allow_reentry;
-create table funnel_test_allow_reentry (dt DateTime, user int, event String) engine = MergeTree() partition by dt order by user;
-insert into funnel_test_allow_reentry values (1, 1, 'a') (2, 1, 'b') (3, 1, 'a') (4, 1, 'c');
-insert into funnel_test_allow_reentry values (1, 2, 'a') (2, 2, 'b') (3, 2, 'a') (4, 2, 'b') (5, 2, 'c');
-insert into funnel_test_allow_reentry values (1, 3, 'a') (2, 3, 'b') (3, 3, 'c') (4, 3, 'b') (5, 3, 'd');
-insert into funnel_test_allow_reentry values (1, 4, 'a') (2, 4, 'c') (3, 4, 'b');
-insert into funnel_test_allow_reentry values (1, 5, 'a') (2, 5, 'b') (3, 5, 'c') (4, 5, 'a') (5, 5, 'b') (6, 5, 'c') (7, 5, 'd');
-select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c') as strict_order_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 2]
-[2, 2]
-[3, 3]
-[4, 1]
-[5, 3]
-select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as allow_reentry_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 3]
-[2, 3]
-[3, 3]
-[4, 1]
-[5, 3]
-select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c', event='d') as strict_order_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 2]
-[2, 2]
-[3, 4]
-[4, 1]
-[5, 3]
-select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c', event='d') as allow_reentry_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 3]
-[2, 3]
-[3, 4]
-[4, 1]
-[5, 4]
-select user, windowFunnel(86400, 'strict_order', 'allow_reentry', 'strict_deduplication')(dt, event='a', event='b', event='c') as combined_modes from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-[1, 3]
-[2, 1]
-[3, 3]
-[4, 1]
-[5, 3]
-drop table funnel_test_allow_reentry;
-drop table if exists funnel_test_ecommerce;
-create table funnel_test_ecommerce (timestamp UInt32, user_id UInt32, action String) engine=Memory;
-insert into funnel_test_ecommerce values (100, 1, 'begin_checkout') (200, 1, 'view_product_detail') (300, 1, 'begin_checkout') (400, 1, 'complete_payment');
-insert into funnel_test_ecommerce values (100, 2, 'begin_checkout') (200, 2, 'view_product_detail') (250, 2, 'view_product_detail') (300, 2, 'begin_checkout') (400, 2, 'complete_payment');
-insert into funnel_test_ecommerce values (100, 3, 'begin_checkout') (200, 3, 'view_product_detail') (300, 3, 'complete_payment');
-select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as normal_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-[1, 2]
-[2, 2]
-[3, 3]
-select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as reentry_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-[1, 3]
-[2, 3]
-[3, 3]
-select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as normal_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
+drop table if exists funnel_test_reentry;
+create table funnel_test_reentry (uid Int32, dt UInt32, event String) engine = Memory;
+insert into funnel_test_reentry values (1, 10, 'a'), (1, 20, 'a'), (1, 30, 'b'), (1, 40, 'a'), (1, 50, 'c');
+insert into funnel_test_reentry values (2, 10, 'a'), (2, 20, 'c'), (2, 30, 'b'), (2, 40, 'c');
+insert into funnel_test_reentry values (3, 10, 'a'), (3, 20, 'c');
+
+select uid, windowFunnel(100, 'strict_order')(dt, event='a', event='b', event='a', event='c') as res
+from funnel_test_reentry where uid = 1 group by uid format JSONCompactEachRow;
 [1, 1]
+
+select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='a', event='c') as res
+from funnel_test_reentry where uid = 1 group by uid format JSONCompactEachRow;
+[1, 4]
+
+select uid, windowFunnel(100, 'strict_order')(dt, event='a', event='b', event='c') as res
+from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
 [2, 1]
-[3, 1]
-select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as reentry_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-[1, 1]
-[2, 1]
-[3, 1]
-drop table funnel_test_ecommerce;
+
+select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
+from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
+[2, 3]
+
+select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
+from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
+[3, 2]
+drop table funnel_test_reentry;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.reference
@@ -196,5 +196,5 @@ from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
 [2, 3]
 select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
 from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
-[3, 2]
+[3, 1]
 drop table funnel_test_reentry;

--- a/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
+++ b/tests/queries/0_stateless/00632_aggregation_window_funnel.sql
@@ -129,36 +129,25 @@ DROP TABLE IF EXISTS funnel_test2;
 
 drop table funnel_test_strict_increase;
 
--- Test allow_reentry mode
-drop table if exists funnel_test_allow_reentry;
-create table funnel_test_allow_reentry (dt DateTime, user int, event String) engine = MergeTree() partition by dt order by user;
+drop table if exists funnel_test_reentry;
+create table funnel_test_reentry (uid Int32, dt UInt32, event String) engine = Memory;
+insert into funnel_test_reentry values (1, 10, 'a'), (1, 20, 'a'), (1, 30, 'b'), (1, 40, 'a'), (1, 50, 'c');
+insert into funnel_test_reentry values (2, 10, 'a'), (2, 20, 'c'), (2, 30, 'b'), (2, 40, 'c');
+insert into funnel_test_reentry values (3, 10, 'a'), (3, 20, 'c');
 
-insert into funnel_test_allow_reentry values (1, 1, 'a') (2, 1, 'b') (3, 1, 'a') (4, 1, 'c');
-insert into funnel_test_allow_reentry values (1, 2, 'a') (2, 2, 'b') (3, 2, 'a') (4, 2, 'b') (5, 2, 'c');
-insert into funnel_test_allow_reentry values (1, 3, 'a') (2, 3, 'b') (3, 3, 'c') (4, 3, 'b') (5, 3, 'd');
-insert into funnel_test_allow_reentry values (1, 4, 'a') (2, 4, 'c') (3, 4, 'b');
-insert into funnel_test_allow_reentry values (1, 5, 'a') (2, 5, 'b') (3, 5, 'c') (4, 5, 'a') (5, 5, 'b') (6, 5, 'c') (7, 5, 'd');
+select uid, windowFunnel(100, 'strict_order')(dt, event='a', event='b', event='a', event='c') as res
+from funnel_test_reentry where uid = 1 group by uid format JSONCompactEachRow;
 
-select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c') as strict_order_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as allow_reentry_result from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='a', event='c') as res
+from funnel_test_reentry where uid = 1 group by uid format JSONCompactEachRow;
 
-select user, windowFunnel(86400, 'strict_order')(dt, event='a', event='b', event='c', event='d') as strict_order_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
-select user, windowFunnel(86400, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c', event='d') as allow_reentry_4step from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+select uid, windowFunnel(100, 'strict_order')(dt, event='a', event='b', event='c') as res
+from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
 
-select user, windowFunnel(86400, 'strict_order', 'allow_reentry', 'strict_deduplication')(dt, event='a', event='b', event='c') as combined_modes from funnel_test_allow_reentry group by user order by user format JSONCompactEachRow;
+select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
+from funnel_test_reentry where uid = 2 group by uid format JSONCompactEachRow;
 
-drop table funnel_test_allow_reentry;
+select uid, windowFunnel(100, 'strict_order', 'allow_reentry')(dt, event='a', event='b', event='c') as res
+from funnel_test_reentry where uid = 3 group by uid format JSONCompactEachRow;
+drop table funnel_test_reentry;
 
-drop table if exists funnel_test_ecommerce;
-create table funnel_test_ecommerce (timestamp UInt32, user_id UInt32, action String) engine=Memory;
-
-insert into funnel_test_ecommerce values (100, 1, 'begin_checkout') (200, 1, 'view_product_detail') (300, 1, 'begin_checkout') (400, 1, 'complete_payment');
-insert into funnel_test_ecommerce values (100, 2, 'begin_checkout') (200, 2, 'view_product_detail') (250, 2, 'view_product_detail') (300, 2, 'begin_checkout') (400, 2, 'complete_payment');
-insert into funnel_test_ecommerce values (100, 3, 'begin_checkout') (200, 3, 'view_product_detail') (300, 3, 'complete_payment');
-
-select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as normal_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='complete_payment') as reentry_funnel from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-select user_id, windowFunnel(600, 'strict_order')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as normal_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-select user_id, windowFunnel(600, 'strict_order', 'allow_reentry')(timestamp, action='begin_checkout', action='view_product_detail', action='begin_checkout', action='complete_payment') as reentry_4step from funnel_test_ecommerce group by user_id order by user_id format JSONCompactEachRow;
-
-drop table funnel_test_ecommerce;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add `allow_reentry` option to `windowFunnel` aggregate function. When enabled with strict_order, it ignores events that violate the order instead of stopping the funnel analysis. This enables handling user journeys with refreshes (A->A->B) or back-navigation (A->B->A->C) without underreporting conversion rates.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details

**Motivation**

The current strict_order mode in windowFunnel is too rigid for analyzing complex user journeys, especially when the funnel definition itself includes re-entry steps (e.g., Step1 -> Step2 -> Step1 -> Step3). In strict_order mode, the funnel stops immediately when any out-of-order event occurs. This creates false negatives and underreporting in reentry scenarios. (In practice, many reentry funnel analysis is needed.)

The new allow_reentry option addresses this by ignoring premature violations instead of terminating the funnel, allowing the analysis to continue and correctly identify.

**Parameters**

**Option**: `allow_reentry`
- **Type**: String option parameter
- **Requires**: Must be used together with `strict_order`
- **Default**: Disabled
- **Description**: Ignore events that violate the strict order instead of stopping. This enables robust analysis of funnels containing re-entry steps. E.g. for funnel A->B->A->C, a user sequence of A->A->B->A->C (refreshing A) matches level 4 by ignoring the redundant A during the strict order check for step 3.
- **Validation**: Throws `BAD_ARGUMENTS` exception if used without `strict_order`

**Syntax:**
```sql
windowFunnel(window, 'strict_order', 'allow_reentry')(timestamp, cond1, cond2, ...)
```

**Example use**
```sql
-- Create sample data
CREATE TABLE user_events (
    user_id UInt32,
    timestamp DateTime,
    event String
) ENGINE = Memory;

INSERT INTO user_events VALUES
    -- User 1: "Comparison Shopper" with a refresh
    -- Behavior: List(A) -> List(A, Refresh) -> Product(B) -> List(A, Back) -> Purchase(C)
    -- Goal: Should reach Level 4
    (1, '2024-01-01 10:00:00', 'view_list'),
    (1, '2024-01-01 10:01:00', 'view_list'),   -- Problematic event for strict_order
    (1, '2024-01-01 10:02:00', 'view_product'),
    (1, '2024-01-01 10:03:00', 'view_list'),
    (1, '2024-01-01 10:04:00', 'purchase');

-- Funnel Definition: List(A) -> Product(B) -> List(A) -> Purchase(C)

-- Without allow_reentry (Current strict_order behavior)
SELECT 
    user_id,
    windowFunnel(3600, 'strict_order')(
        timestamp,
        event = 'view_list',    -- Step 1
        event = 'view_product', -- Step 2
        event = 'view_list',    -- Step 3 (Re-entry)
        event = 'purchase'      -- Step 4
    ) AS funnel_level
FROM user_events
GROUP BY user_id;
-- Result: User 1: 1 
-- Explanation: Stops at 2nd 'view_list' because Step 2 ('view_product') is missing.

-- With allow_reentry (New behavior)  
SELECT 
    user_id,
    windowFunnel(3600, 'strict_order', 'allow_reentry')(
        timestamp,
        event = 'view_list',
        event = 'view_product',
        event = 'view_list',
        event = 'purchase'
    ) AS funnel_level
FROM user_events
GROUP BY user_id;
-- Result: User 1: 4 
-- Explanation: 2nd 'view_list' is ignored for Step 3 check, allowing flow to continue to Step 2, Step 3, and Step 4.
```

**Files Modified**

- `src/AggregateFunctions/AggregateFunctionWindowFunnel.cpp` - Core implementation
- `docs/en/sql-reference/aggregate-functions/parametric-functions.md` - Documentation
- `tests/queries/0_stateless/00632_aggregation_window_funnel.sql` - Test cases
- `tests/queries/0_stateless/00632_aggregation_window_funnel.reference` - Expected results
