### PR TITLE
Query Condition Cache: Reduce lock contention

### DIFF
--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -129,6 +129,7 @@ void QueryConditionCacheWriter::addRanges(const UUID & table_id, const String & 
     }
 
     bool is_insert = false;
+    bool is_new_entry = false;
     /// Create and insert an entry if not found.
     if (!cache_entry)
     {
@@ -145,7 +146,7 @@ void QueryConditionCacheWriter::addRanges(const UUID & table_id, const String & 
             );
 
             cache_entry = it->second;
-
+            is_new_entry = true;
         }
         else
         {
@@ -167,6 +168,7 @@ void QueryConditionCacheWriter::addRanges(const UUID & table_id, const String & 
 
     /// First, check if a cache entry is already registered for the key.
     /// Try to avoid acquiring the RW lock below (*) by early-ing out. Matters for systems with lots of cores.
+    if (!is_new_entry)
     {
         std::shared_lock entry_lock(cache_entry->mutex);
 

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -143,7 +143,7 @@ void QueryConditionCacheWriter::addRanges(const UUID & table_id, const String & 
                 std::forward_as_tuple(key),
                 std::forward_as_tuple(std::make_shared<CacheEntry>(marks_count))
             );
-    
+
             cache_entry = it->second;
 
         }

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -104,6 +104,10 @@ private:
         SharedMutex mutex;
         QueryConditionCache::Entry entry;
 
+        /// true means the result is inconsistent with the query condition cache and must be written to the cache in `finalize`.
+        /// false means the result is consistent with the query condition cache and no write to the cache is required in `finalize`.
+        bool updated;
+
         explicit CacheEntry(size_t marks_count);
         explicit CacheEntry(const QueryConditionCache::Entry & entry_);
     };


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/86076

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
For entries with the same key already present in the cache, clone the entry and cache it into the `QueryConditionCacheWriter` to avoid unnecessary updates and reduce lock contention.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
