### PR TITLE
Throw exception if table is readonly after restore replica

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -139,6 +139,7 @@ namespace ErrorCodes
     extern const int CANNOT_KILL;
     extern const int NOT_IMPLEMENTED;
     extern const int TIMEOUT_EXCEEDED;
+    extern const int TABLE_IS_READ_ONLY;
     extern const int TABLE_WAS_NOT_DROPPED;
     extern const int ABORTED;
     extern const int SUPPORT_IS_DISABLED;
@@ -970,6 +971,9 @@ void InterpreterSystemQuery::restoreReplica()
             settings[Setting::keeper_retry_max_backoff_ms],
             getContext()->getProcessListElementSafe()},
         false);
+
+    if (table_replicated_ptr->isTableReadOnly())
+        throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Table is still in readonly mode after attempting to restore replica");
 }
 
 void InterpreterSystemQuery::restoreDatabaseReplica(ASTSystemQuery & query)


### PR DESCRIPTION
It is possible that the table remains readonly after successfully finished RESTORE REPLICA query. For example then `cloneReplica` fails, `ReplicatedMergeTreeRestartingThread::tryStartup` catches the exception and returns false. Then restart thread function [fails](https://github.com/ClickHouse/ClickHouse/blob/53580a7c8e7939b4b6dfd69c314c099eedd4295b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp#L160). After that `StorageReplicatedMergeTree::startupImpl` finishes with the table in readonly mode as described in the [comment](https://github.com/ClickHouse/ClickHouse/blob/53580a7c8e7939b4b6dfd69c314c099eedd4295b/src/Storages/StorageReplicatedMergeTree.cpp#L5614).
Such behavior can be misleading, because one can forget to check that the table is not readonly after RESTORE REPLICA has finished without an exception.
The proposed solution is to check if table remains in readonly mode and return the exception.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
RESTORE REPLICA queries throw an exception if the table is readonly at the end of the query.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
