### PR TITLE
YTSaurus Redirect heavy requests to heavy proxies. 

### DIFF
--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -100,7 +100,7 @@ ReadBufferPtr YTsaurusClient::executeQuery(const YTsaurusQueryPtr query, const R
     {
         size_t url_index = (recently_used_url_index + num_try) % connection_info.http_proxy_urls.size();
         URI host_for_request(connection_info.http_proxy_urls[url_index].c_str());
-        if (query->isHeavyQuery())
+        if (connection_info.enable_heavy_proxy_redirection && query->isHeavyQuery())
             host_for_request = getHeavyProxyURI(host_for_request);
 
         try

--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -42,10 +42,10 @@ YTsaurusClient::YTsaurusClient(ContextPtr context_, const ConnectionInfo & conne
 }
 
 
-DB::ReadBufferPtr YTsaurusClient::readTable(const String & cypress_path)
+ReadBufferPtr YTsaurusClient::readTable(const String & cypress_path)
 {
     YTsaurusQueryPtr read_table_query(new YTsaurusReadTableQuery(cypress_path));
-    return createQueryRWBuffer(read_table_query);
+    return executeQuery(read_table_query);
 }
 
 YTsaurusNodeType YTsaurusClient::getNodeType(const String & cypress_path)
@@ -58,12 +58,12 @@ YTsaurusNodeType YTsaurusClient::getNodeType(const String & cypress_path)
 YTsaurusNodeType YTsaurusClient::getNodeTypeFromAttributes(const Poco::JSON::Object::Ptr & json_ptr)
 {
     if (!json_ptr->has("type"))
-        throw DB::Exception(DB::ErrorCodes::INCORRECT_DATA, "Incorrect json with yt attributes, no field 'type'.");
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect json with yt attributes, no field 'type'.");
 
     if (json_ptr->getValue<String>("type") == "table")
     {
         if (!json_ptr->has("dynamic"))
-            throw DB::Exception(DB::ErrorCodes::INCORRECT_DATA, "Incorrect json with yt attributes, no field 'dynamic'.");
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect json with yt attributes, no field 'dynamic'.");
 
         return json_ptr->getValue<bool>("dynamic") ? YTsaurusNodeType::DYNAMIC_TABLE : YTsaurusNodeType::STATIC_TABLE;
     }
@@ -73,13 +73,13 @@ YTsaurusNodeType YTsaurusClient::getNodeTypeFromAttributes(const Poco::JSON::Obj
     }
 }
 
-DB::ReadBufferPtr YTsaurusClient::selectRows(const String & cypress_path)
+ReadBufferPtr YTsaurusClient::selectRows(const String & cypress_path)
 {
     YTsaurusQueryPtr select_rows_query(new YTsaurusSelectRowsQuery(cypress_path));
-    return createQueryRWBuffer(select_rows_query);
+    return executeQuery(select_rows_query);
 }
 
-DB::ReadBufferPtr YTsaurusClient::lookupRows(const String & cypress_path, const Block & lookup_block_input)
+ReadBufferPtr YTsaurusClient::lookupRows(const String & cypress_path, const Block & lookup_block_input)
 {
     YTsaurusQueryPtr lookup_rows_query(new YTsaurusLookupRows(cypress_path));
     auto out_callback = [lookup_block_input, this](std::ostream & ostr)
@@ -91,50 +91,31 @@ DB::ReadBufferPtr YTsaurusClient::lookupRows(const String & cypress_path, const 
         formatBlock(output_format, lookup_block_input);
         out_buffer.finalize();
     };
-    return createQueryRWBuffer(lookup_rows_query, std::move(out_callback));
+    return executeQuery(lookup_rows_query, std::move(out_callback));
 }
 
-
-DB::ReadBufferPtr YTsaurusClient::createQueryRWBuffer(const YTsaurusQueryPtr query, ReadWriteBufferFromHTTP::OutStreamCallback out_callback)
+ReadBufferPtr YTsaurusClient::executeQuery(const YTsaurusQueryPtr query, const ReadWriteBufferFromHTTP::OutStreamCallback&& out_callback)
 {
     for (size_t num_try = 0; num_try < connection_info.http_proxy_urls.size(); ++num_try)
     {
         size_t url_index = (recently_used_url_index + num_try) % connection_info.http_proxy_urls.size();
+        URI host_for_request(connection_info.http_proxy_urls[url_index].c_str());
+        if (query->isHeavyQuery())
+            host_for_request = getHeavyProxyURI(host_for_request);
+
         try
         {
-            Poco::URI uri(connection_info.http_proxy_urls[url_index].c_str());
-            uri.setPath(fmt::format("/api/{}/{}", connection_info.api_version, query->getQueryName()));
+            host_for_request.setPath(fmt::format("/api/{}/{}", connection_info.api_version, query->getQueryName()));
 
             for (const auto & query_param : query->getQueryParameters())
             {
-                uri.addQueryParameter(query_param.name, query_param.value);
+                host_for_request.addQueryParameter(query_param.name, query_param.value);
             }
+            LOG_TRACE(log, "URI {} , query type {}", host_for_request.toString(), query->getQueryName());
 
-            DB::HTTPHeaderEntries http_headers{
-                /// Always use json format for input and output.
-                {"Accept", "application/json"},
-                {"Content-Type", "application/json"},
-                {"Authorization", fmt::format("OAuth {}", connection_info.oauth_token)},
-                {"X-YT-Header-Format", "<format=text>yson"},
-                {"X-YT-Output-Format", "<uuid_mode=text_yql;complex_type_mode=positional>json"}
-            };
-
-            LOG_TRACE(log, "URI {} , query type {}", uri.toString(), query->getQueryName());
-            Poco::Net::HTTPBasicCredentials creds;
-            auto buf = DB::BuilderRWBufferFromHTTP(uri)
-                        .withConnectionGroup(DB::HTTPConnectionGroupType::STORAGE)
-                        .withMethod(query->getHTTPMethod())
-                        .withSettings(context->getReadSettings())
-                        .withTimeouts(DB::ConnectionTimeouts::getHTTPTimeouts(context->getSettingsRef(), context->getServerSettings()))
-                        .withHostFilter(&context->getRemoteHostFilter())
-                        .withRedirects(context->getSettingsRef()[Setting::max_http_get_redirects])
-                        .withOutCallback(out_callback)
-                        .withHeaders(http_headers)
-                        .withDelayInit(false)
-                        .create(creds);
-
+            auto buf = createQueryRWBuffer(host_for_request, out_callback, query->getHTTPMethod());
             recently_used_url_index = url_index;
-            return DB::ReadBufferPtr(std::move(buf));
+            return buf;
         }
         catch (Exception & e)
         {
@@ -142,13 +123,65 @@ DB::ReadBufferPtr YTsaurusClient::createQueryRWBuffer(const YTsaurusQueryPtr que
                 connection_info.http_proxy_urls[url_index], e.displayText());
         }
     }
-    throw Exception(ErrorCodes::ALL_CONNECTION_TRIES_FAILED, "All connection tries with ytsaurus http proxies are failed.");
+    throw Exception(ErrorCodes::ALL_CONNECTION_TRIES_FAILED, "All connection tries with ytsaurus http proxies are failed");
+}
+
+YTsaurusClient::URI YTsaurusClient::getHeavyProxyURI(const URI& uri)
+{
+    URI list_of_proxies_uri(uri);
+    list_of_proxies_uri.setPath("/hosts");
+
+    LOG_TRACE(log, "Get list of heavy proxies from path {}", list_of_proxies_uri.toString());
+    auto buf = createQueryRWBuffer(list_of_proxies_uri, nullptr, "GET");
+
+    // Make sure that there are no recursive calls
+    String json_str;
+    readJSONArrayInto(json_str, *buf);
+
+    Poco::JSON::Parser parser;
+    auto list_of_proxies = parser.parse(json_str).extract<Poco::JSON::Array::Ptr>();
+    if (!list_of_proxies || !list_of_proxies->size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't take the list of heavy proxies.");
+
+    URI host;
+    host.setScheme(uri.getScheme());
+    host.setAuthority(list_of_proxies->getElement<std::string>(0));
+    return host;
+}
+
+
+ReadBufferPtr YTsaurusClient::createQueryRWBuffer(const URI& uri, const ReadWriteBufferFromHTTP::OutStreamCallback& out_callback, const std::string & http_method)
+{
+    std::string output_params = "<uuid_mode=text_yql;complex_type_mode=positional>";
+    HTTPHeaderEntries http_headers{
+        /// Always use json format for input and output.
+        {"Accept", "application/json"},
+        {"Content-Type", "application/json"},
+        {"Authorization", fmt::format("OAuth {}", connection_info.oauth_token)},
+        {"X-YT-Header-Format", "<format=text>yson"},
+        {"X-YT-Output-Format", fmt::format("{}json", output_params)},
+    };
+
+    Poco::Net::HTTPBasicCredentials creds;
+    auto buf = BuilderRWBufferFromHTTP(uri)
+                .withConnectionGroup(HTTPConnectionGroupType::STORAGE)
+                .withMethod(http_method)
+                .withSettings(context->getReadSettings())
+                .withTimeouts(ConnectionTimeouts::getHTTPTimeouts(context->getSettingsRef(), context->getServerSettings()))
+                .withHostFilter(&context->getRemoteHostFilter())
+                .withRedirects(context->getSettingsRef()[Setting::max_http_get_redirects])
+                .withOutCallback(out_callback)
+                .withHeaders(http_headers)
+                .withDelayInit(false)
+                .create(creds);
+
+    return ReadBufferPtr(std::move(buf));
 }
 
 Poco::Dynamic::Var YTsaurusClient::getMetadata(const String & path)
 {
     YTsaurusQueryPtr get_query(new YTsaurusGetQuery(path));
-    auto buf = createQueryRWBuffer(get_query);
+    auto buf = executeQuery(get_query);
 
     String json_str;
     readJSONObjectPossiblyInvalid(json_str, *buf);

--- a/src/Core/YTsaurus/YTsaurusClient.h
+++ b/src/Core/YTsaurus/YTsaurusClient.h
@@ -46,6 +46,7 @@ public:
         std::vector<String> http_proxy_urls;
         String oauth_token;
         String api_version = "v3";
+        bool enable_heavy_proxy_redirection = true;
     };
 
     explicit YTsaurusClient(ContextPtr context_, const ConnectionInfo & connection_info_);

--- a/src/Core/YTsaurus/YTsaurusClient.h
+++ b/src/Core/YTsaurus/YTsaurusClient.h
@@ -38,7 +38,7 @@ enum class YTsaurusNodeType : uint8_t
 class YTsaurusClient : private boost::noncopyable
 {
 public:
-
+    using URI = Poco::URI;
     static const uint16_t HTTP_PROXY_DEFAULT_PORT = 80;
 
     struct ConnectionInfo
@@ -73,10 +73,14 @@ private:
     Poco::Dynamic::Var getMetadata(const String & path);
 
 
-    ReadBufferPtr createQueryRWBuffer(YTsaurusQueryPtr query, ReadWriteBufferFromHTTP::OutStreamCallback out_callback = nullptr);
+    ReadBufferPtr createQueryRWBuffer(const URI& uri,  const ReadWriteBufferFromHTTP::OutStreamCallback& out_callback, const std::string & http_method);
+    ReadBufferPtr executeQuery(YTsaurusQueryPtr query, const ReadWriteBufferFromHTTP::OutStreamCallback && out_callback = nullptr);
+
+    URI getHeavyProxyURI(const URI& uri);
+
     ContextPtr context;
 
-    ConnectionInfo connection_info;
+    const ConnectionInfo connection_info;
     LoggerPtr log;
     size_t recently_used_url_index = 0;
 };

--- a/src/Core/YTsaurus/YTsaurusQueries.h
+++ b/src/Core/YTsaurus/YTsaurusQueries.h
@@ -25,9 +25,17 @@ struct IYTsaurusQuery
     virtual ~IYTsaurusQuery() = default;
     /// Follows: https://ytsaurus.tech/docs/en/user-guide/proxy/http-reference#http_method
     virtual String getHTTPMethod() const = 0;
+    virtual bool isHeavyQuery() { return false; }
 };
 
-struct YTsaurusReadTableQuery : public IYTsaurusQuery
+// Follow up: https://ytsaurus.tech/docs/en/api/commands
+struct IYTsaurusHeavyQuery : public IYTsaurusQuery
+{
+    bool isHeavyQuery() override { return true; }
+};
+
+// https://ytsaurus.tech/docs/en/api/commands#read_table
+struct YTsaurusReadTableQuery : public IYTsaurusHeavyQuery
 {
     explicit YTsaurusReadTableQuery(const String & cypress_path_) : cypress_path(cypress_path_) {}
 
@@ -48,7 +56,7 @@ struct YTsaurusReadTableQuery : public IYTsaurusQuery
     String cypress_path;
 };
 
-
+// https://ytsaurus.tech/docs/en/api/commands#get
 struct YTsaurusGetQuery : public IYTsaurusQuery
 {
     explicit YTsaurusGetQuery(const String & cypress_path_) : cypress_path(cypress_path_) {}
@@ -70,8 +78,8 @@ struct YTsaurusGetQuery : public IYTsaurusQuery
     String cypress_path;
 };
 
-
-struct YTsaurusSelectRowsQuery : public IYTsaurusQuery
+// https://ytsaurus.tech/docs/en/api/commands#select_rows
+struct YTsaurusSelectRowsQuery : public IYTsaurusHeavyQuery
 {
     explicit YTsaurusSelectRowsQuery(const String & table_path_) : table_path(table_path_) {}
 
@@ -97,7 +105,8 @@ struct YTsaurusSelectRowsQuery : public IYTsaurusQuery
     String table_path;
 };
 
-struct YTsaurusLookupRows : public IYTsaurusQuery
+// https://ytsaurus.tech/docs/en/api/commands#lookup_rows
+struct YTsaurusLookupRows : public IYTsaurusHeavyQuery
 {
     explicit YTsaurusLookupRows(const String & cypress_path_) : cypress_path(cypress_path_) {}
 
@@ -117,6 +126,7 @@ struct YTsaurusLookupRows : public IYTsaurusQuery
     }
     String cypress_path;
 };
+
 
 using YTsaurusQueryPtr = std::shared_ptr<IYTsaurusQuery>;
 

--- a/src/Dictionaries/YTsaurusDictionarySource.cpp
+++ b/src/Dictionaries/YTsaurusDictionarySource.cpp
@@ -29,6 +29,12 @@ namespace ErrorCodes
     #endif
 }
 
+namespace YTsaurusSetting
+{
+    extern const YTsaurusSettingsBool enable_heavy_proxy_redirection;
+}
+
+
 namespace Setting
 {
     extern const SettingsBool allow_experimental_ytsaurus_dictionary_source;
@@ -127,7 +133,12 @@ YTsarususDictionarySource::YTsarususDictionarySource(
     , configuration{configuration_}
     , sample_block{sample_block_}
     , table_sample_block{table_sample_block_}
-    , client(new YTsaurusClient(context, {.http_proxy_urls = configuration->http_proxy_urls, .oauth_token = configuration->oauth_token}))
+    , client(new YTsaurusClient(context,
+        {
+            .http_proxy_urls = configuration->http_proxy_urls,
+            .oauth_token = configuration->oauth_token,
+            .enable_heavy_proxy_redirection = configuration->settings[YTsaurusSetting::enable_heavy_proxy_redirection],
+        }))
 {
 }
 

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -1303,6 +1303,7 @@ ReturnType readJSONArrayInto(Vector & s, ReadBuffer & buf)
 
 template void readJSONArrayInto<PaddedPODArray<UInt8>, void>(PaddedPODArray<UInt8> & s, ReadBuffer & buf);
 template bool readJSONArrayInto<PaddedPODArray<UInt8>, bool>(PaddedPODArray<UInt8> & s, ReadBuffer & buf);
+template void readJSONArrayInto<String>(String & s, ReadBuffer & buf);
 
 std::string_view readJSONObjectAsViewPossiblyInvalid(ReadBuffer & buf, String & object_buffer)
 {

--- a/src/Storages/YTsaurus/StorageYTsaurus.cpp
+++ b/src/Storages/YTsaurus/StorageYTsaurus.cpp
@@ -30,6 +30,11 @@ namespace Setting
     extern const SettingsBool allow_experimental_ytsaurus_table_engine;
 }
 
+namespace YTsaurusSetting
+{
+    extern const YTsaurusSettingsBool enable_heavy_proxy_redirection;
+}
+
 
 StorageYTsaurus::StorageYTsaurus(
     const StorageID & table_id_,
@@ -40,7 +45,11 @@ StorageYTsaurus::StorageYTsaurus(
     : IStorage{table_id_}
     , cypress_path(std::move(configuration_.cypress_path))
     , settings(configuration_.settings)
-    , client_connection_info{.http_proxy_urls = std::move(configuration_.http_proxy_urls), .oauth_token = std::move(configuration_.oauth_token)}
+    , client_connection_info{
+        .http_proxy_urls = std::move(configuration_.http_proxy_urls),
+        .oauth_token = std::move(configuration_.oauth_token),
+        .enable_heavy_proxy_redirection = settings[YTsaurusSetting::enable_heavy_proxy_redirection],
+    }
     , log(getLogger("StorageYTsaurus(" + table_id_.table_name + ")"))
 {
     StorageInMemoryMetadata storage_metadata;

--- a/src/Storages/YTsaurus/YTsaurusSettings.cpp
+++ b/src/Storages/YTsaurus/YTsaurusSettings.cpp
@@ -21,6 +21,7 @@ namespace ErrorCodes
     DECLARE(Bool, check_table_schema, true, "Check the ClickHouse and YTsaurus table schema for compatibility", 0) \
     DECLARE(Bool, skip_unknown_columns, true, "Skip columns with unknown type", 0) \
     DECLARE(Bool, force_read_table, false, "Force the use of read table instead of lookups for dynamic tables.", 0) \
+    DECLARE(Bool, enable_heavy_proxy_redirection, true, "Enable redirection to heavy proxies for heavy queries. See: https://ytsaurus.tech/docs/en/user-guide/proxy/http-reference#hosts", 0) \
 
 DECLARE_SETTINGS_TRAITS(YTsaurusSettingsTraits, LIST_OF_YTSAURUS_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(YTsaurusSettingsTraits, LIST_OF_YTSAURUS_SETTINGS)

--- a/tests/integration/compose/docker_compose_ytsaurus.yml
+++ b/tests/integration/compose/docker_compose_ytsaurus.yml
@@ -7,7 +7,7 @@ services:
             YT_FORCE_IPV6: 0
             YT_USE_HOSTS: 0
             YT_TOKEN: password
-            YT_PROXY: localhost:${YTSAURUS_PROXY_PORT}
+            YT_PROXY: ytsaurus_backend1:${YTSAURUS_PROXY_PORT}
         ports:
             - ${YTSAURUS_PROXY_PORT}:${YTSAURUS_PROXY_PORT}
-        entrypoint: yt_local start --proxy-port ${YTSAURUS_PROXY_PORT} --local-cypress-dir /var/lib/yt/local-cypress --ytserver-all-path /usr/bin/ytserver-all --sync --fqdn localhost --proxy-config '{coordinator={public_fqdn="localhost:8000"}}' --rpc-proxy-count 0 --rpc-proxy-port 8002 --node-count 1 --queue-agent-count 1 --address-resolver-config '{enable_ipv4=%true;enable_ipv6=%false;}' --native-client-supported --id primary -c '{name=query-tracker}'  --enable-auth --create-admin-user
+        entrypoint: yt_local start --proxy-port ${YTSAURUS_PROXY_PORT} --local-cypress-dir /var/lib/yt/local-cypress --ytserver-all-path /usr/bin/ytserver-all --sync --fqdn ytsaurus_backend1 --proxy-config '{coordinator={public_fqdn="ytsaurus_backend1:80"}}' --rpc-proxy-count 0 --rpc-proxy-port 8002 --node-count 1 --queue-agent-count 1 --address-resolver-config '{enable_ipv4=%true;enable_ipv6=%false;}' --native-client-supported --id primary -c '{name=query-tracker}'  --enable-auth --create-admin-user


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
From ytsaurus doc: https://ytsaurus.tech/docs/en/user-guide/proxy/http-reference#hosts
All YTsaurus commands are classified into two groups: light and heavy. Heavy commands are associated with a large I/O and, consequently, a network load. To isolate this load, light (controlling) commands are separated from the heavy ones. When you try to execute a heavy command, light proxies return code 503. The balancing of heavy commands among heavy proxies is performed by the client.

Before you execute a heavy command, you need to query /hosts and get a list of proxies ordered by load. The load is estimated based on the current CPU and network load, as well as some planned future load on the proxies. The very first proxy in the resulting list is the least loaded, and that's the one you want to use in simple cases (= in 80% of cases).



### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Redirect heavy ytsaurus requests to heavy proxies.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
