### PR TITLE
tests: fix flakiness of test_trace_log_memory_context

### DIFF
--- a/tests/integration/test_trace_log_memory_context/configs/overrides.xml
+++ b/tests/integration/test_trace_log_memory_context/configs/overrides.xml
@@ -6,7 +6,23 @@
     <trace_log>
         <!-- jemalloc has too many events, which leads to slower testing with default value 1KK -->
         <max_size_rows>100000</max_size_rows>
+        <symbolize>false</symbolize>
     </trace_log>
 
-    <text_log remove="remove" />
+    <query_masking_rules remove="remove"/>
+    <query_thread_log remove="remove"/>
+    <query_log remove="remove" />
+    <query_metric_log remove="remove" />
+    <query_views_log remove="remove" />
+    <metric_log remove="remove"/>
+    <error_log remove="remove"/>
+    <text_log remove="remove"/>
+    <asynchronous_metric_log remove="remove" />
+    <session_log remove="remove" />
+    <part_log remove="remove" />
+    <crash_log remove="remove" />
+    <opentelemetry_span_log remove="remove" />
+    <iceberg_metadata_log remove="remove" />
+    <zookeeper_log remove="remove" />
+    <transactions_info_log remove="remove" />
 </clickhouse>

--- a/tests/integration/test_trace_log_memory_context/test.py
+++ b/tests/integration/test_trace_log_memory_context/test.py
@@ -1,5 +1,6 @@
 import uuid
-
+import time
+import logging
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -29,7 +30,7 @@ def test_memory_context_in_trace_log(started_cluster):
         pytest.skip("sanitizers built without jemalloc")
 
     def get_trace_events(memory_context, memory_blocked_context, trace_type, query_id=None):
-        return int(node.query(f"""
+        res = int(node.query(f"""
         SELECT count() FROM system.trace_log
         WHERE
             /* Do not take into account data from other test runs */
@@ -39,13 +40,29 @@ def test_memory_context_in_trace_log(started_cluster):
             AND trace_type = '{trace_type}'
             AND {'empty(query_id)' if query_id is None else f"query_id = '{query_id}'"}
         """).strip())
+        logging.info('memory_context=%s/memory_blocked_context=%s/trace_type=%s/query_id=%s: %s',
+                     memory_context, memory_blocked_context, trace_type, query_id, res)
+        return res
 
-    # Generate some logs to generate entries with memory_blocked_context=Global and trace_type=JemallocSample
-    for i in range(10):
-        node.query("SELECT logTrace('foo')")
-    query_id = uuid.uuid4().hex
-    node.query("SELECT * FROM numbers(100000) ORDER BY number", query_id=query_id)
-    node.query("SYSTEM FLUSH LOGS system.trace_log")
+    for _ in range(0, 15):
+        # Generate some logs to generate entries with memory_blocked_context=Global and trace_type=JemallocSample
+        for i in range(10):
+            node.query("SELECT logTrace('foo')")
+        query_id = uuid.uuid4().hex
+        node.query("SELECT * FROM numbers(100000) ORDER BY number", query_id=query_id)
+
+        node.query("SYSTEM FLUSH LOGS system.trace_log")
+        if (
+            get_trace_events("Unknown", "Max", "MemorySample", query_id) > 0 and
+            get_trace_events("Unknown", "Max", "JemallocSample", query_id) > 0 and
+            get_trace_events("Unknown", "Max", "JemallocSample") > 0 and
+            get_trace_events("Unknown", "Global", "JemallocSample") > 0 and
+            get_trace_events("Global", "Max", "Memory") > 0 and
+            get_trace_events("Global", "Max", "MemoryPeak") > 0 and
+            True
+        ):
+            break
+        time.sleep(1)
 
     # For JemallocSample we have Global (for i.e. logging) and Max (for regular allocations) blocked memory tracker
     for memory_blocked_context in ["Global", "Max"]:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

First a loop added to make sure that events are there, but this was not enough due to sometimes flushing trace_log takes too much time (88 seconds for instance), disabling stacktraces symbolization helps a lot.

Follow up for: https://github.com/ClickHouse/ClickHouse/pull/87765