### PR TITLE
Do not put hive partition columns in format header - fix 87515

### DIFF
--- a/03631_hive_columns_not_in_format_header.reference
+++ b/03631_hive_columns_not_in_format_header.reference
@@ -1,0 +1,2 @@
+1
+raw_blob	String					

--- a/03631_hive_columns_not_in_format_header.sql
+++ b/03631_hive_columns_not_in_format_header.sql
@@ -1,0 +1,13 @@
+-- Tags: no-parallel, no-fasttest, no-random-settings
+
+INSERT INTO FUNCTION s3(
+    s3_conn,
+    filename='03631',
+    format=Parquet,
+    partition_strategy='hive',
+    partition_columns_in_data_file=1) PARTITION BY (year, country) SELECT 'Brazil' as country, 2025 as year, 1 as id;
+
+-- distinct because minio isn't cleaned up
+SELECT count(distinct year) FROM s3(s3_conn, filename='03631/**.parquet', format=RawBLOB) SETTINGS use_hive_partitioning=1;
+
+DESCRIBE s3(s3_conn, filename='03631/**.parquet', format=RawBLOB) SETTINGS use_hive_partitioning=1;

--- a/src/Storages/prepareReadingFromFormat.cpp
+++ b/src/Storages/prepareReadingFromFormat.cpp
@@ -101,7 +101,12 @@ ReadFromFormatInfo prepareReadingFromFormat(
     }
 
     /// Create header for InputFormat with columns that will be read from the data.
-    info.format_header = storage_snapshot->getSampleBlockForColumns(info.columns_description.getNamesOfPhysical());
+    for (const auto & column : columns_in_data_file)
+    {
+        /// Never read hive partition columns from the data file. This fixes https://github.com/ClickHouse/ClickHouse/issues/87515
+        if (!hive_parameters.hive_partition_columns_to_read_from_file_path_map.contains(column.name))
+            info.format_header.insert(ColumnWithTypeAndName{column.type, column.name});
+    }
 
     info.serialization_hints = getSerializationHintsForFileLikeStorage(storage_snapshot->metadata, context);
 

--- a/src/Storages/prepareReadingFromFormat.cpp
+++ b/src/Storages/prepareReadingFromFormat.cpp
@@ -101,7 +101,7 @@ ReadFromFormatInfo prepareReadingFromFormat(
     }
 
     /// Create header for InputFormat with columns that will be read from the data.
-    for (const auto & column : columns_in_data_file)
+    for (const auto & column : info.columns_description)
     {
         /// Never read hive partition columns from the data file. This fixes https://github.com/ClickHouse/ClickHouse/issues/87515
         if (!hive_parameters.hive_partition_columns_to_read_from_file_path_map.contains(column.name))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Never put hive partition columns in the format header. Fixes https://github.com/ClickHouse/ClickHouse/issues/87515

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
