### PR TITLE
Fix EmbeddedRocksDB upgrade

### DIFF
--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -213,17 +213,25 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
     setSettings(std::move(settings_));
 
     if (rocksdb_dir.empty())
-        rocksdb_dir = fs::path{getContext()->getUserFilesPath()} / relative_data_path_;
+    {
+        /// We used to create databases under the database directory by default instead of user files. Check first if it exists there
+        auto old_path = context_->getPath() + relative_data_path_;
+        if (mode >= LoadingStrictnessLevel::ATTACH && fs::exists(old_path))
+            rocksdb_dir = old_path;
+        else
+            rocksdb_dir = fs::path{getContext()->getUserFilesPath()} / relative_data_path_;
+    }
+    else
+    {
+        bool is_local = context_->getApplicationType() == Context::ApplicationType::LOCAL;
+        fs::path user_files_path = is_local ? "" : fs::canonical(getContext()->getUserFilesPath());
+        if (fs::path(rocksdb_dir).is_relative())
+            rocksdb_dir = user_files_path / rocksdb_dir;
+        rocksdb_dir = fs::absolute(rocksdb_dir).lexically_normal();
 
-    bool is_local = context_->getApplicationType() == Context::ApplicationType::LOCAL;
-    fs::path user_files_path = is_local ? "" : fs::canonical(getContext()->getUserFilesPath());
-    if (fs::path(rocksdb_dir).is_relative())
-        rocksdb_dir = user_files_path / rocksdb_dir;
-    rocksdb_dir = fs::absolute(rocksdb_dir).lexically_normal();
-
-    if (!is_local && !pathStartsWith(fs::path(rocksdb_dir), user_files_path))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                        "Path must be inside user-files path: {}", user_files_path.string());
+        if (!is_local && !pathStartsWith(fs::path(rocksdb_dir), user_files_path))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Path must be inside user-files path: {}", user_files_path.string());
+    }
 
     if (mode < LoadingStrictnessLevel::ATTACH)
     {

--- a/tests/integration/test_backward_compatibility/test_rocksdb_upgrade.py
+++ b/tests/integration/test_backward_compatibility/test_rocksdb_upgrade.py
@@ -1,0 +1,51 @@
+import pytest
+
+from helpers.cluster import CLICKHOUSE_CI_MIN_TESTED_VERSION, ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    with_zookeeper=False,
+    image="clickhouse/clickhouse-server",
+    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    stay_alive=True,
+    with_installed_binary=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    node.restart_with_original_version(clear_data_dir=True)
+
+
+def test_rocksdb_upgrade(start_cluster):
+    node.query(
+        """
+               CREATE TABLE vt
+               (
+                   `sha256` FixedString(64),
+                   `amount` Nullable(Int8)
+               )
+               ENGINE = EmbeddedRocksDB
+               PRIMARY KEY sha256
+               """
+    )
+
+    assert node.query("SELECT count() FROM vt") == "0\n"
+
+    node.restart_with_latest_version()
+
+    assert node.query("SELECT count() FROM vt") == "0\n"
+
+    node.query("""DROP TABLE vt""")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix EmbeddedRocksDB upgrade

Before https://github.com/ClickHouse/ClickHouse/pull/87109 we used to a) allow any path for the `EmbeddedRocksDB` table, and b) create it under `databases` if it wasn't provided. https://github.com/ClickHouse/ClickHouse/pull/87109 changed it to only allow using `user_files`, but it breaks upgrades for tables created without path. This addressed this by allowing attaching tables from the old default path

Follow up to https://github.com/ClickHouse/ClickHouse/pull/87109. Must be backported with it
Closes https://github.com/ClickHouse/ClickHouse/issues/87331

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
