### PR TITLE
CI: git unshallow for both parents in ci

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -38,11 +38,16 @@ if __name__ == "__main__":
 
         info.store_kv_data("previous_commits_sha", commits)
 
+    # Unshallow repo to retrieve required info from git.
+    # If commit is a mere-commit - both parents need to be unshallowed. In PRs we might need commits from master to calculate CH version.
+    Shell.check(
+        f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin HEAD ||:",
+        verbose=True,
+        strict=True,
+    )
+
     # store commit sha of release branch base to find binary for performance comparison in the job script later
     # if info.git_branch == "master" and info.repo_name == "ClickHouse/ClickHouse":
-    Shell.check(
-        f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:"
-    )
     release_branch_base_sha = CHVersion.get_release_version_as_dict().get("githash")
     print(f"Release branch base sha: {release_branch_base_sha}")
     assert release_branch_base_sha


### PR DESCRIPTION
Fixes issue in CI when some commits required for CH version calculation (from master) are not fetched in PR CI
```
Run command [git rev-list --count 55d7cf292daa57b7db128ec9e6ad5a6cb86ad385..HEAD]
WARNING: stderr: fatal: could not read Username for 'https://github.com/': No such device or address
fatal: could not read Username for 'https://github.com/': No such device or address
fatal: Invalid revision range 55d7cf292daa57b7db128ec9e6ad5a6cb86ad385..HEAD
```
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
