### PR TITLE
Disable test_storage_delta/test.py::test_replicated_database_and_unavailable_s3

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import logging
 import os
@@ -6,22 +5,18 @@ import random
 import string
 import time
 import uuid
-import threading
 from datetime import datetime
 from multiprocessing.dummy import Pool
 
-import delta
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pyspark
 import pytest
-from azure.storage.blob import BlobServiceClient
 from delta import *
 from deltalake.writer import write_deltalake
 from minio.deleteobjects import DeleteObject
 from pyspark.sql.functions import (
     col,
-    current_timestamp,
     monotonically_increasing_id,
     row_number,
 )
@@ -30,7 +25,6 @@ from pyspark.sql.types import (
     BooleanType,
     DateType,
     IntegerType,
-    LongType,
     ShortType,
     StringType,
     DecimalType,
@@ -41,7 +35,6 @@ from pyspark.sql.types import (
 from decimal import Decimal
 from pyspark.sql.window import Window
 
-import helpers.client
 from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import minio_access_key, minio_secret_key
 from helpers.mock_servers import start_mock_servers
@@ -52,7 +45,6 @@ from helpers.s3_tools import (
     S3Uploader,
     get_file_contents,
     list_s3_objects,
-    prepare_s3_bucket,
     upload_directory,
     LocalDownloader,
     LocalUploader,

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -52,7 +52,6 @@ from helpers.s3_tools import (
 from helpers.test_tools import TSV
 
 
-pytestmark = pytest.mark.skip(reason="Flaky tests")
 
 SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(os.path.dirname(os.path.realpath(__file__)))
 cluster = ClickHouseCluster(__file__, with_spark=True, azurite_default_port=10000)
@@ -1246,6 +1245,7 @@ def test_filesystem_cache(started_cluster, use_delta_kernel):
     )
 
 
+@pytest.mark.skip(reason="Flaky tests")
 @pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
 def test_replicated_database_and_unavailable_s3(started_cluster, use_delta_kernel):
     node1 = started_cluster.instances["node1"]

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -52,6 +52,8 @@ from helpers.s3_tools import (
 from helpers.test_tools import TSV
 
 
+pytestmark = pytest.mark.skip(reason="Flaky tests")
+
 SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(os.path.dirname(os.path.realpath(__file__)))
 cluster = ClickHouseCluster(__file__, with_spark=True, azurite_default_port=10000)
 


### PR DESCRIPTION
`test_storage_delta/test.py::test_replicated_database_and_unavailable_s3` is incredibly flaky. Let's disable it for now while we investigate what's happening in https://github.com/ClickHouse/ClickHouse/pull/87579

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
