### PR TITLE
Fix incorrect handling of timeout for executable dictionaries

### DIFF
--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -160,8 +160,8 @@ public:
         {
             pfds[0].revents = 0;
             pfds[1].revents = 0;
-            size_t num_events = pollWithTimeout(pfds, num_pfds, timeout_milliseconds);
-            if (0 == num_events)
+            int num_events = pollWithTimeout(pfds, num_pfds, timeout_milliseconds);
+            if (num_events <= 0)
                 throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Pipe read timeout exceeded {} milliseconds", timeout_milliseconds);
 
             bool has_stdout = pfds[0].revents > 0;

--- a/tests/integration/test_executable_dictionary/test.py
+++ b/tests/integration/test_executable_dictionary/test.py
@@ -255,26 +255,6 @@ def test_executable_implicit_input_slow_python(started_cluster):
     )
 
 
-def test_executable_input_slow_python(started_cluster):
-    skip_test_msan(node)
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_input_slow_python', 'result', toUInt64(1))"
-    )
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_input_slow_pool_python', 'result', toUInt64(1))"
-    )
-
-
-def test_executable_implicit_input_slow_python(started_cluster):
-    skip_test_msan(node)
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_implicit_input_slow_python', 'result', toUInt64(1))"
-    )
-    assert node.query_and_get_error(
-        "SELECT dictGet('executable_implicit_input_slow_pool_python', 'result', toUInt64(1))"
-    )
-
-
 def test_executable_non_direct_input_bash(started_cluster):
     skip_test_msan(node)
     assert (

--- a/tests/integration/test_executable_dictionary/test.py
+++ b/tests/integration/test_executable_dictionary/test.py
@@ -395,6 +395,7 @@ def test_executable_source_argument_python(started_cluster):
 
 def test_executable_source_updated_python(started_cluster):
     skip_test_msan(node)
+    node.restart_clickhouse()
     assert (
         node.query(
             "SELECT * FROM dictionary(executable_source_simple_key_update_python) ORDER BY input"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect handling of `command_read_timeout` for executable dictionaries

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=87563&sha=f43fe8e980ddb3355dedc608591f360c961e19c7&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29