### PR TITLE
add missing TABLE keyword to SYSTEM DROP REPLICA error message #87031

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1034,7 +1034,7 @@ void InterpreterSystemQuery::dropReplica(ASTSystemQuery & query)
                                         "Please check the path in query. "
                                         "If you want to drop replica "
                                         "of this table, use `DROP TABLE` "
-                                        "or `SYSTEM DROP REPLICA 'name' FROM db.table`",
+                                        "or `SYSTEM DROP REPLICA 'name' FROM TABLE db.table`",
                                         storage_replicated->getStorageID().getNameForLogs());
                 }
             }


### PR DESCRIPTION
`SYSTEM DROP REPLICA 'name' FROM db.table` is recommended in the error message. However, it should be 
 `SYSTEM DROP REPLICA 'name' FROM TABLE db.table``

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
