### PR TITLE
Fix a logger segfault during authentication

### DIFF
--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -567,8 +567,10 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
 
             if (skipped_not_allowed_authentication_methods)
             {
-                LOG_INFO(getLogger(), "Skipped the check for not allowed authentication methods,"
-                              "check allow_no_password and allow_plaintext_password settings in the server configuration");
+                auto logger = getLogger();
+                if (logger)
+                    LOG_INFO(logger, "Skipped the check for not allowed authentication methods,"
+                              " check allow_no_password and allow_plaintext_password settings in the server configuration");
             }
 
             throwInvalidCredentials();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Recently, there was an instance, failing with this stack trace:
https://pastila.nl/?002418fa/b1e101f876badcbd66f670670467ec6e#zq/bJG1qh+YC92DZ++Scwg==

The reason of the segfault seem to be the self-made `getLogger()` function can return null under some cases. (I cannot mention these cases as I could not reproduce the bug.)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
