### PR TITLE
Throws an error if iceberg_metadata_log is not configured

### DIFF
--- a/src/Interpreters/IcebergMetadataLog.cpp
+++ b/src/Interpreters/IcebergMetadataLog.cpp
@@ -37,6 +37,7 @@ extern const SettingsIcebergMetadataLogLevel iceberg_metadata_log_level;
 namespace ErrorCodes
 {
 extern const int CANNOT_CLOCK_GETTIME;
+extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -99,7 +100,7 @@ void insertRowToLogTable(
 
     if (!iceberg_metadata_log)
     {
-        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Iceberg metadata log table is not configured");
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Iceberg metadata log table is not configured");
     }
 
     iceberg_metadata_log->add(

--- a/src/Interpreters/IcebergMetadataLog.cpp
+++ b/src/Interpreters/IcebergMetadataLog.cpp
@@ -95,7 +95,14 @@ void insertRowToLogTable(
     if (clock_gettime(CLOCK_REALTIME, &spec))
         throw ErrnoException(ErrorCodes::CANNOT_CLOCK_GETTIME, "Cannot clock_gettime");
 
-    Context::getGlobalContextInstance()->getIcebergMetadataLog()->add(
+    auto iceberg_metadata_log = Context::getGlobalContextInstance()->getIcebergMetadataLog();
+
+    if (!iceberg_metadata_log)
+    {
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Iceberg metadata log table is not configured");
+    }
+
+    iceberg_metadata_log->add(
         DB::IcebergMetadataLogElement{
             .current_time = spec.tv_sec,
             .query_id = local_context->getCurrentQueryId(),

--- a/tests/integration/test_storage_iceberg_no_spark/configs/config.d/no_metadata_log.xml
+++ b/tests/integration/test_storage_iceberg_no_spark/configs/config.d/no_metadata_log.xml
@@ -1,0 +1,3 @@
+<clickhouse>    
+    <iceberg_metadata_log remove="remove"/>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_no_spark/conftest.py
+++ b/tests/integration/test_storage_iceberg_no_spark/conftest.py
@@ -37,19 +37,7 @@ def started_cluster_iceberg_no_spark():
                 "configs/config.d/cluster.xml",
                 "configs/config.d/named_collections.xml",
                 "configs/config.d/filesystem_caches.xml",
-                "configs/config.d/metadata_log.xml",
-            ],
-            user_configs=["configs/users.d/users.xml"],
-            stay_alive=True,
-        )
-        cluster.add_instance(
-            "node3",
-            main_configs=[
-                "configs/config.d/query_log.xml",
-                "configs/config.d/cluster.xml",
-                "configs/config.d/named_collections.xml",
-                "configs/config.d/filesystem_caches.xml",
-                "configs/config.d/metadata_log.xml",
+                "configs/config.d/no_metadata_log.xml",
             ],
             user_configs=["configs/users.d/users.xml"],
             stay_alive=True,

--- a/tests/integration/test_storage_iceberg_no_spark/test_graceful_error_not_configured_iceberg_metadata_log.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_graceful_error_not_configured_iceberg_metadata_log.py
@@ -18,4 +18,4 @@ def test_graceful_not_configured_iceberg_metadata_log(started_cluster_iceberg_no
     create_iceberg_table("s3", instance, TABLE_NAME, started_cluster_iceberg_no_spark, "(c0 Int)")
     error_message = instance.query_and_get_error(f"SELECT 1 FROM {TABLE_NAME}", settings={"iceberg_metadata_log_level": 'metadata'})
 
-    assert "UNSUPPORTED_METHOD" in error_message, f"Unexpected error message: {error_message}"
+    assert "BAD_ARGUMENTS" in error_message, f"Unexpected error message: {error_message}"

--- a/tests/integration/test_storage_iceberg_no_spark/test_graceful_not_configured_iceberg_metadata_log.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_graceful_not_configured_iceberg_metadata_log.py
@@ -1,0 +1,21 @@
+import pytest
+import os
+
+from helpers.iceberg_utils import (
+    create_iceberg_table,
+    default_download_directory,
+    get_last_snapshot,
+    get_uuid_str
+)
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_graceful_not_configured_iceberg_metadata_log(started_cluster_iceberg_no_spark):
+    instance = started_cluster_iceberg_no_spark.instances["node2"]
+    TABLE_NAME = "test_graceful_not_configured_iceberg_metadata_log_" + get_uuid_str()
+
+    create_iceberg_table("s3", instance, TABLE_NAME, started_cluster_iceberg_no_spark, "(c0 Int)")
+    error_message = instance.query_and_get_error(f"SELECT 1 FROM {TABLE_NAME}", settings={"iceberg_metadata_log_level": 'metadata'})
+
+    assert "UNSUPPORTED_METHOD" in error_message, f"Unexpected error message: {error_message}"


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/86681
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Throws an error if iceberg_metadata_log is not configured, but user tries to get debug iceberg metadata info. Fixes nullptr access

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
