### PR TITLE
Docs: categorising doc type - follow up PR

### DIFF
--- a/docs/en/operations/system-tables/projection_parts.md
+++ b/docs/en/operations/system-tables/projection_parts.md
@@ -3,6 +3,7 @@ description: 'System table containing information about projection parts for tab
 keywords: ['system table', 'projection parts']
 slug: /operations/system-tables/projections-parts
 title: 'system.projection_parts'
+doc_type: 'reference'
 ---
 
 # system.projection_parts

--- a/docs/en/operations/system-tables/projection_parts_columns.md
+++ b/docs/en/operations/system-tables/projection_parts_columns.md
@@ -3,6 +3,7 @@ description: 'System table containing information about columns in projection pa
 keywords: ['system table', 'projection part columns']
 slug: /operations/system-tables/projections-part-columns
 title: 'system.projection_parts'
+doc_type: 'reference'
 ---
 
 # system.projection_parts_columns

--- a/docs/en/sql-reference/formats.mdx
+++ b/docs/en/sql-reference/formats.mdx
@@ -5,6 +5,7 @@ sidebar_label: 'Input and Output Formats'
 title: 'Formats for Input and Output Data'
 description: 'Supported input and output formats'
 hide_title: true
+doc_type: 'reference'
 ---
 
 import Content from '../interfaces/formats.md';


### PR DESCRIPTION
A few leftover docs that were missed so that clickhouse-docs can build.
### Changelog category (leave one):
- Documentation (changelog entry is not required)