### PR TITLE
Safer IObjectStorage::tryGetObjectMetadata() (ignore only object existence error)

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -325,6 +325,18 @@ ObjectMetadata AzureObjectStorage::getObjectMetadata(const std::string & path) c
     return result;
 }
 
+std::optional<ObjectMetadata> AzureObjectStorage::tryGetObjectMetadata(const std::string & path) const
+try
+{
+    return getObjectMetadata(path);
+}
+catch (const Azure::Storage::StorageException & e)
+{
+    if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
+        return {};
+    throw;
+}
+
 void AzureObjectStorage::copyObject( /// NOLINT
     const StoredObject & object_from,
     const StoredObject & object_to,

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -74,6 +74,8 @@ public:
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const override;
+
     ObjectStorageConnectionInfoPtr getConnectionInfo() const override;
 
     void copyObject( /// NOLINT

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -202,6 +202,11 @@ ObjectMetadata CachedObjectStorage::getObjectMetadata(const std::string & path) 
     return object_storage->getObjectMetadata(path);
 }
 
+std::optional<ObjectMetadata> CachedObjectStorage::tryGetObjectMetadata(const std::string & path) const
+{
+    return object_storage->tryGetObjectMetadata(path);
+}
+
 void CachedObjectStorage::shutdown()
 {
     object_storage->shutdown();

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -67,6 +67,8 @@ public:
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const override;
+
     ObjectStorageConnectionInfoPtr getConnectionInfo() const override { return object_storage->getConnectionInfo(); }
 
     void shutdown() override;

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
@@ -84,6 +84,8 @@ public:
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const override;
+
     void copyObject( /// NOLINT
         const StoredObject & object_from,
         const StoredObject & object_to,

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -44,18 +44,6 @@ ObjectStorageIteratorPtr IObjectStorage::iterate(const std::string & path_prefix
     return std::make_shared<ObjectStorageIteratorFromList>(std::move(files));
 }
 
-std::optional<ObjectMetadata> IObjectStorage::tryGetObjectMetadata(const std::string & path) const
-{
-    try
-    {
-        return getObjectMetadata(path);
-    }
-    catch (...)
-    {
-        return {};
-    }
-}
-
 ThreadPool & IObjectStorage::getThreadPoolWriter()
 {
     auto context = Context::getGlobalContextInstance();

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -199,11 +199,10 @@ public:
 
     /// Get object metadata if supported. It should be possible to receive
     /// at least size of object
-    virtual std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const;
-
-    /// Get object metadata if supported. It should be possible to receive
-    /// at least size of object
     virtual ObjectMetadata getObjectMetadata(const std::string & path) const = 0;
+
+    /// Same as getObjectMetadata(), but ignores if object does not exist.
+    virtual std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const = 0;
 
     virtual ObjectStorageConnectionInfoPtr getConnectionInfo() const { return nullptr; }
 

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
@@ -61,6 +61,8 @@ public:
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const override;
+
     void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
 
     bool existsOrHasAnyChild(const std::string & path) const override;

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -283,6 +283,11 @@ ObjectMetadata WebObjectStorage::getObjectMetadata(const std::string & /* path *
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Metadata is not supported for {}", getName());
 }
 
+std::optional<ObjectMetadata> WebObjectStorage::tryGetObjectMetadata(const std::string & /* path */) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Metadata is not supported for {}", getName());
+}
+
 ObjectStorageConnectionInfoPtr WebObjectStorage::getConnectionInfo() const
 {
     return getWebObjectStorageConnectionInfo(url);

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.h
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.h
@@ -51,6 +51,7 @@ public:
     void removeObjectsIfExist(const StoredObjects & objects) override;
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
+    std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path) const override;
 
     ObjectStorageConnectionInfoPtr getConnectionInfo() const override;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Safer IObjectStorage::tryGetObjectMetadata() (ignore only object existence error). Ignoring any errors leads to bugs - https://github.com/ClickHouse/ClickHouse/pull/87426