### PR TITLE
Fix handling error when failing to drop the database completely on the cluster on the secondary node.

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -119,6 +119,8 @@ static struct InitFiu
     REGULAR(sleep_in_logs_flush) \
     ONCE(smt_commit_exception_before_op) \
     ONCE(disk_object_storage_fail_commit_metadata_transaction) \
+    ONCE(database_replicated_drop_before_removing_keeper_failed) \
+    ONCE(database_replicated_drop_after_removing_keeper_failed) \
 
 
 namespace FailPoints

--- a/tests/integration/test_ddl_worker_retry_when_dropping_db_failed/configs/remote_servers.xml
+++ b/tests/integration/test_ddl_worker_retry_when_dropping_db_failed/configs/remote_servers.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+
+    <allow_zookeeper_write>1</allow_zookeeper_write>
+</clickhouse>

--- a/tests/integration/test_ddl_worker_retry_when_dropping_db_failed/test.py
+++ b/tests/integration/test_ddl_worker_retry_when_dropping_db_failed/test.py
@@ -1,0 +1,66 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": "s1", "replica": "r1"},
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    macros={"shard": "s1", "replica": "r2"},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+@pytest.mark.parametrize(
+    "before_removing_keeper_path",
+    [False, True],
+)
+def test_drop_database_failed_on_secondary_node_before_removing_keeper_path(
+    started_cluster,
+    before_removing_keeper_path: bool,
+):
+    node1.query("DROP DATABASE IF EXISTS test SYNC")
+    node2.query("DROP DATABASE IF EXISTS test SYNC")
+
+    failpoint_name = (
+        "database_replicated_drop_before_removing_keeper_failed"
+        if before_removing_keeper_path
+        else "database_replicated_drop_after_removing_keeper_failed"
+    )
+    node2.query(f"SYSTEM ENABLE FAILPOINT {failpoint_name}")
+
+    node1.query(
+        r"CREATE DATABASE test ON CLUSTER 'test_cluster' ENGINE=Replicated('/clickhouse/db/test','{shard}','{replica}')"
+    )
+
+    node1.query("CREATE TABLE test.t (x INT, y String) ENGINE=MergeTree ORDER BY x")
+    assert (
+        node2.query(
+            "SELECT count() FROM system.tables WHERE database='test' AND name='t'"
+        ).strip()
+        == "1"
+    )
+
+    node2.query(f"SYSTEM DISABLE FAILPOINT {failpoint_name}")
+
+    node1.query("DROP DATABASE test ON CLUSTER 'test_cluster' SYNC")
+    node2.query(f"SYSTEM DISABLE FAILPOINT {failpoint_name}")

--- a/tests/queries/0_stateless/01601_detach_permanently.sql
+++ b/tests/queries/0_stateless/01601_detach_permanently.sql
@@ -33,7 +33,8 @@ SELECT 'can still show the create statement';
 SHOW CREATE TABLE test1601_detach_permanently_atomic.test_name_reuse FORMAT Vertical;
 
 SELECT 'can not attach with bad uuid';
-ATTACH TABLE test1601_detach_permanently_atomic.test_name_reuse UUID '00000000-0000-0000-0000-000000001601'　(`number` UInt64　)　ENGINE = MergeTree　ORDER BY tuple()　SETTINGS index_granularity = 8192 ;  -- { serverError TABLE_ALREADY_EXISTS }
+-- STD_EXCEPTION occured when running flaky test, the table directory's access right was removed. Refer `DatabaseCatalog::maybeRemoveDirectory`.
+ATTACH TABLE test1601_detach_permanently_atomic.test_name_reuse UUID '00000000-0000-0000-0000-000000001601'　(`number` UInt64　)　ENGINE = MergeTree　ORDER BY tuple()　SETTINGS index_granularity = 8192 ;  -- { serverError TABLE_ALREADY_EXISTS, STD_EXCEPTION }
 
 SELECT 'can attach with short syntax';
 ATTACH TABLE test1601_detach_permanently_atomic.test_name_reuse;

--- a/tests/queries/0_stateless/01601_detach_permanently.sql
+++ b/tests/queries/0_stateless/01601_detach_permanently.sql
@@ -137,8 +137,6 @@ DETACH table test1601_detach_permanently_ordinary.test_name_reuse PERMANENTLY;
 SELECT 'DROP database - Directory not empty error, but database detached';
 DROP DATABASE test1601_detach_permanently_ordinary; -- { serverError DATABASE_NOT_EMPTY }
 
-ATTACH DATABASE test1601_detach_permanently_ordinary;
-
 ATTACH TABLE test1601_detach_permanently_ordinary.test_name_reuse;
 DROP TABLE test1601_detach_permanently_ordinary.test_name_reuse;
 
@@ -210,8 +208,6 @@ DETACH table test1601_detach_permanently_lazy.test_name_reuse PERMANENTLY;
 
 SELECT 'DROP database - Directory not empty error, but database deteched';
 DROP DATABASE test1601_detach_permanently_lazy; -- { serverError DATABASE_NOT_EMPTY }
-
-ATTACH DATABASE test1601_detach_permanently_lazy;
 
 ATTACH TABLE test1601_detach_permanently_lazy.test_name_reuse;
 DROP TABLE test1601_detach_permanently_lazy.test_name_reuse;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix handling error when failing to drop the database completely on the cluster on the secondary node.

There are 2 problems in https://github.com/ClickHouse/support-escalation/issues/5792:
1. When dropping a DatabaseReplicated in ([DatabaseReplicated::drop](https://github.com/ClickHouse/ClickHouse/blob/a6df40dbd84c5d5830ac9be4411ed1f8bf91a02e/src/Databases/DatabaseReplicated.cpp#L1923)), the process fails when trying to remove the Keeper path.
In [DatabaseCatalog::detachDatabase](https://github.com/ClickHouse/ClickHouse/blob/a6df40dbd84c5d5830ac9be4411ed1f8bf91a02e/src/Interpreters/DatabaseCatalog.cpp#L661), we don't handle the exception, which leads to:
- The database metadata file is still on disk. It will fail if users create a new database with the same name.
- Database is not re-attached, so "DROP DATABASE IF EXISTS" will succeed but have no effect.
2. When dropping the database with  "ON CLUSTER", DDLWorker doesn't handle retry properly. In fact, it just writes down the status on Keeper. We can try to do the task if the task fails and is retriable.

The change in this PR:
- Re-attach the database if it failed to drop the database completely
- In DDLWorker, when the task is not finished, throw an ErrorCodes::UNFINISHED exception if the task is retriable to retry the task.

Closes https://github.com/ClickHouse/support-escalation/issues/5792

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
