### PR TITLE
tests: preserve http server log in test_external_http_authenticator

### DIFF
--- a/tests/integration/test_external_http_authenticator/test.py
+++ b/tests/integration/test_external_http_authenticator/test.py
@@ -28,7 +28,7 @@ def run_echo_server():
         [
             "bash",
             "-c",
-            "python3 /http_auth_server.py > /http_auth_server.log 2>&1",
+            "python3 /http_auth_server.py > /var/log/clickhouse-server/http_auth_server.log 2>&1",
         ],
         detach=True,
         user="root",


### PR DESCRIPTION
It failed once on CI, maybe due to bind failure.
Anyway it is impossible to say without logs, let's save then in directory that we add into artifacts.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)