### PR TITLE
Fix unpacking Rust crate names in `list-licenses.sh`

### DIFF
--- a/ci/jobs/scripts/check_style/codespell-ignore-words.list
+++ b/ci/jobs/scripts/check_style/codespell-ignore-words.list
@@ -1,6 +1,7 @@
 thenn
 fpr
 creat
+crate
 parsering
 nd
 ect

--- a/utils/list-licenses/list-licenses.sh
+++ b/utils/list-licenses/list-licenses.sh
@@ -106,8 +106,11 @@ done
 for dependency in $(find "${LIBS_PATH}/rust_vendor/" -name 'Cargo.toml');
 do
     FOLDER=$(dirname "$dependency")
+
+    # Crate names follow `some-crate-name-1.0.0` pattern.
     CRATE=$(basename "$FOLDER")
     NAME=$(echo "$CRATE" | rev | cut -f2- -d- | rev)
+
     LICENSE_TYPE=$(${GREP_CMD} 'license = "' "$dependency"  | cut -d '"' -f2)
     if echo "${LICENSE_TYPE}" | ${GREP_CMD} -v -P 'MIT|Apache|MPL|ISC|BSD|Unicode|Zlib|CC0-1.0|CDLA-Permissive';
     then

--- a/utils/list-licenses/list-licenses.sh
+++ b/utils/list-licenses/list-licenses.sh
@@ -106,7 +106,8 @@ done
 for dependency in $(find "${LIBS_PATH}/rust_vendor/" -name 'Cargo.toml');
 do
     FOLDER=$(dirname "$dependency")
-    NAME=$(echo "$dependency" | awk -F'/' '{ print $(NF-1) }' | awk -F'-' '{ NF=(NF-1); print $0 }')
+    CRATE=$(basename "$FOLDER")
+    NAME=$(echo "$CRATE" | rev | cut -f2- -d- | rev)
     LICENSE_TYPE=$(${GREP_CMD} 'license = "' "$dependency"  | cut -d '"' -f2)
     if echo "${LICENSE_TYPE}" | ${GREP_CMD} -v -P 'MIT|Apache|MPL|ISC|BSD|Unicode|Zlib|CC0-1.0|CDLA-Permissive';
     then


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix unpacking Rust crate names in `list-licenses.sh`.

