### PR TITLE
ci: temporary disable database disk in integration tests to avoid flakiness

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1913,16 +1913,19 @@ class ClickHouseCluster:
             with_remote_database_disk = False
 
         if with_remote_database_disk is None:
-            if ClickHouseInstance.is_local_server_asan_build == None:
-                build_opts = subprocess.check_output(
-                    f"""{self.server_bin_path} local -q "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'" """,
-                    stderr=subprocess.STDOUT,
-                    shell=True,
-                ).decode()
-                ClickHouseInstance.is_local_server_asan_build = (
-                    "-fsanitize=address" in build_opts
-                )
-            with_remote_database_disk = ClickHouseInstance.is_local_server_asan_build
+            # FIXME: https://github.com/ClickHouse/ClickHouse/issues/87656
+            #
+            # if ClickHouseInstance.is_local_server_asan_build == None:
+            #     build_opts = subprocess.check_output(
+            #         f"""{self.server_bin_path} local -q "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'" """,
+            #         stderr=subprocess.STDOUT,
+            #         shell=True,
+            #     ).decode()
+            #     ClickHouseInstance.is_local_server_asan_build = (
+            #         "-fsanitize=address" in build_opts
+            #     )
+            # with_remote_database_disk = ClickHouseInstance.is_local_server_asan_build
+            with_remote_database_disk = False
 
         if with_remote_database_disk:
             logging.debug(f"Instance {name}, with_remote_database_disk enabled")


### PR DESCRIPTION
Due to server restarts there can be some leftovers after which server is not able to start.

Refs: https://github.com/ClickHouse/ClickHouse/issues/87656

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)