### PR TITLE
fix: add missing TABLE keyword to SYSTEM DROP REPLICA error message

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1199,7 +1199,7 @@ void InterpreterSystemQuery::dropReplica(ASTSystemQuery & query)
                                         "Please check the path in query. "
                                         "If you want to drop replica "
                                         "of this table, use `DROP TABLE` "
-                                        "or `SYSTEM DROP REPLICA 'name' FROM db.table`",
+                                        "or `SYSTEM DROP REPLICA 'name' FROM TABLE db.table`",
                                         storage_replicated->getStorageID().getNameForLogs());
                 }
             }


### PR DESCRIPTION
The current error message for SYSTEM DROP REPLICA suggested the syntax:
`SYSTEM DROP REPLICA 'name' FROM db.table`

This is incorrect and throws a syntax error, the correct syntax requires the TABLE keyword:
`SYSTEM DROP REPLICA 'name' FROM TABLE db.table`

This commit updates the error message in InterpreterSystemQuery.cpp to suggest the valid syntax.

Fix for #86938