### PR TITLE
CI: Fix log export configuration

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -34,6 +34,7 @@ common_ft_job_config = Job.Config(
             "./ci/jobs/functional_tests.py",
             "./ci/jobs/scripts/clickhouse_proc.py",
             "./ci/jobs/scripts/functional_tests_results.py",
+            "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh",
             "./tests/queries",
             "./tests/clickhouse-test",
             "./tests/config",

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -320,7 +320,7 @@ profiles:
         for command in commands:
             res = res and Shell.check(command, verbose=True)
 
-        with open(f"{temp_dir}/config.xml", 'a') as config_file:
+        with open(f"{temp_dir}/config.xml", "a") as config_file:
             config_file.write(c1)
         return res
 
@@ -359,6 +359,9 @@ profiles:
     def start_log_exports(self, check_start_time):
         print("Start log export")
         os.environ["CLICKHOUSE_CI_LOGS_CLUSTER"] = CLICKHOUSE_CI_LOGS_CLUSTER
+        os.environ["CLICKHOUSE_CI_LOGS_HOST"] = self.log_export_host
+        os.environ["CLICKHOUSE_CI_LOGS_USER"] = CLICKHOUSE_CI_LOGS_USER
+        os.environ["CLICKHOUSE_CI_LOGS_PASSWORD"] = self.log_export_password
         info = Info()
         os.environ["EXTRA_COLUMNS_EXPRESSION"] = (
             f"toLowCardinality('{info.repo_name}') AS repo, CAST({info.pr_number} AS UInt32) AS pull_request_number, '{info.sha}' AS commit_sha, toDateTime('{Utils.timestamp_to_str(check_start_time)}', 'UTC') AS check_start_time, toLowCardinality('{info.job_name}') AS check_name, toLowCardinality('{info.instance_type}') AS instance_type, '{info.instance_id}' AS instance_id"

--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -14,9 +14,8 @@ set -e
 # Pre-configured destination cluster, where to export the data
 CLICKHOUSE_CI_LOGS_CLUSTER=${CLICKHOUSE_CI_LOGS_CLUSTER:-system_logs_export}
 
-[ -n "$EXTRA_COLUMNS_EXPRESSION" ] || { echo "ERROR: EXTRA_COLUMNS_EXPRESSION env must be defined"; exit 1; }
 EXTRA_COLUMNS=${EXTRA_COLUMNS:-"repo LowCardinality(String), pull_request_number UInt32, commit_sha String, check_start_time DateTime('UTC'), check_name LowCardinality(String), instance_type LowCardinality(String), instance_id String, INDEX ix_repo (repo) TYPE set(100), INDEX ix_pr (pull_request_number) TYPE set(100), INDEX ix_commit (commit_sha) TYPE set(100), INDEX ix_check_time (check_start_time) TYPE minmax, "}
-echo "EXTRA_COLUMNS_EXPRESSION=$EXTRA_COLUMNS_EXPRESSION"
+echo "EXTRA_COLUMNS_EXPRESSION=${EXTRA_COLUMNS_EXPRESSION:?}"
 EXTRA_ORDER_BY_COLUMNS=${EXTRA_ORDER_BY_COLUMNS:-"check_name"}
 
 # coverage_log needs more columns for symbolization, but only symbol names (the line numbers are too heavy to calculate)
@@ -50,11 +49,10 @@ function check_logs_credentials
 (
     # The function connects with given credentials, and if it's unable to execute the simplest query, returns exit code
 
-    # First check, if all necessary parameters are set
     set +x
     echo "Check CI Log cluster..."
-    __shadow_credentials
     __set_connection_args
+    __shadow_credentials
     local code
     # Catch both success and error to not fail on `set -e`
     clickhouse-client "${CONNECTION_ARGS[@]:?}" -q 'SELECT 1 FORMAT Null' && return 0 || code=$?

--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -76,6 +76,7 @@ function setup_logs_replication
     # The function is launched in a separate shell instance to not expose the
     # exported values
     set +x
+    check_logs_credentials
 
     echo "My hostname is ${HOSTNAME}"
 

--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -23,7 +23,7 @@ EXTRA_COLUMNS_COVERAGE_LOG="${EXTRA_COLUMNS} symbols Array(LowCardinality(String
 EXTRA_COLUMNS_EXPRESSION_COVERAGE_LOG="${EXTRA_COLUMNS_EXPRESSION}, arrayDistinct(arrayMap(x -> demangle(addressToSymbol(x)), coverage))::Array(LowCardinality(String)) AS symbols"
 
 
-function __set_connection_args
+function __set_connection_args()
 {
     # It's impossible to use a generic $CONNECTION_ARGS string, it's unsafe from word splitting perspective.
     # That's why we must stick to the generated option
@@ -34,7 +34,7 @@ function __set_connection_args
     )
 }
 
-function __shadow_credentials
+function __shadow_credentials()
 {
     # The function completely screws the output, it shouldn't be used in normal functions, only in ()
     # The only way to substitute the env as a plain text is using perl 's/\Qsomething\E/another/
@@ -45,8 +45,8 @@ function __shadow_credentials
     ')
 }
 
-function check_logs_credentials
-(
+function check_logs_credentials()
+{
     # The function connects with given credentials, and if it's unable to execute the simplest query, returns exit code
 
     set +x
@@ -60,10 +60,10 @@ function check_logs_credentials
         echo 'Failed to connect to CI Logs cluster'
         return $code
     fi
-)
+}
 
-function setup_logs_replication
-(
+function setup_logs_replication()
+{
     # The function is launched in a separate shell instance to not expose the
     # exported values
     set +x
@@ -158,9 +158,9 @@ function setup_logs_replication
             SELECT ${EXTRA_COLUMNS_EXPRESSION_FOR_TABLE}, * FROM system.${table}
         " || continue
     done
-)
+}
 
-function stop_logs_replication
+function stop_logs_replication()
 {
     echo "Detach all logs replication"
     clickhouse-client --query "select database||'.'||table from system.tables where database = 'system' and (table like '%_sender' or table like '%_watcher')" | {


### PR DESCRIPTION
fix creating tables for log export if format has been changed (no cluster creds were exported to do the queries) 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
