### PR TITLE
Docs: change incorrect table name and fix typos

### DIFF
--- a/docs/en/operations/system-tables/projection_parts.md
+++ b/docs/en/operations/system-tables/projection_parts.md
@@ -1,7 +1,7 @@
 ---
 description: 'System table containing information about projection parts for tables of the MergeTree family.'
 keywords: ['system table', 'projection_parts']
-slug: /operations/system-tables/projection-parts
+slug: /operations/system-tables/projection_parts
 title: 'system.projection_parts'
 doc_type: 'reference'
 ---

--- a/docs/en/operations/system-tables/projection_parts.md
+++ b/docs/en/operations/system-tables/projection_parts.md
@@ -1,7 +1,7 @@
 ---
 description: 'System table containing information about projection parts for tables of the MergeTree family.'
-keywords: ['system table', 'projection parts']
-slug: /operations/system-tables/projections-parts
+keywords: ['system table', 'projection_parts']
+slug: /operations/system-tables/projection-parts
 title: 'system.projection_parts'
 doc_type: 'reference'
 ---

--- a/docs/en/operations/system-tables/projection_parts_columns.md
+++ b/docs/en/operations/system-tables/projection_parts_columns.md
@@ -1,7 +1,7 @@
 ---
 description: 'System table containing information about columns in projection parts for tables of the MergeTree family'
-keywords: ['system table', 'projection part columns']
-slug: /operations/system-tables/projections-part-columns
+keywords: ['system table', 'projection_parts_columns']
+slug: /operations/system-tables/projection-parts-columns
 title: 'system.projection_parts_columns'
 doc_type: 'reference'
 ---

--- a/docs/en/operations/system-tables/projection_parts_columns.md
+++ b/docs/en/operations/system-tables/projection_parts_columns.md
@@ -1,7 +1,7 @@
 ---
 description: 'System table containing information about columns in projection parts for tables of the MergeTree family'
 keywords: ['system table', 'projection_parts_columns']
-slug: /operations/system-tables/projection-parts-columns
+slug: /operations/system-tables/projection_parts_columns
 title: 'system.projection_parts_columns'
 doc_type: 'reference'
 ---

--- a/docs/en/operations/system-tables/projection_parts_columns.md
+++ b/docs/en/operations/system-tables/projection_parts_columns.md
@@ -2,7 +2,7 @@
 description: 'System table containing information about columns in projection parts for tables of the MergeTree family'
 keywords: ['system table', 'projection part columns']
 slug: /operations/system-tables/projections-part-columns
-title: 'system.projection_parts'
+title: 'system.projection_parts_columns'
 doc_type: 'reference'
 ---
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
This PR changes ```title``` in ```docs/en/operations/system-tables/projection_parts_columns.md``` to ```system.projection_parts_columns```, right now it is ```system.projection_parts```

Also there are some typo fixes in ```docs/en/operations/system-tables/projection_parts.md``` and ```docs/en/operations/system-tables/projection_parts_columns.md```

### Changelog category (leave one):
- Documentation (changelog entry is not required)