### PR TITLE
Avoid LOGICAL_ERROR during DROP TABLE from Replicated database (race with shutdown)

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1957,7 +1957,7 @@ void DatabaseReplicated::dropTable(ContextPtr local_context, const String & tabl
 
     auto table = tryGetTable(table_name, getContext());
     if (!table)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table {} doesn't exist", table_name);
+        throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table {} doesn't exist", table_name);
     if (table->getName() == "MaterializedView" || table->getName() == "WindowView" || table->getName() == "SharedSet" || table->getName() == "SharedJoin")
     {
         /// Avoid recursive locking of metadata_mutex


### PR DESCRIPTION
Right now the error code is LOGICAL_ERROR, which is equal to assert.

But, it is possible to have a race between
DatabaseReplicated::dropTable() and server shutdown, and shutdown does not have DDLGuard, and may lead to this error. So, let's relax the code.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid `LOGICAL_ERROR` (=assert) during `DROP TABLE` from Replicated database (race with shutdown)