### PR TITLE
Make the test test_filesystem_cache_log less flaky

### DIFF
--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -831,6 +831,9 @@ SETTINGS disk = disk(type = cache,
     """
     )
 
+    wait_for_cache_initialized(node, "test_filesystem_cache_log")
+    
+
     node.query(
         """
 INSERT INTO test SELECT 1, 'test';

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -831,6 +831,8 @@ SETTINGS disk = disk(type = cache,
     """
     )
 
+    wait_for_cache_initialized(node, "test_filesystem_cache_log")
+
     node.query(
         """
 INSERT INTO test SELECT 1, 'test';

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -831,8 +831,6 @@ SETTINGS disk = disk(type = cache,
     """
     )
 
-    wait_for_cache_initialized(node, "test_filesystem_cache_log")
-
     node.query(
         """
 INSERT INTO test SELECT 1, 'test';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Potential fix to the flaky test issue https://github.com/ClickHouse/ClickHouse/issues/85252

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
