### PR TITLE
unlink METADATA_VERSION_FILE_NAME before rewrite it, fix no such key thrown 

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1277,7 +1277,7 @@ void IMergeTreeDataPart::writeMetadataVersion(ContextPtr context, int32_t metada
 {
     getDataPartStorage().beginTransaction();
     {
-        // we remove old file first to avoid changing it context in the hardlinked files
+        // We need to remove the old file first to overwrite it only, not all its hard links.
         getDataPartStorage().removeFileIfExists(METADATA_VERSION_FILE_NAME);
 
         auto out_metadata = getDataPartStorage().writeFile(METADATA_VERSION_FILE_NAME, 4096, context->getWriteSettings());

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1277,6 +1277,9 @@ void IMergeTreeDataPart::writeMetadataVersion(ContextPtr context, int32_t metada
 {
     getDataPartStorage().beginTransaction();
     {
+        // we remove old file first to avoid changing it context in the hardlinked files
+        getDataPartStorage().removeFileIfExists(METADATA_VERSION_FILE_NAME);
+
         auto out_metadata = getDataPartStorage().writeFile(METADATA_VERSION_FILE_NAME, 4096, context->getWriteSettings());
         writeText(metadata_version_, *out_metadata);
         out_metadata->finalize();


### PR DESCRIPTION
In private repo I see that the race is possible between attaching parts and removing condemned parts.
Removing process reads files, those files are supposed to be immutable. But attach process changes content in `METADATA_VERSION_FILE_NAME` file in a way that hard linked file in condemned directory also is changed. 

https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=a71ec07a0761d5e1a8eb4bf2ec3d6e40d20708fc&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29&name_1=Stateless%20tests%20%28amd_msan%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

This change is not related to public but the function is shared between repos and this code would work correctly for both.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `25.10.1.1224` (included in `25.10` and later)
- Backported to: `25.8.31.8`
<!-- ch-version-info:end -->