### PR TITLE
Docs: add warning about using bcrypt with high-frequency authentication

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -256,6 +256,7 @@ backupview
 balancer
 basename
 bcrypt
+bcrypt's
 bech
 Bech
 benchmarked

--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -63,11 +63,18 @@ This setting is configured by default as:
 
 ## bcrypt_workfactor {#bcrypt_workfactor}
 
-Work factor for the bcrypt_password authentication type which uses the [Bcrypt algorithm](https://wildlyinaccurate.com/bcrypt-choosing-a-work-factor/).
+Work factor for the `bcrypt_password` authentication type which uses the [Bcrypt algorithm](https://wildlyinaccurate.com/bcrypt-choosing-a-work-factor/).
+The work factor defines the amount of computations and time needed to compute the hash and verify the password.
 
 ```xml
 <bcrypt_workfactor>12</bcrypt_workfactor>
 ```
+
+:::warning
+For applications with high-frequency authentication,
+consider alternative authentication methods due to
+bcrypt's computational overhead at higher work factors.
+:::
 
 ## table_engines_require_grant {#table_engines_require_grant}
 

--- a/docs/en/sql-reference/statements/create/user.md
+++ b/docs/en/sql-reference/statements/create/user.md
@@ -123,7 +123,8 @@ In ClickHouse Cloud, by default, passwords must meet the following complexity re
     CREATE USER name5 IDENTIFIED WITH bcrypt_password BY 'my_password'
     ```
 
-    The length of the password is limited to 72 characters with this method. The bcrypt work factor parameter, which defines the amount of computations and time needed to compute the hash and verify the password, can be modified in the server configuration:
+    The length of the password is limited to 72 characters with this method. 
+    The bcrypt work factor parameter, which defines the amount of computations and time needed to compute the hash and verify the password, can be modified in the server configuration:
 
     ```xml
     <bcrypt_workfactor>12</bcrypt_workfactor>
@@ -131,6 +132,12 @@ In ClickHouse Cloud, by default, passwords must meet the following complexity re
 
     The work factor must be between 4 and 31, with a default value of 12.
 
+   :::warning
+   For applications with high-frequency authentication,
+   consider alternative authentication methods due to
+   bcrypt's computational overhead at higher work factors.
+   :::
+6. 
 6. The type of the password can also be omitted:
 
     ```sql


### PR DESCRIPTION
Follow up to discussion in dev channel re. using bcrypt with many authentication requests.
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
