### PR TITLE
Fix output_format_parquet_date_as_uint16 backport to 25.3

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -86,6 +86,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"parallel_replicas_for_cluster_engines", false, true, "New setting."},
             {"parallel_hash_join_threshold", 0, 0, "New setting"},
             {"enable_scopes_for_with_statement", true, true, "New setting for backward compatibility with the old analyzer."},
+            {"output_format_parquet_date_as_uint16", false, false, "(Actually added in 25.8 and backported into here.)"},
             /// Release closed. Please use 25.4
         });
         addSettingsChanges(settings_changes_history, "25.2",


### PR DESCRIPTION
Fix for https://github.com/ClickHouse/ClickHouse/pull/85830