### PR TITLE
feat: add a copy button to the play webui

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -2228,7 +2228,7 @@ async function getQueryUnderCursor() {
     return all_queries;
 }
 
-function getDataAsJson(){
+function getDataAsJson() {
     const dataTable = document.getElementById('data-table');
     const tableData = [];
     if (dataTable.rows.length > 0) {
@@ -2239,10 +2239,9 @@ function getDataAsJson(){
                 const rowData = {};
                 for (let j = 1; j < row.cells.length; j++) { // Skip row number column
                     const columnName = header[j-1].name;
-                    if (row.cells[j].textContent === "ᴺᵁᴸᴸ"){
+                    if (row.cells[j].textContent === "ᴺᵁᴸᴸ") {
                         rowData[columnName] = null;
-                    }
-                    else {
+                    } else {
                         rowData[columnName] = row.cells[j].textContent;
                     }
                 }

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -781,6 +781,7 @@
                 <div id="hint">&nbsp;(Ctrl/Cmd+Enter)</div>
                 <div id="hourglass">⧗</div>
                 <div id="check-mark">✔</div>
+                <button type="submit" onclick="copyResultsToClipboard()" id="copy_button">Copy to clipboard</button>
                 <div id="progress"></div>
                 <div id="stats"></div>
                 <div id="theme"><span id="toggle-dark">🌘</span><span id="toggle-light">☀️</span></div>

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -363,8 +363,8 @@
             display: grid;
             place-items: center;
             gap: 1rem;
-            grid-template-columns: auto auto auto 1fr auto auto;
-            grid-template-areas: "run hint hourglass progress-bar progress-text theme";
+            grid-template-columns: auto auto auto 1fr auto auto auto;
+            grid-template-areas: "run hint hourglass progress-bar copy progress-text theme";
         }
 
         #run
@@ -406,6 +406,24 @@
             display: none;
             font-size: 110%;
             color: #080;
+        }
+
+        #copy_button
+        {
+            grid-area: copy;
+            user-select: none;
+            color: var(--button-text-color);
+            background-color: var(--button-color);
+            padding: 0.25rem 1rem;
+            cursor: pointer;
+            font-weight: bold;
+            font-size: 100%; /* Otherwise button element will have a lower font size. */
+        }
+
+        #copy_button:hover, #copy_button:focus
+        {
+            color: var(--button-active-text-color);
+            background-color: var(--button-active-color);
         }
 
         #stats
@@ -2207,6 +2225,63 @@ async function getQueryUnderCursor() {
     }
 
     return all_queries;
+}
+
+function getDataAsJson(){
+    const dataTable = document.getElementById('data-table');
+    const tableData = [];
+    if (dataTable.rows.length > 0) {
+        const tbody = dataTable.querySelector('tbody');
+        if (tbody) {
+            for (let i = 0; i < tbody.rows.length; i++) {
+                const row = tbody.rows[i];
+                const rowData = {};
+                for (let j = 1; j < row.cells.length; j++) { // Skip row number column
+                    const columnName = header[j-1].name;
+                    if (row.cells[j].textContent === "ᴺᵁᴸᴸ"){
+                        rowData[columnName] = null;
+                    }
+                    else {
+                        rowData[columnName] = row.cells[j].textContent;
+                    }
+                }
+                tableData.push(rowData);
+            }
+        }
+    }
+    return tableData;
+}
+
+
+async function copyResultsToClipboard() {
+    try {
+        const data = JSON.stringify(getDataAsJson(), null, 4);
+        let copy_button = document.getElementById('copy_button')
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            // Modern clipboard API
+            await navigator.clipboard.writeText(data);
+        } else {
+            // Fallback for older browsers and disabled browsers in HTTP
+            const textArea = document.createElement('textarea');
+            textArea.value = data;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-999999px';
+            textArea.style.top = '-999999px';
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+            if (!document.execCommand('copy')) {
+                throw new Error('Copy command failed');
+            }
+            document.body.removeChild(textArea);
+        }
+        copy_button.innerText = "Copied !";
+        copy_button.style.color = "white";
+        copy_button.style.backgroundColor = "green";
+    } catch (err) {
+        copy_button.innerText = "Failed !";
+        copy_button.style.backgroundColor = "red";
+    }
 }
 
 /// First we check if theme is set via the 'theme' GET parameter, if not, we check localStorage, otherwise we check OS preference.

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -385,6 +385,25 @@
             background-color: var(--button-active-color);
         }
 
+
+        #copy_button
+        {
+            grid-area: copy;
+            user-select: none;
+            color: var(--button-text-color);
+            background-color: var(--button-color);
+            padding: 0.25rem 1rem;
+            cursor: pointer;
+            font-weight: bold;
+            font-size: 100%; /* Otherwise button element will have a lower font size. */
+        }
+
+        #copy_button:hover, #copy_button:focus
+        {
+            color: var(--button-active-text-color);
+            background-color: var(--button-active-color);
+        }
+
         #hint
         {
             grid-area: hint;
@@ -406,24 +425,6 @@
             display: none;
             font-size: 110%;
             color: #080;
-        }
-
-        #copy_button
-        {
-            grid-area: copy;
-            user-select: none;
-            color: var(--button-text-color);
-            background-color: var(--button-color);
-            padding: 0.25rem 1rem;
-            cursor: pointer;
-            font-weight: bold;
-            font-size: 100%; /* Otherwise button element will have a lower font size. */
-        }
-
-        #copy_button:hover, #copy_button:focus
-        {
-            color: var(--button-active-text-color);
-            background-color: var(--button-active-color);
         }
 
         #stats
@@ -781,8 +782,8 @@
                 <div id="hint">&nbsp;(Ctrl/Cmd+Enter)</div>
                 <div id="hourglass">⧗</div>
                 <div id="check-mark">✔</div>
-                <button type="submit" onclick="copyResultsToClipboard()" id="copy_button">Copy to clipboard</button>
                 <div id="progress"></div>
+                <button type="submit" onclick="copyResultsToClipboard()" id="copy_button">Copy to clipboard</button>
                 <div id="stats"></div>
                 <div id="theme"><span id="toggle-dark">🌘</span><span id="toggle-light">☀️</span></div>
             </div>
@@ -1105,6 +1106,10 @@ let header = {};
 const default_format = 'JSONStringsEachRowWithProgress';
 
 let controller = null;
+
+/// Buffer to copy data from query into clipboard
+let clipboard_buffer = '';
+
 async function postImpl(posted_request_num, query)
 {
     const user = user_elem.value;
@@ -1286,6 +1291,7 @@ async function postImpl(posted_request_num, query)
         }
         document.title = title;
         previous_query = query;
+        clipboard_buffer = state.data;
     }
 }
 
@@ -2228,40 +2234,16 @@ async function getQueryUnderCursor() {
     return all_queries;
 }
 
-function getDataAsJson() {
-    const dataTable = document.getElementById('data-table');
-    const tableData = [];
-    if (dataTable.rows.length > 0) {
-        const tbody = dataTable.querySelector('tbody');
-        if (tbody) {
-            for (let i = 0; i < tbody.rows.length; i++) {
-                const row = tbody.rows[i];
-                const rowData = {};
-                for (let j = 1; j < row.cells.length; j++) { // Skip row number column
-                    const columnName = header[j-1].name;
-                    if (row.cells[j].textContent === "ᴺᵁᴸᴸ") {
-                        rowData[columnName] = null;
-                    } else {
-                        rowData[columnName] = row.cells[j].textContent;
-                    }
-                }
-                tableData.push(rowData);
-            }
-        }
-    }
-    return tableData;
-}
 
-
-async function copyResultsToClipboard() {
+function copyResultsToClipboard() {
     try {
-        const data = JSON.stringify(getDataAsJson(), null, 4);
+        const data = clipboard_buffer;
         let copy_button = document.getElementById('copy_button')
         if (navigator.clipboard && navigator.clipboard.writeText) {
             // Modern clipboard API
             await navigator.clipboard.writeText(data);
         } else {
-            // Fallback for older browsers and disabled browsers in HTTP
+            // Fallback for older browsers and security disabled browsers in HTTP
             const textArea = document.createElement('textarea');
             textArea.value = data;
             textArea.style.position = 'fixed';
@@ -2270,9 +2252,7 @@ async function copyResultsToClipboard() {
             document.body.appendChild(textArea);
             textArea.focus();
             textArea.select();
-            if (!document.execCommand('copy')) {
-                throw new Error('Copy command failed');
-            }
+            document.execCommand('copy')
             document.body.removeChild(textArea);
         }
         copy_button.innerText = "Copied !";

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1116,11 +1116,8 @@ const default_format = 'JSONStringsEachRowWithProgress';
 
 let controller = null;
 
-/// Buffer to copy data from query into clipboard
-let clipboard_buffer = '';
-
 async function disableCopyButtonIfEmpty() {
-	document.getElementById("copy_button").disabled = (!clipboard_buffer);
+    document.getElementById("copy_button").disabled = (history.state && history.state.data) ? false : true;
 }
 document.getElementById('copy_button').onclick = disableCopyButtonIfEmpty;
 
@@ -1305,7 +1302,6 @@ async function postImpl(posted_request_num, query)
         }
         document.title = title;
         previous_query = query;
-        clipboard_buffer = state.data;
     }
 }
 
@@ -2251,7 +2247,7 @@ async function getQueryUnderCursor() {
 
 async function copyResultsToClipboard() {
     try {
-        const data = clipboard_buffer;
+        const data = history.state.data;
         let copy_button = document.getElementById('copy_button')
         if (navigator.clipboard && navigator.clipboard.writeText) {
             // Modern clipboard API

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -392,10 +392,13 @@
             user-select: none;
             color: var(--button-text-color);
             background-color: var(--button-color);
-            padding: 0.25rem 1rem;
             cursor: pointer;
-            font-weight: bold;
-            font-size: 100%; /* Otherwise button element will have a lower font size. */
+            width: 2.25em;
+        }
+
+        #copy_button:disabled{
+           visibility: hidden;
+           pointer-events: none;
         }
 
         #copy_button:hover, #copy_button:focus
@@ -403,6 +406,7 @@
             color: var(--button-active-text-color);
             background-color: var(--button-active-color);
         }
+
 
         #hint
         {
@@ -783,7 +787,12 @@
                 <div id="hourglass">⧗</div>
                 <div id="check-mark">✔</div>
                 <div id="progress"></div>
-                <button type="submit" onclick="copyResultsToClipboard()" id="copy_button">Copy to clipboard</button>
+                <button type="button" onclick="copyResultsToClipboard()" id="copy_button">
+                    <svg id="clipboard-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                        <title>Copy to clipboard</title>
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" />
+                    </svg>
+                </button>
                 <div id="stats"></div>
                 <div id="theme"><span id="toggle-dark">🌘</span><span id="toggle-light">☀️</span></div>
             </div>
@@ -1109,6 +1118,11 @@ let controller = null;
 
 /// Buffer to copy data from query into clipboard
 let clipboard_buffer = '';
+
+async function disableCopyButtonIfEmpty() {
+	document.getElementById("copy_button").disabled = (!clipboard_buffer);
+}
+document.getElementById('copy_button').onclick = disableCopyButtonIfEmpty;
 
 async function postImpl(posted_request_num, query)
 {
@@ -2235,7 +2249,7 @@ async function getQueryUnderCursor() {
 }
 
 
-function copyResultsToClipboard() {
+async function copyResultsToClipboard() {
     try {
         const data = clipboard_buffer;
         let copy_button = document.getElementById('copy_button')
@@ -2255,11 +2269,11 @@ function copyResultsToClipboard() {
             document.execCommand('copy')
             document.body.removeChild(textArea);
         }
-        copy_button.innerText = "Copied !";
+        copy_button.innerText = "Copied";
         copy_button.style.color = "white";
         copy_button.style.backgroundColor = "green";
     } catch (err) {
-        copy_button.innerText = "Failed !";
+        copy_button.innerText = "Can't copy";
         copy_button.style.backgroundColor = "red";
     }
 }
@@ -2308,5 +2322,8 @@ document.getElementById('toggle-light').onclick = function() {
 document.getElementById('toggle-dark').onclick = function() {
     setColorTheme('dark', true);
 }
+
+/// set the copy_button as disabled while there is no data at first
+disableCopyButtonIfEmpty()
 </script>
 </html>


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add a copy button to the play webUI as a convenient way to share results as JSON.

### Documentation entry for user-facing changes

- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?
  The play webUI is a very quick way to connect to a Clickhouse server and run a query. Adding a copy button to get easily the results in the clipboard let the user to quickly share the results.

- Parameters: no parameters

### Details

Disclaimer: I am not a front-end developer. This code might not be the best or standard way to do what it does. Feel free to improve it.
