### PR TITLE
Ignore only not found errors for s3_plain_rewritable (and some other S3 code)

### DIFF
--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -347,8 +347,7 @@ void S3ObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
 std::optional<ObjectMetadata> S3ObjectStorage::tryGetObjectMetadata(const std::string & path) const
 {
     auto settings_ptr = s3_settings.get();
-    auto object_info = S3::getObjectInfo(
-        *client.get(), uri.bucket, path, {}, /* with_metadata= */ true, /* throw_on_error= */ false);
+    auto object_info = S3::getObjectInfoIfExists(*client.get(), uri.bucket, path, {}, /* with_metadata= */ true);
 
     if (object_info.size == 0 && object_info.last_modification_time == 0 && object_info.metadata.empty())
         return {};

--- a/src/IO/S3/getObjectInfo.cpp
+++ b/src/IO/S3/getObjectInfo.cpp
@@ -100,37 +100,28 @@ ObjectInfo getObjectInfo(
     const String & bucket,
     const String & key,
     const String & version_id,
-    bool with_metadata,
-    bool throw_on_error)
+    bool with_metadata)
 {
-    std::optional<Expect404ResponseScope> scope; // 404 is not an error
-    if (!throw_on_error)
-        scope.emplace();
+    Expect404ResponseScope scope; // 404 is not an error
 
     auto [object_info, error] = tryGetObjectInfo(client, bucket, key, version_id, with_metadata);
     if (object_info)
-    {
         return *object_info;
-    }
-    if (throw_on_error)
-    {
-        throw S3Exception(
-            error.GetErrorType(),
-            "Failed to get object info: {}. HTTP response code: {}",
-            error.GetMessage(),
-            static_cast<size_t>(error.GetResponseCode()));
-    }
-    return {};
+
+    throw S3Exception(
+        error.GetErrorType(),
+        "Failed to get object info: {}. HTTP response code: {}",
+        error.GetMessage(),
+        static_cast<size_t>(error.GetResponseCode()));
 }
 
 size_t getObjectSize(
     const S3::Client & client,
     const String & bucket,
     const String & key,
-    const String & version_id,
-    bool throw_on_error)
+    const String & version_id)
 {
-    return getObjectInfo(client, bucket, key, version_id, {}, throw_on_error).size;
+    return getObjectInfo(client, bucket, key, version_id, /*with_metadata=*/ false).size;
 }
 
 bool objectExists(

--- a/src/IO/S3/getObjectInfo.h
+++ b/src/IO/S3/getObjectInfo.h
@@ -20,6 +20,14 @@ struct ObjectInfo
     std::map<String, String> metadata = {}; /// Set only if getObjectInfo() is called with `with_metadata = true`.
 };
 
+/// Ignore if object does not exist
+ObjectInfo getObjectInfoIfExists(
+    const S3::Client & client,
+    const String & bucket,
+    const String & key,
+    const String & version_id = {},
+    bool with_metadata = false);
+
 ObjectInfo getObjectInfo(
     const S3::Client & client,
     const String & bucket,

--- a/src/IO/S3/getObjectInfo.h
+++ b/src/IO/S3/getObjectInfo.h
@@ -33,15 +33,13 @@ ObjectInfo getObjectInfo(
     const String & bucket,
     const String & key,
     const String & version_id = {},
-    bool with_metadata = false,
-    bool throw_on_error = true);
+    bool with_metadata = false);
 
 size_t getObjectSize(
     const S3::Client & client,
     const String & bucket,
     const String & key,
-    const String & version_id = {},
-    bool throw_on_error = true);
+    const String & version_id = {});
 
 bool objectExists(
     const S3::Client & client,


### PR DESCRIPTION
MergeTree code does call `readFileIfExists()` in some places. For `s3_plain_rewritable`, however, `existsFile()` looks unsafe because it ignores **all** errors from S3.

For example, you might get an error such as "Response status: 503, Slow Down" from S3. In that case, with `s3_slow_all_threads_after_retryable_error`, the number of retries is reduced to `1` (#85918), which makes it possible to get `false` from `existsFile()`

Example stacktrace:

    DB::S3::(anonymous namespace)::tryGetObjectInfo()
    DB::S3::getObjectInfo()
    DB::S3ObjectStorage::tryGetObjectMetadata()
    DB::MetadataStorageFromPlainObjectStorage::getObjectMetadataEntryWithCache()
    DB::MetadataStorageFromPlainObjectStorage::getObjectMetadataEntryWithCache()
    DB::MetadataStorageFromPlainRewritableObjectStorage::existsFile()

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Ignore only not found errors for `s3_plain_rewritable` (which may lead to all sort of troubles)