### PR TITLE
Fix filtering the flaky integration test

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -38,12 +38,12 @@ PRELIMINARY_JOBS = [
 
 INTEGRATION_TEST_FLAKY_CHECK_JOBS = [
     "Build (amd_asan)",
-    "Integration tests (asan, flaky check)",
+    "Integration tests (amd_asan, flaky check)",
 ]
 
 FUNCTIONAL_TEST_FLAKY_CHECK_JOBS = [
     "Build (amd_asan)",
-    "Stateless tests (asan, flaky check)",
+    "Stateless tests (amd_asan, flaky check)",
 ]
 
 _info_cache = None
@@ -78,7 +78,7 @@ def should_skip_job(job_name):
     ):
         return (
             True,
-            f"Skipped, labeled with '{Labels.CI_INTEGRATION_FLAKY}' - run integration test jobs only",
+            f"Skipped, labeled with '{Labels.CI_INTEGRATION_FLAKY}' - run integration test flaky check job only",
         )
 
     if (


### PR DESCRIPTION
Previously, it wasn't working cause at some point the jobs changed the name from `asan` to `amd_asan`:

```
Job [Stateless tests (amd_asan, flaky check)] set to skipped by custom hook [should_skip_job], reason [Skipped, labeled with 'ci-integration-test-flaky' - run integration test jobs only]
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
