### PR TITLE
Docs: remove problematic link for local builds

### DIFF
--- a/src/Functions/demangle.cpp
+++ b/src/Functions/demangle.cpp
@@ -100,7 +100,7 @@ REGISTER_FUNCTION(Demangle)
 {
     FunctionDocumentation::Description description = R"(
 Converts a symbol to a C++ function name.
-The symbol is usually returned by function [`addressToSymbol`](../../sql-reference/functions/introspection.md#addressToSymbol).
+The symbol is usually returned by function `addressToSymbol`.
     )";
     FunctionDocumentation::Syntax syntax = "demangle(symbol)";
     FunctionDocumentation::Arguments arguments = {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Removes a link which causes local builds of docs to fail. This function is platform dependent (doesn't show in system tables for MacOS) and so on local builds of the docs in MacOS the documentation isn't generated from system tables and causes the broken link checker to fail the build.

As a temporary solution just removing this link. (A better solution for future would be to generate documentation not from a downloaded binary but from some endpoint)
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
