### PR TITLE
fs cache: reuse cache priority iterator among threads concurrently reserving space in cache

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -304,6 +304,7 @@
     M(FilesystemCacheDelayedCleanupElements, "Filesystem cache elements in background cleanup queue") \
     M(FilesystemCacheHoldFileSegments, "Filesystem cache file segment which are currently hold as unreleasable") \
     M(FilesystemCacheKeys, "Number of keys in filesystem cache") \
+    M(FilesystemCacheReserveThreads, "Threads number trying to reserve space in cache") \
     M(AsyncInsertCacheSize, "Number of async insert hash id in cache") \
     M(IcebergMetadataFilesCacheBytes, "Size of the iceberg metadata cache in bytes") \
     M(IcebergMetadataFilesCacheFiles, "Number of cached files in the iceberg metadata cache") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -695,9 +695,12 @@ The server successfully detected this situation and will download merged part fr
     M(FilesystemCacheLockMetadataMicroseconds, "Lock filesystem cache metadata time", ValueType::Microseconds) \
     M(FilesystemCacheLockCacheMicroseconds, "Lock filesystem cache time", ValueType::Microseconds) \
     M(FilesystemCacheReserveMicroseconds, "Filesystem cache space reservation time", ValueType::Microseconds) \
+    M(FilesystemCacheReserveAttempts, "Filesystem cache space reservation attempt", ValueType::Number) \
     M(FilesystemCacheEvictMicroseconds, "Filesystem cache eviction time", ValueType::Microseconds) \
     M(FilesystemCacheGetOrSetMicroseconds, "Filesystem cache getOrSet() time", ValueType::Microseconds) \
     M(FilesystemCacheGetMicroseconds, "Filesystem cache get() time", ValueType::Microseconds) \
+    M(FilesystemCacheBackgroundEvictedFileSegments, "Number of file segments evicted by background thread", ValueType::Number) \
+    M(FilesystemCacheBackgroundEvictedBytes, "Number of bytes evicted by background thread", ValueType::Number) \
     M(FileSegmentWaitMicroseconds, "Wait on DOWNLOADING state", ValueType::Microseconds) \
     M(FileSegmentCompleteMicroseconds, "Duration of FileSegment::complete() in filesystem cache", ValueType::Microseconds) \
     M(FileSegmentLockMicroseconds, "Lock file segment time", ValueType::Microseconds) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -691,6 +691,7 @@ The server successfully detected this situation and will download merged part fr
     M(FilesystemCacheEvictionSkippedFileSegments, "Number of file segments skipped for eviction because of being in unreleasable state", ValueType::Number) \
     M(FilesystemCacheEvictionSkippedEvictingFileSegments, "Number of file segments skipped for eviction because of being in evicting state", ValueType::Number) \
     M(FilesystemCacheEvictionTries, "Number of filesystem cache eviction attempts", ValueType::Number) \
+    M(FilesystemCacheEvictionReusedIterator, "Number of filesystem cache iterator reusing", ValueType::Number) \
     M(FilesystemCacheLockKeyMicroseconds, "Lock cache key time", ValueType::Microseconds) \
     M(FilesystemCacheLockMetadataMicroseconds, "Lock filesystem cache metadata time", ValueType::Microseconds) \
     M(FilesystemCacheLockCacheMicroseconds, "Lock filesystem cache time", ValueType::Microseconds) \

--- a/src/Interpreters/Cache/EvictionCandidates.cpp
+++ b/src/Interpreters/Cache/EvictionCandidates.cpp
@@ -86,6 +86,7 @@ void EvictionCandidates::add(
     it->second.candidates.push_back(candidate);
     candidate->setEvictingFlag(locked_key, lock);
     ++candidates_size;
+    candidates_bytes += candidate->size();
 }
 
 void EvictionCandidates::removeQueueEntries(const CachePriorityGuard::Lock & lock)

--- a/src/Interpreters/Cache/EvictionCandidates.h
+++ b/src/Interpreters/Cache/EvictionCandidates.h
@@ -58,6 +58,7 @@ public:
     FailedCandidates getFailedCandidates() const { return failed_candidates; }
 
     size_t size() const { return candidates_size; }
+    size_t bytes() const { return candidates_bytes; }
 
     auto begin() const { return candidates.begin(); }
 
@@ -73,6 +74,7 @@ private:
 
     std::unordered_map<FileCacheKey, KeyCandidates> candidates;
     size_t candidates_size = 0;
+    size_t candidates_bytes = 0;
     FailedCandidates failed_candidates;
 
     std::vector<FinalizeEvictionFunc> on_finalize;

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1059,7 +1059,7 @@ bool FileCache::tryReserve(
         reserve_stat.stat_by_kind.clear();
     }
 
-    bool continue_from_last_eviction_pos = cache_reserve_active_threads > 1;
+    bool continue_from_last_eviction_pos = cache_reserve_active_threads.load(std::memory_order_relaxed) > 1;
     if (!continue_from_last_eviction_pos)
         main_priority->resetEvictionPos(cache_lock);
 
@@ -1159,7 +1159,7 @@ bool FileCache::tryReserve(
     if (main_priority->getSize(cache_lock) > (1ull << 63))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cache became inconsistent. There must be a bug");
 
-    if (cache_reserve_active_threads == 1)
+    if (cache_reserve_active_threads.load(std::memory_order_relaxed) == 1)
     {
         main_priority->resetEvictionPos(cache_lock);
     }

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -962,9 +962,9 @@ bool FileCache::tryReserve(
         return false;
     }
 
-    cache_reserve_active_threads += 1;
+    cache_reserve_active_threads.fetch_add(1, std::memory_order_relaxed);
     SCOPE_EXIT({
-        cache_reserve_active_threads -= 1;
+        cache_reserve_active_threads.fetch_sub(1, std::memory_order_relaxed);
     });
 
     auto cache_lock = tryLockCache(std::chrono::milliseconds(lock_wait_timeout_milliseconds));

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -238,6 +238,8 @@ private:
     std::atomic<bool> shutdown = false;
     std::atomic<bool> cache_is_being_resized = false;
 
+    std::atomic<size_t> cache_reserve_active_threads = 0;
+
     std::mutex apply_settings_mutex;
 
     CacheMetadata metadata;

--- a/src/Interpreters/Cache/IFileCachePriority.h
+++ b/src/Interpreters/Cache/IFileCachePriority.h
@@ -159,8 +159,11 @@ public:
         FileCacheReserveStat & stat,
         EvictionCandidates & res,
         IteratorPtr reservee,
+        bool continue_from_last_eviction_pos,
         const UserID & user_id,
         const CachePriorityGuard::Lock &) = 0;
+
+    virtual void resetEvictionPos(const CachePriorityGuard::Lock & lock) = 0;
 
     /// Collect eviction candidates sufficient to have `desired_size`
     /// and `desired_elements_num` as current cache state.

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -404,14 +404,18 @@ void LRUFileCachePriority::iterateForEviction(
         }
     };
 
-    auto start_eviction_pos = continue_from_last_eviction_pos ? eviction_pos : queue.begin();
-    eviction_pos = iterateImpl(start_eviction_pos, [&](LockedKey & locked_key, const FileSegmentMetadataPtr & segment_metadata)
+    auto iteration_pos = iterateImpl(
+        continue_from_last_eviction_pos ? eviction_pos : queue.begin(),
+        [&](LockedKey & locked_key, const FileSegmentMetadataPtr & segment_metadata)
     {
         if (stop_condition())
             return IterationResult::BREAK;
         iterate_func(locked_key, segment_metadata);
         return stop_condition() ? IterationResult::BREAK : IterationResult::CONTINUE;
     }, lock);
+
+    if (continue_from_last_eviction_pos)
+        eviction_pos = iteration_pos;
 }
 
 LRUFileCachePriority::LRUIterator LRUFileCachePriority::move(

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -185,8 +185,14 @@ LRUFileCachePriority::iterateImpl(LRUQueue::iterator start_pos, IterateFunc func
     if (start_pos == queue.end())
         start_pos = queue.begin();
 
-    for (auto it = start_pos; it != queue.end();)
+    const size_t max_elements_to_iterate = queue.size();
+    auto it = start_pos;
+
+    for (size_t iterated_elements = 0; iterated_elements < max_elements_to_iterate; ++iterated_elements)
     {
+        if (it == queue.end())
+            it = queue.begin();
+
         const auto & entry = **it;
 
         if (entry.size == 0)

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -182,9 +182,6 @@ void LRUFileCachePriority::iterate(IterateFunc func, const CachePriorityGuard::L
 LRUFileCachePriority::LRUQueue::iterator
 LRUFileCachePriority::iterateImpl(LRUQueue::iterator start_pos, IterateFunc func, const CachePriorityGuard::Lock & lock)
 {
-    if (start_pos == queue.end())
-        start_pos = queue.begin();
-
     const size_t max_elements_to_iterate = queue.size();
     auto it = start_pos;
 

--- a/src/Interpreters/Cache/LRUFileCachePriority.h
+++ b/src/Interpreters/Cache/LRUFileCachePriority.h
@@ -60,6 +60,7 @@ public:
         FileCacheReserveStat & stat,
         EvictionCandidates & res,
         IFileCachePriority::IteratorPtr reservee,
+        bool continue_from_last_eviction_pos,
         const UserID & user_id,
         const CachePriorityGuard::Lock &) override;
 
@@ -87,6 +88,14 @@ public:
 
     FileCachePriorityPtr copy() const { return std::make_unique<LRUFileCachePriority>(max_size, max_elements, description, state); }
 
+    void resetEvictionPos(const CachePriorityGuard::Lock &) override { eviction_pos = queue.end(); }
+
+    /// Used only for unit test.
+    size_t getEvictionPos()
+    {
+        return std::distance(queue.begin(), eviction_pos);
+    }
+
 private:
     class LRUIterator;
     using LRUQueue = std::list<EntryPtr>;
@@ -96,6 +105,7 @@ private:
     const std::string description;
     LoggerPtr log;
     StatePtr state;
+    LRUQueue::iterator eviction_pos;
 
     void updateElementsCount(int64_t num);
     void updateSize(int64_t size);
@@ -112,6 +122,7 @@ private:
     LRUQueue::iterator remove(LRUQueue::iterator it, const CachePriorityGuard::Lock &);
 
     void iterate(IterateFunc func, const CachePriorityGuard::Lock &) override;
+    LRUQueue::iterator iterateImpl(LRUQueue::iterator start_pos, IterateFunc func, const CachePriorityGuard::Lock &);
 
     LRUIterator move(LRUIterator & it, LRUFileCachePriority & other, const CachePriorityGuard::Lock &);
     LRUIterator add(EntryPtr entry, const CachePriorityGuard::Lock &);
@@ -121,7 +132,10 @@ private:
         EvictionCandidates & res,
         FileCacheReserveStat & stat,
         StopConditionFunc stop_condition,
+        bool continue_from_last_eviction_pos,
         const CachePriorityGuard::Lock &);
+
+    void increasePriority(LRUQueue::iterator it, const CachePriorityGuard::Lock &);
 
     void holdImpl(
         size_t size,

--- a/src/Interpreters/Cache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/SLRUFileCachePriority.cpp
@@ -166,12 +166,19 @@ void SLRUFileCachePriority::iterate(IterateFunc func, const CachePriorityGuard::
     probationary_queue.iterate(func, lock);
 }
 
+void SLRUFileCachePriority::resetEvictionPos(const CachePriorityGuard::Lock & lock)
+{
+    protected_queue.resetEvictionPos(lock);
+    probationary_queue.resetEvictionPos(lock);
+}
+
 bool SLRUFileCachePriority::collectCandidatesForEviction(
     size_t size,
     size_t elements,
     FileCacheReserveStat & stat,
     EvictionCandidates & res,
     IFileCachePriority::IteratorPtr reservee,
+    bool continue_from_last_eviction_pos,
     const UserID & user_id,
     const CachePriorityGuard::Lock & lock)
 {
@@ -179,7 +186,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
     /// for a corresponding file segment, so it will be directly put into probationary queue.
     if (!reservee)
     {
-        return probationary_queue.collectCandidatesForEviction(size, elements, stat, res, reservee, user_id, lock);
+        return probationary_queue.collectCandidatesForEviction(size, elements, stat, res, reservee, continue_from_last_eviction_pos, user_id, lock);
     }
 
     auto * slru_iterator = assert_cast<SLRUIterator *>(reservee.get());
@@ -191,7 +198,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
     if (!slru_iterator->is_protected)
     {
         chassert(slru_iterator->lru_iterator.cache_priority == &probationary_queue);
-        success = probationary_queue.collectCandidatesForEviction(size, elements, stat, res, reservee, user_id, lock);
+        success = probationary_queue.collectCandidatesForEviction(size, elements, stat, res, reservee, continue_from_last_eviction_pos, user_id, lock);
     }
     else
     {
@@ -199,7 +206,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
         /// Entry is in protected queue.
         /// Check if we have enough space in protected queue to fit a new size of entry.
         /// `size` is the increment to the current entry.size we want to increase.
-        success = collectCandidatesForEvictionInProtected(size, elements, stat, res, reservee, user_id, lock);
+        success = collectCandidatesForEvictionInProtected(size, elements, stat, res, reservee, continue_from_last_eviction_pos, user_id, lock);
     }
 
     /// We eviction_candidates (res) set is non-empty and
@@ -225,6 +232,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
     FileCacheReserveStat & stat,
     EvictionCandidates & res,
     IFileCachePriority::IteratorPtr reservee,
+    bool continue_from_last_eviction_pos,
     const UserID & user_id,
     const CachePriorityGuard::Lock & lock)
 {
@@ -238,7 +246,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
 
     auto downgrade_candidates = std::make_shared<EvictionCandidates>();
     FileCacheReserveStat downgrade_stat;
-    if (!protected_queue.collectCandidatesForEviction(size, elements, downgrade_stat, *downgrade_candidates, reservee, user_id, lock))
+    if (!protected_queue.collectCandidatesForEviction(size, elements, downgrade_stat, *downgrade_candidates, reservee, continue_from_last_eviction_pos, user_id, lock))
     {
         return false;
     }
@@ -252,7 +260,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
 
     if (!probationary_queue.collectCandidatesForEviction(
             downgrade_stat.total_stat.releasable_size, downgrade_stat.total_stat.releasable_count,
-            stat, res, reservee, user_id, lock))
+            stat, res, reservee, continue_from_last_eviction_pos, user_id, lock))
     {
         return false;
     }
@@ -422,7 +430,7 @@ void SLRUFileCachePriority::increasePriority(SLRUIterator & iterator, const Cach
         /// queue to probationary queue.
         ///
         if (!collectCandidatesForEvictionInProtected(
-                entry->size, /* elements */1, stat, eviction_candidates, nullptr, FileCache::getInternalUser().user_id, lock))
+                entry->size, /* elements */1, stat, eviction_candidates, nullptr, false, FileCache::getInternalUser().user_id, lock))
         {
             /// "downgrade" candidates cannot be moved to probationary queue,
             /// so entry cannot be moved to protected queue as well.

--- a/src/Interpreters/Cache/SLRUFileCachePriority.h
+++ b/src/Interpreters/Cache/SLRUFileCachePriority.h
@@ -59,6 +59,7 @@ public:
         FileCacheReserveStat & stat,
         EvictionCandidates & res,
         IFileCachePriority::IteratorPtr reservee,
+        bool continue_from_last_eviction_pos,
         const UserID & user_id,
         const CachePriorityGuard::Lock &) override;
 
@@ -69,6 +70,8 @@ public:
         FileCacheReserveStat & stat,
         EvictionCandidates & res,
         const CachePriorityGuard::Lock &) override;
+
+    void resetEvictionPos(const CachePriorityGuard::Lock &) override;
 
     void iterate(IterateFunc func, const CachePriorityGuard::Lock &) override;
 
@@ -104,6 +107,7 @@ private:
         FileCacheReserveStat & stat,
         EvictionCandidates & res,
         IFileCachePriority::IteratorPtr reservee,
+        bool continue_from_last_eviction_pos,
         const UserID & user_id,
         const CachePriorityGuard::Lock & lock);
 

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -19,6 +19,7 @@
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileCacheSettings.h>
 #include <Interpreters/Cache/FileSegment.h>
+#include <Interpreters/Cache/EvictionCandidates.h>
 #include <Interpreters/Cache/SLRUFileCachePriority.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/TemporaryDataOnDisk.h>
@@ -1499,4 +1500,109 @@ TEST_F(FileCacheTest, FileCacheGetOrSet)
         auto holder = cache.getOrSet(key, 0, 25, /* file_size */20, {}, 0, user, /* boundary_alignment */30);
         assertEqual(holder, { Range(0, 19) }, { State::EMPTY });
     }
+}
+
+TEST_F(FileCacheTest, ContinueEvictionPos)
+{
+    ServerUUID::setRandomForUnitTests();
+
+    size_t max_size = 50;
+    size_t max_elements = 3;
+
+    LRUFileCachePriority priority(max_size, max_elements);
+
+    std::string cache_path = std::filesystem::path(caches_dir) / "test_eviction_pos";
+    CacheMetadata cache_metadata(cache_path, 0, 0, false);
+
+    auto key = DB::FileCacheKey::fromPath("evict_key");
+    auto user = FileCache::getCommonUser();
+
+    CachePriorityGuard cache_guard;
+    auto cache_lock = cache_guard.lock();
+    auto key_metadata = std::make_shared<KeyMetadata>(key, user, &cache_metadata);
+
+    auto add_file_segment = [&](size_t offset, size_t size)
+    {
+        auto it = priority.add(key_metadata, offset, size, user, cache_lock);
+        auto path = cache_metadata.getFileSegmentPath(key, offset, FileSegmentKind::Regular, user);
+
+        if (std::filesystem::exists(path))
+            std::filesystem::remove(path);
+
+        std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+        std::string data(size, '0');
+        WriteBufferFromFile wb(path, DBMS_DEFAULT_BUFFER_SIZE, O_APPEND | O_CREAT | O_WRONLY);
+        DB::writeString(data, wb);
+        wb.finalize();
+
+        auto file_segment = std::make_shared<FileSegment>(
+            key, offset, size, FileSegment::State::DOWNLOADED,
+            CreateFileSegmentSettings{}, false, nullptr, key_metadata, it);
+
+        LockedKey(key_metadata).emplace(offset, std::make_shared<FileSegmentMetadata>(std::move(file_segment)));
+        return it;
+    };
+
+    auto get_file_segment = [&](size_t offset)
+    {
+        return LockedKey(key_metadata).getByOffset(offset)->file_segment;
+    };
+
+    auto it1 = add_file_segment(0, 10);
+    auto it2 = add_file_segment(10, 10);
+
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 2);
+    ASSERT_EQ(priority.getEvictionPos(), 2); /// queue.end()
+
+    FileCacheReserveStat stat;
+    auto evicted = std::make_unique<EvictionCandidates>();
+    priority.collectCandidatesForEviction(10, 1, stat, *evicted, nullptr, false, user.user_id, cache_lock);
+
+    ASSERT_EQ(evicted->size(), 0); /// Nothing is evicted.
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 2);
+    ASSERT_EQ(priority.getEvictionPos(), 2); /// queue.end()
+
+    auto it3 = add_file_segment(20, 10);
+
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 3);
+    ASSERT_EQ(priority.getEvictionPos(), 3); /// queue.end()
+
+    evicted = std::make_unique<EvictionCandidates>();
+    stat = {};
+    priority.collectCandidatesForEviction(10, 1, stat, *evicted, nullptr, true, user.user_id, cache_lock);
+
+    ASSERT_EQ(evicted->size(), 1);
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 3);
+    ASSERT_EQ(priority.getEvictionPos(), 0); /// queue.begin()
+
+    evicted->evict();
+    evicted->finalize(nullptr, cache_lock);
+    evicted.reset();
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 2);
+    ASSERT_EQ(priority.getEvictionPos(), 0); /// still queue.begin(), but it2
+
+    /// Make fs2 (it2) non-evictable.
+    auto fs2 = get_file_segment(10);
+    ASSERT_EQ(it2->getEntry()->offset, fs2->offset());
+    /// Make fs3 (it3) non-evictable.
+    auto fs3 = get_file_segment(20);
+    ASSERT_EQ(it3->getEntry()->offset, fs3->offset());
+
+    auto it4 = add_file_segment(30, 10);
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 3);
+    ASSERT_EQ(priority.getEvictionPos(), 0);
+
+    evicted = std::make_unique<EvictionCandidates>();
+    stat = {};
+    priority.collectCandidatesForEviction(10, 1, stat, *evicted, nullptr, true, user.user_id, cache_lock);
+
+    ASSERT_EQ(evicted->size(), 1);
+    ASSERT_EQ(priority.getElementsCount(cache_lock), 3);
+    ASSERT_EQ(priority.getEvictionPos(), 2); /// Last element in the queue.
+
+    fs2.reset();
+    fs3.reset();
+
+    priority.resetEvictionPos(cache_lock);
+    ASSERT_EQ(priority.getEvictionPos(), 3); /// queue.end()
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Filesystem cache improvement: reuse cache priority iterator among threads concurrently reserving space in cache

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
