### PR TITLE
Fix auto cluster functions schema handling

### DIFF
--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -111,11 +111,11 @@ StoragePtr TableFunctionURL::getStorage(
         return std::make_shared<StorageURLCluster>(
             global_context,
             parallel_replicas_cluster_name,
-            filename,
-            format,
-            compression_method,
+            source,
+            format_,
+            compression_method_,
             StorageID(getDatabaseName(), table_name),
-            columns,
+            getActualTableStructure(global_context, true),
             ConstraintsDescription{},
             configuration);
     }

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.reference
@@ -33,6 +33,7 @@ Expression ((Project names + Projection))
           ReadFromObjectStorage
 4
 4
+4
 Expression ((Project names + (Projection + Change column names to column identifiers)))
   ReadFromURL
 Expression ((Project names + (Projection + Change column names to column identifiers)))

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -24,6 +24,11 @@ CREATE TABLE dupe_test_with_auto_functions (n1 String, n2 String, n3 String) ENG
 INSERT INTO dupe_test_with_auto_functions SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 SELECT count() FROM dupe_test_with_auto_functions;
 
+DROP TABLE IF EXISTS insert_with_url_function;
+CREATE TABLE insert_with_url_function (n1 String, n2 String, n3 String) ENGINE = MergeTree ORDER BY n1;
+INSERT INTO insert_with_url_function SELECT * FROM url('http://localhost:11111/test/a.tsv', 'TSV');
+SELECT count() FROM insert_with_url_function;
+
 
 SET parallel_replicas_for_cluster_engines=false;
 

--- a/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
+++ b/tests/queries/0_stateless/03275_auto_cluster_functions_with_parallel_replicas.sql
@@ -20,7 +20,7 @@ EXPLAIN SELECT number FROM system.numbers n JOIN (SELECT * FROM s3('http://local
 SELECT count() FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 
 DROP TABLE IF EXISTS dupe_test_with_auto_functions;
-CREATE TABLE dupe_test_with_auto_functions (c1 String, c2 String, c3 String) ENGINE = MergeTree ORDER BY c1;
+CREATE TABLE dupe_test_with_auto_functions (n1 String, n2 String, n3 String) ENGINE = MergeTree ORDER BY n1;
 INSERT INTO dupe_test_with_auto_functions SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 SELECT count() FROM dupe_test_with_auto_functions;
 
@@ -33,11 +33,11 @@ EXPLAIN SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 SELECT count() FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 
 DROP TABLE IF EXISTS dupe_test_without_cluster_functions;
-CREATE TABLE dupe_test_without_cluster_functions (c1 String, c2 String, c3 String) ENGINE = MergeTree ORDER BY c1;
+CREATE TABLE dupe_test_without_cluster_functions (n1 String, n2 String, n3 String) ENGINE = MergeTree ORDER BY n1;
 INSERT INTO dupe_test_without_cluster_functions SELECT * FROM s3('http://localhost:11111/test/a.tsv', 'TSV');
 SELECT count() FROM dupe_test_without_cluster_functions;
 
 DROP TABLE IF EXISTS dupe_test_with_cluster_function;
-CREATE TABLE dupe_test_with_cluster_function (c1 String, c2 String, c3 String) ENGINE = MergeTree ORDER BY c1;
+CREATE TABLE dupe_test_with_cluster_function (n1 String, n2 String, n3 String) ENGINE = MergeTree ORDER BY n1;
 INSERT INTO dupe_test_with_cluster_function SELECT * FROM s3Cluster('test_cluster_two_shards', 'http://localhost:11111/test/a.tsv', 'TSV');
 SELECT count() FROM dupe_test_with_cluster_function;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix resolving table schema with `url()` table function when `parallel_replicas_for_cluster_functions` setting is set to 1.

Closes https://github.com/ClickHouse/ClickHouse/issues/86513
