### PR TITLE
Text index: add Array and Map support

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -249,7 +249,7 @@ SELECT count() FROM tab WHERE has(array, 'clickhouse');
 
 #### `mapContains` {#functions-example-mapcontains}
 
-Function [mapContains](/sql-reference/functions/tuple-map-functions#mapcontains)(alias: `mapContainsKey`) matches against a single token in the keys of a map.
+Function [mapContains](/sql-reference/functions/tuple-map-functions#mapcontains)(alias of: `mapContainsKey`) matches against a single token in the keys of a map.
 
 Example:
 
@@ -272,8 +272,8 @@ CREATE TABLE posts (
     content String,
     keywords Array(String) COMMENT 'Author-defined keywords'
 )
-ENGINE = MergeTree;
-ORDER BY (id)
+ENGINE = MergeTree
+ORDER BY (post_id);
 ```
 
 Without a text index, finding posts with a specific keyword (e.g. `clickhouse`) requires scanning all entries:

--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -29,7 +29,7 @@ To create a text index, first enable the corresponding experimental setting:
 SET allow_experimental_full_text_index = true;
 ```
 
-A text index can be defined on a [String](/sql-reference/data-types/string.md) and [FixedString](/sql-reference/data-types/fixedstring.md) column using the following syntax:
+A text index can be defined on a [String](/sql-reference/data-types/string.md), [FixedString](/sql-reference/data-types/fixedstring.md), [Array(String)](/sql-reference/data-types/array.md), and [Array(FixedString)](/sql-reference/data-types/array.md) column using the following syntax:
 
 ```sql
 CREATE TABLE tab
@@ -239,7 +239,7 @@ SELECT count() FROM tab WHERE searchAll(comment, ['clickhouse', 'olap']);
 
 #### `has` {#functions-example-has}
 
-Function [has](/sql-reference/functions/array-functions#has) matches against a single token in the array of strings.
+Array function [has](/sql-reference/functions/array-functions#has) matches against a single token in the array of strings.
 
 Example:
 
@@ -249,7 +249,7 @@ SELECT count() FROM tab WHERE has(array, 'clickhouse');
 
 #### `mapContains` {#functions-example-mapcontains}
 
-Function [mapContains](/sql-reference/functions/tuple-map-functions#mapcontains)(alias: `mapContainsKey`) matches against a single token in the keys of map.
+Function [mapContains](/sql-reference/functions/tuple-map-functions#mapcontains)(alias: `mapContainsKey`) matches against a single token in the keys of a map.
 
 Example:
 

--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -29,7 +29,7 @@ To create a text index, first enable the corresponding experimental setting:
 SET allow_experimental_full_text_index = true;
 ```
 
-A text index can be defined on a [String](/sql-reference/data-types/string.md), [FixedString](/sql-reference/data-types/fixedstring.md), [Array(String)](/sql-reference/data-types/array.md), and [Array(FixedString)](/sql-reference/data-types/array.md) column using the following syntax:
+A text index can be defined on a [String](/sql-reference/data-types/string.md), [FixedString](/sql-reference/data-types/fixedstring.md), [Array(String)](/sql-reference/data-types/array.md), [Array(FixedString)](/sql-reference/data-types/array.md), and [Map](/sql-reference/data-types/map.md) (via [mapKeys](/sql-reference/functions/tuple-map-functions.md/#mapkeys) and [mapValues](/sql-reference/functions/tuple-map-functions.md/#mapvalues) map functions) column using the following syntax:
 
 ```sql
 CREATE TABLE tab
@@ -255,7 +255,22 @@ Example:
 
 ```sql
 SELECT count() FROM tab WHERE mapContainsKey(map, 'clickhouse');
+-- OR
+SELECT count() FROM tab WHERE mapContains(map, 'clickhouse');
 ```
+
+#### `operator[]` {#functions-example-access-operator}
+
+Access [operator[]](/sql-reference/operators#access-operators) can be used with the text index to filter out keys and values.
+
+Example:
+
+```sql
+SELECT count() FROM tab WHERE map['engine'] = 'clickhouse'; -- will use the text index if defined
+```
+
+See the following examples for the usage of `Array(T)` and `Map(K, V)` with the text index.
+
 ### Examples for the text index `Array` and `Map` support.
 
 #### Indexing Array(String)

--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -271,9 +271,9 @@ SELECT count() FROM tab WHERE map['engine'] = 'clickhouse'; -- will use the text
 
 See the following examples for the usage of `Array(T)` and `Map(K, V)` with the text index.
 
-### Examples for the text index `Array` and `Map` support.
+### Examples for the text index `Array` and `Map` support. {#text-index-array-and-map-examples}
 
-#### Indexing Array(String)
+#### Indexing Array(String) {#text-indexi-example-array}
 
 In a simple blogging platform, authors assign keywords to their posts to categorize content.
 A common feature allows users to discover related content by clicking on keywords or searching for topics.
@@ -313,7 +313,7 @@ ALTER TABLE posts MATERIALIZE INDEX keywords_idx;
 ```
 :::
 
-#### Indexing Map
+#### Indexing Map {#text-index-example-map}
 
 In a logging system, server requests often store metadata in key-value pairs. Operations teams need to efficiently search through logs for debugging, security incidents, and monitoring.
 

--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -237,6 +237,26 @@ SELECT count() FROM tab WHERE searchAny(comment, ['clickhouse', 'olap']);
 SELECT count() FROM tab WHERE searchAll(comment, ['clickhouse', 'olap']);
 ```
 
+#### `has` {#functions-example-has}
+
+Function [has](/sql-reference/functions/array-functions#has) matches against a single token in the array of strings.
+
+Example:
+
+```sql
+SELECT count() FROM tab WHERE has(array, 'clickhouse');
+```
+
+#### `mapContains` {#functions-example-mapcontains}
+
+Function [mapContains](/sql-reference/functions/tuple-map-functions#mapcontains)(alias: `mapContainsKey`) matches against a single token in the keys of map.
+
+Example:
+
+```sql
+SELECT count() FROM tab WHERE mapContainsKey(map, 'clickhouse');
+```
+
 ## Implementation {#implementation}
 
 ### Index layout {#index-layout}

--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -510,7 +510,7 @@ Indexes of type `set` can be utilized by all functions. The other index types ar
 | [greaterOrEquals (`>=`)](/sql-reference/functions/comparison-functions.md/#greaterOrEquals)                                    | ✔           | ✔      | ✗          | ✗          | ✗            | ✗    |
 | [empty](/sql-reference/functions/array-functions/#empty)                                                                       | ✔           | ✔      | ✗          | ✗          | ✗            | ✗    |
 | [notEmpty](/sql-reference/functions/array-functions/#notEmpty)                                                                 | ✔           | ✔      | ✗          | ✗          | ✗            | ✗    |
-| [has](/sql-reference/functions/array-functions#has)                                                                            | ✗           | ✗      | ✔          | ✔          | ✔            | ✗    |
+| [has](/sql-reference/functions/array-functions#has)                                                                            | ✗           | ✗      | ✔          | ✔          | ✔            | ✔    |
 | [hasAny](/sql-reference/functions/array-functions#hasAny)                                                                      | ✗           | ✗      | ✔          | ✔          | ✔            | ✗    |
 | [hasAll](/sql-reference/functions/array-functions#hasAll)                                                                      | ✗           | ✗      | ✔          | ✔          | ✔            | ✗    |
 | [hasToken](/sql-reference/functions/string-search-functions.md/#hastoken)                                                      | ✗           | ✗      | ✗          | ✔          | ✗            | ✔    |
@@ -519,6 +519,7 @@ Indexes of type `set` can be utilized by all functions. The other index types ar
 | [hasTokenCaseInsensitiveOrNull (`*`)](/sql-reference/functions/string-search-functions.md/#hastokencaseinsensitiveornull)      | ✗           | ✗      | ✗          | ✔          | ✗            | ✗    |
 | [searchAny](/sql-reference/functions/string-search-functions.md/#searchany)                                                    | ✗           | ✗      | ✗          | ✗          | ✗            | ✔    |
 | [searchAll](/sql-reference/functions/string-search-functions.md/#searchall)                                                    | ✗           | ✗      | ✗          | ✗          | ✗            | ✔    |
+| [mapContains](/sql-reference/functions/tuple-map-functions#mapcontains)                                                        | ✗           | ✗      | ✗          | ✗          | ✗            | ✔    |
 
 Functions with a constant argument that is less than ngram size can't be used by `ngrambf_v1` for query optimization.
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -102,6 +102,8 @@ bool MergeTreeIndexConditionText::isSupportedFunction(const String & function_na
     return isSupportedFunctionForDirectRead(function_name)
         || function_name == "equals"
         || function_name == "notEquals"
+        || function_name == "mapContainsKey"
+        || function_name == "has"
         || function_name == "like"
         || function_name == "notLike"
         || function_name == "hasTokenOrNull"
@@ -154,12 +156,13 @@ bool MergeTreeIndexConditionText::alwaysUnknownOrTrue() const
     return rpnEvaluatesAlwaysUnknownOrTrue(
         rpn,
         {RPNElement::FUNCTION_EQUALS,
-            RPNElement::FUNCTION_NOT_EQUALS,
-            RPNElement::FUNCTION_SEARCH_ANY,
-            RPNElement::FUNCTION_SEARCH_ALL,
-            RPNElement::FUNCTION_IN,
-            RPNElement::FUNCTION_NOT_IN,
-            RPNElement::FUNCTION_MATCH});
+         RPNElement::FUNCTION_NOT_EQUALS,
+         RPNElement::FUNCTION_HAS,
+         RPNElement::FUNCTION_SEARCH_ANY,
+         RPNElement::FUNCTION_SEARCH_ALL,
+         RPNElement::FUNCTION_IN,
+         RPNElement::FUNCTION_NOT_IN,
+         RPNElement::FUNCTION_MATCH});
 }
 
 bool MergeTreeIndexConditionText::mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx_granule) const
@@ -185,7 +188,8 @@ bool MergeTreeIndexConditionText::mayBeTrueOnGranule(MergeTreeIndexGranulePtr id
         }
         else if (element.function == RPNElement::FUNCTION_SEARCH_ALL
             || element.function == RPNElement::FUNCTION_EQUALS
-            || element.function == RPNElement::FUNCTION_NOT_EQUALS)
+            || element.function == RPNElement::FUNCTION_NOT_EQUALS
+            || element.function == RPNElement::FUNCTION_HAS)
         {
             chassert(element.text_search_queries.size() == 1);
             const auto & text_search_query = element.text_search_queries.front();
@@ -354,16 +358,64 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     RPNElement & out) const
 {
     bool index_column_exists = header.has(index_column_node.getColumnName());
-    if (!index_column_exists)
+    bool index_column_map_keys_exists = header.has(fmt::format("mapKeys({})", index_column_node.getColumnName()));
+
+    Field const_value = value_field;
+    if (index_column_node.isFunction())
+    {
+        const auto function = index_column_node.toFunctionNode();
+        if (function.getFunctionName() == "arrayElement")
+        {
+            const auto map_column_name = function.getArgumentAt(0).getColumnName();
+            bool has_maps_keys_index_column_name = header.has(fmt::format("mapKeys({})", map_column_name));
+            bool has_map_values_index_column_name = header.has(fmt::format("mapValues({})", map_column_name));
+            index_column_exists = has_maps_keys_index_column_name || has_map_values_index_column_name;
+            if (has_maps_keys_index_column_name)
+            {
+                const auto & argument_const_key = function.getArgumentAt(1);
+                DataTypePtr key_const_type;
+                if (argument_const_key.tryGetConstant(const_value, key_const_type))
+                {
+                    auto const_data_type = WhichDataType(key_const_type);
+                    if (!const_data_type.isStringOrFixedString())
+                        return false;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    if (!index_column_exists && !index_column_map_keys_exists)
         return false;
 
     auto value_data_type = WhichDataType(value_type);
     if (!value_data_type.isStringOrFixedString() && !value_data_type.isArray())
         return false;
 
-    const Field & const_value = value_field;
     const String & function_name = function_node.getFunctionName();
 
+    if (function_name == "mapContainsKey")
+    {
+        /// mapContainsKey can be used only with an index defined as `mapKeys(Map(String, ...))`
+        if (!index_column_map_keys_exists || !value_data_type.isStringOrFixedString())
+            return false;
+        auto tokens = stringToTokens(const_value, *token_extractor);
+        out.function = RPNElement::FUNCTION_HAS;
+        out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, std::move(tokens)));
+        return true;
+    }
+    if (function_name == "has")
+    {
+        if (!index_column_map_keys_exists || !value_data_type.isStringOrFixedString())
+            return false;
+        auto tokens = stringToTokens(const_value, *token_extractor);
+        out.function = RPNElement::FUNCTION_HAS;
+        out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, std::move(tokens)));
+        return true;
+    }
     if (function_name == "notEquals")
     {
         auto tokens = stringToTokens(const_value, *token_extractor);

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -409,8 +409,6 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     }
     if (function_name == "has")
     {
-        if (!index_column_map_keys_exists || !value_data_type.isStringOrFixedString())
-            return false;
         auto tokens = stringToTokens(const_value, *token_extractor);
         out.function = RPNElement::FUNCTION_HAS;
         out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, std::move(tokens)));

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -352,7 +352,7 @@ std::vector<String> substringToTokens(const Field & field, const ITokenExtractor
     return tokens;
 }
 
-bool traverArrayFunctionNode(const RPNBuilderTreeNode & index_column_node, const Block & header, Field & const_value)
+bool traverseArrayFunctionNode(const RPNBuilderTreeNode & index_column_node, const Block & header, Field & const_value)
 {
     const auto function = index_column_node.toFunctionNode();
     if (function.getFunctionName() == "arrayElement")
@@ -391,7 +391,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
 
     Field const_value = value_field;
     if (index_column_node.isFunction())
-        index_column_exists = index_column_exists || traverArrayFunctionNode(index_column_node, header, const_value);
+        index_column_exists = index_column_exists || traverseArrayFunctionNode(index_column_node, header, const_value);
 
     if (!index_column_exists && !index_column_map_keys_exists)
         return false;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -136,7 +136,7 @@ std::optional<String> MergeTreeIndexConditionText::replaceToVirtualColumn(const 
         return std::nullopt;
 
     size_t counter = function_name_to_index[query.function_name]++;
-    String virtual_column_name = fmt::format("{}{}_{}_{}", TEXT_INDEX_VIRTUAL_COLUMN_PREFIX, index_name, query.function_name, counter);
+    String virtual_column_name = std::format("{}{}_{}_{}", TEXT_INDEX_VIRTUAL_COLUMN_PREFIX, index_name, query.function_name, counter);
 
     virtual_column_to_search_query[virtual_column_name] = it->second;
     return virtual_column_name;
@@ -358,8 +358,8 @@ bool traverseArrayFunctionNode(const RPNBuilderTreeNode & index_column_node, con
     if (function.getFunctionName() == "arrayElement")
     {
         const auto map_column_name = function.getArgumentAt(0).getColumnName();
-        bool has_maps_keys_index_column_name = header.has(fmt::format("mapKeys({})", map_column_name));
-        bool has_map_values_index_column_name = header.has(fmt::format("mapValues({})", map_column_name));
+        bool has_maps_keys_index_column_name = header.has(std::format("mapKeys({})", map_column_name));
+        bool has_map_values_index_column_name = header.has(std::format("mapValues({})", map_column_name));
         if (has_maps_keys_index_column_name)
         {
             const auto & argument_const_key = function.getArgumentAt(1);
@@ -387,7 +387,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     RPNElement & out) const
 {
     bool index_column_exists = header.has(index_column_node.getColumnName());
-    bool index_column_map_keys_exists = header.has(fmt::format("mapKeys({})", index_column_node.getColumnName()));
+    bool index_column_map_keys_exists = header.has(std::format("mapKeys({})", index_column_node.getColumnName()));
 
     Field const_value = value_field;
     if (index_column_node.isFunction())

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -73,6 +73,7 @@ private:
             /// Atoms
             FUNCTION_EQUALS,
             FUNCTION_NOT_EQUALS,
+            FUNCTION_HAS,
             FUNCTION_IN,
             FUNCTION_NOT_IN,
             FUNCTION_MATCH,

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -695,7 +695,7 @@ MergeTreeIndexTextGranuleBuilder::MergeTreeIndexTextGranuleBuilder(MergeTreeInde
 {
 }
 
-void MergeTreeIndexTextGranuleBuilder::addDocument(StringRef document)
+void MergeTreeIndexTextGranuleBuilder::addDocument(StringRef document, bool update_current_row)
 {
     size_t cur = 0;
     size_t token_start = 0;
@@ -721,7 +721,8 @@ void MergeTreeIndexTextGranuleBuilder::addDocument(StringRef document)
         posting_list->addBulk(bulk_context, current_row);
     }
 
-    ++current_row;
+    if (update_current_row)
+        ++current_row;
 }
 
 std::unique_ptr<MergeTreeIndexGranuleTextWritable> MergeTreeIndexTextGranuleBuilder::build()
@@ -791,10 +792,29 @@ void MergeTreeIndexAggregatorText::update(const Block & block, size_t * pos, siz
     size_t current_position = *pos;
     const auto & index_column = block.getByName(index_column_name).column;
 
-    for (size_t i = 0; i < rows_read; ++i)
+    if (isArray(index_column->getDataType()))
     {
-        auto ref = index_column->getDataAt(current_position + i);
-        granule_builder.addDocument(ref);
+        const auto & column_array = assert_cast<const ColumnArray &>(*index_column);
+        const auto & column_data = column_array.getData();
+        const auto & column_offsets = column_array.getOffsets();
+        for (size_t i = 0; i < rows_read; ++i)
+        {
+            size_t element_start_row = column_offsets[current_position + i - 1];
+            size_t elements_size = column_offsets[current_position + i] - element_start_row;
+            for (size_t element_idx = 0; element_idx < elements_size; ++element_idx)
+            {
+                auto ref = column_data.getDataAt(element_start_row + element_idx);
+                granule_builder.addDocument(ref, (element_idx == (elements_size - 1)) /* update current row number on the last element */);
+            }
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < rows_read; ++i)
+        {
+            auto ref = index_column->getDataAt(current_position + i);
+            granule_builder.addDocument(ref);
+        }
     }
 
     *pos += rows_read;
@@ -1035,7 +1055,12 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
         throw Exception(ErrorCodes::INCORRECT_NUMBER_OF_COLUMNS, "Text index must be created on a single column");
 
     WhichDataType data_type(index.data_types[0]);
-    if (data_type.isLowCardinality())
+    if (data_type.isArray())
+    {
+        const auto & array_type = assert_cast<const DataTypeArray &>(*index.data_types[0]);
+        data_type = WhichDataType(array_type.getNestedType());
+    }
+    else if (data_type.isLowCardinality())
     {
         /// TODO Consider removing support for LowCardinality. The index exists for high-cardinality cases.
         const auto & low_cardinality = assert_cast<const DataTypeLowCardinality &>(*index.data_types[0]);
@@ -1046,7 +1071,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     {
         throw Exception(
             ErrorCodes::INCORRECT_QUERY,
-            "Text index must be created on columns of type `String`, `FixedString`, `LowCardinality(String)`, `LowCardinality(FixedString)`");
+            "Text index must be created on columns of type `String`, `FixedString`, `LowCardinality(String)`, `LowCardinality(FixedString)`, `Array(String)` or `Array(FixedString)`");
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -240,7 +240,7 @@ struct MergeTreeIndexTextGranuleBuilder
     MergeTreeIndexTextGranuleBuilder(MergeTreeIndexTextParams params_, TokenExtractorPtr token_extractor_);
 
     /// Extracts tokens from the document and adds them to the granule.
-    void addDocument(StringRef document, bool update_current_row = true);
+    void addDocument(StringRef document, bool increment_current_row = true);
     std::unique_ptr<MergeTreeIndexGranuleTextWritable> build();
     bool empty() const { return current_row == 0; }
     void reset();

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -240,7 +240,7 @@ struct MergeTreeIndexTextGranuleBuilder
     MergeTreeIndexTextGranuleBuilder(MergeTreeIndexTextParams params_, TokenExtractorPtr token_extractor_);
 
     /// Extracts tokens from the document and adds them to the granule.
-    void addDocument(StringRef document);
+    void addDocument(StringRef document, bool update_current_row = true);
     std::unique_ptr<MergeTreeIndexGranuleTextWritable> build();
     bool empty() const { return current_row == 0; }
     void reset();

--- a/tests/queries/0_stateless/02346_text_index_array_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_array_support.reference
@@ -1,51 +1,51 @@
 has support
 -- with String
-3
-3
-2
+3072
+3072
+2048
 -- with FixedString
-3
-3
-2
+3072
+3072
+2048
 -- index analyzer with String
-value exists only in 1 granule
+value exists only in 1024 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 1/6
-value exists only in 2 granules
+Parts: 1/6
+Granules: 1024/6144
+value exists only in 2048 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 2/6
-value exists only in 3 granules
+Parts: 2/6
+Granules: 2048/6144
+value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 3/6
-value exists only in 3 granules
+Parts: 3/6
+Granules: 3072/6144
+value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 3/6
+Parts: 3/6
+Granules: 3072/6144
 value does not exist in granules
 Description: text GRANULARITY 1
-Parts: 0/1
-Granules: 0/6
+Parts: 0/6
+Granules: 0/6144
 -- index analyzer with FixedString
-value exists only in 1 granule
+value exists only in 1024 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 1/6
-value exists only in 2 granules
+Parts: 1/6
+Granules: 1024/6144
+value exists only in 2048 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 2/6
-value exists only in 3 granules
+Parts: 2/6
+Granules: 2048/6144
+value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 3/6
-value exists only in 3 granules
+Parts: 3/6
+Granules: 3072/6144
+value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 1/1
-Granules: 3/6
+Parts: 3/6
+Granules: 3072/6144
 value does not exist in granules
 Description: text GRANULARITY 1
-Parts: 0/1
-Granules: 0/6
+Parts: 0/6
+Granules: 0/6144

--- a/tests/queries/0_stateless/02346_text_index_array_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_array_support.reference
@@ -1,0 +1,51 @@
+has support
+-- with String
+3
+3
+2
+-- with FixedString
+3
+3
+2
+-- index analyzer with String
+value exists only in 1 granule
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 1/6
+value exists only in 2 granules
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 2/6
+value exists only in 3 granules
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 3/6
+value exists only in 3 granules
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 3/6
+value does not exist in granules
+Description: text GRANULARITY 1
+Parts: 0/1
+Granules: 0/6
+-- index analyzer with FixedString
+value exists only in 1 granule
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 1/6
+value exists only in 2 granules
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 2/6
+value exists only in 3 granules
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 3/6
+value exists only in 3 granules
+Description: text GRANULARITY 1
+Parts: 1/1
+Granules: 3/6
+value does not exist in granules
+Description: text GRANULARITY 1
+Parts: 0/1
+Granules: 0/6

--- a/tests/queries/0_stateless/02346_text_index_array_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_array_support.reference
@@ -3,49 +3,51 @@ has support
 3072
 3072
 2048
+0
 -- with FixedString
 3072
 3072
 2048
--- index analyzer with String
-value exists only in 1024 granules
+0
+-- Check that the text index actually gets used (String)
+-- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
 Parts: 1/6
 Granules: 1024/6144
-value exists only in 2048 granules
+-- -- value exists only in 2048 granules
 Description: text GRANULARITY 1
 Parts: 2/6
 Granules: 2048/6144
-value exists only in 3072 granules
+-- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
 Parts: 3/6
 Granules: 3072/6144
-value exists only in 3072 granules
+-- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
 Parts: 3/6
 Granules: 3072/6144
-value does not exist in granules
+-- -- value does not exist in granules
 Description: text GRANULARITY 1
 Parts: 0/6
 Granules: 0/6144
--- index analyzer with FixedString
-value exists only in 1024 granules
+-- Check that the text index actually gets used (FixedString)
+-- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
 Parts: 1/6
 Granules: 1024/6144
-value exists only in 2048 granules
+-- -- value exists only in 2048 granules
 Description: text GRANULARITY 1
 Parts: 2/6
 Granules: 2048/6144
-value exists only in 3072 granules
+-- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
 Parts: 3/6
 Granules: 3072/6144
-value exists only in 3072 granules
+-- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
 Parts: 3/6
 Granules: 3072/6144
-value does not exist in granules
+-- -- value does not exist in granules
 Description: text GRANULARITY 1
 Parts: 0/6
 Granules: 0/6144

--- a/tests/queries/0_stateless/02346_text_index_array_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_array_support.reference
@@ -12,42 +12,32 @@ has support
 -- Check that the text index actually gets used (String)
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Parts: 1/6
 Granules: 1024/6144
 -- -- value exists only in 2048 granules
 Description: text GRANULARITY 1
-Parts: 2/6
 Granules: 2048/6144
 -- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 3/6
 Granules: 3072/6144
 -- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 3/6
 Granules: 3072/6144
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Parts: 0/6
 Granules: 0/6144
 -- Check that the text index actually gets used (FixedString)
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Parts: 1/6
 Granules: 1024/6144
 -- -- value exists only in 2048 granules
 Description: text GRANULARITY 1
-Parts: 2/6
 Granules: 2048/6144
 -- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 3/6
 Granules: 3072/6144
 -- -- value exists only in 3072 granules
 Description: text GRANULARITY 1
-Parts: 3/6
 Granules: 3072/6144
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Parts: 0/6
 Granules: 0/6144

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -53,8 +53,8 @@ CREATE VIEW explain_index_has AS (
             END
         )
     )
-    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-    LIMIT 2, 3
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Granules:%'
+    LIMIT 1, 2
 );
 
 SELECT '-- -- value exists only in 1024 granules';

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -40,86 +40,52 @@ SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('def', 3));
 
 SELECT '-- Check that the text index actually gets used (String)';
 
+DROP VIEW IF EXISTS explain_index_has;
+CREATE VIEW explain_index_has AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN has(arr_fixed, {filter:FixedString(3)})
+                ELSE has(arr, {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
 SELECT '-- -- value exists only in 1024 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr, 'abc')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='abc');
 
 SELECT '-- -- value exists only in 2048 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr, 'baz')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='baz');
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr, 'foo')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='foo');
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr, 'bar')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='bar');
 
 SELECT '-- -- value does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr, 'def')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='def');
 
 SELECT '-- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- value exists only in 1024 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('abc', 3))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('abc', 3));
 
 SELECT '-- -- value exists only in 2048 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('baz', 3));
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('foo', 3));
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('bar', 3));
 
 SELECT '-- -- value does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('def', 3))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('def', 3));
 
+DROP VIEW explain_index_has;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -2,6 +2,7 @@
 
 -- Tests that text indexes can be build on and used with Array columns.
 
+SET enable_analyzer = 1;
 SET allow_experimental_full_text_index = 1;
 SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
 

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -30,42 +30,49 @@ SELECT '-- with String';
 SELECT count() FROM tab WHERE has(arr, 'foo');
 SELECT count() FROM tab WHERE has(arr, 'bar');
 SELECT count() FROM tab WHERE has(arr, 'baz');
+SELECT count() FROM tab WHERE has(arr, 'def');
 
 SELECT '-- with FixedString';
 SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3));
 SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3));
 SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3));
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('def', 3));
 
-SELECT '-- index analyzer with String';
-SELECT 'value exists only in 1024 granules';
+SELECT '-- Check that the text index actually gets used (String)';
+
+SELECT '-- -- value exists only in 1024 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'abc')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 2048 granules';
+
+SELECT '-- -- value exists only in 2048 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'baz')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3072 granules';
+
+SELECT '-- -- value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'foo')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3072 granules';
+
+SELECT '-- -- value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'bar')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value does not exist in granules';
+
+SELECT '-- -- value does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'def')
@@ -73,36 +80,41 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT '-- index analyzer with FixedString';
-SELECT 'value exists only in 1024 granules';
+SELECT '-- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- value exists only in 1024 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('abc', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 2048 granules';
+
+SELECT '-- -- value exists only in 2048 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3072 granules';
+
+SELECT '-- -- value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3072 granules';
+
+SELECT '-- -- value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value does not exist in granules';
+
+SELECT '-- -- value does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('def', 3))

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel-replicas
+-- Tags: no-parallel-replicas
 
 SET allow_experimental_full_text_index = 1;
 SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
@@ -17,12 +17,12 @@ ENGINE = MergeTree()
 ORDER BY (id)
 SETTINGS index_granularity = 1;
 
-INSERT INTO tab VALUES (0, ['abc'], ['abc']);
-INSERT INTO tab VALUES (1, ['foo'], ['foo']);
-INSERT INTO tab VALUES (2, ['bar'], ['bar']);
-INSERT INTO tab VALUES (3, ['foo', 'bar'], ['foo', 'bar']);
-INSERT INTO tab VALUES (4, ['foo', 'baz'], ['foo', 'baz']);
-INSERT INTO tab VALUES (5, ['bar', 'baz'], ['bar', 'baz']);
+INSERT INTO tab SELECT number, ['abc'], ['abc'] FROM numbers(1024);
+INSERT INTO tab SELECT number, ['foo'], ['foo'] FROM numbers(1024);
+INSERT INTO tab SELECT number, ['bar'], ['bar'] FROM numbers(1024);
+INSERT INTO tab SELECT number, ['foo', 'bar'], ['foo', 'bar'] FROM numbers(1024);
+INSERT INTO tab SELECT number, ['foo', 'baz'], ['foo', 'baz'] FROM numbers(1024);
+INSERT INTO tab SELECT number, ['bar', 'baz'], ['bar', 'baz'] FROM numbers(1024);
 
 SELECT 'has support';
 
@@ -37,28 +37,28 @@ SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3));
 SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3));
 
 SELECT '-- index analyzer with String';
-SELECT 'value exists only in 1 granule';
+SELECT 'value exists only in 1024 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'abc')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 2 granules';
+SELECT 'value exists only in 2048 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'baz')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3 granules';
+SELECT 'value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'foo')
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3 granules';
+SELECT 'value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr, 'bar')
@@ -74,28 +74,28 @@ WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '
 LIMIT 2, 3;
 
 SELECT '-- index analyzer with FixedString';
-SELECT 'value exists only in 1 granule';
+SELECT 'value exists only in 1024 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('abc', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 2 granules';
+SELECT 'value exists only in 2048 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3 granules';
+SELECT 'value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3))
 )
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
-SELECT 'value exists only in 3 granules';
+SELECT 'value exists only in 3072 granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3))

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -1,5 +1,7 @@
 -- Tags: no-parallel-replicas
 
+-- Tests that text indexes can be build on and used with Array columns.
+
 SET allow_experimental_full_text_index = 1;
 SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
 
@@ -43,9 +45,9 @@ SELECT '-- Check that the text index actually gets used (String)';
 DROP VIEW IF EXISTS explain_index_has;
 CREATE VIEW explain_index_has AS (
     SELECT trimLeft(explain) AS explain FROM (
-        EXPLAIN indexes=1
+        EXPLAIN indexes = 1
         SELECT count() FROM tab WHERE (
-            CASE 
+            CASE
                 WHEN {use_idx_fixed:boolean} = 1 THEN has(arr_fixed, {filter:FixedString(3)})
                 ELSE has(arr, {filter:String})
             END
@@ -56,36 +58,36 @@ CREATE VIEW explain_index_has AS (
 );
 
 SELECT '-- -- value exists only in 1024 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='abc');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'abc');
 
 SELECT '-- -- value exists only in 2048 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='baz');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'baz');
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='foo');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'foo');
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='bar');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'bar');
 
 SELECT '-- -- value does not exist in granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='def');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'def');
 
 SELECT '-- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- value exists only in 1024 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('abc', 3));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('abc', 3));
 
 SELECT '-- -- value exists only in 2048 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('baz', 3));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('baz', 3));
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('foo', 3));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('foo', 3));
 
 SELECT '-- -- value exists only in 3072 granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('bar', 3));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('bar', 3));
 
 SELECT '-- -- value does not exist in granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('def', 3));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('def', 3));
 
 DROP VIEW explain_index_has;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -1,0 +1,113 @@
+-- Tags: no-fasttest, no-parallel-replicas
+
+SET allow_experimental_full_text_index = 1;
+SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    arr Array(String),
+    arr_fixed Array(FixedString(3)),
+    INDEX array_idx(arr) TYPE text(tokenizer = 'default') GRANULARITY 1,
+    INDEX array_fixed_idx(arr_fixed) TYPE text(tokenizer = 'default') GRANULARITY 1,
+)
+ENGINE = MergeTree()
+ORDER BY (id)
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES (0, ['abc'], ['abc']);
+INSERT INTO tab VALUES (1, ['foo'], ['foo']);
+INSERT INTO tab VALUES (2, ['bar'], ['bar']);
+INSERT INTO tab VALUES (3, ['foo', 'bar'], ['foo', 'bar']);
+INSERT INTO tab VALUES (4, ['foo', 'baz'], ['foo', 'baz']);
+INSERT INTO tab VALUES (5, ['bar', 'baz'], ['bar', 'baz']);
+
+SELECT 'has support';
+
+SELECT '-- with String';
+SELECT count() FROM tab WHERE has(arr, 'foo');
+SELECT count() FROM tab WHERE has(arr, 'bar');
+SELECT count() FROM tab WHERE has(arr, 'baz');
+
+SELECT '-- with FixedString';
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3));
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3));
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3));
+
+SELECT '-- index analyzer with String';
+SELECT 'value exists only in 1 granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr, 'abc')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value exists only in 2 granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr, 'baz')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value exists only in 3 granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr, 'foo')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value exists only in 3 granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr, 'bar')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr, 'def')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '-- index analyzer with FixedString';
+SELECT 'value exists only in 1 granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('abc', 3))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value exists only in 2 granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value exists only in 3 granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value exists only in 3 granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+SELECT 'value does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('def', 3))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -25,4 +25,4 @@ Must be created on single column.
 A column must not have >1 text index
 -- CREATE TABLE
 -- ALTER TABLE
-Must be created on String or FixedString or LowCardinality(String) or LowCardinality(FixedString) columns.
+Must be created on String or FixedString or LowCardinality(String) or LowCardinality(FixedString), Array(String) or Array(FixedString) columns.

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -25,4 +25,4 @@ Must be created on single column.
 A column must not have >1 text index
 -- CREATE TABLE
 -- ALTER TABLE
-Must be created on String or FixedString or LowCardinality(String) or LowCardinality(FixedString), Array(String) or Array(FixedString) columns.
+Must be created on String, FixedString, LowCardinality(String), LowCardinality(FixedString), Array(String) or Array(FixedString) columns.

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -26,3 +26,15 @@ A column must not have >1 text index
 -- CREATE TABLE
 -- ALTER TABLE
 Must be created on String, FixedString, LowCardinality(String), LowCardinality(FixedString), Array(String) or Array(FixedString) columns.
+-- Negative tests
+-- Positive tests
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -418,30 +418,12 @@ ALTER TABLE tab ADD INDEX idx_3(lower(str)) TYPE text(tokenizer = 'ngram', ngram
 
 DROP TABLE tab;
 
-SELECT 'Must be created on String or FixedString or LowCardinality(String) or LowCardinality(FixedString), Array(String) or Array(FixedString) columns.';
+SELECT 'Must be created on String, FixedString, LowCardinality(String), LowCardinality(FixedString), Array(String) or Array(FixedString) columns.';
 
 CREATE TABLE tab
 (
     key UInt64,
     str UInt64,
-    INDEX idx str TYPE text(tokenizer = 'default')
-)
-ENGINE = MergeTree
-ORDER BY key; -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    key UInt64,
-    str Array(UInt64),
-    INDEX idx str TYPE text(tokenizer = 'default')
-)
-ENGINE = MergeTree
-ORDER BY key; -- { serverError INCORRECT_QUERY }
-
-CREATE TABLE tab
-(
-    key UInt64,
-    str Array(Float32),
     INDEX idx str TYPE text(tokenizer = 'default')
 )
 ENGINE = MergeTree
@@ -459,8 +441,82 @@ ORDER BY key; -- { serverError INCORRECT_QUERY }
 CREATE TABLE tab
 (
     key UInt64,
+    arr Array(UInt64),
+    INDEX idx arr TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
+    arr Array(Float32),
+    INDEX idx arr TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
+    map Map(UInt64, String),
+    INDEX idx mapKeys(map) TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
+    map Map(Float32, String),
+    INDEX idx mapKeys(map) TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
+    map Map(String, UInt64),
+    INDEX idx mapValues(map) TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
+    map Map(String, Float32),
+    INDEX idx mapValues(map) TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
     n_str Nullable(String),
     INDEX idx n_str TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+CREATE TABLE tab
+(
+    key UInt64,
+    lc LowCardinality(UInt64),
+    INDEX idx lc TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+CREATE TABLE tab
+(
+    key UInt64,
+    lc LowCardinality(Float32),
+    INDEX idx lc TYPE text(tokenizer = 'default')
 )
 ENGINE = MergeTree
 ORDER BY key; -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -423,8 +423,8 @@ SELECT 'Must be created on String, FixedString, LowCardinality(String), LowCardi
 CREATE TABLE tab
 (
     key UInt64,
-    str UInt64,
-    INDEX idx str TYPE text(tokenizer = 'default')
+    u64 UInt64,
+    INDEX idx u64 TYPE text(tokenizer = 'default')
 )
 ENGINE = MergeTree
 ORDER BY key; -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -420,6 +420,8 @@ DROP TABLE tab;
 
 SELECT 'Must be created on String, FixedString, LowCardinality(String), LowCardinality(FixedString), Array(String) or Array(FixedString) columns.';
 
+SELECT '-- Negative tests';
+
 CREATE TABLE tab
 (
     key UInt64,
@@ -520,3 +522,79 @@ CREATE TABLE tab
 )
 ENGINE = MergeTree
 ORDER BY key; -- { serverError INCORRECT_QUERY }
+
+SELECT '-- Positive tests';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    key UInt64,
+    str String,
+    str_fixed FixedString(3),
+    INDEX idx str TYPE text(tokenizer = 'default'),
+    INDEX idx_fixed str_fixed TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, 'foo', toFixedString('foo', 3)), (2, 'bar', toFixedString('bar', 3)), (3, 'baz', toFixedString('baz', 3));
+
+SELECT count() FROM tab WHERE str = 'foo' SETTINGS force_data_skipping_indices='idx';
+SELECT count() FROM tab WHERE str_fixed = toFixedString('foo', 3) SETTINGS force_data_skipping_indices='idx_fixed';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    key UInt64,
+    lc LowCardinality(String),
+    lc_fixed LowCardinality(FixedString(3)),
+    INDEX idx lc TYPE text(tokenizer = 'default'),
+    INDEX idx_fixed lc_fixed TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, 'foo', toFixedString('foo', 3)), (2, 'bar', toFixedString('bar', 3)), (3, 'baz', toFixedString('baz', 3));
+
+SELECT count() FROM tab WHERE lc = 'foo' SETTINGS force_data_skipping_indices='idx';
+SELECT count() FROM tab WHERE lc_fixed = toFixedString('foo', 3) SETTINGS force_data_skipping_indices='idx_fixed';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    key UInt64,
+    arr Array(String),
+    arr_fixed Array(FixedString(3)),
+    INDEX idx arr TYPE text(tokenizer = 'default'),
+    INDEX idx_fixed arr_fixed TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, ['foo'], [toFixedString('foo', 3)]), (2, ['bar'], [toFixedString('bar', 3)]), (3, ['baz'], [toFixedString('baz', 3)]);
+
+SELECT count() FROM tab WHERE has(arr, 'foo') SETTINGS force_data_skipping_indices='idx';
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3)) SETTINGS force_data_skipping_indices='idx_fixed';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    key UInt64,
+    map Map(String, String),
+    map_fixed Map(FixedString(3), FixedString(3)),
+    INDEX idx_keys mapKeys(map) TYPE text(tokenizer = 'default'),
+    INDEX idx_keys_fixed mapKeys(map_fixed) TYPE text(tokenizer = 'default'),
+    INDEX idx_values mapValues(map) TYPE text(tokenizer = 'default'),
+    INDEX idx_values_fixed mapValues(map_fixed) TYPE text(tokenizer = 'default')
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, {'foo' : 'foo'}, {'foo' : 'foo'}), (2, {'bar' : 'bar'}, {'bar' : 'bar'});
+
+SELECT count() FROM tab WHERE mapContainsKey(map, 'foo') SETTINGS force_data_skipping_indices='idx_keys';
+SELECT count() FROM tab WHERE mapContainsKey(map_fixed, toFixedString('foo', 3)) SETTINGS force_data_skipping_indices='idx_keys_fixed';
+SELECT count() FROM tab WHERE has(mapValues(map), 'foo') SETTINGS force_data_skipping_indices='idx_values';
+SELECT count() FROM tab WHERE has(mapValues(map_fixed), toFixedString('foo', 3)) SETTINGS force_data_skipping_indices='idx_values_fixed';
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -418,7 +418,7 @@ ALTER TABLE tab ADD INDEX idx_3(lower(str)) TYPE text(tokenizer = 'ngram', ngram
 
 DROP TABLE tab;
 
-SELECT 'Must be created on String or FixedString or LowCardinality(String) or LowCardinality(FixedString) columns.';
+SELECT 'Must be created on String or FixedString or LowCardinality(String) or LowCardinality(FixedString), Array(String) or Array(FixedString) columns.';
 
 CREATE TABLE tab
 (
@@ -432,7 +432,7 @@ ORDER BY key; -- { serverError INCORRECT_QUERY }
 CREATE TABLE tab
 (
     key UInt64,
-    str Array(String),
+    str Array(UInt64),
     INDEX idx str TYPE text(tokenizer = 'default')
 )
 ENGINE = MergeTree
@@ -441,7 +441,7 @@ ORDER BY key; -- { serverError INCORRECT_QUERY }
 CREATE TABLE tab
 (
     key UInt64,
-    str Array(FixedString(2)),
+    str Array(Float32),
     INDEX idx str TYPE text(tokenizer = 'default')
 )
 ENGINE = MergeTree

--- a/tests/queries/0_stateless/02346_text_index_map_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_map_support.reference
@@ -1,182 +1,182 @@
 text index with mapKeys
 -- mapContainsKey support
----- query with String
+-- -- query with String
 1
 2
 1
 0
----- query with FixedString
+-- -- query with FixedString
 1
 2
 1
 0
----- index analyzer with String
-key exists only in the first granule
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
----- index analyzer with FixedString
-key exists only in the first granule
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
 -- arrayElement(map, key) support
----- query with String
+-- -- query with String
 1
 2
 1
 0
----- query with FixedString
+-- -- query with FixedString
 1
 2
 1
 0
----- index analyzer with String
-key exists only in the first granule
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
----- index analyzer with FixedString
-key exists only in the first granule
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
 -- has support
----- query with String
+-- -- query with String
 1
 2
 1
 0
----- query with FixedString
+-- -- query with FixedString
 1
 2
 1
 0
----- index analyzer with String
-key exists only in the first granule
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
----- index analyzer with FixedString
-key exists only in the first granule
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
 text index with mapValues
 -- arrayElement(map, key) support
----- query with String
+-- -- query with String
 1
 2
 1
 0
----- query with FixedString
+-- -- query with FixedString
 1
 2
 1
 0
----- index analyzer with String
-key exists only in the first granule
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
----- index analyzer with FixedString
-key exists only in the first granule
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in the second granule
+-- -- -- key exists only in the second granule
 Description: text GRANULARITY 64
 Parts: 1/2
 Granules: 1/2
-key exists only in both granules
+-- -- -- key exists only in both granules
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
-key does not exist in granules
+-- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2

--- a/tests/queries/0_stateless/02346_text_index_map_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_map_support.reference
@@ -1,0 +1,182 @@
+text index with mapKeys
+-- mapContainsKey support
+---- query with String
+1
+2
+1
+0
+---- query with FixedString
+1
+2
+1
+0
+---- index analyzer with String
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+---- index analyzer with FixedString
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- arrayElement(map, key) support
+---- query with String
+1
+2
+1
+0
+---- query with FixedString
+1
+2
+1
+0
+---- index analyzer with String
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+---- index analyzer with FixedString
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- has support
+---- query with String
+1
+2
+1
+0
+---- query with FixedString
+1
+2
+1
+0
+---- index analyzer with String
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+---- index analyzer with FixedString
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+text index with mapValues
+-- arrayElement(map, key) support
+---- query with String
+1
+2
+1
+0
+---- query with FixedString
+1
+2
+1
+0
+---- index analyzer with String
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+---- index analyzer with FixedString
+key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2

--- a/tests/queries/0_stateless/02346_text_index_map_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_map_support.reference
@@ -180,3 +180,38 @@ Granules: 2/2
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
+-- has support
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2

--- a/tests/queries/0_stateless/02346_text_index_map_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_map_support.reference
@@ -1,5 +1,5 @@
-text index with mapKeys
--- mapContainsKey support
+Function mapKeys
+-- mapContains support
 -- -- query with String
 1
 2
@@ -44,7 +44,7 @@ Granules: 2/2
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
--- arrayElement(map, key) support
+-- operator[] support
 -- -- query with String
 1
 2
@@ -134,8 +134,8 @@ Granules: 2/2
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
-text index with mapValues
--- arrayElement(map, key) support
+Function mapValues
+-- operator[] support
 -- -- query with String
 1
 2

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -23,23 +23,23 @@ INSERT INTO tab VALUES (1, {'K1':'V1', 'K2':'V2'}, {'K1':'V1', 'K2':'V2'});
 
 SELECT '-- mapContainsKey support';
 
-SELECT '---- query with String';
+SELECT '-- -- query with String';
 
 SELECT count() FROM tab WHERE mapContains(map, 'K0');
 SELECT count() FROM tab WHERE mapContains(map, 'K1');
 SELECT count() FROM tab WHERE mapContains(map, 'K2');
 SELECT count() FROM tab WHERE mapContains(map, 'K3');
 
-SELECT '---- query with FixedString';
+SELECT '-- -- query with FixedString';
 
 SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K0', 2));
 SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K1', 2));
 SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K2', 2));
 SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K3', 2));
 
-SELECT '---- index analyzer with String';
+SELECT '-- -- Check that the text index actually gets used (String)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map, 'K0')
@@ -47,7 +47,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map, 'K2')
@@ -55,7 +55,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map, 'K1')
@@ -63,7 +63,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map, 'K3')
@@ -71,9 +71,9 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT '---- index analyzer with FixedString';
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K0', 2))
@@ -81,7 +81,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K2', 2))
@@ -89,7 +89,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K1', 2))
@@ -97,7 +97,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K3', 2))
@@ -107,23 +107,23 @@ LIMIT 2, 3;
 
 SELECT '-- arrayElement(map, key) support';
 
-SELECT '---- query with String';
+SELECT '-- -- query with String';
 
 SELECT count() FROM tab WHERE map['K0'] = 'V0';
 SELECT count() FROM tab WHERE map['K1'] = 'V1';
 SELECT count() FROM tab WHERE map['K2'] = 'V2';
 SELECT count() FROM tab WHERE map['K3'] = 'V3';
 
-SELECT '---- query with FixedString';
+SELECT '-- -- query with FixedString';
 
 SELECT count() FROM tab WHERE map_fixed[toFixedString('K0', 2)] = 'V0';
 SELECT count() FROM tab WHERE map_fixed[toFixedString('K1', 2)] = 'V1';
 SELECT count() FROM tab WHERE map_fixed[toFixedString('K2', 2)] = 'V2';
 SELECT count() FROM tab WHERE map_fixed[toFixedString('K3', 2)] = 'V3';
 
-SELECT '---- index analyzer with String';
+SELECT '-- -- Check that the text index actually gets used (String)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K0'] = 'V0'
@@ -131,7 +131,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K2'] = 'V2'
@@ -139,7 +139,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K1'] = 'V1'
@@ -147,7 +147,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K3'] = 'V3'
@@ -155,9 +155,9 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT '---- index analyzer with FixedString';
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed[toFixedString('K0', 2)] = 'V0'
@@ -165,7 +165,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed[toFixedString('K2', 2)] = 'V2'
@@ -173,7 +173,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed[toFixedString('K1', 2)] = 'V1'
@@ -181,7 +181,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed[toFixedString('K3', 2)] = 'V3'
@@ -191,23 +191,23 @@ LIMIT 2, 3;
 
 SELECT '-- has support';
 
-SELECT '---- query with String';
+SELECT '-- -- query with String';
 
 SELECT count() FROM tab WHERE has(map, 'K0');
 SELECT count() FROM tab WHERE has(map, 'K1');
 SELECT count() FROM tab WHERE has(map, 'K2');
 SELECT count() FROM tab WHERE has(map, 'K3');
 
-SELECT '---- query with FixedString';
+SELECT '-- -- query with FixedString';
 
 SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K0', 2));
 SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K1', 2));
 SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K2', 2));
 SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K3', 2));
 
-SELECT '---- index analyzer with String';
+SELECT '-- -- Check that the text index actually gets used (String)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map, 'K0')
@@ -215,7 +215,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map, 'K2')
@@ -223,7 +223,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map, 'K1')
@@ -231,7 +231,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map, 'K3')
@@ -239,9 +239,9 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT '---- index analyzer with FixedString';
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K0', 2))
@@ -249,7 +249,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K2', 2))
@@ -257,7 +257,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K1', 2))
@@ -265,7 +265,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K3', 2))
@@ -294,23 +294,23 @@ INSERT INTO tab VALUES (1, {'K1':'V1', 'K2':'V2'}, {'K1':'V1', 'K2':'V2'});
 
 SELECT '-- arrayElement(map, key) support';
 
-SELECT '---- query with String';
+SELECT '-- -- query with String';
 
 SELECT count() FROM tab WHERE map['K0'] = 'V0';
 SELECT count() FROM tab WHERE map['K1'] = 'V1';
 SELECT count() FROM tab WHERE map['K2'] = 'V2';
 SELECT count() FROM tab WHERE map['K3'] = 'V3';
 
-SELECT '---- query with FixedString';
+SELECT '-- -- query with FixedString';
 
 SELECT count() FROM tab WHERE map_fixed['K0'] = toFixedString('V0', 2);
 SELECT count() FROM tab WHERE map_fixed['K1'] = toFixedString('V1', 2);
 SELECT count() FROM tab WHERE map_fixed['K2'] = toFixedString('V2', 2);
 SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2);
 
-SELECT '---- index analyzer with String';
+SELECT '-- -- Check that the text index actually gets used (String)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K0'] = 'V0'
@@ -318,7 +318,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K2'] = 'V2'
@@ -326,7 +326,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K1'] = 'V1'
@@ -334,7 +334,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map['K3'] = 'V3'
@@ -342,9 +342,9 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT '---- index analyzer with FixedString';
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
-SELECT 'key exists only in the first granule';
+SELECT '-- -- -- key exists only in the first granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed['K0'] = toFixedString('V0', 2)
@@ -352,7 +352,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in the second granule';
+SELECT '-- -- -- key exists only in the second granule';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed['K2'] = toFixedString('V2', 2)
@@ -360,7 +360,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key exists only in both granules';
+SELECT '-- -- -- key exists only in both granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed['K1'] = toFixedString('V1', 2)
@@ -368,7 +368,7 @@ SELECT trimLeft(explain) AS explain FROM (
 WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
 LIMIT 2, 3;
 
-SELECT 'key does not exist in granules';
+SELECT '-- -- -- key does not exist in granules';
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes=1
     SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2)

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-parallel-replicas
+-- Tags: no-parallel-replicas
 
 SET allow_experimental_full_text_index = 1;
 SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -2,6 +2,7 @@
 
 -- Tests that text indexes can be build on and used with Map columns.
 
+SET enable_analyzer = 1;
 SET allow_experimental_full_text_index = 1;
 SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
 

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -39,71 +39,46 @@ SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K3', 2));
 
 SELECT '-- -- Check that the text index actually gets used (String)';
 
+DROP VIEW IF EXISTS explain_index_mapContains;
+CREATE VIEW explain_index_mapContains AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN mapContains(map_fixed, {filter:FixedString(2)})
+                ELSE mapContains(map, {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map, 'K0')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K0');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map, 'K2')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K2');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map, 'K1')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K1');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map, 'K3')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K0', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K0', 2));
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K2', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K2', 2));
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K1', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K1', 2));
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K3', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K3', 2));
 
 SELECT '-- arrayElement(map, key) support';
 
@@ -123,71 +98,46 @@ SELECT count() FROM tab WHERE map_fixed[toFixedString('K3', 2)] = 'V3';
 
 SELECT '-- -- Check that the text index actually gets used (String)';
 
+DROP VIEW IF EXISTS explain_index_equals;
+CREATE VIEW explain_index_equals AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN map_fixed[{filter:FixedString(2)}] = {value:String}
+                ELSE map[{filter:String}] = {value:String}
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K0'] = 'V0'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K0', value='V3');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K2'] = 'V2'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K2', value='V3');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K1'] = 'V1'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K1', value='V3');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K3'] = 'V3'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed[toFixedString('K0', 2)] = 'V0'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K0', value='V3');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed[toFixedString('K2', 2)] = 'V2'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K2', value='V3');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed[toFixedString('K1', 2)] = 'V1'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K1', value='V3');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed[toFixedString('K3', 2)] = 'V3'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value='V3');
 
 SELECT '-- has support';
 
@@ -207,72 +157,46 @@ SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K3', 2));
 
 SELECT '-- -- Check that the text index actually gets used (String)';
 
+DROP VIEW IF EXISTS explain_index_has;
+CREATE VIEW explain_index_has AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN has(map_fixed, {filter:FixedString(2)})
+                ELSE has(map, {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map, 'K0')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K0');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map, 'K2')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K2');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map, 'K1')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K1');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map, 'K3')
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K0', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K0', 2));
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K2', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K2', 2));
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K1', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K1', 2));
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K3', 2))
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
-DROP TABLE tab;
+SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K3', 2));
 
 SELECT 'text index with mapValues';
 
@@ -311,69 +235,32 @@ SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2);
 SELECT '-- -- Check that the text index actually gets used (String)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K0'] = 'V0'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V0');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K2'] = 'V2'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V2');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K1'] = 'V1'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V1');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map['K3'] = 'V3'
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed['K0'] = toFixedString('V0', 2)
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V0', 2));
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed['K2'] = toFixedString('V2', 2)
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V2', 2));
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed['K1'] = toFixedString('V1', 2)
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V1', 2));
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT trimLeft(explain) AS explain FROM (
-    EXPLAIN indexes=1
-    SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2)
-)
-WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
-LIMIT 2, 3;
+SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V3', 2));
 
+DROP VIEW explain_index_mapContains;
+DROP VIEW explain_index_equals;
+DROP VIEW explain_index_has;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -1,9 +1,11 @@
 -- Tags: no-parallel-replicas
 
+-- Tests that text indexes can be build on and used with Map columns.
+
 SET allow_experimental_full_text_index = 1;
 SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
 
-SELECT 'text index with mapKeys';
+SELECT 'Function mapKeys';
 
 DROP TABLE IF EXISTS tab;
 
@@ -21,7 +23,7 @@ ORDER BY (id);
 INSERT INTO tab VALUES (0, {'K0':'V0', 'K1':'V1'}, {'K0':'V0', 'K1':'V1'});
 INSERT INTO tab VALUES (1, {'K1':'V1', 'K2':'V2'}, {'K1':'V1', 'K2':'V2'});
 
-SELECT '-- mapContainsKey support';
+SELECT '-- mapContains support';
 
 SELECT '-- -- query with String';
 
@@ -42,9 +44,9 @@ SELECT '-- -- Check that the text index actually gets used (String)';
 DROP VIEW IF EXISTS explain_index_mapContains;
 CREATE VIEW explain_index_mapContains AS (
     SELECT trimLeft(explain) AS explain FROM (
-        EXPLAIN indexes=1
+        EXPLAIN indexes = 1
         SELECT count() FROM tab WHERE (
-            CASE 
+            CASE
                 WHEN {use_idx_fixed:boolean} = 1 THEN mapContains(map_fixed, {filter:FixedString(2)})
                 ELSE mapContains(map, {filter:String})
             END
@@ -55,32 +57,32 @@ CREATE VIEW explain_index_mapContains AS (
 );
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K0');
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 0, filter = 'K0');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K2');
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 0, filter = 'K2');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K1');
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 0, filter = 'K1');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=0, filter='K3');
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 0, filter = 'K3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K0', 2));
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 1, filter = toFixedString('K0', 2));
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K2', 2));
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 1, filter = toFixedString('K2', 2));
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K1', 2));
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 1, filter = toFixedString('K1', 2));
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_mapContains(use_idx_fixed=1, filter=toFixedString('K3', 2));
+SELECT * FROM explain_index_mapContains(use_idx_fixed = 1, filter = toFixedString('K3', 2));
 
-SELECT '-- arrayElement(map, key) support';
+SELECT '-- operator[] support';
 
 SELECT '-- -- query with String';
 
@@ -101,9 +103,9 @@ SELECT '-- -- Check that the text index actually gets used (String)';
 DROP VIEW IF EXISTS explain_index_equals;
 CREATE VIEW explain_index_equals AS (
     SELECT trimLeft(explain) AS explain FROM (
-        EXPLAIN indexes=1
+        EXPLAIN indexes = 1
         SELECT count() FROM tab WHERE (
-            CASE 
+            CASE
                 WHEN {use_idx_fixed:boolean} = 1 THEN map_fixed[{filter:FixedString(2)}] = {value:String}
                 ELSE map[{filter:String}] = {value:String}
             END
@@ -114,30 +116,30 @@ CREATE VIEW explain_index_equals AS (
 );
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K0', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K0', value = 'V3');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K2', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K2', value = 'V3');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K1', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K1', value = 'V3');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K3', value = 'V3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K0', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K0', value = 'V3');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K2', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K2', value = 'V3');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K1', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K1', value = 'V3');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K3', value = 'V3');
 
 SELECT '-- has support';
 
@@ -160,9 +162,9 @@ SELECT '-- -- Check that the text index actually gets used (String)';
 DROP VIEW IF EXISTS explain_index_has;
 CREATE VIEW explain_index_has AS (
     SELECT trimLeft(explain) AS explain FROM (
-        EXPLAIN indexes=1
+        EXPLAIN indexes = 1
         SELECT count() FROM tab WHERE (
-            CASE 
+            CASE
                 WHEN {use_idx_fixed:boolean} = 1 THEN has(map_fixed, {filter:FixedString(2)})
                 ELSE has(map, {filter:String})
             END
@@ -173,34 +175,34 @@ CREATE VIEW explain_index_has AS (
 );
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K0');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'K0');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K2');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'K2');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K1');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'K1');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_has(use_idx_fixed=0, filter='K3');
+SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'K3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K0', 2));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('K0', 2));
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K2', 2));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('K2', 2));
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K1', 2));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('K1', 2));
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_has(use_idx_fixed=1, filter=toFixedString('K3', 2));
+SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('K3', 2));
 
-SELECT 'text index with mapValues';
+SELECT 'Function mapValues';
 
-DROP TABLE IF EXISTS tab;
+DROP TABLE tab;
 
 CREATE TABLE tab
 (
@@ -216,7 +218,7 @@ ORDER BY (id);
 INSERT INTO tab VALUES (0, {'K0':'V0', 'K1':'V1'}, {'K0':'V0', 'K1':'V1'});
 INSERT INTO tab VALUES (1, {'K1':'V1', 'K2':'V2'}, {'K1':'V1', 'K2':'V2'});
 
-SELECT '-- arrayElement(map, key) support';
+SELECT '-- operator[] support';
 
 SELECT '-- -- query with String';
 
@@ -235,30 +237,30 @@ SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2);
 SELECT '-- -- Check that the text index actually gets used (String)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V0');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K3', value = 'V0');
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V2');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K3', value = 'V2');
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V1');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K3', value = 'V1');
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=0, filter='K3', value='V3');
+SELECT * FROM explain_index_equals(use_idx_fixed = 0, filter = 'K3', value = 'V3');
 
 SELECT '-- -- Check that the text index actually gets used (FixedString)';
 
 SELECT '-- -- -- key exists only in the first granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V0', 2));
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K3', value = toFixedString('V0', 2));
 
 SELECT '-- -- -- key exists only in the second granule';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V2', 2));
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K3', value = toFixedString('V2', 2));
 
 SELECT '-- -- -- key exists only in both granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V1', 2));
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K3', value = toFixedString('V1', 2));
 
 SELECT '-- -- -- key does not exist in granules';
-SELECT * FROM explain_index_equals(use_idx_fixed=1, filter='K3', value=toFixedString('V3', 2));
+SELECT * FROM explain_index_equals(use_idx_fixed = 1, filter = 'K3', value = toFixedString('V3', 2));
 
 DROP VIEW explain_index_mapContains;
 DROP VIEW explain_index_equals;

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -1,0 +1,379 @@
+-- Tags: no-fasttest, no-parallel-replicas
+
+SET allow_experimental_full_text_index = 1;
+SET use_skip_indexes_on_data_read = 0; --- for EXPLAIN indexes = 1 <query>
+
+SELECT 'text index with mapKeys';
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    map Map(String, String),
+    map_fixed Map(FixedString(2), String),
+    INDEX map_keys_idx mapKeys(map) TYPE text(tokenizer = 'default'),
+    INDEX map_fixed_keys_idx mapKeys(map_fixed) TYPE text(tokenizer = 'default'),
+)
+ENGINE = MergeTree
+ORDER BY (id);
+
+INSERT INTO tab VALUES (0, {'K0':'V0', 'K1':'V1'}, {'K0':'V0', 'K1':'V1'});
+INSERT INTO tab VALUES (1, {'K1':'V1', 'K2':'V2'}, {'K1':'V1', 'K2':'V2'});
+
+SELECT '-- mapContainsKey support';
+
+SELECT '---- query with String';
+
+SELECT count() FROM tab WHERE mapContains(map, 'K0');
+SELECT count() FROM tab WHERE mapContains(map, 'K1');
+SELECT count() FROM tab WHERE mapContains(map, 'K2');
+SELECT count() FROM tab WHERE mapContains(map, 'K3');
+
+SELECT '---- query with FixedString';
+
+SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K0', 2));
+SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K1', 2));
+SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K2', 2));
+SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K3', 2));
+
+SELECT '---- index analyzer with String';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map, 'K0')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map, 'K2')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map, 'K1')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map, 'K3')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '---- index analyzer with FixedString';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K0', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K2', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K1', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE mapContains(map_fixed, toFixedString('K3', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '-- arrayElement(map, key) support';
+
+SELECT '---- query with String';
+
+SELECT count() FROM tab WHERE map['K0'] = 'V0';
+SELECT count() FROM tab WHERE map['K1'] = 'V1';
+SELECT count() FROM tab WHERE map['K2'] = 'V2';
+SELECT count() FROM tab WHERE map['K3'] = 'V3';
+
+SELECT '---- query with FixedString';
+
+SELECT count() FROM tab WHERE map_fixed[toFixedString('K0', 2)] = 'V0';
+SELECT count() FROM tab WHERE map_fixed[toFixedString('K1', 2)] = 'V1';
+SELECT count() FROM tab WHERE map_fixed[toFixedString('K2', 2)] = 'V2';
+SELECT count() FROM tab WHERE map_fixed[toFixedString('K3', 2)] = 'V3';
+
+SELECT '---- index analyzer with String';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K0'] = 'V0'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K2'] = 'V2'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K1'] = 'V1'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K3'] = 'V3'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '---- index analyzer with FixedString';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed[toFixedString('K0', 2)] = 'V0'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed[toFixedString('K2', 2)] = 'V2'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed[toFixedString('K1', 2)] = 'V1'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed[toFixedString('K3', 2)] = 'V3'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '-- has support';
+
+SELECT '---- query with String';
+
+SELECT count() FROM tab WHERE has(map, 'K0');
+SELECT count() FROM tab WHERE has(map, 'K1');
+SELECT count() FROM tab WHERE has(map, 'K2');
+SELECT count() FROM tab WHERE has(map, 'K3');
+
+SELECT '---- query with FixedString';
+
+SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K0', 2));
+SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K1', 2));
+SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K2', 2));
+SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K3', 2));
+
+SELECT '---- index analyzer with String';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map, 'K0')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map, 'K2')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map, 'K1')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map, 'K3')
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '---- index analyzer with FixedString';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K0', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K2', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K1', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE has(map_fixed, toFixedString('K3', 2))
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+DROP TABLE tab;
+
+SELECT 'text index with mapValues';
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    map Map(String, String),
+    map_fixed Map(String, FixedString(2)),
+    INDEX map_values_idx mapValues(map) TYPE text(tokenizer = 'default'),
+    INDEX map_fixed_values_idx mapValues(map_fixed) TYPE text(tokenizer = 'default'),
+)
+ENGINE = MergeTree
+ORDER BY (id);
+
+INSERT INTO tab VALUES (0, {'K0':'V0', 'K1':'V1'}, {'K0':'V0', 'K1':'V1'});
+INSERT INTO tab VALUES (1, {'K1':'V1', 'K2':'V2'}, {'K1':'V1', 'K2':'V2'});
+
+SELECT '-- arrayElement(map, key) support';
+
+SELECT '---- query with String';
+
+SELECT count() FROM tab WHERE map['K0'] = 'V0';
+SELECT count() FROM tab WHERE map['K1'] = 'V1';
+SELECT count() FROM tab WHERE map['K2'] = 'V2';
+SELECT count() FROM tab WHERE map['K3'] = 'V3';
+
+SELECT '---- query with FixedString';
+
+SELECT count() FROM tab WHERE map_fixed['K0'] = toFixedString('V0', 2);
+SELECT count() FROM tab WHERE map_fixed['K1'] = toFixedString('V1', 2);
+SELECT count() FROM tab WHERE map_fixed['K2'] = toFixedString('V2', 2);
+SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2);
+
+SELECT '---- index analyzer with String';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K0'] = 'V0'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K2'] = 'V2'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K1'] = 'V1'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map['K3'] = 'V3'
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT '---- index analyzer with FixedString';
+
+SELECT 'key exists only in the first granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed['K0'] = toFixedString('V0', 2)
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in the second granule';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed['K2'] = toFixedString('V2', 2)
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key exists only in both granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed['K1'] = toFixedString('V1', 2)
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+SELECT 'key does not exist in granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1
+    SELECT count() FROM tab WHERE map_fixed['K3'] = toFixedString('V3', 2)
+)
+WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+LIMIT 2, 3;
+
+DROP TABLE tab;


### PR DESCRIPTION
Restores functionality deleted by https://github.com/ClickHouse/ClickHouse/pull/83031

### Changelog category:

- Improvement

### Changelog entry:

Add text index support for `Array` and `Map` (`mapKeys` and `mapValues`) values. The supported functions are `mapContainsKey` and `has`.

