### PR TITLE
disallow creating index for S3 table

### DIFF
--- a/tests/queries/0_stateless/03629_storage_s3_disallow_index_alter.sql
+++ b/tests/queries/0_stateless/03629_storage_s3_disallow_index_alter.sql
@@ -3,7 +3,7 @@
 -- Issue: https://github.com/ClickHouse/ClickHouse/issues/87059
     
 DROP TABLE IF EXISTS test_03629;
-CREATE TABLE test_03629 (a UInt64) ENGINE = S3('http://localhost:9101/root', filename='test_03629_{_partition_id}', format='Native') PARTITION BY a;
+CREATE TABLE test_03629 (a UInt64) ENGINE = S3(s3_conn, filename='test_03629_{_partition_id}', format='Native') PARTITION BY a;
 ALTER TABLE test_03629 ADD INDEX a_idx a TYPE set(0); -- { serverError NOT_IMPLEMENTED }
 
 DROP TABLE test_03629;

--- a/tests/queries/0_stateless/03629_storage_s3_disallow_index_alter.sql
+++ b/tests/queries/0_stateless/03629_storage_s3_disallow_index_alter.sql
@@ -1,0 +1,9 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: Depends on S3
+-- Issue: https://github.com/ClickHouse/ClickHouse/issues/87059
+    
+DROP TABLE IF EXISTS test_03629;
+CREATE TABLE test_03629 (a UInt64) ENGINE = S3('http://localhost:9101/root', filename='test_03629_{_partition_id}', format='Native') PARTITION BY a;
+ALTER TABLE test_03629 ADD INDEX a_idx a TYPE set(0); -- { serverError NOT_IMPLEMENTED }
+
+DROP TABLE test_03629;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/87059

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disallow creating data skipping index for S3 table.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
