### PR TITLE
Fix wrong result of non-correlated EXISTS.

### DIFF
--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -277,8 +277,6 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                 if (chunk.getNumRows() != 1)
                     throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one row");
 
-                LOG_TRACE(getLogger("QueryAnalyzer"), "Has rows");
-
                 Chunk tmp_chunk;
                 while (tmp_chunk.getNumRows() == 0 && executor->pull(tmp_chunk))
                 {

--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -11,6 +11,7 @@
 #include <Processors/QueryPlan/LimitStep.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <Processors/Chunk.h>
 
 #include <Core/Settings.h>
 #include <Columns/ColumnNullable.h>
@@ -226,7 +227,7 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
             }
 
             std::optional<PullingAsyncPipelineExecutor> executor;
-            Block block;
+            Chunk chunk;
 
             if (!skip_execution_for_exists)
             {
@@ -235,12 +236,12 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                 io.pipeline.setConcurrencyControl(context->getSettingsRef()[Setting::use_concurrency_control]);
 
                 executor.emplace(io.pipeline);
-                while (block.rows() == 0 && executor->pull(block))
+                while (chunk.getNumRows() == 0 && executor->pull(chunk))
                 {
                 }
             }
 
-            if (block.rows() == 0)
+            if (chunk.getNumRows() == 0)
             {
                 DataTypePtr type;
                 if (execute_for_exists)
@@ -273,15 +274,17 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
             }
             else
             {
-                if (block.rows() != 1)
+                if (chunk.getNumRows() != 1)
                     throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one row");
 
-                Block tmp_block;
-                while (tmp_block.rows() == 0 && executor->pull(tmp_block))
+                LOG_TRACE(getLogger("QueryAnalyzer"), "Has rows");
+
+                Chunk tmp_chunk;
+                while (tmp_chunk.getNumRows() == 0 && executor->pull(tmp_chunk))
                 {
                 }
 
-                if (tmp_block.rows() != 0)
+                if (tmp_chunk.getNumRows() != 0)
                     throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one row");
 
                 if (execute_for_exists)
@@ -293,6 +296,7 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
                 }
                 else
                 {
+                    auto block = executor->getHeader().cloneWithColumns(chunk.getColumns());
                     wrap_with_nullable_or_tuple(block);
                     scalar_block = std::move(block);
                 }

--- a/tests/queries/0_stateless/03595_exists_as_scalar_subquery.reference
+++ b/tests/queries/0_stateless/03595_exists_as_scalar_subquery.reference
@@ -1,2 +1,3 @@
 3
 ScalarSubqueriesGlobalCacheHit 1
+1

--- a/tests/queries/0_stateless/03595_exists_as_scalar_subquery.sql
+++ b/tests/queries/0_stateless/03595_exists_as_scalar_subquery.sql
@@ -13,3 +13,5 @@ set force_primary_key = 0;
 system flush logs query_log;
 SELECT 'ScalarSubqueriesGlobalCacheHit ' || ProfileEvents['ScalarSubqueriesGlobalCacheHit'] FROM system.query_log
 WHERE type != 'QueryStart' AND current_database = currentDatabase() AND query like 'select%' AND Settings['execute_exists_as_scalar_subquery']='1';
+
+SELECT EXISTS(SELECT 1 from numbers(2) where number != 0) settings execute_exists_as_scalar_subquery = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible wrong result of non-correlated `EXISTS`. It was broken with `execute_exists_as_scalar_subquery=1` which was introduced in https://github.com/ClickHouse/ClickHouse/pull/85481 and affects `25.8`.
Fixes https://github.com/ClickHouse/ClickHouse/issues/86415

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
