### PR TITLE
Partial filter pushdown for JOIN

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -234,6 +234,13 @@ static void projectDagInputs(ActionsDAG & actions_dag)
     }
 }
 
+std::optional<ActionsDAG> tryToExtractPartialPredicate(
+    const ActionsDAG & original_dag,
+    const std::string & filter_name,
+    const Names & available_columns);
+
+void addFilterOnTop(QueryPlan::Node & join_node, size_t child_idx, QueryPlan::Nodes & nodes, ActionsDAG filter_dag);
+
 static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes, QueryPlan::Node * child_node)
 {
     auto & parent = parent_node->step;
@@ -482,11 +489,46 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             /// This means that all predicates of filter were pushed down.
             /// Replace current actions to expression, as we don't need to filter anything.
             parent = std::make_unique<ExpressionStep>(child->getOutputHeader(), std::move(filter_expression));
+            filter = nullptr;
         }
         else
         {
             filter->updateInputHeader(child->getOutputHeader());
         }
+    }
+
+    if (filter && !filter->getStepDescription().contains("partial predicates extracted"))
+    {
+        {
+            auto left_partial_filter_dag = tryToExtractPartialPredicate(filter->getExpression(), filter->getFilterColumnName(), left_stream_available_columns_to_push_down);
+            if (left_partial_filter_dag.has_value())
+            {
+                const auto partial_predicate_column_name = left_partial_filter_dag->getOutputs().front()->result_name;
+                addFilterOnTop(*child_node, 0, nodes, std::move(*left_partial_filter_dag));
+                ++updated_steps;
+                LOG_DEBUG(&Poco::Logger::get("QueryPlanOptimizations"),
+                    "Pushed down partial filter {} to the {} side of join",
+                    partial_predicate_column_name,
+                    JoinKind::Left);
+            }
+        }
+
+        {
+            auto right_partial_filter_dag = tryToExtractPartialPredicate(filter->getExpression(), filter->getFilterColumnName(), right_stream_available_columns_to_push_down);
+            if (right_partial_filter_dag.has_value())
+            {
+                const auto partial_predicate_column_name = right_partial_filter_dag->getOutputs().front()->result_name;
+                addFilterOnTop(*child_node, 1, nodes, std::move(*right_partial_filter_dag));
+                ++updated_steps;
+                LOG_DEBUG(&Poco::Logger::get("QueryPlanOptimizations"),
+                    "Pushed down partial filter {} to the {} side of join",
+                    partial_predicate_column_name,
+                    JoinKind::Right);
+            }
+        }
+
+        /// FIXME: better way to avoid applying the partial predicate extraction again
+        filter->setStepDescription(fmt::format("{}, with partial predicates extracted", filter->getStepDescription()), 2000);
     }
 
     return updated_steps;

--- a/src/Processors/QueryPlan/Optimizations/partialFilterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/partialFilterPushDown.cpp
@@ -20,14 +20,14 @@ namespace
 ///     (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY') OR
 ///     (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
 /// the goal is to extract separate partial filters for each table
-/// for n1: 
-///     n1.n_name = 'FRANCE' OR n1.n_name = 'GERMANY' 
-/// for n2: 
+/// for n1:
+///     n1.n_name = 'FRANCE' OR n1.n_name = 'GERMANY'
+/// for n2:
 ///     n2.n_name = 'GERMANY' OR n2.n_name = 'FRANCE'
 ///
 /// The idea is to traverse the all conjunctions and disjunctions in the original condition and
 ///  1. replace elements of conjunctions that depend on other columns with 'True'
-///  2. replace the whole disjunctions with 'True' if any element depends on other columns 
+///  2. replace the whole disjunctions with 'True' if any element depends on other columns
 struct ConditionList
 {
     enum ConditionType

--- a/src/Processors/QueryPlan/Optimizations/partialFilterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/partialFilterPushDown.cpp
@@ -1,0 +1,254 @@
+#include <Interpreters/ActionsDAG.h>
+#include <Functions/FunctionsLogical.h>
+#include <Functions/IFunctionAdaptors.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/FilterStep.h>
+#include <base/types.h>
+#include <vector>
+
+
+namespace DB::QueryPlanOptimizations
+{
+
+namespace
+{
+
+/// Represents a list of conjunctive or disjunctive conditions
+/// Some sub-conditions are references to the existing nodes in the DAG, others are conjctions or disjunctions
+/// that are not present in the original DAG
+/// Example: when we have a filter on 2 tables n1 and n2:
+///     (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY') OR
+///     (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+/// the goal is to extract separate partial filters for each table
+/// for n1: 
+///     n1.n_name = 'FRANCE' OR n1.n_name = 'GERMANY' 
+/// for n2: 
+///     n2.n_name = 'GERMANY' OR n2.n_name = 'FRANCE'
+///
+/// The idea is to traverse the all conjunctions and disjunctions in the original condition and
+///  1. replace elements of conjunctions that depend on other columns with 'True'
+///  2. replace the whole disjunctions with 'True' if any element depends on other columns 
+struct ConditionList
+{
+    enum ConditionType
+    {
+        SingleCondition,
+        And,
+        Or
+    };
+
+    ConditionType condition_type = SingleCondition;
+    std::vector<const ActionsDAG::Node *> existing_nodes;
+    std::vector<ConditionList> subconditions;
+
+    bool assumedTrue() const
+    {
+        return existing_nodes.empty() &&
+            (subconditions.empty() || (subconditions.size() == 1 && subconditions.front().assumedTrue()));
+    }
+
+//    void dump(WriteBuffer & out) const
+//    {
+//        if (op.empty() || (existing_nodes.size() + subconditions.size() == 1))
+//        {
+//            chassert(existing_nodes.size() + subconditions.size() <= 1);
+//            if (existing_nodes.empty() && subconditions.empty())
+//                out << "True";
+//            else if (!existing_nodes.empty())
+//                out << existing_nodes.front()->result_name;
+//            else
+//                subconditions.front().dump(out);
+//
+//            return;
+//        }
+//        out << op << "(";
+//        bool need_comma = false;
+//        for (const auto * node : existing_nodes)
+//        {
+//            if (need_comma)
+//                out << ", ";
+//            out << node->result_name;
+//            need_comma = true;
+//        }
+//        for (const auto & condition : subconditions)
+//        {
+//            if (need_comma)
+//                out << ", ";
+//            condition.dump(out);
+//            need_comma = true;
+//        }
+//        out << ")";
+//    }
+//
+//    String dump() const
+//    {
+//        WriteBufferFromOwnString out;
+//        dump(out);
+//        return out.str();
+//    }
+};
+
+/// Check if the whole subgraph that calculates the node only uses columns from the list
+bool onlyDependsOnAvailableColumns(const ActionsDAG::Node & node, const NameSet & available_columns)
+{
+    if (node.type == ActionsDAG::ActionType::INPUT)
+    {
+        return available_columns.contains(node.result_name);
+    }
+    else
+    {
+        for (const auto * child : node.children)
+        {
+            if (!onlyDependsOnAvailableColumns(*child, available_columns))
+                return false;
+        }
+        return true;
+    }
+}
+
+/// Extract all conditions from the filter that use only columns from the list.
+/// The resulting condition is broader then the full filter but can be used to early pre-filtering of the data
+ConditionList extractPartialPredicate(const ActionsDAG::Node & node, const NameSet & available_columns)
+{
+    const bool is_conjunction = node.type == ActionsDAG::ActionType::FUNCTION && node.function_base->getName() == "and";
+    const bool is_disjunction = node.type == ActionsDAG::ActionType::FUNCTION && node.function_base->getName() == "or";
+    if (is_conjunction)
+    {
+        ConditionList conjuction_template;
+        conjuction_template.condition_type = ConditionList::And;
+        for (const auto * child : node.children)
+        {
+            auto child_condition_template = extractPartialPredicate(*child, available_columns);
+            if (!child_condition_template.assumedTrue())
+                conjuction_template.subconditions.emplace_back(std::move(child_condition_template));
+        }
+        return conjuction_template;
+    }
+    else if (is_disjunction)
+    {
+        ConditionList disjuction_template;
+        disjuction_template.condition_type = ConditionList::Or;
+        for (const auto * child : node.children)
+        {
+            auto child_condition_template = extractPartialPredicate(*child, available_columns);
+            if (child_condition_template.assumedTrue())
+                return ConditionList{}; /// The whole disjunction can be assumed True, so it in not included into partial predicate
+
+            disjuction_template.subconditions.emplace_back(std::move(child_condition_template));
+        }
+        return disjuction_template;
+    }
+    else if (node.type == ActionsDAG::ActionType::ALIAS)
+    {
+        return extractPartialPredicate(*node.children.front(), available_columns);
+    }
+    else
+    {
+        if (!onlyDependsOnAvailableColumns(node, available_columns))
+            return ConditionList{}; /// If the subtree depends on other columns then we cannot include it into partial predicate, so assume it's True
+
+        return ConditionList{
+            .condition_type = ConditionList::SingleCondition,
+            .existing_nodes = {&node},
+            .subconditions = {}
+        };
+    }
+}
+
+const ActionsDAG::Node * buildPredicateFromTemplate(ActionsDAG & full_dag, const ConditionList & predicate_template)
+{
+    if (predicate_template.assumedTrue())
+        return nullptr;
+
+    /// Just 1 element?
+    if (predicate_template.existing_nodes.size() + predicate_template.subconditions.size() == 1)
+    {
+        if (predicate_template.existing_nodes.size() == 1)
+            return predicate_template.existing_nodes.front();
+        else
+            return buildPredicateFromTemplate(full_dag, predicate_template.subconditions.front());
+    }
+
+    ActionsDAG::NodeRawConstPtrs children(predicate_template.existing_nodes);
+
+    for (const auto & subcondition : predicate_template.subconditions)
+    {
+        const auto * subcondition_node = buildPredicateFromTemplate(full_dag, subcondition);
+        if (subcondition_node)
+            children.push_back(subcondition_node);
+    }
+
+    if (children.size() == 1)
+        return children.front();
+
+    chassert(predicate_template.condition_type == ConditionList::And || predicate_template.condition_type == ConditionList::Or);
+
+    FunctionOverloadResolverPtr function =
+        predicate_template.condition_type == ConditionList::And ?
+        std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionAnd>()) :
+        std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+
+    return &full_dag.addFunction(function, children, {});
+}
+
+}
+
+std::optional<ActionsDAG> tryToExtractPartialPredicate(
+    const ActionsDAG & original_dag,
+    const std::string & filter_name,
+    const Names & available_columns)
+{
+//    std::cerr << fmt::format("BEFORE:\n{}\nFILTER: {}\nAVAILABLE COLUMNS: {}\n\n\n",
+//        original_dag.dumpDAG(), filter_name, fmt::join(available_columns, ","));
+
+    if (!original_dag.tryFindInOutputs(filter_name))
+        return {};
+
+    ActionsDAG full_dag = original_dag.clone();
+
+    const ActionsDAG::Node & predicate = full_dag.findInOutputs(filter_name);
+
+    auto predicate_template = extractPartialPredicate(predicate, NameSet(available_columns.begin(), available_columns.end()));
+
+//    std::cerr << "PREDICATE TEMPLATE: " << predicate_template.dump() << "\n\n\n";
+
+    if (predicate_template.assumedTrue())
+        return {};
+
+    const auto * predicate_node = buildPredicateFromTemplate(full_dag, predicate_template);
+
+    if (!predicate_node)
+        return {};
+
+    full_dag.getOutputs().clear();
+    full_dag.addOrReplaceInOutputs(*predicate_node);
+    full_dag.removeUnusedActions();
+
+//    std::cerr << "AFTER:\n" << full_dag.dumpDAG() << "\n\n\n";
+
+    return full_dag;
+}
+
+void addFilterOnTop(QueryPlan::Node & join_node, size_t child_idx, QueryPlan::Nodes & nodes, ActionsDAG filter_dag)
+{
+    auto & new_filter_node = nodes.emplace_back();
+    new_filter_node.children = {join_node.children[child_idx]};
+    join_node.children[child_idx] = &new_filter_node;
+
+    auto filter_column_name = filter_dag.getOutputs().front()->result_name;
+    for (const auto * input : filter_dag.getInputs())
+        filter_dag.addOrReplaceInOutputs(*input);
+
+//    std::cerr << "ADD FILTER:\n" << filter_dag.dumpDAG() << "\n\n\n";
+
+    const auto input_header = new_filter_node.children.at(0)->step->getOutputHeader();
+//    std::cerr << input_header->dumpNames() << "\n\n";
+
+    new_filter_node.step = std::make_unique<FilterStep>(
+        input_header,
+        std::move(filter_dag),
+        filter_column_name,
+        true);
+}
+
+}

--- a/tests/queries/0_stateless/03624_partial_filter_pushdown.reference
+++ b/tests/queries/0_stateless/03624_partial_filter_pushdown.reference
@@ -1,0 +1,12 @@
+  Filter (WHERE, with partial predicates extracted)
+  Filter column: or(and(equals(__table1.number, 1_UInt8), equals(__table2.number, 2_UInt8)), and(equals(__table1.number, 3_UInt8), equals(__table2.number, 4_UInt8))) (removed)
+    Join (JOIN FillRightFirst)
+    Algorithm: HashJoin
+      Filter
+      Filter column: or(equals(__table1.number, 1_UInt8), equals(__table1.number, 3_UInt8)) (removed)
+          ReadFromSystemNumbers
+      Filter
+      Filter column: or(equals(__table2.number, 2_UInt8), equals(__table2.number, 4_UInt8)) (removed)
+          ReadFromSystemNumbers
+1	2
+3	4

--- a/tests/queries/0_stateless/03624_partial_filter_pushdown.sql
+++ b/tests/queries/0_stateless/03624_partial_filter_pushdown.sql
@@ -1,0 +1,10 @@
+select * from (
+    explain actions=1
+    select n1.number, n2.number
+    from numbers(5) as n1, numbers(6) as n2
+    where (n1.number = 1 and n2.number = 2) or (n1.number = 3 and n2.number = 4)
+) where explain like '%Filter%' or explain like '%Join%' or explain like '%Read%';
+
+select n1.number, n2.number
+from numbers(5) as n1, numbers(6) as n2
+where (n1.number = 1 and n2.number = 2) or (n1.number = 3 and n2.number = 4);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description]
For a filter condition on 2 tables n1 and n2 like `(n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY') OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')` extract separate partial filters for each table `n1.n_name = 'FRANCE' OR n1.n_name = 'GERMANY'` for n1 and `n2.n_name = 'GERMANY' OR n2.n_name = 'FRANCE'` for n2.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
