### PR TITLE
More logs for backups

### DIFF
--- a/src/Backups/BackupIO.h
+++ b/src/Backups/BackupIO.h
@@ -48,7 +48,7 @@ public:
 
     virtual bool fileExists(const String & file_name) = 0;
     virtual UInt64 getFileSize(const String & file_name) = 0;
-    virtual bool fileContentsEqual(const String & file_name, const String & expected_file_contents) = 0;
+    virtual bool fileContentsEqual(const String & file_name, const String & expected_file_contents, String & actual_file_contents) = 0;
 
     virtual std::unique_ptr<WriteBuffer> writeFile(const String & file_name) = 0;
 

--- a/src/Backups/BackupIO_Default.cpp
+++ b/src/Backups/BackupIO_Default.cpp
@@ -44,7 +44,7 @@ BackupWriterDefault::BackupWriterDefault(const ReadSettings & read_settings_, co
 {
 }
 
-bool BackupWriterDefault::fileContentsEqual(const String & file_name, const String & expected_file_contents)
+bool BackupWriterDefault::fileContentsEqual(const String & file_name, const String & expected_file_contents, String & actual_file_contents)
 {
     if (!fileExists(file_name))
         return false;
@@ -52,7 +52,7 @@ bool BackupWriterDefault::fileContentsEqual(const String & file_name, const Stri
     try
     {
         auto in = readFile(file_name, expected_file_contents.size());
-        String actual_file_contents(expected_file_contents.size(), ' ');
+        actual_file_contents = String(expected_file_contents.size(), ' ');
         return (in->read(actual_file_contents.data(), actual_file_contents.size()) == actual_file_contents.size())
             && (actual_file_contents == expected_file_contents) && in->eof();
     }

--- a/src/Backups/BackupIO_Default.h
+++ b/src/Backups/BackupIO_Default.h
@@ -49,7 +49,7 @@ public:
     BackupWriterDefault(const ReadSettings & read_settings_, const WriteSettings & write_settings_, LoggerPtr log_);
     ~BackupWriterDefault() override = default;
 
-    bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
+    bool fileContentsEqual(const String & file_name, const String & expected_file_contents, String & actual_file_contents) override;
     void copyDataToFile(const String & path_in_backup, const CreateReadBufferFunction & create_read_buffer, UInt64 start_pos, UInt64 length) override;
     void copyFileFromDisk(const String & path_in_backup, DiskPtr src_disk, const String & src_path, bool copy_encrypted, UInt64 start_pos, UInt64 length) override;
 

--- a/src/Backups/BackupIO_Null.cpp
+++ b/src/Backups/BackupIO_Null.cpp
@@ -76,7 +76,7 @@ std::unique_ptr<ReadBuffer> BackupWriterNull::readFile(const String & file_name,
     throw Exception(ErrorCodes::BACKUP_ENTRY_NOT_FOUND, "Backup entry {} not found (Null backup is always empty)", file_name);
 }
 
-bool BackupWriterNull::fileContentsEqual(const String & file_name, const String & /* expected_file_contents */)
+bool BackupWriterNull::fileContentsEqual(const String & file_name, const String & /* expected_file_contents */, String & /* actual_file_contents */)
 {
     if (fs::path{file_name}.filename() == ".lock")
         return true; /// To pass the check for the ".lock" file in BackupImpl::checkLockFile().

--- a/src/Backups/BackupIO_Null.h
+++ b/src/Backups/BackupIO_Null.h
@@ -25,7 +25,7 @@ public:
 
     bool fileExists(const String & file_name) override;
     UInt64 getFileSize(const String & file_name) override;
-    bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
+    bool fileContentsEqual(const String & file_name, const String & expected_file_contents, String & actual_file_contents) override;
 
 private:
     std::unique_ptr<ReadBuffer> readFile(const String & file_name, size_t expected_file_size) override;

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -605,9 +605,12 @@ bool BackupImpl::checkLockFile(bool throw_if_failed) const
 {
     if (!lock_file_name.empty() && uuid)
     {
+        LOG_TRACE(log, "Checking lock file {}", lock_file_name);
         ProfileEvents::increment(ProfileEvents::BackupLockFileReads);
-        if (writer->fileContentsEqual(lock_file_name, toString(*uuid)))
+        String actual_file_contents;
+        if (writer->fileContentsEqual(lock_file_name, toString(*uuid), actual_file_contents))
             return true;
+        LOG_TRACE(log, "Lock file {} contents do not match, expected: {}, actual: {}", lock_file_name, toString(*uuid), actual_file_contents);
     }
 
     if (throw_if_failed)

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -831,7 +831,7 @@ void Client::slowDownAfterRetryableError() const
         if (current_time_ms >= next_time_ms)
         {
             if (next_time_ms != 0)
-                LOG_TEST(log, "Retry time has passed; proceeding without delay");
+                LOG_TRACE(log, "Retry time has passed; proceeding without delay");
             break;
         }
         UInt64 sleep_ms = next_time_ms - current_time_ms;


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a few log lines for a backup execution process. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
