### PR TITLE
Add --connection support for clickhouse-benchmarks

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -9,6 +9,7 @@
 #include <pcg_random.hpp>
 #include <Poco/UUIDGenerator.h>
 #include <Poco/Util/Application.h>
+#include <Common/Config/parseConnectionCredentials.h>
 #include <Common/Stopwatch.h>
 #include <Common/ThreadPool.h>
 #include <AggregateFunctions/ReservoirSampler.h>
@@ -65,92 +66,49 @@ extern const int EMPTY_DATA_PASSED;
 class Benchmark : public Poco::Util::Application
 {
 public:
-    Benchmark(unsigned concurrency_,
-            unsigned max_concurrency_,
-            double delay_,
-            bool precise_,
-            Strings && hosts_,
-            Ports && ports_,
-            bool round_robin_,
-            bool cumulative_,
-            bool secure_,
-            const String & default_database_,
-            const String & user_,
-            const String & password_,
-            const String & proto_send_chunked_,
-            const String & proto_recv_chunked_,
-            const String & quota_key_,
-            const String & stage,
-            bool randomize_,
-            size_t max_iterations_,
-            double max_time_,
-            size_t confidence_,
-            const String & query_id_,
-            const String & query_id_prefix_,
-            const String & query_to_execute_,
-            size_t max_consecutive_errors_,
-            bool continue_on_errors_,
-            size_t reconnect_,
-            bool display_client_side_time_,
-            bool print_stacktrace_,
-            const Settings & settings_)
-        :
-        round_robin(round_robin_),
-        concurrency(concurrency_),
-        max_concurrency(std::max(concurrency_, max_concurrency_)),
-        threads(concurrency_),
-        delay(delay_),
-        precise(precise_),
+    Benchmark(
+        const boost::program_options::variables_map & options,
+        String && proto_send_chunked,
+        String && proto_recv_chunked,
+        bool print_stacktrace_,
+        Settings && settings_)
+        : connection_arguments(ConnectionArguments{
+            .hosts = options.contains("host") ? std::make_optional(options["host"].as<Strings>()) : std::nullopt,
+            .ports = options.contains("port") ? std::make_optional(options["port"].as<Ports>()) : std::nullopt,
+            .user = options.contains("user") ? std::make_optional(options["user"].as<std::string>()) : std::nullopt,
+            .password = options.contains("password") ? std::make_optional(options["password"].as<std::string>()) : std::nullopt,
+            .database = options.contains("database") ? std::make_optional(options["database"].as<std::string>()) : std::nullopt,
+            .secure = options.contains("secure") ? std::make_optional(true) : std::nullopt,
+            .quota_key = options.contains("quota_key") ? std::make_optional(options["quota_key"].as<std::string>()) : std::nullopt,
+            .proto_send_chunked = proto_send_chunked,
+            .proto_recv_chunked = proto_recv_chunked,
+        }),
+        connection_name(options.contains("connection") ? std::make_optional(options["connection"].as<std::string>()) : std::nullopt),
+        round_robin(options.contains("roundrobin")),
+        concurrency(options["concurrency"].as<unsigned>()),
+        max_concurrency(std::max(concurrency, options["max_concurrency"].as<unsigned>())),
+        threads(concurrency),
+        delay(options["delay"].as<double>()),
+        precise(options.contains("precise")),
         queue(max_concurrency),
-        randomize(randomize_),
-        cumulative(cumulative_),
-        max_iterations(max_iterations_),
-        max_time(max_time_),
-        confidence(confidence_),
-        query_id(query_id_),
-        query_id_prefix(query_id_prefix_),
-        query_to_execute(query_to_execute_),
-        continue_on_errors(continue_on_errors_),
-        max_consecutive_errors(max_consecutive_errors_),
-        reconnect(reconnect_),
-        display_client_side_time(display_client_side_time_),
+        randomize(options.contains("randomize")),
+        cumulative(options.contains("cumulative")),
+        max_iterations(options["iterations"].as<size_t>()),
+        max_time(options["timelimit"].as<double>()),
+        confidence(options["confidence"].as<size_t>()),
+        query_id(options["query_id"].as<std::string>()),
+        query_id_prefix(options["query_id_prefix"].as<std::string>()),
+        query_to_execute(options["query"].as<std::string>()),
+        continue_on_errors(options.contains("ignore-error")),
+        max_consecutive_errors(options["max-consecutive-errors"].as<size_t>()),
+        reconnect(options["reconnect"].as<size_t>()),
+        display_client_side_time(options.contains("client-side-time")),
         print_stacktrace(print_stacktrace_),
-        settings(settings_),
+        settings(std::move(settings_)),
         shared_context(Context::createShared()),
         global_context(Context::createGlobal(shared_context.get())),
         pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, max_concurrency)
     {
-        const auto secure = secure_ ? Protocol::Secure::Enable : Protocol::Secure::Disable;
-        size_t connections_cnt = std::max(ports_.size(), hosts_.size());
-
-        connections.reserve(connections_cnt);
-        total_stats.reserve(round_robin ? 1 : connections_cnt);
-
-        for (size_t i = 0; i < connections_cnt; ++i)
-        {
-            UInt16 cur_port = i >= ports_.size() ? 9000 : ports_[i];
-            std::string cur_host = i >= hosts_.size() ? "localhost" : hosts_[i];
-
-            connections.emplace_back(std::make_unique<ConnectionPool>(
-                max_concurrency,
-                cur_host, cur_port,
-                default_database_, user_, password_,
-                proto_send_chunked_, proto_recv_chunked_,
-                quota_key_,
-                /* cluster_= */ "",
-                /* cluster_secret_= */ "",
-                /* client_name_= */ std::string(DEFAULT_CLIENT_NAME),
-                Protocol::Compression::Enable,
-                secure,
-                /* bind_host_= */ ""));
-
-            if (!round_robin || total_stats.empty())
-                total_stats.emplace_back(std::make_shared<Stats>());
-        }
-
-        // Initialize queries_per_connection to track queries for each connection
-        queries_per_connection.resize(connections.size(), 0);
-
         global_context->makeGlobalContext();
         global_context->setSettings(settings);
         global_context->setClientName(std::string(DEFAULT_CLIENT_NAME));
@@ -160,7 +118,10 @@ public:
         /// (example: when using stage = 'with_mergeable_state')
         registerAggregateFunctions();
 
-        query_processing_stage = QueryProcessingStage::fromString(stage);
+        query_processing_stage = QueryProcessingStage::fromString(options["stage"].as<std::string>());
+
+        if (options.contains("config"))
+            config().setString("config-file", options["config"].as<std::string>());
     }
 
     void initialize(Poco::Util::Application & self [[maybe_unused]]) override
@@ -181,6 +142,33 @@ public:
             auto loaded_config = config_processor.loadConfig();
             config().add(loaded_config.configuration);
         }
+
+        if (connection_name.has_value())
+        {
+            std::string default_host;
+            if (connection_arguments.hosts.has_value())
+                default_host = connection_arguments.hosts->front();
+            else if (const char * env_host = getenv("CLICKHOUSE_HOST")) // NOLINT(concurrency-mt-unsafe)
+                default_host = env_host;
+            else
+                default_host = "localhost";
+
+            auto overrides = parseConnectionsCredentials(config(), default_host, connection_name);
+            if (overrides.hostname.has_value() && !connection_arguments.hosts.has_value())
+                connection_arguments.hosts.emplace({overrides.hostname.value()});
+            if (overrides.port.has_value() && !connection_arguments.ports.has_value())
+                connection_arguments.ports.emplace({overrides.port.value()});
+            if (overrides.secure.has_value() && !connection_arguments.secure.has_value())
+                connection_arguments.secure.emplace(overrides.secure.value());
+            if (overrides.user.has_value() && !connection_arguments.user.has_value())
+                connection_arguments.user.emplace(overrides.user.value());
+            if (overrides.password.has_value() && !connection_arguments.password.has_value())
+                connection_arguments.password.emplace(overrides.password.value());
+            if (overrides.database.has_value() && !connection_arguments.database.has_value())
+                connection_arguments.database.emplace(overrides.database.value());
+        }
+
+        makeConnections();
     }
 
     int main(const std::vector<std::string> &) override
@@ -194,6 +182,21 @@ private:
     using Entry = ConnectionPool::Entry;
     using EntryPtr = std::shared_ptr<Entry>;
     using EntryPtrs = std::vector<EntryPtr>;
+
+    struct ConnectionArguments
+    {
+        std::optional<Strings> hosts;
+        std::optional<Ports> ports;
+        std::optional<String> user;
+        std::optional<String> password;
+        std::optional<String> database;
+        std::optional<bool> secure;
+
+        std::optional<String> quota_key;
+        const String proto_send_chunked;
+        const String proto_recv_chunked;
+    } connection_arguments;
+    std::optional<String> connection_name;
 
     bool round_robin;
     unsigned concurrency;
@@ -333,6 +336,75 @@ private:
     Stopwatch delay_watch;
 
     ThreadPool pool;
+
+    void makeConnections()
+    {
+        const bool is_secure = connection_arguments.secure.value_or(false);
+        const auto secure = is_secure ? Protocol::Secure::Enable : Protocol::Secure::Disable;
+
+        /// Note: according to the standard, subsequent calls to getenv can mangle previous result.
+        /// So we copy the results to std::string.
+        std::optional<std::string> env_user_str;
+        std::optional<std::string> env_password_str;
+        std::optional<std::string> env_host_str;
+        std::optional<std::string> env_quota_key_str;
+
+        const char * env_user = getenv("CLICKHOUSE_USER"); // NOLINT(concurrency-mt-unsafe)
+        if (env_user != nullptr)
+            env_user_str.emplace(std::string(env_user));
+
+        const char * env_password = getenv("CLICKHOUSE_PASSWORD"); // NOLINT(concurrency-mt-unsafe)
+        if (env_password != nullptr)
+            env_password_str.emplace(std::string(env_password));
+
+        const char * env_host = getenv("CLICKHOUSE_HOST"); // NOLINT(concurrency-mt-unsafe)
+        if (env_host != nullptr)
+            env_host_str.emplace(std::string(env_host));
+
+        const char * env_quota_key = getenv("CLICKHOUSE_QUOTA_KEY"); // NOLINT(concurrency-mt-unsafe)
+        if (env_quota_key != nullptr)
+            env_quota_key_str.emplace(std::string(env_quota_key));
+
+        UInt16 default_port = is_secure ? DBMS_DEFAULT_SECURE_PORT : DBMS_DEFAULT_PORT;
+        Ports ports = connection_arguments.ports.value_or(Ports({default_port}));
+        Strings hosts = connection_arguments.hosts.value_or(Strings({env_host_str.value_or("localhost")}));
+
+        size_t connections_cnt = std::max(ports.size(), hosts.size());
+        for (size_t i = 0; i < connections_cnt; ++i)
+        {
+            UInt16 cur_port = i >= ports.size() ? default_port : ports[i];
+            std::string cur_host = i >= hosts.size() ? "localhost" : hosts[i];
+
+            connections.emplace_back(std::make_unique<ConnectionPool>(
+                max_concurrency,
+                cur_host,
+                cur_port,
+                connection_arguments.database.value_or("default"),
+                connection_arguments.user.value_or(env_user_str.value_or("default")),
+                connection_arguments.password.value_or(env_password_str.value_or("")),
+                connection_arguments.proto_send_chunked,
+                connection_arguments.proto_recv_chunked,
+                connection_arguments.quota_key.value_or(env_quota_key_str.value_or("")),
+                /* cluster_= */ "",
+                /* cluster_secret_= */ "",
+                /* client_name_= */ std::string(DEFAULT_CLIENT_NAME),
+                Protocol::Compression::Enable,
+                secure,
+                /* bind_host_= */ ""));
+
+            if (!round_robin || total_stats.empty())
+                total_stats.emplace_back(std::make_shared<Stats>());
+        }
+
+        connections.reserve(connections_cnt);
+        total_stats.reserve(round_robin ? 1 : connections_cnt);
+
+        // Initialize queries_per_connection to track queries for each connection
+        {
+            std::lock_guard lock(queries_per_connection_mutex);
+            queries_per_connection.resize(connections.size(), 0);
+        }
+    }
 
     void readQueries()
     {
@@ -748,29 +820,6 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
     {
         using boost::program_options::value;
 
-        /// Note: according to the standard, subsequent calls to getenv can mangle previous result.
-        /// So we copy the results to std::string.
-        std::optional<std::string> env_user_str;
-        std::optional<std::string> env_password_str;
-        std::optional<std::string> env_host_str;
-        std::optional<std::string> env_quota_key_str;
-
-        const char * env_user = getenv("CLICKHOUSE_USER"); // NOLINT(concurrency-mt-unsafe)
-        if (env_user != nullptr)
-            env_user_str.emplace(std::string(env_user));
-
-        const char * env_password = getenv("CLICKHOUSE_PASSWORD"); // NOLINT(concurrency-mt-unsafe)
-        if (env_password != nullptr)
-            env_password_str.emplace(std::string(env_password));
-
-        const char * env_host = getenv("CLICKHOUSE_HOST"); // NOLINT(concurrency-mt-unsafe)
-        if (env_host != nullptr)
-            env_host_str.emplace(std::string(env_host));
-
-        const char * env_quota_key = getenv("CLICKHOUSE_QUOTA_KEY"); // NOLINT(concurrency-mt-unsafe)
-        if (env_quota_key != nullptr)
-            env_quota_key_str.emplace(std::string(env_quota_key));
-
         boost::program_options::options_description options_description = createOptionsDescription("Allowed options", getTerminalWidth());
         options_description.add_options()
             ("help", "Print usage summary and exit; combine with --verbose to display all options")
@@ -786,13 +835,15 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             ("randomize,r",                                                     "randomize order of execution")
             ("host,h",        value<Strings>()->multitoken(),                   "list of hosts")
             ("port",          value<Ports>()->multitoken(),                     "list of ports")
+            ("connection",    value<std::string>(),                             "connection name (define under connections_credentials in client config)")
             ("roundrobin",    "Instead of comparing queries for different --host/--port just pick one random --host/--port for every query and send query to it.")
             ("cumulative",    "prints cumulative data instead of data per interval")
             ("secure,s",      "Use TLS connection")
-            ("user,u",        value<std::string>()->default_value(env_user_str.value_or("default")), "")
-            ("password",      value<std::string>()->default_value(env_password_str.value_or("")), "")
-            ("quota_key",     value<std::string>()->default_value(env_quota_key_str.value_or("")), "")
-            ("database", value<std::string>()->default_value("default"), "")
+            ("user,u",        value<std::string>(), "")
+            ("password",      value<std::string>(), "")
+            ("quota_key",     value<std::string>(), "")
+            ("database",      value<std::string>(), "")
+            ("config",        value<std::string>(), "Path to client config")
             ("stacktrace", "print stack traces of exceptions")
             ("confidence", value<size_t>()->default_value(5), "set the level of confidence for T-test [0=80%, 1=90%, 2=95%, 3=98%, 4=99%, 5=99.5%(default)")
             ("query_id", value<std::string>()->default_value(""), "")
@@ -827,14 +878,6 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
         print_stacktrace = options.contains("stacktrace");
 
         /// NOTE Maybe clickhouse-benchmark should also respect .xml configuration of clickhouse-client.
-
-        UInt16 default_port = options.contains("secure") ? DBMS_DEFAULT_SECURE_PORT : DBMS_DEFAULT_PORT;
-
-        Ports ports = options.contains("port")
-            ? options["port"].as<Ports>()
-            : Ports({default_port});
-
-        Strings hosts = options.contains("host") ? options["host"].as<Strings>() : Strings({env_host_str.value_or("localhost")});
 
         String proto_send_chunked {"notchunked"};
         String proto_recv_chunked {"notchunked"};
@@ -879,37 +922,12 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             }
         }
 
-
         Benchmark benchmark(
-            options["concurrency"].as<unsigned>(),
-            options["max_concurrency"].as<unsigned>(),
-            options["delay"].as<double>(),
-            options.contains("precise"),
-            std::move(hosts),
-            std::move(ports),
-            options.contains("roundrobin"),
-            options.contains("cumulative"),
-            options.contains("secure"),
-            options["database"].as<std::string>(),
-            options["user"].as<std::string>(),
-            options["password"].as<std::string>(),
-            proto_send_chunked,
-            proto_recv_chunked,
-            options["quota_key"].as<std::string>(),
-            options["stage"].as<std::string>(),
-            options.contains("randomize"),
-            options["iterations"].as<size_t>(),
-            options["timelimit"].as<double>(),
-            options["confidence"].as<size_t>(),
-            options["query_id"].as<std::string>(),
-            options["query_id_prefix"].as<std::string>(),
-            options["query"].as<std::string>(),
-            options["max-consecutive-errors"].as<size_t>(),
-            options.contains("ignore-error"),
-            options["reconnect"].as<size_t>(),
-            options.contains("client-side-time"),
+            options,
+            std::move(proto_send_chunked),
+            std::move(proto_recv_chunked),
             print_stacktrace,
-            settings);
+            std::move(settings));
         return benchmark.run();
     }
     catch (...)

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -4,6 +4,7 @@
 #include <Core/Settings.h>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/program_options.hpp>
+#include <Common/Config/parseConnectionCredentials.h>
 #include <Common/ThreadStatus.h>
 
 #include <Access/AccessControl.h>
@@ -60,7 +61,6 @@ namespace ErrorCodes
     extern const int NETWORK_ERROR;
     extern const int AUTHENTICATION_FAILED;
     extern const int REQUIRED_PASSWORD;
-    extern const int NO_ELEMENTS_IN_CONFIG;
     extern const int USER_EXPIRED;
 }
 
@@ -136,81 +136,6 @@ void Client::showWarnings()
     }
 }
 
-void Client::parseConnectionsCredentials(Poco::Util::AbstractConfiguration & config, const std::string & connection_name)
-{
-    std::optional<String> default_connection_name;
-    if (hosts_and_ports.empty())
-    {
-        if (config.has("host"))
-            default_connection_name = config.getString("host");
-    }
-    else
-    {
-        default_connection_name = hosts_and_ports.front().host;
-    }
-
-    String connection;
-    if (!connection_name.empty())
-        connection = connection_name;
-    else
-        connection = default_connection_name.value_or("localhost");
-
-    Strings keys;
-    config.keys("connections_credentials", keys);
-    bool connection_found = false;
-    for (const auto & key : keys)
-    {
-        const String & prefix = "connections_credentials." + key;
-
-        const String & name = config.getString(prefix + ".name", "");
-        if (name != connection)
-            continue;
-        connection_found = true;
-
-        String connection_hostname;
-        if (config.has(prefix + ".hostname"))
-            connection_hostname = config.getString(prefix + ".hostname");
-        else
-            connection_hostname = name;
-
-        config.setString("host", connection_hostname);
-        if (config.has(prefix + ".port"))
-            config.setInt("port", config.getInt(prefix + ".port"));
-        if (config.has(prefix + ".secure"))
-        {
-            bool secure = config.getBool(prefix + ".secure");
-            if (secure)
-                config.setBool("secure", true);
-            else
-                config.setBool("no-secure", true);
-        }
-        if (config.has(prefix + ".user"))
-            config.setString("user", config.getString(prefix + ".user"));
-        if (config.has(prefix + ".password"))
-            config.setString("password", config.getString(prefix + ".password"));
-        if (config.has(prefix + ".database"))
-            config.setString("database", config.getString(prefix + ".database"));
-        if (config.has(prefix + ".history_file"))
-        {
-            String history_file = config.getString(prefix + ".history_file");
-            if (history_file.starts_with("~") && !home_path.empty())
-                history_file = home_path + "/" + history_file.substr(1);
-            config.setString("history_file", history_file);
-        }
-        if (config.has(prefix + ".history_max_entries"))
-        {
-            config.setUInt("history_max_entries", history_max_entries);
-        }
-        if (config.has(prefix + ".accept-invalid-certificate"))
-            config.setBool("accept-invalid-certificate", config.getBool(prefix + ".accept-invalid-certificate"));
-        if (config.has(prefix + ".prompt"))
-            config.setString("prompt", config.getString(prefix + ".prompt"));
-    }
-
-    if (!connection_name.empty() && !connection_found)
-        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "No such connection '{}' in connections_credentials", connection);
-}
-
 /// Make query to get all server warnings
 std::vector<String> Client::loadWarningMessages()
 {
@@ -282,6 +207,8 @@ void Client::initialize(Poco::Util::Application & self)
     if (home_path_cstr)
         home_path = home_path_cstr;
 
+    const char * env_host = getenv("CLICKHOUSE_HOST"); // NOLINT(concurrency-mt-unsafe)
+
     std::optional<std::string> config_path;
     if (config().has("config-file"))
         config_path.emplace(config().getString("config-file"));
@@ -291,7 +218,57 @@ void Client::initialize(Poco::Util::Application & self)
     {
         ConfigProcessor config_processor(*config_path);
         auto loaded_config = config_processor.loadConfig();
-        parseConnectionsCredentials(*loaded_config.configuration, config().getString("connection", ""));
+        auto & configuration = *loaded_config.configuration;
+
+        std::string default_host;
+        if (!hosts_and_ports.empty())
+            default_host = hosts_and_ports.front().host;
+        else if (config().has("host"))
+            default_host = config().getString("host");
+        else if (configuration.has("host"))
+            default_host = configuration.getString("host");
+        else if (env_host)
+            default_host = env_host;
+        else
+            default_host = "localhost";
+
+        std::optional<std::string> connection_name;
+        if (config().has("connection"))
+            connection_name.emplace(config().getString("connection"));
+
+        /// Connection credentials overrides should be set via loaded_config.configuration to have proper order.
+        auto overrides = parseConnectionsCredentials(configuration, default_host, connection_name);
+        if (overrides.hostname.has_value())
+            configuration.setString("host", overrides.hostname.value());
+        if (overrides.port.has_value())
+            configuration.setInt("port", overrides.port.value());
+        if (overrides.secure.has_value())
+        {
+            if (overrides.secure.value())
+                configuration.setBool("secure", true);
+            else
+                configuration.setBool("no-secure", true);
+        }
+        if (overrides.user.has_value())
+            configuration.setString("user", overrides.user.value());
+        if (overrides.password.has_value())
+            configuration.setString("password", overrides.password.value());
+        if (overrides.database.has_value())
+            configuration.setString("database", overrides.database.value());
+        if (overrides.history_file.has_value())
+        {
+            auto history_file = overrides.history_file.value();
+            if (history_file.starts_with("~") && !home_path.empty())
+                history_file = home_path + "/" + history_file.substr(1);
+            configuration.setString("history_file", history_file);
+        }
+        if (overrides.history_max_entries.has_value())
+            configuration.setUInt("history_max_entries", overrides.history_max_entries.value());
+        if (overrides.accept_invalid_certificate.has_value())
+            configuration.setBool("accept-invalid-certificate", overrides.accept_invalid_certificate.value());
+        if (overrides.prompt.has_value())
+            configuration.setString("prompt", overrides.prompt.value());
+
         config().add(loaded_config.configuration);
     }
     else if (config().has("connection"))
@@ -324,7 +301,6 @@ void Client::initialize(Poco::Util::Application & self)
     if (env_password && !config().has("password"))
         config().setString("password", env_password);
 
-    const char * env_host = getenv("CLICKHOUSE_HOST"); // NOLINT(concurrency-mt-unsafe)
     if (env_host && !config().has("host"))
         config().setString("host", env_host);
 

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -68,7 +68,6 @@ private:
     bool processBuzzHouseQuery(const String & full_query);
     bool fuzzLoopReconnect();
 #endif
-    void parseConnectionsCredentials(Poco::Util::AbstractConfiguration & config, const std::string & connection_name);
     std::vector<String> loadWarningMessages();
 
     std::optional<CurrentThread::QueryScope> query_scope;

--- a/src/Common/Config/CMakeLists.txt
+++ b/src/Common/Config/CMakeLists.txt
@@ -6,6 +6,7 @@ set (SRCS
     ConfigReloader.cpp
     YAMLParser.cpp
     ConfigHelper.cpp
+    parseConnectionCredentials.cpp
 )
 
 add_library(clickhouse_common_config ${SRCS})

--- a/src/Common/Config/parseConnectionCredentials.cpp
+++ b/src/Common/Config/parseConnectionCredentials.cpp
@@ -1,0 +1,65 @@
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Common/Config/parseConnectionCredentials.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NO_ELEMENTS_IN_CONFIG;
+}
+
+ConnectionsCredentials parseConnectionsCredentials(const Poco::Util::AbstractConfiguration & config, const std::string & host, const std::optional<std::string> & connection_name)
+{
+    ConnectionsCredentials res;
+
+    std::string connection_or_host = connection_name.value_or(host);
+
+    std::vector<std::string> keys;
+    config.keys("connections_credentials", keys);
+    bool connection_found = false;
+    for (const auto & key : keys)
+    {
+        const std::string & prefix = "connections_credentials." + key;
+
+        const std::string & name = config.getString(prefix + ".name", "");
+        if (name != connection_or_host)
+            continue;
+        connection_found = true;
+
+        if (config.has(prefix + ".hostname"))
+            res.hostname.emplace(config.getString(prefix + ".hostname"));
+        else
+            res.hostname.emplace(name);
+
+        if (config.has(prefix + ".port"))
+            res.port.emplace(config.getInt(prefix + ".port"));
+        if (config.has(prefix + ".secure"))
+        {
+            bool secure = config.getBool(prefix + ".secure");
+            res.secure.emplace(secure);
+        }
+        if (config.has(prefix + ".user"))
+            res.user.emplace(config.getString(prefix + ".user"));
+        if (config.has(prefix + ".password"))
+            res.password.emplace(config.getString(prefix + ".password"));
+        if (config.has(prefix + ".database"))
+            res.database.emplace(config.getString(prefix + ".database"));
+        if (config.has(prefix + ".history_file"))
+            res.history_file.emplace(config.getString(prefix + ".history_file"));
+        if (config.has(prefix + ".history_max_entries"))
+            res.history_max_entries.emplace(config.getUInt(prefix + ".history_max_entries"));
+        if (config.has(prefix + ".accept-invalid-certificate"))
+            res.accept_invalid_certificate.emplace(config.getBool(prefix + ".accept-invalid-certificate"));
+        if (config.has(prefix + ".prompt"))
+            res.prompt.emplace(config.getString(prefix + ".prompt"));
+    }
+
+    if (connection_name.has_value() && !connection_found)
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "No such connection '{}' in connections_credentials", connection_name.value());
+
+    return res;
+}
+
+}

--- a/src/Common/Config/parseConnectionCredentials.h
+++ b/src/Common/Config/parseConnectionCredentials.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <optional>
+#include <base/types.h>
+
+namespace Poco::Util { class AbstractConfiguration; }
+
+namespace DB
+{
+
+struct ConnectionsCredentials
+{
+    /// .hostname or fallback to connection
+    std::optional<std::string> hostname;
+    std::optional<UInt16> port;
+    std::optional<bool> secure;
+    std::optional<std::string> user;
+    std::optional<std::string> password;
+    std::optional<std::string> database;
+    std::optional<std::string> history_file;
+    std::optional<UInt32> history_max_entries;
+    std::optional<bool> accept_invalid_certificate;
+    std::optional<std::string> prompt;
+};
+
+/// Parse <connections_credentials> section from client config.
+///
+/// @param config - to search for connection_credentials for
+/// @param host - will look for a connection with name equals to host, but will not fail if such does not exist
+/// @param connection_name - connection name to look at, fails if there is no such connection defined
+ConnectionsCredentials parseConnectionsCredentials(const Poco::Util::AbstractConfiguration & config, const std::string & host, const std::optional<std::string> & connection_name);
+
+}

--- a/tests/queries/0_stateless/02550_benchmark_connections_credentials.reference
+++ b/tests/queries/0_stateless/02550_benchmark_connections_credentials.reference
@@ -1,0 +1,15 @@
+connection
+No such connection 'no_such_connection' in connections_credentials
+hostname
+Not found address of host: test_hostname_invalid
+port
+Connection refused (localhost:0).
+secure
+certificate verify failed
+database
+user
+MySQL: Authentication failed
+password
+default: Authentication failed: password is incorrect, or there is no user with such name.
+root overrides (not supported)
+foo2: Authentication failed: password is incorrect, or there is no user with such name.

--- a/tests/queries/0_stateless/02550_benchmark_connections_credentials.sh
+++ b/tests/queries/0_stateless/02550_benchmark_connections_credentials.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: require SSL
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Overrides
+TEST_DATABASE=$CLICKHOUSE_DATABASE
+TEST_HOST=${CLICKHOUSE_HOST:-"localhost"}
+TEST_PORT=${CLICKHOUSE_PORT_TCP:-9000}
+CLICKHOUSE_DATABASE="system"
+CLICKHOUSE_HOST=""
+CLICKHOUSE_PORT_TCP=""
+
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CONFIG=$CLICKHOUSE_TMP/client.xml
+cat > $CONFIG <<EOL
+<clickhouse>
+    <host>$TEST_HOST</host>
+    <port>$TEST_PORT</port>
+    <database>$TEST_DATABASE</database>
+
+    <connections_credentials>
+        <connection>
+            <name>test_hostname_invalid</name>
+            <hostname>MySQL</hostname>
+        </connection>
+
+        <connection>
+            <name>$TEST_HOST</name>
+            <database>system</database>
+        </connection>
+
+        <connection>
+            <name>test_port</name>
+            <hostname>$TEST_HOST</hostname>
+            <port>0</port>
+        </connection>
+
+        <connection>
+            <name>test_secure</name>
+            <hostname>$TEST_HOST</hostname>
+            <secure>1</secure>
+        </connection>
+
+        <connection>
+            <name>test_database</name>
+            <hostname>$TEST_HOST</hostname>
+            <database>$CLICKHOUSE_DATABASE</database>
+        </connection>
+
+        <connection>
+            <name>test_user</name>
+            <hostname>$TEST_HOST</hostname>
+            <user>MySQL</user>
+        </connection>
+
+        <connection>
+            <name>test_password</name>
+            <hostname>$TEST_HOST</hostname>
+            <password>MySQL</password>
+        </connection>
+
+        <connection>
+            <name>test_history_file</name>
+            <hostname>$TEST_HOST</hostname>
+            <history_file>/no/such/dir/.history</history_file>
+        </connection>
+    </connections_credentials>
+</clickhouse>
+EOL
+
+CONFIG_ROOT_OVERRIDES=$CLICKHOUSE_TMP/client_user_pass.xml
+cat > $CONFIG_ROOT_OVERRIDES <<EOL
+<clickhouse>
+    <host>$TEST_HOST</host>
+    <port>$TEST_PORT</port>
+    <database>$TEST_DATABASE</database>
+    <user>foo</user>
+    <password>pass</password>
+
+    <connections_credentials>
+        <connection>
+            <name>incorrect_auth</name>
+            <hostname>$TEST_HOST</hostname>
+            <database>system</database>
+        </connection>
+
+        <connection>
+            <name>default</name>
+            <user>default</user>
+            <password></password>
+            <hostname>$TEST_HOST</hostname>
+            <database>system</database>
+        </connection>
+    </connections_credentials>
+</clickhouse>
+EOL
+
+echo 'connection'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection no_such_connection |& grep -F -o "No such connection 'no_such_connection' in connections_credentials"
+echo 'hostname'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --host test_hostname_invalid |& grep -F -o -m1 'Not found address of host: test_hostname_invalid'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection test_hostname_invalid --host $TEST_HOST |& grep -F -o Exception
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG |& grep -F -o Exception
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --host $TEST_HOST |& grep -F -o Exception
+echo 'port'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection test_port |& grep -F -o 'Connection refused (localhost:0).'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection test_port --port $TEST_PORT |& grep -F -o Exception
+echo 'secure'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection test_secure |& grep -m1 -F -o -e 'SSL routines::wrong version number' -e 'tcp_secure protocol is disabled because poco library was built without NetSSL support.' -e 'certificate verify failed'
+echo 'database'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT * FROM one" --config $CONFIG --connection test_database |& grep -F -e Exception
+echo 'user'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection test_user |& grep -m1 -F -o 'MySQL: Authentication failed'
+echo 'password'
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG --connection test_password |& grep -m1 -F -o 'default: Authentication failed: password is incorrect, or there is no user with such name.'
+
+# Just in case
+unset CLICKHOUSE_USER
+unset CLICKHOUSE_PASSWORD
+unset CLICKHOUSE_HOST
+echo 'root overrides (not supported)'
+# this ignores default values in config and only uses values from incorrect_auth connection, so it works correctly
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG_ROOT_OVERRIDES --connection incorrect_auth |& grep -F -e Exception
+# this one due to override explicitly via cli args, fails due to foo2 user does not exist
+$CLICKHOUSE_BENCHMARK -i 1 --query "SELECT 1" --config $CONFIG_ROOT_OVERRIDES --connection default --user foo2 |& grep -m1 -F -o 'foo2: Authentication failed: password is incorrect, or there is no user with such name.'
+
+rm -f "${CONFIG:?}"

--- a/tests/queries/0_stateless/03630_benchmark_accept_invalid_certificate.reference
+++ b/tests/queries/0_stateless/03630_benchmark_accept_invalid_certificate.reference
@@ -1,0 +1,1 @@
+certificate verify failed

--- a/tests/queries/0_stateless/03630_benchmark_accept_invalid_certificate.sh
+++ b/tests/queries/0_stateless/03630_benchmark_accept_invalid_certificate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: require SSL
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+config_path=$(mktemp "$CUR_DIR/$(basename "${BASH_SOURCE[0]}" ".sh")-XXXXXX.yaml")
+touch $config_path
+
+$CLICKHOUSE_BENCHMARK --config $config_path -q "select 1" -i 1 --secure |& grep -m1 -F -o -e "certificate verify failed" || {
+  echo "--secure should require --accept-invalid-certificate" >&2
+  $CLICKHOUSE_BENCHMARK --config $config_path -q "select 1" -i 1 --secure >&2
+}
+$CLICKHOUSE_BENCHMARK --config $config_path -q "select 1" -i 1 --secure --accept-invalid-certificate |& grep -F -e Exception
+
+rm -f "${config_path:?}"
+exit 0


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support `--connection` in `clickhouse-benchmarks`. It is the same as supported by `clickhouse-client`, you can specify predefined connections in client `config.xml`/`config.yaml` under `connections_credentials` path, to avoid explicitly specifying user/password via command line arguments. Add support for `--accept-invalid-certificate` into `clickhouse-benchmark`.

Refs: https://github.com/ClickHouse/ClickHouse/pull/45715 (cc @kssenii )