### PR TITLE
Time type docs improvements

### DIFF
--- a/docs/en/sql-reference/data-types/time.md
+++ b/docs/en/sql-reference/data-types/time.md
@@ -10,39 +10,48 @@ doc_type: 'reference'
 
 # Time
 
-The `Time` data type is used to store a time value independent of any calendar date. It is ideal for representing daily schedules, event times, or any situation where only the time component (hours, minutes, seconds) is important.
+Data type `Time` represents a time with hour, minute, and second components. It is independent of any calendar date and is suitable for values where only the time-of-day component is needed.
 
 Syntax:
 
 ``` sql
-Time()
+Time
 ```
 
-Supported range of values: \[-999:59:59, 999:59:59\].
+Text representation range: [-999:59:59, 999:59:59].
 
 Resolution: 1 second.
 
-## Speed {#speed}
+## Performance {#performance}
 
-The `Date` data type is faster than `Time` under _most_ conditions. But the `Time` data type is around the same as `DateTime` data type.
+Operations on `Time` are comparable to `DateTime` because both are represented as integers internally. Choose the type based on semantics and storage size, not raw speed.
 
-Due to the implementation details, the `Time` and `DateTime` type requires 4 bytes of storage, while `Date` requires 2 bytes. However, during compression, the size difference between Date and Time becomes more significant.
+Storage size:
+- `Time`: 4 bytes per value (signed 32-bit integer)
+- `DateTime`: 4 bytes per value
+- `Date`: 2 bytes per value
 
-## Usage Remarks {#usage-remarks}
+On-disk size after compression depends on data distribution. Narrower types often compress better, but the actual difference is workload- and data-dependent.
 
-The point in time is saved as a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time), regardless of the time zone or daylight saving time.
+## Implementation details {#implementation-details}
 
-**Note:** The Time data type does not observe time zones. It represents a time‐of‐day value on its own, without any date or regional offset context. **Specifying timezone during Time type initialization is not allowed and will result in an error**. Attempting to apply or change a time zone on Time columns has no effect and is not supported.
+- Representation: `Time` stores a signed 32-bit integer that encodes seconds since 00:00:00 (no date component is stored).
+- Normalization: When parsing text, components are normalized rather than strictly validated. For example, `25:70:70` is interpreted as `26:11:10`.
+- Negative values: A leading minus sign is supported and preserved on output. Negative values typically arise from arithmetic; they do not represent a calendar concept of "negative time-of-day". When parsing from text, negative inputs are clamped to `00:00:00`; numeric inputs preserve the sign.
+- Display saturation: When formatting values for output, hours above 999 are saturated to `999:59:59`.
+- Time zones: `Time` does not support time zones. The value is interpreted without any regional context. Specifying a time zone for `Time` (as a type parameter or during value creation) throws an error.
+
+Note: Attempting to apply or change a time zone on `Time` columns is not supported and results in an error. `Time` values are not silently reinterpreted under different time zones.
 
 ## Examples {#examples}
 
 **1.** Creating a table with a `Time`-type column and inserting data into it:
 
 ``` sql
-CREATE TABLE dt
+CREATE TABLE tab
 (
-    `time` Time,
-    `event_id` UInt8
+    `event_id` UInt8,
+    `time` Time
 )
 ENGINE = TinyLog;
 ```
@@ -50,52 +59,54 @@ ENGINE = TinyLog;
 ``` sql
 -- Parse Time
 -- - from string,
--- - from integer interpreted as number of seconds since 1970-01-01.
-INSERT INTO dt VALUES ('100:00:00', 1), (12453, 3);
+-- - from integer interpreted as number of seconds since 00:00:00.
+INSERT INTO tab VALUES (1, '14:30:25'), (2, 52225);
 
-SELECT * FROM dt;
+SELECT * FROM tab ORDER BY event_id;
 ```
 
 ``` text
-   ┌──────time─┬─event_id─┐
-1. │ 100:00:00 │        1 │
-2. │  03:27:33 │        3 │
-   └───────────┴──────────┘
+   ┌─event_id─┬──────time─┐
+1. │        1 │ 14:30:25 │
+2. │        2 │ 14:30:25 │
+   └──────────┴───────────┘
 ```
 
 **2.** Filtering on `Time` values
 
 ``` sql
-SELECT * FROM dt WHERE time = toTime('100:00:00')
+SELECT * FROM tab WHERE time = toTime('14:30:25')
 ```
 
 ``` text
-   ┌──────time─┬─event_id─┐
-1. │ 100:00:00 │        1 │
-   └───────────┴──────────┘
+   ┌─event_id─┬──────time─┐
+1. │        1 │ 14:30:25 │
+2. │        2 │ 14:30:25 │
+   └──────────┴───────────┘
 ```
 
 `Time` column values can be filtered using a string value in `WHERE` predicate. It will be converted to `Time` automatically:
 
 ``` sql
-SELECT * FROM dt WHERE time = '100:00:00'
+SELECT * FROM tab WHERE time = '14:30:25'
 ```
 
 ``` text
-   ┌──────time─┬─event_id─┐
-1. │ 100:00:00 │        1 │
-   └───────────┴──────────┘
+   ┌─event_id─┬──────time─┐
+1. │        1 │ 14:30:25 │
+2. │        2 │ 14:30:25 │
+   └──────────┴───────────┘
 ```
 
-**3.** Getting a time zone for a `Time`-type column:
+**3.** Inspecting the resulting type:
 
 ``` sql
-SELECT toTime(now()) AS column, toTypeName(column) AS x
+SELECT CAST('14:30:25' AS Time) AS column, toTypeName(column) AS type
 ```
 
 ``` text
-   ┌────column─┬─x────┐
-1. │  18:55:15 │ Time │
+   ┌────column─┬─type─┐
+1. │ 14:30:25 │ Time │
    └───────────┴──────┘
 ```
 

--- a/docs/en/sql-reference/data-types/time.md
+++ b/docs/en/sql-reference/data-types/time.md
@@ -10,7 +10,8 @@ doc_type: 'reference'
 
 # Time
 
-Data type `Time` represents a time with hour, minute, and second components. It is independent of any calendar date and is suitable for values where only the time-of-day component is needed.
+Data type `Time` represents a time with hour, minute, and second components.
+It is independent of any calendar date and is suitable for values which do not need day, months and year components.
 
 Syntax:
 
@@ -22,26 +23,29 @@ Text representation range: [-999:59:59, 999:59:59].
 
 Resolution: 1 second.
 
-## Performance {#performance}
-
-Operations on `Time` are comparable to `DateTime` because both are represented as integers internally. Choose the type based on semantics and storage size, not raw speed.
-
-Storage size:
-- `Time`: 4 bytes per value (signed 32-bit integer)
-- `DateTime`: 4 bytes per value
-- `Date`: 2 bytes per value
-
-On-disk size after compression depends on data distribution. Narrower types often compress better, but the actual difference is workload- and data-dependent.
-
 ## Implementation details {#implementation-details}
 
-- Representation: `Time` stores a signed 32-bit integer that encodes seconds since 00:00:00 (no date component is stored).
-- Normalization: When parsing text, components are normalized rather than strictly validated. For example, `25:70:70` is interpreted as `26:11:10`.
-- Negative values: A leading minus sign is supported and preserved on output. Negative values typically arise from arithmetic; they do not represent a calendar concept of "negative time-of-day". When parsing from text, negative inputs are clamped to `00:00:00`; numeric inputs preserve the sign.
-- Display saturation: When formatting values for output, hours above 999 are saturated to `999:59:59`.
-- Time zones: `Time` does not support time zones. The value is interpreted without any regional context. Specifying a time zone for `Time` (as a type parameter or during value creation) throws an error.
+**Representation and Performance**.
+Data type `Time` internally stores a signed 32-bit integer that encodes the seconds since 00:00:00.
+Values of type `Time` and `DateTime` have the same byte size and thus comparable performance.
 
-Note: Attempting to apply or change a time zone on `Time` columns is not supported and results in an error. `Time` values are not silently reinterpreted under different time zones.
+**Normalization**.
+When parsing strings to `Time`, the time components are normalized and not validated.
+For example, `25:70:70` is interpreted as `26:11:10`.
+
+**Negative values**
+Leading minus signs are supported and preserved.
+Negative values typically arise from arithmetic operations on `Time` values.
+When parsing text to `Time`, negative inputs are clamped to `00:00:00`; numeric inputs preserve the sign.
+
+**Display saturation**.
+When formatting values for output, hours above 999 are saturated to `999:59:59`.
+
+**Time zones**.
+`Time` does not support time zones, i.e. `Time` value are interpreted without regional context.
+Specifying a time zone for `Time` as a type parameter or during value creation throws an error.
+Likewise, attempts to apply or change the time zone on `Time` columns is not supported and results in an error.
+`Time` values are not silently reinterpreted under different time zones.
 
 ## Examples {#examples}
 

--- a/docs/en/sql-reference/data-types/time.md
+++ b/docs/en/sql-reference/data-types/time.md
@@ -26,25 +26,26 @@ Resolution: 1 second.
 ## Implementation details {#implementation-details}
 
 **Representation and Performance**.
-Data type `Time` internally stores a signed 32-bit integer that encodes the seconds since 00:00:00.
+Data type `Time` internally stores a signed 32-bit integer that encodes the seconds.
 Values of type `Time` and `DateTime` have the same byte size and thus comparable performance.
 
 **Normalization**.
 When parsing strings to `Time`, the time components are normalized and not validated.
 For example, `25:70:70` is interpreted as `26:11:10`.
 
-**Negative values**
+**Negative values**.
 Leading minus signs are supported and preserved.
 Negative values typically arise from arithmetic operations on `Time` values.
-When parsing text to `Time`, negative inputs are clamped to `00:00:00`; numeric inputs preserve the sign.
+For `Time` type, negative inputs are preserved for both text (e.g., `'-01:02:03'`) and numeric inputs (e.g., `-3723`).
 
-**Display saturation**.
-When formatting values for output, hours above 999 are saturated to `999:59:59`.
+**Saturation**.
+The time-of-day component is capped to the range [-999:59:59, 999:59:59].
+Values with hours beyond 999 (or below -999) are represented and round-tripped via text as `999:59:59` (or `-999:59:59`).
 
 **Time zones**.
 `Time` does not support time zones, i.e. `Time` value are interpreted without regional context.
 Specifying a time zone for `Time` as a type parameter or during value creation throws an error.
-Likewise, attempts to apply or change the time zone on `Time` columns is not supported and results in an error.
+Likewise, attempts to apply or change the time zone on `Time` columns are not supported and result in an error.
 `Time` values are not silently reinterpreted under different time zones.
 
 ## Examples {#examples}

--- a/docs/en/sql-reference/data-types/time64.md
+++ b/docs/en/sql-reference/data-types/time64.md
@@ -10,7 +10,9 @@ doc_type: 'reference'
 
 # Time64
 
-Data type `Time64` represents a time-of-day with fractional seconds. It has no calendar date component. The `precision` parameter defines the number of fractional digits and therefore the tick size.
+Data type `Time64` represents a time-of-day with fractional seconds.
+It has no calendar date components (day, month, year).
+The `precision` parameter defines the number of fractional digits and therefore the tick size.
 
 Tick size (precision): 10<sup>-precision</sup> seconds. Valid range: 0..9. Common choices are 3 (milliseconds), 6 (microseconds), and 9 (nanoseconds).
 
@@ -20,19 +22,36 @@ Tick size (precision): 10<sup>-precision</sup> seconds. Valid range: 0..9. Commo
 Time64(precision)
 ```
 
-Internally, `Time64` stores a signed 64-bit decimal (Decimal64) number of fractional seconds since 00:00:00. The tick resolution is determined by the `precision` parameter. Time zones are not supported: specifying a time zone with `Time64` will throw an error.
+Internally, `Time64` stores a signed 64-bit decimal (Decimal64) number of fractional seconds since 00:00:00.
+The tick resolution is determined by the `precision` parameter.
+Time zones are not supported: specifying a time zone with `Time64` will throw an error.
 
-Unlike `DateTime64`, `Time64` does not store a date component. See also [`Time`](../../sql-reference/data-types/time.md).
+Unlike `DateTime64`, `Time64` does not store a date component.
+See also [`Time`](../../sql-reference/data-types/time.md).
 
 Displayed range of values: 00:00:00.000 to 999:59:59.999 for `precision = 3` (the number of fractional digits depends on `precision`).
 
 ## Implementation details {#implementation-details}
 
-- Representation: signed `Decimal64` value counting fractional seconds since 00:00:00 with `precision` fractional digits.
-- Normalization: When parsing text, components are normalized rather than strictly validated. For example, `25:70:70.250` is interpreted as `26:11:10.250`.
-- Negative values: A leading minus sign is supported and preserved on output. Negative values typically arise from arithmetic; they do not represent a calendar concept of "negative time-of-day".
-- Display saturation: When formatting values for output, hours above 999 are saturated to `999:59:59.xxx`.
-- Time zones: `Time64` does not support time zones. Specifying a time zone when creating a `Time64` type or value throws an error.
+**Representation**.
+Signed `Decimal64` value counting fractional seconds since 00:00:00 with `precision` fractional digits.
+
+**Normalization**.
+When parsing strings to `Time64`, the time components are normalized and not validated.
+For example, `25:70:70` is interpreted as `26:11:10`.
+
+**Negative values**
+Leading minus signs are supported and preserved.
+Negative values typically arise from arithmetic operations on `Time64` values.
+When parsing text to `Time64`, negative inputs are clamped to `00:00:00`; numeric inputs preserve the sign.
+
+**Display saturation**.
+When formatting values for output, hours above 999 are saturated to `999:59:59.xxx`.
+
+**Time zones**.
+`Time64` does not support time zones.
+Specifying a time zone when creating a `Time64` type or value throws an error.
+Likewise, attempts to apply or change the time zone on `Time64` columns is not supported and results in an error.
 
 ## Examples {#examples}
 


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/4421<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


List of TODOs:

- [x]  1. Rewrite the introduction for both Time and Time64 to a short, user‑centric definition. Example: “Data type Time represents a time‑of‑day (hours, minutes, seconds). Time64 extends it with fractional seconds.”
- [x] 2. Correct and clearly document ranges and semantics.
 - State the true internal numeric bounds (e.g., signed 32‑bit seconds for Time, signed 64‑bit with scale for Time64), not a pseudo “[-999:59:59, 999:59:59]”.
 - Explicitly explain how negative times and times with hours > 23 are interpreted or displayed (and whether normalization occurs).
- [x] 3. Document validation policy explicitly.
- Clarify ClickHouse’s general stance (minimal validation for performance).
- State which components are checked (or not), and why “hours” may exceed 23 while minutes/seconds are constrained.
- [x] 4. Rename “Speed” to “Performance” and make comparisons meaningful.
- Compare Time vs DateTime (not Date), and specify the conditions/workloads where one is faster/slower (e.g., filtering, parsing, arithmetic).
- [x] 5. Move storage details into a clear “Implementation details” section and clarify compression.
- State byte sizes: Time uses 4 bytes; Time64 uses 8 bytes (with scale).
- Replace the confusing compression sentence with a precise statement or omit it if we can’t be specific.
- [x] 6. Fix the “Usage Remarks” wording and content.
- Change to “Implementation details”.
- Replace “saved as a Unix timestamp” with the correct internal representation: “Internally stored as signed integer ...”
- [x] 7. Clarify time zone behavior and error semantics.
- “The Time data type does not support time zones. Supplying a time zone throws an error.”
- Replace “has no effect and is not supported” with “throws an error” to avoid implying silent failure.
- Mirror the same clarity for Time64.
- [x] 8. Fix and simplify examples.
- Rename table from dt to tab; put the event_id (ID) column first.
- Start with a regular integer example (e.g., 12453) before any edge cases.
- Avoid 100‑hour examples unless explicitly illustrating lack of normalization/bounds checking, and add a note when used.
- Replace “getting a time zone for a Time-type column” with a relevant example (e.g., toTime(now()) strips the date; show toTypeName), and show a concise Time64 example with fractional seconds.
- [x] 9. Align the Time64 page with the Time page.
