### PR TITLE
Fix documentation slug inconsistency causing 404 on direct links

### DIFF
--- a/docs/en/engines/table-engines/special/alias.md
+++ b/docs/en/engines/table-engines/special/alias.md
@@ -2,7 +2,7 @@
 description: 'Create an alias of a table.'
 sidebar_label: 'Alias'
 sidebar_position: 120
-slug: /en/engines/table-engines/special/alias
+slug: /engines/table-engines/special/alias
 title: 'Alias Table Engine'
 doc_type: 'reference'
 ---

--- a/docs/en/sql-reference/aggregate-functions/reference/varpop.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/varpop.md
@@ -1,7 +1,7 @@
 ---
 description: 'Calculates the population variance.'
 sidebar_position: 210
-slug: /en/sql-reference/aggregate-functions/reference/varPop
+slug: /sql-reference/aggregate-functions/reference/varPop
 title: 'varPop'
 doc_type: 'reference'
 ---


### PR DESCRIPTION
This PR fixes an issue where direct links to certain documentation pages result in 404 errors due to inconsistent slug formatting

* https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/varPop redirects to https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varPop → 404 Page Not Found
* https://clickhouse.com/docs/en/engines/table-engines/special/alias has the same issue

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)