### PR TITLE
Doc. Note about arrayJoin and empty arrays

### DIFF
--- a/docs/en/sql-reference/functions/array-join.md
+++ b/docs/en/sql-reference/functions/array-join.md
@@ -16,6 +16,11 @@ The `arrayJoin` function takes each row and generates a set of rows (unfold).
 This function takes an array as an argument, and propagates the source row to multiple rows for the number of elements in the array.
 All the values in columns are simply copied, except the values in the column where this function is applied; it is replaced with the corresponding array value.
 
+:::note
+If the array is empty, `arrayJoin` produces no rows. 
+To return a single row instead, you can wrap it with [emptyArrayToSingle](../array-functions#emptyArrayToSingle), for example: `arrayJoin(emptyArrayToSingle(...))`.
+:::
+
 For example:
 
 ```sql title="Query"

--- a/docs/en/sql-reference/functions/array-join.md
+++ b/docs/en/sql-reference/functions/array-join.md
@@ -17,8 +17,8 @@ This function takes an array as an argument, and propagates the source row to mu
 All the values in columns are simply copied, except the values in the column where this function is applied; it is replaced with the corresponding array value.
 
 :::note
-If the array is empty, `arrayJoin` produces no rows. 
-To return a single row instead, you can wrap it with [emptyArrayToSingle](./array-functions.md#emptyArrayToSingle), for example: `arrayJoin(emptyArrayToSingle(...))`.
+If the array is empty, `arrayJoin` produces no rows.
+To return a single row containing the default value of the array type, you can wrap it with [emptyArrayToSingle](./array-functions.md#emptyArrayToSingle), for example: `arrayJoin(emptyArrayToSingle(...))`.
 :::
 
 For example:

--- a/docs/en/sql-reference/functions/array-join.md
+++ b/docs/en/sql-reference/functions/array-join.md
@@ -18,7 +18,7 @@ All the values in columns are simply copied, except the values in the column whe
 
 :::note
 If the array is empty, `arrayJoin` produces no rows. 
-To return a single row instead, you can wrap it with [emptyArrayToSingle](../array-functions#emptyArrayToSingle), for example: `arrayJoin(emptyArrayToSingle(...))`.
+To return a single row instead, you can wrap it with [emptyArrayToSingle](./array-functions.md#emptyArrayToSingle), for example: `arrayJoin(emptyArrayToSingle(...))`.
 :::
 
 For example:


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


Motivation for my PR is that users don't expect this

https://fiddle.clickhouse.com/8cdd78b7-e04e-442e-8906-a653b6580343

```
CREATE TABLE users (uid Int16, name Array(String), age Int16) ENGINE=Memory;

INSERT INTO users VALUES (1231, ['John'], 33);
INSERT INTO users VALUES (6666, [], 48);

SELECT *, arrayJoin(name) FROM users;

   +--uid-+-name-----+-age-+-arrayJoin(name)-+
1. | 1231 | ['John'] |  33 | John            |
   +------+----------+-----+-----------------+
                                                     no row for 6666
```

Even if users understand why arrayJoin ate the row (with uid=6666) they don't know the solution.
But solution is quite simple

```
SELECT *, arrayJoin(emptyArrayToSingle(name)) FROM users;

   +--uid-+-name-----+-age-+-arrayJoin(em~ngle(name))-+
1. | 1231 | ['John'] |  33 | John                     |
2. | 6666 | []       |  48 |                          |
   +------+----------+-----+--------------------------+
```

I suggested FR But unfortunately it's not implemented yet
* https://github.com/ClickHouse/ClickHouse/issues/3954


