### PR TITLE
Fix lightweight updates with subqueries from `MergeTree`

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -6827,14 +6827,15 @@ void Context::setClientProtocolVersion(UInt64 version)
     client_protocol_version = version;
 }
 
-void Context::setPartitionIdToMaxBlock(PartitionIdToMaxBlockPtr partitions)
+void Context::setPartitionIdToMaxBlock(const UUID & table_uuid, PartitionIdToMaxBlockPtr partitions)
 {
-    partition_id_to_max_block = std::move(partitions);
+    partition_id_to_max_block[table_uuid] = std::move(partitions);
 }
 
-PartitionIdToMaxBlockPtr Context::getPartitionIdToMaxBlock() const
+PartitionIdToMaxBlockPtr Context::getPartitionIdToMaxBlock(const UUID & table_uuid) const
 {
-    return partition_id_to_max_block;
+    auto it = partition_id_to_max_block.find(table_uuid);
+    return it != partition_id_to_max_block.end() ? it->second : nullptr;
 }
 
 const ServerSettings & Context::getServerSettings() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -378,7 +378,8 @@ protected:
     UInt64 client_protocol_version = 0;
 
     /// Max block numbers in partitions to read from MergeTree tables.
-    PartitionIdToMaxBlockPtr partition_id_to_max_block;
+    /// Saved separately for each table uuid used in the query.
+    std::unordered_map<UUID, PartitionIdToMaxBlockPtr> partition_id_to_max_block;
 
 public:
     /// Record entities accessed by current query, and store this information in system.query_log.
@@ -1596,8 +1597,8 @@ public:
     void setStorageAliasBehaviour(uint8_t storage_alias_behaviour_);
     uint8_t getStorageAliasBehaviour() const;
 
-    void setPartitionIdToMaxBlock(PartitionIdToMaxBlockPtr partitions);
-    PartitionIdToMaxBlockPtr getPartitionIdToMaxBlock() const;
+    void setPartitionIdToMaxBlock(const UUID & table_uuid, PartitionIdToMaxBlockPtr partitions);
+    PartitionIdToMaxBlockPtr getPartitionIdToMaxBlock(const UUID & table_uuid) const;
 
     const ServerSettings & getServerSettings() const;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -9893,7 +9893,7 @@ StorageSnapshotPtr MergeTreeData::createStorageSnapshot(const StorageMetadataPtr
         .metadata_version = metadata_snapshot->getMetadataVersion(),
         .min_part_metadata_version = getMinMetadataVersion(parts),
         .min_part_data_versions = getMinDataVersionForEachPartition(parts),
-        .max_mutation_versions = query_context->getPartitionIdToMaxBlock(),
+        .max_mutation_versions = query_context->getPartitionIdToMaxBlock(getStorageID().uuid),
         .need_data_mutations = apply_mutations_on_fly,
         .need_alter_mutations = apply_mutations_on_fly || apply_patch_parts,
         .need_patch_parts = apply_patch_parts,

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -318,7 +318,7 @@ void StorageMergeTree::read(
         local_context,
         max_block_size,
         num_streams,
-        local_context->getPartitionIdToMaxBlock(),
+        local_context->getPartitionIdToMaxBlock(getStorageID().uuid),
         enable_parallel_reading);
 
     if (plan)
@@ -777,8 +777,7 @@ QueryPipeline StorageMergeTree::updateLightweight(const MutationCommands & comma
             partition_id_to_max_block->emplace(partition_id, block_number);
     }
 
-    context_copy->setPartitionIdToMaxBlock(std::move(partition_id_to_max_block));
-
+    context_copy->setPartitionIdToMaxBlock(getStorageID().uuid, std::move(partition_id_to_max_block));
     /// Updates currently don't work with parallel replicas.
     context_copy->setSetting("max_parallel_replicas", Field(1));
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5935,7 +5935,7 @@ void StorageReplicatedMergeTree::readLocalSequentialConsistencyImpl(
 {
     auto max_added_blocks = std::make_shared<PartitionIdToMaxBlock>(getMaxAddedBlocks());
 
-    if (auto additional_blocks = local_context->getPartitionIdToMaxBlock())
+    if (auto additional_blocks = local_context->getPartitionIdToMaxBlock(getStorageID().uuid))
     {
         for (const auto & [partition_id, max_block] : *additional_blocks)
         {
@@ -5987,7 +5987,7 @@ void StorageReplicatedMergeTree::readLocalImpl(
         local_context,
         max_block_size,
         num_streams,
-        local_context->getPartitionIdToMaxBlock(),
+        local_context->getPartitionIdToMaxBlock(getStorageID().uuid),
         enable_parallel_reading);
 
     if (plan)
@@ -8156,7 +8156,7 @@ QueryPipeline StorageReplicatedMergeTree::updateLightweight(const MutationComman
 
     const auto & block_numbers = update_holder.partition_block_numbers.getBlockNumbers();
     auto partitions = std::make_shared<PartitionIdToMaxBlock>(block_numbers.begin(), block_numbers.end());
-    context_copy->setPartitionIdToMaxBlock(std::move(partitions));
+    context_copy->setPartitionIdToMaxBlock(getStorageID().uuid, std::move(partitions));
 
     /// Updates currently don't work with parallel replicas.
     context_copy->setSetting("max_parallel_replicas", Field(1));
@@ -8167,7 +8167,7 @@ QueryPipeline StorageReplicatedMergeTree::updateLightweight(const MutationComman
         auto sync_timeout = query_context->getSettingsRef()[Setting::receive_timeout].totalMilliseconds();
 
         std::set<CommittingBlock::Op> ops{CommittingBlock::Op::NewPart, CommittingBlock::Op::Mutation};
-        waitForCommittingOpsToFinish(zookeeper, context_copy->getPartitionIdToMaxBlock(), ops, backoff_ms, sync_timeout);
+        waitForCommittingOpsToFinish(zookeeper, context_copy->getPartitionIdToMaxBlock(getStorageID().uuid), ops, backoff_ms, sync_timeout);
     }
 
     auto pipeline = updateLightweightImpl(commands, context_copy);

--- a/tests/queries/0_stateless/03100_lwu_43_subquery_from_rmt.reference
+++ b/tests/queries/0_stateless/03100_lwu_43_subquery_from_rmt.reference
@@ -1,0 +1,2 @@
+key	val
+key	UPDATED-1

--- a/tests/queries/0_stateless/03100_lwu_43_subquery_from_rmt.sql
+++ b/tests/queries/0_stateless/03100_lwu_43_subquery_from_rmt.sql
@@ -1,0 +1,35 @@
+DROP TABLE IF EXISTS lightweight_test SYNC;
+DROP TABLE IF EXISTS keys SYNC;
+
+CREATE TABLE lightweight_test
+(
+    ts DateTime,
+    value String,
+    key String
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/lightweight_test', '1')
+PARTITION BY toYYYYMMDD(ts)
+ORDER BY (key)
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+CREATE TABLE keys
+(
+    key String
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/keys', '1')
+ORDER BY (key);
+
+INSERT INTO lightweight_test VALUES (now(), 'val', 'key');
+
+INSERT INTO keys VALUES ('key');
+
+SELECT key, value FROM lightweight_test ORDER BY key;
+
+UPDATE lightweight_test
+SET value = 'UPDATED-1'
+WHERE key IN (SELECT key FROM keys);
+
+SELECT key, value FROM lightweight_test ORDER BY key;
+
+DROP TABLE IF EXISTS lightweight_test SYNC;
+DROP TABLE IF EXISTS keys SYNC;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed lightweight updates with subqueries that read from another `MergeTree` tables.


Fixes #87265.
