### PR TITLE
Reapply "Use Analyzer to generate actions from default expression" and fix prewhere issue

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -163,7 +163,11 @@ void QueryAnalyzer::resolve(QueryTreeNodePtr & node, const QueryTreeNodePtr & ta
             }
 
             if (node_type == QueryTreeNodeType::LIST)
+            {
+                QueryExpressionsAliasVisitor visitor(scope.aliases);
+                visitor.visit(node);
                 resolveExpressionNodeList(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+            }
             else
                 resolveExpressionNode(node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
 
@@ -191,7 +195,6 @@ void QueryAnalyzer::resolve(QueryTreeNodePtr & node, const QueryTreeNodePtr & ta
 void QueryAnalyzer::resolveConstantExpression(QueryTreeNodePtr & node, const QueryTreeNodePtr & table_expression, ContextPtr context)
 {
     IdentifierResolveScope & scope = createIdentifierResolveScope(node, /*parent_scope=*/ nullptr);
-
     if (!scope.context)
         scope.context = context;
 

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -1,29 +1,47 @@
 #include <Interpreters/inplaceBlockConversions.h>
 
+#include <utility>
+
 #include <Core/Block.h>
-#include <Interpreters/TreeRewriter.h>
-#include <Interpreters/ExpressionAnalyzer.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/TreeRewriter.h>
 #include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTWithAlias.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTFunction.h>
-#include <utility>
-#include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/ObjectUtils.h>
-#include <Interpreters/RequiredSourceColumnsVisitor.h>
-#include <Common/checkStackSize.h>
-#include <Storages/ColumnsDescription.h>
-#include <DataTypes/NestedUtils.h>
+#include <Parsers/ASTWithAlias.h>
+
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/NestedUtils.h>
+#include <DataTypes/ObjectUtils.h>
+#include <Interpreters/RequiredSourceColumnsVisitor.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/StorageInMemoryMetadata.h>
+#include <Storages/StorageDummy.h>
+#include <Common/checkStackSize.h>
+
+#include <Planner/CollectTableExpressionData.h>
+#include <Planner/Utils.h>
+#include <Planner/CollectSets.h>
+#include <Planner/PlannerActionsVisitor.h>
+#include <Analyzer/QueryTreeBuilder.h>
+#include <Analyzer/Resolve/QueryAnalyzer.h>
+#include <Analyzer/TableNode.h>
 
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsBool allow_experimental_analyzer;
+}
 
 namespace ErrorCode
 {
@@ -32,7 +50,6 @@ namespace ErrorCode
 
 namespace
 {
-
 /// Add all required expressions for missing columns calculation
 void addDefaultRequiredExpressionsRecursively(
     const Block & block,
@@ -173,6 +190,53 @@ std::optional<ActionsDAG> createExpressions(
     return ActionsDAG::merge(std::move(dag), std::move(actions));
 }
 
+std::optional<ActionsDAG> createExpressionsAnalyzer(
+    const Block & header,
+    ASTPtr expr_list,
+    bool save_unneeded_columns,
+    ContextPtr context)
+{
+    if (!expr_list)
+        return {};
+
+    auto execution_context = Context::createCopy(context);
+    auto expression = buildQueryTree(expr_list, execution_context);
+
+    ColumnsDescription fake_column_descriptions(header.getNamesAndTypesList());
+    auto storage = std::make_shared<StorageDummy>(StorageID{"dummy", "dummy"}, fake_column_descriptions);
+    QueryTreeNodePtr fake_table_expression = std::make_shared<TableNode>(storage, execution_context);
+
+    QueryAnalyzer analyzer(false);
+    analyzer.resolve(expression, fake_table_expression, execution_context);
+
+    GlobalPlannerContextPtr global_planner_context = std::make_shared<GlobalPlannerContext>(nullptr, nullptr, FiltersForTableExpressionMap{});
+    auto planner_context = std::make_shared<PlannerContext>(execution_context, global_planner_context, SelectQueryOptions{});
+
+    collectSourceColumns(expression, planner_context, true /*keep_alias_columns*/);
+    collectSets(expression, *planner_context);
+
+    auto actions = buildActionsDAGFromExpressionNode(expression, header.getColumnsWithTypeAndName(), planner_context, {}).first;
+    chassert(expression->getChildren().size() == actions.getOutputs().size());
+
+    NamesWithAliases result_columns;
+    for (size_t i = 0; i < expression->getChildren().size(); ++i)
+        result_columns.emplace_back(actions.getOutputs()[i]->result_name, expr_list->children[i]->getAliasOrColumnName());
+
+    if (!save_unneeded_columns)
+        actions.addAliases(result_columns);
+    else
+        actions.project(result_columns);
+
+    // Output columns without expression as-is
+    NameSet outputs;
+    for (const auto & output : actions.getOutputs())
+        outputs.insert(output->result_name);
+    for (const auto & input : actions.getInputs())
+        if (!outputs.contains(input->result_name))
+            actions.getOutputs().push_back(input);
+
+    return actions;
+}
 }
 
 void performRequiredConversions(Block & block, const NamesAndTypesList & required_columns, ContextPtr context)
@@ -181,7 +245,13 @@ void performRequiredConversions(Block & block, const NamesAndTypesList & require
     if (conversion_expr_list->children.empty())
         return;
 
-    if (auto dag = createExpressions(block, conversion_expr_list, true, context))
+    std::optional<ActionsDAG> dag;
+    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        dag = createExpressionsAnalyzer(block, conversion_expr_list, true, context);
+    else
+        dag = createExpressions(block, conversion_expr_list, true, context);
+
+    if (dag)
     {
         auto expression = std::make_shared<ExpressionActions>(std::move(*dag), ExpressionActionsSettings(context));
         expression->execute(block);
@@ -210,6 +280,8 @@ std::optional<ActionsDAG> evaluateMissingDefaults(
         return {};
 
     ASTPtr expr_list = defaultRequiredExpressions(header, required_columns, columns, null_as_default);
+    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        return createExpressionsAnalyzer(header, expr_list, save_unneeded_columns, context);
     return createExpressions(header, expr_list, save_unneeded_columns, context);
 }
 

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -202,7 +202,10 @@ std::optional<ActionsDAG> createExpressionsAnalyzer(
     auto execution_context = Context::createCopy(context);
     auto expression = buildQueryTree(expr_list, execution_context);
 
-    ColumnsDescription fake_column_descriptions(header.getNamesAndTypesList());
+    ColumnsDescription fake_column_descriptions{};
+    // Add columns from index to ensure names are unique in case of duplicated columns.
+    for (const auto & column : header.getIndexByName())
+        fake_column_descriptions.add(ColumnDescription(column.first, header.getByPosition(column.second).type));
     auto storage = std::make_shared<StorageDummy>(StorageID{"dummy", "dummy"}, fake_column_descriptions);
     QueryTreeNodePtr fake_table_expression = std::make_shared<TableNode>(storage, execution_context);
 

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -206,6 +206,7 @@ void IMergeTreeReader::evaluateMissingDefaults(Block additional_columns, Columns
         /// Default/materialized expression can contain experimental/suspicious types that can be disabled in current context.
         /// We should not perform any checks during reading from an existing table.
         enableAllExperimentalSettings(context_copy);
+        context_copy->setSetting("enable_analyzer", settings.enable_analyzer);
         auto dag = DB::evaluateMissingDefaults(
             additional_columns, full_requested_columns,
             storage_snapshot->metadata->getColumns(),

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -112,6 +112,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::create(const ContextPtr & conte
         .merge_tree_min_bytes_for_seek = settings[Setting::merge_tree_min_bytes_for_seek],
         .merge_tree_min_rows_for_seek = settings[Setting::merge_tree_min_rows_for_seek],
         .filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit],
+        .enable_analyzer = settings[Setting::allow_experimental_analyzer],
     };
 }
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -65,6 +65,7 @@ struct MergeTreeReaderSettings
     UInt64 merge_tree_min_bytes_for_seek = 0;
     UInt64 merge_tree_min_rows_for_seek = 0;
     size_t filesystem_prefetches_limit = 0;
+    bool enable_analyzer = false;
 
     /// Note storage_settings used only in private, do not remove
     static MergeTreeReaderSettings create(const ContextPtr & context, const MergeTreeSettings & storage_settings, const SelectQueryInfo & query_info);

--- a/src/Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.cpp
+++ b/src/Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.cpp
@@ -262,7 +262,7 @@ bool tryBuildPrewhereSteps(
         const auto & condition_group = condition_groups[step_index];
         ActionsDAGPtr step_dag = std::make_unique<ActionsDAG>();
         const ActionsDAG::Node * original_node = nullptr;
-         const ActionsDAG::Node * result_node;
+        const ActionsDAG::Node * result_node;
 
         std::vector<const ActionsDAG::Node *> new_condition_nodes;
         for (const auto * node : condition_group)
@@ -299,7 +299,10 @@ bool tryBuildPrewhereSteps(
         if (node_remap.contains(output))
         {
             const auto & new_node_info = node_remap[output];
-            new_node_info.dag->getOutputs().push_back(new_node_info.node);
+            auto & new_outputs = new_node_info.dag->getOutputs();
+            // If not `remove_prewhere_column` then column present in all_outputs, but it's already in the outputs
+            if (std::ranges::find(new_outputs, new_node_info.node) == new_outputs.end())
+                new_outputs.push_back(new_node_info.node);
         }
         else if (output->result_name == prewhere_info->prewhere_column_name)
         {

--- a/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.reference
+++ b/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.reference
@@ -3,5 +3,5 @@
 1
 1
 1	[]	[]	[]	0
-CREATE TABLE default.defaults_on_defaults\n(\n    `key` UInt64,\n    `Arr.C1` Array(UInt32) DEFAULT emptyArrayUInt32(),\n    `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C1)),\n    `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(Arr.C2)),\n    `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C3)),\n    `ArrLen` UInt64 DEFAULT length(Arr.C4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.defaults_on_defaults\n(\n    `key` UInt64,\n    `Arr.C1` Array(UInt32) DEFAULT emptyArrayUInt32(),\n    `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C1`)),\n    `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(`Arr.C2`)),\n    `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C3`)),\n    `ArrLen` UInt64 DEFAULT length(`Arr.C4`)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 1

--- a/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.sql
+++ b/tests/queries/0_stateless/01513_defaults_on_defaults_no_column.sql
@@ -9,19 +9,19 @@ INSERT INTO defaults_on_defaults values (1);
 
 ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C1` Array(UInt32) DEFAULT emptyArrayUInt32();
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C1));
+ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C2` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C1`));
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(Arr.C2));
+ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C3` Array(UInt32) ALIAS arrayResize(emptyArrayUInt32(), length(`Arr.C2`));
 
 SELECT 1 from defaults_on_defaults where length(`Arr.C2`) = 0;
 
 SELECT 1 from defaults_on_defaults where length(`Arr.C3`) = 0;
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(Arr.C3));
+ALTER TABLE defaults_on_defaults ADD COLUMN `Arr.C4` Array(UInt32) DEFAULT arrayResize(emptyArrayUInt32(), length(`Arr.C3`));
 
 SELECT 1 from defaults_on_defaults where length(`Arr.C4`) = 0;
 
-ALTER TABLE defaults_on_defaults ADD COLUMN `ArrLen` UInt64 DEFAULT length(Arr.C4);
+ALTER TABLE defaults_on_defaults ADD COLUMN `ArrLen` UInt64 DEFAULT length(`Arr.C4`);
 
 SELECT 1 from defaults_on_defaults where ArrLen = 0;
 

--- a/tests/queries/0_stateless/03560_new_analyzer_default_expression.reference
+++ b/tests/queries/0_stateless/03560_new_analyzer_default_expression.reference
@@ -1,0 +1,13 @@
+-- { echoOn }
+SELECT * FROM default ORDER BY ALL;
+1
+SELECT * FROM clashing_name ORDER BY ALL;
+7
+SELECT * FROM dependent_defaults ORDER BY ALL;
+7	14	98
+SELECT * FROM regular_column ORDER BY ALL;
+2	7	14
+SELECT * FROM complex_name_backward_compat ORDER BY ALL;
+3	7	21
+SELECT * FROM compound_id ORDER BY ALL;
+(1,2)	8

--- a/tests/queries/0_stateless/03560_new_analyzer_default_expression.sql
+++ b/tests/queries/0_stateless/03560_new_analyzer_default_expression.sql
@@ -1,0 +1,26 @@
+SET enable_analyzer=1;
+
+CREATE TABLE default (a Int64 DEFAULT 1) Engine=Memory();
+-- This case is failing with old analyzer, because "_subquery" name prefix has a special treatment.
+CREATE TABLE clashing_name (_subquery_test Int64 DEFAULT 7) Engine=Memory();
+CREATE TABLE dependent_defaults (a Int64 DEFAULT 7, b Int64 DEFAULT a + 7, c Int64 DEFAULT a * b) Engine=Memory();
+CREATE TABLE regular_column (a Int64, b Int64 DEFAULT 7, c Int64 DEFAULT a * b) Engine=Memory();
+CREATE TABLE complex_name_backward_compat (a Int64, `b.b` Int64 DEFAULT 7, c Int64 DEFAULT a * `b.b`) Engine=Memory();
+CREATE TABLE compound_id (a Tuple(x Int64, y Int64), b Int64 DEFAULT a.x + 7) Engine=Memory();
+
+SET insert_null_as_default=1;
+
+INSERT INTO default SELECT NULL FROM system.one;
+INSERT INTO clashing_name SELECT NULL FROM system.one;
+INSERT INTO dependent_defaults SELECT NULL, NULL, NULL FROM system.one;
+INSERT INTO regular_column SELECT 2, NULL, NULL FROM system.one;
+INSERT INTO complex_name_backward_compat SELECT 3, NULL, NULL FROM system.one;
+INSERT INTO compound_id (a) VALUES ((1, 2));
+
+-- { echoOn }
+SELECT * FROM default ORDER BY ALL;
+SELECT * FROM clashing_name ORDER BY ALL;
+SELECT * FROM dependent_defaults ORDER BY ALL;
+SELECT * FROM regular_column ORDER BY ALL;
+SELECT * FROM complex_name_backward_compat ORDER BY ALL;
+SELECT * FROM compound_id ORDER BY ALL;


### PR DESCRIPTION
Query failed after an attempt to create `ColumnsDescription` from the block with a duplicated column.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
