### PR TITLE
Docs + test for setting `network_compression_method`

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -841,6 +841,14 @@ void Connection::sendQuery(
         std::string method = Poco::toUpper((*settings)[Setting::network_compression_method].toString());
 
         /// Bad custom logic
+        /// We only allow any of following generic codecs. CompressionCodecFactory will happily return other
+        /// codecs (e.g. T64) but these may be specialized and not support all data types, i.e. SELECT 'abc' may
+        /// be broken afterwards.
+        if (method != "NONE" && method != "ZSTD" && method != "LZ4" && method != "LZ4HC")
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Setting 'network_compression_method' must be NONE, ZSTD, LZ4 or LZ4HC");
+
+        /// More bad custom logic
         if (method == "ZSTD")
             level = (*settings)[Setting::network_zstd_compression_level];
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1643,12 +1643,14 @@ Ask more streams when reading from Merge table. Streams will be spread across ta
 )", 0) \
     \
     DECLARE(String, network_compression_method, "LZ4", R"(
-Sets the method of data compression that is used for communication between servers and between server and [clickhouse-client](../../interfaces/cli.md).
+The codec for compressing the client/server and server/server communication.
 
 Possible values:
 
-- `LZ4` — sets LZ4 compression method.
-- `ZSTD` — sets ZSTD compression method.
+- `NONE` — no compression.
+- `LZ4` — use the LZ4 codec.
+- `LZ5HC` — use the LZ4HC codec.
+- `ZSTD` — use the ZSTD codec.
 
 **See Also**
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1649,7 +1649,7 @@ Possible values:
 
 - `NONE` — no compression.
 - `LZ4` — use the LZ4 codec.
-- `LZ5HC` — use the LZ4HC codec.
+- `LZ4HC` — use the LZ4HC codec.
 - `ZSTD` — use the ZSTD codec.
 
 **See Also**

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -159,6 +159,7 @@ namespace DB::ErrorCodes
     extern const int ABORTED;
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int AUTHENTICATION_FAILED;
+    extern const int BAD_ARGUMENTS;
     extern const int CLIENT_HAS_CONNECTED_TO_WRONG_PORT;
     extern const int CLIENT_INFO_DOES_NOT_MATCH;
     extern const int LOGICAL_ERROR;
@@ -2439,6 +2440,16 @@ CompressionCodecPtr TCPHandler::getCompressionCodec(const Settings & query_setti
 {
     std::string method = Poco::toUpper(query_settings[Setting::network_compression_method].toString());
     std::optional<int> level;
+
+    /// Bad custom logic
+    /// We only allow any of following generic codecs. CompressionCodecFactory will happily return other
+    /// codecs (e.g. T64) but these may be specialized and not support all data types, i.e. SELECT 'abc' may
+    /// be broken afterwards.
+    if (method != "NONE" && method != "ZSTD" && method != "LZ4" && method != "LZ4HC")
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Setting 'network_compression_method' must be NONE, ZSTD, LZ4 or LZ4HC");
+
+    /// More bad custom logic
     if (method == "ZSTD")
         level = query_settings[Setting::network_zstd_compression_level];
 

--- a/tests/queries/0_stateless/03623_network_compression_method.reference
+++ b/tests/queries/0_stateless/03623_network_compression_method.reference
@@ -1,0 +1,4 @@
+1	1	abc
+1	1	abc
+1	1	abc
+1	1	abc

--- a/tests/queries/0_stateless/03623_network_compression_method.sql
+++ b/tests/queries/0_stateless/03623_network_compression_method.sql
@@ -1,0 +1,20 @@
+-- Tests setting 'network_compression_method'
+
+SET network_compression_method = 'NONE';
+SELECT 1, 1.0, 'abc'; -- The major classes of data types which codecs support or don't support
+
+SET network_compression_method = 'LZ4';
+SELECT 1, 1.0, 'abc';
+
+SET network_compression_method = 'LZ4HC';
+SELECT 1, 1.0, 'abc';
+
+SET network_compression_method = 'ZSTD';
+SELECT 1, 1.0, 'abc';
+
+SET network_compression_method = 'NOT_A_CODEC';
+SELECT 1, 1.0, 'abc'; -- { clientError BAD_ARGUMENTS }
+
+-- At this point, the connection parameters are broken and cannot be repaired
+-- Users at least get an error message what is wrong
+SET network_compression_method = 'ZSTD'; -- { clientError BAD_ARGUMENTS }


### PR DESCRIPTION
In https://github.com/ClickHouse/clickhouse-cpp/issues/436, someone asked if T64 can be used for client/server and server/server communication. Turned out that it is possible via setting [network_compression_method](https://clickhouse.com/docs/operations/settings/settings#network_compression_method). However setting T64 as codec silently broke the transmission of strings, e.g. `SELECT 'abc'` as T64 does not support strings. This PR improves error handling a bit and limits the codecs to generic codecs.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Throw an exception if setting `network_compression_method` is not a supported generic codec.