### PR TITLE
Fix index analysis with session_timezone specified

### DIFF
--- a/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
+++ b/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
@@ -234,7 +234,7 @@ SELECT toString(toDate('2000-01-01') + 10 * number) FROM numbers(50)
 UNION ALL
 SELECT toString(toDate('2100-01-01') + 10 * number) FROM numbers(50);
 
-SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('2000-01-21', '2023-05-02') SETTINGS log_comment='03173_nested_date_parsing';
+SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('2000-01-21', '2023-05-02') SETTINGS log_comment='03173_nested_date_parsing', session_timezone = '';
 SYSTEM FLUSH LOGS query_log;
 SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_date_parsing';
 SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('not a date');

--- a/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
+++ b/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
@@ -1,4 +1,4 @@
--- Tags: no-msan
+-- Tags: no-msan, long
 -- msan: too slow
 
 SELECT '-- Single partition by function';

--- a/tests/queries/0_stateless/03636_index_analysis_with_session_tz.reference
+++ b/tests/queries/0_stateless/03636_index_analysis_with_session_tz.reference
@@ -1,0 +1,41 @@
+-- PK UTC timezone
+1
+Condition: (toStartOfDay(ts) in [1756857600, 1756857600])
+Parts: 1/1
+Granules: 1/1
+
+-- PK EST timezone
+1
+Condition: (toStartOfDay(ts) in [1756857600, 1756857600])
+Parts: 1/1
+Granules: 1/1
+
+-- Partitions UTC timezone
+1
+Condition: (ts in [1756882680, 1756882680])
+Parts: 1/1
+Granules: 1/1
+Condition: (toStartOfDay(ts) in [1756857600, 1756857600])
+Parts: 1/1
+Granules: 1/1
+
+-- Partitions EST timezone
+1
+Condition: (ts in [1756882680, 1756882680])
+Parts: 1/1
+Granules: 1/1
+Condition: (toStartOfDay(ts) in [1756857600, 1756857600])
+Parts: 1/1
+Granules: 1/1
+
+-- Partitions UTC timezone
+1
+Condition: true
+Parts: 1/1
+Granules: 1/1
+
+-- Partitions EST timezone
+1
+Condition: true
+Parts: 1/1
+Granules: 1/1

--- a/tests/queries/0_stateless/03636_index_analysis_with_session_tz.sql
+++ b/tests/queries/0_stateless/03636_index_analysis_with_session_tz.sql
@@ -1,0 +1,103 @@
+SET session_timezone = 'UTC';
+-- For explain with indexes and key condition values verification
+SET parallel_replicas_local_plan = 1;
+
+DROP TABLE IF EXISTS 03636_data_pk, 03636_data_partitions, 03636_data_parsed;
+
+CREATE TABLE 03636_data_pk (ts DateTime) ENGINE = MergeTree ORDER BY toStartOfDay(ts)
+AS
+SELECT 1756882680;
+
+SELECT '-- PK UTC timezone';
+
+SELECT count() FROM 03636_data_pk WHERE ts = 1756882680;
+
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM 03636_data_pk WHERE ts = 1756882680
+)
+WHERE trim(explain) ilike 'condition: %'
+   OR trim(explain) ilike 'parts: %'
+   OR trim(explain) ilike 'granules: %';
+
+SELECT '';
+SELECT '-- PK EST timezone';
+
+SELECT count() FROM 03636_data_pk WHERE ts = 1756882680 SETTINGS session_timezone = 'EST';
+
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM 03636_data_pk WHERE ts = 1756882680
+)
+WHERE trim(explain) ilike 'condition: %'
+   OR trim(explain) ilike 'parts: %'
+   OR trim(explain) ilike 'granules: %'
+SETTINGS session_timezone = 'EST';
+
+DROP TABLE 03636_data_pk;
+
+CREATE TABLE 03636_data_partitions (ts DateTime) ENGINE = MergeTree ORDER BY tuple() PARTITION BY toStartOfDay(ts)
+AS
+SELECT 1756882680;
+
+SELECT '';
+SELECT '-- Partitions UTC timezone';
+
+SELECT count() FROM 03636_data_partitions WHERE ts = 1756882680;
+
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM 03636_data_partitions WHERE ts = 1756882680
+)
+WHERE trim(explain) ilike 'condition: %'
+   OR trim(explain) ilike 'parts: %'
+   OR trim(explain) ilike 'granules: %';
+
+SELECT '';
+SELECT '-- Partitions EST timezone';
+
+SELECT count() FROM 03636_data_partitions WHERE ts = 1756882680 SETTINGS session_timezone = 'EST';
+
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM 03636_data_partitions WHERE ts = 1756882680
+)
+WHERE trim(explain) ilike 'condition: %'
+   OR trim(explain) ilike 'parts: %'
+   OR trim(explain) ilike 'granules: %'
+SETTINGS session_timezone = 'EST';
+
+DROP TABLE 03636_data_partitions;
+
+CREATE TABLE 03636_data_parsed (ts String) ENGINE = MergeTree ORDER BY toStartOfDay(toDateTime(ts))
+AS
+SELECT '2025-09-02 19:00:00';
+
+SELECT '';
+SELECT '-- Partitions UTC timezone';
+
+SELECT count() FROM 03636_data_parsed WHERE ts = '2025-09-02 19:00:00';
+
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM 03636_data_parsed WHERE ts = '2025-09-02 19:00:00'
+)
+WHERE trim(explain) ilike 'condition: %'
+   OR trim(explain) ilike 'parts: %'
+   OR trim(explain) ilike 'granules: %';
+
+SELECT '';
+SELECT '-- Partitions EST timezone';
+
+SELECT count() FROM 03636_data_parsed WHERE ts = '2025-09-02 19:00:00' SETTINGS session_timezone = 'EST';
+
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM 03636_data_parsed WHERE ts = '2025-09-02 19:00:00'
+)
+WHERE trim(explain) ilike 'condition: %'
+   OR trim(explain) ilike 'parts: %'
+   OR trim(explain) ilike 'granules: %'
+SETTINGS session_timezone = 'EST';
+
+DROP TABLE 03636_data_parsed;


### PR DESCRIPTION
Closes #86654 

- The main issue was caused by rebuilding key functions chain using the query context (which inferred timezone into the functions)
- Disabling index analysis for indexes containing date parsing functions in case the query specifies non-empty session timezone, and parsing datetime from string is required, as this part is not working properly since at least 24.1 ([example](https://fiddle.clickhouse.com/86f8db88-5b14-48ea-9cd9-ba1f574e322b))

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix for incorrect granules/partitions elimination for datetime-based keys, when using `session_timezone` setting in queries

Fixes: https://github.com/ClickHouse/ClickHouse/pull/65335