### PR TITLE
Speed up the common case of Field destructor

### DIFF
--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -617,7 +617,9 @@ private:
 
     ALWAYS_INLINE void destroy()
     {
-        switch (which)
+        auto old_which = which;
+        which = Types::Null;    /// for exception safety in subsequent calls to destroy and create, when create fails.
+        switch (old_which)
         {
             case Types::String:
                 destroy<String>();
@@ -640,15 +642,13 @@ private:
             case Types::CustomType:
                 destroy<CustomType>();
                 break;
-            default:
+            default: [[likely]]
                  break;
         }
-
-        which = Types::Null;    /// for exception safety in subsequent calls to destroy and create, when create fails.
     }
 
     template <typename T>
-    void destroy()
+    NO_INLINE void destroy()
     {
         T * MAY_ALIAS ptr = reinterpret_cast<T*>(&storage);
         ptr->~T();


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up the common case of Field destructor

Fields are commonly used on index analysis (which is a topic for another improvement) and the Field destructor shows up as an expensive function in queries like ClickBench Q19: `SELECT UserID FROM hits WHERE UserID = 435090932899640449;`

```
+   15.76%    10.56%           609  MergeTreeIndex   clickhouse         [.] DB::Field::~Field()                                                                                                                                                                                         ▒
```

We can tell the compiler to prioritize the common types (integers) and leave the destructor as simple as possible, at the cost of an extra indirect call for complex types.

* Before: `0.0.0.0:49000, queries: 2947, QPS: 243.072, RPS: 15512963.860, MiB/s: 118.355, result RPS: 972.288, result MiB/s: 0.007.`
* After: `0.0.0.0:49000, queries: 1779, QPS: 268.742, RPS: 18293934.486, MiB/s: 139.572, result RPS: 1074.967, result MiB/s: 0.008.`

Similar improvement if we just look at perf report (was 15%, not 6%):
```
+    6.63%     4.18%          6739  MergeTreeIndex  clickhouse  [.] DB::Field::~Field()
```

Let's see what the perf report thinks about it