### PR TITLE
EmbeddedRocksDB: Path must be inside user_files

### DIFF
--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -212,6 +212,9 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
     setInMemoryMetadata(metadata_);
     setSettings(std::move(settings_));
 
+    if (rocksdb_dir.empty())
+        rocksdb_dir = getContext()->getUserFilesPath() + relative_data_path_;
+
     bool is_local = context_->getApplicationType() == Context::ApplicationType::LOCAL;
     fs::path user_files_path = is_local ? "" : fs::canonical(getContext()->getUserFilesPath());
     if (fs::path(rocksdb_dir).is_relative())
@@ -222,10 +225,6 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "Path must be inside user-files path: {}", user_files_path.string());
 
-    if (rocksdb_dir.empty())
-    {
-        rocksdb_dir = context_->getPath() + relative_data_path_;
-    }
     if (mode < LoadingStrictnessLevel::ATTACH)
     {
         fs::create_directories(rocksdb_dir);

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -213,7 +213,7 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
     setSettings(std::move(settings_));
 
     if (rocksdb_dir.empty())
-        rocksdb_dir = getContext()->getUserFilesPath() + relative_data_path_;
+        rocksdb_dir = fs::path{getContext()->getUserFilesPath()} / relative_data_path_;
 
     bool is_local = context_->getApplicationType() == Context::ApplicationType::LOCAL;
     fs::path user_files_path = is_local ? "" : fs::canonical(getContext()->getUserFilesPath());

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -31,6 +31,7 @@
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
 #include <Common/Exception.h>
+#include <Common/filesystemHelpers.h>
 #include <Common/JSONBuilder.h>
 #include <Core/Settings.h>
 
@@ -210,6 +211,17 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
 {
     setInMemoryMetadata(metadata_);
     setSettings(std::move(settings_));
+
+    bool is_local = context_->getApplicationType() == Context::ApplicationType::LOCAL;
+    fs::path user_files_path = is_local ? "" : fs::canonical(getContext()->getUserFilesPath());
+    if (fs::path(rocksdb_dir).is_relative())
+        rocksdb_dir = user_files_path / rocksdb_dir;
+    rocksdb_dir = fs::absolute(rocksdb_dir).lexically_normal();
+
+    if (!is_local && !pathStartsWith(fs::path(rocksdb_dir), user_files_path))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "Path must be inside user-files path: {}", user_files_path.string());
+
     if (rocksdb_dir.empty())
     {
         rocksdb_dir = context_->getPath() + relative_data_path_;

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1596,6 +1596,10 @@ class TestCase:
         if tags and ("no-replicated-database" in tags) and args.replicated_database:
             return FailureReason.REPLICATED_DB
 
+        # RocksDB tests cannot be used with replicated database as, in our CI, the databases share the same user_files
+        if tags and ("use-rocksdb" in tags) and args.replicated_database:
+            return FailureReason.REPLICATED_DB
+
         if tags and ("no-distributed-cache" in tags) and args.distributed_cache:
             return FailureReason.DISTRIBUTED_CACHE
 

--- a/tests/integration/test_rocksdb_options/test.py
+++ b/tests/integration/test_rocksdb_options/test.py
@@ -44,13 +44,13 @@ def test_valid_options(start_cluster):
     )
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only') PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only') PRIMARY KEY(key);
     DROP TABLE test;
     """
     )
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/store/test_rocksdb_read_only', 1) PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/user_files/test_rocksdb_read_only', 1) PRIMARY KEY(key);
     DROP TABLE test;
     """
     )

--- a/tests/integration/test_rocksdb_options/test.py
+++ b/tests/integration/test_rocksdb_options/test.py
@@ -44,13 +44,13 @@ def test_valid_options(start_cluster):
     )
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only') PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_test_valid_options') PRIMARY KEY(key);
     DROP TABLE test;
     """
     )
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/user_files/test_rocksdb_read_only', 1) PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_test_valid_options', 1) PRIMARY KEY(key);
     DROP TABLE test;
     """
     )

--- a/tests/integration/test_rocksdb_read_only/test.py
+++ b/tests/integration/test_rocksdb_read_only/test.py
@@ -28,13 +28,13 @@ def test_read_only(start_cluster):
     with pytest.raises(QueryRuntimeException):
         node.query(
             """
-        CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only', 1) PRIMARY KEY(key);
+        CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only', 1) PRIMARY KEY(key);
         """
         )
     # create directory if read_only = false
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only') PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only') PRIMARY KEY(key);
     INSERT INTO test (key, value) VALUES (0, 'a'), (1, 'b'), (2, 'c');
     """
     )
@@ -42,25 +42,25 @@ def test_read_only(start_cluster):
     with pytest.raises(QueryRuntimeException):
         node.query(
             """
-        CREATE TABLE test_fail (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only') PRIMARY KEY(key);
+        CREATE TABLE test_fail (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only') PRIMARY KEY(key);
         """
         )
     with pytest.raises(QueryRuntimeException):
         node.query(
             """
-        CREATE TABLE test_fail (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/store/test_rocksdb_read_only') PRIMARY KEY(key);
+        CREATE TABLE test_fail (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/user_files/test_rocksdb_read_only') PRIMARY KEY(key);
         """
         )
     # success if create multiple read-only tables on the same directory
     node.query(
         """
-    CREATE TABLE test_1 (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only', 1) PRIMARY KEY(key);
+    CREATE TABLE test_1 (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only', 1) PRIMARY KEY(key);
     DROP TABLE test_1;
     """
     )
     node.query(
         """
-    CREATE TABLE test_2 (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/store/test_rocksdb_read_only', 1) PRIMARY KEY(key);
+    CREATE TABLE test_2 (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/user_files/test_rocksdb_read_only', 1) PRIMARY KEY(key);
     DROP TABLE test_2;
     """
     )
@@ -68,7 +68,7 @@ def test_read_only(start_cluster):
     node.query(
         """
     DROP TABLE test;
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/store/test_rocksdb_read_only', 1) PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(10, '/var/lib/clickhouse/user_files/test_rocksdb_read_only', 1) PRIMARY KEY(key);
     """
     )
     result = node.query("""SELECT count() FROM test;""")
@@ -90,7 +90,7 @@ def test_dirctory_missing_after_stop(start_cluster):
     # for read_only = false
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only_missing') PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_missing') PRIMARY KEY(key);
     """
     )
     node.stop_clickhouse()
@@ -98,7 +98,7 @@ def test_dirctory_missing_after_stop(start_cluster):
         [
             "bash",
             "-c",
-            "rm -r /var/lib/clickhouse/store/test_rocksdb_read_only_missing",
+            "rm -r /var/lib/clickhouse/user_files/test_rocksdb_read_only_missing",
         ]
     )
     node.start_clickhouse()
@@ -115,7 +115,7 @@ def test_dirctory_missing_after_stop(start_cluster):
     # for read_only = true
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/store/test_rocksdb_read_only_missing', 1) PRIMARY KEY(key);
+    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_missing', 1) PRIMARY KEY(key);
     """
     )
     node.stop_clickhouse()
@@ -123,7 +123,7 @@ def test_dirctory_missing_after_stop(start_cluster):
         [
             "bash",
             "-c",
-            "rm -r /var/lib/clickhouse/store/test_rocksdb_read_only_missing",
+            "rm -r /var/lib/clickhouse/user_files/test_rocksdb_read_only_missing",
         ]
     )
     node.start_clickhouse()

--- a/tests/integration/test_rocksdb_read_only/test.py
+++ b/tests/integration/test_rocksdb_read_only/test.py
@@ -90,7 +90,7 @@ def test_dirctory_missing_after_stop(start_cluster):
     # for read_only = false
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_missing') PRIMARY KEY(key);
+    CREATE TABLE test_missing (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_missing') PRIMARY KEY(key);
     """
     )
     node.stop_clickhouse()
@@ -103,19 +103,19 @@ def test_dirctory_missing_after_stop(start_cluster):
     )
     node.start_clickhouse()
     result = node.query(
-        """INSERT INTO test (key, value) VALUES (0, 'a');
-    SELECT * FROM test;
+        """INSERT INTO test_missing (key, value) VALUES (0, 'a');
+    SELECT * FROM test_missing;
     """
     )
     assert result.strip() == "0\ta"
     node.query(
-        """DROP TABLE test;
+        """DROP TABLE test_missing;
     """
     )
     # for read_only = true
     node.query(
         """
-    CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_missing', 1) PRIMARY KEY(key);
+    CREATE TABLE test_missing (key UInt64, value String) Engine=EmbeddedRocksDB(0, '/var/lib/clickhouse/user_files/test_rocksdb_read_only_missing', 1) PRIMARY KEY(key);
     """
     )
     node.stop_clickhouse()
@@ -128,10 +128,10 @@ def test_dirctory_missing_after_stop(start_cluster):
     )
     node.start_clickhouse()
     with pytest.raises(QueryRuntimeException):
-        node.query("""INSERT INTO test (key, value) VALUES (1, 'b');""")
-    result = node.query("""SELECT * FROM test;""")
+        node.query("""INSERT INTO test_missing (key, value) VALUES (1, 'b');""")
+    result = node.query("""SELECT * FROM test_missing;""")
     assert result.strip() == ""
     node.query(
-        """DROP TABLE test;
+        """DROP TABLE test_missing;
     """
     )

--- a/tests/queries/0_stateless/01504_rocksdb.sql
+++ b/tests/queries/0_stateless/01504_rocksdb.sql
@@ -1,4 +1,4 @@
--- Tags: no-ordinary-database, no-fasttest
+-- Tags: no-ordinary-database, no-fasttest, use-rocksdb
 -- Tag no-ordinary-database: Sometimes cannot lock file most likely due to concurrent or adjacent tests, but we don't care how it works in Ordinary database
 -- Tag no-fasttest: In fasttest, ENABLE_LIBRARIES=0, so rocksdb engine is not enabled by default
 

--- a/tests/queries/0_stateless/01686_rocksdb.sql
+++ b/tests/queries/0_stateless/01686_rocksdb.sql
@@ -1,4 +1,4 @@
--- Tags: no-ordinary-database, no-fasttest
+-- Tags: no-ordinary-database, no-fasttest, use-rocksdb
 -- Tag no-ordinary-database: Sometimes cannot lock file most likely due to concurrent or adjacent tests, but we don't care how it works in Ordinary database
 -- Tag no-fasttest: In fasttest, ENABLE_LIBRARIES=0, so rocksdb engine is not enabled by default
 

--- a/tests/queries/0_stateless/01821_table_comment.sql
+++ b/tests/queries/0_stateless/01821_table_comment.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-fasttest
+-- Tags: no-parallel, no-fasttest, use-rocksdb
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;

--- a/tests/queries/0_stateless/02030_rocksdb_race_long.sh
+++ b/tests/queries/0_stateless/02030_rocksdb_race_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race
+# Tags: race, use-rocksdb
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
+++ b/tests/queries/0_stateless/02375_rocksdb_with_filters.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, use-rocksdb
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02416_rocksdb_delete_update.sql
+++ b/tests/queries/0_stateless/02416_rocksdb_delete_update.sql
@@ -1,4 +1,4 @@
--- Tags: no-ordinary-database, no-fasttest
+-- Tags: no-ordinary-database, no-fasttest, use-rocksdb
 
 DROP TABLE IF EXISTS 02416_rocksdb;
 

--- a/tests/queries/0_stateless/02811_invalid_embedded_rocksdb_create.sql
+++ b/tests/queries/0_stateless/02811_invalid_embedded_rocksdb_create.sql
@@ -1,2 +1,2 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, use-rocksdb
 CREATE TABLE dict (`k` String, `v` String) ENGINE = EmbeddedRocksDB(k) PRIMARY KEY k; -- {serverError BAD_ARGUMENTS}

--- a/tests/queries/0_stateless/03223_system_tables_set_not_ready.sql
+++ b/tests/queries/0_stateless/03223_system_tables_set_not_ready.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-shared-merge-tree
+-- Tags: no-fasttest, no-shared-merge-tree, use-rocksdb
 -- Tag no-fasttest -- due to EmbeddedRocksDB
 -- Tag no-shared-merge-tree -- due to system.replication_queue
 

--- a/tests/queries/0_stateless/03370_rocks_db_engine_subcolumn_in_pk.sql
+++ b/tests/queries/0_stateless/03370_rocks_db_engine_subcolumn_in_pk.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, use-rocksdb
 
 CREATE TABLE test (t Tuple(a Int32)) ENGINE = EmbeddedRocksDB() PRIMARY KEY (t.a); -- {serverError BAD_ARGUMENTS}
 

--- a/tests/queries/0_stateless/03578_distributed_kv_global_in.sql
+++ b/tests/queries/0_stateless/03578_distributed_kv_global_in.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, use-rocksdb
 
 SET prefer_localhost_replica = 0;
 

--- a/tests/queries/0_stateless/03578_kv_in_type_casts.sql
+++ b/tests/queries/0_stateless/03578_kv_in_type_casts.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, use-rocksdb
 
 DROP TABLE IF EXISTS 03578_rocksdb;
 

--- a/tests/queries/0_stateless/03602_embeddedrock_path.sql
+++ b/tests/queries/0_stateless/03602_embeddedrock_path.sql
@@ -1,0 +1,11 @@
+-- Tags: no-fasttest
+-- no-fasttest: EmbeddedRocksDB requires libraries
+CREATE TABLE embeddedrock_exploit
+(
+    `key` String,
+    `v1` UInt32,
+    `v2` String,
+    `v3` Float32
+)
+ENGINE = EmbeddedRocksDB(150,'/tmp/exploit')
+PRIMARY KEY key; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03602_embeddedrock_path.sql
+++ b/tests/queries/0_stateless/03602_embeddedrock_path.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, use-rocksdb
 -- no-fasttest: EmbeddedRocksDB requires libraries
 CREATE TABLE embeddedrock_exploit
 (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
EmbeddedRocksDB: Path must be inside user_files.

If you were using the default path before (under databases), tables will keep working but new tables will be created under `user_files`. If you were using different paths you will need to move them inside user_paths and adapt the table metadata, as not having this check was a security vulnerability allowing CH clients to access any file the user running the binary had access to. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
