### PR TITLE
tests: fix flakiness of test_keeper_memory_soft_limit (make it less fragile)

### DIFF
--- a/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config1.xml
+++ b/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config1.xml
@@ -15,7 +15,7 @@
             <value>az-zoo1</value>
         </availability_zone>
         <server_id>1</server_id>
-        <max_memory_usage_soft_limit>90000000</max_memory_usage_soft_limit>
+        <max_memory_usage_soft_limit>300000000</max_memory_usage_soft_limit>
 
         <coordination_settings>
             <operation_timeout_ms>10000</operation_timeout_ms>

--- a/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config2.xml
+++ b/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config2.xml
@@ -16,7 +16,7 @@
             <value>az-zoo2</value>
             <enable_auto_detection_on_cloud>1</enable_auto_detection_on_cloud>
         </availability_zone>
-        <max_memory_usage_soft_limit>90000000</max_memory_usage_soft_limit>
+        <max_memory_usage_soft_limit>300000000</max_memory_usage_soft_limit>
 
         <coordination_settings>
             <operation_timeout_ms>10000</operation_timeout_ms>

--- a/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config3.xml
+++ b/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config3.xml
@@ -13,7 +13,7 @@
         <tcp_port>2181</tcp_port>
         <server_id>3</server_id>
 
-        <max_memory_usage_soft_limit>90000000</max_memory_usage_soft_limit>
+        <max_memory_usage_soft_limit>300000000</max_memory_usage_soft_limit>
 
         <coordination_settings>
             <operation_timeout_ms>10000</operation_timeout_ms>


### PR DESCRIPTION
Apparently it got broken after the peak has been fixed for total memory tracker [1], but, this test does not work for me locally (even before mentioned changes, including the whole PR) because my local build takes ~240MiB in RAM while on CI it is ~70. Plus there can be also difference in x86_64 and aarch64.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/87584/commits/24e16b04cc2ec6b6b1ecbe92df265f965bf37074

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/87787