### PR TITLE
Support alter table ... materialize statistics all

### DIFF
--- a/docs/en/sql-reference/statements/alter/statistics.md
+++ b/docs/en/sql-reference/statements/alter/statistics.md
@@ -24,7 +24,7 @@ The following operations are available:
 
 -   `ALTER TABLE [db].table CLEAR STATISTICS [IF EXISTS] (column list)` - Deletes all statistics objects in all parts for the specified columns. Statistics objects can be rebuild using `ALTER TABLE MATERIALIZE STATISTICS`.
 
--   `ALTER TABLE [db.]table MATERIALIZE STATISTICS [IF EXISTS] (column list)` - Rebuilds the statistic for columns. Implemented as a [mutation](../../../sql-reference/statements/alter/index.md#mutations). 
+-   `ALTER TABLE [db.]table MATERIALIZE STATISTICS (ALL | [IF EXISTS] (column list))` - Rebuilds the statistic for columns. Implemented as a [mutation](../../../sql-reference/statements/alter/index.md#mutations). 
 
 The first two commands are lightweight in a sense that they only change metadata or remove files.
 

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -930,12 +930,12 @@ void MutationsInterpreter::prepare(bool dry_run)
             mutation_kind.set(MutationKind::MUTATE_INDEX_STATISTICS_PROJECTION);
             if (command.statistics_columns.empty())
             {
-                for (auto column_it = columns_desc.begin(); column_it != columns_desc.end(); column_it++)
+                for (const auto & column_desc : columns_desc)
                 {
-                    if (!column_it->statistics.empty())
+                    if (column_desc.statistics.empty())
                     {
-                        dependencies.emplace(column_it->name, ColumnDependency::STATISTICS);
-                        materialized_statistics.emplace(column_it->name);
+                        dependencies.emplace(column_desc.name, ColumnDependency::STATISTICS);
+                        materialized_statistics.emplace(column_desc.name);
                     }
                 }
             }

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -928,6 +928,17 @@ void MutationsInterpreter::prepare(bool dry_run)
         else if (command.type == MutationCommand::MATERIALIZE_STATISTICS)
         {
             mutation_kind.set(MutationKind::MUTATE_INDEX_STATISTICS_PROJECTION);
+            if (command.statistics_columns.empty())
+            {
+                for (auto column_it = columns_desc.begin(); column_it != columns_desc.end(); column_it++)
+                {
+                    if (!column_it->statistics.empty())
+                    {
+                        dependencies.emplace(column_it->name, ColumnDependency::STATISTICS);
+                        materialized_statistics.emplace(column_it->name);
+                    }
+                }
+            }
             for (const auto & stat_column_name: command.statistics_columns)
             {
                 if (!columns_desc.has(stat_column_name) || columns_desc.get(stat_column_name).statistics.empty())

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -238,12 +238,17 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     else if (type == ASTAlterCommand::MATERIALIZE_STATISTICS)
     {
         ostr << "MATERIALIZE STATISTICS ";
-        statistics_decl->format(ostr, settings, state, frame);
-        if (partition)
+        if (statistics_decl)
         {
-            ostr << " IN PARTITION ";
-            partition->format(ostr, settings, state, frame);
+            statistics_decl->format(ostr, settings, state, frame);
+            if (partition)
+            {
+                ostr << " IN PARTITION ";
+                partition->format(ostr, settings, state, frame);
+            }
         }
+        else
+            ostr << " ALL";
     }
     else if (type == ASTAlterCommand::UNLOCK_SNAPSHOT)
     {

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -431,19 +431,21 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             }
             else if (s_materialize_statistics.ignore(pos, expected))
             {
-                if (s_if_exists.ignore(pos, expected))
-                    command->if_exists = true;
-
-                if (!parser_stat_decl_without_types.parse(pos, command_statistics_decl, expected))
-                    return false;
-
                 command->type = ASTAlterCommand::MATERIALIZE_STATISTICS;
                 command->detach = false;
-
-                if (s_in_partition.ignore(pos, expected))
+                if (!ParserKeyword(Keyword::ALL).ignore(pos, expected))
                 {
-                    if (!parser_partition.parse(pos, command_partition, expected))
+                    if (s_if_exists.ignore(pos, expected))
+                        command->if_exists = true;
+
+                    if (!parser_stat_decl_without_types.parse(pos, command_statistics_decl, expected))
                         return false;
+
+                    if (s_in_partition.ignore(pos, expected))
+                    {
+                        if (!parser_partition.parse(pos, command_partition, expected))
+                            return false;
+                    }
                 }
             }
             else if (s_add_projection.ignore(pos, expected))

--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -104,7 +104,10 @@ std::optional<MutationCommand> MutationCommand::parse(ASTAlterCommand * command,
         if (command->partition)
             res.partition = command->partition->clone();
         res.predicate = nullptr;
-        res.statistics_columns = command->statistics_decl->as<ASTStatisticsDeclaration &>().getColumnNames();
+        if (command->statistics_decl)
+        {
+            res.statistics_columns = command->statistics_decl->as<ASTStatisticsDeclaration &>().getColumnNames();
+        }
         return res;
     }
     if (command->type == ASTAlterCommand::MATERIALIZE_PROJECTION)

--- a/tests/queries/0_stateless/02864_statistics_usage.sql
+++ b/tests/queries/0_stateless/02864_statistics_usage.sql
@@ -27,7 +27,7 @@ SELECT 'After drop statistic';
 SELECT replaceRegexpAll(explain, '__table1\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM tab WHERE b < 10 and a < 10) WHERE explain LIKE '%Prewhere%'; -- checks b first, then a (statistics not used)
 
 ALTER TABLE tab ADD STATISTICS a, b TYPE tdigest;
-ALTER TABLE tab MATERIALIZE STATISTICS a, b;
+ALTER TABLE tab MATERIALIZE STATISTICS ALL;
 INSERT INTO tab select number, -number FROM system.numbers LIMIT 10000;
 SELECT 'After add and materialize statistic';
 SELECT replaceRegexpAll(explain, '__table1\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM tab WHERE b < 10 and a < 10) WHERE explain LIKE '%Prewhere%'; -- checks a first, then b (statistics used)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support `alter table ... materialize statistics all` will materialize all the statistics of a table

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
