### PR TITLE
Remove code which looks really stupid

### DIFF
--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -147,20 +147,6 @@ void MergedBlockOutputStream::Finalizer::Impl::finish()
             file->sync();
     }
 
-    /// TODO: this code looks really stupid. It's because DiskTransaction is
-    /// unable to see own write operations. When we merge part with column TTL
-    /// and column completely outdated we first write empty column and after
-    /// remove it. In case of single DiskTransaction it's impossible because
-    /// remove operation will not see just written files. That is why we finish
-    /// one transaction and start new...
-    ///
-    /// FIXME: DiskTransaction should see own writes. Column TTL implementation shouldn't be so stupid...
-    if (!files_to_remove_after_finish.empty())
-    {
-        part->getDataPartStorage().commitTransaction();
-        part->getDataPartStorage().beginTransaction();
-    }
-
     for (const auto & file_name : files_to_remove_after_finish)
         part->getDataPartStorage().removeFile(file_name);
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
