### PR TITLE
Use `StoredObject` everywhere in `ObjectStorage` disks metadata

### DIFF
--- a/src/Disks/MetadataStorageWithPathWrapper.h
+++ b/src/Disks/MetadataStorageWithPathWrapper.h
@@ -55,19 +55,14 @@ public:
         delegate->writeInlineDataToFile(wrappedPath(path), data);
     }
 
-    void createEmptyMetadataFile(const std::string & path) override
+    void createMetadataFile(const std::string & path, const StoredObjects & objects) override
     {
-        delegate->createEmptyMetadataFile(wrappedPath(path));
+        delegate->createMetadataFile(wrappedPath(path), objects);
     }
 
-    void createMetadataFile(const std::string & path, ObjectStorageKey object_key, uint64_t size_in_bytes) override
+    void addBlobToMetadata(const std::string & path, const StoredObject & object) override
     {
-        delegate->createMetadataFile(wrappedPath(path), object_key, size_in_bytes);
-    }
-
-    void addBlobToMetadata(const std::string & path, ObjectStorageKey object_key, uint64_t size_in_bytes) override
-    {
-        delegate->addBlobToMetadata(wrappedPath(path), object_key, size_in_bytes);
+        delegate->addBlobToMetadata(wrappedPath(path), object);
     }
 
     void setLastModified(const std::string & path, const Poco::Timestamp & timestamp) override

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
@@ -70,8 +70,8 @@ void DiskObjectStorageMetadata::deserialize(ReadBuffer & buf)
 
     if (serialized_total_size != serialized_objects_size)
         throw Exception(ErrorCodes::LOGICAL_ERROR,
-            "Serialized total bytes size is not equal to real sum of blob sizes ({} != {})",
-            serialized_total_size, serialized_objects_size);
+            "Serialized total bytes size of metadata file '{}' is not equal to real sum of blob sizes ({} != {})",
+            metadata_file_path, serialized_total_size, serialized_objects_size);
 
     readIntText(ref_count, buf);
     assertChar('\n', buf);

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
@@ -1,13 +1,8 @@
 #include <Disks/ObjectStorages/DiskObjectStorageMetadata.h>
 
 #include <IO/ReadBufferFromString.h>
-#include <IO/WriteBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
-#include <IO/WriteBufferFromFileBase.h>
-#include <Common/logger_useful.h>
-#include <Core/ServerSettings.h>
-#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -16,6 +11,12 @@ namespace ErrorCodes
 {
     extern const int UNKNOWN_FORMAT;
     extern const int LOGICAL_ERROR;
+}
+
+DiskObjectStorageMetadata::DiskObjectStorageMetadata(std::string compatible_key_prefix_, std::string metadata_file_path_)
+    : compatible_key_prefix(std::move(compatible_key_prefix_))
+    , metadata_file_path(std::move(metadata_file_path_))
+{
 }
 
 void DiskObjectStorageMetadata::deserialize(ReadBuffer & buf)
@@ -32,45 +33,45 @@ void DiskObjectStorageMetadata::deserialize(ReadBuffer & buf)
     UInt32 keys_count;
     readIntText(keys_count, buf);
     assertChar('\t', buf);
-    keys_with_meta.resize(keys_count);
+    objects.reserve(keys_count);
 
-    readIntText(total_size, buf);
+    int64_t serialized_total_size = 0;
+    readIntText(serialized_total_size, buf);
     assertChar('\n', buf);
 
+    int64_t serialized_objects_size = 0;
     for (UInt32 i = 0; i < keys_count; ++i)
     {
-        UInt64 object_size;
+        int64_t object_size = 0;
         readIntText(object_size, buf);
         assertChar('\t', buf);
 
-        keys_with_meta[i].metadata.size_bytes = object_size;
-
-        String key_value;
-        readEscapedString(key_value, buf);
+        std::string remote_path;
+        readEscapedString(remote_path, buf);
         assertChar('\n', buf);
 
         if (version == VERSION_ABSOLUTE_PATHS)
         {
-            if (!key_value.starts_with(compatible_key_prefix))
-                throw Exception(
-                    ErrorCodes::UNKNOWN_FORMAT,
-                    "Path in metadata does not correspond to root path. Path: {}, root path: {}, disk path: {}",
-                    key_value,
-                    compatible_key_prefix,
-                    metadata_file_path);
+            if (!remote_path.starts_with(compatible_key_prefix))
+                throw Exception(ErrorCodes::UNKNOWN_FORMAT,
+                    "Remote path in metadata does not correspond to root path. Path: {}, Root path: {}, Metadata path: {}",
+                    remote_path, compatible_key_prefix, metadata_file_path);
 
-            keys_with_meta[i].key = ObjectStorageKey::createAsRelative(
-                compatible_key_prefix, key_value.substr(compatible_key_prefix.size()));
+            remote_path = ObjectStorageKey::createAsRelative(compatible_key_prefix, remote_path.substr(compatible_key_prefix.size())).serialize();
         }
         else if (version < VERSION_FULL_OBJECT_KEY)
         {
-            keys_with_meta[i].key = ObjectStorageKey::createAsRelative(compatible_key_prefix, key_value);
+            remote_path = ObjectStorageKey::createAsRelative(compatible_key_prefix, remote_path).serialize();
         }
-        else if (version >= VERSION_FULL_OBJECT_KEY)
-        {
-            keys_with_meta[i].key = ObjectStorageKey::createAsAbsolute(key_value);
-        }
+
+        const StoredObject & object = objects.emplace_back(remote_path, metadata_file_path, object_size);
+        serialized_objects_size += object.bytes_size;
     }
+
+    if (serialized_total_size != serialized_objects_size)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Serialized total bytes size is not equal to real sum of blob sizes ({} != {})",
+            serialized_total_size, serialized_objects_size);
 
     readIntText(ref_count, buf);
     assertChar('\n', buf);
@@ -86,14 +87,6 @@ void DiskObjectStorageMetadata::deserialize(ReadBuffer & buf)
         readEscapedString(inline_data, buf);
         assertChar('\n', buf);
     }
-}
-
-void DiskObjectStorageMetadata::createFromSingleObject(ObjectStorageKey object_key, size_t bytes_size, size_t ref_count_, bool read_only_)
-{
-    keys_with_meta.emplace_back(std::move(object_key), ObjectMetadata{.size_bytes = bytes_size, .last_modified = {}, .etag = "", .attributes = {}});
-    total_size = bytes_size;
-    ref_count = static_cast<uint32_t>(ref_count_);
-    read_only = read_only_;
 }
 
 void DiskObjectStorageMetadata::deserializeFromString(const std::string & data)
@@ -120,25 +113,24 @@ catch (...)
     return false;
 }
 
-void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
+void DiskObjectStorageMetadata::serialize(WriteBuffer & buf) const
 {
     constexpr UInt32 write_version = VERSION_FULL_OBJECT_KEY;
 
     writeIntText(write_version, buf);
-
     writeChar('\n', buf);
 
-    writeIntText(keys_with_meta.size(), buf);
+    writeIntText(objects.size(), buf);
     writeChar('\t', buf);
-    writeIntText(total_size, buf);
+    writeIntText(getTotalSize(objects), buf);
     writeChar('\n', buf);
 
-    for (const auto & [object_key, object_meta] : keys_with_meta)
+    for (const auto & object : objects)
     {
-        writeIntText(object_meta.size_bytes, buf);
+        writeIntText(object.bytes_size, buf);
         writeChar('\t', buf);
 
-        writeEscapedString(object_key.serialize(), buf);
+        writeEscapedString(object.remote_path, buf);
         writeChar('\n', buf);
     }
 
@@ -153,44 +145,13 @@ void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
         writeEscapedString(inline_data, buf);
         writeChar('\n', buf);
     }
-
-    buf.finalize();
-    if (sync)
-        buf.sync();
 }
 
 String DiskObjectStorageMetadata::serializeToString() const
 {
     WriteBufferFromOwnString result;
-    serialize(result, false);
+    serialize(result);
     return result.str();
-}
-
-/// Load metadata by path or create empty if `create` flag is set.
-DiskObjectStorageMetadata::DiskObjectStorageMetadata(
-    String compatible_key_prefix_,
-    String metadata_file_path_)
-    : compatible_key_prefix(std::move(compatible_key_prefix_))
-    , metadata_file_path(std::move(metadata_file_path_))
-{
-}
-
-void DiskObjectStorageMetadata::addObject(ObjectStorageKey key, size_t size)
-{
-    total_size += size;
-    keys_with_meta.emplace_back(std::move(key), ObjectMetadata{size, {}, {}, {}});
-}
-
-ObjectKeyWithMetadata DiskObjectStorageMetadata::popLastObject()
-{
-    if (keys_with_meta.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't pop last object from metadata {}. Metadata already empty", metadata_file_path);
-
-    ObjectKeyWithMetadata object = std::move(keys_with_meta.back());
-    keys_with_meta.pop_back();
-    total_size -= object.metadata.size_bytes;
-
-    return object;
 }
 
 }

--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.h
@@ -1,136 +1,48 @@
 #pragma once
 
-#include <Disks/IDisk.h>
 #include <Disks/ObjectStorages/IMetadataStorage.h>
+#include <Disks/IDisk.h>
+
 #include <Core/Types.h>
 
 namespace DB
 {
 
-
-/// Metadata for DiskObjectStorage, stored on local disk
+/// Metadata for DiskObjectStorage
 struct DiskObjectStorageMetadata
 {
-private:
-    /// Metadata file version.
-    static constexpr UInt32 VERSION_ABSOLUTE_PATHS = 1;
-    static constexpr UInt32 VERSION_RELATIVE_PATHS = 2;
-    static constexpr UInt32 VERSION_READ_ONLY_FLAG = 3;
-    static constexpr UInt32 VERSION_INLINE_DATA = 4;
-    static constexpr UInt32 VERSION_FULL_OBJECT_KEY = 5; /// only for reading data
-
-    UInt32 version = VERSION_FULL_OBJECT_KEY;
-
-    /// Absolute paths of blobs
-    ObjectKeysWithMetadata keys_with_meta;
-
     const std::string compatible_key_prefix;
-
-    /// Relative path to metadata file on local FS.
     const std::string metadata_file_path;
 
-    /// Total size of all remote FS (S3, HDFS) objects.
-    UInt64 total_size = 0;
-
-    /// Number of references (hardlinks) to this metadata file.
-    ///
-    /// FIXME: Why we are tracking it explicitly, without
-    /// info from filesystem????
-    UInt32 ref_count = 0;
-
-    /// Flag indicates that file is read only.
-    bool read_only = false;
+    /// All blobs related to this metadata file.
+    StoredObjects objects;
 
     /// This data will be stored inline
     std::string inline_data;
 
+    /// Number of references (hardlinks) to this metadata file.
+    int32_t ref_count = 0;
+
+    /// Flag indicates that file is read only.
+    bool read_only = false;
+
+private:
+    static constexpr uint32_t VERSION_ABSOLUTE_PATHS = 1;
+    static constexpr uint32_t VERSION_RELATIVE_PATHS = 2;
+    static constexpr uint32_t VERSION_READ_ONLY_FLAG = 3;
+    static constexpr uint32_t VERSION_INLINE_DATA = 4;
+    static constexpr uint32_t VERSION_FULL_OBJECT_KEY = 5; /// only for reading data
+    uint32_t version = VERSION_FULL_OBJECT_KEY;
+
 public:
-
-    DiskObjectStorageMetadata(
-        String compatible_key_prefix_,
-        String metadata_file_path_);
-
-    void addObject(ObjectStorageKey key, size_t size);
-
-    ObjectKeyWithMetadata popLastObject();
+    DiskObjectStorageMetadata(std::string compatible_key_prefix_, std::string metadata_file_path_);
 
     void deserialize(ReadBuffer & buf);
     void deserializeFromString(const std::string & data);
     bool tryDeserializeFromString(const std::string & data) noexcept;
-    /// This method was deleted from public fork recently by Azat
-    void createFromSingleObject(ObjectStorageKey object_key, size_t bytes_size, size_t ref_count_, bool is_read_only_);
 
-    void serialize(WriteBuffer & buf, bool sync) const;
+    void serialize(WriteBuffer & buf) const;
     std::string serializeToString() const;
-
-    const ObjectKeysWithMetadata & getKeysWithMeta() const
-    {
-        return keys_with_meta;
-    }
-
-    StoredObjects getStorageObjects(const std::string & local_path)
-    {
-        StoredObjects objects;
-        objects.reserve(keys_with_meta.size());
-        for (const auto & [object_key, object_meta] : keys_with_meta)
-        {
-            objects.emplace_back(object_key.serialize(), local_path, object_meta.size_bytes);
-        }
-        return objects;
-    }
-
-    bool isReadOnly() const
-    {
-        return read_only;
-    }
-
-    UInt32 getRefCount() const
-    {
-        return ref_count;
-    }
-
-    UInt64 getTotalSizeBytes() const
-    {
-        return total_size;
-    }
-
-    void incrementRefCount()
-    {
-        ++ref_count;
-    }
-
-    void decrementRefCount()
-    {
-        --ref_count;
-    }
-
-    void resetRefCount()
-    {
-        ref_count = 0;
-    }
-
-    void setReadOnly()
-    {
-        read_only = true;
-    }
-
-    void setInlineData(const std::string & data)
-    {
-        inline_data = data;
-    }
-
-    void resetData()
-    {
-        inline_data.clear();
-        keys_with_meta.clear();
-        total_size = 0;
-    }
-
-    const std::string & getInlineData() const
-    {
-        return inline_data;
-    }
-
 };
 
 using DiskObjectStorageMetadataPtr = std::unique_ptr<DiskObjectStorageMetadata>;

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -610,6 +610,8 @@ struct CopyFileObjectStorageOperation final : public IDiskObjectStorageOperation
 
     void execute(MetadataTransactionPtr tx) override
     {
+        /// We need this call to clear to_path metadata file if it exists
+        tx->createMetadataFile(to_path, /*objects=*/{});
         auto source_blobs = metadata_storage.getStorageObjects(from_path); /// Full paths
 
         if (source_blobs.empty())

--- a/src/Disks/ObjectStorages/IMetadataStorage.h
+++ b/src/Disks/ObjectStorages/IMetadataStorage.h
@@ -12,6 +12,7 @@
 #include <Disks/DirectoryIterator.h>
 #include <Disks/WriteMode.h>
 #include <Disks/ObjectStorages/IObjectStorage.h>
+#include <Disks/ObjectStorages/StoredObject.h>
 #include <Disks/DiskCommitTransactionOptions.h>
 #include <Disks/DiskType.h>
 #include <Common/ErrorCodes.h>
@@ -144,18 +145,13 @@ public:
 
     /// Metadata related methods
 
-    /// Create empty file in metadata storage
-    virtual void createEmptyMetadataFile(const std::string & path) = 0;
-
-    virtual void createEmptyFile(const std::string & /* path */) {}
-
-    /// Create metadata file on paths with content (blob_name, size_in_bytes)
-    virtual void createMetadataFile(const std::string & path, ObjectStorageKey key, uint64_t size_in_bytes) = 0;
+    /// Create metadata file on paths with content consisting of objects
+    virtual void createMetadataFile(const std::string & path, const StoredObjects & objects) = 0;
 
     virtual bool supportAddingBlobToMetadata() { return false; }
     /// Add to new blob to metadata file (way to implement appends).
     /// If `addBlobToMetadata` is supported, `supportAddingBlobToMetadata` must return `true`
-    virtual void addBlobToMetadata(const std::string & /* path */, ObjectStorageKey /* key */, uint64_t /* size_in_bytes */)
+    virtual void addBlobToMetadata(const std::string & /* path */, const StoredObject & /* object */)
     {
         throwNotImplemented();
     }

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -117,7 +117,7 @@ std::unordered_map<String, String> MetadataStorageFromDisk::getSerializedMetadat
     for (const auto & path : file_paths)
     {
         auto metadata = readMetadataUnlocked(path, lock);
-        metadata->ref_count -= 1;
+        metadata->ref_count = 0;
         WriteBufferFromOwnString buf;
         metadata->serialize(buf);
         metadatas[path] = buf.str();

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -1,6 +1,7 @@
 #include <Disks/ObjectStorages/IMetadataStorage.h>
 #include <Disks/ObjectStorages/MetadataStorageFromDisk.h>
 #include <Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.h>
+#include <Disks/ObjectStorages/StoredObject.h>
 #include <Storages/PartitionCommands.h>
 
 #include <IO/ReadHelpers.h>
@@ -57,8 +58,7 @@ bool MetadataStorageFromDisk::supportsPartitionCommand(const PartitionCommand & 
 
 uint64_t MetadataStorageFromDisk::getFileSize(const String & path) const
 {
-    auto metadata = readMetadata(path);
-    return metadata->getTotalSizeBytes();
+    return getTotalSize(readMetadata(path)->objects);
 }
 
 std::vector<std::string> MetadataStorageFromDisk::listDirectory(const std::string & path) const
@@ -84,7 +84,7 @@ std::string MetadataStorageFromDisk::readFileToString(const std::string & path) 
 
 std::string MetadataStorageFromDisk::readInlineDataToString(const std::string & path) const
 {
-    return readMetadata(path)->getInlineData();
+    return readMetadata(path)->inline_data;
 }
 
 DiskObjectStorageMetadataPtr MetadataStorageFromDisk::readMetadataUnlocked(const std::string & path, std::shared_lock<SharedMutex> &) const
@@ -117,9 +117,9 @@ std::unordered_map<String, String> MetadataStorageFromDisk::getSerializedMetadat
     for (const auto & path : file_paths)
     {
         auto metadata = readMetadataUnlocked(path, lock);
-        metadata->resetRefCount();
+        metadata->ref_count -= 1;
         WriteBufferFromOwnString buf;
-        metadata->serialize(buf, false);
+        metadata->serialize(buf);
         metadatas[path] = buf.str();
     }
 
@@ -133,14 +133,12 @@ MetadataTransactionPtr MetadataStorageFromDisk::createTransaction()
 
 StoredObjects MetadataStorageFromDisk::getStorageObjects(const std::string & path) const
 {
-    auto metadata = readMetadata(path);
-    return metadata->getStorageObjects(path);
+    return readMetadata(path)->objects;
 }
 
 uint32_t MetadataStorageFromDisk::getHardlinkCount(const std::string & path) const
 {
-    auto metadata = readMetadata(path);
-    return metadata->getRefCount();
+    return readMetadata(path)->ref_count;
 }
 
 const IMetadataStorage & MetadataStorageFromDiskTransaction::getStorageForNonTransactionalReads() const
@@ -243,19 +241,14 @@ void MetadataStorageFromDiskTransaction::setReadOnly(const std::string & path)
     operations.addOperation(std::make_unique<SetReadonlyFileOperation>(path, metadata_storage.compatible_key_prefix, *metadata_storage.getDisk()));
 }
 
-void MetadataStorageFromDiskTransaction::createEmptyMetadataFile(const std::string & path)
+void MetadataStorageFromDiskTransaction::createMetadataFile(const std::string & path, const StoredObjects & objects)
 {
-    operations.addOperation(std::make_unique<RewriteFileOperation>(path, /*objects=*/std::vector<std::pair<ObjectStorageKey, uint64_t>>{}, metadata_storage.compatible_key_prefix, *metadata_storage.getDisk()));
+    operations.addOperation(std::make_unique<RewriteFileOperation>(path, objects, metadata_storage.compatible_key_prefix, *metadata_storage.disk));
 }
 
-void MetadataStorageFromDiskTransaction::createMetadataFile(const std::string & path, ObjectStorageKey key, uint64_t size_in_bytes)
+void MetadataStorageFromDiskTransaction::addBlobToMetadata(const std::string & path, const StoredObject & object)
 {
-    operations.addOperation(std::make_unique<RewriteFileOperation>(path, /*objects=*/std::vector<std::pair<ObjectStorageKey, uint64_t>>{{key, size_in_bytes}}, metadata_storage.compatible_key_prefix, *metadata_storage.disk));
-}
-
-void MetadataStorageFromDiskTransaction::addBlobToMetadata(const std::string & path, ObjectStorageKey key, uint64_t size_in_bytes)
-{
-    operations.addOperation(std::make_unique<AddBlobOperation>(path, std::move(key), size_in_bytes, metadata_storage.compatible_key_prefix, *metadata_storage.disk));
+    operations.addOperation(std::make_unique<AddBlobOperation>(path, object, metadata_storage.compatible_key_prefix, *metadata_storage.disk));
 }
 
 TruncateFileOperationOutcomePtr MetadataStorageFromDiskTransaction::truncateFile(const std::string & src_path, size_t target_size)

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -5,6 +5,7 @@
 #include <Disks/ObjectStorages/MetadataOperationsHolder.h>
 #include <Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.h>
 #include <Disks/ObjectStorages/MetadataStorageTransactionState.h>
+#include <Disks/ObjectStorages/StoredObject.h>
 #include <Disks/IDisk.h>
 
 namespace DB
@@ -96,13 +97,11 @@ public:
 
     void writeInlineDataToFile(const std::string & path, const std::string & data) override;
 
-    void createEmptyMetadataFile(const std::string & path) override;
-
-    void createMetadataFile(const std::string & path, ObjectStorageKey key, uint64_t size_in_bytes) override;
+    void createMetadataFile(const std::string & path, const StoredObjects & objects) override;
 
     bool supportAddingBlobToMetadata() override { return true; }
 
-    void addBlobToMetadata(const std::string & path, ObjectStorageKey key, uint64_t size_in_bytes) override;
+    void addBlobToMetadata(const std::string & path, const StoredObject & object) override;
 
     void setLastModified(const std::string & path, const Poco::Timestamp & timestamp) override;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.cpp
@@ -432,6 +432,8 @@ WriteInlineDataOperation::WriteInlineDataOperation(std::string path_, std::strin
 void WriteInlineDataOperation::execute()
 {
     auto object_metadata = tryReadMetadataFile(compatible_key_prefix, path, disk).value_or(DiskObjectStorageMetadata(disk.getPath(), path));
+
+    object_metadata.objects.clear();
     object_metadata.inline_data = inline_data;
 
     write_operation = std::make_unique<WriteFileOperation>(path, object_metadata.serializeToString(), disk);

--- a/src/Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.cpp
@@ -432,8 +432,6 @@ WriteInlineDataOperation::WriteInlineDataOperation(std::string path_, std::strin
 void WriteInlineDataOperation::execute()
 {
     auto object_metadata = tryReadMetadataFile(compatible_key_prefix, path, disk).value_or(DiskObjectStorageMetadata(disk.getPath(), path));
-
-    object_metadata.objects.clear();
     object_metadata.inline_data = inline_data;
 
     write_operation = std::make_unique<WriteFileOperation>(path, object_metadata.serializeToString(), disk);
@@ -457,7 +455,6 @@ RewriteFileOperation::RewriteFileOperation(std::string path_, StoredObjects obje
 void RewriteFileOperation::execute()
 {
     auto object_metadata = tryReadMetadataFile(compatible_key_prefix, path, disk).value_or(DiskObjectStorageMetadata(disk.getPath(), path));
-
     object_metadata.inline_data.clear();
     object_metadata.objects = objects;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.h
@@ -2,6 +2,7 @@
 
 #include <Disks/ObjectStorages/IMetadataOperation.h>
 #include <Disks/ObjectStorages/IMetadataStorage.h>
+#include <Disks/ObjectStorages/StoredObject.h>
 
 #include <unordered_set>
 
@@ -223,14 +224,14 @@ private:
 
 struct RewriteFileOperation final : public IMetadataOperation
 {
-    RewriteFileOperation(std::string path_, std::vector<std::pair<ObjectStorageKey, uint64_t>> objects_, const std::string & compatible_key_prefix, IDisk & disk_);
+    RewriteFileOperation(std::string path_, StoredObjects objects_, const std::string & compatible_key_prefix, IDisk & disk_);
 
     void execute() override;
     void undo() override;
 
 private:
     const std::string path;
-    const std::vector<std::pair<ObjectStorageKey, uint64_t>> objects;
+    const StoredObjects objects;
     const std::string & compatible_key_prefix;
     IDisk & disk;
 
@@ -239,15 +240,14 @@ private:
 
 struct AddBlobOperation final : public IMetadataOperation
 {
-    AddBlobOperation(std::string path_, ObjectStorageKey key_, uint64_t size_in_bytes_, const std::string & compatible_key_prefix, IDisk & disk_);
+    AddBlobOperation(std::string path_, StoredObject object_, const std::string & compatible_key_prefix, IDisk & disk_);
 
     void execute() override;
     void undo() override;
 
 private:
     const std::string path;
-    const ObjectStorageKey key;
-    const uint64_t size_in_bytes;
+    const StoredObject object;
     const std::string & compatible_key_prefix;
     IDisk & disk;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -268,20 +268,13 @@ void MetadataStorageFromPlainObjectStorageTransaction::replaceFile(const std::st
         true, path_from, path_to, *metadata_storage.getPathMap(), object_storage));
 }
 
-
-void MetadataStorageFromPlainObjectStorageTransaction::createEmptyMetadataFile(const std::string & path)
+void MetadataStorageFromPlainObjectStorageTransaction::createMetadataFile(const std::string & path, const StoredObjects & /* objects */)
 {
     if (metadata_storage.object_storage->isWriteOnce())
         return;
 
     operations.addOperation(
         std::make_unique<MetadataStorageFromPlainObjectStorageWriteFileOperation>(path, *metadata_storage.getPathMap(), object_storage));
-}
-
-void MetadataStorageFromPlainObjectStorageTransaction::createMetadataFile(
-    const std::string & path, ObjectStorageKey /*object_key*/, uint64_t /* size_in_bytes */)
-{
-    createEmptyMetadataFile(path);
 }
 
 void MetadataStorageFromPlainObjectStorageTransaction::createDirectory(const std::string & path)

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
@@ -133,9 +133,7 @@ public:
         /// Noop
     }
 
-    void createEmptyMetadataFile(const std::string & /* path */) override;
-
-    void createMetadataFile(const std::string & /* path */, ObjectStorageKey /* object_key */, uint64_t /* size_in_bytes */) override;
+    void createMetadataFile(const std::string & /* path */, const StoredObjects & /* objects */) override;
 
     void createDirectory(const std::string & path) override;
 

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -77,7 +77,7 @@ TEST_F(MetadataLocalDiskTest, TestHardlinkRewrite)
 
     {
         auto transaction = metadata->createTransaction();
-        transaction->createMetadataFile("original_file", DB::ObjectStorageKey::createAsAbsolute("key1"), 111);
+        transaction->createMetadataFile("original_file", {DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("key1").serialize(), "original_file", 111)});
         transaction->commit();
     }
 
@@ -97,7 +97,7 @@ TEST_F(MetadataLocalDiskTest, TestHardlinkRewrite)
 
     {
         auto transaction = metadata->createTransaction();
-        transaction->createMetadataFile("hardlinked_file", DB::ObjectStorageKey::createAsAbsolute("key2"), 222);
+        transaction->createMetadataFile("hardlinked_file", {DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("key2").serialize(), "hardlinked_file", 222)});
         transaction->commit();
     }
 
@@ -141,8 +141,8 @@ TEST_F(MetadataLocalDiskTest, TestValidAddBlob)
     {
         auto transaction = metadata->createTransaction();
 
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "hello"), 1000);
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsAbsolute("world"), 2000);
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "hello").serialize(), "f.txt", 1000));
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("world").serialize(), "f.txt", 2000));
         transaction->commit();
     }
 
@@ -158,8 +158,8 @@ TEST_F(MetadataLocalDiskTest, TestValidAddBlob)
     {
         auto transaction = metadata->createTransaction();
 
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "goodbye"), 300);
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsAbsolute("everybody"), 400);
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "goodbye").serialize(), "f.txt", 300));
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("everybody").serialize(), "f.txt", 400));
         transaction->commit();
     }
 
@@ -181,12 +181,12 @@ TEST_F(MetadataLocalDiskTest, TestValidAddBlob)
 
         transaction->moveFile("f.txt", "fff.txt");
 
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "I've"), 500);
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "got"), 600);
-        transaction->addBlobToMetadata("f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "to go"), 700);
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "I've").serialize(), "f.txt", 500));
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "got").serialize(), "f.txt", 600));
+        transaction->addBlobToMetadata("f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "to go").serialize(), "f.txt", 700));
 
-        transaction->addBlobToMetadata("fff.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "goodbye"), 700);
-        transaction->addBlobToMetadata("fff.txt", DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "everybody"), 800);
+        transaction->addBlobToMetadata("fff.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "goodbye").serialize(), "fff.txt", 700));
+        transaction->addBlobToMetadata("fff.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidAddBlob", "everybody").serialize(), "fff.txt", 800));
 
         transaction->commit();
     }
@@ -223,24 +223,24 @@ TEST_F(MetadataLocalDiskTest, TestValidCreateMetadataAddBlob)
     {
         auto transaction = metadata->createTransaction();
         transaction->createDirectory("tmp_part");
-        transaction->createMetadataFile("tmp_part/f.txt.tmp", DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "hello"), 1000);
+        transaction->createMetadataFile("tmp_part/f.txt.tmp", {DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "hello").serialize(), "tmp_part/f.txt.tmp", 1000)});
         transaction->moveFile("tmp_part/f.txt.tmp", "tmp_part/f.txt");
         transaction->moveDirectory("tmp_part", "part");
-        transaction->addBlobToMetadata("part/f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "world"), 2000);
+        transaction->addBlobToMetadata("part/f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "world").serialize(), "part/f.txt", 2000));
         transaction->commit();
     }
 
     {
         auto transaction = metadata->createTransaction();
 
-        transaction->addBlobToMetadata("part/f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "goodbye"), 300);
+        transaction->addBlobToMetadata("part/f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "goodbye").serialize(), "part/f.txt", 300));
         transaction->commit();
     }
 
     {
         auto transaction = metadata->createTransaction();
 
-        transaction->addBlobToMetadata("part/f.txt", DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "everybody"), 400);
+        transaction->addBlobToMetadata("part/f.txt", DB::StoredObject(DB::ObjectStorageKey::createAsRelative("/TestValidCreateMetadataAddBlob", "everybody").serialize(), "part/f.txt", 400));
         transaction->commit();
     }
 
@@ -343,10 +343,10 @@ TEST_F(MetadataLocalDiskTest, TestValidUnlinkMetadata)
         auto tx = metadata->createTransaction();
 
         /// Create a file with 1 reference
-        tx->createEmptyMetadataFile("a");
+        tx->createMetadataFile("a", /*objects=*/{});
 
         /// Create another file and make a hardlink to it
-        tx->createEmptyMetadataFile("b");
+        tx->createMetadataFile("b", /*objects=*/{});
         tx->createHardLink("b", "bb");
 
         tx->commit();
@@ -359,7 +359,7 @@ TEST_F(MetadataLocalDiskTest, TestValidUnlinkMetadata)
         auto unlink_outcome_b = tx->unlinkMetadata("b");
 
         /// Create a file and remove it in the same Tx
-        tx->createEmptyMetadataFile("c");
+        tx->createMetadataFile("c", /*objects=*/{});
         auto unlink_outcome_c = tx->unlinkMetadata("c");
 
         tx->commit();
@@ -383,7 +383,7 @@ TEST_F(MetadataLocalDiskTest, TestValidUnlinkMetadata)
         auto unlink_outcome_bb = tx->unlinkMetadata("bb");
 
         /// Create another file and make a hardlink to it
-        tx->createEmptyMetadataFile("d");
+        tx->createMetadataFile("d", /*objects=*/{});
         tx->createHardLink("d", "dd");
         auto unlink_outcome_d = tx->unlinkMetadata("d");
         auto unlink_outcome_dd = tx->unlinkMetadata("dd");
@@ -1125,7 +1125,7 @@ TEST_F(MetadataLocalDiskTest, TestUnlinkRollbackHardlinks)
 
     {
         auto tx = metadata->createTransaction();
-        tx->createEmptyMetadataFile("file");
+        tx->createMetadataFile("file", /*objects=*/{});
         tx->createHardLink("file", "file-link-1");
         tx->createHardLink("file", "file-link-2");
         tx->commit();
@@ -1138,7 +1138,7 @@ TEST_F(MetadataLocalDiskTest, TestUnlinkRollbackHardlinks)
         auto tx = metadata->createTransaction();
         tx->unlinkFile("file-link-1");
         tx->unlinkFile("file");
-        tx->createEmptyMetadataFile("non-existing/fail-tx");
+        tx->createMetadataFile("non-existing/fail-tx", /*objects=*/{});
         EXPECT_THROW(tx->commit(), std::exception);
     }
 
@@ -1165,7 +1165,7 @@ TEST_F(MetadataLocalDiskTest, TestFoldedRemoveRecursiveRollback)
         tx_2->removeRecursive("a/b/c/d");
         tx_2->removeRecursive("a/b/c");
         tx_2->removeRecursive("a/b");
-        tx_2->createEmptyMetadataFile("non-existing/fail-tx");
+        tx_2->createMetadataFile("non-existing/fail-tx", /*objects=*/{});
         EXPECT_THROW(tx_2->commit(), std::exception);
 
         EXPECT_EQ(metadata->readFileToString("a/b/c/d/e/truth"), "Reality is an illusion, the universe is a hologram");
@@ -1201,10 +1201,10 @@ TEST_F(MetadataLocalDiskTest, TestTruncate)
 
     {
         auto tx = metadata->createTransaction();
-        tx->addBlobToMetadata("file", DB::ObjectStorageKey::createAsAbsolute("blob-1"), 100);
-        tx->addBlobToMetadata("file", DB::ObjectStorageKey::createAsAbsolute("blob-2"), 200);
-        tx->addBlobToMetadata("file", DB::ObjectStorageKey::createAsAbsolute("blob-3"), 100);
-        tx->addBlobToMetadata("file", DB::ObjectStorageKey::createAsAbsolute("blob-4"), 400);
+        tx->addBlobToMetadata("file", DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("blob-1").serialize(), "file", 100));
+        tx->addBlobToMetadata("file", DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("blob-2").serialize(), "file", 200));
+        tx->addBlobToMetadata("file", DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("blob-3").serialize(), "file", 100));
+        tx->addBlobToMetadata("file", DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("blob-4").serialize(), "file", 400));
         tx->commit();
     }
 
@@ -1266,7 +1266,7 @@ TEST_F(MetadataLocalDiskTest, TestNonExistingObjectsInTransaction)
     {
         auto transaction = metadata->createTransaction();
         transaction->createDirectory("dir");
-        transaction->createEmptyMetadataFile("file.txt");
+        transaction->createMetadataFile("file.txt", /*objects=*/{});
         transaction->commit();
         EXPECT_TRUE(metadata->existsDirectory("dir"));
         EXPECT_TRUE(metadata->existsFile("file.txt"));
@@ -1275,7 +1275,7 @@ TEST_F(MetadataLocalDiskTest, TestNonExistingObjectsInTransaction)
     {
         auto transaction = metadata->createTransaction();
         EXPECT_THROW({
-                transaction->createEmptyMetadataFile("non-existing/file.txt");
+                transaction->createMetadataFile("non-existing/file.txt", /*objects=*/{});
                 transaction->commit();
             }, std::exception);
     }
@@ -1283,7 +1283,7 @@ TEST_F(MetadataLocalDiskTest, TestNonExistingObjectsInTransaction)
     {
         auto transaction = metadata->createTransaction();
         EXPECT_THROW({
-                transaction->createMetadataFile("non-existing/file.txt", DB::ObjectStorageKey::createAsAbsolute("blob_name"), 42);
+                transaction->createMetadataFile("non-existing/file.txt", {DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute("blob_name").serialize(), "non-existing/file.txt", 42)});
                 transaction->commit();
             }, std::exception);
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Let's simplify interfaces with using `StoredObject` directly instead of `ObjectStorageKey`
