### PR TITLE
Use official ctcache repo again after PR merged

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -67,11 +67,9 @@ RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/M
   && ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64 \
   && rm /MacOSX11.0.sdk.tar.xz
 
-# This is a custom version from a PR to the original clang-tidy-cache: https://github.com/matus-chochlik/ctcache/pull/89
-# Once it's merged (if ever) we'll point back to the original matus-chochlik/ctcache repo.
-ARG CLANG_TIDY_SHA1=a646e24c642c15d85334577fadadc14d041f2f8a
+ARG CLANG_TIDY_SHA1=e33c063ca6e52b48bcefbc45d46d8c150ffa81ca
 RUN curl -Lo /usr/bin/clang-tidy-cache.py \
-        "https://raw.githubusercontent.com/pamarcos/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
+        "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
     && chmod +x /usr/bin/clang-tidy-cache.py
 
 COPY clang-tidy-cache.sh /usr/bin/clang-tidy-cache


### PR DESCRIPTION
The PR https://github.com/matus-chochlik/ctcache/pull/89 got merged, so we can go back to using the official repo

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
