### PR TITLE
More traces for prefetched pool and marks loader

### DIFF
--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -1,15 +1,16 @@
 #include <Compression/CompressedReadBufferFromFile.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadHelpers.h>
-#include <Common/threadPoolCallbackRunner.h>
+#include <Interpreters/Context.h>
+#include <Parsers/parseIdentifierOrStringLiteral.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeMarksLoader.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/OpenTelemetryTraceContext.h>
 #include <Common/ThreadPool.h>
-#include <Parsers/parseIdentifierOrStringLiteral.h>
-#include <Interpreters/Context.h>
+#include <Common/threadPoolCallbackRunner.h>
 
 #include <utility>
 
@@ -95,6 +96,8 @@ MergeTreeMarksLoader::~MergeTreeMarksLoader()
 
 MergeTreeMarksGetterPtr MergeTreeMarksLoader::loadMarks()
 {
+    OpenTelemetry::SpanHolder span("MergeTreeMarksLoader::loadMarks");
+
     std::lock_guard lock(load_mutex);
 
     if (marks)

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -13,6 +13,7 @@
 #include <base/getThreadId.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/FailPoint.h>
+#include <Common/OpenTelemetryTraceContext.h>
 #include <Common/logger_useful.h>
 #include <Common/threadPoolCallbackRunner.h>
 
@@ -87,12 +88,16 @@ MergeTreePrefetchedReadPool::PrefetchedReaders::PrefetchedReaders(
 
 void MergeTreePrefetchedReadPool::PrefetchedReaders::wait()
 {
+    OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::PrefetchedReaders::wait");
+
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::WaitPrefetchTaskMicroseconds);
     prefetch_runner.waitForAllToFinish();
 }
 
 MergeTreeReadTask::Readers MergeTreePrefetchedReadPool::PrefetchedReaders::get()
 {
+    OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::PrefetchedReaders::get");
+
     SCOPE_EXIT({ is_valid = false; });
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::WaitPrefetchTaskMicroseconds);
 
@@ -168,6 +173,8 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
 
 void MergeTreePrefetchedReadPool::startPrefetches()
 {
+    OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::startPrefetches");
+
     if (prefetch_queue.empty())
         return;
 
@@ -194,6 +201,8 @@ void MergeTreePrefetchedReadPool::startPrefetches()
 
 MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::getTask(size_t task_idx, MergeTreeReadTask * previous_task)
 {
+    OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::getTask");
+
     std::lock_guard lock(mutex);
 
     if (per_thread_tasks.empty())


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Some more introspection for the case when we wait a lot on the lock in `getTask` because of the marks. 