### PR TITLE
Make test_allow_feature_tier/test.py::test_allow_feature_tier_in_mergetree_settings fail more clearly

### DIFF
--- a/tests/integration/test_allow_feature_tier/test.py
+++ b/tests/integration/test_allow_feature_tier/test.py
@@ -154,6 +154,7 @@ def test_allow_feature_tier_in_mergetree_settings(start_cluster):
     """
     )
     assert output == ""
+    assert error == ""
 
     output, error = instance.query_and_get_answer_with_error(
         """


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make test_allow_feature_tier/test.py::test_allow_feature_tier_in_mergetree_settings fail more clearly

If the table creation failed you'd not see any error until the next query, and would not now what happened unless you checked the log

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
