### PR TITLE
Add starts and endsWithCaseInsensitive test coverage

### DIFF
--- a/src/Functions/FunctionStartsEndsWith.h
+++ b/src/Functions/FunctionStartsEndsWith.h
@@ -61,9 +61,9 @@ struct NameStartsWithUTF8
     static constexpr auto is_utf8 = true;
     static constexpr auto is_case_insensitive = false;
 };
-struct NameStartsWithUTF8CaseInsensitive
+struct NameStartsWithCaseInsensitiveUTF8
 {
-    static constexpr auto name = "startsWithUTF8CaseInsensitive";
+    static constexpr auto name = "startsWithCaseInsensitiveUTF8";
     static constexpr auto is_utf8 = true;
     static constexpr auto is_case_insensitive = true;
 };
@@ -74,9 +74,9 @@ struct NameEndsWithUTF8
     static constexpr auto is_utf8 = true;
     static constexpr auto is_case_insensitive = false;
 };
-struct NameEndsWithUTF8CaseInsensitive
+struct NameEndsWithCaseInsensitiveUTF8
 {
-    static constexpr auto name = "endsWithUTF8CaseInsensitive";
+    static constexpr auto name = "endsWithCaseInsensitiveUTF8";
     static constexpr auto is_utf8 = true;
     static constexpr auto is_case_insensitive = true;
 };
@@ -347,11 +347,11 @@ private:
                 {
                     if constexpr (std::is_same_v<Name, NameStartsWithCaseInsensitive>)
                         res_data[row_num] = std::get<std::unique_ptr<ASCIICaseInsensitiveStringSearcher>>(const_comparator)->compare(haystack.data, haystack.data + haystack.size, haystack.data);
-                    else if constexpr (std::is_same_v<Name, NameStartsWithUTF8CaseInsensitive>)
+                    else if constexpr (std::is_same_v<Name, NameStartsWithCaseInsensitiveUTF8>)
                         res_data[row_num] = std::get<std::unique_ptr<UTF8CaseInsensitiveStringSearcher>>(const_comparator)->compare(haystack.data, haystack.data + haystack.size, haystack.data);
                     else if constexpr (std::is_same_v<Name, NameEndsWithCaseInsensitive>)
                         res_data[row_num] = std::get<std::unique_ptr<ASCIICaseInsensitiveStringSearcher>>(const_comparator)->compare(haystack.data + haystack.size - needle.size, haystack.data + haystack.size, haystack.data + haystack.size - needle.size);
-                    else if constexpr (std::is_same_v<Name, NameEndsWithUTF8CaseInsensitive>)
+                    else if constexpr (std::is_same_v<Name, NameEndsWithCaseInsensitiveUTF8>)
                         res_data[row_num] = std::get<std::unique_ptr<UTF8CaseInsensitiveStringSearcher>>(const_comparator)->compare(haystack.data + haystack.size - needle.size, haystack.data + haystack.size, haystack.data + haystack.size - needle.size);
                     else
                         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function '{}'", name);
@@ -360,11 +360,11 @@ private:
                 {
                     if constexpr (std::is_same_v<Name, NameStartsWithCaseInsensitive>)
                         res_data[row_num] = ASCIICaseInsensitiveStringSearcher(needle.data, needle.size).compare(haystack.data, haystack.data + haystack.size, haystack.data);
-                    else if constexpr (std::is_same_v<Name, NameStartsWithUTF8CaseInsensitive>)
+                    else if constexpr (std::is_same_v<Name, NameStartsWithCaseInsensitiveUTF8>)
                         res_data[row_num] = UTF8CaseInsensitiveStringSearcher(needle.data, needle.size).compare(haystack.data, haystack.data + haystack.size, haystack.data);
                     else if constexpr (std::is_same_v<Name, NameEndsWithCaseInsensitive>)
                         res_data[row_num] = ASCIICaseInsensitiveStringSearcher(needle.data, needle.size).compare(haystack.data + haystack.size - needle.size, haystack.data + haystack.size, haystack.data + haystack.size - needle.size);
-                    else if constexpr (std::is_same_v<Name, NameEndsWithUTF8CaseInsensitive>)
+                    else if constexpr (std::is_same_v<Name, NameEndsWithCaseInsensitiveUTF8>)
                         res_data[row_num] = UTF8CaseInsensitiveStringSearcher(needle.data, needle.size).compare(haystack.data + haystack.size - needle.size, haystack.data + haystack.size, haystack.data + haystack.size - needle.size);
                     else
                         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function '{}'", name);

--- a/src/Functions/FunctionStartsEndsWith.h
+++ b/src/Functions/FunctionStartsEndsWith.h
@@ -90,8 +90,6 @@ public:
     static constexpr auto name = Name::name;
     static constexpr auto is_utf8 = Name::is_utf8;
     static constexpr bool is_case_insensitive = Name::is_case_insensitive;
-    static constexpr bool is_case_insensitive_prefix = std::is_same_v<Name, NameStartsWithCaseInsensitive> || std::is_same_v<Name, NameStartsWithUTF8CaseInsensitive>;
-    static constexpr bool is_case_insensitive_sufffix = std::is_same_v<Name, NameEndsWithCaseInsensitive> || std::is_same_v<Name, NameEndsWithUTF8CaseInsensitive>;
 
     String getName() const override
     {
@@ -308,6 +306,7 @@ private:
         std::unique_ptr<UTF8CaseInsensitiveStringSearcher>>;
 
     template <typename NeedleSource>
+    requires is_case_insensitive
     static CaseInsensitiveComparator constCaseInsensitiveComparatorOf(NeedleSource needle_source)
     {
         if constexpr (std::is_same_v<NeedleSource, ConstSource<StringSource>> || std::is_same_v<NeedleSource, ConstSource<FixedStringSource>>)
@@ -355,7 +354,7 @@ private:
                     else if constexpr (std::is_same_v<Name, NameEndsWithUTF8CaseInsensitive>)
                         res_data[row_num] = std::get<std::unique_ptr<UTF8CaseInsensitiveStringSearcher>>(const_comparator)->compare(haystack.data + haystack.size - needle.size, haystack.data + haystack.size, haystack.data + haystack.size - needle.size);
                     else
-                        chassert(false, "Unexpected function");
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function '{}'", name);
                 }
                 else /// Non-constant needle comparison
                 {
@@ -368,7 +367,7 @@ private:
                     else if constexpr (std::is_same_v<Name, NameEndsWithUTF8CaseInsensitive>)
                         res_data[row_num] = UTF8CaseInsensitiveStringSearcher(needle.data, needle.size).compare(haystack.data + haystack.size - needle.size, haystack.data + haystack.size, haystack.data + haystack.size - needle.size);
                     else
-                        chassert(false, "Unexpected function");
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected function '{}'", name);
                 }
             }
 

--- a/src/Functions/endsWith.cpp
+++ b/src/Functions/endsWith.cpp
@@ -43,7 +43,7 @@ REGISTER_FUNCTION(EndsWithCaseInsensitive)
     FunctionDocumentation::Description description = R"(
 Checks whether a string ends with the provided case-insensitive suffix.
 )";
-    FunctionDocumentation::Syntax syntax = "endsWith(s, suffix)";
+    FunctionDocumentation::Syntax syntax = "endsWithCaseInsensitive(s, suffix)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "String to check.", {"String"}},
         {"suffix", "Case-insensitive suffix to check for.", {"String"}}

--- a/src/Functions/endsWithUTF8.cpp
+++ b/src/Functions/endsWithUTF8.cpp
@@ -7,7 +7,7 @@ namespace DB
 {
 
 using FunctionEndsWithUTF8 = FunctionStartsEndsWith<NameEndsWithUTF8>;
-using FunctionEndsWithUTF8CaseInsensitive = FunctionStartsEndsWith<NameEndsWithUTF8CaseInsensitive>;
+using FunctionEndsWithCaseInsensitiveUTF8 = FunctionStartsEndsWith<NameEndsWithCaseInsensitiveUTF8>;
 
 REGISTER_FUNCTION(EndsWithUTF8)
 {
@@ -40,14 +40,14 @@ If this assumption is violated, no exception is thrown and the result is undefin
     factory.registerFunction<FunctionEndsWithUTF8>(documentation);
 }
 
-REGISTER_FUNCTION(EndsWithUTF8CaseInsensitive)
+REGISTER_FUNCTION(EndsWithCaseInsensitiveUTF8)
 {
     FunctionDocumentation::Description description = R"(
 Returns whether string `s` ends with case-insensitive `suffix`.
 Assumes that the string contains valid UTF-8 encoded text.
 If this assumption is violated, no exception is thrown and the result is undefined.
 )";
-    FunctionDocumentation::Syntax syntax = "endsWithUTF8CaseInsensitive(s, suffix)";
+    FunctionDocumentation::Syntax syntax = "endsWithCaseInsensitiveUTF8(s, suffix)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "String to check.", {"String"}},
         {"suffix", "Case-insensitive suffix to check for.", {"String"}}
@@ -56,9 +56,9 @@ If this assumption is violated, no exception is thrown and the result is undefin
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",
-        "SELECT endsWithUTF8CaseInsensitive('данных', 'ых');",
+        "SELECT endsWithCaseInsensitiveUTF8('данных', 'ых');",
         R"(
-┌─endsWithUTF8CaseInsensitive('данных', 'ых')─┐
+┌─endsWithCaseInsensitiveUTF8('данных', 'ых')─┐
 │                                           1 │
 └─────────────────────────────────────────────┘
         )"
@@ -68,6 +68,6 @@ If this assumption is violated, no exception is thrown and the result is undefin
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionEndsWithUTF8CaseInsensitive>(documentation);
+    factory.registerFunction<FunctionEndsWithCaseInsensitiveUTF8>(documentation);
 }
 }

--- a/src/Functions/startsWithUTF8.cpp
+++ b/src/Functions/startsWithUTF8.cpp
@@ -7,7 +7,7 @@ namespace DB
 {
 
 using FunctionStartsWithUTF8 = FunctionStartsEndsWith<NameStartsWithUTF8>;
-using FunctionStartsWithUTF8CaseInsensitive = FunctionStartsEndsWith<NameStartsWithUTF8CaseInsensitive>;
+using FunctionStartsWithCaseInsensitiveUTF8 = FunctionStartsEndsWith<NameStartsWithCaseInsensitiveUTF8>;
 
 REGISTER_FUNCTION(StartsWithUTF8)
 {
@@ -40,14 +40,14 @@ If this assumption is violated, no exception is thrown and the result is undefin
     factory.registerFunction<FunctionStartsWithUTF8>(documentation);
 }
 
-REGISTER_FUNCTION(StartsWithUTF8CaseInsensitive)
+REGISTER_FUNCTION(StartsWithCaseInsensitiveUTF8)
 {
     FunctionDocumentation::Description description = R"(
 Checks if a string starts with the provided case-insensitive prefix.
 Assumes that the string contains valid UTF-8 encoded text.
 If this assumption is violated, no exception is thrown and the result is undefined.
 )";
-    FunctionDocumentation::Syntax syntax = "startsWithUTF8CaseInsensitive(s, prefix)";
+    FunctionDocumentation::Syntax syntax = "startsWithCaseInsensitiveUTF8(s, prefix)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "String to check.", {"String"}},
         {"prefix", "Case-insensitive prefix to check for.", {"String"}}
@@ -56,7 +56,7 @@ If this assumption is violated, no exception is thrown and the result is undefin
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",
-        "SELECT startsWithUTF8CaseInsensitive('приставка', 'при')",
+        "SELECT startsWithCaseInsensitiveUTF8('приставка', 'при')",
         R"(
 ┌─startsWithUT⋯ка', 'при')─┐
 │                        1 │
@@ -68,7 +68,7 @@ If this assumption is violated, no exception is thrown and the result is undefin
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionStartsWithUTF8CaseInsensitive>(documentation);
+    factory.registerFunction<FunctionStartsWithCaseInsensitiveUTF8>(documentation);
 }
 
 }

--- a/src/Functions/startsWithUTF8.cpp
+++ b/src/Functions/startsWithUTF8.cpp
@@ -16,7 +16,7 @@ Checks if a string starts with the provided prefix.
 Assumes that the string contains valid UTF-8 encoded text.
 If this assumption is violated, no exception is thrown and the result is undefined.
 )";
-    FunctionDocumentation::Syntax syntax = "startsWithUTF8(str, prefix)";
+    FunctionDocumentation::Syntax syntax = "startsWithUTF8(s, prefix)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "String to check.", {"String"}},
         {"prefix", "Prefix to check for.", {"String"}}
@@ -47,7 +47,7 @@ Checks if a string starts with the provided case-insensitive prefix.
 Assumes that the string contains valid UTF-8 encoded text.
 If this assumption is violated, no exception is thrown and the result is undefined.
 )";
-    FunctionDocumentation::Syntax syntax = "startsWithUTF8CaseInsensitive(str, prefix)";
+    FunctionDocumentation::Syntax syntax = "startsWithUTF8CaseInsensitive(s, prefix)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "String to check.", {"String"}},
         {"prefix", "Case-insensitive prefix to check for.", {"String"}}

--- a/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.reference
+++ b/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.reference
@@ -4,11 +4,11 @@
 1	0
 -- Test startsWithCaseInsensitive UTF8 non-Latin
 1	0
--- Test startsWithUTF8CaseInsensitive ASCII
+-- Test startsWithCaseInsensitiveUTF8 ASCII
 1	0
--- Test startsWithUTF8CaseInsensitive UTF8 Latin
+-- Test startsWithCaseInsensitiveUTF8 UTF8 Latin
 1	1
--- Test startsWithUTF8CaseInsensitive UTF8 non-Latin
+-- Test startsWithCaseInsensitiveUTF8 UTF8 non-Latin
 1	0
 -- Test endsWithCaseInsensitive ASCII
 1	0
@@ -16,11 +16,11 @@
 1	0
 -- Test endsWithCaseInsensitive UTF8 non-Latin
 1	0
--- Test endsWithUTF8CaseInsensitive ASCII
+-- Test endsWithCaseInsensitiveUTF8 ASCII
 1	0
--- Test endsWithUTF8CaseInsensitive UTF8 Latin
+-- Test endsWithCaseInsensitiveUTF8 UTF8 Latin
 1	1
--- Test endsWithUTF8CaseInsensitive UTF8 non-Latin
+-- Test endsWithCaseInsensitiveUTF8 UTF8 non-Latin
 1	0
 -- Test invalid UTF8
 1	0

--- a/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.reference
+++ b/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.reference
@@ -25,3 +25,27 @@
 -- Test invalid UTF8
 1	0
 1	0
+-- Test constant needle with haystack - prefix
+1
+1
+1
+1
+1
+-- Test constant needle with haystack - suffix
+1
+1
+1
+1
+1
+-- Test column needle with haystack - prefix
+3
+1
+0
+3
+1
+-- Test column needle with haystack - suffix
+3
+1
+0
+3
+1

--- a/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.sql
+++ b/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.sql
@@ -39,3 +39,46 @@ SELECT endsWithUTF8CaseInsensitive('中国', '国'), endsWithUTF8CaseInsensitive
 SELECT '-- Test invalid UTF8';
 SELECT startsWithCaseInsensitive('中国', '\xe4'), startsWithUTF8CaseInsensitive('中国', '\xe4');
 SELECT endsWithCaseInsensitive('中国', '\xbd'), endsWithUTF8CaseInsensitive('中国', '\xbd');
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab(S1 String, S2 String, S3 FixedString(4)) ENGINE=Memory;
+INSERT INTO tab values ('1a', 'a', 'AbA'), ('22', 'A', 'ab'), ('中国', '中', '国');
+
+SELECT '-- Test constant needle with haystack - prefix';
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S1, '1');
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S2, '中');
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S3, '国');
+
+SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S1, '1');
+SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S2, '中');
+-- startsWithCaseUTF8CaseInsensitive does not support FixedString
+
+SELECT '-- Test constant needle with haystack - suffix';
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S1, '2');
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S2, '中');
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S3, '国\0');
+
+SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S1, '2');
+SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S2, '中');
+-- endsWithCaseUTF8CaseInsensitive does not support FixedString
+
+SELECT '-- Test column needle with haystack - prefix';
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S1, S1);
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S1, S2);
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S2, S3);
+
+SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S1, S1);
+SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S1, S2);
+-- endsWithCaseUTF8CaseInsensitive does not support FixedString
+
+SELECT '-- Test column needle with haystack - suffix';
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S1, S1);
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S1, S2);
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S2, S3);
+
+SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S1, S1);
+SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S1, S2);
+-- endsWithCaseUTF8CaseInsensitive does not support FixedString
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.sql
+++ b/tests/queries/0_stateless/03629_starts_endswith_caseinsensitive.sql
@@ -9,14 +9,14 @@ SELECT startsWithCaseInsensitive('Bär', 'bä'), startsWithCaseInsensitive('Bär
 SELECT '-- Test startsWithCaseInsensitive UTF8 non-Latin';
 SELECT startsWithCaseInsensitive('中国', '中'), startsWithCaseInsensitive('中国', '国');
 
-SELECT '-- Test startsWithUTF8CaseInsensitive ASCII';
-SELECT startsWithUTF8CaseInsensitive('Marta', 'mA'), startsWithUTF8CaseInsensitive('match_me_not', 'Na');
+SELECT '-- Test startsWithCaseInsensitiveUTF8 ASCII';
+SELECT startsWithCaseInsensitiveUTF8('Marta', 'mA'), startsWithCaseInsensitiveUTF8('match_me_not', 'Na');
 
-SELECT '-- Test startsWithUTF8CaseInsensitive UTF8 Latin';
-SELECT startsWithUTF8CaseInsensitive('Bär', 'bä'), startsWithUTF8CaseInsensitive('Bär', 'BÄ');
+SELECT '-- Test startsWithCaseInsensitiveUTF8 UTF8 Latin';
+SELECT startsWithCaseInsensitiveUTF8('Bär', 'bä'), startsWithCaseInsensitiveUTF8('Bär', 'BÄ');
 
-SELECT '-- Test startsWithUTF8CaseInsensitive UTF8 non-Latin';
-SELECT startsWithUTF8CaseInsensitive('中国', '中'), startsWithUTF8CaseInsensitive('Hello中国', '中');
+SELECT '-- Test startsWithCaseInsensitiveUTF8 UTF8 non-Latin';
+SELECT startsWithCaseInsensitiveUTF8('中国', '中'), startsWithCaseInsensitiveUTF8('Hello中国', '中');
 
 SELECT '-- Test endsWithCaseInsensitive ASCII';
 SELECT endsWithCaseInsensitive('Marta', 'tA'), endsWithCaseInsensitive('match_me_not', 'Na');
@@ -27,18 +27,18 @@ SELECT endsWithCaseInsensitive('Bär', 'äR'), endsWithCaseInsensitive('Bär', '
 SELECT '-- Test endsWithCaseInsensitive UTF8 non-Latin';
 SELECT endsWithCaseInsensitive('中国', '国'), endsWithCaseInsensitive('中国', '中');
 
-SELECT '-- Test endsWithUTF8CaseInsensitive ASCII';
-SELECT endsWithUTF8CaseInsensitive('Marta', 'tA'), endsWithUTF8CaseInsensitive('match_me_not', 'Na');
+SELECT '-- Test endsWithCaseInsensitiveUTF8 ASCII';
+SELECT endsWithCaseInsensitiveUTF8('Marta', 'tA'), endsWithCaseInsensitiveUTF8('match_me_not', 'Na');
 
-SELECT '-- Test endsWithUTF8CaseInsensitive UTF8 Latin';
-SELECT endsWithUTF8CaseInsensitive('Bär', 'äR'), endsWithUTF8CaseInsensitive('Bär', 'ÄR');
+SELECT '-- Test endsWithCaseInsensitiveUTF8 UTF8 Latin';
+SELECT endsWithCaseInsensitiveUTF8('Bär', 'äR'), endsWithCaseInsensitiveUTF8('Bär', 'ÄR');
 
-SELECT '-- Test endsWithUTF8CaseInsensitive UTF8 non-Latin';
-SELECT endsWithUTF8CaseInsensitive('中国', '国'), endsWithUTF8CaseInsensitive('中国', '中');
+SELECT '-- Test endsWithCaseInsensitiveUTF8 UTF8 non-Latin';
+SELECT endsWithCaseInsensitiveUTF8('中国', '国'), endsWithCaseInsensitiveUTF8('中国', '中');
 
 SELECT '-- Test invalid UTF8';
-SELECT startsWithCaseInsensitive('中国', '\xe4'), startsWithUTF8CaseInsensitive('中国', '\xe4');
-SELECT endsWithCaseInsensitive('中国', '\xbd'), endsWithUTF8CaseInsensitive('中国', '\xbd');
+SELECT startsWithCaseInsensitive('中国', '\xe4'), startsWithCaseInsensitiveUTF8('中国', '\xe4');
+SELECT endsWithCaseInsensitive('中国', '\xbd'), endsWithCaseInsensitiveUTF8('中国', '\xbd');
 
 DROP TABLE IF EXISTS tab;
 
@@ -50,35 +50,35 @@ SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S1, '1');
 SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S2, '中');
 SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S3, '国');
 
-SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S1, '1');
-SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S2, '中');
--- startsWithCaseUTF8CaseInsensitive does not support FixedString
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitiveUTF8(S1, '1');
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitiveUTF8(S2, '中');
+-- startsWithCaseCaseInsensitiveUTF8 does not support FixedString
 
 SELECT '-- Test constant needle with haystack - suffix';
 SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S1, '2');
 SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S2, '中');
 SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S3, '国\0');
 
-SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S1, '2');
-SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S2, '中');
--- endsWithCaseUTF8CaseInsensitive does not support FixedString
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitiveUTF8(S1, '2');
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitiveUTF8(S2, '中');
+-- endsWithCaseCaseInsensitiveUTF8 does not support FixedString
 
 SELECT '-- Test column needle with haystack - prefix';
 SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S1, S1);
 SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S1, S2);
 SELECT COUNT() FROM tab WHERE startsWithCaseInsensitive(S2, S3);
 
-SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S1, S1);
-SELECT COUNT() FROM tab WHERE startsWithUTF8CaseInsensitive(S1, S2);
--- endsWithCaseUTF8CaseInsensitive does not support FixedString
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitiveUTF8(S1, S1);
+SELECT COUNT() FROM tab WHERE startsWithCaseInsensitiveUTF8(S1, S2);
+-- endsWithCaseCaseInsensitiveUTF8 does not support FixedString
 
 SELECT '-- Test column needle with haystack - suffix';
 SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S1, S1);
 SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S1, S2);
 SELECT COUNT() FROM tab WHERE endsWithCaseInsensitive(S2, S3);
 
-SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S1, S1);
-SELECT COUNT() FROM tab WHERE endsWithUTF8CaseInsensitive(S1, S2);
--- endsWithCaseUTF8CaseInsensitive does not support FixedString
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitiveUTF8(S1, S1);
+SELECT COUNT() FROM tab WHERE endsWithCaseInsensitiveUTF8(S1, S2);
+-- endsWithCaseCaseInsensitiveUTF8 does not support FixedString
 
 DROP TABLE tab;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


This patch increases test coverage to `startsWithCaseInsensitive`, `endsWithCaseInsensitive` and their `UTF8` counterparts, in particular on
- non-constant `haystack`
- non-constant `needle`
- FixedString

One caveat is FixedString is illegal (ruled out by query parser) for those `UTF8` functions.

Also included is minor cleanup, based on @vdimir's review on https://github.com/ClickHouse/ClickHouse/pull/87374.
