### PR TITLE
changelog.py: Fix handling for PRs from Copilot user

### DIFF
--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -52,7 +52,16 @@ class Description:
     ):
         self.number = number
         self.html_url = html_url
-        self.user = gh.get_user_cached(user._rawData["login"])  # type: ignore
+        user_login = user._rawData["login"]
+        if user_login == 'Copilot':
+            class CopilotUser:
+                name = "Copilot"
+                login = "Copilot"
+                html_url = ""
+            self.user = CopilotUser()
+        else:
+            self.user = gh.get_user_cached(user_login)  # type: ignore
+
         self.entry = entry
         self.category = category
 
@@ -85,7 +94,7 @@ class Description:
                 gh.sleep_on_rate_limit()
         return (
             f"* {entry} [#{self.number}]({self.html_url}) "
-            f"([{user_name}]({self.user.html_url}))."
+            f"({f"[{user_name}]({self.user.html_url})" if self.user.html_url else user_name})."
         )
 
     # Sort PR descriptions by numbers


### PR DESCRIPTION
changelog.py: Fix handling for PRs from Copilot user
Fix this error:
```
-> import argparse
(Pdb) c
2025-09-25 12:43:32,041 INFO     [private_changelog.py:384]:
Starting to build changelog
🪵  Parsing git log...
👌 Parsed
Will search for all PRs which were merged between 2025-09-08 00:00:00 and now
2025-09-25 12:45:06,465 INFO     [credentials.py:1278]:
Found credentials in shared credentials file: ~/.aws/credentials
2025-09-25 12:45:06,514 INFO     [cache_utils.py:221]:
Searching cache for GitHub class
2025-09-25 12:45:06,535 INFO     [compress_files.py:54]:
zstd will be used for decompression ('/home/nik/work/clickhouse-private1/tests/ci/tmp/GitHub.tar.zst' -> '/home/nik/work/clickhouse-private1/tests/ci')
📥 Fetching PRs from public repo
PRs will be filtered by base branch [master]
2025-09-25 12:45:07,570 INFO     [private_changelog.py:146]:
Fetch PRs with query type:pr repo:ClickHouse/ClickHouse is:merged base:master
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 300/300 [00:06<00:00, 49.68it/s]
👀 We have 300 pull requests. Will get descriptions...
Traceback (most recent call last):
  File "/home/nik/.pyenv/versions/3.11.6/lib/python3.11/pdb.py", line 1778, in main
    pdb._run(target)
  File "/home/nik/.pyenv/versions/3.11.6/lib/python3.11/pdb.py", line 1646, in _run
    self.run(target.code)
  File "/home/nik/.pyenv/versions/3.11.6/lib/python3.11/bdb.py", line 600, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/nik/work/clickhouse-private1/tests/ci/private_changelog.py", line 389, in <module>
    main()
  File "/home/nik/work/clickhouse-private1/tests/ci/private_changelog.py", line 385, in main
    build_changelog(from_release, to_release, token, args.pretty)
  File "/home/nik/work/clickhouse-private1/tests/ci/private_changelog.py", line 261, in build_changelog
    os_descriptions = get_descriptions(prs)
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/work/clickhouse-private1/tests/ci/changelog.py", line 120, in get_descriptions
    desc = generate_description(pr, repos[repo_name])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/work/clickhouse-private1/tests/ci/changelog.py", line 312, in generate_description
    return Description(item.number, item.user, item.html_url, entry, category)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/work/clickhouse-private1/tests/ci/changelog.py", line 55, in __init__
    self.user = gh.get_user_cached(user._rawData["login"])  # type: ignore
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/work/clickhouse-private1/tests/ci/github_helper.py", line 238, in get_user_cached
    user = self.get_user(login)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/.pyenv/versions/3.11.6/lib/python3.11/site-packages/github/MainClass.py", line 379, in get_user
    headers, data = self.__requester.requestJsonAndCheck("GET", f"/users/{login}")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/.pyenv/versions/3.11.6/lib/python3.11/site-packages/github/Requester.py", line 586, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nik/.pyenv/versions/3.11.6/lib/python3.11/site-packages/github/Requester.py", line 744, in __check
    raise self.createException(status, responseHeaders, data)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest", "status": "404"}
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
> /home/nik/.pyenv/versions/3.11.6/lib/python3.11/site-packages/github/Requester.py(744)__check()
-> raise self.createException(status, responseHeaders, data)
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
