### PR TITLE
Enable ZooKeeper connection log by default

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1440,6 +1440,15 @@
         <ttl>event_date + INTERVAL 30 DAY</ttl>
     </aggregated_zookeeper_log>
 
+    <!-- ZooKeeper connection log.
+    -->
+    <zookeeper_connection_log>
+        <database>system</database>
+        <table>zookeeper_connection_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 30 DAY</ttl>
+    </zookeeper_connection_log>
+
     <!-- Configure system.dashboards for dashboard.html.
 
          Could have any query parameters, for which there will be an input on the page.


### PR DESCRIPTION
It is quite lightweight table and it can help debug Keeper related issues.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

From now `system.zookeeper_connection_log` is enabled by default and it can be used to get information about Keeper sessions.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
