### PR TITLE
storage_metadata_write_full_object_key is turned on by default

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -892,7 +892,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     ```xml
     <validate_tcp_client_information>false</validate_tcp_client_information>
     ```)", 0) \
-    DECLARE(Bool, storage_metadata_write_full_object_key, false, R"(Write disk metadata files with VERSION_FULL_OBJECT_KEY format)", 0) \
+    DECLARE(Bool, storage_metadata_write_full_object_key, true, R"(Write disk metadata files with VERSION_FULL_OBJECT_KEY format. This is enabled by default. The setting is deprecated.)", SettingsTierType::OBSOLETE) \
     DECLARE(UInt64, max_materialized_views_count_for_table, 0, R"(
     A limit on the number of materialized views attached to a table.
 

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
@@ -12,11 +12,6 @@
 namespace DB
 {
 
-namespace ServerSetting
-{
-    extern const ServerSettingsBool storage_metadata_write_full_object_key;
-}
-
 namespace ErrorCodes
 {
     extern const int UNKNOWN_FORMAT;
@@ -115,31 +110,8 @@ catch (Exception & e)
 
 void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
 {
-    /// These are the changes for backward compatibility
-    /// No new file should be written as VERSION_FULL_OBJECT_KEY until storage_metadata_write_full_object_key feature is enabled
-    /// However, in case of rollback, once file had been written as VERSION_FULL_OBJECT_KEY
-    /// it has to be always rewritten as VERSION_FULL_OBJECT_KEY
+    constexpr UInt32 write_version = VERSION_FULL_OBJECT_KEY;
 
-    bool storage_metadata_write_full_object_key = getWriteFullObjectKeySetting();
-
-    if (version == VERSION_FULL_OBJECT_KEY && !storage_metadata_write_full_object_key)
-    {
-        LoggerPtr logger = getLogger("DiskObjectStorageMetadata");
-        LOG_WARNING(
-            logger,
-            "Metadata file {} is written with VERSION_FULL_OBJECT_KEY version"
-            "However storage_metadata_write_full_object_key is off.",
-            metadata_file_path);
-    }
-
-    UInt32 write_version = version;
-    if (storage_metadata_write_full_object_key)
-        write_version = VERSION_FULL_OBJECT_KEY;
-
-    if (!inline_data.empty() && write_version < VERSION_INLINE_DATA)
-        write_version = VERSION_INLINE_DATA;
-
-    chassert(write_version >= VERSION_ABSOLUTE_PATHS && write_version <= VERSION_FULL_OBJECT_KEY);
     writeIntText(write_version, buf);
 
     writeChar('\n', buf);
@@ -154,20 +126,8 @@ void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
         writeIntText(object_meta.size_bytes, buf);
         writeChar('\t', buf);
 
-        if (write_version == VERSION_FULL_OBJECT_KEY)
-        {
-            /// if the metadata file has VERSION_FULL_OBJECT_KEY version
-            /// all keys inside are written as absolute paths
-            writeEscapedString(object_key.serialize(), buf);
-            writeChar('\n', buf);
-        }
-        else
-        {
-            /// otherwise keys are written as relative paths
-            /// therefore keys have to have suffix and prefix
-            writeEscapedString(object_key.getSuffix(), buf);
-            writeChar('\n', buf);
-        }
+        writeEscapedString(object_key.serialize(), buf);
+        writeChar('\n', buf);
     }
 
     writeIntText(ref_count, buf);
@@ -205,24 +165,6 @@ DiskObjectStorageMetadata::DiskObjectStorageMetadata(
 
 void DiskObjectStorageMetadata::addObject(ObjectStorageKey key, size_t size)
 {
-    if (!key.hasPrefix())
-    {
-        version = VERSION_FULL_OBJECT_KEY;
-
-        bool storage_metadata_write_full_object_key = getWriteFullObjectKeySetting();
-        if (!storage_metadata_write_full_object_key)
-        {
-            LoggerPtr logger = getLogger("DiskObjectStorageMetadata");
-            LOG_WARNING(
-                logger,
-                "Metadata file {} has at least one key {} without fixed common key prefix."
-                "That forces using VERSION_FULL_OBJECT_KEY version for that metadata file."
-                "However storage_metadata_write_full_object_key is off.",
-                metadata_file_path,
-                key.serialize());
-        }
-    }
-
     total_size += size;
     keys_with_meta.emplace_back(std::move(key), ObjectMetadata{size, {}, {}, {}});
 }
@@ -237,11 +179,6 @@ ObjectKeyWithMetadata DiskObjectStorageMetadata::popLastObject()
     total_size -= object.metadata.size_bytes;
 
     return object;
-}
-
-bool DiskObjectStorageMetadata::getWriteFullObjectKeySetting()
-{
-    return Context::getGlobalContextInstance()->getServerSettings()[ServerSetting::storage_metadata_write_full_object_key];
 }
 
 }

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h
@@ -19,7 +19,7 @@ private:
     static constexpr UInt32 VERSION_INLINE_DATA = 4;
     static constexpr UInt32 VERSION_FULL_OBJECT_KEY = 5; /// only for reading data
 
-    UInt32 version = VERSION_READ_ONLY_FLAG;
+    UInt32 version = VERSION_FULL_OBJECT_KEY;
 
     /// Absolute paths of blobs
     ObjectKeysWithMetadata keys_with_meta;
@@ -119,7 +119,6 @@ public:
         return inline_data;
     }
 
-    static bool getWriteFullObjectKeySetting();
 };
 
 using DiskObjectStorageMetadataPtr = std::unique_ptr<DiskObjectStorageMetadata>;

--- a/src/Disks/ObjectStorages/S3/DiskS3Utils.cpp
+++ b/src/Disks/ObjectStorages/S3/DiskS3Utils.cpp
@@ -18,8 +18,6 @@ ObjectStorageKeysGeneratorPtr getKeyGenerator(
     const Poco::Util::AbstractConfiguration & config,
     const String & config_prefix)
 {
-    bool storage_metadata_write_full_object_key = DiskObjectStorageMetadata::getWriteFullObjectKeySetting();
-
     String object_key_compatibility_prefix = config.getString(config_prefix + ".key_compatibility_prefix", String());
     String object_key_template = config.getString(config_prefix + ".key_template", String());
 
@@ -41,12 +39,6 @@ ObjectStorageKeysGeneratorPtr getKeyGenerator(
 
         return createObjectStorageKeysGeneratorByPrefix(uri.key);
     }
-
-    if (!storage_metadata_write_full_object_key)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                        "Wrong configuration in {}. "
-                        "Feature 'storage_metadata_write_full_object_key' has to be enabled in order to use setting 'key_template'.",
-                        config_prefix);
 
     if (!uri.key.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS,

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -447,8 +447,6 @@ void DiskEncryptedTest::testSeekAndReadUntilPosition(DiskPtr disk, const String 
 
 TEST_F(DiskEncryptedTest, LocalBlobs)
 {
-    getContext().context->setServerSetting("storage_metadata_write_full_object_key", true);
-
     auto object_storage = std::make_shared<LocalObjectStorage>(LocalObjectStorageSettings(fs::path{getDirectory()} / "local_blobs", false));
     auto metadata_disk = std::make_shared<DiskLocal>("metadata_disk", fs::path{getDirectory()} / "metadata");
     auto metadata_storage = std::make_shared<MetadataStorageFromDisk>(metadata_disk, "/");

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -250,7 +250,6 @@ possible_properties = {
     "shutdown_wait_backups_and_restores": true_false_lambda,
     "shutdown_wait_unfinished_queries": true_false_lambda,
     "startup_mv_delay_ms": threshold_generator(0.2, 0.2, 0, 1000),
-    "storage_metadata_write_full_object_key": true_false_lambda,
     "storage_shared_set_join_use_inner_uuid": true_false_lambda,
     "tables_loader_background_pool_size": threads_lambda,
     "tables_loader_foreground_pool_size": threads_lambda,

--- a/tests/config/config.d/s3_storage_policy_with_template_object_key.xml
+++ b/tests/config/config.d/s3_storage_policy_with_template_object_key.xml
@@ -7,7 +7,6 @@
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
                 <key_compatibility_prefix>test</key_compatibility_prefix>
-                <!--key_template should not be used without enabled storage_metadata_write_full_object_key-->
                 <key_template>[a-z]{3}-first-random-part/new-style-prefix/[a-z]{3}/[a-z]{29}</key_template>
             </s3>
             <cached_s3>

--- a/tests/config/config.d/storage_metadata_with_full_object_key.xml
+++ b/tests/config/config.d/storage_metadata_with_full_object_key.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<clickhouse>
-    <storage_metadata_write_full_object_key>1</storage_metadata_write_full_object_key>
-</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -275,7 +275,7 @@ if [[ -n "$USE_DATABASE_ORDINARY" ]] && [[ "$USE_DATABASE_ORDINARY" -eq 1 ]]; th
     ln -sf $SRC_PATH/users.d/database_ordinary.xml $DEST_SERVER_PATH/users.d/
 fi
 
-object_key_types_options=("generate-suffix" "generate-full-key" "generate-template-key")
+object_key_types_options=("generate-full-key" "generate-template-key")
 object_key_type="${object_key_types_options[0]}"
 
 if [[ -n "$RANDOMIZE_OBJECT_KEY_TYPE" ]] && [[ "$RANDOMIZE_OBJECT_KEY_TYPE" -eq 1 ]]; then
@@ -286,15 +286,10 @@ function setup_storage_policy()
 {
     case $object_key_type in
         "generate-full-key")
-            ln -sf $SRC_PATH/config.d/storage_metadata_with_full_object_key.xml $DEST_SERVER_PATH/config.d/
             ln -sf $SRC_PATH/config.d/s3_storage_policy_by_default.xml $DEST_SERVER_PATH/config.d/
             ;;
         "generate-template-key")
-            ln -sf $SRC_PATH/config.d/storage_metadata_with_full_object_key.xml $DEST_SERVER_PATH/config.d/
             ln -sf $SRC_PATH/config.d/s3_storage_policy_with_template_object_key.xml $DEST_SERVER_PATH/config.d/s3_storage_policy_by_default.xml
-            ;;
-        "generate-suffix"|*)
-            ln -sf $SRC_PATH/config.d/s3_storage_policy_by_default.xml $DEST_SERVER_PATH/config.d/
             ;;
     esac
 }

--- a/tests/integration/test_remote_blobs_naming/configs/new_node.xml
+++ b/tests/integration/test_remote_blobs_naming/configs/new_node.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<clickhouse>
-    <storage_metadata_write_full_object_key>1</storage_metadata_write_full_object_key>
-</clickhouse>

--- a/tests/integration/test_remote_blobs_naming/configs/switching_node.xml
+++ b/tests/integration/test_remote_blobs_naming/configs/switching_node.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<clickhouse>
-    <storage_metadata_write_full_object_key>0</storage_metadata_write_full_object_key>
-</clickhouse>

--- a/tests/queries/0_stateless/02888_obsolete_settings.reference
+++ b/tests/queries/0_stateless/02888_obsolete_settings.reference
@@ -1,4 +1,5 @@
 -- Obsolete server settings
+storage_metadata_write_full_object_key
 -- Obsolete general settings
 1
 -- Obsolete merge tree settings


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
storage_metadata_write_full_object_key server option is turned on by default, it can't be set off now. This is backward compatible change. I used the label for attention. This change is forward compatible only with 25.x releases. That means that you could downgrade only on any 25.x release in case you have to rollback the new release.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
