### PR TITLE
Exclude MD5-related tests from FIPS test run

### DIFF
--- a/tests/queries/0_stateless/03593_funcs_on_empty_string.sql
+++ b/tests/queries/0_stateless/03593_funcs_on_empty_string.sql
@@ -1,5 +1,6 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-openssl-fips
 -- ^ certain functions are disabled in the fast test build.
+-- ^ MD5 function is not available in FIPS build
 
 SET session_timezone = 'UTC';
 

--- a/tests/queries/0_stateless/03595_funcs_on_zero.sql
+++ b/tests/queries/0_stateless/03595_funcs_on_zero.sql
@@ -1,5 +1,6 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-openssl-fips
 -- ^ certain functions are disabled in the fast test build.
+-- ^ MD5 function is not available in FIPS build
 
 SET session_timezone = 'UTC';
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

