### PR TITLE
Docs: add clarifying note to grant.md

### DIFF
--- a/docs/en/sql-reference/statements/grant.md
+++ b/docs/en/sql-reference/statements/grant.md
@@ -75,7 +75,7 @@ Also `john` has the `GRANT OPTION` privilege, so it can grant other users with p
 Access to the `system` database is always allowed (since this database is used for processing queries).
 
 :::note
-While there are manu system tables which new users can access by default, they  may not be able to access every system table by default without grants.
+While there are many system tables which new users can access by default, they  may not be able to access every system table by default without grants.
 Additionally, access to certain system tables such as `system.zookeeper` is restricted for Cloud users for security reasons.
 :::
 

--- a/docs/en/sql-reference/statements/grant.md
+++ b/docs/en/sql-reference/statements/grant.md
@@ -74,8 +74,8 @@ Also `john` has the `GRANT OPTION` privilege, so it can grant other users with p
 
 Access to the `system` database is always allowed (since this database is used for processing queries).
 
-:::note ClickHouse Cloud
-New ClickHouse Cloud users are not able to access system tables by default without grants.
+:::note
+While there are manu system tables which new users can access by default, they  may not be able to access every system table by default without grants.
 Additionally, access to certain system tables such as `system.zookeeper` is restricted for Cloud users for security reasons.
 :::
 

--- a/docs/en/sql-reference/statements/grant.md
+++ b/docs/en/sql-reference/statements/grant.md
@@ -74,6 +74,11 @@ Also `john` has the `GRANT OPTION` privilege, so it can grant other users with p
 
 Access to the `system` database is always allowed (since this database is used for processing queries).
 
+:::note ClickHouse Cloud
+New ClickHouse Cloud users are not able to access system tables by default without grants.
+Additionally, access to certain system tables such as `system.zookeeper` is restricted for Cloud users for security reasons.
+:::
+
 You can grant multiple privileges to multiple accounts in one query. The query `GRANT SELECT, INSERT ON *.* TO john, robin` allows accounts `john` and `robin` to execute the `INSERT` and `SELECT` queries over all the tables in all the databases on the server.
 
 ## Wildcard grants {#wildcard-grants}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Adds a clarifying note to grant.md for statement "Access to the system database is always allowed (since this database is used for processing queries)".
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
