### PR TITLE
Fix output_format_parquet_date_as_uint16 backport

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -94,7 +94,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_scopes_for_with_statement", true, true, "New setting for backward compatibility with the old analyzer."},
             {"backup_slow_all_threads_after_retryable_s3_error", false, false, "New setting"},
             {"s3_slow_all_threads_after_retryable_error", false, false, "Added an alias for setting `backup_slow_all_threads_after_retryable_s3_error`"},
-            {"output_format_parquet_date_as_uint16", true, false, "(Actually added in 25.8 and backported into here.)"},
+            {"output_format_parquet_date_as_uint16", false, false, "(Actually added in 25.8 and backported into here.)"},
             /// RELEASE CLOSED
         });
         addSettingsChanges(settings_changes_history, "25.5",


### PR DESCRIPTION
Fix for https://github.com/ClickHouse/ClickHouse/pull/85832