### PR TITLE
AVX512 for iota

### DIFF
--- a/src/Common/iota.cpp
+++ b/src/Common/iota.cpp
@@ -21,6 +21,9 @@ void iota(T * begin, size_t count, T first_value)
     if (isArchSupported(TargetArch::AVX512BW))
         return iotaImplAVX512BW(begin, count, first_value);
 
+    if (isArchSupported(TargetArch::AVX512F))
+        return iotaImplAVX512F(begin, count, first_value);
+
     if (isArchSupported(TargetArch::AVX2))
         return iotaImplAVX2(begin, count, first_value);
 
@@ -45,6 +48,9 @@ void iotaWithStep(T * begin, size_t count, T first_value, T step)
 #if USE_MULTITARGET_CODE
     if (isArchSupported(TargetArch::AVX512BW))
         return iotaWithStepImplAVX512BW(begin, count, first_value, step);
+
+    if (isArchSupported(TargetArch::AVX512F))
+        return iotaWithStepImplAVX512F(begin, count, first_value, step);
 
     if (isArchSupported(TargetArch::AVX2))
         return iotaWithStepImplAVX2(begin, count, first_value, step);

--- a/src/Common/iota.cpp
+++ b/src/Common/iota.cpp
@@ -5,7 +5,7 @@
 namespace DB
 {
 
-MULTITARGET_FUNCTION_AVX2_SSE42(
+MULTITARGET_FUNCTION_AVX512BW_AVX512F_AVX2_SSE42(
     MULTITARGET_FUNCTION_HEADER(template <iota_supported_types T> static void NO_INLINE),
     iotaImpl, MULTITARGET_FUNCTION_BODY((T * begin, size_t count, T first_value) /// NOLINT
     {
@@ -18,6 +18,9 @@ template <iota_supported_types T>
 void iota(T * begin, size_t count, T first_value)
 {
 #if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX512BW))
+        return iotaImplAVX512BW(begin, count, first_value);
+
     if (isArchSupported(TargetArch::AVX2))
         return iotaImplAVX2(begin, count, first_value);
 
@@ -27,7 +30,7 @@ void iota(T * begin, size_t count, T first_value)
     return iotaImpl(begin, count, first_value);
 }
 
-MULTITARGET_FUNCTION_AVX2_SSE42(
+MULTITARGET_FUNCTION_AVX512BW_AVX512F_AVX2_SSE42(
     MULTITARGET_FUNCTION_HEADER(template <iota_supported_types T> static void NO_INLINE),
     iotaWithStepImpl, MULTITARGET_FUNCTION_BODY((T * begin, size_t count, T first_value, T step) /// NOLINT
     {
@@ -40,6 +43,9 @@ template <iota_supported_types T>
 void iotaWithStep(T * begin, size_t count, T first_value, T step)
 {
 #if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX512BW))
+        return iotaWithStepImplAVX512BW(begin, count, first_value, step);
+
     if (isArchSupported(TargetArch::AVX2))
         return iotaWithStepImplAVX2(begin, count, first_value, step);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `AVX-512` for iota.