### PR TITLE
Fix merge with projections when the last block is empty

### DIFF
--- a/src/Storages/MergeTree/MergeProjectionPartsTask.h
+++ b/src/Storages/MergeTree/MergeProjectionPartsTask.h
@@ -50,7 +50,10 @@ public:
         }
 
     void onCompleted() override { throw Exception(ErrorCodes::LOGICAL_ERROR, "Not implemented"); }
-    void cancel() noexcept override { chassert(false, "Not implemented"); }
+    void cancel() noexcept override
+    {
+        /// FIXME: See `executeHere` from MergeTask.h called in executeStep
+    }
     StorageID getStorageID() const override { throw Exception(ErrorCodes::LOGICAL_ERROR, "Not implemented"); }
     Priority getPriority() const override { throw Exception(ErrorCodes::LOGICAL_ERROR, "Not implemented"); }
     String getQueryId() const override { throw Exception(ErrorCodes::LOGICAL_ERROR, "Not implemented"); }

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -887,6 +887,9 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::calculateProjections(const Blo
     {
         const auto & projection = *global_ctx->projections_to_rebuild[i];
         Block block_to_squash = projection.calculate(block, global_ctx->context);
+        /// Avoid replacing the projection squash header if nothing was generated (it used to return an empty block)
+        if (block_to_squash.rows() == 0)
+            return;
         auto & projection_squash_plan = ctx->projection_squashes[i];
         projection_squash_plan.setHeader(block_to_squash.cloneEmpty());
         Chunk squashed_chunk = Squashing::squash(projection_squash_plan.add({block_to_squash.getColumns(), block_to_squash.rows()}));

--- a/tests/queries/0_stateless/03636_empty_projection_block.sql
+++ b/tests/queries/0_stateless/03636_empty_projection_block.sql
@@ -1,0 +1,26 @@
+-- This test would hit a LOGICAL_ERROR during merge
+CREATE TABLE post_state
+(
+    `ts` DateTime,
+    `id` Int64,
+    `state` Nullable(UInt8) TTL ts + INTERVAL 1 MONTH,
+    PROJECTION p_digest_posts_state
+    (
+        SELECT
+            id,
+            argMax(state, ts) AS state
+        GROUP BY id
+    )
+)
+ENGINE = MergeTree()
+ORDER BY id
+TTL ts + toIntervalSecond(0) WHERE state IS NULL
+SETTINGS index_granularity = 8192, deduplicate_merge_projection_mode='rebuild';
+
+SYSTEM STOP MERGES post_state;
+INSERT INTO post_state VALUES ('2024-01-01 00:00:00', 1, NULL);
+INSERT INTO post_state VALUES ('2024-01-01 00:00:00', 1, NULL);
+INSERT INTO post_state VALUES ('2024-01-01 00:00:00', 1, 1);
+INSERT INTO post_state VALUES ('2024-01-01 00:00:00', 1, NULL);
+SYSTEM START MERGES post_state;
+OPTIMIZE TABLE post_state;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix merge with projections when the last block is empty

Introduced in https://github.com/ClickHouse/ClickHouse/pull/84158. If the last block generated by the projection was empty the header for squashing ended up empty, failing to squash the previous blocks (when any), leading to a LOGICAL_ERROR such as: `Cannot clone block with columns because block [] has 0 columns, but 2 columns given [Int64(size = 1), AggregateFunction(size = 1)]. (LOGICAL_ERROR)`.

This PR is applying 2 separate fixes for the issue. Any of the 2 solve it, but I think it's better to include both

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
