### PR TITLE
Avoid leaking of tracked memory for async logging and text_log

### DIFF
--- a/docs/en/operations/system-tables/trace_log.md
+++ b/docs/en/operations/system-tables/trace_log.md
@@ -38,6 +38,8 @@ Columns:
   - `MemorySample` represents collecting random allocations and deallocations.
   - `MemoryPeak` represents collecting updates of peak memory usage.
   - `ProfileEvent` represents collecting of increments of profile events.
+  - `JemallocSample` represents collecting of jemalloc samples.
+  - `MemoryAllocatedWithoutCheck` represents collection of significant allocations (>16MiB) that is done with ignoring any memory limits (for ClickHouse developers only).
 - `thread_id` ([UInt64](../../sql-reference/data-types/int-uint.md)) — Thread identifier.
 - `query_id` ([String](../../sql-reference/data-types/string.md)) — Query identifier that can be used to get details about a query that was running from the [query_log](/operations/system-tables/query_log) system table.
 - `trace` ([Array(UInt64)](../../sql-reference/data-types/array.md)) — Stack trace at the moment of sampling. Each element is a virtual memory address inside ClickHouse server process.

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -255,8 +255,9 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         if (level == VariableContext::Global)
         {
             /// For global memory tracker always update memory usage.
-            amount.fetch_add(size, std::memory_order_relaxed);
+            Int64 will_be = amount.fetch_add(size, std::memory_order_relaxed);
             rss.fetch_add(size, std::memory_order_relaxed);
+            updatePeak(will_be, /*log_memory_usage=*/ false);
 
             auto metric_loaded = metric.load(std::memory_order_relaxed);
             if (metric_loaded != CurrentMetrics::end())

--- a/src/Common/MemoryTrackerDebugBlockerInThread.h
+++ b/src/Common/MemoryTrackerDebugBlockerInThread.h
@@ -2,6 +2,7 @@
 
 #include <base/defines.h> /// DEBUG_OR_SANITIZER_BUILD
 
+/// Use it if you need to suppress MemoryAllocatedWithoutCheck for known big allocations.
 #ifdef DEBUG_OR_SANITIZER_BUILD
 struct MemoryTrackerDebugBlockerInThread
 {

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -77,8 +77,12 @@ void SystemLogQueue<LogElement>::push(LogElement&& element)
     recursive_push_call = true;
     SCOPE_EXIT({ recursive_push_call = false; });
 
-    /// Queue resize can allocate enough memory hit the limit for MemoryAllocatedWithoutCheck, let's suppress it.
+
+    /// Queue resize can allocate memory
+    /// - MemoryTrackerDebugBlockerInThread here due to the allocation can hit the limit for MemoryAllocatedWithoutCheck, let's suppress it.
+    /// - MemoryTrackerBlockerInThread here because this allocation should not be take into account in the query scope (since it will be freed outside of it)
     [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+    MemoryTrackerBlockerInThread temporarily_disable_memory_tracker;
 
     /// Should not log messages under mutex.
     bool buffer_size_rows_flush_threshold_exceeded = false;
@@ -310,6 +314,8 @@ void SystemLogBase<LogElement>::stopFlushThread()
 template <typename LogElement>
 void SystemLogBase<LogElement>::add(LogElement element)
 {
+    /// This allocation should not be take into account in the query scope (since it will be freed outside of it)
+    MemoryTrackerBlockerInThread temporarily_disable_memory_tracker;
     queue->push(std::move(element));
 }
 

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -310,7 +310,6 @@ void SystemLogBase<LogElement>::stopFlushThread()
 template <typename LogElement>
 void SystemLogBase<LogElement>::add(LogElement element)
 {
-    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
     queue->push(std::move(element));
 }
 

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -68,7 +68,7 @@ SystemLogQueue<LogElement>::SystemLogQueue(const SystemLogQueueSettings & settin
 static thread_local bool recursive_push_call = false;
 
 template <typename LogElement>
-void SystemLogQueue<LogElement>::push(LogElement&& element)
+void SystemLogQueue<LogElement>::push(LogElement && element)
 {
     /// It is possible that the method will be called recursively.
     /// Better to drop these events to avoid complications.

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -77,6 +77,9 @@ void SystemLogQueue<LogElement>::push(LogElement&& element)
     recursive_push_call = true;
     SCOPE_EXIT({ recursive_push_call = false; });
 
+    /// Queue resize can allocate enough memory hit the limit for MemoryAllocatedWithoutCheck, let's suppress it.
+    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
+
     /// Should not log messages under mutex.
     bool buffer_size_rows_flush_threshold_exceeded = false;
 

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -77,12 +77,6 @@ void SystemLogQueue<LogElement>::push(LogElement&& element)
     recursive_push_call = true;
     SCOPE_EXIT({ recursive_push_call = false; });
 
-    /// Memory can be allocated while resizing on queue.push_back.
-    /// The size of allocation can be in order of a few megabytes.
-    /// But this should not be accounted for query memory usage.
-    /// Otherwise the tests like 01017_uniqCombined_memory_usage.sql will be flaky.
-    MemoryTrackerBlockerInThread temporarily_disable_memory_tracker;
-
     /// Should not log messages under mutex.
     bool buffer_size_rows_flush_threshold_exceeded = false;
 

--- a/src/Common/logger_useful.h
+++ b/src/Common/logger_useful.h
@@ -9,6 +9,7 @@
 #include <Common/AtomicLogger.h>
 #include <Common/CurrentThreadHelpers.h>
 #include <Common/Logger.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/LoggingFormatStringHelpers.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
@@ -73,6 +74,7 @@ constexpr bool constexprContains(std::string_view haystack, std::string_view nee
 {                                                                                                                   \
     static_assert(!constexprContains(#__VA_ARGS__, "formatWithSecretsOneLine"), "Think twice!");                    \
     static_assert(!constexprContains(#__VA_ARGS__, "formatWithSecretsMultiLine"), "Think twice!");                  \
+                                                                                                                    \
     auto _logger = ::impl::getLoggerHelper(logger);                                                                 \
     const bool _is_clients_log = DB::currentThreadHasGroup() && DB::currentThreadLogsLevel() >= (priority);         \
     if (!_is_clients_log && !_logger->is((PRIORITY)))                                                               \
@@ -86,6 +88,11 @@ constexpr bool constexprContains(std::string_view haystack, std::string_view nee
                                                                                                                     \
     constexpr size_t _nargs = CH_VA_ARGS_NARGS(__VA_ARGS__);                                                        \
     using LogTypeInfo = FormatStringTypeInfo<std::decay_t<decltype(LOG_IMPL_FIRST_ARG(__VA_ARGS__))>>;              \
+                                                                                                                    \
+    /* Note, we need to block memory tracking to avoid taking into account this memory in the query context */      \
+    /* Since this memory will be freed either in OwnAsyncSplitChannel::runChannel() (in case of async logging) */   \
+    /* Or in a system thread for flushing system.text_log (in case of sync logging) */                              \
+    MemoryTrackerBlockerInThread block_memory_tracker(VariableContext::Global);                                     \
                                                                                                                     \
     std::string_view _format_string;                                                                                \
     std::string _formatted_message;                                                                                 \

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -7,6 +7,7 @@
 #include <Common/DNSResolver.h>
 #include <Common/IO.h>
 #include <Common/LockMemoryExceptionInThread.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/ProfileEvents.h>
 #include <Common/SensitiveDataMasker.h>
@@ -140,7 +141,9 @@ void logToSystemTextLogQueue(
 void OwnSplitChannel::logSplit(
     const ExtendedLogMessage & msg_ext, const std::shared_ptr<InternalTextLogsQueue> & logs_queue, const std::string & msg_thread_name)
 {
-    LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+    /// The memory that will be allocated in this scope will be freed from another context (during system table flush),
+    /// so it should not be take into account in this scope
+    MemoryTrackerBlockerInThread block_memory_tracker(VariableContext::Global);
     const Poco::Message & msg = *msg_ext.base;
 
     try
@@ -395,7 +398,10 @@ void OwnAsyncSplitChannel::log(const Poco::Message & msg)
 
 void OwnAsyncSplitChannel::log(Poco::Message && msg)
 {
-    LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+    /// The memory that will be allocated in this scope will be freed from another context (in OwnAsyncSplitChannel::runChannel()),
+    /// so it should not be take into account in this scope.
+    MemoryTrackerBlockerInThread block_memory_tracker(VariableContext::Global);
+
     try
     {
         /// Based on logger_useful.h this won't be called if the message is not needed

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -7,7 +7,6 @@
 #include <Common/DNSResolver.h>
 #include <Common/IO.h>
 #include <Common/LockMemoryExceptionInThread.h>
-#include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/ProfileEvents.h>
 #include <Common/SensitiveDataMasker.h>
@@ -140,9 +139,6 @@ void logToSystemTextLogQueue(
 void OwnSplitChannel::logSplit(
     const ExtendedLogMessage & msg_ext, const std::shared_ptr<InternalTextLogsQueue> & logs_queue, const std::string & msg_thread_name)
 {
-    /// The memory that will be allocated in this scope will be freed from another context (during system table flush),
-    /// so it should not be take into account in this scope
-    MemoryTrackerBlockerInThread block_memory_tracker(VariableContext::Global);
     const Poco::Message & msg = *msg_ext.base;
 
     try
@@ -397,10 +393,6 @@ void OwnAsyncSplitChannel::log(const Poco::Message & msg)
 
 void OwnAsyncSplitChannel::log(Poco::Message && msg)
 {
-    /// The memory that will be allocated in this scope will be freed from another context (in OwnAsyncSplitChannel::runChannel()),
-    /// so it should not be take into account in this scope.
-    MemoryTrackerBlockerInThread block_memory_tracker(VariableContext::Global);
-
     try
     {
         /// Based on logger_useful.h this won't be called if the message is not needed

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -133,7 +133,6 @@ void logToSystemTextLogQueue(
 
 #undef SET_VALUE_IF_EXISTS
 
-    [[maybe_unused]] MemoryTrackerDebugBlockerInThread blocker;
     text_log_locked->push(std::move(elem));
 }
 }

--- a/src/Loggers/OwnSplitChannel.h
+++ b/src/Loggers/OwnSplitChannel.h
@@ -33,6 +33,8 @@ using TextLogQueue = SystemLogQueue<TextLogElement>;
 using AsyncLogQueueSize = std::pair<std::string, size_t>;
 using AsyncLogQueueSizes = std::vector<AsyncLogQueueSize>;
 
+class ExtendedLogMessage;
+
 class OwnSplitChannelBase : public Poco::Channel
 {
 public:

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -58,7 +58,7 @@ def test_soft_limit_create(started_cluster):
         txn.create("/test_soft_limit/node_1000001" + str(i), b"abcde")
         txn.commit()
         node.query("system flush logs metric_log")
-        assert "0\n"  == node.query("select sum(ProfileEvent_ZooKeeperHardwareExceptions) from system.metric_log")
+        assert int(node.query("select sum(ProfileEvent_ZooKeeperHardwareExceptions) from system.metric_log").strip()) > 0
         return
 
     raise Exception("all records are inserted but no error occurs")

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-import random
-import string
-
 import pytest
 from kazoo.client import KazooClient
 from helpers.cluster import ClickHouseCluster
@@ -16,10 +13,6 @@ node = cluster.add_instance(
     with_remote_database_disk=False,  # Disable `with_remote_database_disk` as the test does not use the default Keeper.
     main_configs=["configs/setting.xml"],
 )
-
-
-def random_string(length):
-    return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
 
 
 def get_connection_zk(nodename, timeout=30.0):

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -64,6 +64,7 @@ def test_soft_limit_create(started_cluster):
 
         txn.create("/test_soft_limit/node_1000001" + str(i), b"abcde")
         txn.commit()
+        node.query("system flush logs metric_log")
         assert "0\n"  == node.query("select sum(ProfileEvent_ZooKeeperHardwareExceptions) from system.metric_log")
         return
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid leaking of tracked memory for async logging (can have a significant drift, for 10 hours, ~100GiB) and text_log (almost same drift is possible).

Fixes: https://github.com/ClickHouse/ClickHouse/issues/82036