### PR TITLE
Docs: escape `<` character in description which breaks docs check

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1178,7 +1178,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
 
     Possible values: -20 to 19.
     )", 0) \
-    DECLARE(String, keeper_hosts, "", R"(Dynamic setting. Contains a set of [Zoo]Keeper hosts ClickHouse can potentially connect to. Doesn't expose information from <auxiliary_zookeepers>)", 0) \
+    DECLARE(String, keeper_hosts, "", R"(Dynamic setting. Contains a set of [Zoo]Keeper hosts ClickHouse can potentially connect to. Doesn't expose information from `<auxiliary_zookeepers>`)", 0) \
 
 // clang-format on
 

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -529,7 +529,7 @@ class CI:
         ),
         JobNames.DOCS_CHECK: JobConfig(
             digest=DigestConfig(
-                include_paths=["**/*.md", "./docs", "tests/ci/docs_check.py"],
+                include_paths=["**/*.md", "./docs", "tests/ci/docs_check.py", "src/Core/ServerSettings.cpp"],
                 docker=["clickhouse/docs-builder"],
             ),
             run_command="docs_check.py",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
`<auxillary_zookeepers>` without escaped `<` breaks the docs check: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=87922&sha=latest&name_0=PR due to docs framework thinking it's an MDX component without a closing tag.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
