### PR TITLE
Fix requesting structure of a dataset from ArrowFlight server when creating a table

### DIFF
--- a/src/Storages/StorageArrowFlight.h
+++ b/src/Storages/StorageArrowFlight.h
@@ -58,7 +58,7 @@ public:
     SinkToStoragePtr
     write(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, ContextPtr context_, bool async_write) override;
 
-    Names getColumnNames();
+    static ColumnsDescription getTableStructureFromData(std::shared_ptr<ArrowFlightConnection> connection_, const String & dataset_name_);
 
 private:
     std::shared_ptr<ArrowFlightConnection> connection;

--- a/src/TableFunctions/TableFunctionArrowFlight.cpp
+++ b/src/TableFunctions/TableFunctionArrowFlight.cpp
@@ -1,8 +1,6 @@
 #include <TableFunctions/TableFunctionArrowFlight.h>
 
 #if USE_ARROWFLIGHT
-#include <DataTypes/DataTypeString.h>
-#include <Interpreters/Context.h>
 #include <Parsers/ASTFunction.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/StorageArrowFlight.h>
@@ -16,53 +14,27 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int ARROWFLIGHT_FETCH_SCHEMA_ERROR;
 }
 
 StoragePtr TableFunctionArrowFlight::executeImpl(
     const ASTPtr & /*ast_function*/,
     ContextPtr context,
     const String & table_name,
-    ColumnsDescription /*cached_columns*/,
-    bool is_insert_query) const
+    ColumnsDescription cached_columns,
+    bool /*is_insert_query*/) const
 {
-    auto columns = getActualTableStructure(context, is_insert_query);
-
     return std::make_shared<StorageArrowFlight>(
         StorageID{"arrow_flight", table_name},
         connection,
         config.dataset_name,
-        columns,
-        ConstraintsDescription(),
+        cached_columns,
+        ConstraintsDescription{},
         context);
 }
 
 ColumnsDescription TableFunctionArrowFlight::getActualTableStructure(ContextPtr /*context*/, bool /*is_insert_query*/) const
 {
-    auto client = connection->getClient();
-    auto options = connection->getOptions();
-
-    arrow::flight::FlightDescriptor descriptor = arrow::flight::FlightDescriptor::Path({config.dataset_name});
-    auto status = client->GetSchema(*options, descriptor);
-    if (!status.ok())
-    {
-        throw Exception(ErrorCodes::ARROWFLIGHT_FETCH_SCHEMA_ERROR, "Failed to get table schema: {}", status.status().ToString());
-    }
-    arrow::ipc::DictionaryMemo dict;
-    auto schema_result = status.ValueOrDie()->GetSchema(&dict);
-    if (!schema_result.ok())
-    {
-        throw Exception(ErrorCodes::ARROWFLIGHT_FETCH_SCHEMA_ERROR, "Failed to get table schema: {}", schema_result.status().ToString());
-    }
-    auto schema = std::move(schema_result).ValueOrDie();
-
-    auto fields = schema->fields();
-    ColumnsDescription desr;
-    for (const auto & field : fields)
-    {
-        desr.add(ColumnDescription(field->name(), std::make_shared<DataTypeString>()));
-    }
-    return desr;
+    return StorageArrowFlight::getTableStructureFromData(connection, config.dataset_name);
 }
 
 void TableFunctionArrowFlight::parseArguments(const ASTPtr & ast_function, ContextPtr context)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix requesting the structure of a dataset from the ArrowFlight server when creating a table.

When creating a table
```
CREATE TABLE tablefunc45 (x int) AS arrowFlight('arrowflight1:5006', 'dataset')
```
it shouldn't request the actual structure of the dataset from the ArrowFlight server because the command already specifies the columns of this table.

This PR fixes [failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0153594656abf37648912c330f69db13736c5b54&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%203%2F5%29&name_1=Integration%20tests%20%28amd_binary%2C%203%2F5%29) of test **test_mask_sensitive_info/test.py::test_table_functions**.