### PR TITLE
Fix add-test for multi-extension files

### DIFF
--- a/tests/queries/0_stateless/add-test
+++ b/tests/queries/0_stateless/add-test
@@ -19,8 +19,8 @@ NEW_TEST_NO=$(printf "%05d\n" $((10#$LAST_TEST_NO + 1)))
 FILENAME="${1}"
 FILEEXT="sql"
 if [[ $1 == *.* ]] ; then
-    FILENAME="${1%.*}"
-    FILEEXT="${1##*.}"
+    FILENAME="${1%%.*}"
+    FILEEXT="${1#*.}"
 fi
 
 set -x


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

This ensures `add-test foo.sql.j2` creates matching test/reference files: `00001_foo.sql.j2` and `00001_foo.reference`.
Previously would incorrectly produce `00001_foo.sql.reference`