### PR TITLE
tests: disable 02700_s3_part_INT_MAX for slow builds

### DIFF
--- a/tests/queries/0_stateless/02700_s3_part_INT_MAX.sh
+++ b/tests/queries/0_stateless/02700_s3_part_INT_MAX.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel, long, no-fasttest
+# Tags: no-parallel, long, no-fasttest, no-debug, no-asan, no-tsan, no-msan, no-ubsan, no-sanitize-coverage
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=fb4fb109f4a245e5cfc8310dea4b0b7a4fe043ec&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_ubsan%2C%20sequential%29&name_1=Stateless%20tests%20%28amd_ubsan%2C%20sequential%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)