### PR TITLE
Support storage class in S3 table function and table engine

### DIFF
--- a/src/Storages/ObjectStorage/S3/Configuration.h
+++ b/src/Storages/ObjectStorage/S3/Configuration.h
@@ -19,7 +19,7 @@ public:
     static constexpr auto type_name = "s3";
     static constexpr auto namespace_name = "bucket";
     /// All possible signatures for S3 storage with structure argument (for example for s3 table function).
-    static constexpr auto max_number_of_arguments_with_structure = 9;
+    static constexpr auto max_number_of_arguments_with_structure = 10;
     static constexpr auto signatures_with_structure =
         " - url\n"
         " - url, NOSIGN\n"
@@ -41,10 +41,11 @@ public:
         " - url, access_key_id, secret_access_key, session_token, format, structure, compression_method, partition_strategy\n"
         " - url, access_key_id, secret_access_key, session_token, format, structure, partition_strategy, partition_columnns_in_data_file\n"
         " - url, access_key_id, secret_access_key, session_token, format, structure, compression_method, partition_strategy, partition_columnns_in_data_file\n"
+        " - url, access_key_id, secret_access_key, session_token, format, structure, compression_method, partition_strategy, partition_columnns_in_data_file, storage_class_name\n"
         "All signatures supports optional headers (specified as `headers('name'='value', 'name2'='value2')`)";
 
     /// All possible signatures for S3 storage without structure argument (for example for S3 table engine).
-    static constexpr auto max_number_of_arguments_without_structure = 8;
+    static constexpr auto max_number_of_arguments_without_structure = 9;
     static constexpr auto signatures_without_structure =
         " - url\n"
         " - url, NOSIGN\n"

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -697,7 +697,7 @@ def test_wrong_s3_syntax(started_cluster):
     instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
     expected_err_msg = "Code: 42"  # NUMBER_OF_ARGUMENTS_DOESNT_MATCH
 
-    query = "create table test_table_s3_syntax (id UInt32) ENGINE = S3('', '', '', '', '', '', '', '', '')"
+    query = "create table test_table_s3_syntax (id UInt32) ENGINE = S3('', '', '', '', '', '', '', '', '', '')"
     assert expected_err_msg in instance.query_and_get_error(query)
 
     expected_err_msg = "Code: 36"  # BAD_ARGUMENTS

--- a/tests/integration/test_storage_s3_intelligent_tier/__init__.py
+++ b/tests/integration/test_storage_s3_intelligent_tier/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_storage_s3_intelligent_tier/test.py
+++ b/tests/integration/test_storage_s3_intelligent_tier/test.py
@@ -1,0 +1,58 @@
+
+import os
+import logging
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_queue_common import generate_random_string
+
+logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().addHandler(logging.StreamHandler())
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    with_minio=True,
+)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_s3_storage_class(started_cluster):
+    node = started_cluster.instances["node"]
+    table_name = f"test_s3_storage_class_{generate_random_string()}"
+    bucket = started_cluster.minio_bucket
+
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_name}"
+
+    node.query(
+        f"""
+        CREATE TABLE {table_name} (a Int32, b Int32, c String) ENGINE = S3('{url}', access_key_id = 'minio', secret_access_key='ClickHouse_Minio_P@ssw0rd', format = 'Parquet', storage_class_name='STANDARD')
+    """
+    )
+
+    node.query(f"INSERT INTO {table_name} VALUES (1, 2, '3')")
+
+    assert node.query("SELECT b FROM {}".format(table_name)).strip() == "2"
+
+    table_function_name = f"test_s3_storage_class_{generate_random_string()}_table_function"
+
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_function_name}"
+
+    table_function_def = f"s3('{url}', 'minio', 'ClickHouse_Minio_P@ssw0rd', '', 'Parquet', 'a Int32, b Int32, c String', 'zstd', 'WILDCARD', 0, 'STANDARD')"
+    node.query(f"INSERT INTO TABLE FUNCTION {table_function_def} VALUES (1, 2, '3')")
+
+    assert node.query("SELECT b FROM {}".format(table_function_def)).strip() == "2"
+
+    with pytest.raises(Exception):
+        node.query(
+            f"""
+        CREATE TABLE {table_name}_invalid (a Int32, b Int32, c String) ENGINE = S3('{url}', access_key_id = 'minio', secret_access_key='ClickHouse_Minio_P@ssw0rd', format = 'Parquet', storage_class_name='INVALID')
+    """
+        )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add new parameter to `S3` table engine and `s3` table function named `storage_class_name` which allows to specify intelligent tiring supported by AWS. Supported both in key-value format and in positional (deprecated) format).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
