### PR TITLE
Fix indent for Ranges output in EXPLAIN indexes=1

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2916,7 +2916,7 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
                 format_settings.out << prefix << indent << indent << "Search Algorithm: " << search_algorithm << "\n";
         }
 
-        format_settings.out << prefix << indent << indent << "Ranges: " << result.selected_ranges << '\n';
+        format_settings.out << prefix << indent << "Ranges: " << result.selected_ranges << '\n';
     }
 }
 

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
@@ -19,7 +19,7 @@ Expression ((Projection + Before ORDER BY))
             Parts: 1/1
             Granules: 1/1
             Search Algorithm: binary search
-            Ranges: 1
+          Ranges: 1
       Expression ((Joined actions + (Rename joined columns + (Projection + Before ORDER BY))))
         ReadFromMergeTree (default.t2)
         Indexes:
@@ -27,7 +27,7 @@ Expression ((Projection + Before ORDER BY))
             Condition: true
             Parts: 1/1
             Granules: 1/1
-            Ranges: 1
+          Ranges: 1
 Expression ((Project names + Projection))
   Filter (WHERE)
     Join (JOIN FillRightFirst)
@@ -41,7 +41,7 @@ Expression ((Project names + Projection))
             Parts: 1/1
             Granules: 1/1
             Search Algorithm: binary search
-            Ranges: 1
+          Ranges: 1
       Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
         ReadFromMergeTree (default.t2)
         Indexes:
@@ -49,4 +49,4 @@ Expression ((Project names + Projection))
             Condition: true
             Parts: 1/1
             Granules: 1/1
-            Ranges: 1
+          Ranges: 1

--- a/tests/queries/0_stateless/01786_explain_merge_tree.reference
+++ b/tests/queries/0_stateless/01786_explain_merge_tree.reference
@@ -28,7 +28,7 @@
         Description: set GRANULARITY 2
         Parts: 1/1
         Granules: 2/3
-        Ranges: 1
+      Ranges: 1
 -----------------
               "Node Type": "ReadFromMergeTree",
               "Node Id": "ReadFromMergeTree_0",
@@ -111,7 +111,7 @@
         Parts: 1/1
         Granules: 1/1
         Search Algorithm: generic exclusion search
-        Ranges: 1
+      Ranges: 1
     ReadFromMergeTree (default.test_index)
     Indexes:
       MinMax
@@ -142,7 +142,7 @@
         Description: set GRANULARITY 2
         Parts: 1/1
         Granules: 2/3
-        Ranges: 1
+      Ranges: 1
 -----------------
               "Node Type": "ReadFromMergeTree",
               "Node Id": "ReadFromMergeTree_0",
@@ -227,4 +227,4 @@
         Parts: 1/1
         Granules: 1/1
         Search Algorithm: generic exclusion search
-        Ranges: 1
+      Ranges: 1

--- a/tests/queries/0_stateless/02354_vector_search_queries.reference
+++ b/tests/queries/0_stateless/02354_vector_search_queries.reference
@@ -18,7 +18,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 100000000
               Parts: 1/1
               Granules: 1/1
-              Ranges: 1
+            Ranges: 1
 12 rows, index_granularity = 3, GRANULARITY = 2 --> 4 granules, 2 indexed block
 6	[0,2]	0
 7	[0,2.1]	0.09999990463256836
@@ -39,7 +39,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 2/4
-              Ranges: 2
+            Ranges: 2
 Special cases
 -- Non-default metric, hnsw_max_connections_per_layer, hnsw_candidate_list_size_for_construction
 6	[1,9.3]	0.005731362878640178
@@ -61,7 +61,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 -- Setting "max_limit_for_vector_search_queries"
 Expression (Project names)
   LazilyRead (Lazily Read)
@@ -74,7 +74,7 @@ Expression (Project names)
               Condition: true
               Parts: 1/1
               Granules: 4/4
-              Ranges: 1
+            Ranges: 1
 -- Test all distance metrics x all quantization
 1	[2,3.2]	2.3323807824711897
 4	[2.4,5.2]	3.9999999046325727
@@ -95,7 +95,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 4/4
-              Ranges: 1
+            Ranges: 1
 1	[2,3.2]	2.3323807824711897
 4	[2.4,5.2]	3.9999999046325727
 2	[4.2,3.4]	4.427188573446585
@@ -115,7 +115,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 4/4
-              Ranges: 1
+            Ranges: 1
 1	[2,3.2]	2.3323807824711897
 4	[2.4,5.2]	3.9999999046325727
 2	[4.2,3.4]	4.427188573446585
@@ -135,7 +135,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 4/4
-              Ranges: 1
+            Ranges: 1
 1	[2,3.2]	2.3323807824711897
 4	[2.4,5.2]	3.9999999046325727
 2	[4.2,3.4]	4.427188573446585
@@ -155,7 +155,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 4/4
-              Ranges: 1
+            Ranges: 1
 1	[2,3.2]	2.3323807824711897
 4	[2.4,5.2]	3.9999999046325727
 2	[4.2,3.4]	4.427188573446585
@@ -175,7 +175,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 6	[1,9.3]	0.005731362878640178
 4	[2.4,5.2]	0.09204062768384846
 1	[2,3.2]	0.15200169244542905
@@ -195,7 +195,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 6	[1,9.3]	0.005731362878640178
 4	[2.4,5.2]	0.09204062768384846
 1	[2,3.2]	0.15200169244542905
@@ -215,7 +215,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 6	[1,9.3]	0.005731362878640178
 4	[2.4,5.2]	0.09204062768384846
 1	[2,3.2]	0.15200169244542905
@@ -235,7 +235,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 6	[1,9.3]	0.005731362878640178
 4	[2.4,5.2]	0.09204062768384846
 1	[2,3.2]	0.15200169244542905
@@ -255,7 +255,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 6	[1,9.3]	0.005731362878640178
 4	[2.4,5.2]	0.09204062768384846
 1	[2,3.2]	0.15200169244542905
@@ -275,7 +275,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 3/4
-              Ranges: 1
+            Ranges: 1
 -- Index on Array(Float64) column
 6	[0,2]	0
 7	[0,2.1]	0.10000000000000009

--- a/tests/queries/0_stateless/02354_vector_search_subquery.reference
+++ b/tests/queries/0_stateless/02354_vector_search_subquery.reference
@@ -14,7 +14,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 2/4
-              Ranges: 1
+            Ranges: 1
 Expression (Project names)
   LazilyRead (Lazily Read)
     Limit (preliminary LIMIT (without OFFSET))
@@ -31,7 +31,7 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 2/4
-              Ranges: 2
+            Ranges: 2
 Expression (Project names)
   LazilyRead (Lazily Read)
     Limit (preliminary LIMIT (without OFFSET))
@@ -48,4 +48,4 @@ Expression (Project names)
               Description: vector_similarity GRANULARITY 2
               Parts: 1/1
               Granules: 2/4
-              Ranges: 1
+            Ranges: 1

--- a/tests/queries/0_stateless/02713_array_low_cardinality_string.reference
+++ b/tests/queries/0_stateless/02713_array_low_cardinality_string.reference
@@ -10,4 +10,4 @@ Expression
         Description: bloom_filter GRANULARITY 1
         Parts: 1/1
         Granules: 1/1
-        Ranges: 1
+      Ranges: 1

--- a/tests/queries/0_stateless/02771_ignore_data_skipping_indices.reference
+++ b/tests/queries/0_stateless/02771_ignore_data_skipping_indices.reference
@@ -22,7 +22,7 @@
         Description: minmax GRANULARITY 1
         Parts: 0/0
         Granules: 0/0
-        Ranges: 0
+      Ranges: 0
     ReadFromMergeTree (default.data_02771)
     Indexes:
       PrimaryKey
@@ -39,7 +39,7 @@
         Description: minmax GRANULARITY 1
         Parts: 0/0
         Granules: 0/0
-        Ranges: 0
+      Ranges: 0
     ReadFromMergeTree (default.data_02771)
     Indexes:
       PrimaryKey
@@ -61,7 +61,7 @@
         Description: minmax GRANULARITY 1
         Parts: 0/0
         Granules: 0/0
-        Ranges: 0
+      Ranges: 0
     ReadFromMergeTree (default.data_02771)
     Indexes:
       PrimaryKey
@@ -78,4 +78,4 @@
         Description: minmax GRANULARITY 1
         Parts: 0/0
         Granules: 0/0
-        Ranges: 0
+      Ranges: 0

--- a/tests/queries/0_stateless/02866_size_of_marks_skip_idx_explain.reference
+++ b/tests/queries/0_stateless/02866_size_of_marks_skip_idx_explain.reference
@@ -12,7 +12,7 @@ Expression ((Project names + Projection))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/2
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test_skip_idx)
@@ -27,4 +27,4 @@ Expression ((Project names + Projection))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 2/2
-        Ranges: 1
+      Ranges: 1

--- a/tests/queries/0_stateless/02882_primary_key_index_in_function_different_types.reference
+++ b/tests/queries/0_stateless/02882_primary_key_index_in_function_different_types.reference
@@ -11,7 +11,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -25,7 +25,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -39,7 +39,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -53,7 +53,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -67,7 +67,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -81,7 +81,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -95,7 +95,7 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1
 CreatingSets
   Expression
     Expression
@@ -109,4 +109,4 @@ CreatingSets
           Parts: 1/1
           Granules: 1/1
           Search Algorithm: generic exclusion search
-          Ranges: 1
+        Ranges: 1

--- a/tests/queries/0_stateless/02911_support_alias_column_in_indices.reference
+++ b/tests/queries/0_stateless/02911_support_alias_column_in_indices.reference
@@ -14,7 +14,7 @@ Expression ((Projection + Before ORDER BY))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/1
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + (Change column names to column identifiers + Compute alias columns)))
     ReadFromMergeTree (02911_support_alias_column_in_indices.test1)
@@ -31,7 +31,7 @@ Expression ((Project names + Projection))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/1
-        Ranges: 1
+      Ranges: 1
 Expression ((Projection + Before ORDER BY))
   Filter (WHERE)
     ReadFromMergeTree (02911_support_alias_column_in_indices.test2)
@@ -48,7 +48,7 @@ Expression ((Projection + Before ORDER BY))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/1
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + (Change column names to column identifiers + Compute alias columns)))
     ReadFromMergeTree (02911_support_alias_column_in_indices.test2)
@@ -65,4 +65,4 @@ Expression ((Project names + Projection))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/1
-        Ranges: 1
+      Ranges: 1

--- a/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.reference
+++ b/tests/queries/0_stateless/03152_join_filter_push_down_equivalent_columns.reference
@@ -22,7 +22,7 @@ Header: name String
               Parts: 1/3
               Granules: 1/3
               Search Algorithm: generic exclusion search
-              Ranges: 1
+            Ranges: 1
       Expression (Right Pre Join Actions)
       Header: __table2.name String
         Filter ((WHERE + Change column names to column identifiers))
@@ -37,7 +37,7 @@ Header: name String
               Parts: 1/3
               Granules: 1/3
               Search Algorithm: generic exclusion search
-              Ranges: 1
+            Ranges: 1
 SELECT '--';
 --
 EXPLAIN header = 1, indexes = 1
@@ -62,7 +62,7 @@ Header: name String
               Parts: 1/3
               Granules: 1/3
               Search Algorithm: generic exclusion search
-              Ranges: 1
+            Ranges: 1
       Expression (Right Pre Join Actions)
       Header: __table2.name String
         Filter ((WHERE + Change column names to column identifiers))
@@ -77,7 +77,7 @@ Header: name String
               Parts: 1/3
               Granules: 1/3
               Search Algorithm: generic exclusion search
-              Ranges: 1
+            Ranges: 1
 SELECT '--';
 --
 EXPLAIN header = 1, indexes = 1
@@ -102,7 +102,7 @@ Header: name String
               Parts: 1/3
               Granules: 1/3
               Search Algorithm: generic exclusion search
-              Ranges: 1
+            Ranges: 1
       Expression (Right Pre Join Actions)
       Header: __table2.name String
         Filter ((WHERE + Change column names to column identifiers))
@@ -117,4 +117,4 @@ Header: name String
               Parts: 1/3
               Granules: 1/3
               Search Algorithm: generic exclusion search
-              Ranges: 1
+            Ranges: 1

--- a/tests/queries/0_stateless/03164_materialize_skip_index.reference
+++ b/tests/queries/0_stateless/03164_materialize_skip_index.reference
@@ -15,7 +15,7 @@ Expression ((Project names + Projection))
             Description: set GRANULARITY 1
             Parts: 2/2
             Granules: 50/50
-            Ranges: 2
+          Ranges: 2
 20
 Expression ((Project names + Projection))
   Aggregating
@@ -33,7 +33,7 @@ Expression ((Project names + Projection))
             Description: set GRANULARITY 1
             Parts: 1/1
             Granules: 6/6
-            Ranges: 1
+          Ranges: 1
 20
 Expression ((Project names + Projection))
   Aggregating
@@ -51,5 +51,5 @@ Expression ((Project names + Projection))
             Description: set GRANULARITY 1
             Parts: 1/1
             Granules: 6/6
-            Ranges: 1
+          Ranges: 1
 4	0

--- a/tests/queries/0_stateless/03166_skip_indexes_vertical_merge_1.reference
+++ b/tests/queries/0_stateless/03166_skip_indexes_vertical_merge_1.reference
@@ -14,7 +14,7 @@ Expression ((Project names + Projection))
             Description: minmax GRANULARITY 1
             Parts: 2/2
             Granules: 4/32
-            Ranges: 2
+          Ranges: 2
 200
 Expression ((Project names + Projection))
   Aggregating
@@ -31,5 +31,5 @@ Expression ((Project names + Projection))
             Description: minmax GRANULARITY 1
             Parts: 1/1
             Granules: 4/32
-            Ranges: 1
+          Ranges: 1
 4	1	3

--- a/tests/queries/0_stateless/03272_partition_pruning_monotonic_func_bug.reference
+++ b/tests/queries/0_stateless/03272_partition_pruning_monotonic_func_bug.reference
@@ -10,4 +10,4 @@ Expression
       Parts: 1/1
       Granules: 1/1
       Search Algorithm: binary search
-      Ranges: 1
+    Ranges: 1

--- a/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
+++ b/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
@@ -36,7 +36,7 @@ Union
           Parts: 1/1
           Granules: 1/123
           Search Algorithm: binary search
-          Ranges: 1
+        Ranges: 1
   Expression ((Project names + Projection))
   Actions: INPUT : 0 -> __table1.x UInt32 : 0
            INPUT : 1 -> __table1.y UInt32 : 1
@@ -85,7 +85,7 @@ Union
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
 ============ lambdas
 41	41
 41	41
@@ -134,7 +134,7 @@ Positions: 1
               Parts: 1/1
               Granules: 1/123
               Search Algorithm: binary search
-              Ranges: 1
+            Ranges: 1
       Expression (Before GROUP BY)
       Actions: INPUT :: 0 -> __table1.y UInt32 : 0
       Positions: 0
@@ -179,7 +179,7 @@ Positions: 1
                     Parts: 1/1
                     Granules: 1/123
                     Search Algorithm: binary search
-                    Ranges: 1
+                  Ranges: 1
 Expression ((Project names + (Projection + (WHERE + (Change column names to column identifiers + (Project names + Projection))))))
 Actions: INPUT : 0 -> sum(__table2.y) UInt64 : 0
          INPUT : 1 -> __table2.x UInt32 : 1
@@ -236,7 +236,7 @@ Positions: 1 0
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
       Filter (( + Change remote column names to local column names))
       Filter column: equals(__table1.x, 42_UInt8) (removed)
       Actions: INPUT : 0 -> __table1.x UInt32 : 0
@@ -270,7 +270,7 @@ Positions: 1 0
                     Condition: true
                     Parts: 1/1
                     Granules: 123/123
-                    Ranges: 1
+                  Ranges: 1
 ============ in / global in
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -287,7 +287,7 @@ CreatingSets (Create sets before main query execution)
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -303,7 +303,7 @@ CreatingSets (Create sets before main query execution)
                         Parts: 1/1
                         Granules: 1/123
                         Search Algorithm: binary search
-                        Ranges: 1
+                      Ranges: 1
 42
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -323,7 +323,7 @@ CreatingSets (Create sets before main query execution)
                       Parts: 1/1
                       Granules: 1/123
                       Search Algorithm: binary search
-                      Ranges: 1
+                    Ranges: 1
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
@@ -342,7 +342,7 @@ CreatingSets (Create sets before main query execution)
               Parts: 1/1
               Granules: 1/123
               Search Algorithm: binary search
-              Ranges: 1
+            Ranges: 1
 84
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -362,7 +362,7 @@ CreatingSets (Create sets before main query execution)
                       Parts: 1/1
                       Granules: 1/123
                       Search Algorithm: binary search
-                      Ranges: 1
+                    Ranges: 1
             CreatingSets (Create sets before main query execution)
               Expression ((Project names + Projection))
                 Expression ((WHERE + Change column names to column identifiers))
@@ -375,7 +375,7 @@ CreatingSets (Create sets before main query execution)
                       Parts: 1/1
                       Granules: 1/123
                       Search Algorithm: binary search
-                      Ranges: 1
+                    Ranges: 1
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
@@ -395,7 +395,7 @@ CreatingSets (Create sets before main query execution)
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -411,7 +411,7 @@ CreatingSets (Create sets before main query execution)
                         Parts: 1/1
                         Granules: 1/123
                         Search Algorithm: binary search
-                        Ranges: 1
+                      Ranges: 1
 126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -428,7 +428,7 @@ CreatingSets (Create sets before main query execution)
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -444,7 +444,7 @@ CreatingSets (Create sets before main query execution)
                         Parts: 1/1
                         Granules: 1/123
                         Search Algorithm: binary search
-                        Ranges: 1
+                      Ranges: 1
               CreatingSets (Create sets before main query execution)
                 Expression ((Project names + Projection))
                   Expression ((WHERE + Change column names to column identifiers))
@@ -457,7 +457,7 @@ CreatingSets (Create sets before main query execution)
                         Parts: 1/1
                         Granules: 1/123
                         Search Algorithm: binary search
-                        Ranges: 1
+                      Ranges: 1
 126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -471,7 +471,7 @@ CreatingSets (Create sets before main query execution)
                 Condition: true
                 Parts: 1/1
                 Granules: 123/123
-                Ranges: 1
+              Ranges: 1
         Expression (Before GROUP BY)
           Filter (( + Change column names to column identifiers))
             ReadFromRemote (Read from remote replica)
@@ -484,7 +484,7 @@ CreatingSets (Create sets before main query execution)
                         Condition: true
                         Parts: 1/1
                         Granules: 123/123
-                        Ranges: 1
+                      Ranges: 1
                 CreatingSet (Create set for subquery)
                   Expression ((Project names + (Projection + Change column names to column identifiers)))
                     ReadFromSystemNumbers
@@ -497,7 +497,7 @@ CreatingSets (Create sets before main query execution)
                         Condition: true
                         Parts: 1/1
                         Granules: 123/123
-                        Ranges: 1
+                      Ranges: 1
                 CreatingSet (Create set for subquery)
                   Expression ((Project names + (Projection + Change column names to column identifiers)))
                     ReadFromSystemNumbers
@@ -518,7 +518,7 @@ CreatingSets (Create sets before main query execution)
             Parts: 0/1
             Granules: 0/1
             Search Algorithm: generic exclusion search
-            Ranges: 0
+          Ranges: 0
     Expression ((Project names + Projection))
       Filter (( + Change column names to column identifiers))
         ReadFromRemote (Read from remote replica)
@@ -534,7 +534,7 @@ CreatingSets (Create sets before main query execution)
                     Parts: 0/1
                     Granules: 0/1
                     Search Algorithm: generic exclusion search
-                    Ranges: 0
+                  Ranges: 0
 ============ #68030
 Union
   Expression ((Project names + Projection))
@@ -562,7 +562,7 @@ Union
           Parts: 1/1
           Granules: 1/62
           Search Algorithm: binary search
-          Ranges: 1
+        Ranges: 1
   Expression ((Project names + Projection))
   Actions: INPUT : 0 -> __table1.n UInt64 : 0
            ALIAS __table1.n :: 0 -> n UInt64 : 1
@@ -601,4 +601,4 @@ Union
                 Parts: 1/1
                 Granules: 1/62
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1

--- a/tests/queries/0_stateless/03305_mergine_aggregated_filter_push_down.reference
+++ b/tests/queries/0_stateless/03305_mergine_aggregated_filter_push_down.reference
@@ -18,7 +18,7 @@ Expression ((Project names + (Projection + (WHERE + (Change column names to colu
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)
 select * from (select x, sum(y) from remote('127.0.0.{1,2}', currentDatabase(), tab) group by grouping sets ((x, z + 1), (x, z + 2))) where x = 42;
@@ -41,7 +41,7 @@ Expression ((Project names + (Projection + (WHERE + (Change column names to colu
                   Parts: 1/1
                   Granules: 1/123
                   Search Algorithm: binary search
-                  Ranges: 1
+                Ranges: 1
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)
 select * from (select x, sum(y), z + 1 as q from remote('127.0.0.{1,2}', currentDatabase(), tab) group by grouping sets ((x, z + 1), (x, z + 2))) where q = 42;
@@ -60,7 +60,7 @@ Expression ((Project names + Projection))
                   Condition: true
                   Parts: 1/1
                   Granules: 123/123
-                  Ranges: 1
+                Ranges: 1
         Expression (Change remote column names to local column names)
           ReadFromRemote (Read from remote replica)
 set group_by_use_nulls=1;
@@ -82,7 +82,7 @@ Expression ((Project names + (Projection + (WHERE + (Change column names to colu
                 Parts: 1/1
                 Granules: 1/123
                 Search Algorithm: binary search
-                Ranges: 1
+              Ranges: 1
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)
 select * from (select x, sum(y) from remote('127.0.0.{1,2}', currentDatabase(), tab) group by grouping sets ((x, z + 1), (x, z + 2))) where x = 42;
@@ -101,6 +101,6 @@ Expression ((Project names + (Projection + (WHERE + (Change column names to colu
                 Condition: true
                 Parts: 1/1
                 Granules: 123/123
-                Ranges: 1
+              Ranges: 1
       Filter (( + Change remote column names to local column names))
         ReadFromRemote (Read from remote replica)

--- a/tests/queries/0_stateless/03356_array_join_subcolumns_indexes.reference
+++ b/tests/queries/0_stateless/03356_array_join_subcolumns_indexes.reference
@@ -17,4 +17,4 @@ Expression ((Project names + (Projection + WHERE [split])))
           Description: set GRANULARITY 1
           Parts: 1/1
           Granules: 1/5
-          Ranges: 1
+        Ranges: 1

--- a/tests/queries/0_stateless/03374_indexes_with_literals.reference
+++ b/tests/queries/0_stateless/03374_indexes_with_literals.reference
@@ -7,7 +7,7 @@ Expression ((Project names + Projection))
         Description: bloom_filter GRANULARITY 1
         Parts: 1/1
         Granules: 33/1000
-        Ranges: 29
+      Ranges: 29
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -17,7 +17,7 @@ Expression ((Project names + Projection))
         Description: set GRANULARITY 1
         Parts: 1/1
         Granules: 1/1000
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -27,7 +27,7 @@ Expression ((Project names + Projection))
         Description: tokenbf_v1 GRANULARITY 1
         Parts: 1/1
         Granules: 1/1000
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -37,7 +37,7 @@ Expression ((Project names + Projection))
         Description: ngrambf_v1 GRANULARITY 1
         Parts: 1/1
         Granules: 1000/1000
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -47,4 +47,4 @@ Expression ((Project names + Projection))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/1000
-        Ranges: 1
+      Ranges: 1

--- a/tests/queries/0_stateless/03374_indexes_with_trivial_cast.reference
+++ b/tests/queries/0_stateless/03374_indexes_with_trivial_cast.reference
@@ -7,7 +7,7 @@ Expression ((Project names + Projection))
         Description: bloom_filter GRANULARITY 1
         Parts: 1/1
         Granules: 33/1000
-        Ranges: 29
+      Ranges: 29
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -17,7 +17,7 @@ Expression ((Project names + Projection))
         Description: set GRANULARITY 1
         Parts: 1/1
         Granules: 1/1000
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -27,7 +27,7 @@ Expression ((Project names + Projection))
         Description: tokenbf_v1 GRANULARITY 1
         Parts: 1/1
         Granules: 1/1000
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -37,7 +37,7 @@ Expression ((Project names + Projection))
         Description: ngrambf_v1 GRANULARITY 1
         Parts: 1/1
         Granules: 1000/1000
-        Ranges: 1
+      Ranges: 1
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test)
@@ -47,4 +47,4 @@ Expression ((Project names + Projection))
         Description: minmax GRANULARITY 1
         Parts: 1/1
         Granules: 1/1000
-        Ranges: 1
+      Ranges: 1

--- a/tests/queries/0_stateless/03402_secondary_indexes_analyzer_bugs.reference
+++ b/tests/queries/0_stateless/03402_secondary_indexes_analyzer_bugs.reference
@@ -12,7 +12,7 @@ Expression ((Projection + Before ORDER BY))
         Description: ngrambf_v1 GRANULARITY 1
         Parts: 0/1
         Granules: 0/8
-        Ranges: 0
+      Ranges: 0
 Expression ((Project names + Projection))
   Expression ((WHERE + (Change column names to column identifiers + Compute alias columns)))
     ReadFromMergeTree (default.t)
@@ -26,7 +26,7 @@ Expression ((Project names + Projection))
         Description: ngrambf_v1 GRANULARITY 1
         Parts: 0/1
         Granules: 0/8
-        Ranges: 0
+      Ranges: 0
 index is applied to view
 0
 0

--- a/tests/queries/0_stateless/03448_analyzer_skip_index_and_lambdas.reference
+++ b/tests/queries/0_stateless/03448_analyzer_skip_index_and_lambdas.reference
@@ -14,7 +14,7 @@ Expression
         Description: bloom_filter GRANULARITY 1
         Parts: 1/1
         Granules: 1/4
-        Ranges: 1
+      Ranges: 1
 SELECT arr
 FROM index_test
 WHERE has(arrayMap(x -> lower(x), arr), lower('a_12'))
@@ -36,7 +36,7 @@ Expression
         Description: bloom_filter GRANULARITY 1
         Parts: 1/1
         Granules: 1/4
-        Ranges: 1
+      Ranges: 1
 SELECT arr
 FROM index_test
 WHERE has(arrayMap((x, y) -> concat(lower(x), y), arr, arr), 'a_12A_12')
@@ -58,7 +58,7 @@ Expression
         Description: bloom_filter GRANULARITY 1
         Parts: 1/1
         Granules: 1/4
-        Ranges: 1
+      Ranges: 1
 SELECT arr
 FROM index_test
 WHERE has(arrayMap((x, y) -> concat(lower(x), y, '_', toString(id)), arr, arr), 'a_12A_12_13')

--- a/tests/queries/0_stateless/03464_projections_with_subcolumns.reference
+++ b/tests/queries/0_stateless/03464_projections_with_subcolumns.reference
@@ -9,7 +9,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 2/100
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p1)
 {"a":1,"b":"str","c":[{"d":1}]}
 Expression ((Project names + Projection))
@@ -23,7 +23,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 2/100
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p2)
 (1,1)
 Expression ((Project names + Projection))
@@ -37,7 +37,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 2/100
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p3)
 {"a":1,"b":"str","c":[{"d":1}]}
 Expression ((Project names + Projection))
@@ -51,7 +51,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 3/200
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p1)
 {"a":1,"b":"str","c":[{"d":1}]}
 {"a":1,"b":"str","c":[{"d":1}]}
@@ -66,7 +66,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 3/200
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p2)
 (1,1)
 (1,1)
@@ -81,7 +81,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 3/200
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p3)
 {"a":1,"b":"str","c":[{"d":1}]}
 {"a":1,"b":"str","c":[{"d":1}]}
@@ -97,7 +97,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 2/100
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p1)
 {"a":1,"b":"str","c":[{"d":1}]}
 Expression ((Project names + Projection))
@@ -111,7 +111,7 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 2/100
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p2)
 (1,1)
 Expression ((Project names + Projection))
@@ -125,6 +125,6 @@ Expression ((Project names + Projection))
         Parts: 1/1
         Granules: 2/100
         Search Algorithm: binary search
-        Ranges: 1
+      Ranges: 1
 ReadFromMergeTree (p3)
 {"a":1,"b":"str","c":[{"d":1}]}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix indent for `Ranges` output in `EXPLAIN indexes=1`

Refs: #79938 (cc @cwurm)