### PR TITLE
Vector similarity index: Fix uncaught exception during serialization/deserialization

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -128,8 +128,17 @@ void USearchIndexWithSerialization::serialize(WriteBuffer & ostr) const
 {
     auto callback = [&ostr](void * from, size_t n)
     {
-        ostr.write(reinterpret_cast<const char *>(from), n);
-        return true;
+        /// USearch may call callback from noexcept function
+        try
+        {
+            ostr.write(reinterpret_cast<const char *>(from), n);
+            return true;
+        }
+        catch (...)
+        {
+            tryLogCurrentException("USearchIndexWithSerialization", "An error while serializing USearch index");
+            return false;
+        }
     };
 
     if (auto result = Base::save_to_stream(callback); !result)
@@ -140,8 +149,17 @@ void USearchIndexWithSerialization::deserialize(ReadBuffer & istr)
 {
     auto callback = [&istr](void * from, size_t n)
     {
-        istr.readStrict(reinterpret_cast<char *>(from), n);
-        return true;
+        /// USearch may call callback from noexcept function
+        try
+        {
+            istr.readStrict(reinterpret_cast<char *>(from), n);
+            return true;
+        }
+        catch (...)
+        {
+            tryLogCurrentException("USearchIndexWithSerialization", "An error while deserializing USearch index");
+            return false;
+        }
     };
 
     if (auto result = Base::load_from_stream(callback); !result)

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -136,7 +136,7 @@ void USearchIndexWithSerialization::serialize(WriteBuffer & ostr) const
         }
         catch (...)
         {
-            tryLogCurrentException("USearchIndexWithSerialization", "An error while serializing USearch index");
+            tryLogCurrentException("VectorSimilarityIndex", "An error while serializing USearch index");
             return false;
         }
     };
@@ -157,7 +157,7 @@ void USearchIndexWithSerialization::deserialize(ReadBuffer & istr)
         }
         catch (...)
         {
-            tryLogCurrentException("USearchIndexWithSerialization", "An error while deserializing USearch index");
+            tryLogCurrentException("VectorSimilarityIndex", "An error while deserializing USearch index");
             return false;
         }
     };


### PR DESCRIPTION
Found on CI [1]:

```
    ./ci/tmp/build/./src/Common/SignalHandlers.cpp:0: terminate_handler() @ 0x00000000163e9be6
    ./ci/tmp/build/./contrib/llvm-project/libcxxabi/src/cxa_handlers.cpp:59: std::__terminate(void (*)()) @ 0x000000001ffade03
    ./ci/tmp/build/./contrib/llvm-project/libcxxabi/src/cxa_handlers.cpp:88: std::terminate() @ 0x000000001ffaddef
    ? @ 0x000000000cad88db
    . inlined from ./contrib/usearch/include/usearch/index.hpp:3333: unum::usearch::serialization_result_t unum::usearch::index_gt<float, unsigned long, unsigned int, unum::usearch::aligned_allocator_gt<char, 64ul>, unum::usearch::memory_mapping_allocator_gt<8ul>>::load_from_stream<DB::USearchIndexWithSerialization::deserialize(DB::ReadBuffer&)::$_0&, unum::usearch::dummy_progress_t>(DB::USearchIndexWithSerialization::deserialize(DB::ReadBuffer&)::$_0&, unum::usearch::dummy_progress_t&&)
    . inlined from ./contrib/usearch/include/usearch/index_dense.hpp:1168: unum::usearch::serialization_result_t unum::usearch::index_dense_gt<unsigned long, unsigned int>::load_from_stream<DB::USearchIndexWithSerialization::deserialize(DB::ReadBuffer&)::$_0&, unum::usearch::dummy_progress_t>(DB::USearchIndexWithSerialization::deserialize(DB::ReadBuffer&)::$_0&, unum::usearch::index_dense_serialization_config_t, unum::usearch::dummy_progress_t&&)
    . inlined from ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp:147: DB::USearchIndexWithSerialization::deserialize(DB::ReadBuffer&)
```

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=87765&sha=1c7134af77cea73c514cb9e257b260010241c5f1&name_0=PR&name_1=Upgrade%20check%20%28amd_debug%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Don't crash if a vector similarity index cannot be saved to / loaded from persistence