### PR TITLE
Rename table function "arrowflight" to "arrowFlight".

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -165,7 +165,9 @@ arrayUniq
 arrayWithConstant
 arrayZip
 arrayZipUnaligned
+arrowFlight
 ArrowCompression
+ArrowFlight
 ArrowStream
 ASan
 ascii

--- a/docs/en/engines/table-engines/integrations/arrowflight.md
+++ b/docs/en/engines/table-engines/integrations/arrowflight.md
@@ -1,15 +1,15 @@
 ---
 description: 'The engine allows querying remote datasets via Apache Arrow Flight.'
-sidebar_label: 'Arrow Flight'
+sidebar_label: 'ArrowFlight'
 sidebar_position: 186
 slug: /engines/table-engines/integrations/arrowflight
-title: 'Arrow Flight'
+title: 'ArrowFlight'
 doc_type: 'reference'
 ---
 
-# Arrow Flight
+# ArrowFlight
 
-The Arrow Flight table engine enables ClickHouse to query remote datasets via the [Apache Arrow Flight](https://arrow.apache.org/docs/format/Flight.html) protocol.
+The ArrowFlight table engine enables ClickHouse to query remote datasets via the [Apache Arrow Flight](https://arrow.apache.org/docs/format/Flight.html) protocol.
 This integration allows ClickHouse to fetch data from external Flight-enabled servers in a columnar Arrow format with high performance.
 
 ## Creating a Table {#creating-a-table}

--- a/docs/en/sql-reference/table-functions/arrowflight.md
+++ b/docs/en/sql-reference/table-functions/arrowflight.md
@@ -1,13 +1,13 @@
 ---
 description: 'Allows to perform queries on data exposed via an Apache Arrow Flight server.'
-sidebar_label: 'Arrow Flight'
+sidebar_label: 'arrowFlight'
 sidebar_position: 186
 slug: /sql-reference/table-functions/arrowflight
-title: 'Arrow Flight'
+title: 'arrowFlight'
 doc_type: 'reference'
 ---
 
-# Arrow Flight Table Function
+# arrowFlight Table Function
 
 Allows to perform queries on data exposed via an [Apache Arrow Flight](../../interfaces/arrowflight.md) server.
 

--- a/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
+++ b/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
@@ -2323,7 +2323,7 @@ static void ValuesStatementToString(String & ret, const bool tudf, const ValuesS
 
 CONV_FN(ArrowFlightFunc, afunc)
 {
-    ret += "arrowflight('";
+    ret += "arrowFlight('";
     ret += afunc.address();
     ret += "', '";
     ret += afunc.dataset();

--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -144,7 +144,7 @@ protected:
         {
             findYTsaurusStorageTableEngineSecretArguments();
         }
-        else if (function->name() == "arrowflight")
+        else if ((function->name() == "arrowFlight") || (function->name() == "arrowflight"))
         {
             findArrowFlightSecretArguments();
         }

--- a/src/TableFunctions/TableFunctionArrowFlight.cpp
+++ b/src/TableFunctions/TableFunctionArrowFlight.cpp
@@ -85,6 +85,9 @@ void registerTableFunctionArrowFlight(TableFunctionFactory & factory)
          = {.description = R"(Allows to perform queries on data exposed via an Apache Arrow Flight server.)",
             .examples{{"arrowFlight", "SELECT * FROM arrowFlight('127.0.0.1:9005', 'sample_dataset') ORDER BY id;", ""}},
             .category = FunctionDocumentation::Category::TableFunction}});
+
+    /// "arrowflight" is an obsolete name.
+    factory.registerAlias("arrowflight", "arrowFlight");
 }
 
 }

--- a/src/TableFunctions/TableFunctionArrowFlight.h
+++ b/src/TableFunctions/TableFunctionArrowFlight.h
@@ -13,7 +13,7 @@ namespace DB
 class TableFunctionArrowFlight : public ITableFunction
 {
 public:
-    static constexpr auto name = "arrowflight";
+    static constexpr auto name = "arrowFlight";
     String getName() const override { return name; }
 
 private:

--- a/tests/integration/test_arrowflight_interface/test.py
+++ b/tests/integration/test_arrowflight_interface/test.py
@@ -506,7 +506,7 @@ def test_table_function():
 
     # FIXME
     assert "Failed to get table schema" in node.query_and_get_error(
-        "SELECT * FROM arrowflight(flight1, dataset = 'mytable')"
+        "SELECT * FROM arrowFlight(flight1, dataset = 'mytable')"
     )
 
     node.query("DROP TABLE mytable")

--- a/tests/integration/test_arrowflight_storage/test.py
+++ b/tests/integration/test_arrowflight_storage/test.py
@@ -19,7 +19,7 @@ def start_cluster():
 
 
 def test_table_function():
-    result = node.query(f"SELECT * FROM arrowflight('arrowflight1:5005', 'ABC')")
+    result = node.query(f"SELECT * FROM arrowFlight('arrowflight1:5005', 'ABC')")
     assert result == TSV(
         [
             ["test_value_1", "data1"],
@@ -31,7 +31,7 @@ def test_table_function():
 
 def test_table_function_with_auth():
     result = node.query(
-        f"SELECT * FROM arrowflight('arrowflight1:5006', 'ABC', '{arrowflight_user}', '{arrowflight_pass}')"
+        f"SELECT * FROM arrowFlight('arrowflight1:5006', 'ABC', '{arrowflight_user}', '{arrowflight_pass}')"
     )
     assert result == TSV(
         [
@@ -42,13 +42,13 @@ def test_table_function_with_auth():
     )
 
     assert "No credentials supplied" in node.query_and_get_error(
-        f"SELECT * FROM arrowflight('arrowflight1:5006', 'ABC')"
+        f"SELECT * FROM arrowFlight('arrowflight1:5006', 'ABC')"
     )
     assert "Unknown user" in node.query_and_get_error(
-        f"SELECT * FROM arrowflight('arrowflight1:5006', 'ABC', 'default', '')"
+        f"SELECT * FROM arrowFlight('arrowflight1:5006', 'ABC', 'default', '')"
     )
     assert "Wrong password" in node.query_and_get_error(
-        f"SELECT * FROM arrowflight('arrowflight1:5006', 'ABC', '{arrowflight_user}', 'qwe123')"
+        f"SELECT * FROM arrowFlight('arrowflight1:5006', 'ABC', '{arrowflight_user}', 'qwe123')"
     )
 
 
@@ -93,7 +93,7 @@ def test_arrowflight_storage():
     )
 
     table_func_result = node.query(
-        f"SELECT * FROM arrowflight('arrowflight1:5005', '{dataset}') ORDER BY column1"
+        f"SELECT * FROM arrowFlight('arrowflight1:5005', '{dataset}') ORDER BY column1"
     )
     assert table_func_result == TSV(
         [

--- a/tests/integration/test_arrowflight_storage/test.py
+++ b/tests/integration/test_arrowflight_storage/test.py
@@ -29,6 +29,18 @@ def test_table_function():
     )
 
 
+def test_table_function_old_name():
+    # "arrowflight" is an obsolete name.
+    result = node.query(f"SELECT * FROM arrowflight('arrowflight1:5005', 'ABC')")
+    assert result == TSV(
+        [
+            ["test_value_1", "data1"],
+            ["abcadbc", "text_text_text"],
+            ["123456789", "data3"],
+        ]
+    )
+
+
 def test_table_function_with_auth():
     result = node.query(
         f"SELECT * FROM arrowFlight('arrowflight1:5006', 'ABC', '{arrowflight_user}', '{arrowflight_pass}')"

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -491,7 +491,8 @@ def test_table_functions():
         f"icebergAzure('{azure_storage_account_url}', 'cont', 'test_simple_6.csv', '{azure_account_name}', '{azure_account_key}', 'CSV', 'none', 'auto')",
         f"deltaLakeAzure('{azure_storage_account_url}', 'cont', 'test_simple_6.csv', '{azure_account_name}', '{azure_account_key}', 'CSV', 'none', 'auto')",
         f"hudi('http://minio1:9001/root/data/test7.csv', 'minio', '{password}')",
-        f"arrowflight('arrowflight1:5006', 'dataset', 'arrowflight_user', '{password}')",
+        f"arrowFlight('arrowflight1:5006', 'dataset', 'arrowflight_user', '{password}')",
+        f"arrowFlight(named_collection_1, host = 'arrowflight1', port = 5006, dataset = 'dataset', username = 'arrowflight_user', password = '{password}')",
         f"arrowflight(named_collection_1, host = 'arrowflight1', port = 5006, dataset = 'dataset', username = 'arrowflight_user', password = '{password}')",
     ]
 
@@ -578,8 +579,9 @@ def test_table_functions():
             f"CREATE TABLE tablefunc42 (`x` int) AS icebergAzure('{azure_storage_account_url}', 'cont', 'test_simple_6.csv', '{azure_account_name}', '[HIDDEN]', 'CSV', 'none', 'auto')",
             f"CREATE TABLE tablefunc43 (`x` int) AS deltaLakeAzure('{azure_storage_account_url}', 'cont', 'test_simple_6.csv', '{azure_account_name}', '[HIDDEN]', 'CSV', 'none', 'auto')",
             "CREATE TABLE tablefunc44 (`x` int) AS hudi('http://minio1:9001/root/data/test7.csv', 'minio', '[HIDDEN]')",
-            "CREATE TABLE tablefunc45 (`x` int) AS arrowflight('arrowflight1:5006', 'dataset', 'arrowflight_user', '[HIDDEN]')",
-            "CREATE TABLE tablefunc46 (`x` int) AS arrowflight(named_collection_1, host = 'arrowflight1', port = 5006, dataset = 'dataset', username = 'arrowflight_user', password = '[HIDDEN]')",
+            "CREATE TABLE tablefunc45 (`x` int) AS arrowFlight('arrowflight1:5006', 'dataset', 'arrowflight_user', '[HIDDEN]')",
+            "CREATE TABLE tablefunc46 (`x` int) AS arrowFlight(named_collection_1, host = 'arrowflight1', port = 5006, dataset = 'dataset', username = 'arrowflight_user', password = '[HIDDEN]')",
+            "CREATE TABLE tablefunc47 (`x` int) AS arrowflight(named_collection_1, host = 'arrowflight1', port = 5006, dataset = 'dataset', username = 'arrowflight_user', password = '[HIDDEN]')",
         ],
         must_not_contain=[password],
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Rename table function `arrowflight` to `arrowFlight`.

This function was named `arrowFlight` in the documentation, but in fact its name was `arrowflight`.
This PR renames this function to `arrowFlight` keeping `arrowflight` as an alias.
