### PR TITLE
Fix dictionaries with YTSaurus source and *range_hashed layouts.

### DIFF
--- a/src/Dictionaries/YTsaurusDictionarySource.cpp
+++ b/src/Dictionaries/YTsaurusDictionarySource.cpp
@@ -79,24 +79,8 @@ void registerDictionarySourceYTsaurus(DictionarySourceFactory & factory)
         boost::split(configuration->http_proxy_urls, config.getString(config_prefix + ".http_proxy_urls"), [](char c) { return c == '|'; });
         configuration->cypress_path = config.getString(config_prefix + ".cypress_path");
         configuration->oauth_token = config.getString(config_prefix + ".oauth_token");
-        BlockPtr table_sample_block = std::make_shared<Block>();
-        if (dict_struct.id)
-        {
-            table_sample_block->insert(ColumnWithTypeAndName(dict_struct.id->type, dict_struct.id->name));
-        }
-        if (dict_struct.key)
-        {
-            for (const auto & attr : dict_struct.key.value())
-            {
-                table_sample_block->insert(ColumnWithTypeAndName(attr.type, attr.name));
-            }
-        }
-        for (const auto & attr : dict_struct.attributes)
-        {
-            table_sample_block->insert(ColumnWithTypeAndName(attr.type, attr.name));
-        }
 
-        return std::make_unique<YTsarususDictionarySource>(context, dict_struct, std::move(configuration), std::move(sample_block), std::move(table_sample_block));
+        return std::make_unique<YTsarususDictionarySource>(context, dict_struct, std::move(configuration), sample_block);
     };
 
     #else
@@ -126,13 +110,11 @@ YTsarususDictionarySource::YTsarususDictionarySource(
     ContextPtr context_,
     const DictionaryStructure & dict_struct_,
     std::shared_ptr<YTsaurusStorageConfiguration> configuration_,
-    Block sample_block_,
-    SharedHeader table_sample_block_)
+    const Block& sample_block_)
     : context(context_)
     , dict_struct{dict_struct_}
     , configuration{configuration_}
-    , sample_block{sample_block_}
-    , table_sample_block{table_sample_block_}
+    , sample_block{new Block(sample_block_)}
     , client(new YTsaurusClient(context,
         {
             .http_proxy_urls = configuration->http_proxy_urls,
@@ -143,7 +125,7 @@ YTsarususDictionarySource::YTsarususDictionarySource(
 }
 
 YTsarususDictionarySource::YTsarususDictionarySource(const YTsarususDictionarySource & other)
-    : YTsarususDictionarySource{other.context, other.dict_struct, other.configuration, other.sample_block, other.table_sample_block}
+    : YTsarususDictionarySource{other.context, other.dict_struct, other.configuration, *other.sample_block}
 {
 }
 
@@ -151,7 +133,7 @@ YTsarususDictionarySource::~YTsarususDictionarySource() = default;
 
 QueryPipeline YTsarususDictionarySource::loadAll()
 {
-    return QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings}, table_sample_block, max_block_size));
+    return QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings}, sample_block, max_block_size));
 }
 
 QueryPipeline YTsarususDictionarySource::loadIds(const std::vector<UInt64> & ids)
@@ -163,7 +145,7 @@ QueryPipeline YTsarususDictionarySource::loadIds(const std::vector<UInt64> & ids
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Can't make selective update of YTsaurus dictionary because data source doesn't supports lookups.");
 
     auto block = blockForIds(dict_struct, ids);
-    return QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block)}, table_sample_block, max_block_size));
+    return QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block)}, sample_block, max_block_size));
 }
 
 QueryPipeline YTsarususDictionarySource::loadKeys(const Columns & key_columns, const std::vector<size_t> & requested_rows)
@@ -178,7 +160,7 @@ QueryPipeline YTsarususDictionarySource::loadKeys(const Columns & key_columns, c
         throw Exception(ErrorCodes::LOGICAL_ERROR, "The size of key_columns does not equal to the size of dictionary key");
 
     auto block = blockForKeys(dict_struct, key_columns, requested_rows);
-    return QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block)}, table_sample_block, max_block_size));
+    return QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block)}, sample_block, max_block_size));
 }
 
 bool YTsarususDictionarySource::supportsSelectiveLoad() const

--- a/src/Dictionaries/YTsaurusDictionarySource.cpp
+++ b/src/Dictionaries/YTsaurusDictionarySource.cpp
@@ -110,11 +110,11 @@ YTsarususDictionarySource::YTsarususDictionarySource(
     ContextPtr context_,
     const DictionaryStructure & dict_struct_,
     std::shared_ptr<YTsaurusStorageConfiguration> configuration_,
-    const Block& sample_block_)
+    const Block & sample_block_)
     : context(context_)
     , dict_struct{dict_struct_}
     , configuration{configuration_}
-    , sample_block{new Block(sample_block_)}
+    , sample_block{std::make_shared<Block>(sample_block_)}
     , client(new YTsaurusClient(context,
         {
             .http_proxy_urls = configuration->http_proxy_urls,

--- a/src/Dictionaries/YTsaurusDictionarySource.h
+++ b/src/Dictionaries/YTsaurusDictionarySource.h
@@ -25,8 +25,7 @@ public:
         ContextPtr context_,
         const DictionaryStructure & dict_struct_,
         std::shared_ptr<YTsaurusStorageConfiguration> configuration_,
-        Block sample_block_,
-        SharedHeader table_sample_block_);
+        const Block& sample_block_);
 
     YTsarususDictionarySource(const YTsarususDictionarySource & other);
 
@@ -58,8 +57,7 @@ private:
     ContextPtr context;
     const DictionaryStructure dict_struct;
     const std::shared_ptr<YTsaurusStorageConfiguration> configuration;
-    Block sample_block;
-    SharedHeader table_sample_block;
+    SharedHeader sample_block;
     YTsaurusClientPtr client;
 };
 

--- a/src/Dictionaries/YTsaurusDictionarySource.h
+++ b/src/Dictionaries/YTsaurusDictionarySource.h
@@ -25,7 +25,7 @@ public:
         ContextPtr context_,
         const DictionaryStructure & dict_struct_,
         std::shared_ptr<YTsaurusStorageConfiguration> configuration_,
-        const Block& sample_block_);
+        const Block & sample_block_);
 
     YTsarususDictionarySource(const YTsarususDictionarySource & other);
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Without the fix, an exception occurs:
```
2025.09.23 10:30:45.309998 [ 689 ] {efbc8e0a-0b71-4e76-993f-9d60d1098ce0} <Error> ExternalDictionariesLoader: Could not load external dictionary 'f8a48679-a4b1-4ecf-aa46-99623b1d70bc', next update is scheduled at 2025-09-23 10:30:50: Code: 1. DB::Exception: Block size mismatch. Actual 2. Expected 4. Structure id UInt64 UInt64(size = 3), value Int32 Int32(size = 3). (UNSUPPORTED_METHOD), Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:113: Poco::Exception::Exception(String const&, int) @ 0x000000001f9e08f2
1. /home/mburdukov/workspace/clickhouse_build/./src/Common/Exception.cpp:128: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000fd1a89e
2. DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000915934e
3. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000009158f40
4. ./src/Common/Exception.h:141: DB::Exception::Exception<unsigned long&, unsigned long&, String>(int, FormatStringHelperImpl<std::type_identity<unsigned long&>::type, std::type_identity<unsigned long&>::type, std::type_identity<String>::type>, unsigned long&, unsigned long&, String&&) @ 0x00000000122ee42b
5. ./src/Dictionaries/RangeHashedDictionary.h:757: DB::RangeHashedDictionary<(DB::DictionaryKeyType)0>::blockToAttributes(DB::Block const&) @ 0x000000001318f2a3
6. ./src/Dictionaries/RangeHashedDictionary.h:555: DB::RangeHashedDictionary<(DB::DictionaryKeyType)0>::loadData() @ 0x000000001318ca1a
7. ./src/Dictionaries/RangeHashedDictionary.h:345: DB::RangeHashedDictionary<(DB::DictionaryKeyType)0>::RangeHashedDictionary(DB::StorageID const&, DB::DictionaryStructure const&, std::shared_ptr<DB::IDictionarySource>, DB::ExternalLoadableLifetime, DB::RangeHashedDictionaryConfiguration, std::shared_ptr<DB::Block>) @ 0x000000001318c465
8. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:634: std::unique_ptr<DB::IDictionary, std::default_delete<DB::IDictionary>> std::__function::__policy_invoker<std::unique_ptr<DB::IDictionary, std::default_delete<DB::IDictionary>> (String const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::IDictionarySource>, std::shared_ptr<DB::Context const>, bool)>::__call_impl[abi:ne190107]<std::__function::__default_alloc_func<DB::registerDictionaryRangeHashed(DB::DictionaryFactory&)::$_0, std::unique_ptr<DB::IDictionary, std::default_delete<DB::IDictionary>> (String const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::IDictionarySource>, std::shared_ptr<DB::Context const>, bool)>>(std::__function::__policy_storage const*, String const&, DB::DictionaryStructure const&, Poco::Util::AbstractConfiguration const&, String const&, std::shared_ptr<DB::IDictionarySource>&&, std::shared_ptr<DB::Context const>&&, bool) @ 0x000000001318ab50
9. ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ? @ 0x0000000013e47496
10. /home/mburdukov/workspace/clickhouse_build/./src/Interpreters/ExternalDictionariesLoader.cpp:47: DB::ExternalDictionariesLoader::createObject(String const&, Poco::Util::AbstractConfiguration const&, String const&, String const&) const @ 0x0000000015e5eaa0
....
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix dictionaries with YTSaurus source and *range_hashed layouts.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
