### PR TITLE
Added missing quota fields to documentation

### DIFF
--- a/docs/en/operations/quotas.md
+++ b/docs/en/operations/quotas.md
@@ -57,10 +57,12 @@ The resource consumption calculated for each interval is output to the server lo
         <queries>1000</queries>
         <query_selects>100</query_selects>
         <query_inserts>100</query_inserts>
+        <written_bytes>5000000</written_bytes>
         <errors>100</errors>
         <result_rows>1000000000</result_rows>
         <read_rows>100000000000</read_rows>
         <execution_time>900</execution_time>
+        <failed_sequential_authentications>5</failed_sequential_authentications>
     </interval>
 
     <interval>
@@ -71,7 +73,9 @@ The resource consumption calculated for each interval is output to the server lo
         <query_inserts>10000</query_inserts>
         <errors>1000</errors>
         <result_rows>5000000000</result_rows>
+        <result_bytes>160000000000</result_bytes>
         <read_rows>500000000000</read_rows>
+        <result_bytes>16000000000000</result_bytes>
         <execution_time>7200</execution_time>
     </interval>
 </statbox>
@@ -93,9 +97,17 @@ Here are the amounts that can be restricted:
 
 `result_rows` – The total number of rows given as a result.
 
+`result_bytes` - The total size of rows given as a result.
+
 `read_rows` – The total number of source rows read from tables for running the query on all remote servers.
 
+`read_bytes` - The total size read from tables for running the query on all remote servers.
+
+`written_bytes` - The total size of a writing operation. 
+
 `execution_time` – The total query execution time, in seconds (wall time).
+
+`failed_sequential_authentications` - The total number of sequential authentication errors. 
 
 If the limit is exceeded for at least one time interval, an exception is thrown with a text about which restriction was exceeded, for which interval, and when the new interval begins (when queries can be sent again).
 

--- a/docs/en/sql-reference/statements/create/quota.md
+++ b/docs/en/sql-reference/statements/create/quota.md
@@ -15,14 +15,14 @@ CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
     [IN access_storage_type]
     [KEYED BY {user_name | ip_address | client_key | client_key,user_name | client_key,ip_address} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {second | minute | hour | day | week | month | quarter | year}
-        {MAX { {queries | query_selects | query_inserts | errors | result_rows | result_bytes | read_rows | read_bytes | execution_time} = number } [,...] |
+        {MAX { {queries | query_selects | query_inserts | errors | result_rows | result_bytes | read_rows | read_bytes | written_bytes | execution_time | failed_sequential_authentications} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
 
 Keys `user_name`, `ip_address`, `client_key`, `client_key, user_name` and `client_key, ip_address` correspond to the fields in the [system.quotas](../../../operations/system-tables/quotas.md) table.
 
-Parameters `queries`, `query_selects`, `query_inserts`, `errors`, `result_rows`, `result_bytes`, `read_rows`, `read_bytes`, `execution_time`, `failed_sequential_authentications` correspond to the fields in the [system.quotas_usage](../../../operations/system-tables/quotas_usage.md) table.
+Parameters `queries`, `query_selects`, `query_inserts`, `errors`, `result_rows`, `result_bytes`, `read_rows`, `read_bytes`, `written_bytes`, `execution_time`, `failed_sequential_authentications` correspond to the fields in the [system.quotas_usage](../../../operations/system-tables/quotas_usage.md) table.
 
 `ON CLUSTER` clause allows creating quotas on a cluster, see [Distributed DDL](../../../sql-reference/distributed-ddl.md).
 


### PR DESCRIPTION

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Motivation: 
The quota documentation does not contain all available fields.
