### PR TITLE
Rename the log level settings from startupLevel and shutdownLevel to startup_level and shutdown_level to match the general settings format

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -834,8 +834,8 @@ The location and format of log messages.
 | `syslog_level`         | Log level for logging to syslog.                                                                                                                                   |
 | `async`                | When `true` (default) logging will happen asynchronously (one background thread per output channel). Otherwise it will log inside the thread calling LOG           |
 | `async_queue_max_size` | When using async logging, the max amount of messages that will be kept in the the queue waiting for flushing. Extra messages will be dropped                       |
-| `startupLevel`         | Startup level is used to set the root logger level at server startup. After startup log level is reverted to the `level` setting                                   |
-| `shutdownLevel`        | Shutdown level is used to set the root logger level at server Shutdown.                                                                                            |
+| `startup_level`        | Startup level is used to set the root logger level at server startup. After startup log level is reverted to the `level` setting                                   |
+| `shutdown_level`       | Shutdown level is used to set the root logger level at server Shutdown.                                                                                            |
 
 **Log format specifiers**
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1028,20 +1028,20 @@ try
 
     Poco::Logger * log = &logger();
 
-    // If the startupLevel is set in the config, we override the root logger level.
+    // If the startup_level is set in the config, we override the root logger level.
     // Specific loggers can still override it.
     std::string default_logger_level_config = config().getString("logger.level", "");
     bool should_restore_default_logger_level = false;
-    if (config().has("logger.startupLevel") && !config().getString("logger.startupLevel").empty())
+    if (config().has("logger.startup_level") && !config().getString("logger.startup_level").empty())
     {
         /// Set the root logger level to the startup level.
         /// This is useful for debugging startup issues.
         /// The root logger level will be reset to the default level after the server is fully initialized.
-        config().setString("logger.level", config().getString("logger.startupLevel"));
+        config().setString("logger.level", config().getString("logger.startup_level"));
         Loggers::updateLevels(config(), logger());
         should_restore_default_logger_level = true;
 
-        LOG_INFO(log, "Starting root logger in level {}", config().getString("logger.startupLevel"));
+        LOG_INFO(log, "Starting root logger in level {}", config().getString("logger.startup_level"));
     }
 
     MainThreadStatus::getInstance();
@@ -2813,14 +2813,14 @@ try
 #endif
 
         SCOPE_EXIT_SAFE({
-            if (config().has("logger.shutdownLevel") && !config().getString("logger.shutdownLevel").empty())
+            if (config().has("logger.shutdown_level") && !config().getString("logger.shutdown_level").empty())
             {
                 /// Set the root logger level to the shutdown level.
                 /// This is useful for debugging shutdown issues.
-                config().setString("logger.level", config().getString("logger.shutdownLevel"));
+                config().setString("logger.level", config().getString("logger.shutdown_level"));
                 Loggers::updateLevels(config(), logger());
 
-                LOG_INFO(log, "Set root logger in level {} before shutdown", config().getString("logger.shutdownLevel"));
+                LOG_INFO(log, "Set root logger in level {} before shutdown", config().getString("logger.shutdown_level"));
             }
             LOG_DEBUG(log, "Received termination signal.");
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -26,10 +26,10 @@
         <!-- Startup level is used to set the root logger level at server startup.
              It is useful for debugging startup issues.
              The root logger level will be reset to the default level after the server is fully initialized -->
-        <!-- <startupLevel>trace</startupLevel> -->
+        <!-- <startup_level>trace</startup_level> -->
        <!-- Shutdown level is used to set the root logger level at server Shutdown.
              It is useful for debugging shutdown issues -->
-        <!-- <shutdownLevel>trace</shutdownLevel> -->
+        <!-- <shutdown_level>trace</shutdown_level> -->
 
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>

--- a/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger.xml
+++ b/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger.xml
@@ -1,7 +1,7 @@
  <clickhouse>
     <logger>
         <level>none</level>
-        <startupLevel>trace</startupLevel>
-        <shutdownLevel>trace</shutdownLevel>
+        <startup_level>trace</startup_level>
+        <shutdown_level>trace</shutdown_level>
     </logger>
 </clickhouse>


### PR DESCRIPTION
Rename the log level settings from startupLevel and shutdownLevel to startup_level and shutdown_level to match the general settings format
Settings were introduced in https://github.com/ClickHouse/ClickHouse/pull/85967#discussion_r2334727232

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Rename the log level settings from startupLevel and shutdownLevel to startup_level and shutdown_level to match the general settings format


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
