### PR TITLE
Make `system.query_cache` show all cache entries

### DIFF
--- a/tests/queries/0_stateless/02494_query_cache_user_isolation.reference
+++ b/tests/queries/0_stateless/02494_query_cache_user_isolation.reference
@@ -4,7 +4,7 @@ system.query_cache with old user	1
 0
 0	1
 1	0
-system.query_cache with new user	0
+system.query_cache with new user	1
 0
 0	1
 1	0

--- a/tests/queries/0_stateless/02494_query_cache_user_isolation.sh
+++ b/tests/queries/0_stateless/02494_query_cache_user_isolation.sh
@@ -35,19 +35,19 @@ ${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT 'system.query_cache with old
 # Run query again. The 1st run must be a cache miss, the 2nd run a cache hit
 ${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT 0 == $rnd SETTINGS use_query_cache = 1"
 ${CLICKHOUSE_CLIENT} --user "admin" --query "SYSTEM FLUSH LOGS query_log"
-${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT ProfileEvents['QueryCacheHits'], ProfileEvents['QueryCacheMisses'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND query = 'SELECT 0 == $rnd SETTINGS use_query_cache = 1' order by event_time_microseconds"
+${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT ProfileEvents['QueryCacheHits'], ProfileEvents['QueryCacheMisses'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND query = 'SELECT 0 == $rnd SETTINGS use_query_cache = 1' ORDER BY event_time_microseconds"
 
 ${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS admin"
 ${CLICKHOUSE_CLIENT} --query "CREATE USER admin"
 ${CLICKHOUSE_CLIENT} --query "GRANT CURRENT GRANTS ON *.* TO admin WITH GRANT OPTION"
 
-# Check that the system view reports the cache as empty
+# system.query_cache reports the old entry. That is okay since the system table only shows the query string, not the query result.
 ${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT 'system.query_cache with new user', count(*) FROM system.query_cache"
 
 # Run same query as old user. Expect a cache miss.
 ${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT 0 == $rnd SETTINGS use_query_cache = 1"
 ${CLICKHOUSE_CLIENT} --user "admin" --query "SYSTEM FLUSH LOGS query_log"
-${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT ProfileEvents['QueryCacheHits'], ProfileEvents['QueryCacheMisses'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND query = 'SELECT 0 == $rnd SETTINGS use_query_cache = 1' order by event_time_microseconds"
+${CLICKHOUSE_CLIENT} --user "admin" --query "SELECT ProfileEvents['QueryCacheHits'], ProfileEvents['QueryCacheMisses'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND query = 'SELECT 0 == $rnd SETTINGS use_query_cache = 1' ORDER BY event_time_microseconds"
 
 # Cleanup
 ${CLICKHOUSE_CLIENT} --query "DROP USER admin"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
System table `system.query_cache` now returns _all_ query result cache entries, whereas it previously returned only shared entries or non-shared entries of the same user and role. That is okay as non-shared entries are supposed to not reveal _query results_, whereas `system.query_cache` returns _query strings_. This makes the behavior of the system table more similar to `system.query_log`.