### PR TITLE
Forbid clear column for iceberg

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -612,6 +612,8 @@ void alter(
             metadata_json_generator.generateAddColumnMetadata(params[0].column_name, params[0].data_type);
             break;
         case AlterCommand::Type::DROP_COLUMN:
+            if (params[0].clear)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Clear column is not supported for iceberg. Please use UPDATE instead");
             metadata_json_generator.generateDropColumnMetadata(params[0].column_name);
             break;
         case AlterCommand::Type::MODIFY_COLUMN:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This closes https://github.com/ClickHouse/ClickHouse/issues/87619

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `25.10.1.1271`
- Backported to: `25.8.22.6`
<!-- ch-version-info:end -->