### PR TITLE
do not use S3 defaults for other remotes

### DIFF
--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -15,7 +15,6 @@
 #include <IO/HTTPCommon.h>
 #include <IO/HTTPHeaderEntries.h>
 #include <IO/SessionAwareIOStream.h>
-#include <IO/S3Defines.h>
 
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/HttpClient.h>
@@ -47,15 +46,15 @@ struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
 {
     struct RetryStrategy
     {
-        unsigned int max_retries = DEFAULT_RETRY_ATTEMPTS;
-        unsigned int initial_delay_ms = DEFAULT_RETRY_INITIAL_DELAY_MS;
-        unsigned int max_delay_ms = DEFAULT_RETRY_MAX_DELAY_MS;
-        double jitter_factor = DEFAULT_RETRY_JITTER_FACTOR;
+        unsigned int max_retries = 10;
+        unsigned int initial_delay_ms = 25;
+        unsigned int max_delay_ms = 5000;
+        double jitter_factor = 0;
     };
     std::function<ProxyConfiguration()> per_request_configuration;
     String force_region;
     const RemoteHostFilter & remote_host_filter;
-    unsigned int s3_max_redirects = DEFAULT_MAX_REDIRECTS;
+    unsigned int s3_max_redirects = 10;
     RetryStrategy retry_strategy;
     bool s3_slow_all_threads_after_network_error;
     bool s3_slow_all_threads_after_retryable_error;


### PR DESCRIPTION
This is a fix for the remark https://github.com/ClickHouse/ClickHouse/pull/82642/files#r2334898904

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
