### PR TITLE
exclude userspace cache for memory overload warning

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -923,7 +923,7 @@ void AsynchronousMetrics::processWarningForMemoryOverload(const AsynchronousMetr
 
     /// Compute the user space page cache size (in bytes) and subtract from total memory used if possible
     double user_space_cache_bytes{};
-    if (const auto *rss = getAsynchronousMetricValue(new_values, "MemoryResident"),
+    if (const auto * rss = getAsynchronousMetricValue(new_values, "MemoryResident"),
         *rss_wo_pc = getAsynchronousMetricValue(new_values, "MemoryResidentWithoutPageCache");
         rss && rss_wo_pc && rss->value >= rss_wo_pc->value)
     {


### PR DESCRIPTION
Follow up for https://github.com/ClickHouse/ClickHouse/pull/86838
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Exclude userspace page cache bytes (if possible) when computing memory overload warning.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
