### PR TITLE
Improve introspection of memory allocations done without memory limits checks

### DIFF
--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -119,7 +119,6 @@ class QuantileTDigest
         static constexpr size_t PART_SIZE_BITS = 8;
 
         using Transform = RadixSortFloatTransform<KeyBits>;
-        using Allocator = RadixSortAllocator;
 
         /// The function to get the key from an array element.
         static Key & extractKey(Element & elem) { return elem.mean; }

--- a/src/Common/AllocationInterceptors.cpp
+++ b/src/Common/AllocationInterceptors.cpp
@@ -202,7 +202,7 @@ void operator delete[](void * ptr, std::size_t size, std::align_val_t align) noe
 extern "C" void * __wrap_malloc(size_t size) // NOLINT
 {
     AllocationTrace trace;
-    std::size_t actual_size = Memory::trackMemory(size, trace);
+    std::size_t actual_size = Memory::trackMemoryFromC(size, trace);
     void * ptr = __real_malloc(size);
     if (unlikely(!ptr))
     {
@@ -220,7 +220,7 @@ extern "C" void * __wrap_calloc(size_t number_of_members, size_t size) // NOLINT
         return nullptr;
 
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(real_size, trace);
+    size_t actual_size = Memory::trackMemoryFromC(real_size, trace);
     void * res = __real_calloc(number_of_members, size);
     if (unlikely(!res))
     {
@@ -240,7 +240,7 @@ extern "C" void * __wrap_realloc(void * ptr, size_t size) // NOLINT
         trace.onFree(ptr, actual_size);
     }
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(size, trace);
+    size_t actual_size = Memory::trackMemoryFromC(size, trace);
     void * res = __real_realloc(ptr, size);
     if (unlikely(!res))
     {
@@ -254,7 +254,7 @@ extern "C" void * __wrap_realloc(void * ptr, size_t size) // NOLINT
 extern "C" int __wrap_posix_memalign(void ** memptr, size_t alignment, size_t size) // NOLINT
 {
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(size, trace, static_cast<std::align_val_t>(alignment));
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
     int res = __real_posix_memalign(memptr, alignment, size);
     if (unlikely(res != 0))
     {
@@ -268,7 +268,7 @@ extern "C" int __wrap_posix_memalign(void ** memptr, size_t alignment, size_t si
 extern "C" void * __wrap_aligned_alloc(size_t alignment, size_t size) // NOLINT
 {
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(size, trace, static_cast<std::align_val_t>(alignment));
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
     void * res = __real_aligned_alloc(alignment, size);
     if (unlikely(!res))
     {
@@ -282,7 +282,7 @@ extern "C" void * __wrap_aligned_alloc(size_t alignment, size_t size) // NOLINT
 extern "C" void * __wrap_valloc(size_t size) // NOLINT
 {
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(size, trace);
+    size_t actual_size = Memory::trackMemoryFromC(size, trace);
     void * res = __real_valloc(size);
     if (unlikely(!res))
     {
@@ -314,7 +314,7 @@ extern "C" void __wrap_free(void * ptr) // NOLINT
 extern "C" void * __wrap_memalign(size_t alignment, size_t size) // NOLINT
 {
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(size, trace, static_cast<std::align_val_t>(alignment));
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
     void * res = __real_memalign(alignment, size);
     if (unlikely(!res))
     {
@@ -330,7 +330,7 @@ extern "C" void * __wrap_memalign(size_t alignment, size_t size) // NOLINT
 extern "C" void * __wrap_pvalloc(size_t size) // NOLINT
 {
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemory(size, trace);
+    size_t actual_size = Memory::trackMemoryFromC(size, trace);
     void * res = __real_pvalloc(size);
     if (unlikely(!res))
     {

--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -100,14 +100,12 @@ void CurrentMemoryTracker::check()
 
 AllocationTrace CurrentMemoryTracker::alloc(Int64 size)
 {
-    bool throw_if_memory_exceeded = true;
-    return allocImpl(size, throw_if_memory_exceeded);
+    return allocImpl(size, /*throw_if_memory_exceeded=*/ true);
 }
 
 AllocationTrace CurrentMemoryTracker::allocNoThrow(Int64 size)
 {
-    bool throw_if_memory_exceeded = false;
-    return allocImpl(size, throw_if_memory_exceeded);
+    return allocImpl(size, /*throw_if_memory_exceeded=*/ false);
 }
 
 AllocationTrace CurrentMemoryTracker::free(Int64 size)

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -208,35 +208,34 @@ void MemoryTracker::injectFault() const
         description ? " memory tracker" : "Memory tracker");
 }
 
-/// Big allocations through allocNoThrow (without checking memory limits) may easily lead to OOM (and it's hard to debug).
-/// Let's find them.
-void MemoryTracker::debugLogBigAllocationWithoutCheck(Int64 size)
+void incrementAllocationWithoutCheck(Int64 size)
 {
+    /// Note, it is always blocked for release build, so we do not write MemoryAllocatedWithoutCheck there
+    if (MemoryTrackerDebugBlockerInThread::isBlocked())
+        return;
+
+    /// The choice is arbitrary (maybe we should decrease it)
+    constexpr Int64 threshold = 16 * 1024 * 1024;
+
     ProfileEvents::increment(ProfileEvents::MemoryAllocatedWithoutCheck);
     if (size < 0)
         return;
     ProfileEvents::increment(ProfileEvents::MemoryAllocatedWithoutCheckBytes, size);
 
-    if constexpr (MemoryTrackerDebugBlockerInThread::isEnabled())
+    if (size > threshold)
     {
-        /// The choice is arbitrary (maybe we should decrease it)
-        constexpr Int64 threshold = 16 * 1024 * 1024;
-        if (size < threshold)
-            return;
-
-        if (MemoryTrackerDebugBlockerInThread::isBlocked())
-            return;
-
         MemoryTrackerBlockerInThread tracker_blocker(VariableContext::Global);
-        /// Forbid recursive calls, since the first time debugLogBigAllocationWithoutCheck() can be called from logging,
-        /// and then it may be called again for the line below
+        /// Forbid recursive calls
         [[maybe_unused]] MemoryTrackerDebugBlockerInThread debug_blocker;
-        LOG_TRACE(
-            getLogger("MemoryTracker"),
-            "Too big allocation ({} bytes) without checking memory limits, "
-            "it may lead to OOM. Stack trace: {}",
-            size,
-            StackTrace().toString());
+
+        try
+        {
+            DB::TraceSender::send(DB::TraceType::MemoryAllocatedWithoutCheck, StackTrace(), DB::TraceSender::Extras{.size = size});
+        }
+        catch (...)
+        {
+            /// Ignore failures, we have ProfileEvents anyway
+        }
     }
 }
 
@@ -322,7 +321,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         }
 
         memory_limit_exceeded_ignored = true;
-        debugLogBigAllocationWithoutCheck(size);
+        incrementAllocationWithoutCheck(size);
     }
 
     if (unlikely(
@@ -411,7 +410,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         else
         {
             memory_limit_exceeded_ignored = true;
-            debugLogBigAllocationWithoutCheck(size);
+            incrementAllocationWithoutCheck(size);
         }
     }
 
@@ -432,7 +431,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         {
             bool log_memory_usage = false;
             peak_updated = updatePeak(will_be, log_memory_usage);
-            debugLogBigAllocationWithoutCheck(size);
+            incrementAllocationWithoutCheck(size);
         }
     }
 

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -232,7 +232,7 @@ void incrementAllocationWithoutCheck(Int64 size)
         {
             DB::TraceSender::send(DB::TraceType::MemoryAllocatedWithoutCheck, StackTrace(), DB::TraceSender::Extras{.size = size});
         }
-        catch (...)
+        catch (...) // NOLINT(bugprone-empty-catch)
         {
             /// Ignore failures, we have ProfileEvents anyway
         }

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -278,7 +278,7 @@ public:
     /// Prints info about peak memory consumption into log.
     void logPeakMemoryUsage();
 
-    void debugLogBigAllocationWithoutCheck(Int64 size [[maybe_unused]]);
+    void debugLogBigAllocationWithoutCheck(Int64 size);
 };
 
 extern MemoryTracker total_memory_tracker;

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -277,8 +277,6 @@ public:
 
     /// Prints info about peak memory consumption into log.
     void logPeakMemoryUsage();
-
-    void debugLogBigAllocationWithoutCheck(Int64 size);
 };
 
 extern MemoryTracker total_memory_tracker;

--- a/src/Common/MemoryTrackerDebugBlockerInThread.h
+++ b/src/Common/MemoryTrackerDebugBlockerInThread.h
@@ -9,14 +9,12 @@ public:
     MemoryTrackerDebugBlockerInThread();
     ~MemoryTrackerDebugBlockerInThread();
 
-    static constexpr bool isEnabled() { return true; }
     static bool isBlocked();
 };
 #else
 struct MemoryTrackerDebugBlockerInThread
 {
 public:
-    static constexpr bool isEnabled() { return false; }
     static constexpr bool isBlocked() { return true; }
 };
 #endif

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -626,6 +626,8 @@ The server successfully detected this situation and will download merged part fr
     M(WriteBufferFromS3RequestsErrors, "Number of exceptions while writing to S3.", ValueType::Number) \
     M(WriteBufferFromS3WaitInflightLimitMicroseconds, "Time spent on waiting while some of the current requests are done when its number reached the limit defined by s3_max_inflight_parts_for_one_file.", ValueType::Microseconds) \
     M(QueryMemoryLimitExceeded, "Number of times when memory limit exceeded for query.", ValueType::Number) \
+    M(MemoryAllocatedWithoutCheck, "Number of times memory has been allocated without checking for memory constraints.", ValueType::Number) \
+    M(MemoryAllocatedWithoutCheckBytes, "About of bytes has been allocated without checking for memory constraints.", ValueType::Number) \
     \
     M(AzureGetObject, "Number of Azure API GetObject calls.", ValueType::Number) \
     M(AzureUpload, "Number of Azure blob storage API Upload calls", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -627,7 +627,7 @@ The server successfully detected this situation and will download merged part fr
     M(WriteBufferFromS3WaitInflightLimitMicroseconds, "Time spent on waiting while some of the current requests are done when its number reached the limit defined by s3_max_inflight_parts_for_one_file.", ValueType::Microseconds) \
     M(QueryMemoryLimitExceeded, "Number of times when memory limit exceeded for query.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheck, "Number of times memory has been allocated without checking for memory constraints.", ValueType::Number) \
-    M(MemoryAllocatedWithoutCheckBytes, "About of bytes has been allocated without checking for memory constraints.", ValueType::Number) \
+    M(MemoryAllocatedWithoutCheckBytes, "Amount of bytes that has been allocated without checking for memory constraints.", ValueType::Number) \
     \
     M(AzureGetObject, "Number of Azure API GetObject calls.", ValueType::Number) \
     M(AzureUpload, "Number of Azure blob storage API Upload calls", ValueType::Number) \

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -550,8 +550,8 @@ const SymbolIndex & SymbolIndex::instance()
     /// To avoid recursive initialization of SymbolIndex we need to block debug
     /// checks in MemoryTracker.
     ///
-    /// Those debug checks capture the stacktrace for the log if big enough
-    /// allocation is done (big enough > 16MiB), while SymbolIndex will do
+    /// Those debug checks capture the stacktrace for collecting big
+    /// allocation (> 16MiB), while SymbolIndex will do
     /// ~25MiB, and so if exception will be thrown before SymbolIndex
     /// initialized (this is the case for client/local, and no, we do not want
     /// to initialize it explicitly, since this will increase startup time for

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -15,6 +15,7 @@
 #include <Interpreters/FilesystemCacheLog.h>
 #include <Interpreters/ObjectStorageQueueLog.h>
 #include <Interpreters/IcebergMetadataLog.h>
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
 #if CLICKHOUSE_CLOUD
 #include <Interpreters/DistributedCacheLog.h>
 #include <Interpreters/DistributedCacheServerLog.h>
@@ -200,6 +201,8 @@ void SystemLogQueue<LogElement>::confirm(SystemLogQueue<LogElement>::Index last_
 template <typename LogElement>
 typename SystemLogQueue<LogElement>::PopResult SystemLogQueue<LogElement>::pop()
 {
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+
     PopResult result;
     size_t prev_ignored_logs = 0;
 
@@ -308,6 +311,7 @@ void SystemLogBase<LogElement>::stopFlushThread()
 template <typename LogElement>
 void SystemLogBase<LogElement>::add(LogElement element)
 {
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
     queue->push(std::move(element));
 }
 

--- a/src/Common/TraceSender.h
+++ b/src/Common/TraceSender.h
@@ -20,6 +20,7 @@ enum class TraceType : uint8_t
     MemoryPeak,
     ProfileEvent,
     JemallocSample,
+    MemoryAllocatedWithoutCheck,
 };
 
 /// This is the second part of TraceCollector, that sends stacktrace to the pipe.

--- a/src/Common/TrackedString.h
+++ b/src/Common/TrackedString.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+#include <Common/AllocatorWithMemoryTracking.h>
+
+/// String that can throw MEMORY_LIMIT_EXCEEDED
+/// Use it when the string may require significant memory.
+class TrackedString : public std::basic_string<char, std::char_traits<char>, AllocatorWithMemoryTracking<char>>
+{
+    using std::basic_string<char, std::char_traits<char>, AllocatorWithMemoryTracking<char>>::basic_string;
+};

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -26,6 +26,7 @@
 #include <Common/logger_useful.h>
 #include <Common/setThreadName.h>
 #include <Common/thread_local_rng.h>
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
 
@@ -771,6 +772,8 @@ void ZooKeeper::sendAuth(const String & scheme, const String & data)
 
 void ZooKeeper::sendThread()
 {
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+
     setThreadName("ZooKeeperSend");
 
     scope_guard os_thread_nice_value_guard;
@@ -860,6 +863,8 @@ void ZooKeeper::sendThread()
 
 void ZooKeeper::receiveThread()
 {
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+
     setThreadName("ZooKeeperRecv");
 
     scope_guard os_thread_nice_value_guard;
@@ -1817,6 +1822,8 @@ void ZooKeeper::setZooKeeperLog(std::shared_ptr<DB::ZooKeeperLog> zk_log_)
 #ifdef ZOOKEEPER_LOG
 void ZooKeeper::logOperationIfNeeded(const ZooKeeperRequestPtr & request, const ZooKeeperResponsePtr & response, bool finalize, UInt64 elapsed_microseconds)
 {
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+
     auto maybe_zk_log = std::atomic_load(&zk_log);
     if (!maybe_zk_log)
         return;

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -6,6 +6,7 @@
 #include <Common/AllocationInterceptors.h>
 #include <Common/Concepts.h>
 #include <Common/CurrentMemoryTracker.h>
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/ProfileEvents.h>
 
 #include "config.h"
@@ -130,6 +131,17 @@ template <std::same_as<std::align_val_t>... TAlign>
 requires DB::OptionalArgument<TAlign...>
 inline ALWAYS_INLINE size_t trackMemory(std::size_t size, AllocationTrace & trace, TAlign... align)
 {
+    std::size_t actual_size = getActualAllocationSize(size, align...);
+    trace = CurrentMemoryTracker::allocNoThrow(actual_size);
+    return actual_size;
+}
+
+/// We cannot throw from C API
+template <std::same_as<std::align_val_t>... TAlign>
+requires DB::OptionalArgument<TAlign...>
+inline ALWAYS_INLINE size_t trackMemoryFromC(std::size_t size, AllocationTrace & trace, TAlign... align)
+{
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
     std::size_t actual_size = getActualAllocationSize(size, align...);
     trace = CurrentMemoryTracker::allocNoThrow(actual_size);
     return actual_size;

--- a/src/Functions/h3kRing.cpp
+++ b/src/Functions/h3kRing.cpp
@@ -11,6 +11,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
+#include <Common/AllocatorWithMemoryTracking.h>
 #include <Interpreters/castColumn.h>
 
 #include <h3api.h>
@@ -115,7 +116,7 @@ public:
                 throw Exception(ErrorCodes::PARAMETER_OUT_OF_BOUND, "Argument 'k' for {} function must be non negative", getName());
 
             const auto vec_size = maxGridDiskSize(k);
-            std::vector<H3Index> hindex_vec;
+            std::vector<H3Index, AllocatorWithMemoryTracking<H3Index>> hindex_vec;
             hindex_vec.resize(vec_size);
             gridDisk(origin_hindex, k, hindex_vec.data());
 

--- a/src/IO/WriteBufferFromTrackedString.cpp
+++ b/src/IO/WriteBufferFromTrackedString.cpp
@@ -1,0 +1,21 @@
+#include <Common/Exception.h>
+#include <IO/WriteBufferFromTrackedString.h>
+
+namespace DB
+{
+
+/// It is safe to make them autofinalizable.
+WriteBufferFromTrackedString::~WriteBufferFromTrackedString()
+{
+    try
+    {
+        if (!this->finalized && !this->canceled)
+            this->finalize();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
+}

--- a/src/IO/WriteBufferFromTrackedString.h
+++ b/src/IO/WriteBufferFromTrackedString.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <IO/WriteBufferFromVector.h>
+#include <Common/TrackedString.h>
+
+namespace DB
+{
+
+class WriteBufferFromTrackedString final : public WriteBufferFromVectorImpl<TrackedString>
+{
+    using Base = WriteBufferFromVectorImpl;
+public:
+    explicit WriteBufferFromTrackedString(TrackedString & vector_)
+        : Base(vector_)
+    {
+    }
+
+    WriteBufferFromTrackedString(TrackedString & vector_, AppendModeTag tag_)
+        : Base(vector_, tag_)
+    {
+    }
+    ~WriteBufferFromTrackedString() override;
+};
+
+}

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <optional>
 #include <Core/Settings.h>
+#include <base/defines.h>
 #include <Poco/Util/Application.h>
 
 #ifdef OS_LINUX
@@ -1219,7 +1220,14 @@ void NO_INLINE Aggregator::executeImplBatch(
     /// - this affects only optimize_aggregation_in_order,
     /// - this is just a pointer, so it should not be significant,
     /// - and plus this will require other changes in the interface.
-    std::unique_ptr<AggregateDataPtr[]> places(new AggregateDataPtr[all_keys_are_const ? 1 : row_end]);
+    size_t places_size = all_keys_are_const ? 1 : row_end;
+    AllocatorWithMemoryTracking<AggregateDataPtr> allocator;
+    auto places_deleter = [&allocator, &places_size](auto * ptr)
+    {
+        if (likely(ptr))
+            allocator.deallocate(ptr, places_size);
+    };
+    std::unique_ptr<AggregateDataPtr[], decltype(places_deleter)> places(allocator.allocate(places_size), places_deleter);
 
     size_t key_start;
     size_t key_end;
@@ -1312,7 +1320,7 @@ void NO_INLINE Aggregator::executeImplBatch(
         row_begin,
         row_end,
         aggregate_instructions,
-        places,
+        places.get(),
         key_start,
         state.hasOnlyOneValueSinceLastReset(),
         all_keys_are_const,
@@ -1324,7 +1332,7 @@ void Aggregator::executeAggregateInstructions(
     size_t row_begin,
     size_t row_end,
     AggregateFunctionInstruction * aggregate_instructions,
-    const std::unique_ptr<AggregateDataPtr[]> &places,
+    AggregateDataPtr * places,
     size_t key_start,
     bool has_only_one_value_since_last_reset,
     bool all_keys_are_const,
@@ -1358,7 +1366,7 @@ void Aggregator::executeAggregateInstructions(
         else
         {
             auto add_into_aggregate_states_function = compiled_aggregate_functions_holder->compiled_aggregate_functions.add_into_aggregate_states_function;
-            add_into_aggregate_states_function(row_begin, row_end, columns_data.data(), places.get());
+            add_into_aggregate_states_function(row_begin, row_end, columns_data.data(), places);
         }
     }
 #endif
@@ -1380,7 +1388,7 @@ void Aggregator::executeAggregateInstructions(
         }
         else
         {
-            addBatch(row_begin, row_end, inst, places.get(), aggregates_pool);
+            addBatch(row_begin, row_end, inst, places, aggregates_pool);
         }
     }
 

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1224,7 +1224,7 @@ void NO_INLINE Aggregator::executeImplBatch(
     AllocatorWithMemoryTracking<AggregateDataPtr> allocator;
     auto places_deleter = [&allocator, &places_size](auto * ptr)
     {
-        if (likely(ptr))
+        if (ptr) [[likely]]
             allocator.deallocate(ptr, places_size);
     };
     std::unique_ptr<AggregateDataPtr[], decltype(places_deleter)> places(allocator.allocate(places_size), places_deleter);

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -414,7 +414,7 @@ private:
         size_t row_begin,
         size_t row_end,
         AggregateFunctionInstruction * aggregate_instructions,
-        const std::unique_ptr<AggregateDataPtr[]> & places,
+        AggregateDataPtr * places,
         size_t key_start,
         bool has_only_one_value_since_last_reset,
         bool all_keys_are_const,

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -10,6 +10,7 @@
 #include <IO/ConcatReadBuffer.h>
 #include <IO/LimitReadBuffer.h>
 #include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromTrackedString.h>
 #include <IO/copyData.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/AsynchronousInsertLog.h>
@@ -399,7 +400,7 @@ AsynchronousInsertQueue::pushQueryWithInlinedData(ASTPtr query, ContextPtr query
     }
     preprocessInsertQuery(query, query_context);
 
-    String bytes;
+    TrackedString bytes;
     {
         /// Read at most 'async_insert_max_data_size' bytes of data.
         /// If limit is exceeded we will fallback to synchronous insert
@@ -424,7 +425,7 @@ AsynchronousInsertQueue::pushQueryWithInlinedData(ASTPtr query, ContextPtr query
         }
 
         {
-            WriteBufferFromString write_buf(bytes);
+            WriteBufferFromTrackedString write_buf(bytes);
             copyData(limit_buf, write_buf);
         }
 

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -6,6 +6,7 @@
 #include <Common/MemoryTrackerSwitcher.h>
 #include <Common/SettingsChanges.h>
 #include <Common/ThreadPool.h>
+#include <Common/TrackedString.h>
 #include <Interpreters/AsynchronousInsertQueueDataKind.h>
 
 #include <future>
@@ -92,9 +93,9 @@ public:
     };
 
 private:
-    struct DataChunk : public std::variant<String, Block>
+    struct DataChunk : public std::variant<TrackedString, Block>
     {
-        using std::variant<String, Block>::variant;
+        using std::variant<TrackedString, Block>::variant;
 
         size_t byteSize() const
         {
@@ -125,7 +126,7 @@ private:
             }, *this);
         }
 
-        const String * asString() const { return std::get_if<String>(this); }
+        const TrackedString * asString() const { return std::get_if<TrackedString>(this); }
         const Block * asBlock() const { return std::get_if<Block>(this); }
     };
 

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/TraceLog.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/Exception.h>
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/TraceSender.h>
 #include <Common/ProfileEvents.h>
 #include <Common/setThreadName.h>
@@ -99,6 +100,8 @@ TraceCollector::~TraceCollector()
 
 void TraceCollector::run()
 {
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+
     setThreadName("TraceCollector");
 
     MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -32,7 +32,7 @@ const TraceDataType::Values TraceLogElement::trace_values =
     {"MemoryPeak", static_cast<UInt8>(TraceType::MemoryPeak)},
     {"ProfileEvent", static_cast<UInt8>(TraceType::ProfileEvent)},
     {"JemallocSample", static_cast<UInt8>(TraceType::JemallocSample)},
-
+    {"MemoryAllocatedWithoutCheck", static_cast<UInt8>(TraceType::MemoryAllocatedWithoutCheck)},
 };
 
 ColumnsDescription TraceLogElement::getColumnsDescription()
@@ -53,12 +53,14 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "`Memory` represents collecting allocations and deallocations when memory allocation exceeds the subsequent watermark. "
             "`MemorySample` represents collecting random allocations and deallocations. "
             "`MemoryPeak` represents collecting updates of peak memory usage. "
-            "`ProfileEvent` represents collecting of increments of profile events."
+            "`ProfileEvent` represents collecting of increments of profile events. "
+            "`JemallocSample` represents collecting of jemalloc samples. "
+            "`MemoryAllocatedWithoutCheck` represents collection of significant allocations (>16MiB) that is done with ignoring any memory limits (for ClickHouse developers only)."
         },
         {"thread_id", std::make_shared<DataTypeUInt64>(), "Thread identifier."},
         {"query_id", std::make_shared<DataTypeString>(), "Query identifier that can be used to get details about a query that was running from the query_log system table."},
         {"trace", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>()), "Stack trace at the moment of sampling. Each element is a virtual memory address inside ClickHouse server process."},
-        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
+        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
         {"ptr", std::make_shared<DataTypeUInt64>(), "The address of the allocated chunk."},
         {"event", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "For trace type ProfileEvent is the name of updated profile event, for other trace types is an empty string."},
         {"increment", std::make_shared<DataTypeInt64>(), "For trace type ProfileEvent is the amount of increment of profile event, for other trace types is 0."},

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -7,6 +7,7 @@
 #include <Common/DNSResolver.h>
 #include <Common/IO.h>
 #include <Common/LockMemoryExceptionInThread.h>
+#include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/ProfileEvents.h>
 #include <Common/SensitiveDataMasker.h>
 #include <Common/setThreadName.h>
@@ -131,6 +132,7 @@ void logToSystemTextLogQueue(
 
 #undef SET_VALUE_IF_EXISTS
 
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
     text_log_locked->push(std::move(elem));
 }
 }

--- a/src/Storages/FileLog/FileLogConsumer.h
+++ b/src/Storages/FileLog/FileLogConsumer.h
@@ -3,9 +3,8 @@
 #include <Core/BackgroundSchedulePoolTaskHolder.h>
 #include <IO/ReadBuffer.h>
 #include <Storages/FileLog/StorageFileLog.h>
-
-#include <fstream>
-#include <mutex>
+#include <Common/AllocatorWithMemoryTracking.h>
+#include <Common/TrackedString.h>
 
 namespace DB
 {
@@ -30,7 +29,7 @@ public:
 
     auto getFileName() const { return current[-1].file_name; }
     auto getOffset() const { return current[-1].offset; }
-    const String & getCurrentRecord() const { return current[-1].data; }
+    const auto & getCurrentRecord() const { return current[-1].data; }
 
 private:
     enum class BufferStatus : uint8_t
@@ -56,15 +55,14 @@ private:
     size_t stream_number;
     size_t max_streams_number;
 
-    using RecordData = std::string;
     struct Record
     {
-        RecordData data;
+        TrackedString data;
         std::string file_name;
         /// Offset is the start of a row, which is needed for virtual columns.
         UInt64 offset;
     };
-    using Records = std::vector<Record>;
+    using Records = std::vector<Record, AllocatorWithMemoryTracking<Record>>;
 
     Records records;
     Records::const_iterator current;

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3626,6 +3626,10 @@ def main(args):
     else:
         print("All tests have finished.")
 
+    unchecked_memory = int(clickhouse_execute(args, "SELECT sum(value) FROM system.events WHERE event = 'MemoryAllocatedWithoutCheckBytes'"))
+    if unchecked_memory > 1e9:
+        print(f"Too much memory has been allocated without checking for memory limits: {unchecked_memory/1024/1024/1024} GiB")
+
     if args.report_logs_stats:
         try:
             reportLogStats(args)


### PR DESCRIPTION
- Introduce new profile events - `MemoryAllocatedWithoutCheck` and `MemoryAllocatedWithoutCheckBytes`
- Replace log with new trace event - `MemoryAllocatedWithoutCheck`. Logging may lead to deadlock and it is not good for analytics
- Add suppression for some existing code, that is OK for now (though maybe if this goes to a `trace_log`, we shouldn't suppress anything)
- And also **respect memory limits from some places that allocate >16MiB of RAM (radix sort, async inserts, aggregator, some functions and filelog - all these should be exception safe)**
- Also do not log significant allocations from C

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Respect memory limits in some places that are known to allocate significant (>16MiB) amount of memory (sorting, async inserts, file log)