### PR TITLE
tests: fix flaky 03591_client_hilite_hex_highlight (increase timeout)

### DIFF
--- a/tests/queries/0_stateless/03591_client_hilite_hex_highlight.expect
+++ b/tests/queries/0_stateless/03591_client_hilite_hex_highlight.expect
@@ -13,7 +13,7 @@ exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
 set history_file $CLICKHOUSE_TMP/$basename.history
 
 log_user 0
-set timeout 10
+set timeout 60
 match_max 100000
 
 expect_after {


### PR DESCRIPTION
All other expect tests has timeout of 60 seconds

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f947d5fff3fe04cc12e764a15f68b790448dafb2&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_coverage%2C%20parallel%29&name_1=Stateless%20tests%20%28arm_coverage%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: #84806 (cc @rishabh1815769)