### PR TITLE
Fix doc_type frontmatter for studenttestonesample.md

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/studentttestonesample.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/studentttestonesample.md
@@ -4,6 +4,7 @@ sidebar_label: 'studentTTestOneSample'
 sidebar_position: 195
 slug: /sql-reference/aggregate-functions/reference/studentttestonesample
 title: 'studentTTestOneSample'
+doc_type: 'reference'
 ---
 
 # studentTTestOneSample


### PR DESCRIPTION
When running `yarn build` in https://github.com/ClickHouse/clickhouse-docs/

```
📄 docs/sql-reference/aggregate-functions/reference/studentttestonesample.md:
  • missing required field: doc_type
```

Every other file in docs/en/sql-reference/aggregate-functions/reference/
has `doc_type` and only `index.md` has something besides `'reference'`

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
