### PR TITLE
ci: fix sending system.*_log to ci-logs cluster

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -38,6 +38,7 @@ common_ft_job_config = Job.Config(
             "./tests/clickhouse-test",
             "./tests/config",
             "./tests/*.txt",
+            "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh",
             "./ci/docker/stateless-test",
         ],
     ),

--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -73,6 +73,8 @@ function check_logs_credentials
 
 function setup_logs_replication
 (
+    check_logs_credentials
+
     # The function is launched in a separate shell instance to not expose the
     # exported values
     set +x


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ci: fix sending system.*_log to ci-logs cluster

Fixes: https://github.com/ClickHouse/ClickHouse/pull/82418