### PR TITLE
ITableFunction: Enforce that the engine name is found when checking permissions

### DIFF
--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -266,7 +266,7 @@ std::optional<AccessTypeObjects::Source> StorageFactory::getSourceAccessObject(c
 {
     auto it = storages.find(table_engine);
     if (it == storages.end())
-        return std::nullopt;
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown table engine {}", table_engine);
     return it->second.features.source_access_type;
 }
 

--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -268,7 +268,7 @@ std::optional<AccessTypeObjects::Source> StorageFactory::getSourceAccessObject(c
         return {};
     const auto it = storages.find(table_engine);
     if (it == storages.end())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown table engine {}", table_engine);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown table engine '{}' when checking for access type", table_engine);
     return it->second.features.source_access_type;
 }
 

--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -264,7 +264,11 @@ StorageFactory & StorageFactory::instance()
 
 std::optional<AccessTypeObjects::Source> StorageFactory::getSourceAccessObject(const String & table_engine) const
 {
-    auto it = storages.find(table_engine);
+    /// System tables are not registered. As they are simply generating data we do not require any access rights.
+    std::unordered_set<String> system_engines{"SystemNumbers", "SystemZeros"};
+    if (system_engines.contains(table_engine))
+        return std::nullopt;
+    const auto it = storages.find(table_engine);
     if (it == storages.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown table engine {}", table_engine);
     return it->second.features.source_access_type;

--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -264,10 +264,8 @@ StorageFactory & StorageFactory::instance()
 
 std::optional<AccessTypeObjects::Source> StorageFactory::getSourceAccessObject(const String & table_engine) const
 {
-    /// System tables are not registered. As they are simply generating data we do not require any access rights.
-    std::unordered_set<String> system_engines{"SystemNumbers", "SystemZeros"};
-    if (system_engines.contains(table_engine))
-        return std::nullopt;
+    if (table_engine.empty())
+        return {};
     const auto it = storages.find(table_engine);
     if (it == storages.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown table engine {}", table_engine);

--- a/src/TableFunctions/TableFunctionExplain.cpp
+++ b/src/TableFunctions/TableFunctionExplain.cpp
@@ -46,7 +46,11 @@ public:
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const String & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "Explain"; }
+    const char * getStorageEngineName() const override
+    {
+        /// No underlying storage engine
+        return "";
+    }
 
     std::vector<size_t> skipAnalysisForArguments(const QueryTreeNodePtr & query_node_table_function, ContextPtr context) const override;
 

--- a/src/TableFunctions/TableFunctionFormat.cpp
+++ b/src/TableFunctions/TableFunctionFormat.cpp
@@ -53,7 +53,11 @@ public:
 
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
-    const char * getStorageEngineName() const override { return "Values"; }
+    const char * getStorageEngineName() const override
+    {
+        /// No underlying storage engine
+        return "";
+    }
 
     ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
     void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;

--- a/src/TableFunctions/TableFunctionFuzzQuery.h
+++ b/src/TableFunctions/TableFunctionFuzzQuery.h
@@ -32,7 +32,7 @@ private:
         ColumnsDescription cached_columns,
         bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "fuzzQuery"; }
+    const char * getStorageEngineName() const override { return "FuzzQuery"; }
 
     String source;
     std::optional<UInt64> random_seed;

--- a/src/TableFunctions/TableFunctionGenerateSeries.cpp
+++ b/src/TableFunctions/TableFunctionGenerateSeries.cpp
@@ -42,7 +42,11 @@ private:
         const std::string & table_name,
         ColumnsDescription cached_columns,
         bool is_insert_query) const override;
-    const char * getStorageEngineName() const override { return "SystemNumbers"; }
+    const char * getStorageEngineName() const override
+    {
+        /// No underlying storage engine
+        return "";
+    }
 
     UInt64 evaluateArgument(ContextPtr context, ASTPtr & argument) const;
 

--- a/src/TableFunctions/TableFunctionInput.cpp
+++ b/src/TableFunctions/TableFunctionInput.cpp
@@ -36,7 +36,11 @@ public:
 
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
-    const char * getStorageEngineName() const override { return "Input"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's Input but it doesn't register itself
+        return "";
+    }
 
     ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
     void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;

--- a/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
@@ -40,7 +40,11 @@ private:
         ColumnsDescription cached_columns,
         bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "MergeTreeIndex"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's MergeTreeIndex but it doesn't register itself
+        return "";
+    }
 
     StorageID source_table_id{StorageID::createEmpty()};
     bool with_marks = false;

--- a/src/TableFunctions/TableFunctionNumbers.cpp
+++ b/src/TableFunctions/TableFunctionNumbers.cpp
@@ -45,7 +45,11 @@ private:
         const std::string & table_name,
         ColumnsDescription cached_columns,
         bool is_insert_query) const override;
-    const char * getStorageEngineName() const override { return "SystemNumbers"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's SystemNumbers but it doesn't register itself
+        return "";
+    }
 
     UInt64 evaluateArgument(ContextPtr context, ASTPtr & argument) const;
 

--- a/src/TableFunctions/TableFunctionProjection.cpp
+++ b/src/TableFunctions/TableFunctionProjection.cpp
@@ -31,7 +31,11 @@ private:
         ColumnsDescription cached_columns,
         bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "MergeTreeProjection"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's MergeTreeProjection but it doesn't register itself
+        return "";
+    }
 
     StorageID source_table_id{StorageID::createEmpty()};
     String projection_name;

--- a/src/TableFunctions/TableFunctionPrometheusQuery.h
+++ b/src/TableFunctions/TableFunctionPrometheusQuery.h
@@ -36,7 +36,11 @@ private:
 
     ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "PrometheusQuery"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's PrometheusQuery but it doesn't register itself
+        return "";
+    }
 
     StorageID time_series_storage_id = StorageID::createEmpty();
     PrometheusQueryTree promql_query;

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.h
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.h
@@ -31,7 +31,11 @@ private:
 
     ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "TimeSeriesSelector"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's TimeSeriesSelector but it doesn't register itself
+        return "";
+    }
 
     StorageID time_series_storage_id = StorageID::createEmpty();
     PrometheusQueryTree instant_selector;

--- a/src/TableFunctions/TableFunctionValues.cpp
+++ b/src/TableFunctions/TableFunctionValues.cpp
@@ -45,7 +45,11 @@ public:
     bool hasStaticStructure() const override { return true; }
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
-    const char * getStorageEngineName() const override { return "Values"; }
+    const char * getStorageEngineName() const override
+    {
+        /// It'd be StorageValues but it's not registered as a table engine
+        return "";
+    }
 
     ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
     void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;

--- a/src/TableFunctions/TableFunctionViewIfPermitted.cpp
+++ b/src/TableFunctions/TableFunctionViewIfPermitted.cpp
@@ -47,7 +47,7 @@ public:
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const String & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
 
-    const char * getStorageEngineName() const override { return "ViewIfPermitted"; }
+    const char * getStorageEngineName() const override { return "View"; }
 
     std::vector<size_t> skipAnalysisForArguments(const QueryTreeNodePtr & query_node_table_function, ContextPtr context) const override;
 

--- a/src/TableFunctions/TableFunctionZeros.cpp
+++ b/src/TableFunctions/TableFunctionZeros.cpp
@@ -33,7 +33,11 @@ public:
     bool hasStaticStructure() const override { return true; }
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
-    const char * getStorageEngineName() const override { return "SystemZeros"; }
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's SystemZeros but it doesn't register itself
+        return "";
+    }
 
     UInt64 evaluateArgument(ContextPtr context, ASTPtr & argument) const;
 

--- a/tests/queries/0_stateless/03611_table_function_file_like_permissions.sh
+++ b/tests/queries/0_stateless/03611_table_function_file_like_permissions.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: Requires libs
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03611_table_function_file_like_permissions.sh
+++ b/tests/queries/0_stateless/03611_table_function_file_like_permissions.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-msan
 # Tag no-fasttest: Requires libs
+# Tag no-msan: DeltaKernel is not compiled with msan
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03611_table_function_file_like_permissions.sh
+++ b/tests/queries/0_stateless/03611_table_function_file_like_permissions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+USER="user_3611_${CLICKHOUSE_DATABASE}"
+
+function cleanup()
+{
+    ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
+}
+trap cleanup EXIT
+
+FILE="${USER_FILES_PATH}/file_that_does_not_exist.csv"
+
+function run_table_functions()
+{
+    EXPECTED_ERROR=$1
+
+    for table_function in "file" "icebergLocal" "deltaLakeLocal"; do
+        ${CLICKHOUSE_CLIENT} --user="${USER}" --query "SELECT * FROM ${table_function}('${FILE}') -- { serverError ${EXPECTED_ERROR} }"
+    done
+}
+
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${USER}"
+${CLICKHOUSE_CLIENT} -q "GRANT CREATE TEMPORARY TABLE ON *.* TO ${USER};"
+run_table_functions "ACCESS_DENIED"
+${CLICKHOUSE_CLIENT} -q "GRANT FILE ON *.* TO ${USER};"
+run_table_functions "FILE_DOESNT_EXIST, DELTA_KERNEL_ERROR, CANNOT_STAT"
+${CLICKHOUSE_CLIENT} -q "REVOKE FILE ON *.* FROM ${USER};"
+run_table_functions "ACCESS_DENIED"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ITableFunction: Enforce that the engine name is found when checking permissions

This is a follow-up for https://github.com/ClickHouse/ClickHouse/pull/84938, which fixes several cases where we were declaring an storage type for table functions that didn't exist. Since the function failed silently when the storage is not found it was error prone, so let's change it into a LOGICAL_ERROR

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
