### PR TITLE
Extend trace_log with memory_context and memory_blocked_context for ClickHouse debugging

### DIFF
--- a/src/Common/Jemalloc.cpp
+++ b/src/Common/Jemalloc.cpp
@@ -118,7 +118,11 @@ void jemallocAllocationTracker(const void * ptr, size_t /*size*/, void ** backtr
         TraceSender::send(
             TraceType::JemallocSample,
             StackTrace(std::move(frame_pointers), stacktrace_size),
-            TraceSender::Extras{.size = static_cast<Int64>(usize), .ptr = const_cast<void *>(ptr)});
+            TraceSender::Extras{
+                .size = static_cast<Int64>(usize),
+                .ptr = const_cast<void *>(ptr),
+                .memory_blocked_context = MemoryTrackerBlockerInThread::getLevel(),
+            });
     }
     catch (...)
     {
@@ -137,7 +141,11 @@ void jemallocDeallocationTracker(const void * ptr, unsigned usize)
         TraceSender::send(
             TraceType::JemallocSample,
             StackTrace(),
-            TraceSender::Extras{.size = -static_cast<Int64>(usize), .ptr = const_cast<void *>(ptr)});
+            TraceSender::Extras{
+                .size = -static_cast<Int64>(usize),
+                .ptr = const_cast<void *>(ptr),
+                .memory_blocked_context = MemoryTrackerBlockerInThread::getLevel(),
+            });
     }
     catch (...)
     {

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -105,8 +105,13 @@ void AllocationTrace::onAllocImpl(void * ptr, size_t size) const
     if (sample_probability < 1 && !shouldTrackAllocation(sample_probability, ptr))
         return;
 
+    auto memory_blocked_context = MemoryTrackerBlockerInThread::getLevel();
     MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
-    DB::TraceSender::send(DB::TraceType::MemorySample, StackTrace(), {.size = Int64(size), .ptr = ptr});
+    DB::TraceSender::send(DB::TraceType::MemorySample, StackTrace(), {
+        .size = Int64(size),
+        .ptr = ptr,
+        .memory_blocked_context = memory_blocked_context,
+    });
 }
 
 void AllocationTrace::onFreeImpl(void * ptr, size_t size) const
@@ -114,8 +119,13 @@ void AllocationTrace::onFreeImpl(void * ptr, size_t size) const
     if (sample_probability < 1 && !shouldTrackAllocation(sample_probability, ptr))
         return;
 
+    auto memory_blocked_context = MemoryTrackerBlockerInThread::getLevel();
     MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
-    DB::TraceSender::send(DB::TraceType::MemorySample, StackTrace(), {.size = -Int64(size), .ptr = ptr});
+    DB::TraceSender::send(DB::TraceType::MemorySample, StackTrace(), {
+        .size = -Int64(size),
+        .ptr = ptr,
+        .memory_blocked_context = memory_blocked_context,
+    });
 }
 
 namespace ProfileEvents
@@ -224,13 +234,17 @@ void incrementAllocationWithoutCheck(Int64 size)
 
     if (size > threshold)
     {
+        auto memory_blocked_context = MemoryTrackerBlockerInThread::getLevel();
         MemoryTrackerBlockerInThread tracker_blocker(VariableContext::Global);
         /// Forbid recursive calls
         [[maybe_unused]] MemoryTrackerDebugBlockerInThread debug_blocker;
 
         try
         {
-            DB::TraceSender::send(DB::TraceType::MemoryAllocatedWithoutCheck, StackTrace(), DB::TraceSender::Extras{.size = size});
+            DB::TraceSender::send(DB::TraceType::MemoryAllocatedWithoutCheck, StackTrace(), DB::TraceSender::Extras{
+                .size = size,
+                .memory_blocked_context = memory_blocked_context,
+            });
         }
         catch (...) // NOLINT(bugprone-empty-catch)
         {
@@ -291,8 +305,13 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
     bool allocation_traced = false;
     if (unlikely(current_profiler_limit && will_be > current_profiler_limit))
     {
+        auto memory_blocked_context = MemoryTrackerBlockerInThread::getLevel();
         MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
-        DB::TraceSender::send(DB::TraceType::Memory, StackTrace(), {.size = size});
+        DB::TraceSender::send(DB::TraceType::Memory, StackTrace(), {
+            .size = size,
+            .memory_context = level,
+            .memory_blocked_context = memory_blocked_context,
+        });
         setOrRaiseProfilerLimit((will_be + profiler_step - 1) / profiler_step * profiler_step);
         allocation_traced = true;
     }
@@ -442,8 +461,13 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
 
     if (peak_updated && allocation_traced)
     {
+        auto memory_blocked_context = MemoryTrackerBlockerInThread::getLevel();
         MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
-        DB::TraceSender::send(DB::TraceType::MemoryPeak, StackTrace(), {.size = will_be});
+        DB::TraceSender::send(DB::TraceType::MemoryPeak, StackTrace(), {
+            .size = will_be,
+            .memory_context = level,
+            .memory_blocked_context = memory_blocked_context,
+        });
     }
 
     if (auto * loaded_next = parent.load(std::memory_order_relaxed))

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -1,3 +1,4 @@
+#include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/TraceSender.h>
 
 #include <IO/WriteBufferFromFileDescriptorDiscardOnFailure.h>
@@ -46,6 +47,8 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
         + sizeof(UInt64)                     /// thread_id
         + sizeof(Int64)                      /// size
         + sizeof(void *)                     /// ptr
+        + sizeof(UInt8)                      /// memory_context
+        + sizeof(UInt8)                      /// memory_blocked_context
         + sizeof(ProfileEvents::Event)       /// event
         + sizeof(ProfileEvents::Count);      /// increment
 
@@ -88,6 +91,14 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
     writePODBinary(thread_id, out);
     writePODBinary(extras.size, out);
     writePODBinary(UInt64(extras.ptr), out);
+    if (extras.memory_context.has_value())
+        writePODBinary(static_cast<Int8>(extras.memory_context.value()), out);
+    else
+        writePODBinary(static_cast<Int8>(MEMORY_CONTEXT_UNKNOWN), out);
+    if (extras.memory_blocked_context.has_value())
+        writePODBinary(static_cast<Int8>(extras.memory_blocked_context.value()), out);
+    else
+        writePODBinary(static_cast<Int8>(MEMORY_CONTEXT_UNKNOWN), out);
     writePODBinary(extras.event, out);
     writePODBinary(extras.increment, out);
 

--- a/src/Common/TraceSender.h
+++ b/src/Common/TraceSender.h
@@ -2,6 +2,7 @@
 
 #include <Common/PipeFDs.h>
 #include <Common/ProfileEvents.h>
+#include <Common/VariableContext.h>
 #include <base/types.h>
 
 class StackTrace;
@@ -28,11 +29,15 @@ enum class TraceType : uint8_t
 class TraceSender
 {
 public:
+    static constexpr Int8 MEMORY_CONTEXT_UNKNOWN = -1;
+
     struct Extras
     {
         /// size, ptr - for memory tracing is the amount of memory allocated; for other trace types it is 0.
         Int64 size{};
         void * ptr = nullptr;
+        std::optional<VariableContext> memory_context{};
+        std::optional<VariableContext> memory_blocked_context{};
         /// Event type and increment for 'ProfileEvent' trace type; for other trace types defaults.
         ProfileEvents::Event event{ProfileEvents::end()};
         ProfileEvents::Count increment{};

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -10,6 +10,7 @@
 #include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/TraceSender.h>
 #include <Common/ProfileEvents.h>
+#include <Common/VariableContext.h>
 #include <Common/setThreadName.h>
 #include <Common/logger_useful.h>
 #include <Common/SymbolIndex.h>
@@ -159,6 +160,11 @@ void TraceCollector::run()
             UInt64 ptr;
             readPODBinary(ptr, in);
 
+            Int8 memory_context;
+            readPODBinary(memory_context, in);
+            Int8 memory_blocked_context;
+            readPODBinary(memory_blocked_context, in);
+
             ProfileEvents::Event event;
             readPODBinary(event, in);
 
@@ -172,10 +178,25 @@ void TraceCollector::run()
                 struct timespec ts;
                 clock_gettime(CLOCK_REALTIME, &ts); /// NOLINT(cert-err33-c)
 
-                UInt64 time = static_cast<UInt64>(ts.tv_sec * 1000000000LL + ts.tv_nsec);
+                UInt64 timestamp_ns = static_cast<UInt64>(ts.tv_sec * 1000000000LL + ts.tv_nsec);
                 UInt64 time_in_microseconds = static_cast<UInt64>((ts.tv_sec * 1000000LL) + (ts.tv_nsec / 1000));
 
-                TraceLogElement element{symbolize, time_t(time / 1000000000), time_in_microseconds, time, trace_type, thread_id, query_id, std::move(trace), size, ptr, event, increment};
+                TraceLogElement element{
+                    .symbolize = symbolize,
+                    .event_time = time_t(timestamp_ns / 1000000000),
+                    .event_time_microseconds = time_in_microseconds,
+                    .timestamp_ns = timestamp_ns,
+                    .trace_type = trace_type,
+                    .thread_id = thread_id,
+                    .query_id = query_id,
+                    .trace = std::move(trace),
+                    .size = size,
+                    .ptr = ptr,
+                    .memory_context = memory_context == TraceSender::MEMORY_CONTEXT_UNKNOWN ? std::nullopt : std::make_optional<VariableContext>(static_cast<VariableContext>(memory_context)),
+                    .memory_blocked_context = memory_blocked_context == TraceSender::MEMORY_CONTEXT_UNKNOWN ? std::nullopt : std::make_optional<VariableContext>(static_cast<VariableContext>(memory_blocked_context)),
+                    .event = event,
+                    .increment = increment,
+                };
                 trace_log->add(std::move(element));
             }
         }

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -22,7 +22,6 @@ namespace DB
 {
 
 using TraceDataType = TraceLogElement::TraceDataType;
-
 const TraceDataType::Values TraceLogElement::trace_values =
 {
     {"Real", static_cast<UInt8>(TraceType::Real)},
@@ -35,9 +34,30 @@ const TraceDataType::Values TraceLogElement::trace_values =
     {"MemoryAllocatedWithoutCheck", static_cast<UInt8>(TraceType::MemoryAllocatedWithoutCheck)},
 };
 
+static_assert(TraceSender::MEMORY_CONTEXT_UNKNOWN == -1);
+using ContextDataType = TraceLogElement::ContextDataType;
+const ContextDataType::Values TraceLogElement::context_values =
+{
+    {"Unknown", static_cast<Int8>(TraceSender::MEMORY_CONTEXT_UNKNOWN)},
+    {"Global", static_cast<Int8>(VariableContext::Global)},
+    {"User", static_cast<Int8>(VariableContext::User)},
+    {"Process", static_cast<Int8>(VariableContext::Process)},
+    {"Thread", static_cast<Int8>(VariableContext::Thread)},
+    /// Only for MemoryTrackerBlockerInThread, Max means inactive.
+    {"Max", static_cast<Int8>(VariableContext::Max)},
+};
+
 ColumnsDescription TraceLogElement::getColumnsDescription()
 {
     DataTypePtr symbolized_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()));
+
+    constexpr std::string_view context_description =
+        "`Unknown` context is not defined for this trace_type. "
+        "`Global` represents server context. "
+        "`User` represents user/merge context. "
+        "`Process` represents process (i.e. query) context. "
+        "`Thread` represents thread (thread of particular process) context. "
+        "`Max` this is a special value means that memory tracker is not blocked (for blocked_context column). ";
 
     return ColumnsDescription
     {
@@ -62,6 +82,8 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
         {"trace", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>()), "Stack trace at the moment of sampling. Each element is a virtual memory address inside ClickHouse server process."},
         {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
         {"ptr", std::make_shared<DataTypeUInt64>(), "The address of the allocated chunk."},
+        {"memory_context", std::make_shared<ContextDataType>(context_values), fmt::format("Memory Tracker context (only for Memory/MemoryPeak): {}", context_description)},
+        {"memory_blocked_context", std::make_shared<ContextDataType>(context_values), fmt::format("Context for which memory tracker is blocked (for ClickHouse developers only): {}", context_description)},
         {"event", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "For trace type ProfileEvent is the name of updated profile event, for other trace types is an empty string."},
         {"increment", std::make_shared<DataTypeInt64>(), "For trace type ProfileEvent is the amount of increment of profile event, for other trace types is 0."},
         {"symbols", symbolized_type, "If the symbolization is enabled, contains demangled symbol names, corresponding to the `trace`."},
@@ -166,6 +188,14 @@ void TraceLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(Array(trace.begin(), trace.end()));
     columns[i++]->insert(size);
     columns[i++]->insert(ptr);
+    if (memory_context.has_value())
+        columns[i++]->insert(static_cast<Int8>(memory_context.value()));
+    else
+        columns[i++]->insert(static_cast<Int8>(TraceSender::MEMORY_CONTEXT_UNKNOWN));
+    if (memory_blocked_context.has_value())
+        columns[i++]->insert(static_cast<Int8>(memory_blocked_context.value()));
+    else
+        columns[i++]->insert(static_cast<Int8>(TraceSender::MEMORY_CONTEXT_UNKNOWN));
 
     String event_name;
     if (event != ProfileEvents::end())

--- a/src/Interpreters/TraceLog.h
+++ b/src/Interpreters/TraceLog.h
@@ -23,6 +23,9 @@ struct TraceLogElement
     using TraceDataType = DataTypeEnum8;
     static const TraceDataType::Values trace_values;
 
+    using ContextDataType = DataTypeEnum8;
+    static const ContextDataType::Values context_values;
+
     time_t event_time{};
     Decimal64 event_time_microseconds{};
     UInt64 timestamp_ns{};
@@ -34,6 +37,9 @@ struct TraceLogElement
     Int64 size{};
     /// Allocation ptr for TraceType::MemorySample.
     UInt64 ptr{};
+    /// For memory tracing
+    std::optional<VariableContext> memory_context{};
+    std::optional<VariableContext> memory_blocked_context{};
     /// ProfileEvent for TraceType::ProfileEvent.
     ProfileEvents::Event event{ProfileEvents::end()};
     /// Increment of profile event for TraceType::ProfileEvent.

--- a/tests/integration/test_trace_log_memory_context/configs/overrides.xml
+++ b/tests/integration/test_trace_log_memory_context/configs/overrides.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <jemalloc_enable_global_profiler>1</jemalloc_enable_global_profiler>
+    <jemalloc_collect_global_profile_samples_in_trace_log>1</jemalloc_collect_global_profile_samples_in_trace_log>
+    <total_memory_tracker_sample_probability>0.1</total_memory_tracker_sample_probability>
+
+    <trace_log>
+        <!-- jemalloc has too many events, which leads to slower testing with default value 1KK -->
+        <max_size_rows>100000</max_size_rows>
+    </trace_log>
+
+    <text_log remove="remove" />
+</clickhouse>

--- a/tests/integration/test_trace_log_memory_context/test.py
+++ b/tests/integration/test_trace_log_memory_context/test.py
@@ -1,0 +1,65 @@
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node",
+    main_configs=["configs/overrides.xml"],
+    stay_alive=True,
+    env_variables={"MALLOC_CONF": "lg_prof_sample=20"},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_memory_context_in_trace_log(started_cluster):
+    if node.is_built_with_sanitizer():
+        pytest.skip("sanitizers built without jemalloc")
+
+    def get_trace_events(memory_context, memory_blocked_context, trace_type, query_id=None):
+        return int(node.query(f"""
+        SELECT count() FROM system.trace_log
+        WHERE
+            /* Do not take into account data from other test runs */
+            event_time >= now()-uptime()
+            AND memory_context = '{memory_context}'
+            AND memory_blocked_context = '{memory_blocked_context}'
+            AND trace_type = '{trace_type}'
+            AND {'empty(query_id)' if query_id is None else f"query_id = '{query_id}'"}
+        """).strip())
+
+    # Generate some logs to generate entries with memory_blocked_context=Global and trace_type=JemallocSample
+    for i in range(10):
+        node.query("SELECT logTrace('foo')")
+    query_id = uuid.uuid4().hex
+    node.query("SELECT * FROM numbers(100000) ORDER BY number", query_id=query_id)
+    node.query("SYSTEM FLUSH LOGS system.trace_log")
+
+    # For JemallocSample we have Global (for i.e. logging) and Max (for regular allocations) blocked memory tracker
+    for memory_blocked_context in ["Global", "Max"]:
+        assert get_trace_events("Unknown", memory_blocked_context, "JemallocSample") > 0
+
+    for memory_context in ["Global"]:
+        for trace_type in ["Memory", "MemoryPeak"]:
+            assert get_trace_events(memory_context, "Max", trace_type) > 0
+
+    assert get_trace_events("Unknown", "Max", "MemorySample", query_id) > 0
+    # It is better not to check for memory_blocked_context=Global, since we
+    # cannot be sure that allocations for logging for that tiny query will be
+    # sampled by jemalloc.
+    assert get_trace_events("Unknown", "Max", "JemallocSample", query_id) > 0
+
+    # Graceful shutdown too slow due to flushing trace_log
+    node.restart_clickhouse(kill=True)


### PR DESCRIPTION
The following new columns has been added to trace_log:
- memory_context is one of Global/User/Process/Thread
- memory_blocked_context does the memory tracker blocked with MemoryTrackerBlockerInThread

This additional information is useful to track memory bugs, for instance to investigate drift for query memory usage we need to known was this allocation respected for the query or not (memory_blocked_context = 'Max' - means that it was respected).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Extend trace_log with memory_context and memory_blocked_context for ClickHouse debugging