### PR TITLE
Docs: fix two typos and add an example for system.query_log

### DIFF
--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -33,11 +33,11 @@ Each query creates one or two rows in the `query_log` table, depending on the st
 2.  If an error occurred during query processing, two events with the `QueryStart` and `ExceptionWhileProcessing` types are created.
 3.  If an error occurred before launching the query, a single event with the `ExceptionBeforeStart` type is created.
 
-You can use the [log_queries_probability](/operations/settings/settings#log_queries_probability)) setting to reduce the number of queries, registered in the `query_log` table.
+You can use the [log_queries_probability](/operations/settings/settings#log_queries_probability) setting to reduce the number of queries, registered in the `query_log` table.
 
-You can use the [log_formatted_queries](/operations/settings/settings#log_formatted_queries)) setting to log formatted queries to the `formatted_query` column.
+You can use the [log_formatted_queries](/operations/settings/settings#log_formatted_queries) setting to log formatted queries to the `formatted_query` column.
 
-Columns:
+## Columns {#columns}
 
 - `hostname` ([LowCardinality(String)](../../sql-reference/data-types/string.md)) — Hostname of the server executing the query.
 - `type` ([Enum8](../../sql-reference/data-types/enum.md)) — Type of an event that occurred when executing the query. Values:
@@ -130,7 +130,9 @@ Columns:
   - `'Write'` = The query result was written into the query cache.
   - `'Read'` = The query result was read from the query cache.
 
-**Example**
+## Examples {#examples}
+
+**Basic example**
 
 ```sql
 SELECT * FROM system.query_log WHERE type = 'QueryFinish' ORDER BY query_start_time DESC LIMIT 1 FORMAT Vertical;
@@ -210,6 +212,20 @@ used_sql_user_defined_functions:       []
 used_privileges:                       []
 missing_privileges:                    []
 query_cache_usage:                     None
+```
+
+**Cloud example**
+
+In ClickHouse Cloud, `system.query_log` is local to each node; to see all entries you must query via [`clusterAllReplicas`](/sql-reference/table-functions/cluster).
+
+For example, to aggregate query_log rows from every replica in the “default” cluster you can write:
+
+```sql
+SELECT * 
+FROM clusterAllReplicas('default', system.query_log)
+WHERE event_time >= now() - toIntervalHour(1)
+LIMIT 10
+SETTINGS skip_unavailable_shards = 1;
 ```
 
 **See Also**


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
- Fixes the additional `)` in two places.
- Adds an example of querying system.query_log on Cloud to reinforce the note at the top of the page.
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
