### PR TITLE
Limit the size of invalid JSON printed in the error message

### DIFF
--- a/src/DataTypes/Serializations/SerializationJSON.cpp
+++ b/src/DataTypes/Serializations/SerializationJSON.cpp
@@ -305,7 +305,7 @@ void SerializationJSON<Parser>::deserializeObject(IColumn & column, std::string_
     typename Parser::Element document;
     auto parser = parsers_pool.get([] { return new Parser; });
     if (!parser->parse(object, document))
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse JSON object here: {}{}", std::string_view(object.data(), std::min(object.size(), size_t(1000))), object.size() > 1000 ? "... (JSON object is too long to display as a whole)" : "");
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse JSON object here: {}{}", std::string_view(object.data(), std::min(object.size(), 1000uz)), object.size() > 1000 ? "... (JSON object is too long to display as a whole)" : "");
 
     String error;
     JSONExtractInsertSettings insert_settings;

--- a/src/DataTypes/Serializations/SerializationJSON.cpp
+++ b/src/DataTypes/Serializations/SerializationJSON.cpp
@@ -305,7 +305,7 @@ void SerializationJSON<Parser>::deserializeObject(IColumn & column, std::string_
     typename Parser::Element document;
     auto parser = parsers_pool.get([] { return new Parser; });
     if (!parser->parse(object, document))
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse JSON object here: {}{}", std::string_view(object.data(), std::min(object.size(), 1000uz)), object.size() > 1000 ? "... (JSON object is too long to display as a whole)" : "");
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse JSON object here: {}{}", object.substr(0, std::min(object.size(), 1000uz)), object.size() > 1000 ? "... (JSON object is too long to display as a whole)" : "");
 
     String error;
     JSONExtractInsertSettings insert_settings;

--- a/src/DataTypes/Serializations/SerializationJSON.cpp
+++ b/src/DataTypes/Serializations/SerializationJSON.cpp
@@ -305,7 +305,7 @@ void SerializationJSON<Parser>::deserializeObject(IColumn & column, std::string_
     typename Parser::Element document;
     auto parser = parsers_pool.get([] { return new Parser; });
     if (!parser->parse(object, document))
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse JSON object here: {}", object);
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot parse JSON object here: {}{}", std::string_view(object.data(), std::min(object.size(), size_t(1000))), object.size() > 1000 ? "... (JSON object is too long to display as a whole)" : "");
 
     String error;
     JSONExtractInsertSettings insert_settings;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
