### PR TITLE
Add ability to limit requests for keeper (max_request_size setting)

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -520,6 +520,7 @@ def main():
             f"rm {perf_right_config}/config.d/memory_profiler.yaml ||:",
             f"rm {perf_right_config}/config.d/serverwide_trace_collector.xml ||:",
             f"rm {perf_right_config}/config.d/jemalloc_flush_profile.yaml ||:",
+            f"rm -vf {perf_right_config}/config.d/keeper_max_request_size.xml",
             # backups disk uses absolute path, and this overlaps between servers, that could lead to errors
             f"rm {perf_right_config}/config.d/backups.xml ||:",
             f"cp -rv {perf_right_config} {perf_left}/",

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -44,6 +44,7 @@ namespace ErrorCodes
     DECLARE(UInt64, max_request_queue_size, 100000, "Maximum number of request that can be in queue for processing", 0) \
     DECLARE(UInt64, max_requests_batch_size, 100, "Max size of batch of requests that can be sent to RAFT", 0) \
     DECLARE(UInt64, max_requests_batch_bytes_size, 100*1024, "Max size in bytes of batch of requests that can be sent to RAFT", 0) \
+    DECLARE(UInt64, max_request_size, 0, "Max request size (in bytes). Zero means unlimited.", 0) \
     DECLARE(UInt64, max_requests_append_size, 100, "Max size of batch of requests that can be sent to replica in append request", 0) \
     DECLARE(UInt64, max_flush_batch_size, 1000, "Max size of batch of requests that can be flushed together", 0) \
     DECLARE(UInt64, max_requests_quick_batch_size, 100, "Max size of batch of requests to try to get before proceeding with RAFT. Keeper will not wait for requests but take only requests that are already in queue" , 0) \
@@ -237,6 +238,8 @@ void KeeperConfigurationAndSettings::dump(WriteBufferFromOwnString & buf) const
     write_int(coordination_settings[CoordinationSetting::max_requests_batch_size]);
     writeText("max_requests_batch_bytes_size=", buf);
     write_int(coordination_settings[CoordinationSetting::max_requests_batch_bytes_size]);
+    writeText("max_request_size=", buf);
+    write_int(coordination_settings[CoordinationSetting::max_request_size]);
     writeText("max_flush_batch_size=", buf);
     write_int(coordination_settings[CoordinationSetting::max_flush_batch_size]);
     writeText("max_request_queue_size=", buf);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -303,6 +303,9 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
 
     int32_t length;
     Coordination::read(length, buffer);
+    /// Request should not exceed max_request_size (this is verified in KeeperTCPHandler)
+    if (length < 0)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid request length: {}", length);
 
     /// because of backwards compatibility, only 32bit xid could be written
     /// for that reason we serialize XID in 2 parts:

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -10,6 +10,7 @@
 #    include <IO/ReadBufferFromFileDescriptor.h>
 #    include <IO/ReadBufferFromPocoSocket.h>
 #    include <IO/WriteBufferFromPocoSocket.h>
+#    include <IO/LimitReadBuffer.h>
 #    include <base/defines.h>
 #    include <base/hex.h>
 #    include <Poco/Net/NetException.h>
@@ -47,6 +48,7 @@ namespace CoordinationSetting
 {
     extern const CoordinationSettingsUInt64 log_slow_connection_operation_threshold_ms;
     extern const CoordinationSettingsUInt64 log_slow_total_threshold_ms;
+    extern const CoordinationSettingsUInt64 max_request_size;
     extern const CoordinationSettingsBool use_xid_64;
 }
 
@@ -68,6 +70,7 @@ namespace ErrorCodes
     extern const int UNEXPECTED_PACKET_FROM_CLIENT;
     extern const int TIMEOUT_EXCEEDED;
     extern const int BAD_ARGUMENTS;
+    extern const int LIMIT_EXCEEDED;
     extern const int AUTHENTICATION_FAILED;
 }
 
@@ -436,6 +439,8 @@ void KeeperTCPHandler::runImpl()
         compressed_out.emplace(*out, CompressionCodecFactory::instance().get("LZ4",{}));
     }
 
+    max_request_size = static_cast<UInt64>(keeper_context->getCoordinationSettings()[CoordinationSetting::max_request_size]);
+
     auto response_callback = [my_responses = this->responses, my_poll_wrapper = this->poll_wrapper](
                                  const Coordination::ZooKeeperResponsePtr & response, Coordination::ZooKeeperRequestPtr request)
     {
@@ -628,9 +633,22 @@ ReadBuffer & KeeperTCPHandler::getReadBuffer()
 
 std::pair<Coordination::OpNum, Coordination::XID> KeeperTCPHandler::receiveRequest()
 {
-    auto & read_buffer = getReadBuffer();
+    std::optional<LimitReadBuffer> limited_buffer_holder;
+    /// Wrap regular read buffer with LimitReadBuffer to apply max_request_size
+    /// (this should be done on per-request basis)
+    auto get_read_buffer_with_limit = [&]() -> ReadBuffer &
+    {
+        if (max_request_size == 0)
+            return getReadBuffer();
+        limited_buffer_holder.emplace(getReadBuffer(), LimitReadBuffer::Settings{.read_no_more = max_request_size, .expect_eof = false, .excetion_hint = "too long packet."});
+        return *limited_buffer_holder;
+    };
+    auto & read_buffer = get_read_buffer_with_limit();
     int32_t length;
     Coordination::read(length, read_buffer);
+    if (length < 0 || (max_request_size > 0 && static_cast<uint32_t>(length) > max_request_size))
+        throw Exception(ErrorCodes::LIMIT_EXCEEDED, "Request size {} is too big request (limit: {})", length, max_request_size);
+
     int64_t xid;
     if (use_xid_64)
         Coordination::read(xid, read_buffer);

--- a/src/Server/KeeperTCPHandler.h
+++ b/src/Server/KeeperTCPHandler.h
@@ -92,6 +92,8 @@ private:
     std::optional<CompressedReadBuffer> compressed_in;
     std::optional<CompressedWriteBuffer> compressed_out;
 
+    size_t max_request_size = 0;
+
     std::atomic<bool> connected{false};
 
     void runImpl();

--- a/tests/config/config.d/keeper_max_request_size.xml
+++ b/tests/config/config.d/keeper_max_request_size.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <keeper_server>
+        <coordination_settings>
+            <max_request_size>10000000</max_request_size>
+        </coordination_settings>
+    </keeper_server>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -104,6 +104,9 @@ ln -sf $SRC_PATH/config.d/merge_tree_old_dirs_cleanup.xml $DEST_SERVER_PATH/conf
 ln -sf $SRC_PATH/config.d/test_cluster_with_incorrect_pw.xml $DEST_SERVER_PATH/config.d/
 # copy to not update original file later on in the script
 cp $SRC_PATH/config.d/keeper_port.xml $DEST_SERVER_PATH/config.d/
+if check_clickhouse_version 25.10; then
+    ln -sf $SRC_PATH/config.d/keeper_max_request_size.xml $DEST_SERVER_PATH/config.d/
+fi
 ln -sf $SRC_PATH/config.d/logging_no_rotate.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/merge_tree.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/lost_forever_check.xml $DEST_SERVER_PATH/config.d/
@@ -347,6 +350,7 @@ if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
     ln -sf $SRC_PATH/config.d/database_replicated.xml $DEST_SERVER_PATH/config.d/
     rm $DEST_SERVER_PATH/config.d/zookeeper.xml
     rm $DEST_SERVER_PATH/config.d/keeper_port.xml
+    rm $DEST_SERVER_PATH/config.d/keeper_max_request_size.xml
 
     # There is a bug in config reloading, so we cannot override macros using --macros.replica r2
     # And we have to copy configs...

--- a/tests/integration/helpers/keeper_config1.xml
+++ b/tests/integration/helpers/keeper_config1.xml
@@ -29,6 +29,7 @@
 
             <async_replication>1</async_replication>
             <use_xid_64>1</use_xid_64>
+            <max_request_size>10000000</max_request_size>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/helpers/keeper_config2.xml
+++ b/tests/integration/helpers/keeper_config2.xml
@@ -29,6 +29,7 @@
 
             <async_replication>1</async_replication>
             <use_xid_64>1</use_xid_64>
+            <max_request_size>10000000</max_request_size>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/helpers/keeper_config3.xml
+++ b/tests/integration/helpers/keeper_config3.xml
@@ -24,6 +24,7 @@
 
             <async_replication>1</async_replication>
             <use_xid_64>1</use_xid_64>
+            <max_request_size>10000000</max_request_size>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/test_keeper_max_request_size/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_max_request_size/configs/keeper_config.xml
@@ -1,0 +1,28 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <max_request_size>1048576</max_request_size>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <snapshot_distance>75</snapshot_distance>
+            <!-- For instant start in single node configuration -->
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_max_request_size/configs/overrides.xml
+++ b/tests/integration/test_keeper_max_request_size/configs/overrides.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>localhost</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+
+    <allow_zookeeper_write>1</allow_zookeeper_write>
+</clickhouse>

--- a/tests/integration/test_keeper_max_request_size/test.py
+++ b/tests/integration/test_keeper_max_request_size/test.py
@@ -1,0 +1,27 @@
+import pytest
+
+from helpers import keeper_utils
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/keeper_config.xml", "configs/overrides.xml"],
+    with_zookeeper=False,
+    use_keeper=False,
+)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        keeper_utils.wait_until_connected(cluster, node)
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_max_request_size(started_cluster):
+    node.query("insert into system.zookeeper (name, path, value) select number::String, '/test_soft_limit', repeat('a', 3000) from numbers(100)")
+    with pytest.raises(Exception, match=r"Connection loss"):
+        node.query("insert into system.zookeeper (name, path, value) select number::String, '/test_soft_limit', repeat('a', 3000) from numbers(10000)")


### PR DESCRIPTION
I found that the simple query will lead to:

```sql
insert into system.zookeeper (name, path, value) select number::String, '/test_soft_limit', repeat('a', 3000) from numbers(1e6)
```

```
2025.09.30 22:00:10.699397 [ 10382 ] {} <Error> void DB::KeeperDispatcher::requestThread(): Code: 361. DB::Exception: Seek position is out of bounds. Offset: -1 224 078 329, Max: 3 070 889 012. (SEEK_POSITION_OUT_OF_BOUND), Stack trace (when copying this message, always include the lines below)
```

<details>

```
0. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__exception/exception.h:113: Poco::Exception::Exception(String const&, int) @ 0x000000001ede2a79
1. /src/ch/clickhouse/src/Common/Exception.cpp:128: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000f74ad62
2. /src/ch/clickhouse/src/Common/Exception.h:123: DB::Exception::Exception(String&&, int, String, bool) @ 0x0000000008b2b211
3. /src/ch/clickhouse/src/Common/Exception.h:58: DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000008b2adfb
4. /src/ch/clickhouse/src/Common/Exception.h:141: DB::Exception::Exception<long&, String>(int, FormatStringHelperImpl<std::type_identity<long&>::type, std::type_identity<String>::type>, long&, String&&) @ 0x000000000d44f12f
5. /src/ch/clickhouse/src/IO/ReadBufferFromMemory.cpp:45: DB::ReadBufferFromMemoryHelper<DB::ReadBufferFromMemory>::seekImpl(long, int) @ 0x000000000f820bf7
6. /src/ch/clickhouse/src/IO/ReadBufferFromMemory.h:36: DB::IKeeperStateMachine::parseRequest(nuraft::buffer&, bool, DB::IKeeperStateMachine::ZooKeeperLogSerializationVersion*, unsigned long*) @ 0x00000000198fa56c
7. /src/ch/clickhouse/src/Coordination/KeeperServer.cpp:984: DB::KeeperServer::callbackFunc(nuraft::cb_func::Type, nuraft::cb_func::Param*) @ 0x00000000198bccff
8. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__functional/function.h:716: ? @ 0x000000001c615ba2
9. /src/ch/clickhouse/contrib/NuRaft/src/handle_client_request.cxx:93: nuraft::raft_server::handle_cli_req_prelock(nuraft::req_msg&, nuraft::raft_server::req_ext_params const&) @ 0x000000001c614d0f
10. /src/ch/clickhouse/contrib/NuRaft/src/raft_server.cxx:747: nuraft::raft_server::process_req(nuraft::req_msg&, nuraft::raft_server::req_ext_params const&) @ 0x000000001c60b899
11. /src/ch/clickhouse/contrib/NuRaft/src/handle_user_cmd.cxx:184: nuraft::raft_server::send_msg_to_leader(std::shared_ptr<nuraft::req_msg>&, nuraft::raft_server::req_ext_params const&) @ 0x000000001c62a205
12. /src/ch/clickhouse/contrib/NuRaft/src/handle_user_cmd.cxx:109: nuraft::raft_server::append_entries_ext(std::vector<std::shared_ptr<nuraft::buffer>, std::allocator<std::shared_ptr<nuraft::buffer>>> const&, nuraft::raft_server::req_ext_params const&) @ 0x000000001c62c0b0
13. /src/ch/clickhouse/contrib/NuRaft/src/handle_user_cmd.cxx:84: nuraft::raft_server::append_entries(std::vector<std::shared_ptr<nuraft::buffer>, std::allocator<std::shared_ptr<nuraft::buffer>>> const&) @ 0x000000001c62be71
14. /src/ch/clickhouse/src/Coordination/KeeperServer.cpp:681: DB::KeeperServer::putRequestBatch(std::vector<DB::KeeperRequestForSession, std::allocator<DB::KeeperRequestForSession>> const&) @ 0x00000000198bc2df
15. /src/ch/clickhouse/src/Coordination/KeeperDispatcher.cpp:271: DB::KeeperDispatcher::requestThread() @ 0x0000000019896a3e
16. /src/ch/clickhouse/src/Coordination/KeeperDispatcher.cpp:465: void std::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::KeeperDispatcher::initialize(Poco::Util::Abstract
Configuration const&, bool, bool, std::shared_ptr<DB::Macros const> const&)::$_1>(DB::KeeperDispatcher::initialize(Poco::Util::AbstractConfiguration const&, bool, bool, std::shared_ptr<DB::Macros const> const&)::$_1&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x0000000
0198a548b
17. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__functional/function.h:716: ? @ 0x000000000f87e998
18. /src/ch/clickhouse/contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: void* std::__thread_proxy[abi:ne190107]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolIm
pl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x000000000f884342
19. /usr/src/debug/glibc/glibc/nptl/pthread_create.c:448: start_thread @ 0x00000000000969cb
20. ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78: __clone3 @ 0x000000000011aa0c
 (version 25.10.1.1)
```

</details>

The reason for this is that the request length is not verified at all, so let's introduce a separate setting for this - `max_request_size`

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ability to limit requests for `Keeper` (`max_request_size` setting, same as `jute.maxbuffer` for `ZooKeeper`, default **OFF** for backward compatibility, will be set in the next releases)