### PR TITLE
EmbeddedRocksDB: Go back to using data/ path by default

### DIFF
--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -214,12 +214,8 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
 
     if (rocksdb_dir.empty())
     {
-        /// We used to create databases under the database directory by default instead of user files. Check first if it exists there
-        auto old_path = context_->getPath() + relative_data_path_;
-        if (mode >= LoadingStrictnessLevel::ATTACH && fs::exists(old_path))
-            rocksdb_dir = old_path;
-        else
-            rocksdb_dir = fs::path{getContext()->getUserFilesPath()} / relative_data_path_;
+        /// We create tables under the database directory by default and enforce user_files path check for explicitly declared paths
+        rocksdb_dir = context_->getPath() + relative_data_path_;
     }
     else
     {
@@ -229,7 +225,7 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
             rocksdb_dir = user_files_path / rocksdb_dir;
         rocksdb_dir = fs::absolute(rocksdb_dir).lexically_normal();
 
-        if (!is_local && !pathStartsWith(fs::path(rocksdb_dir), user_files_path))
+        if (!is_local && !fileOrSymlinkPathStartsWith(fs::path(rocksdb_dir), user_files_path))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Path must be inside user-files path: {}", user_files_path.string());
     }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
EmbeddedRocksDB: Go back to using data/ path by default

Follow up to https://github.com/ClickHouse/ClickHouse/pull/87109 and https://github.com/ClickHouse/ClickHouse/pull/87392.
Internal discussion confirmed that the preferred default path (when it's not provided) should be under data/ as it was, and only use and enforce user_files for explicitly declared paths.

Not for changelog since it's unreleased and will be backported with the rest of the security fixes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
