### PR TITLE
Reduce level for "Request stream is shared by multiple threads. HTTP keep alive is not possible."

### DIFF
--- a/src/Server/HTTP/HTTPServerRequest.h
+++ b/src/Server/HTTP/HTTPServerRequest.h
@@ -67,7 +67,7 @@ public:
 
         if (stream.use_count() > 1)
         {
-            LOG_ERROR(getLogger("HTTPServerRequest"), "Request stream is shared by multiple threads. HTTP keep alive is not possible. Use count {}", stream.use_count());
+            LOG_INFO(getLogger("HTTPServerRequest"), "Request stream is shared by multiple threads. HTTP keep alive is not possible. Use count {}", stream.use_count());
             return false;
         }
         else


### PR DESCRIPTION
To reduce noise in error log (on one of services it prints 1-3 times per second).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)