### PR TITLE
tests: fix flakiness of test_check_table_name_length due to invalid identifier generated

### DIFF
--- a/tests/integration/test_check_table_name_length/test.py
+++ b/tests/integration/test_check_table_name_length/test.py
@@ -36,7 +36,7 @@ def start_cluster():
 
 
 def generate_random_name(length):
-    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(length))
+    return ''.join(random.choice(string.ascii_letters) for _ in range(length))
 
 
 def test_backward_compatibility(start_cluster):


### PR DESCRIPTION
In one of CI runs the generated name was completelly from digits [1], while it is not a valid identifier, so the test failed.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=87888&sha=edc7f7ddbe1ac2910244def7f77cf1858a9e5af7&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20old%20analyzer%2C%202%2F6%29

I've looked through all other usages of `gg choice.*string.digits` and this is mostly the only one (except for kafka, which I will fix in #87719)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)