### PR TITLE
use exponential backoff for chcache upload

### DIFF
--- a/rust/chcache/Cargo.toml
+++ b/rust/chcache/Cargo.toml
@@ -14,6 +14,7 @@ serde_bytes = "0.11.15"
 serde_json = "1.0.140"
 tar = "0.4.44"
 tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
+tokio-retry = "0.3"
 toml = "0.9"
 xdg = "3.0.0"
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Replace manual retry loop with tokio-retry using exponential backoff.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
