### PR TITLE
Avoid utilizing thread pool asynchonous marks loading when marks are in cache

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -341,6 +341,7 @@
     \
     M(WaitMarksLoadMicroseconds, "Time spent loading marks", ValueType::Microseconds) \
     M(BackgroundLoadingMarksTasks, "Number of background tasks for loading marks", ValueType::Number) \
+    M(SynchronousMarksTasks, "Number of times marks was loaded synchronously because they were presented in cache already", ValueType::Number) \
     M(LoadingMarksTasksCanceled, "Number of times background tasks for loading marks were canceled", ValueType::Number) \
     M(LoadedMarksFiles, "Number of mark files loaded.", ValueType::Number) \
     M(LoadedMarksCount, "Number of marks loaded (total across columns).", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -341,7 +341,7 @@
     \
     M(WaitMarksLoadMicroseconds, "Time spent loading marks", ValueType::Microseconds) \
     M(BackgroundLoadingMarksTasks, "Number of background tasks for loading marks", ValueType::Number) \
-    M(SynchronousMarksTasks, "Number of times marks were loaded synchronously because they were already present in the cache.", ValueType::Number) \
+    M(MarksTasksFromCache, "Number of times marks were loaded synchronously because they were already present in the cache.", ValueType::Number) \
     M(LoadingMarksTasksCanceled, "Number of times background tasks for loading marks were canceled", ValueType::Number) \
     M(LoadedMarksFiles, "Number of mark files loaded.", ValueType::Number) \
     M(LoadedMarksCount, "Number of marks loaded (total across columns).", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -341,7 +341,7 @@
     \
     M(WaitMarksLoadMicroseconds, "Time spent loading marks", ValueType::Microseconds) \
     M(BackgroundLoadingMarksTasks, "Number of background tasks for loading marks", ValueType::Number) \
-    M(SynchronousMarksTasks, "Number of times marks was loaded synchronously because they were presented in cache already", ValueType::Number) \
+    M(SynchronousMarksTasks, "Number of times marks were loaded synchronously because they were already present in the cache.", ValueType::Number) \
     M(LoadingMarksTasksCanceled, "Number of times background tasks for loading marks were canceled", ValueType::Number) \
     M(LoadedMarksFiles, "Number of mark files loaded.", ValueType::Number) \
     M(LoadedMarksCount, "Number of marks loaded (total across columns).", ValueType::Number) \

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -18,6 +18,7 @@ namespace ProfileEvents
     extern const Event WaitMarksLoadMicroseconds;
     extern const Event BackgroundLoadingMarksTasks;
     extern const Event LoadingMarksTasksCanceled;
+    extern const Event SynchronousMarksTasks;
     extern const Event LoadedMarksFiles;
     extern const Event LoadedMarksCount;
     extern const Event LoadedMarksMemoryBytes;
@@ -256,6 +257,17 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksSync()
 
 std::future<MarkCache::MappedPtr> MergeTreeMarksLoader::loadMarksAsync()
 {
+    /// Avoid queueing jobs into thread pool if marks are in cache
+    auto data_part_storage = data_part_reader->getDataPartStorage();
+    auto key = MarkCache::hash(fs::path(data_part_storage->getFullPath()) / mrk_path);
+    if (MarkCache::MappedPtr loaded_marks = mark_cache->get(key))
+    {
+        ProfileEvents::increment(ProfileEvents::SynchronousMarksTasks);
+        auto promise = std::promise<MarkCache::MappedPtr>();
+        promise.set_value(std::move(loaded_marks));
+        return promise.get_future();
+    }
+
     return scheduleFromThreadPoolUnsafe<MarkCache::MappedPtr>(
         [this]() -> MarkCache::MappedPtr
         {

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -18,7 +18,7 @@ namespace ProfileEvents
     extern const Event WaitMarksLoadMicroseconds;
     extern const Event BackgroundLoadingMarksTasks;
     extern const Event LoadingMarksTasksCanceled;
-    extern const Event SynchronousMarksTasks;
+    extern const Event MarksTasksFromCache;
     extern const Event LoadedMarksFiles;
     extern const Event LoadedMarksCount;
     extern const Event LoadedMarksMemoryBytes;
@@ -262,7 +262,7 @@ std::future<MarkCache::MappedPtr> MergeTreeMarksLoader::loadMarksAsync()
     auto key = MarkCache::hash(fs::path(data_part_storage->getFullPath()) / mrk_path);
     if (MarkCache::MappedPtr loaded_marks = mark_cache->get(key))
     {
-        ProfileEvents::increment(ProfileEvents::SynchronousMarksTasks);
+        ProfileEvents::increment(ProfileEvents::MarksTasksFromCache);
         auto promise = std::promise<MarkCache::MappedPtr>();
         promise.set_value(std::move(loaded_marks));
         return promise.get_future();

--- a/tests/queries/0_stateless/03640_load_marks_synchronously.reference
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.reference
@@ -1,0 +1,11 @@
+Row 1:
+──────
+query: select * from data settings load_marks_asynchronously=1 format Null /* 1 */;
+async: 1
+sync:  0
+
+Row 2:
+──────
+query: select * from data settings load_marks_asynchronously=1 format Null /* 2 */;
+async: 0
+sync:  1

--- a/tests/queries/0_stateless/03640_load_marks_synchronously.sql
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.sql
@@ -1,0 +1,16 @@
+create table data (key int) engine=MergeTree() order by key settings prewarm_mark_cache=0;
+insert into data select * from numbers(1000);
+
+-- Clear marks cache
+detach table data;
+attach table data;
+
+select * from data settings load_marks_asynchronously=1 format Null /* 1 */;
+select * from data settings load_marks_asynchronously=1 format Null /* 2 */;
+
+system flush logs;
+select query, ProfileEvents['BackgroundLoadingMarksTasks']>0 async, ProfileEvents['SynchronousMarksTasks']>0 sync
+from system.query_log
+where current_database = currentDatabase() and query_kind = 'Select' and type != 'QueryStart'
+order by event_time_microseconds
+format Vertical;

--- a/tests/queries/0_stateless/03640_load_marks_synchronously.sql
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel-replicas
+
 create table data (key int) engine=MergeTree() order by key settings prewarm_mark_cache=0;
 insert into data select * from numbers(1000);
 

--- a/tests/queries/0_stateless/03640_load_marks_synchronously.sql
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.sql
@@ -9,7 +9,7 @@ select * from data settings load_marks_asynchronously=1 format Null /* 1 */;
 select * from data settings load_marks_asynchronously=1 format Null /* 2 */;
 
 system flush logs;
-select query, ProfileEvents['BackgroundLoadingMarksTasks']>0 async, ProfileEvents['SynchronousMarksTasks']>0 sync
+select query, ProfileEvents['BackgroundLoadingMarksTasks']>0 async, ProfileEvents['MarksTasksFromCache']>0 sync
 from system.query_log
 where current_database = currentDatabase() and query_kind = 'Select' and type != 'QueryStart'
 order by event_time_microseconds


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid utilizing thread pool asynchonous marks loading (`load_marks_asynchronously=1`) when marks are in cache (since the pool can be under pressure and queries will pay penalty for this even if the marks already in cache)