### PR TITLE
Fix old KeeperMap tables leaving data behind after DROP

### DIFF
--- a/tests/integration/test_keeper_map/test.py
+++ b/tests/integration/test_keeper_map/test.py
@@ -132,3 +132,22 @@ def test_keeper_map_with_failed_drop(started_cluster):
     run_query(
         "CREATE TABLE test_keeper_map_with_failed_drop_another (key UInt64, value UInt64) ENGINE = KeeperMap('/test_keeper_map_with_failed_drop') PRIMARY KEY(key);"
     )
+
+def test_keeper_drop_after_update(started_cluster):
+    run_query("DROP TABLE IF EXISTS test_keeper_drop_after_update SYNC")
+    run_query(
+        "CREATE TABLE test_keeper_drop_after_update (key UInt64, value UInt64) ENGINE = KeeperMap('/test_keeper_drop_after_update') PRIMARY KEY(key);"
+    )
+
+    zk_client = get_genuine_zk()
+    assert (
+        zk_client.delete("/test_keeper_map/test_keeper_drop_after_update/metadata/drop_lock_version")
+        is not None
+    )
+
+    run_query("DROP TABLE test_keeper_drop_after_update SYNC")
+
+    assert (
+        zk_client.exists("/test_keeper_map/test_keeper_drop_after_update/data")
+        is None
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix KeeperMap tables created before 25.1, leaving data in ZooKeeper after the DROP query.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
