### PR TITLE
RFC: Optimize MarkRanges by using devector over deque

### DIFF
--- a/src/Storages/MergeTree/MarkRange.h
+++ b/src/Storages/MergeTree/MarkRange.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstddef>
-#include <deque>
 #include <Processors/Chunk.h>
+#include <boost/container/devector.hpp>
 #include <fmt/format.h>
 #include <base/types.h>
 
@@ -30,7 +30,7 @@ struct MarkRange
     bool operator<(const MarkRange & rhs) const;
 };
 
-struct MarkRanges : public std::deque<MarkRange>
+struct MarkRanges : public boost::container::devector<MarkRange>
 {
     enum class SearchAlgorithm : uint8_t
     {
@@ -39,7 +39,7 @@ struct MarkRanges : public std::deque<MarkRange>
         GenericExclusionSearch,
     };
 
-    using std::deque<MarkRange>::deque; /// NOLINT(modernize-type-traits)
+    using boost::container::devector<MarkRange>::devector; /// NOLINT(modernize-type-traits)
 
     size_t getNumberOfMarks() const;
     bool isOneRangeForWholePart(size_t num_marks_in_part) const;

--- a/src/Storages/MergeTree/MergeTreeLazilyReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeLazilyReader.cpp
@@ -169,7 +169,7 @@ void MergeTreeLazilyReader::readLazyColumns(
             ReadBufferFromFileBase::ProfileCallback{});
 
         size_t idx = 0;
-        auto mark_range_iter = mark_ranges.begin();
+        auto * mark_range_iter = mark_ranges.begin();
         auto row_offset = row_offsets[idx].row_offset;
         size_t next_offset = row_offset - index_granularity.getMarkStartingRow(mark_range_iter->begin);
         size_t skipped_rows = next_offset;

--- a/src/Storages/MergeTree/PatchParts/MergeTreePatchReader.cpp
+++ b/src/Storages/MergeTree/PatchParts/MergeTreePatchReader.cpp
@@ -164,7 +164,7 @@ static void filterReadRanges(MarkRanges & all_ranges, const MarkRanges & read_ra
 {
     std::unordered_set<MarkRange, MarkRangeHash> read_ranges_set(read_ranges.begin(), read_ranges.end());
 
-    for (auto it = all_ranges.begin(); it != all_ranges.end();)
+    for (auto * it = all_ranges.begin(); it != all_ranges.end();)
     {
         if (read_ranges_set.contains(*it))
             it = all_ranges.erase(it);

--- a/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
+++ b/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
@@ -227,8 +227,8 @@ MarkRanges RangesInPatchParts::getIntersectingRanges(const String & patch_name, 
 
     for (const auto & range : ranges)
     {
-        auto left = std::lower_bound(patch_ranges.begin(), patch_ranges.end(), range.begin, [](const MarkRange & r, UInt64 value) { return r.end < value; });
-        auto right = std::upper_bound(patch_ranges.begin(), patch_ranges.end(), range.end, [](UInt64 value, const MarkRange & r) { return value < r.begin; });
+        const auto * left = std::lower_bound(patch_ranges.begin(), patch_ranges.end(), range.begin, [](const MarkRange & r, UInt64 value) { return r.end < value; });
+        const auto * right = std::upper_bound(patch_ranges.begin(), patch_ranges.end(), range.end, [](UInt64 value, const MarkRange & r) { return value < r.begin; });
 
         res.insert(left, right);
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improves performance of fast queries with lots of parts in table (by optimizing `MarkRanges` by using `devector` over `deque`)

While reviewing #85535 I noticed that `MarkRanges` copying is very slow, let's try to replace it with more efficient container (hope that we do not rely on iterators guarantees anywhere in the code)

### Test

```sql
create or replace table data (key Int, part Int) engine=MergeTree() order by key partition by part;
insert into data select *, *%10000 from numbers(10000) settings max_partitions_per_insert_block=10000;
```

```sh
clickhouse-benchmark -q 'select * from data where key = 1' -i 100
```

### Results

- Before - `localhost:9000, queries: 100, QPS: 11.763, RPS: 11.763, MiB/s: 0.000, result RPS: 11.763, result MiB/s: 0.000.`
- After - `localhost:9000, queries: 100, QPS: 16.347, RPS: 16.347, MiB/s: 0.000, result RPS: 16.347, result MiB/s: 0.000.`

**And when #85535 will be merged this will be moved to INSERT side**:

- w/o #85535 INSERT takes **~4.1 seconds**
- #85535 - **26 seconds**
- #85535 + #86933 - **9.5 seconds**